### PR TITLE
Phase 7 (2a polish): honest firmCount, DataProtection keys, doc seed creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ BenchmarkDotNet.Artifacts/
 ## Node.js (frontend tooling, when/if introduced)
 node_modules/
 package-lock.json
+
+# Local docker compose env (contains real secrets — TRADING_AUTH_SIGNING_KEY)
+docker/.env

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using B3.Trading.Api;
 using B3.Trading.Api.Auth;
@@ -236,8 +237,24 @@ builder.Services.AddSingleton<IExchangeGateway>(sp =>
 builder.Services.AddSingleton<ExchangeStatus>(sp =>
 {
     var opts = sp.GetRequiredService<IOptions<ExchangeOptions>>().Value;
-    return new ExchangeStatus(opts.ResolveMode(), opts.Firms.Count);
+    return ExchangeStatus.FromOptions(opts);
 });
+
+// Persist DataProtection keys onto the data volume. JWT auth uses HMAC and
+// doesn't depend on DataProtection, but ASP.NET still spins it up for
+// cookie/antiforgery defaults. Without persistence it logs a warning every
+// boot ("No XML encryptor configured. Key ... may be persisted ... in
+// unencrypted form.") and regenerates keys on every container restart.
+{
+    var persistOpts = builder.Configuration
+        .GetSection(PersistenceOptions.SectionName)
+        .Get<PersistenceOptions>() ?? new PersistenceOptions();
+    var keysDir = Path.Combine(persistOpts.DataDirectory, "dp-keys");
+    Directory.CreateDirectory(keysDir);
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(new DirectoryInfo(keysDir))
+        .SetApplicationName("b3-trading-host");
+}
 
 var app = builder.Build();
 

--- a/backend/src/B3.Trading.Host/appsettings.Docker.json
+++ b/backend/src/B3.Trading.Host/appsettings.Docker.json
@@ -19,11 +19,13 @@
       "DataDirectory": "/var/lib/b3trading"
     }
   },
+  "_dp_comment": "DataProtection persists keys to /var/lib/b3trading/dp-keys (volume-protected). The XML-encryptor warning is about encryption-at-rest, which is not in scope at the container layer (no DPAPI on Linux, no X509 cert provisioning yet). Silenced because JWT auth is HMAC and doesn't depend on DataProtection; only ASP.NET defaults (cookie/antiforgery) consume it.",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error"
     }
   }
 }

--- a/backend/src/B3.Trading.Infrastructure/ExchangeStatus.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeStatus.cs
@@ -24,6 +24,25 @@ public sealed class ExchangeStatus
     public int FirmCount { get; }
 
     /// <summary>
+    /// Build the <c>/health</c>-facing snapshot from the bound options so
+    /// the same semantics apply in tests, in <c>Program.cs</c>, and any
+    /// future composition root: <see cref="ExchangeMode.Unavailable"/>
+    /// reports zero firms (nothing is operationally wired regardless of
+    /// what the config slot contains), and configured slots with empty
+    /// FirmIds are filtered so the count matches what the gateway
+    /// actually sees.
+    /// </summary>
+    public static ExchangeStatus FromOptions(ExchangeOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var mode = options.ResolveMode();
+        var count = mode == ExchangeMode.Unavailable
+            ? 0
+            : options.Firms.Count(f => !string.IsNullOrWhiteSpace(f.FirmId));
+        return new ExchangeStatus(mode, count);
+    }
+
+    /// <summary>
     /// True when submits will reach a gateway implementation that does NOT
     /// fail-closed. <see cref="ExchangeMode.Unavailable"/> is the only mode
     /// that returns false; <see cref="ExchangeMode.Stub"/> still returns

--- a/backend/tests/B3.Trading.Api.Tests/ExchangeModeTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/ExchangeModeTests.cs
@@ -87,4 +87,56 @@ public class ExchangeStatusTests
         var status = new ExchangeStatus(mode, firmCount: 0);
         Assert.Equal(expected, status.ReadyForOrders);
     }
+
+    [Fact]
+    public void FromOptions_Unavailable_Reports_Zero_Firms_Even_With_Configured_Slot()
+    {
+        // Reproduces the IConfiguration array-merge gotcha: a base
+        // appsettings.json carries a default firm and a Docker overlay
+        // can't clear it via Firms:[]. With Mode=Unavailable, the
+        // operational firm count must still be 0.
+        var opts = new ExchangeOptions
+        {
+            Mode = ExchangeMode.Unavailable,
+            Firms = { new FirmConfig { FirmId = "DEFAULT", Endpoint = "localhost:9000" } },
+        };
+        var status = ExchangeStatus.FromOptions(opts);
+        Assert.Equal(ExchangeMode.Unavailable, status.Mode);
+        Assert.Equal(0, status.FirmCount);
+        Assert.False(status.ReadyForOrders);
+    }
+
+    [Fact]
+    public void FromOptions_Filters_Empty_FirmIds()
+    {
+        var opts = new ExchangeOptions
+        {
+            Mode = ExchangeMode.Real,
+            Firms =
+            {
+                new FirmConfig { FirmId = "REAL", Endpoint = "h:1" },
+                new FirmConfig { FirmId = "  ", Endpoint = "h:2" },
+                new FirmConfig { FirmId = "", Endpoint = "h:3" },
+            },
+        };
+        var status = ExchangeStatus.FromOptions(opts);
+        Assert.Equal(1, status.FirmCount);
+    }
+
+    [Fact]
+    public void FromOptions_Counts_Configured_Firms_When_Wired()
+    {
+        var opts = new ExchangeOptions
+        {
+            Mode = ExchangeMode.Mock,
+            Firms =
+            {
+                new FirmConfig { FirmId = "A", Endpoint = "h:1" },
+                new FirmConfig { FirmId = "B", Endpoint = "h:2" },
+            },
+        };
+        var status = ExchangeStatus.FromOptions(opts);
+        Assert.Equal(2, status.FirmCount);
+        Assert.True(status.ReadyForOrders);
+    }
 }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,13 +7,14 @@
 #   openssl rand -base64 48
 TRADING_AUTH_SIGNING_KEY=replace-me-with-openssl-rand-base64-48-output
 
-# Seed user (one is enough for the frontend to log in; add more by
-# mounting an appsettings.Production.json or by extending the env block
-# in docker-compose.yml).
+# Seed user. The defaults below correspond to username "alice" with
+# password "wonderland" — STRICTLY for first-time smoke testing of the
+# container. Anyone reading this repo can log in with those, so generate
+# fresh hash/salt for any environment beyond your laptop:
 #
-# Hash + salt below correspond to the dev-bundled "alice" creds in
-# backend/src/B3.Trading.Host/appsettings.json. CHANGE THEM for any real
-# environment — anyone reading this repo can log in otherwise.
+#   dotnet run --project backend/tools/PasswordHasher -- '<your-password>'
+#   # (helper TBD; for now compute manually with PBKDF2-HMAC-SHA256,
+#   #  600_000 iterations, 32-byte hash, see PasswordHasher.cs)
 TRADING_SEED_USER=alice
 TRADING_SEED_PASSWORD_HASH=ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
 TRADING_SEED_PASSWORD_SALT=rXA+be7/gEYYZQrQDsUr2g==

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -69,6 +69,31 @@ services:
       Trading__Exchange__Mode: Mock
 ```
 
+## Logging in (dev only)
+
+The `.env.example` ships a seed user that lets you smoke-test the UI
+immediately:
+
+| Field | Value |
+|---|---|
+| Username | `alice` |
+| Password | `wonderland` |
+
+These match the `Trading:Auth:Users[0]` block in
+[`appsettings.json`](../backend/src/B3.Trading.Host/appsettings.json) and
+are PBKDF2-HMAC-SHA256, 600 000 iterations. Anyone reading this repo can
+log in with them — **rotate the hash + salt for anything beyond a
+laptop demo.**
+
+```bash
+# verify the seed user works once the stack is up
+TOKEN=$(curl -sS -X POST http://localhost:8080/auth/login \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"alice","password":"wonderland"}' | jq -r .token)
+curl -sS -H "Authorization: Bearer $TOKEN" http://localhost:8080/positions
+# []  (no broker connected — see Honest no-broker mode)
+```
+
 ## Required env vars
 
 The trading-host **refuses to boot** without these. That's


### PR DESCRIPTION
Three small follow-ups discovered during local validation of the docker compose stack from #9 / commit 5ec3e7c. All non-blocking but tightened before moving on to PR 7-2b (OTel wire-up).

## What changed

### 1. `firmCount` honest in `Mode=Unavailable`

Before: `/health` returned `firmCount: 1` even though no firm was operationally wired, because the IConfiguration array-merge gotcha leaks `Firms[0]` from `appsettings.json` past the `Firms:[]` overlay in `appsettings.Docker.json`.

After: extracted `ExchangeStatus.FromOptions(opts)` — `Unavailable` → 0, otherwise count of non-empty `FirmId`s. 3 new unit tests cover the gotcha.

### 2. DataProtection silenced + persisted

Before: every boot logged `No XML encryptor configured. Key {...} may be persisted ... in unencrypted form.` and keys regenerated on every restart.

After: `AddDataProtection().PersistKeysToFileSystem(<data>/dp-keys)` so cookie/antiforgery keys survive restart on the same volume as the WAL; the encryption-at-rest warning is silenced only in `appsettings.Docker.json` via a targeted `Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager: Error` log filter, with a sibling `_dp_comment` explaining why (JWT auth is HMAC, doesn't depend on DataProtection; only ASP.NET cookie/antiforgery defaults consume it, and DPAPI/X509 wrap is not in scope at the container layer).

### 3. Seed user credentials documented

Before: `alice / wonderland` was buried as a const in `TestAppFactory.cs` — operators couldn't log into the running container without source diving.

After: `docs/DOCKER.md` has a 'Logging in (dev only)' section with a verifiable `curl` recipe; `docker/.env.example` carries the same warning inline. Also `.gitignore docker/.env` so the local file with a real signing key doesn't show up as a stageable change.

## Validation

After rebuild, on the running stack:

| | result |
|---|---|
| `GET /health` | mode=Unavailable, firmCount=**0**, ready=false ✅ |
| `POST /orders` | 502 `gateway unavailable` (unchanged) ✅ |
| WS upgrade via nginx | 101 (unchanged) ✅ |
| Logs | only the cosmetic HTTP_PORTS-override warn from aspnet base image remains; no DataProtection warns ✅ |

Build: 0 warnings, 0 errors. Tests: 58 / 43 / 5 / 1 skipped (conformance).

Refs #9.