### PR TITLE
Phase 7 (2b): wire OpenTelemetry SDK (opt-in via OTEL_EXPORTER_OTLP_ENDPOINT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ package-lock.json
 
 # Local docker compose env (contains real secrets — TRADING_AUTH_SIGNING_KEY)
 docker/.env
+
+# Local dotnet run data dir (WAL + snapshots + DataProtection keys)
+backend/src/B3.Trading.Host/data/
+

--- a/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
+++ b/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
@@ -17,6 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/B3.Trading.Host/Observability/OpenTelemetryRegistration.cs
+++ b/backend/src/B3.Trading.Host/Observability/OpenTelemetryRegistration.cs
@@ -1,0 +1,90 @@
+using B3.Trading.Application.Observability;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace B3.Trading.Host.Observability;
+
+/// <summary>
+/// Wires the OpenTelemetry SDK against the application's existing
+/// <see cref="MetricsRegistry.Meter"/> and ASP.NET Core diagnostics.
+///
+/// <para>
+/// Activation is gated on the standard <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>
+/// environment variable: when unset, this method is a no-op so dev loops,
+/// unit tests, and "I just want to read /health" smoke runs pay zero
+/// overhead and don't spam stderr with failed exporter retries. When set,
+/// the OTLP exporter is honoured directly by the SDK (endpoint, protocol,
+/// headers all read from the standard <c>OTEL_*</c> envs).
+/// </para>
+///
+/// <para>
+/// The Prometheus-friendly view is <b>not</b> wired here — the local docker
+/// observability stack (PR 7-2c) collects via the OTLP receiver in
+/// otel-collector and exposes <c>/metrics</c> from the collector side.
+/// Keeps the host-side surface small and the protocol single.
+/// </para>
+/// </summary>
+public static class OpenTelemetryRegistration
+{
+    public const string EndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+    /// <summary>
+    /// Logical service name reported in <c>service.name</c> resource
+    /// attribute. Must match what the otel-collector / Grafana datasources
+    /// filter on, so it is intentionally a const.
+    /// </summary>
+    public const string ServiceName = "b3-trading-host";
+
+    public static IServiceCollection AddTradingObservability(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var endpoint = Environment.GetEnvironmentVariable(EndpointEnvVar);
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            // Honest no-op: log nothing, register nothing. The
+            // /metrics-via-collector path stays dark until an operator
+            // explicitly opts in via env. PR 7-2c will set this in the
+            // observability compose profile.
+            return services;
+        }
+
+        var environmentName = configuration["ASPNETCORE_ENVIRONMENT"]
+            ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+            ?? "Production";
+
+        var serviceVersion = typeof(OpenTelemetryRegistration).Assembly
+            .GetName().Version?.ToString() ?? "0.0.0";
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(r => r
+                .AddService(serviceName: ServiceName, serviceVersion: serviceVersion)
+                .AddAttributes(new KeyValuePair<string, object>[]
+                {
+                    new("deployment.environment", environmentName),
+                }))
+            .WithMetrics(b => b
+                // Application meter: every counter / histogram / gauge in
+                // MetricsRegistry rides this one Meter, so a single
+                // AddMeter is enough.
+                .AddMeter(MetricsRegistry.Meter.Name)
+                .AddAspNetCoreInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddOtlpExporter())
+            .WithTracing(b => b
+                .AddAspNetCoreInstrumentation(o =>
+                {
+                    // Health probes flood the trace stream and never carry
+                    // useful diagnostic signal. Drop them at source.
+                    o.Filter = ctx => ctx.Request.Path != "/live"
+                                   && ctx.Request.Path != "/ready"
+                                   && ctx.Request.Path != "/health";
+                })
+                .AddOtlpExporter());
+
+        return services;
+    }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -10,6 +10,7 @@ using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Host.Observability;
 using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -255,6 +256,11 @@ builder.Services.AddSingleton<ExchangeStatus>(sp =>
         .PersistKeysToFileSystem(new DirectoryInfo(keysDir))
         .SetApplicationName("b3-trading-host");
 }
+
+// OpenTelemetry: opt-in via OTEL_EXPORTER_OTLP_ENDPOINT. No-op when unset,
+// so this is safe to leave registered for tests, dev loops, and the
+// no-broker compose default. PR 7-2c flips it on inside the obs profile.
+builder.Services.AddTradingObservability(builder.Configuration);
 
 var app = builder.Build();
 

--- a/backend/tests/B3.Trading.Api.Tests/OpenTelemetryRegistrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OpenTelemetryRegistrationTests.cs
@@ -1,0 +1,59 @@
+using B3.Trading.Host.Observability;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// The <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> gate is critical: leaving the
+/// SDK on without an endpoint floods stderr with retry warnings every
+/// few seconds and pulls in a periodic background pump for nothing. These
+/// tests pin the contract: unset env -> nothing registered; set env ->
+/// SDK registered.
+/// </summary>
+public class OpenTelemetryRegistrationTests
+{
+    private const string EnvVar = OpenTelemetryRegistration.EndpointEnvVar;
+
+    [Fact]
+    public void Without_Endpoint_Env_Skips_Registration()
+    {
+        var prior = Environment.GetEnvironmentVariable(EnvVar);
+        Environment.SetEnvironmentVariable(EnvVar, null);
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddTradingObservability(new ConfigurationBuilder().Build());
+            using var sp = services.BuildServiceProvider();
+            // No MeterProvider gets registered when AddOpenTelemetry isn't called.
+            Assert.Null(sp.GetService<MeterProvider>());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVar, prior);
+        }
+    }
+
+    [Fact]
+    public void With_Endpoint_Env_Registers_Sdk()
+    {
+        var prior = Environment.GetEnvironmentVariable(EnvVar);
+        // localhost:4317 is the OTLP/grpc default; we never actually
+        // connect — building the provider is enough to prove registration.
+        Environment.SetEnvironmentVariable(EnvVar, "http://localhost:4317");
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddTradingObservability(new ConfigurationBuilder().Build());
+            using var sp = services.BuildServiceProvider();
+            Assert.NotNull(sp.GetService<MeterProvider>());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVar, prior);
+        }
+    }
+}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -109,6 +109,16 @@ a real environment.
 
 `docker/.env.example` is your starting point — copy to `docker/.env`.
 
+## Observability (opt-in)
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` (and friends) and the host wires up
+OpenTelemetry: application meter (`B3.Trading`), ASP.NET Core, .NET
+runtime instrumentation, traces. Without it the SDK is not registered at
+all — zero overhead for the no-broker default. See
+[`docs/METRICS.md`](METRICS.md) for the full instrument list and a
+collector-only smoke test recipe; the bundled obs profile lands in PR
+7-2c.
+
 ## Persistence
 
 The event store WAL + snapshots live in the named volume `b3-trading-data`

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,155 @@
+# Metrics
+
+The trading-host emits OpenTelemetry metrics + traces opt-in via the
+standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. When that
+variable is unset, the OTel SDK is **not registered at all** — no
+exporter, no periodic pump, no warnings — so dev loops and unit tests pay
+zero overhead.
+
+## Activation
+
+Minimum env to turn it on:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc        # default; can also be http/protobuf
+```
+
+All other `OTEL_*` standard envs (`OTEL_RESOURCE_ATTRIBUTES`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_METRIC_EXPORT_INTERVAL`,
+`OTEL_TRACES_SAMPLER`, etc.) are honoured by the SDK directly — we don't
+shadow them in code.
+
+## Resource attributes
+
+Every signal carries:
+
+| Attribute | Value |
+|---|---|
+| `service.name` | `b3-trading-host` (const, used by Grafana datasources) |
+| `service.version` | Assembly version (`1.0.0.0` today) |
+| `deployment.environment` | `ASPNETCORE_ENVIRONMENT` (`Development`, `Docker`, `Production`, ...) |
+
+Operators can layer more via `OTEL_RESOURCE_ATTRIBUTES=foo=bar,baz=qux`.
+
+## Application meter (`B3.Trading`)
+
+All app-layer instruments live on a single `Meter("B3.Trading", "1.0.0")`
+declared in
+[`MetricsRegistry.cs`](../backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs).
+One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
+
+| OTel name | Type | Tags |
+|---|---|---|
+| `trading.orders.submitted` | Counter | (none, planned: firm/symbol) |
+| `trading.orders.rejected_by_risk` | Counter | `check` |
+| `trading.orders.gateway_failed` | Counter | (none) |
+| `trading.orders.cancel_requested` | Counter | (none) |
+| `trading.er.received` | Counter | `type` (Fill, Canceled, Rejected, ...) |
+| `trading.kill_switch.toggled` | Counter | `state` (on/off) |
+| `trading.wal.appended` | Counter | (none) |
+| `trading.wal.backpressure` | Counter | `call_site` |
+| `trading.wal.segments_rotated` | Counter | (none) |
+| `trading.snapshots.taken` | Counter | (none) |
+| `trading.snapshots.failed` | Counter | (none) |
+| `trading.snapshots.duration_ms` | Histogram | (none) |
+| `trading.recovery.events_replayed` | Counter | (none) |
+| `trading.ws.connections.active` | UpDownCounter | (none) |
+| `trading.ws.messages.sent` | Counter | `topic` |
+| `trading.drain.rejections` | Counter | `route` |
+| `trading.entrypoint.connected` | UpDownCounter | `firm` |
+| `trading.entrypoint.events_received` | Counter | `firm`, `type` |
+| `trading.entrypoint.reconnect_attempts` | Counter | `firm` |
+| `trading.entrypoint.translation_errors` | Counter | `firm` |
+| `trading.entrypoint.business_rejects` | Counter | `firm`, `code` |
+| `trading.entrypoint.terminated` | Counter | `firm`, `cause` |
+
+## Auto-instrumentation also exported
+
+Wired alongside the application meter so a single OTLP pipeline carries
+everything:
+
+- **ASP.NET Core**: `http.server.request.duration`,
+  `http.server.active_requests`, `kestrel.active_connections`,
+  `kestrel.connection.duration`, `kestrel.queued_connections`,
+  `aspnetcore.routing.match_attempts`,
+  `aspnetcore.authentication.authenticate.duration`,
+  `aspnetcore.memory_pool.{rented,pooled,allocated,evicted}`.
+- **.NET runtime**: `dotnet.gc.{collections,heap.total_allocated,...}`,
+  `dotnet.thread_pool.*`, `dotnet.exceptions`, `dotnet.assembly.count`,
+  `dotnet.process.{cpu,memory}`, `dotnet.jit.*`.
+
+## Traces
+
+- AspNetCore instrumentation only.
+- Health probes (`/live`, `/ready`, `/health`) are filtered at the source
+  — they flood the trace stream and never carry useful diagnostic
+  signal.
+
+## Prometheus naming
+
+We export OTLP, **not** the Prometheus exposition format. The PR 7-2c
+otel-collector translates with the standard rules:
+
+- Dots become underscores: `trading.orders.submitted` →
+  `trading_orders_submitted`.
+- Counters get a `_total` suffix appended:
+  `trading_orders_submitted_total`.
+- Histograms become `<name>_bucket` / `_sum` / `_count` triples.
+- UpDownCounters keep their natural name (no `_total`).
+
+That mapping lives in the collector config, not in the host, so we keep
+exactly one wire format here.
+
+## Smoke test
+
+Quick local verification with a debug-output collector — proves SDK
+activation, resource attributes, and that at least one application
+counter exports:
+
+```bash
+# 1. Start a collector that prints whatever it receives
+cat > /tmp/otel-debug.yaml <<'EOF'
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    metrics: { receivers: [otlp], exporters: [debug] }
+    traces:  { receivers: [otlp], exporters: [debug] }
+EOF
+
+docker run -d --rm --name otelcol-test -p 4317:4317 \
+  -v /tmp/otel-debug.yaml:/etc/otelcol-contrib/config.yaml \
+  otel/opentelemetry-collector-contrib:0.119.0
+
+# 2. Run the host pointing at it (any non-default signing key works)
+cd backend/src/B3.Trading.Host
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_METRIC_EXPORT_INTERVAL=2000 \
+ASPNETCORE_URLS=http://localhost:5050 \
+Trading__Auth__SigningKey="dev-only-test-key-32-bytes-min-length____padding!" \
+  dotnet run --no-build
+
+# 3. Hit a counter (in another shell)
+TOKEN=$(curl -sX POST http://localhost:5050/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"wonderland"}' | jq -r .token)
+curl -sX POST http://localhost:5050/orders/ \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"symbol":"PETR4","securityId":1,"side":"Buy","type":"Limit","quantity":100,"price":30.5}'
+
+# 4. Watch it land in the collector
+docker logs otelcol-test 2>&1 | grep "Name: trading."
+#  -> Name: trading.orders.submitted
+#  -> Name: trading.wal.appended
+```
+
+The full observability stack (collector + Prometheus + Grafana) ships
+behind the `obs` compose profile in PR 7-2c.


### PR DESCRIPTION
Adds the OpenTelemetry SDK to the trading-host, gated on the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var so dev loops, unit tests, and the no-broker compose default pay zero overhead until an operator opts in.

## What's wired

- **Application meter** `B3.Trading` — single `AddMeter` covers every instrument in [`MetricsRegistry`](../backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs) (orders, ER, abort/halt switch, WAL, snapshots, recovery, WS, drain, EntryPoint).
- **AspNetCore instrumentation** — kestrel + http.server.* + routing + auth.
- **.NET runtime instrumentation** — GC, threadpool, exceptions, JIT, memory.
- **Traces** for AspNetCore only; `/live`, `/ready`, `/health` filtered at the source.
- **Resource attributes**: `service.name=b3-trading-host` (const, datasources filter on it), `service.version` (assembly), `deployment.environment` (ASPNETCORE_ENVIRONMENT).

## Why opt-in via env

Without an endpoint the OTLP exporter retries every few seconds and spams stderr. Worse, the periodic export pump stays alive doing nothing. Skipping registration entirely is cleaner than installing a no-op exporter — the cost shows up as zero process work when nobody's watching.

## Why no Prometheus exposition format here

We export OTLP only. PR 7-2c will add an otel-collector behind an OTLP receiver that runs the standard `dots→underscores + _total-suffix` mapping for Prometheus scrapes. Keeping exactly one wire format on the host side avoids drift between two exposition surfaces.

## Validation

- **Unit tests** pin the env-var gate: with `OTEL_EXPORTER_OTLP_ENDPOINT` unset the SDK isn't registered (no `MeterProvider` in DI); with it set the SDK is.
- **Local smoke** against `otel/opentelemetry-collector-contrib:0.119.0` with the debug exporter:
  - Resource attrs propagate (`service.name=b3-trading-host`, `deployment.environment=Production`, `service.version=1.0.0.0`).
  - ASP.NET + .NET runtime instruments arrive within 2s of `OTEL_METRIC_EXPORT_INTERVAL`.
  - After `POST /orders`: `trading.orders.submitted` + `trading.wal.appended` show up in collector stdout.
- **Build**: 0 warnings, 0 errors.
- **Tests**: 60 + 43 + 5 + 1 skipped.

## Docs

- New [`docs/METRICS.md`](../docs/METRICS.md): full instrument table, smoke recipe, Prometheus mapping rules (executed by the collector).
- [`docs/DOCKER.md`](../docs/DOCKER.md) gets a one-paragraph 'Observability (opt-in)' section.

Refs #9. Unblocks PR 7-2c (compose obs profile).
