### PR TITLE
Phase 7 (2c): observability overlay (otel-collector + Prometheus + Grafana)

### DIFF
--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -1,0 +1,125 @@
+# Observability overlay. Bring up alongside the base compose:
+#
+#   docker compose \
+#     -f docker/docker-compose.yml \
+#     -f docker/docker-compose.observability.yml \
+#     up
+#
+# What this adds:
+#   1. otel-collector (OTLP/gRPC + http receivers; Prometheus exposition out)
+#   2. prometheus (scrapes the collector)
+#   3. grafana (provisioned datasource + 1 'Process Up' dashboard)
+#
+# What this changes in trading-host:
+#   - Sets OTEL_EXPORTER_OTLP_ENDPOINT so the SDK we wired in PR 7-2b
+#     actually starts exporting. Without this overlay the env stays unset
+#     and the SDK stays a no-op (see docs/METRICS.md).
+#
+# UIs after `up`:
+#   - Grafana:    http://localhost:3000 (admin / admin on first login)
+#   - Prometheus: http://localhost:9090
+#   - Collector health: http://localhost:13133 (for k8s-style probes)
+
+name: b3trading
+
+services:
+  trading-host:
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+      # Faster than the 60s SDK default so the dashboard feels alive
+      # during local exploration. Production should leave this unset and
+      # accept the default.
+      OTEL_METRIC_EXPORT_INTERVAL: "5000"
+    depends_on:
+      otel-collector:
+        # otel-collector-contrib is distroless (no wget/curl/sh) so we
+        # can't probe its /health endpoint from the container. The SDK
+        # already retries with backoff on connection failures, so
+        # service_started is the right knob: trading-host doesn't crash
+        # if the collector is briefly unavailable, just buffers and
+        # retries the next periodic export.
+        condition: service_started
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.119.0
+    container_name: b3-otel-collector
+    restart: unless-stopped
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./observability/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    networks:
+      - b3-net
+    expose:
+      - "4317"
+      - "4318"
+      - "8889"
+    ports:
+      # Exposed on the host so external scripts / sub-collectors can also
+      # send OTLP into the same pipeline. Comment out to keep
+      # collector-internal.
+      - "${OTEL_OTLP_GRPC_PORT:-4317}:4317"
+      - "${OTEL_OTLP_HTTP_PORT:-4318}:4318"
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: b3-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=24h
+      - --web.enable-lifecycle
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - b3-net
+    expose:
+      - "9090"
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    depends_on:
+      - otel-collector
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-T", "2", "--spider", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+
+  grafana:
+    image: grafana/grafana:11.3.1
+    container_name: b3-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_INSTALL_PLUGINS: ""
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/process-up.json
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - b3-net
+    expose:
+      - "3000"
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -T 2 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 10s
+
+volumes:
+  prometheus-data:
+    name: b3-prometheus-data
+  grafana-data:
+    name: b3-grafana-data

--- a/docker/observability/grafana/dashboards/process-up.json
+++ b/docker/observability/grafana/dashboards/process-up.json
@@ -1,0 +1,239 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Honest Process Up view of the B3 trading-host. Built from instruments verified to actually export — no ack-latency panel until the histogram lands.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "1 = trading-host is exporting telemetry within the last 30s. Source: target_info from the OTel resource (presence-based; turns 0 when the SDK pump goes silent).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "clamp_max(count(target_info{exported_job=\"b3-trading-host\"}), 1)",
+          "legendFormat": "trading-host",
+          "refId": "A"
+        }
+      ],
+      "title": "Service",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cumulative count of orders accepted by /orders POST since process start. Stays at 0 in Mode=Unavailable (no submits get past UnavailableExchangeGateway, so the increment never fires).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(trading_orders_submitted_total{service_name=\"b3-trading-host\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Orders submitted (cumulative)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Active WebSocket connections to the trader UI. UpDownCounter from the application meter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(trading_ws_connections_active{service_name=\"b3-trading-host\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Active WS connections",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Resident set size of the trading-host process. From dotnet.process.memory.working_set (runtime instrumentation).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "purple", "value": null } ] },
+          "unit": "decbytes"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max(dotnet_process_memory_working_set_bytes{service_name=\"b3-trading-host\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Working set",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "HTTP request rate by route (auto-instrumentation, AspNetCore). /live, /ready, /health are filtered from traces but still appear in metrics — that's intentional, you want to know when probes flake.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count{service_name=\"b3-trading-host\"}[1m]))",
+          "legendFormat": "{{http_route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP request rate (per route)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "GC collection rate by generation. Sustained spikes in gen2 hint at allocation pressure on the order path.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (dotnet_gc_heap_generation) (rate(dotnet_gc_collections_total{service_name=\"b3-trading-host\"}[1m]))",
+          "legendFormat": "gen {{dotnet_gc_heap_generation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GC collections / s",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["b3-trading", "process-up"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "B3 Trading — Process Up",
+  "uid": "b3-trading-process-up",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/observability/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker/observability/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: b3-trading
+    orgId: 1
+    folder: B3 Trading
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/observability/grafana/provisioning/datasources/prometheus.yaml
+++ b/docker/observability/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 5s
+      httpMethod: POST

--- a/docker/observability/otel-collector-config.yaml
+++ b/docker/observability/otel-collector-config.yaml
@@ -1,0 +1,80 @@
+# otel-collector pipeline for the local observability profile.
+#
+# OTLP/gRPC in (from trading-host) -> prometheus exposition out (scraped
+# by the local Prometheus). Traces are accepted but only debug-logged in
+# this profile — Tempo / Jaeger get added later when the trace volume
+# justifies it.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      # http on 4318 too, in case operators prefer it for ad-hoc scripts
+      # against the same collector.
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    # Smooth out the periodic export bursts from the SDK so Prometheus
+    # sees a steady stream rather than spikes per export interval.
+    timeout: 5s
+    send_batch_size: 1024
+
+  resource/normalize:
+    # Promote service.name into a stable label every signal carries.
+    attributes:
+      - key: service.name
+        action: upsert
+        from_attribute: service.name
+
+exporters:
+  # Prometheus exposition for the local Prometheus to scrape.
+  # The exporter applies the standard OTel->Prometheus name translation:
+  #   - dots become underscores
+  #   - sums get a `_total` suffix appended
+  #   - histograms become `<name>_bucket` / `_sum` / `_count` triples
+  # so `trading.orders.submitted` (Counter) -> `trading_orders_submitted_total`.
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    # Promote resource attrs (service.name, deployment.environment,
+    # service.version) onto every metric so dashboards can filter on them.
+    resource_to_telemetry_conversion:
+      enabled: true
+    # Counters keep their cumulative semantics — Prometheus scrapes the
+    # current value and the rate() function does the differentiation
+    # downstream. No _created lines (noisy and rarely used).
+    enable_open_metrics: false
+    add_metric_suffixes: true
+
+  # Traces just go to stdout for now. Wired so smoke tests can confirm
+  # both pipelines work end-to-end before PR 7-2c+1 introduces a tracing
+  # backend.
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource/normalize, batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      # Expose the collector's own internal telemetry on :8888 so the
+      # bundled Prometheus can scrape it (export drops, queue sizes,
+      # receiver/exporter rates). Useful for debugging the obs pipeline
+      # itself.
+      address: 0.0.0.0:8888

--- a/docker/observability/prometheus.yml
+++ b/docker/observability/prometheus.yml
@@ -1,0 +1,24 @@
+# Local Prometheus for the obs profile. Single scrape target: the
+# otel-collector's prometheus exporter. The trading-host itself never
+# exposes /metrics — see docs/METRICS.md for why we pin one wire format.
+
+global:
+  scrape_interval: 5s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets:
+          - otel-collector:8889
+        labels:
+          source: otel-collector
+
+  - job_name: otel-collector-self
+    # The collector emits its own internal telemetry on :8888 (Go runtime,
+    # receiver/exporter metrics). Useful for spotting export drops.
+    static_configs:
+      - targets:
+          - otel-collector:8888
+        labels:
+          source: otel-collector-self

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -116,8 +116,48 @@ OpenTelemetry: application meter (`B3.Trading`), ASP.NET Core, .NET
 runtime instrumentation, traces. Without it the SDK is not registered at
 all — zero overhead for the no-broker default. See
 [`docs/METRICS.md`](METRICS.md) for the full instrument list and a
-collector-only smoke test recipe; the bundled obs profile lands in PR
-7-2c.
+collector-only smoke test recipe.
+
+### Bundled obs stack
+
+An overlay file ships otel-collector + Prometheus + Grafana with a
+provisioned datasource and a starter dashboard ("B3 Trading — Process
+Up"). Bring it up alongside the base stack:
+
+```bash
+docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.observability.yml \
+    up -d --build
+```
+
+This exports `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317`
+into the trading-host container automatically — no extra env required.
+
+Default ports:
+
+| Service        | URL                          | Credentials       |
+| -------------- | ---------------------------- | ----------------- |
+| trading-host   | http://localhost:5000        | `alice` / `wonderland` |
+| frontend       | http://localhost:8080        | (proxy to host)   |
+| Prometheus     | http://localhost:9090        | —                 |
+| Grafana        | http://localhost:3000        | `admin` / `admin` (change at first login) |
+| otel-collector | (internal: 4317 OTLP, 8889 prom expo) | — |
+
+The Grafana home dashboard is pre-set to "B3 Trading — Process Up". It
+shows: service-up indicator, orders submitted, active WS connections,
+working-set memory, HTTP request rate by route, and GC collections by
+generation. All panels query only verified-real instruments — no fake
+ack-latency placeholders.
+
+Tear down (keeping data volumes):
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml down
+```
+
+Use `down -v` to also drop the Prometheus/Grafana volumes
+(`b3-prometheus-data`, `b3-grafana-data`).
 
 ## Persistence
 
@@ -158,9 +198,6 @@ The build context is the **repo root** (the Dockerfile copies
   Until that's resolved, `Mode=Real` requires you to BYO an EntryPoint
   endpoint or use `B3.EntryPoint.Client.TestPeer` from a separate test
   container.
-- **No observability stack yet** — pending PR 7-2c. The host already
-  emits OTel-friendly meters via `MetricsRegistry`, but no exporter is
-  wired and nothing scrapes it.
 - **Frontend isn't AOT-compiled** — it's static HTML/JS served by nginx;
   good enough for the trader UI scope.
 - **Single-instance only** — the event store is local-disk; running two


### PR DESCRIPTION
## What

Adds an opt-in observability overlay: `docker-compose.observability.yml`
brings up otel-collector + Prometheus + Grafana alongside the base
trading stack, with a provisioned datasource and a starter dashboard
("B3 Trading — Process Up").

```bash
docker compose \
    -f docker/docker-compose.yml \
    -f docker/docker-compose.observability.yml \
    up -d --build
```

The overlay sets `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317`
on trading-host automatically — no extra env required to start exporting.

## Files added

- `docker/docker-compose.observability.yml` — overlay (not a profile,
  so the base file stays usable on its own).
- `docker/observability/otel-collector-config.yaml` — OTLP/gRPC :4317 +
  HTTP :4318 in, prometheus exposition :8889 out, traces to `debug`
  exporter, health_check extension on :13133, internal telemetry on
  :8888 so the bundled Prometheus can scrape the collector itself.
- `docker/observability/prometheus.yml` — 5s scrape, two jobs:
  `otel-collector` (the prom exposition) and `otel-collector-self`
  (the collector's internal telemetry).
- `docker/observability/grafana/provisioning/datasources/prometheus.yaml` —
  default Prometheus datasource (uid `prometheus`, POST, 5s timeInterval).
- `docker/observability/grafana/provisioning/dashboards/dashboards.yaml` —
  file provider for `/var/lib/grafana/dashboards`, folder "B3 Trading".
- `docker/observability/grafana/dashboards/process-up.json` — 6-panel
  starter dashboard. Set as Grafana home dashboard.

## Dashboard panels (only verified-real instruments)

| Panel | Query |
| --- | --- |
| Service Up | `clamp_max(count(target_info{exported_job="b3-trading-host"}), 1)` |
| Orders submitted | `sum(trading_orders_submitted_total{service_name="b3-trading-host"})` |
| WS connections active | `sum(trading_ws_connections_active{service_name="b3-trading-host"})` |
| Working set | `max(dotnet_process_memory_working_set_bytes{service_name="b3-trading-host"})` |
| HTTP request rate by route | `sum by (http_route) (rate(http_server_request_duration_seconds_count{service_name="b3-trading-host"}[1m]))` |
| GC collections by gen | `sum by (dotnet_gc_heap_generation) (rate(dotnet_gc_collections_total{service_name="b3-trading-host"}[1m]))` |

No fake ack-latency placeholders — there is no histogram source for it
yet. Add the panel when the instrument lands.

## Verified locally

```
SERVICE          STATUS
grafana          Up (healthy)
otel-collector   Up
prometheus       Up (healthy)
frontend         Up (healthy)
trading-host     Up (healthy)
```

- Prometheus targets: both `otel-collector:8889` and `:8888` UP.
- After login as `alice`/`wonderland` + a `POST /orders/`:
  `trading_orders_submitted_total` shows up in Prometheus with full
  resource attrs (`service_name`, `deployment_environment`, `symbol`,
  `side`).
- A WS connection bumps `trading_ws_connections_active` to 1 and
  drops back to 0 on disconnect.
- Grafana datasource health: OK. Dashboard "B3 Trading — Process Up"
  is provisioned and renders.

## Notes

- The collector image (`otel/opentelemetry-collector-contrib:0.119.0`)
  is distroless (no shell / wget / curl), so it cannot run a Docker
  HEALTHCHECK. We use `depends_on: service_started` instead. The SDK
  retries OTLP exports with backoff so this is safe — the collector
  starts in <1s.
- The host-side metric labels include `service_name`. `target_info`
  uses `exported_job` instead because Prometheus already has
  `job=otel-collector` from the scrape config (label-conflict
  resolution).

Closes the obs slice of phase 7 (2/N). Conformance overlay (PR 7-2d)
comes next.
