### PR TITLE
Phase 7 (2d): conformance runner image + compose overlay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,8 +42,13 @@ README.md
 # inside the trading-host runtime.
 frontend/
 
-# Tests don't ship to runtime
+# Tests don't ship to runtime — except the conformance suite, which IS
+# packaged as its own runner image (docker/conformance/Dockerfile).
 backend/tests/
+!backend/tests/B3.Trading.Conformance/
+!backend/tests/B3.Trading.Conformance/**
+**/bin/
+**/obj/
 
 # NuGet packages cache
 **/*.nupkg

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,4 +117,71 @@ jobs:
           TRADING_AUTH_SIGNING_KEY: validate-only-placeholder-key-min-32-bytes-long-aaaaa
           TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
           TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
-        run: docker compose -f docker/docker-compose.yml config --quiet
+        run: |
+          docker compose -f docker/docker-compose.yml config --quiet
+          docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml config --quiet
+          docker compose -f docker/docker-compose.yml -f docker/docker-compose.conformance.yml config --quiet
+
+  conformance:
+    name: Run conformance suite against compose stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: trading-host
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Bring up trading-host
+        env:
+          # alice/wonderland — the committed hash/salt match this plaintext.
+          # Signing key is a CI-only placeholder; conformance only checks
+          # the round-trip works, not that the key is unique.
+          TRADING_AUTH_SIGNING_KEY: ci-conformance-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_USER: alice
+          TRADING_SEED_PASSWORD: wonderland
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.conformance.yml \
+              up -d --build --wait trading-host
+
+      - name: Run conformance
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-conformance-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_USER: alice
+          TRADING_SEED_PASSWORD: wonderland
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.conformance.yml \
+              run --rm conformance
+
+      - name: Trading-host logs (always)
+        if: always()
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-conformance-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.conformance.yml \
+              logs trading-host || true
+
+      - name: Tear down
+        if: always()
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-conformance-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.conformance.yml \
+              down -v

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
@@ -7,12 +7,33 @@ namespace B3.Trading.Conformance.Infrastructure;
 /// <c>B3.EntryPoint.Conformance.ConformanceFactAttribute</c> so the two
 /// suites have the same operator ergonomics: drop env vars, run, ship.
 /// </summary>
+/// <remarks>
+/// When <c>B3T_REQUIRE_CONFIGURED=true</c> is set (the conformance Docker
+/// image always sets it), missing/invalid env is treated as a hard failure
+/// instead of a silent skip — this prevents a misconfigured CI run from
+/// passing with zero tests executed.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class ConformanceFactAttribute : FactAttribute
 {
+    public const string EnvRequireConfigured = "B3T_REQUIRE_CONFIGURED";
+
     public ConformanceFactAttribute()
     {
-        if (PlatformEndpoint.TryResolve() is null)
-            Skip = PlatformEndpoint.SkipReason;
+        if (PlatformEndpoint.TryResolve() is not null)
+            return;
+
+        var require = Environment.GetEnvironmentVariable(EnvRequireConfigured);
+        if (string.Equals(require, "true", StringComparison.OrdinalIgnoreCase) ||
+            require == "1")
+        {
+            // Throwing here makes xUnit surface a discovery error instead of
+            // a skip. The CI pipeline fails loudly rather than passing with
+            // zero executed tests.
+            throw new InvalidOperationException(
+                $"{EnvRequireConfigured}=true but {PlatformEndpoint.SkipReason}");
+        }
+
+        Skip = PlatformEndpoint.SkipReason;
     }
 }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -18,6 +18,10 @@ TRADING_AUTH_SIGNING_KEY=replace-me-with-openssl-rand-base64-48-output
 TRADING_SEED_USER=alice
 TRADING_SEED_PASSWORD_HASH=ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
 TRADING_SEED_PASSWORD_SALT=rXA+be7/gEYYZQrQDsUr2g==
+# Plaintext that produced the hash/salt above. Only consumed by the
+# conformance overlay (docker-compose.conformance.yml) — the trading-host
+# itself never sees this value. Keep in sync when rotating credentials.
+TRADING_SEED_PASSWORD=wonderland
 
 # Host port mappings (defaults are usually fine).
 TRADING_HOST_PORT=5000

--- a/docker/conformance/Dockerfile
+++ b/docker/conformance/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# Standalone runner for the B3.Trading.Conformance suite.
+#
+# Build context MUST be the repo root so the multi-project layout
+# (Directory.Build.props, slnx, the conformance .csproj) resolves the same
+# way it does for the trading-host build. Compose passes `context: ..`.
+#
+# The image is intentionally a *single* stage on the SDK image: the
+# artefact IS a test runner, not a publishable app. Restoring + building
+# happens at image-build time so the runtime entrypoint just executes
+# `dotnet test --no-build --no-restore`.
+#
+# Bring it up by setting B3T_BASE_URL / B3T_AUTH_USER / B3T_AUTH_PASS
+# (the entrypoint validates them and bails with a clear exit code if
+# missing or the API isn't reachable).
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201
+
+# curl is used by the entrypoint to wait for /ready before invoking
+# dotnet test. ca-certificates so https targets work too.
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Copy only what the conformance project needs. The .dockerignore lets
+# backend/tests/B3.Trading.Conformance/** through and excludes every
+# other test project plus all bin/obj.
+COPY global.json Directory.Build.props ./
+COPY backend/tests/B3.Trading.Conformance/ ./backend/tests/B3.Trading.Conformance/
+
+# Restore + build the conformance project explicitly. We do NOT restore
+# via the slnx because the trading-host source isn't in the build context
+# and slnx-level restore would fail on the missing references.
+RUN dotnet restore backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj
+RUN dotnet build   backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj \
+        --configuration Release \
+        --no-restore
+
+WORKDIR /src/backend/tests/B3.Trading.Conformance
+
+COPY docker/conformance/entrypoint.sh /usr/local/bin/conformance-entrypoint
+RUN chmod +x /usr/local/bin/conformance-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/conformance-entrypoint"]

--- a/docker/conformance/entrypoint.sh
+++ b/docker/conformance/entrypoint.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Conformance runner entrypoint.
+#
+# Validates env vars + readiness before invoking dotnet test, so
+# misconfiguration fails loudly instead of producing a green run with
+# zero tests executed (the bare ConformanceFactAttribute would skip).
+#
+# Exit codes follow the BSD sysexits convention so CI can tell apart:
+#   64 EX_USAGE       — missing/invalid env
+#   69 EX_UNAVAILABLE — trading-host not reachable in time
+#   78 EX_CONFIG      — login preflight failed (creds wrong / store empty)
+#   <test-runner exit code> — anything from dotnet test itself
+
+set -euo pipefail
+
+readonly EX_USAGE=64
+readonly EX_UNAVAILABLE=69
+readonly EX_CONFIG=78
+
+require_env() {
+    local name=$1
+    local value=${!name:-}
+    if [[ -z $value ]]; then
+        echo "ERROR: $name is required (see docs/DOCKER.md 'Running conformance')" >&2
+        exit $EX_USAGE
+    fi
+}
+
+require_env B3T_BASE_URL
+require_env B3T_AUTH_USER
+require_env B3T_AUTH_PASS
+
+# Force the test infrastructure to fail (not skip) if anything in
+# PlatformEndpoint.TryResolve trips — we already validated env above, so
+# any skip from this point is a config/contract drift we want to see.
+export B3T_REQUIRE_CONFIGURED=true
+
+# Strip a single trailing slash so $url/ready doesn't collapse into
+# // and trip the most paranoid reverse proxies.
+base_url=${B3T_BASE_URL%/}
+ready_url=${B3T_READY_URL:-$base_url/ready}
+login_url=$base_url/auth/login
+
+echo "[conformance] target: $base_url"
+echo "[conformance] waiting for $ready_url ..."
+
+# The trading-host /ready returns 200 when up + not draining, 503 when
+# draining. We treat anything 2xx as ready. Total wait budget: 60 s.
+deadline=$((SECONDS + 60))
+until curl --silent --show-error --fail --max-time 3 -o /dev/null "$ready_url"; do
+    if (( SECONDS >= deadline )); then
+        echo "ERROR: $ready_url never became ready within 60s" >&2
+        exit $EX_UNAVAILABLE
+    fi
+    sleep 1
+done
+
+echo "[conformance] /ready ok; preflight login as '$B3T_AUTH_USER' ..."
+
+# Preflight the login so a wrong password / missing seed user fails with
+# a clear EX_CONFIG (78) before we spin up the test runner. The actual
+# test re-does this through HttpClient — that's intentional.
+login_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+    --max-time 5 \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$B3T_AUTH_USER\",\"password\":\"$B3T_AUTH_PASS\"}" \
+    "$login_url" || true)
+
+if [[ $login_status != 2* ]]; then
+    echo "ERROR: preflight login at $login_url returned HTTP $login_status" >&2
+    echo "       (check TRADING_SEED_PASSWORD matches the hash/salt the host was started with)" >&2
+    exit $EX_CONFIG
+fi
+
+echo "[conformance] preflight ok; running suite ..."
+exec dotnet test \
+    --configuration Release \
+    --no-build \
+    --no-restore \
+    --logger "console;verbosity=normal" \
+    "$@"

--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -1,0 +1,37 @@
+# Conformance overlay for the family stack. Adds a one-shot
+# `conformance` service that runs the B3.Trading.Conformance suite
+# against the running trading-host on the same network.
+#
+# Usage:
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.conformance.yml \
+#       up -d --wait trading-host
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.conformance.yml \
+#       run --rm conformance
+#
+# Profile-gated so it does NOT auto-start with `docker compose up`. It's
+# always invoked explicitly via `run --rm`.
+
+services:
+  conformance:
+    build:
+      context: ..
+      dockerfile: docker/conformance/Dockerfile
+    image: ${CONFORMANCE_IMAGE:-b3-trading-conformance:dev}
+    profiles: ["conformance"]
+    depends_on:
+      trading-host:
+        condition: service_healthy
+    environment:
+      # Internal DNS via the b3-net bridge — same network as trading-host.
+      B3T_BASE_URL: http://trading-host:5000
+      B3T_AUTH_USER: ${TRADING_SEED_USER:-alice}
+      # Plaintext password that produced TRADING_SEED_PASSWORD_HASH +
+      # _SALT. Default `wonderland` matches the seeds committed in
+      # .env.example. Override in .env when rotating.
+      B3T_AUTH_PASS: ${TRADING_SEED_PASSWORD:-wonderland}
+    networks:
+      - b3-net

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -159,6 +159,60 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.observabili
 Use `down -v` to also drop the Prometheus/Grafana volumes
 (`b3-prometheus-data`, `b3-grafana-data`).
 
+## Running conformance
+
+The conformance suite (`backend/tests/B3.Trading.Conformance/`) lives
+behind its own overlay. It builds a standalone runner image and runs it
+against the trading-host on the internal `b3-net`:
+
+```bash
+docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.conformance.yml \
+    up -d --build --wait trading-host
+
+docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.conformance.yml \
+    run --rm conformance
+```
+
+The runner expects three env vars (the overlay wires sane defaults from
+your `.env`):
+
+| Var | Default | Notes |
+| --- | --- | --- |
+| `B3T_BASE_URL` | `http://trading-host:5000` | Internal DNS via the bridge network. |
+| `B3T_AUTH_USER` | `${TRADING_SEED_USER:-alice}` | Must exist in the host's user store. |
+| `B3T_AUTH_PASS` | `${TRADING_SEED_PASSWORD:-wonderland}` | Plaintext that produced the host's hash/salt. |
+
+The entrypoint preflights the env, waits up to 60 s for `/ready`, and
+attempts a login before invoking `dotnet test`. Exit codes follow BSD
+sysexits so failures are easy to distinguish:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All tests passed. |
+| `1` | A test failed (or `B3T_REQUIRE_CONFIGURED=true` and env is invalid — the runner image always sets this so a misconfig fails loudly instead of silently skipping). |
+| `64` | A required env var is missing. |
+| `69` | `B3T_BASE_URL/ready` never came up within 60 s. |
+| `78` | Preflight login was rejected (creds don't match the host's seed). |
+
+You can also point the same image at any deployed host (UAT / staging),
+no compose needed:
+
+```bash
+docker run --rm \
+    -e B3T_BASE_URL=https://trading.uat.example.com \
+    -e B3T_AUTH_USER=alice \
+    -e B3T_AUTH_PASS='...' \
+    b3-trading-conformance:dev
+```
+
+CI runs this on every PR via the `conformance` job in
+`.github/workflows/docker.yml`, with the alice/wonderland defaults that
+match the committed seed hash/salt.
+
 ## Persistence
 
 The event store WAL + snapshots live in the named volume `b3-trading-data`


### PR DESCRIPTION
## What

Adds a profile-gated `conformance` overlay so the
`backend/tests/B3.Trading.Conformance` suite can run against the family
stack with one command:

```bash
docker compose \
    -f docker/docker-compose.yml \
    -f docker/docker-compose.conformance.yml \
    up -d --build --wait trading-host

docker compose \
    -f docker/docker-compose.yml \
    -f docker/docker-compose.conformance.yml \
    run --rm conformance
```

## Files

- `docker/conformance/Dockerfile` — standalone runner image (SDK 10.0.201
  base + curl + the conformance project, restored & built at image-build
  time so runtime is just `dotnet test --no-build --no-restore`). Single
  stage on purpose: the artefact IS a test runner, not a publishable
  app.
- `docker/conformance/entrypoint.sh` — preflight that:
  - asserts `B3T_BASE_URL` / `B3T_AUTH_USER` / `B3T_AUTH_PASS` are set
    (exit 64 / EX_USAGE if not),
  - waits up to 60 s on `${B3T_BASE_URL}/ready` (exit 69 / EX_UNAVAILABLE
    on timeout),
  - does a real `POST /auth/login` to verify the seed creds match the
    host's hash/salt (exit 78 / EX_CONFIG on 401),
  - exports `B3T_REQUIRE_CONFIGURED=true` before invoking dotnet test so
    a misconfigured env fails loudly (see attribute change below) instead
    of producing a silent zero-tests-skipped green run.
- `docker/docker-compose.conformance.yml` — overlay (not part of base).
  `profiles: ["conformance"]` so it never auto-starts. `depends_on:
  trading-host: service_healthy` plus `up --wait` in CI as a belt-and-
  braces dependency on readiness.
- `.dockerignore` — narrow exception that lets only
  `backend/tests/B3.Trading.Conformance/**` through (other test projects
  remain excluded; bin/obj stay excluded for the conformance dir too).
- `backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs`
  — when `B3T_REQUIRE_CONFIGURED=true|1` is set, missing/invalid env
  throws at discovery instead of marking the test Skipped. The container
  always sets it; humans running `dotnet test` from the repo still get
  the friendly skip behavior.
- `docker/.env.example` — adds `TRADING_SEED_PASSWORD=wonderland` (the
  plaintext that produced the committed hash/salt). Only the conformance
  overlay reads it; the trading-host never sees plaintext.
- `.github/workflows/docker.yml` — new `conformance` job: brings up
  trading-host with `--wait`, runs the suite, dumps host logs on
  failure, tears down with `-v`. Also extends the existing
  `compose-validate` job to validate the new overlay (and the
  observability one, which was missing).
- `docs/DOCKER.md` — new "Running conformance" section with the recipe,
  env table, exit-code table, and a "point at any deployed host" recipe
  for UAT/staging.

## Verified locally

End-to-end, using the committed alice/wonderland seed:

```
[conformance] target: http://trading-host:5000
[conformance] waiting for http://trading-host:5000/ready ...
[conformance] /ready ok; preflight login as 'alice' ...
[conformance] preflight ok; running suite ...
  Passed B3.Trading.Conformance.Spec_HTTP_Auth.HelloLoginTests.Login_ReturnsJwt_AcceptedByProtectedEndpoint [344 ms]
Test Run Successful. Total tests: 1, Passed: 1
exit: 0
```

Failure paths verified to exit non-zero with clear diagnostics:

| Scenario | Exit |
| --- | --- |
| `B3T_AUTH_PASS` empty | 64 |
| Wrong password (HTTP 401 from /auth/login) | 78 |
| `B3T_REQUIRE_CONFIGURED=true` + invalid `B3T_BASE_URL` | 1 (1 Failed, 0 Skipped — proves the silent-skip class of failure is closed) |

Repo-wide tests still green: 60 api / 43 application / 5 domain pass; 1
conformance skipped (correct — no env exported in `dotnet test` from the
repo).

## Notes on choices

- **Profile gating** keeps `docker compose up` clean. The runner is
  always invoked via `run --rm`.
- **Standalone image** (vs. bind-mounted SDK) so the same artefact runs
  in CI and against deployed envs (UAT/staging) without depending on
  the caller's working tree.
- **No `container_name`** on the one-shot service — `run --rm` creates
  ephemeral names so repeats don't collide.
- **CI depends on the `trading-host` job** (just for ordering), but
  builds the trading-host image from source again since GHA jobs don't
  share the local image store. This guarantees CI tests *this PR's
  code*, not a previously published `:latest`.

Wraps up the 7-2 family (compose / OTel SDK / obs overlay / conformance
overlay). Phase 7 ops hardening (`phase-7-ops`) is next.
