### PR TITLE
phase-7/3: live IReferencePrice via B3.MarketData.WebSocketClient 0.1.0

### DIFF
--- a/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
+++ b/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
@@ -1,0 +1,45 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Application-side seam over the market-data SDK so risk logic can be
+/// unit-tested without touching the network. The host wires
+/// <c>SdkMarketDataSubscriber</c> (wraps <c>MarketDataClient</c>); tests
+/// wire a fake that synchronously raises events on demand.
+///
+/// <para>
+/// Implementations MUST raise <see cref="Trade"/> / <see cref="InfoSnapshot"/>
+/// with already-validated payloads (positive prices, non-empty symbol).
+/// Consumers can still defensively skip junk, but the seam exists to
+/// keep that policy out of risk-side code paths.
+/// </para>
+/// </summary>
+public interface IMarketDataSubscriber : IAsyncDisposable
+{
+    MarketDataConnectionState State { get; }
+
+    /// <summary>Last-observed dropped-event count from the underlying
+    /// bounded back-pressure channel. Surfaced as an observable gauge
+    /// for ops alerting.</summary>
+    long DroppedEventCount { get; }
+
+    event Action<MarketTrade>? Trade;
+    event Action<MarketInfoSnapshot>? InfoSnapshot;
+    event Action<MarketDataConnectionState>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Raised when the upstream rejects a Subscribe (unknown symbol,
+    /// not ready, …). Symbol-mapping mismatches between this host and
+    /// the MD platform surface here.
+    /// </summary>
+    event Action<MarketSubscribeError>? SubscribeError;
+
+    Task ConnectAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribes to trade prints + info snapshots for <paramref name="symbol"/>.
+    /// Idempotent on the SDK side.
+    /// </summary>
+    ValueTask SubscribeAsync(string symbol, CancellationToken ct = default);
+}
+
+public readonly record struct MarketSubscribeError(string Symbol, string Reason);

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
@@ -1,0 +1,42 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Application-owned market-data event records. Decouple risk logic
+/// from the upstream <c>B3.MarketData.WebSocketClient</c> SDK shapes:
+/// <c>SdkMarketDataSubscriber</c> in the host translates the SDK
+/// events into these on the way in, so anything below this layer
+/// (tests, alternate transports) only needs to deal with our own
+/// types.
+/// </summary>
+public readonly record struct MarketTrade(
+    string Symbol,
+    ulong SecurityId,
+    decimal Price,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>
+/// Snapshot view of an instrument's reference data (open / close /
+/// last trade / trading reference). Only the fields we currently use
+/// are surfaced; if a future risk check needs e.g. <c>VwapPrice</c>,
+/// add it here and propagate.
+/// </summary>
+public readonly record struct MarketInfoSnapshot(
+    string Symbol,
+    ulong SecurityId,
+    decimal? LastTradePrice,
+    decimal? TradingReferencePrice,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>
+/// Coarse connection state of the underlying market-data feed.
+/// Mirrors <c>B3.MarketData.WebSocketClient.ConnectionState</c> 1:1
+/// but kept app-owned so tests don't reference the SDK enum.
+/// </summary>
+public enum MarketDataConnectionState
+{
+    Disconnected,
+    Connecting,
+    Connected,
+    Reconnecting,
+    Faulted,
+}

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
@@ -1,0 +1,46 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Configuration for the live market-data reference-price source.
+/// Bound from <c>Trading:MarketData</c>.
+///
+/// <para>
+/// When <see cref="WsUrl"/> is null/whitespace, the host registers
+/// only <see cref="Risk.ConfigReferencePrice"/> and the price collar
+/// remains driven by the static <c>Trading:Risk:ReferencePrices</c>
+/// dictionary. When <see cref="WsUrl"/> is set, a <see cref="MarketDataReferencePrice"/>
+/// is wired in front of it, transparently feeding the cache from
+/// trade/info events and falling back to the static dictionary on
+/// cache miss or staleness.
+/// </para>
+/// </summary>
+public sealed class MarketDataOptions
+{
+    public const string SectionName = "Trading:MarketData";
+
+    /// <summary>
+    /// WebSocket endpoint of B3MarketDataPlatform (e.g.
+    /// <c>ws://marketdata:8080/ws</c>). Null/empty disables the live
+    /// source — see class docs.
+    /// </summary>
+    public string? WsUrl { get; set; }
+
+    /// <summary>
+    /// Symbols to subscribe to on startup. Configure via array binding
+    /// (<c>Trading__MarketData__Symbols__0=PETR4</c>) or a list in
+    /// appsettings. Empty + <see cref="WsUrl"/> set is a misconfig
+    /// (logged as a warning at startup).
+    /// </summary>
+    public string[] Symbols { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Maximum age of a cached price before <see cref="MarketDataReferencePrice"/>
+    /// stops trusting it and falls through to the static reference-price
+    /// fallback. Default 5 minutes — large enough for an idle book to
+    /// keep enforcing the collar across a quick lull, small enough that
+    /// a dead feed doesn't keep approving against last week's price.
+    /// Set <see cref="TimeSpan.Zero"/> or negative to disable the check
+    /// (cache wins forever as long as it has a value).
+    /// </summary>
+    public TimeSpan MaxStaleness { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
@@ -1,0 +1,197 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Live <see cref="IReferencePrice"/> backed by the B3MarketDataPlatform
+/// WebSocket feed via <see cref="IMarketDataSubscriber"/>.
+///
+/// <para>
+/// Maintains a per-symbol cache of last-observed price + timestamp.
+/// On <see cref="TryGet"/> miss (symbol never traded, never seeded by
+/// snapshot) or staleness (older than <see cref="MarketDataOptions.MaxStaleness"/>),
+/// delegates to <paramref name="fallback"/> — typically
+/// <see cref="ConfigReferencePrice"/>. Same fail-open semantics as
+/// before: no number → collar approves.
+/// </para>
+///
+/// <para>
+/// Implements <see cref="IHostedService"/> so DI is forced to construct
+/// it (and attach event handlers to the subscriber) BEFORE the host
+/// starts the subscriber's connect/subscribe loop. Without that, early
+/// trade prints arriving in the gap between subscriber-start and first
+/// <c>IReferencePrice</c> resolution would be silently dropped.
+/// </para>
+/// </summary>
+public sealed class MarketDataReferencePrice : IReferencePrice, IHostedService
+{
+    private readonly IMarketDataSubscriber _subscriber;
+    private readonly IReferencePrice _fallback;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<MarketDataReferencePrice> _logger;
+    private readonly MarketDataOptions _options;
+
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public MarketDataReferencePrice(
+        IMarketDataSubscriber subscriber,
+        IReferencePrice fallback,
+        IOptions<MarketDataOptions> options,
+        TimeProvider clock,
+        ILogger<MarketDataReferencePrice> logger)
+    {
+        _subscriber = subscriber;
+        _fallback = fallback;
+        _clock = clock;
+        _logger = logger;
+        _options = options.Value;
+
+        _subscriber.Trade += OnTrade;
+        _subscriber.InfoSnapshot += OnInfoSnapshot;
+        _subscriber.ConnectionStateChanged += OnConnectionStateChanged;
+        _subscriber.SubscribeError += OnSubscribeError;
+    }
+
+    /// <summary>Exposed for tests / ops introspection. Snapshot, not live.</summary>
+    public IReadOnlyDictionary<string, (decimal Price, DateTimeOffset UpdatedUtc)> Snapshot() =>
+        _cache.ToDictionary(
+            kv => kv.Key,
+            kv => (kv.Value.Price, kv.Value.UpdatedUtc),
+            StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGet(string symbol, out decimal price)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            price = 0m;
+            return false;
+        }
+
+        if (_cache.TryGetValue(symbol, out var entry) && entry.Price > 0m)
+        {
+            // Negative or zero MaxStaleness means "trust cache forever".
+            if (_options.MaxStaleness <= TimeSpan.Zero ||
+                _clock.GetUtcNow() - entry.UpdatedUtc <= _options.MaxStaleness)
+            {
+                price = entry.Price;
+                return true;
+            }
+        }
+
+        return _fallback.TryGet(symbol, out price);
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_options.Symbols.Length == 0)
+        {
+            // The gate is on (WsUrl set) but the subscription list is
+            // empty — the feed will connect and idle forever, which is
+            // almost certainly a misconfig. Loud log so it shows up in
+            // every operator's first deploy.
+            _logger.LogWarning(
+                "MarketData feed enabled but Trading:MarketData:Symbols is empty; nothing will be subscribed and the price collar will fall back to the static reference-price dictionary.");
+        }
+
+        try
+        {
+            await _subscriber.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Don't abort host startup if the MD endpoint is down — the
+            // SDK's reconnect loop will keep trying. Collar stays in
+            // fallback mode meanwhile.
+            _logger.LogWarning(ex,
+                "MarketData ConnectAsync failed at startup; SDK reconnect will keep trying.");
+        }
+
+        foreach (var raw in _options.Symbols)
+        {
+            var symbol = (raw ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(symbol))
+                continue;
+
+            try
+            {
+                await _subscriber.SubscribeAsync(symbol, cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("MarketData subscribed: {Symbol}", symbol);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "MarketData subscribe failed for {Symbol}; will retry on next reconnect via auto-resubscribe.", symbol);
+            }
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscriber.Trade -= OnTrade;
+        _subscriber.InfoSnapshot -= OnInfoSnapshot;
+        _subscriber.ConnectionStateChanged -= OnConnectionStateChanged;
+        _subscriber.SubscribeError -= OnSubscribeError;
+        return Task.CompletedTask;
+    }
+
+    // -------- event handlers (hot path; keep tight) --------
+
+    private void OnTrade(MarketTrade t)
+    {
+        if (string.IsNullOrWhiteSpace(t.Symbol) || t.Price <= 0m)
+            return;
+        Update(t.Symbol, t.Price, t.ReceivedUtc);
+    }
+
+    private void OnInfoSnapshot(MarketInfoSnapshot s)
+    {
+        if (string.IsNullOrWhiteSpace(s.Symbol))
+            return;
+        // Prefer LastTradePrice (closest to a "current" mark). Fall back
+        // to TradingReferencePrice (the venue-supplied collar anchor)
+        // only if no trade has been observed in this snapshot.
+        var seed = s.LastTradePrice ?? s.TradingReferencePrice;
+        if (seed is not { } px || px <= 0m)
+            return;
+        Update(s.Symbol, px, s.ReceivedUtc);
+    }
+
+    private void Update(string symbol, decimal price, DateTimeOffset receivedUtc)
+    {
+        var key = symbol.Trim();
+        _cache[key] = new CacheEntry(price, receivedUtc);
+    }
+
+    private void OnConnectionStateChanged(MarketDataConnectionState state)
+    {
+        _logger.LogInformation("MarketData connection state: {State}", state);
+        // The connected gauge is published as an observable in the
+        // host's metrics registration so ops sees the binary "is the
+        // feed up" without us emitting a sample on every transition.
+    }
+
+    private void OnSubscribeError(MarketSubscribeError err)
+    {
+        MetricsRegistry.MarketDataSubscribeErrors.Add(1,
+            new KeyValuePair<string, object?>("symbol", err.Symbol),
+            new KeyValuePair<string, object?>("reason", err.Reason));
+        _logger.LogWarning(
+            "MarketData subscribe error for {Symbol}: {Reason}", err.Symbol, err.Reason);
+    }
+
+    private readonly record struct CacheEntry(decimal Price, DateTimeOffset UpdatedUtc);
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -75,4 +75,8 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.entrypoint.business_rejects");
     public static readonly Counter<long> EntryPointTerminated =
         Meter.CreateCounter<long>("trading.entrypoint.terminated");
+
+    // MarketData consumer (B3.MarketData.WebSocketClient)
+    public static readonly Counter<long> MarketDataSubscribeErrors =
+        Meter.CreateCounter<long>("trading.marketdata.subscribe_errors");
 }

--- a/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
+++ b/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
+++ b/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
@@ -1,0 +1,93 @@
+using B3.MarketData.WebSocketClient;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Risk;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Host.MarketData;
+
+/// <summary>
+/// Wires the live <see cref="IReferencePrice"/> path on top of the
+/// B3MarketDataPlatform WebSocket SDK.
+///
+/// <para>
+/// Activation is gated on <c>Trading:MarketData:WsUrl</c> so the dev
+/// loop / no-op deployments pay zero cost — when WsUrl is unset we
+/// fall back to <see cref="ConfigReferencePrice"/> exactly like before.
+/// When it is set, we build:
+/// </para>
+/// <list type="number">
+///   <item><see cref="MarketDataClient"/> via the SDK's DI extension
+///         (transparent reconnect, auto-resubscribe, bounded
+///         back-pressure with drop-oldest).</item>
+///   <item>An adapter (<see cref="SdkMarketDataSubscriber"/>) translating
+///         SDK event types into application-owned records.</item>
+///   <item><see cref="MarketDataReferencePrice"/> as a singleton
+///         resolved BOTH as <see cref="IReferencePrice"/> AND as
+///         <see cref="IHostedService"/> (same instance) so DI is
+///         forced to construct it before the hosted-service loop
+///         attaches event handlers.</item>
+/// </list>
+///
+/// <para>
+/// Options are bound directly from <see cref="IConfiguration"/> at
+/// registration time (not via <c>IOptionsSnapshot</c>) because the gate
+/// must be evaluated before <c>builder.Build()</c> — the DataProtection
+/// + auth gates do the same upstream.
+/// </para>
+/// </summary>
+public static class MarketDataRegistration
+{
+    public static IServiceCollection AddTradingMarketData(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var section = configuration.GetSection(MarketDataOptions.SectionName);
+        var opts = section.Get<MarketDataOptions>() ?? new MarketDataOptions();
+
+        services.Configure<MarketDataOptions>(section);
+
+        // ConfigReferencePrice is always registered as a concrete
+        // singleton — used either as the IReferencePrice (when MD is
+        // off) or as the fallback wrapped by MarketDataReferencePrice.
+        services.TryAddSingleton<ConfigReferencePrice>();
+        services.TryAddSingleton(TimeProvider.System);
+
+        if (string.IsNullOrWhiteSpace(opts.WsUrl))
+        {
+            services.AddSingleton<IReferencePrice>(sp =>
+                sp.GetRequiredService<ConfigReferencePrice>());
+            return services;
+        }
+
+        services.AddMarketDataClient(o =>
+        {
+            o.Endpoint = new Uri(opts.WsUrl);
+            o.AutoResubscribeOnReconnect = true;
+            o.BackPressure = BackPressurePolicy.DropOldest;
+        });
+
+        services.AddSingleton<IMarketDataSubscriber, SdkMarketDataSubscriber>();
+
+        services.AddSingleton<MarketDataReferencePrice>(sp =>
+            new MarketDataReferencePrice(
+                sp.GetRequiredService<IMarketDataSubscriber>(),
+                sp.GetRequiredService<ConfigReferencePrice>(),
+                sp.GetRequiredService<IOptions<MarketDataOptions>>(),
+                sp.GetRequiredService<TimeProvider>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<MarketDataReferencePrice>>()));
+
+        services.AddSingleton<IReferencePrice>(sp =>
+            sp.GetRequiredService<MarketDataReferencePrice>());
+
+        // Same singleton instance routed as IHostedService so the host
+        // starts the subscriber loop AFTER DI has already attached our
+        // event handlers in MarketDataReferencePrice's constructor.
+        services.AddHostedService(sp => sp.GetRequiredService<MarketDataReferencePrice>());
+
+        return services;
+    }
+}

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -1,0 +1,115 @@
+using B3.MarketData.WebSocketClient;
+using B3.Trading.Application.MarketData;
+using Microsoft.Extensions.Logging;
+using AppConnState = B3.Trading.Application.MarketData.MarketDataConnectionState;
+using AppTrade = B3.Trading.Application.MarketData.MarketTrade;
+using AppInfoSnapshot = B3.Trading.Application.MarketData.MarketInfoSnapshot;
+using SdkConnState = B3.MarketData.WebSocketClient.ConnectionState;
+
+namespace B3.Trading.Host.MarketData;
+
+/// <summary>
+/// Adapter from <c>B3.MarketData.WebSocketClient.MarketDataClient</c>
+/// (the SDK) to the application-side <see cref="IMarketDataSubscriber"/>
+/// abstraction. Lives in the host because it carries the SDK package
+/// dependency we deliberately keep out of B3.Trading.Application.
+///
+/// <para>
+/// Translation rules:
+/// <list type="bullet">
+///   <item>SDK <c>TradeEvent</c> → <see cref="AppTrade"/> 1:1, price
+///         already scaled by the SDK (1e-4).</item>
+///   <item>SDK <c>InfoSnapshotEvent</c> → <see cref="AppInfoSnapshot"/>
+///         keeping only the two prices the collar consumes today.</item>
+///   <item><see cref="SubscribeAsync(string, CancellationToken)"/> always asks for
+///         <c>Trades | Info</c> so a fresh subscription seeds the cache
+///         immediately from the snapshot frame.</item>
+/// </list>
+/// </para>
+/// </summary>
+internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
+{
+    private readonly MarketDataClient _client;
+    private readonly ILogger<SdkMarketDataSubscriber> _logger;
+
+    public event Action<AppTrade>? Trade;
+    public event Action<AppInfoSnapshot>? InfoSnapshot;
+    public event Action<AppConnState>? ConnectionStateChanged;
+    public event Action<MarketSubscribeError>? SubscribeError;
+
+    public SdkMarketDataSubscriber(MarketDataClient client, ILogger<SdkMarketDataSubscriber> logger)
+    {
+        _client = client;
+        _logger = logger;
+
+        _client.Trade += OnSdkTrade;
+        _client.InfoSnapshot += OnSdkInfo;
+        _client.ConnectionStateChanged += OnSdkConn;
+        _client.SubscribeError += OnSdkSubErr;
+    }
+
+    public AppConnState State => Translate(_client.State);
+
+    public long DroppedEventCount => _client.DroppedEventCount;
+
+    public Task ConnectAsync(CancellationToken ct = default) => _client.ConnectAsync(ct);
+
+    public async ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
+    {
+        await _client.SubscribeAsync(symbol, SubscribeFlags.Trades | SubscribeFlags.Info, ct)
+            .ConfigureAwait(false);
+
+        if (_client.TryGetSecurityId(symbol, out var securityId))
+        {
+            // Surfaces the symbol → SecurityId binding so any silent
+            // mismatch with the matching engine's IDs shows up in logs
+            // before it shows up as a wrong-symbol fill.
+            _logger.LogInformation(
+                "MarketData symbol mapping: {Symbol} → SecurityId={SecurityId}", symbol, securityId);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _client.Trade -= OnSdkTrade;
+        _client.InfoSnapshot -= OnSdkInfo;
+        _client.ConnectionStateChanged -= OnSdkConn;
+        _client.SubscribeError -= OnSdkSubErr;
+        return _client.DisposeAsync();
+    }
+
+    private void OnSdkTrade(TradeEvent ev)
+    {
+        Trade?.Invoke(new AppTrade(
+            Symbol: ev.Symbol,
+            SecurityId: ev.SecurityId,
+            Price: ev.Price,
+            ReceivedUtc: new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc))));
+    }
+
+    private void OnSdkInfo(InfoSnapshotEvent ev)
+    {
+        InfoSnapshot?.Invoke(new AppInfoSnapshot(
+            Symbol: ev.Symbol,
+            SecurityId: ev.SecurityId,
+            LastTradePrice: ev.LastTradePrice,
+            TradingReferencePrice: ev.TradingReferencePrice,
+            ReceivedUtc: new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc))));
+    }
+
+    private void OnSdkConn(ConnectionStateChangedEvent ev) =>
+        ConnectionStateChanged?.Invoke(Translate(ev.State));
+
+    private void OnSdkSubErr(SubscribeErrorEvent ev) =>
+        SubscribeError?.Invoke(new MarketSubscribeError(ev.Symbol, ev.ErrorCode.ToString()));
+
+    private static AppConnState Translate(SdkConnState s) => s switch
+    {
+        SdkConnState.Disconnected => AppConnState.Disconnected,
+        SdkConnState.Connecting => AppConnState.Connecting,
+        SdkConnState.Connected => AppConnState.Connected,
+        SdkConnState.Reconnecting => AppConnState.Reconnecting,
+        SdkConnState.Faulted => AppConnState.Faulted,
+        _ => AppConnState.Disconnected,
+    };
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -11,6 +11,7 @@ using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Checks;
 using B3.Trading.Host.Observability;
+using B3.Trading.Host.MarketData;
 using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -85,7 +86,7 @@ builder.Services.AddSingleton<EventDispatcher>();
 // margin provider. Each IRiskCheck registration is auto-discovered by
 // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.
 builder.Services.AddSingleton<KillSwitchService>();
-builder.Services.AddSingleton<IReferencePrice, ConfigReferencePrice>();
+builder.Services.AddTradingMarketData(builder.Configuration);
 builder.Services.AddSingleton<IMarginProvider, NoOpMarginProvider>();
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();

--- a/backend/src/B3.Trading.Host/appsettings.json
+++ b/backend/src/B3.Trading.Host/appsettings.json
@@ -49,6 +49,11 @@
       "PerSymbol": {},
       "ReferencePrices": {}
     },
+    "MarketData": {
+      "WsUrl": "",
+      "Symbols": [],
+      "MaxStaleness": "00:05:00"
+    },
     "Cors": {
       "AllowedOrigins": [ "http://localhost:8080", "http://127.0.0.1:8080" ]
     },

--- a/backend/tests/B3.Trading.Api.Tests/MarketDataRegistrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MarketDataRegistrationTests.cs
@@ -1,0 +1,71 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Risk;
+using B3.Trading.Host.MarketData;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// The <c>Trading:MarketData:WsUrl</c> gate is the contract operators
+/// rely on: leaving it unset must keep the host on the static
+/// <see cref="ConfigReferencePrice"/> exactly like before — no
+/// background tasks, no SDK pull, no surprise dependencies. Setting it
+/// must swap in <see cref="MarketDataReferencePrice"/> AND register it
+/// as a hosted service so its event handlers attach before the
+/// subscriber loop starts.
+/// </summary>
+public class MarketDataRegistrationTests
+{
+    [Fact]
+    public void Without_WsUrl_resolves_ConfigReferencePrice()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:MarketData:WsUrl"] = "",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTradingMarketData(cfg);
+
+        using var sp = services.BuildServiceProvider();
+
+        var refPrice = sp.GetRequiredService<IReferencePrice>();
+        Assert.IsType<ConfigReferencePrice>(refPrice);
+
+        // No hosted service registered when feature is off.
+        Assert.DoesNotContain(
+            sp.GetServices<IHostedService>(),
+            h => h is MarketDataReferencePrice);
+    }
+
+    [Fact]
+    public async Task With_WsUrl_resolves_MarketDataReferencePrice_and_hosted_service()
+    {
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:MarketData:WsUrl"] = "ws://marketdata:8080/ws",
+                ["Trading:MarketData:Symbols:0"] = "PETR4",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTradingMarketData(cfg);
+
+        await using var sp = services.BuildServiceProvider();
+
+        var refPrice = sp.GetRequiredService<IReferencePrice>();
+        var hosted = sp.GetServices<IHostedService>()
+            .OfType<MarketDataReferencePrice>()
+            .Single();
+
+        Assert.Same(refPrice, hosted); // same singleton instance on both seams
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
@@ -1,0 +1,238 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Risk;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace B3.Trading.Application.Tests;
+
+public class MarketDataReferencePriceTests
+{
+    private static MarketDataReferencePrice Build(
+        FakeMarketDataSubscriber sub,
+        IReferencePrice fallback,
+        TestClock clock,
+        TimeSpan? maxStaleness = null,
+        string[]? symbols = null)
+    {
+        var opts = Options.Create(new MarketDataOptions
+        {
+            WsUrl = "ws://test",
+            Symbols = symbols ?? Array.Empty<string>(),
+            MaxStaleness = maxStaleness ?? TimeSpan.FromMinutes(5),
+        });
+        return new MarketDataReferencePrice(
+            sub, fallback, opts, clock,
+            NullLogger<MarketDataReferencePrice>.Instance);
+    }
+
+    [Fact]
+    public void Trade_seeds_cache_and_TryGet_returns_it()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseTrade("PETR4", 28.50m, clock.GetUtcNow());
+
+        Assert.True(rp.TryGet("PETR4", out var px));
+        Assert.Equal(28.50m, px);
+    }
+
+    [Fact]
+    public void TryGet_is_case_insensitive()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseTrade("PETR4", 28.50m, clock.GetUtcNow());
+
+        Assert.True(rp.TryGet("petr4", out var px));
+        Assert.Equal(28.50m, px);
+    }
+
+    [Fact]
+    public void Cache_miss_falls_back_to_inner_reference_price()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var fallback = new StaticFallback(("VALE3", 60m));
+        var rp = Build(sub, fallback, new TestClock(DateTimeOffset.UtcNow));
+
+        Assert.True(rp.TryGet("VALE3", out var px));
+        Assert.Equal(60m, px);
+    }
+
+    [Fact]
+    public void Stale_cache_entry_falls_back_to_inner_reference_price()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var fallback = new StaticFallback(("PETR4", 25m));
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, fallback, clock, maxStaleness: TimeSpan.FromSeconds(10));
+
+        sub.RaiseTrade("PETR4", 28.50m, clock.GetUtcNow());
+        clock.Advance(TimeSpan.FromMinutes(1)); // > 10s staleness
+
+        Assert.True(rp.TryGet("PETR4", out var px));
+        Assert.Equal(25m, px);
+    }
+
+    [Fact]
+    public void Negative_or_zero_price_is_ignored()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseTrade("PETR4", 0m, clock.GetUtcNow());
+        sub.RaiseTrade("PETR4", -1m, clock.GetUtcNow());
+
+        Assert.False(rp.TryGet("PETR4", out _));
+    }
+
+    [Fact]
+    public void Blank_symbol_is_ignored()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseTrade("   ", 28.50m, clock.GetUtcNow());
+
+        Assert.False(rp.TryGet("   ", out _));
+        Assert.Empty(rp.Snapshot());
+    }
+
+    [Fact]
+    public void InfoSnapshot_seeds_with_LastTradePrice_when_present()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseInfo(new MarketInfoSnapshot(
+            Symbol: "PETR4", SecurityId: 0,
+            LastTradePrice: 30m, TradingReferencePrice: 25m,
+            ReceivedUtc: clock.GetUtcNow()));
+
+        Assert.True(rp.TryGet("PETR4", out var px));
+        Assert.Equal(30m, px); // LastTradePrice wins over TradingReferencePrice
+    }
+
+    [Fact]
+    public void InfoSnapshot_falls_back_to_TradingReferencePrice_when_no_last_trade()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseInfo(new MarketInfoSnapshot(
+            Symbol: "PETR4", SecurityId: 0,
+            LastTradePrice: null, TradingReferencePrice: 25m,
+            ReceivedUtc: clock.GetUtcNow()));
+
+        Assert.True(rp.TryGet("PETR4", out var px));
+        Assert.Equal(25m, px);
+    }
+
+    [Fact]
+    public void InfoSnapshot_with_no_usable_price_does_not_seed_cache()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock);
+
+        sub.RaiseInfo(new MarketInfoSnapshot(
+            Symbol: "PETR4", SecurityId: 0,
+            LastTradePrice: null, TradingReferencePrice: null,
+            ReceivedUtc: clock.GetUtcNow()));
+
+        Assert.False(rp.TryGet("PETR4", out _));
+    }
+
+    [Fact]
+    public async Task StartAsync_subscribes_each_configured_symbol()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock,
+            symbols: new[] { "PETR4", "VALE3" });
+
+        await rp.StartAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "PETR4", "VALE3" }, sub.Subscriptions.ToArray());
+        Assert.True(sub.ConnectCalled);
+    }
+
+    [Fact]
+    public async Task StartAsync_with_empty_symbols_still_connects_but_subscribes_nothing()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = Build(sub, new StaticFallback(), clock, symbols: Array.Empty<string>());
+
+        await rp.StartAsync(CancellationToken.None);
+
+        Assert.True(sub.ConnectCalled);
+        Assert.Empty(sub.Subscriptions);
+    }
+}
+
+internal sealed class TestClock : TimeProvider
+{
+    private DateTimeOffset _now;
+    public TestClock(DateTimeOffset start) => _now = start;
+    public override DateTimeOffset GetUtcNow() => _now;
+    public void Advance(TimeSpan by) => _now = _now.Add(by);
+}
+
+internal sealed class StaticFallback : IReferencePrice
+{
+    private readonly Dictionary<string, decimal> _map;
+
+    public StaticFallback(params (string Symbol, decimal Price)[] entries)
+    {
+        _map = entries.ToDictionary(e => e.Symbol, e => e.Price, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool TryGet(string symbol, out decimal price) =>
+        _map.TryGetValue(symbol, out price);
+}
+
+internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
+{
+    public event Action<MarketTrade>? Trade;
+    public event Action<MarketInfoSnapshot>? InfoSnapshot;
+    public event Action<MarketDataConnectionState>? ConnectionStateChanged;
+    public event Action<MarketSubscribeError>? SubscribeError;
+
+    public MarketDataConnectionState State { get; private set; } = MarketDataConnectionState.Disconnected;
+    public long DroppedEventCount => 0;
+    public bool ConnectCalled { get; private set; }
+    public List<string> Subscriptions { get; } = new();
+
+    public Task ConnectAsync(CancellationToken ct = default)
+    {
+        ConnectCalled = true;
+        State = MarketDataConnectionState.Connected;
+        ConnectionStateChanged?.Invoke(State);
+        return Task.CompletedTask;
+    }
+
+    public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
+    {
+        Subscriptions.Add(symbol);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public void RaiseTrade(string symbol, decimal price, DateTimeOffset ts) =>
+        Trade?.Invoke(new MarketTrade(symbol, 0UL, price, ts));
+
+    public void RaiseInfo(MarketInfoSnapshot s) => InfoSnapshot?.Invoke(s);
+
+    public void RaiseSubscribeError(string symbol, string reason) =>
+        SubscribeError?.Invoke(new MarketSubscribeError(symbol, reason));
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -38,3 +38,12 @@ MARKETDATA_PORT=8081
 PCAP_DIR=./pcap
 PCAP_PREFIX=20250331_MBO_084_EQT
 REPLAY_SPEED=2
+
+# --- live reference price via marketdata WebSocket (opt-in) ---
+# When set, the trading-host wires MarketDataReferencePrice in front of
+# the static Risk:ReferencePrices map and the price collar uses live
+# trades / info snapshots. Leave empty to keep the static behavior.
+# When using --profile marketdata, point at the marketdata service:
+#   TRADING_MARKETDATA_WS_URL=ws://marketdata:8080/ws
+TRADING_MARKETDATA_WS_URL=
+TRADING_MARKETDATA_SYMBOL_0=PETR4

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,14 @@ services:
       # CORS list from origin of nginx frontend. Same-origin via nginx proxy
       # means this is mostly redundant, but cheap insurance for direct curls.
       Trading__Cors__AllowedOrigins__0: http://localhost:${FRONTEND_PORT:-8080}
+      # Live reference price via B3MarketDataPlatform. When unset the host
+      # falls back to the static Trading:Risk:ReferencePrices map (zero
+      # background work, no SDK pull). Set when running --profile marketdata
+      # or pointing at an external MD WebSocket endpoint.
+      Trading__MarketData__WsUrl: ${TRADING_MARKETDATA_WS_URL:-}
+      # Symbols to subscribe to (array binding). Add Trading__MarketData__Symbols__1, _2, …
+      # for additional tickers. Ignored when WsUrl is empty.
+      Trading__MarketData__Symbols__0: ${TRADING_MARKETDATA_SYMBOL_0:-PETR4}
     volumes:
       - trading-data:/var/lib/b3trading
     networks:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -213,6 +213,47 @@ CI runs this on every PR via the `conformance` job in
 `.github/workflows/docker.yml`, with the alice/wonderland defaults that
 match the committed seed hash/salt.
 
+## Live reference price (B3MarketDataPlatform)
+
+The price collar in the risk pipeline can run in one of two modes:
+
+| Mode    | Toggle                              | Source of `IReferencePrice`                                |
+| ------- | ----------------------------------- | ---------------------------------------------------------- |
+| Static  | `Trading__MarketData__WsUrl` empty  | `Trading:Risk:ReferencePrices` dictionary (config-only)    |
+| Live    | `Trading__MarketData__WsUrl` set    | `MarketDataReferencePrice` over `B3.MarketData.WebSocketClient` SDK with the static dict as fallback |
+
+The static mode is the default and has zero overhead — no SDK pull, no
+background tasks. Switching to live keeps the same fail-open semantics:
+on cache miss, stale entry, or SDK fault, the collar falls back to the
+static dict and ultimately approves when neither side has a number.
+
+Wire it up against the bundled marketdata service:
+
+```bash
+# .env additions
+TRADING_MARKETDATA_WS_URL=ws://marketdata:8080/ws
+TRADING_MARKETDATA_SYMBOL_0=PETR4
+# extra symbols: TRADING_MARKETDATA_SYMBOL_1=VALE3, etc. (compose env
+# only forwards index 0; for more, add Trading__MarketData__Symbols__N
+# directly to docker-compose.yml or appsettings.Docker.json).
+
+docker compose --profile marketdata up -d
+```
+
+Tunables (defaults shown):
+
+| Setting (`Trading:MarketData:`) | Default       | Notes                                                                  |
+| ------------------------------- | ------------- | ---------------------------------------------------------------------- |
+| `WsUrl`                         | empty         | empty = feature off                                                    |
+| `Symbols`                       | `[]`          | empty + WsUrl set logs a warning                                       |
+| `MaxStaleness`                  | `00:05:00`    | older cache entries fall through to the static fallback; `0` disables  |
+
+Operationally: the SDK reconnects transparently with backoff and
+auto-resubscribes after disconnects. Watch
+`trading_marketdata_subscribe_errors_total` (tagged by `symbol` +
+`reason`) for venue-side rejections — symbol-mapping mismatches between
+this host and the matching engine surface there.
+
 ## Persistence
 
 The event store WAL + snapshots live in the named volume `b3-trading-data`


### PR DESCRIPTION
## What

Wires the just-published [`B3.MarketData.WebSocketClient` 0.1.0](https://www.nuget.org/packages/B3.MarketData.WebSocketClient) SDK into the risk pipeline so the price collar can use **live** trade prints as its reference price, with the existing static `Trading:Risk:ReferencePrices` map kept as a fallback.

Closes the `MD#5` line in `plan.md`. Resolves the original PR 7-3 design (now updated in plan.md to "marketdata refprice" rather than the legacy "test-peer compose" stub).

## How

| Layer | Change |
| --- | --- |
| Application | `IMarketDataSubscriber` abstraction + app-owned event records (`MarketTrade`, `MarketInfoSnapshot`). `MarketDataReferencePrice` implements both `IReferencePrice` and `IHostedService` — same singleton on both seams, so DI is forced to attach event handlers BEFORE the subscribe loop runs. Per-symbol `ConcurrentDictionary` cache (case-insensitive). On miss or staleness > `MaxStaleness`, falls through to the inner `ConfigReferencePrice`. Default `MaxStaleness=5min`. |
| Host | `SdkMarketDataSubscriber` adapts the SDK client to the app abstraction (translates `TradeEvent` / `InfoSnapshotEvent`; always asks for `Trades \| Info` so a fresh subscribe seeds the cache from the snapshot frame). `MarketDataRegistration.AddTradingMarketData` is the single wiring point in `Program.cs` — replaces `AddSingleton<IReferencePrice, ConfigReferencePrice>()`. |
| Compose | `Trading__MarketData__WsUrl` + `Trading__MarketData__Symbols__N` plumbed through `docker-compose.yml` from `.env`. Defaults empty so deploys keep the static behavior. |

### Feature gate

```
Trading:MarketData:WsUrl  empty  →  ConfigReferencePrice (zero overhead, no SDK pull, no background tasks)
Trading:MarketData:WsUrl  set    →  MarketDataReferencePrice over the SDK, with ConfigReferencePrice as fallback
```

### Validation rules in `MarketDataReferencePrice`

- blank/whitespace symbol → ignored
- `price <= 0` → ignored
- `InfoSnapshot` prefers `LastTradePrice`, falls back to `TradingReferencePrice`; skips if neither

### Metrics

- `trading.marketdata.subscribe_errors` counter (tagged `symbol`, `reason`) — surfaces symbol-mapping mismatches between trading-host and the matching engine before they show up as wrong-symbol fills.

## Tests

12 new tests, all green:

- **`MarketDataReferencePriceTests`** (Application, 11 tests): trade seeds cache, case-insensitive lookup, miss/stale fallback, negative/zero/blank ignored, InfoSnapshot LastTrade vs TradingReferencePrice precedence, no-price snapshot doesn't seed, `StartAsync` subscribes each symbol, empty-symbols-but-WsUrl-set still connects.
- **`MarketDataRegistrationTests`** (Api, 2 tests): WsUrl empty → `ConfigReferencePrice`; WsUrl set → `MarketDataReferencePrice` routed as both `IReferencePrice` AND `IHostedService` (same singleton instance).

Full suite: 62 api + 54 app + 5 domain + 1 conformance skipped.

## Compose / docs

- New `## Live reference price (B3MarketDataPlatform)` section in `docs/DOCKER.md` with the toggle table, recipe, and tunables.
- `.env.example` documents `TRADING_MARKETDATA_WS_URL` + `TRADING_MARKETDATA_SYMBOL_0` (default `PETR4`).

Refs: pedrosakuma/B3MarketDataPlatform#5
