### PR TITLE
phase-7/4: cross-stream MD on the trader UI

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -66,6 +66,7 @@ body {
 .status-connected    { background: rgba(54,196,111,.18); color: var(--green); }
 .status-connecting   { background: rgba(245,166,35,.18); color: var(--warn); }
 .status-disconnected { background: rgba(239,83,80,.18);  color: var(--red); }
+.status-not_ready    { background: rgba(245,166,35,.18); color: var(--warn); }
 .user-label { color: var(--muted); }
 .link-button {
   background: transparent; border: 0; color: var(--accent); cursor: pointer; font: inherit;
@@ -165,3 +166,16 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
       "execs     md";
   }
 }
+
+/* ---------- Market data panel ---------- */
+.md-form { display: flex; flex-direction: column; gap: .5rem; margin-bottom: .8rem; }
+.md-form label { display: grid; gap: .2rem; font-size: .75rem; color: var(--muted); }
+.md-form input {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: .35rem .5rem; font: inherit;
+}
+.md-form button {
+  background: var(--accent); color: #fff; border: 0; border-radius: 4px;
+  padding: .35rem .8rem; font-weight: 600; cursor: pointer; align-self: flex-start;
+}
+.market-data h2 { display: flex; align-items: center; gap: .55rem; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -116,14 +116,38 @@
         <ol id="executions-log" class="executions-log"></ol>
       </section>
 
-      <!-- MARKET DATA placeholder ------------------------------------ -->
+      <!-- MARKET DATA ----------------------------------------------- -->
       <section class="panel market-data">
-        <h2>Market data</h2>
-        <p class="empty">
-          Reserved for the second WebSocket directly to
-          <code>B3MarketDataPlatform</code>. Lands in the MD-integration
-          follow-up.
-        </p>
+        <h2>
+          Market data
+          <span id="md-status" class="status-pill status-disconnected" title="MarketData WebSocket connection">disconnected</span>
+        </h2>
+        <form id="md-form" class="md-form">
+          <label>
+            <span>WS URL</span>
+            <input id="md-url" type="url" placeholder="ws://localhost:8081/ws" />
+          </label>
+          <label>
+            <span>Watchlist (comma-separated)</span>
+            <input id="md-symbols" type="text" placeholder="PETR4,VALE3" />
+          </label>
+          <button type="submit" id="md-apply">Apply</button>
+          <p id="md-feedback" class="feedback" hidden></p>
+        </form>
+        <div class="table-scroll">
+          <table id="md-table">
+            <thead>
+              <tr>
+                <th>Symbol</th>
+                <th class="num">Last</th>
+                <th class="num">Qty</th>
+                <th class="num">TradeID</th>
+                <th>Updated</th>
+              </tr>
+            </thead>
+            <tbody id="md-body"></tbody>
+          </table>
+        </div>
       </section>
     </main>
   </section>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -5,9 +5,13 @@ import * as state from "./state.js";
 import * as ui from "./ui.js";
 
 const SESSION_KEY = "b3tp.session";
+const MD_KEY = "b3tp.md";
+const DEFAULT_WATCHLIST = ["PETR4", "VALE3"];
 
 let worker = null;
+let mdWorker = null;
 let session = null;          // { token, expiresAt, username, backend }
+let mdConfig = null;         // { url, symbols }
 let expiryTimer = null;
 
 function init() {
@@ -18,6 +22,7 @@ function init() {
     onSubmitOrder: handleSubmitOrder,
     onCancelOrder: handleCancelOrder,
     onLogout: logout,
+    onApplyMd: handleApplyMd,
   });
 
   const stored = readSession();
@@ -49,6 +54,7 @@ function startSession(next) {
   ui.showTrader();
 
   startWorker();
+  startMdWorker();
   scheduleExpiry();
 }
 
@@ -64,6 +70,103 @@ function startWorker() {
   worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
   worker.onmessage = (ev) => onWorkerMessage(ev.data);
   worker.postMessage({ type: "start", backend: session.backend, token: session.token });
+}
+
+function defaultMdUrl() {
+  // Heuristic: same host as the trading-host backend with port 8081 and
+  // ws:// scheme. Operators on a different topology can override.
+  try {
+    const u = new URL(session.backend);
+    u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
+    u.port = "8081";
+    u.pathname = "/ws";
+    return u.toString();
+  } catch { return ""; }
+}
+
+function readMdConfig() {
+  try {
+    const raw = sessionStorage.getItem(MD_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.url === "string" && Array.isArray(parsed.symbols)) {
+        return parsed;
+      }
+    }
+  } catch { /* fall through */ }
+  return { url: defaultMdUrl(), symbols: DEFAULT_WATCHLIST.slice() };
+}
+
+function writeMdConfig(cfg) { sessionStorage.setItem(MD_KEY, JSON.stringify(cfg)); }
+function clearMdConfig()    { sessionStorage.removeItem(MD_KEY); }
+
+function startMdWorker() {
+  mdConfig = readMdConfig();
+  ui.setMdInputs(mdConfig);
+  state.setWatchlist(mdConfig.symbols);
+  state.setMarketDataStatus("disconnected");
+  if (!mdConfig.url) return; // user hasn't configured an endpoint yet
+
+  mdWorker = new Worker(new URL("./mdWorker.js", import.meta.url), { type: "module" });
+  mdWorker.onmessage = (ev) => onMdWorkerMessage(ev.data);
+  mdWorker.postMessage({
+    type: "start",
+    url: mdConfig.url,
+    symbols: mdConfig.symbols,
+  });
+}
+
+function handleApplyMd({ url, symbols }) {
+  if (!url) {
+    ui.setMdFeedback("ws url required", "error");
+    return;
+  }
+  const next = { url, symbols };
+  // URL change forces a full restart (different endpoint = different
+  // session / securityIds). Symbol-only changes go via setSymbols so
+  // we don't blip the connection on every watchlist tweak.
+  const urlChanged = !mdConfig || mdConfig.url !== url;
+  mdConfig = next;
+  writeMdConfig(next);
+  state.setWatchlist(symbols);
+
+  if (urlChanged || !mdWorker) {
+    if (mdWorker) {
+      try { mdWorker.postMessage({ type: "stop" }); } catch { /* swallow */ }
+      mdWorker.terminate();
+      mdWorker = null;
+    }
+    state.clearMarketData();
+    startMdWorker();
+  } else {
+    mdWorker.postMessage({ type: "setSymbols", symbols });
+    // Clear cache entries for symbols no longer in the watchlist.
+    const wanted = new Set(symbols);
+    for (const sym of [...state.getState().marketData.keys()]) {
+      if (!wanted.has(sym)) state.removeMdSymbol(sym);
+    }
+  }
+  ui.setMdFeedback(`watching ${symbols.length} symbol(s)`, "ok");
+}
+
+function onMdWorkerMessage(msg) {
+  switch (msg.type) {
+    case "md.status":   state.setMarketDataStatus(msg.value); break;
+    case "md.clear":    state.clearMarketData(); break;
+    case "md.trade":    state.applyMdTrade(msg); break;
+    case "md.info":     state.applyMdInfo(msg); break;
+    case "md.bust":
+      // Risk consumers ignore busts (the next live trade overwrites);
+      // surface in the executions log so the trader sees it happened.
+      console.warn("[md] trade bust", msg);
+      break;
+    case "md.subError":
+      ui.setMdFeedback(`subscribe ${msg.symbol}: ${msg.errorName}`, "error");
+      state.removeMdSymbol(msg.symbol);
+      break;
+    case "md.removed":  state.removeMdSymbol(msg.symbol); break;
+    case "md.error":    console.warn("[md]", msg); break;
+  }
 }
 
 function onWorkerMessage(msg) {
@@ -123,11 +226,21 @@ function logout() {
     worker.terminate();
     worker = null;
   }
+  if (mdWorker) {
+    try { mdWorker.postMessage({ type: "stop" }); } catch { /* swallow */ }
+    mdWorker.terminate();
+    mdWorker = null;
+  }
   session = null;
+  mdConfig = null;
   clearSession();
+  clearMdConfig();
   state.setUser(null);
   state.setStatus("disconnected");
+  state.setMarketDataStatus("disconnected");
   state.clearAll();
+  state.clearMarketData();
+  state.setWatchlist([]);
   ui.showLogin();
 }
 

--- a/frontend/js/mdProtocol.js
+++ b/frontend/js/mdProtocol.js
@@ -1,0 +1,169 @@
+// Minimal binary protocol for B3MarketDataPlatform's WebSocket
+// (subset used by the trader UI). Mirrors the wire format documented
+// in the MD repo's WEBSOCKET_API.md / WEBSOCKET-PROTOCOL.md.
+//
+// We deliberately *do not* depend on the MD repo's frontend protocol
+// helper — keeping a thin, hand-rolled subset here means the trader UI
+// has no upstream coupling beyond the wire.
+
+export const MSG = {
+  SUBSCRIBE: 0x0001,
+  UNSUBSCRIBE: 0x0002,
+  SUBSCRIBE_OK: 0x0010,
+  SUBSCRIBE_ERROR: 0x0011,
+  INFO_SNAPSHOT: 0x0021,
+  TRADE: 0x0033,
+  TRADE_BUST: 0x0035,
+  SERVER_STATUS: 0x0050,
+};
+
+// DataFlags bits we use. `Trades` alone is enough to update last-trade
+// price; `Info` adds the periodic snapshot which seeds the cache before
+// the first live trade and surfaces venue-side trading status.
+export const FLAGS = {
+  INFO: 0x02,
+  TRADES: 0x10,
+};
+
+// Order matches the bit indices in InfoSnapshot.fieldMask. We only
+// surface the two prices the trader UI uses; extending later is just
+// adding entries here in bit order.
+const INFO_FIELDS = [
+  'OpeningPrice', 'ClosingPrice', 'HighPrice', 'LowPrice',
+  'LastTradePrice', 'LastTradeSize', 'SettlementPrice', 'TheoreticalOpeningPrice',
+  'TheoreticalOpeningSize', 'AuctionImbalanceSize', 'TradeVolume', 'VwapPrice',
+  'NetChange', 'NumberOfTrades', 'OpenInterest', 'PriceBandLow',
+  'PriceBandHigh', 'TradingReferencePrice', 'AvgDailyTradedQty', 'MaxTradeVol',
+  'TradingStatus', 'TradingEvent', 'PriceLimitType', 'MinPriceIncrement',
+];
+
+// SBE exponents per price field (negative power of 10). Anything not
+// listed is treated as a raw integer.
+const FIELD_DECIMALS = {
+  OpeningPrice: 4, ClosingPrice: 8, HighPrice: 4, LowPrice: 4,
+  LastTradePrice: 4, SettlementPrice: 4, TheoreticalOpeningPrice: 4,
+  VwapPrice: 4, NetChange: 8, PriceBandLow: 4, PriceBandHigh: 4,
+  TradingReferencePrice: 8,
+};
+
+const SUBSCRIBE_ERROR_NAMES = { 1: 'UnknownSymbol', 2: 'NotReady' };
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+// ── Builders ──────────────────────────────────────────────────────────
+
+export function buildSubscribe(symbol, flags = FLAGS.TRADES | FLAGS.INFO) {
+  const symBytes = encoder.encode(symbol.toUpperCase().trim());
+  if (symBytes.length === 0 || symBytes.length > 255) {
+    throw new Error(`invalid symbol length: ${symBytes.length}`);
+  }
+  const totalLen = 4 + 1 + 1 + symBytes.length;
+  const buf = new ArrayBuffer(totalLen);
+  const v = new DataView(buf);
+  v.setUint16(0, totalLen, true);
+  v.setUint16(2, MSG.SUBSCRIBE, true);
+  v.setUint8(4, flags);
+  v.setUint8(5, symBytes.length);
+  new Uint8Array(buf, 6).set(symBytes);
+  return buf;
+}
+
+export function buildUnsubscribe(securityId) {
+  const buf = new ArrayBuffer(12);
+  const v = new DataView(buf);
+  v.setUint16(0, 12, true);
+  v.setUint16(2, MSG.UNSUBSCRIBE, true);
+  v.setBigUint64(4, BigInt(securityId), true);
+  return buf;
+}
+
+// ── Parser ────────────────────────────────────────────────────────────
+
+/**
+ * Parse every frame in a binary WebSocket message. The MD server may
+ * coalesce multiple protocol frames into one WS message; each frame
+ * carries its own length prefix. Returns an array of decoded events.
+ *
+ * Skips unknown message types defensively (forward-compat with new
+ * MSG.* values added under the v1-additive guarantee).
+ */
+export function parseFrames(arrayBuffer) {
+  const out = [];
+  const total = arrayBuffer.byteLength;
+  let off = 0;
+  while (off + 4 <= total) {
+    const v = new DataView(arrayBuffer, off, Math.min(4, total - off));
+    const len = v.getUint16(0, true);
+    if (len < 4 || off + len > total) break; // truncated/garbage; bail
+    const ev = parseOne(arrayBuffer, off, len);
+    if (ev) out.push(ev);
+    off += len;
+  }
+  return out;
+}
+
+function parseOne(buf, base, len) {
+  const v = new DataView(buf, base, len);
+  const type = v.getUint16(2, true);
+  let o = 4;
+  switch (type) {
+    case MSG.SERVER_STATUS:
+      return { type: 'ServerStatus', ready: v.getUint8(o) === 1 };
+
+    case MSG.SUBSCRIBE_OK: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const flags = v.getUint8(o); o += 1;
+      const sLen = v.getUint8(o); o += 1;
+      const symbol = decoder.decode(new Uint8Array(buf, base + o, sLen));
+      return { type: 'SubscribeOk', securityId, flags, symbol };
+    }
+
+    case MSG.SUBSCRIBE_ERROR: {
+      const code = v.getUint8(o); o += 1;
+      const sLen = v.getUint8(o); o += 1;
+      const symbol = decoder.decode(new Uint8Array(buf, base + o, sLen));
+      return {
+        type: 'SubscribeError',
+        symbol,
+        errorCode: code,
+        errorName: SUBSCRIBE_ERROR_NAMES[code] || `Code ${code}`,
+      };
+    }
+
+    case MSG.INFO_SNAPSHOT: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const mask = v.getUint32(o, true); o += 4;
+      const fields = {};
+      for (let i = 0; i < INFO_FIELDS.length; i++) {
+        if (!(mask & (1 << i))) continue;
+        if (o + 8 > len) break;
+        const raw = Number(v.getBigInt64(o, true)); o += 8;
+        const exp = FIELD_DECIMALS[INFO_FIELDS[i]];
+        fields[INFO_FIELDS[i]] = exp ? raw / Math.pow(10, exp) : raw;
+      }
+      return { type: 'InfoSnapshot', securityId, fields };
+    }
+
+    case MSG.TRADE: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const priceMantissa = v.getBigInt64(o, true); o += 8;
+      const qty = Number(v.getBigInt64(o, true)); o += 8;
+      const tradeId = Number(v.getBigInt64(o, true));
+      // Price field has SBE exponent -4. Use Number() because at typical
+      // B3 magnitudes (R$ 1e0–1e3 with 4 decimals) we are nowhere near
+      // 2^53; risk consumers care about the divided value, not the i64.
+      const price = Number(priceMantissa) / 10_000;
+      return { type: 'Trade', securityId, price, qty, tradeId };
+    }
+
+    case MSG.TRADE_BUST: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const tradeId = Number(v.getBigInt64(o, true));
+      return { type: 'TradeBust', securityId, tradeId };
+    }
+
+    default:
+      return null; // forward-compat: ignore unknown types
+  }
+}

--- a/frontend/js/mdWorker.js
+++ b/frontend/js/mdWorker.js
@@ -1,0 +1,223 @@
+// Web Worker: owns the SECOND WebSocket — the one that talks directly
+// to B3MarketDataPlatform for live trade prints + info snapshots.
+//
+// Decoupled from worker.js (which owns the trading-host WS) because:
+//   - different protocol (binary little-endian vs JSON)
+//   - different lifecycle (no auth; reconnect-on-drop with no replay)
+//   - different failure surface (server may NOT_READY at startup)
+//
+// Inputs (main thread → us):
+//   { type: "start", url, symbols: [string] }
+//   { type: "stop" }
+//   { type: "setSymbols", symbols: [string] }   // diff applied
+//
+// Outputs (us → main thread):
+//   { type: "md.status", value: "connecting"|"connected"|"disconnected"|"not_ready" }
+//   { type: "md.trade",    symbol, price, qty, tradeId }
+//   { type: "md.info",     symbol, fields }     // raw InfoSnapshot fields
+//   { type: "md.bust",     symbol, tradeId }
+//   { type: "md.subError", symbol, errorName }
+//   { type: "md.clear" }                        // dropped; main thread should reset cache
+//   { type: "md.error",    message }
+
+import { buildSubscribe, buildUnsubscribe, parseFrames } from './mdProtocol.js';
+
+let ws = null;
+let url = null;
+let stopped = false;
+let attempt = 0;
+let reconnectTimer = null;
+let serverReady = false;
+
+// Subscribed symbols. Keys are normalized (UPPERCASE, trimmed) so set
+// arithmetic is straightforward. Value is the resolved securityId once
+// the server replies SubscribeOk; null while pending.
+const subscriptions = new Map();
+// Reverse index for events that arrive keyed by securityId only.
+const securityIdToSymbol = new Map();
+
+const MAX_RECONNECT_DELAY = 15_000;
+
+function post(message) { self.postMessage(message); }
+
+function safeSend(buf) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    try { ws.send(buf); } catch (err) { post({ type: 'md.error', message: String(err) }); }
+  }
+}
+
+function scheduleReconnect() {
+  if (stopped) return;
+  const delay = Math.min(MAX_RECONNECT_DELAY, 500 * Math.pow(2, attempt++));
+  reconnectTimer = setTimeout(connect, delay);
+  post({ type: 'md.status', value: 'connecting' });
+}
+
+function connect() {
+  if (stopped || !url) return;
+  reconnectTimer = null;
+  serverReady = false;
+
+  // Drop resolved securityIds — the server reassigns them per session.
+  // Keep the symbol set so we re-subscribe on (re)open.
+  securityIdToSymbol.clear();
+  for (const sym of subscriptions.keys()) subscriptions.set(sym, null);
+  post({ type: 'md.clear' });
+
+  let socket;
+  try { socket = new WebSocket(url); }
+  catch (err) {
+    post({ type: 'md.error', message: String(err) });
+    scheduleReconnect();
+    return;
+  }
+  socket.binaryType = 'arraybuffer';
+  ws = socket;
+
+  socket.onopen = () => {
+    attempt = 0;
+    post({ type: 'md.status', value: 'connected' });
+    // Subscriptions wait for ServerStatus(ready=1). The server emits
+    // one immediately on connect; resending now would be racy.
+  };
+
+  socket.onmessage = (ev) => {
+    if (!(ev.data instanceof ArrayBuffer)) return; // text frames not used
+    let frames;
+    try { frames = parseFrames(ev.data); }
+    catch (err) { post({ type: 'md.error', message: String(err) }); return; }
+    for (const f of frames) handleFrame(f);
+  };
+
+  socket.onclose = () => {
+    ws = null;
+    serverReady = false;
+    post({ type: 'md.status', value: 'disconnected' });
+    scheduleReconnect();
+  };
+
+  socket.onerror = () => {
+    // onclose runs after onerror; let it drive the reconnect path.
+  };
+}
+
+function handleFrame(f) {
+  switch (f.type) {
+    case 'ServerStatus':
+      serverReady = f.ready;
+      if (f.ready) {
+        post({ type: 'md.status', value: 'connected' });
+        flushSubscribes();
+      } else {
+        post({ type: 'md.status', value: 'not_ready' });
+      }
+      return;
+
+    case 'SubscribeOk': {
+      const symbol = f.symbol.toUpperCase();
+      const id = f.securityId;
+      subscriptions.set(symbol, id);
+      securityIdToSymbol.set(id.toString(), symbol);
+      return;
+    }
+
+    case 'SubscribeError': {
+      const symbol = f.symbol.toUpperCase();
+      // Drop from the active set so we don't keep retrying every
+      // reconnect; UI is informed and the user can re-add.
+      subscriptions.delete(symbol);
+      post({ type: 'md.subError', symbol, errorName: f.errorName });
+      return;
+    }
+
+    case 'Trade': {
+      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      if (!symbol) return; // arrived before SubscribeOk landed; drop
+      post({ type: 'md.trade', symbol, price: f.price, qty: f.qty, tradeId: f.tradeId });
+      return;
+    }
+
+    case 'TradeBust': {
+      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      if (!symbol) return;
+      post({ type: 'md.bust', symbol, tradeId: f.tradeId });
+      return;
+    }
+
+    case 'InfoSnapshot': {
+      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      if (!symbol) return;
+      post({ type: 'md.info', symbol, fields: f.fields });
+      return;
+    }
+  }
+}
+
+function flushSubscribes() {
+  for (const [symbol, id] of subscriptions) {
+    if (id !== null) continue; // already resolved
+    try { safeSend(buildSubscribe(symbol)); }
+    catch (err) {
+      subscriptions.delete(symbol);
+      post({ type: 'md.subError', symbol, errorName: String(err.message || err) });
+    }
+  }
+}
+
+function applySymbolDiff(next) {
+  const wanted = new Set(next.map(s => s.toUpperCase().trim()).filter(Boolean));
+  // Remove dropped subscriptions.
+  for (const [symbol, id] of [...subscriptions]) {
+    if (wanted.has(symbol)) continue;
+    if (id !== null) safeSend(buildUnsubscribe(id));
+    subscriptions.delete(symbol);
+    securityIdToSymbol.delete(id?.toString() ?? '');
+    post({ type: 'md.removed', symbol });
+  }
+  // Add new ones.
+  for (const symbol of wanted) {
+    if (subscriptions.has(symbol)) continue;
+    subscriptions.set(symbol, null);
+    if (serverReady) {
+      try { safeSend(buildSubscribe(symbol)); }
+      catch (err) {
+        subscriptions.delete(symbol);
+        post({ type: 'md.subError', symbol, errorName: String(err.message || err) });
+      }
+    }
+  }
+}
+
+self.onmessage = (ev) => {
+  const msg = ev.data || {};
+  switch (msg.type) {
+    case 'start':
+      url = msg.url;
+      stopped = false;
+      attempt = 0;
+      subscriptions.clear();
+      securityIdToSymbol.clear();
+      for (const s of msg.symbols || []) {
+        const sym = String(s).toUpperCase().trim();
+        if (sym) subscriptions.set(sym, null);
+      }
+      connect();
+      break;
+
+    case 'stop':
+      stopped = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+      if (ws) {
+        try { ws.close(1000, 'client logout'); } catch { /* swallow */ }
+      }
+      ws = null;
+      subscriptions.clear();
+      securityIdToSymbol.clear();
+      break;
+
+    case 'setSymbols':
+      applySymbolDiff(msg.symbols || []);
+      break;
+  }
+};

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -11,6 +11,9 @@ const state = {
   executions: [],          // bounded ring of ExecutionDto
   status: "disconnected",  // disconnected | connecting | connected
   user: null,              // { username, expiresAt, token, backend, firm }
+  marketData: new Map(),   // Symbol -> { lastPrice, lastQty, lastTradeId, updatedAt, info }
+  marketDataStatus: "disconnected", // disconnected | connecting | connected | not_ready
+  watchlist: [],           // [string] symbols (UPPERCASE)
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -69,6 +72,57 @@ export function clearAll() {
   state.positions.clear();
   state.executions = [];
   notify("all");
+}
+
+// ── Market data slice ──────────────────────────────────────────────
+
+export function setMarketDataStatus(status) {
+  state.marketDataStatus = status;
+  notify("marketDataStatus");
+}
+
+export function applyMdTrade({ symbol, price, qty, tradeId }) {
+  const prev = state.marketData.get(symbol) || {};
+  state.marketData.set(symbol, {
+    ...prev,
+    lastPrice: price,
+    lastQty: qty,
+    lastTradeId: tradeId,
+    updatedAt: Date.now(),
+  });
+  notify("marketData");
+}
+
+export function applyMdInfo({ symbol, fields }) {
+  const prev = state.marketData.get(symbol) || {};
+  // Seed lastPrice from snapshot if we haven't seen a live trade yet.
+  // Otherwise the live tape wins to avoid the snapshot stomping on a
+  // newer print that happened to race the periodic snapshot.
+  const seed = prev.lastPrice == null
+    ? (fields.LastTradePrice ?? fields.TradingReferencePrice ?? null)
+    : prev.lastPrice;
+  state.marketData.set(symbol, {
+    ...prev,
+    lastPrice: seed,
+    info: fields,
+    updatedAt: Date.now(),
+  });
+  notify("marketData");
+}
+
+export function removeMdSymbol(symbol) {
+  if (state.marketData.delete(symbol)) notify("marketData");
+}
+
+export function clearMarketData() {
+  if (state.marketData.size === 0) return;
+  state.marketData.clear();
+  notify("marketData");
+}
+
+export function setWatchlist(symbols) {
+  state.watchlist = symbols.slice();
+  notify("watchlist");
 }
 
 export function isTerminalOrderStatus(status) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -10,11 +10,13 @@ const $ = (id) => document.getElementById(id);
 let onSubmitOrder = () => {};
 let onCancelOrder = () => {};
 let onLogout      = () => {};
+let onApplyMd     = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder = handlers.onSubmitOrder ?? onSubmitOrder;
   onCancelOrder = handlers.onCancelOrder ?? onCancelOrder;
   onLogout      = handlers.onLogout      ?? onLogout;
+  onApplyMd     = handlers.onApplyMd     ?? onApplyMd;
 }
 
 export function showLogin() {
@@ -68,8 +70,32 @@ export function bindUi() {
     if (clOrdId) onCancelOrder(clOrdId);
   });
 
+  // Market data form: apply WS URL + watchlist atomically.
+  $("md-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const url = $("md-url").value.trim();
+    const symbols = $("md-symbols").value
+      .split(/[,\s]+/)
+      .map(s => s.trim().toUpperCase())
+      .filter(Boolean);
+    onApplyMd({ url, symbols });
+  });
+
   subscribe(renderForSlice);
   renderAll();
+}
+
+export function setMdInputs({ url, symbols }) {
+  if (typeof url === "string") $("md-url").value = url;
+  if (Array.isArray(symbols)) $("md-symbols").value = symbols.join(",");
+}
+
+export function setMdFeedback(message, kind) {
+  const el = $("md-feedback");
+  if (!message) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false;
+  el.textContent = message;
+  el.className = `feedback ${kind === "ok" ? "ok" : "error"}`;
 }
 
 export function setTicketFeedback(message, kind) {
@@ -107,6 +133,8 @@ function renderForSlice(slice) {
   if (slice === "executions" || slice === "all") renderExecutions();
   if (slice === "status") setStatusPill(getState().status);
   if (slice === "user")   setUserLabel(getState().user);
+  if (slice === "marketData" || slice === "all") renderMarketData();
+  if (slice === "marketDataStatus") setMdStatusPill(getState().marketDataStatus);
 }
 
 function renderAll() {
@@ -115,6 +143,43 @@ function renderAll() {
   renderExecutions();
   setStatusPill(getState().status);
   setUserLabel(getState().user);
+  renderMarketData();
+  setMdStatusPill(getState().marketDataStatus);
+}
+
+function setMdStatusPill(status) {
+  const el = $("md-status");
+  if (!el) return;
+  el.textContent = status;
+  el.className = `status-pill status-${status}`;
+}
+
+function renderMarketData() {
+  const body = $("md-body");
+  if (!body) return;
+  const watch = getState().watchlist;
+  const md = getState().marketData;
+  // Show one row per watchlist symbol so the user sees pending
+  // subscriptions even before the first trade arrives.
+  const rows = watch.length > 0 ? watch : [...md.keys()];
+  if (rows.length === 0) {
+    body.innerHTML = `<tr><td colspan="5" style="color:var(--muted);text-align:center;padding:1rem">No subscriptions</td></tr>`;
+    return;
+  }
+  body.innerHTML = rows.map(symbol => {
+    const e = md.get(symbol);
+    if (!e || e.lastPrice == null) {
+      return `<tr><td>${escapeHtml(symbol)}</td><td colspan="4" style="color:var(--muted)">awaiting data…</td></tr>`;
+    }
+    const ts = e.updatedAt ? new Date(e.updatedAt).toISOString().slice(11, 19) : "—";
+    return `<tr>
+      <td>${escapeHtml(symbol)}</td>
+      <td class="num">${Number(e.lastPrice).toFixed(2)}</td>
+      <td class="num">${e.lastQty ?? "—"}</td>
+      <td class="num">${e.lastTradeId ?? "—"}</td>
+      <td>${ts}</td>
+    </tr>`;
+  }).join("");
 }
 
 function renderBlotter() {


### PR DESCRIPTION
## What

Frontend now opens a **second** WebSocket directly to `B3MarketDataPlatform` so the trader sees live trade prints alongside the existing order/exec/position channels coming from the trading-host. Closes the visual loop on PR #14 (live `IReferencePrice`): the backend uses the SDK in C#; the trader UI does it natively in the browser via the binary WS protocol.

Implements option (b) from the original issue #1 brief and `p7-4-frontend-md-stream` from the roadmap.

## How

- **`mdProtocol.js`** — hand-rolled minimal subset of the v1 binary protocol (Subscribe / SubscribeOk / SubscribeError / ServerStatus / InfoSnapshot / Trade / TradeBust). `parseFrames(arrayBuffer)` walks the buffer and returns an array of decoded events because the server may coalesce multiple protocol frames in one WS message. Price fields apply SBE exponents (-4 / -8) so consumers always see display values, never mantissas.
- **`mdWorker.js`** — owns the second WebSocket. Drives backoff (capped 15 s), waits for `ServerStatus(ready=1)` before subscribing, flushes pending subscribes on the rising edge of `ready`, applies `setSymbols` diffs (only restarts the connection on URL change), defensively drops `Trade`/`Info` frames that arrive before `SubscribeOk` landed.
- **`state.js`** — new `marketData: Map<symbol, {lastPrice, lastQty, lastTradeId, updatedAt, info}>` + `marketDataStatus` + `watchlist` slices. `InfoSnapshot` seeds `lastPrice` only if no live trade has been observed yet (the tape wins to avoid the snapshot stomping on a newer print).
- **`app.js`** — persists `{url, symbols}` in `sessionStorage`; default URL = same host as backend with port `8081` + `/ws` (matches `MARKETDATA_PORT` exposed by `docker-compose --profile marketdata`). Default watchlist = `PETR4,VALE3`.
- **`ui.js` / `index.html` / `styles.css`** — replaces the placeholder panel with a watchlist input + per-symbol last-price table + status pill (with new `status-not_ready` warn-color variant).

## Operational behavior

| Scenario | Behavior |
|---|---|
| MD endpoint down | own backoff; trading-host WS unaffected |
| `ServerStatus.ready=0` | pill shows `not_ready`; subscribes deferred until `ready=1` |
| `SubscribeError` (UnknownSymbol/NotReady) | symbol popped off active set; UI surfaces reason |
| `TradeBust` | logged only (risk consumers ignore; next live trade overwrites) |
| Logout | both workers terminated; `sessionStorage` cleared |
| URL change | full restart (different session = different securityIds); cache cleared |
| Watchlist edit | applied as diff via `setSymbols`; no connection blip |

## Validation

- `node --check` on every JS file (no transpile pipeline; nginx serves raw ES modules).
- `mdProtocol.parseFrames` smoke-tested against the documented hex examples in `WEBSOCKET_API.md` for Trade (`0x0033`) and InfoSnapshot (`0x0021`) frames; concatenated frames in one buffer return the expected count of 2.

Refs: pedrosakuma/B3MarketDataPlatform#5, #14
