### PR TITLE
phase-3/1a: idempotent + ordered ER processor

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 
@@ -10,6 +11,18 @@ namespace B3.Trading.Application;
 /// <see cref="WorkingOrderBook"/>, applies fills to
 /// <see cref="PositionKeeper"/>, and publishes an
 /// <see cref="ExecutionEvent"/> for downstream fan-out.
+///
+/// <para>
+/// <b>Idempotency:</b> safe to call with the same ER twice and with ERs
+/// arriving out-of-order. Fills are advanced via cumulative-quantity
+/// (<see cref="Order.ApplyCumulativeFill"/>) — only the forward delta
+/// books to <see cref="PositionKeeper"/>, so a replayed ER (FIXP
+/// retransmit after reconnect, or WAL replay at cold start) cannot
+/// double-count a position. Terminal-state ERs are guarded against
+/// regression. The method never throws for a replay-realistic input,
+/// because the WAL writes ERs unconditionally before mutation: a throw
+/// here would poison recovery.
+/// </para>
 /// </summary>
 public sealed class ExecutionReportProcessor
 {
@@ -66,20 +79,69 @@ public sealed class ExecutionReportProcessor
         switch (kind)
         {
             case ExecKind.New:
+                if (order.Status != OrderStatus.PendingNew)
+                {
+                    MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
+                    _logger.LogDebug("Dropping replayed New ER for {ClOrdId}; order already in {Status}.", lookupId, order.Status);
+                    return;
+                }
                 order.MarkWorking();
                 break;
             case ExecKind.PartialFill:
             case ExecKind.Fill:
-                if (lastQty > 0)
+            {
+                var wasTerminal = order.Status is OrderStatus.Cancelled or OrderStatus.Rejected;
+                var delta = order.ApplyCumulativeFill(cumQty);
+                if (delta == 0)
                 {
-                    order.ApplyFill(lastQty);
-                    _positions.ApplyFill(owner, order.Symbol, order.Side, lastQty, lastPx);
+                    // Stale or duplicate fill (cumQty didn't advance). Expected
+                    // after FIXP retransmit; harmless because we book nothing.
+                    MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
+                    _logger.LogDebug(
+                        "Dropping stale fill for {ClOrdId}: ER cumQty={ErCum} <= order cumQty={OrderCum}.",
+                        lookupId, cumQty, order.CumulativeQuantity);
+                    return;
                 }
+                if (wasTerminal)
+                {
+                    // Late fill against a terminal order — exchange's truth
+                    // wins for position keeping; order keeps its terminal
+                    // status (preserved by ApplyCumulativeFill).
+                    MetricsRegistry.ExecutionReportsLateFillAfterTerminal.Add(1, KindTag(kind));
+                    _logger.LogWarning(
+                        "Late fill after terminal status for {ClOrdId}: status={Status}, delta={Delta}, lastPx={LastPx}.",
+                        lookupId, order.Status, delta, lastPx);
+                }
+                if (delta != lastQty)
+                {
+                    // Cumulative advanced by an amount that disagrees with the
+                    // ER's own LastQuantity — most often because an
+                    // intermediate fill ER was lost or arrived out of order.
+                    // Position is booked at the observed delta @ lastPx.
+                    MetricsRegistry.ExecutionReportsFillDeltaMismatch.Add(1, KindTag(kind));
+                    _logger.LogWarning(
+                        "Fill delta mismatch for {ClOrdId}: ER lastQty={LastQty}, computed delta={Delta}.",
+                        lookupId, lastQty, delta);
+                }
+                _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
                 break;
+            }
             case ExecKind.Canceled:
+                if (order.Status is OrderStatus.Cancelled or OrderStatus.Filled or OrderStatus.Rejected)
+                {
+                    MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
+                    _logger.LogDebug("Dropping Cancelled ER for {ClOrdId}; order already {Status}.", lookupId, order.Status);
+                    return;
+                }
                 order.MarkCancelled();
                 break;
             case ExecKind.Rejected:
+                if (order.Status is OrderStatus.Rejected or OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Cancelled)
+                {
+                    MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
+                    _logger.LogDebug("Dropping Rejected ER for {ClOrdId}; order already {Status}.", lookupId, order.Status);
+                    return;
+                }
                 order.MarkRejected();
                 break;
             case ExecKind.Replaced:
@@ -104,6 +166,9 @@ public sealed class ExecutionReportProcessor
             rejectReason,
             DateTimeOffset.UtcNow));
     }
+
+    private static KeyValuePair<string, object?> KindTag(ExecKind kind) =>
+        new("kind", kind.ToString());
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -29,6 +29,24 @@ public static class MetricsRegistry
     // Execution reports inbound
     public static readonly Counter<long> ExecutionReportsReceived =
         Meter.CreateCounter<long>("trading.er.received");
+    // Idempotency: an ER carries the same (or older) cumulative-quantity /
+    // terminal-state we already have. Expected after FIXP retransmit on
+    // reconnect; surfaced so a sustained spike is visible to operators.
+    public static readonly Counter<long> ExecutionReportsReplayDeduped =
+        Meter.CreateCounter<long>("trading.er.replay_dedup");
+    // Fill ER advanced cumulative-quantity by an amount that doesn't equal
+    // its own LastQuantity — i.e. an intermediate fill ER was lost or
+    // delivered out-of-order. Position is still booked at the reported
+    // delta and lastPx (best-effort attribution); the gauge is for
+    // operators to spot delivery issues.
+    public static readonly Counter<long> ExecutionReportsFillDeltaMismatch =
+        Meter.CreateCounter<long>("trading.er.fill_delta_mismatch");
+    // A fill ER arrived for an order already in a terminal state
+    // (Cancelled/Rejected). Position is still booked — the exchange's
+    // cumulative-quantity is the source of truth — but the order keeps
+    // its terminal status.
+    public static readonly Counter<long> ExecutionReportsLateFillAfterTerminal =
+        Meter.CreateCounter<long>("trading.er.late_fill_after_terminal");
 
     // Risk / kill-switch
     public static readonly Counter<long> KillSwitchToggled =

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -81,9 +81,66 @@ public sealed class Order
         Status = LeavesQuantity == 0 ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
     }
 
-    public void MarkWorking() => Status = OrderStatus.Working;
-    public void MarkCancelled() => Status = OrderStatus.Cancelled;
-    public void MarkRejected() => Status = OrderStatus.Rejected;
+    /// <summary>
+    /// Cumulative-quantity-driven fill application. Returns the delta that
+    /// was applied (0 when the incoming <paramref name="newCumulativeQty"/>
+    /// is stale/duplicate). Designed to be safe under ER replay and
+    /// out-of-order delivery: only ever advances forward, never throws,
+    /// and preserves a terminal <see cref="OrderStatus.Cancelled"/> /
+    /// <see cref="OrderStatus.Rejected"/> when a "late" fill arrives after
+    /// the terminal ER (the exchange may legitimately deliver a fill that
+    /// happened pre-cancel after the cancel-ack).
+    ///
+    /// <para>
+    /// Overfill (newCumQty &gt; Quantity) is permitted: leaves clamps at 0
+    /// and the field still advances to whatever the exchange reports,
+    /// because the WAL replay must remain total — throwing here would
+    /// poison recovery for any persisted ER stream containing an overfill.
+    /// </para>
+    /// </summary>
+    public long ApplyCumulativeFill(long newCumulativeQty)
+    {
+        if (newCumulativeQty <= CumulativeQuantity)
+            return 0;
+
+        var delta = newCumulativeQty - CumulativeQuantity;
+        CumulativeQuantity = newCumulativeQty;
+        LeavesQuantity = Math.Max(0, Quantity - newCumulativeQty);
+
+        // Status only advances; never regresses out of a terminal state.
+        if (Status is not (OrderStatus.Cancelled or OrderStatus.Rejected))
+            Status = LeavesQuantity == 0 ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
+
+        return delta;
+    }
+
+    public void MarkWorking()
+    {
+        // Idempotency: New ER may be re-delivered after reconnect. Only the
+        // PendingNew→Working transition is meaningful; later ERs (including
+        // any that re-state New) must not regress an already-fillable
+        // order back to Working.
+        if (Status == OrderStatus.PendingNew)
+            Status = OrderStatus.Working;
+    }
+
+    public void MarkCancelled()
+    {
+        // Once filled, the order can't be cancelled — a stale Cancelled ER
+        // delivered after the final fill would otherwise regress status.
+        if (Status is OrderStatus.Filled or OrderStatus.Rejected or OrderStatus.Cancelled)
+            return;
+        Status = OrderStatus.Cancelled;
+    }
+
+    public void MarkRejected()
+    {
+        // Rejection is only valid before any fill. A stale Reject after a
+        // partial/full fill must be ignored.
+        if (Status is OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Rejected or OrderStatus.Cancelled)
+            return;
+        Status = OrderStatus.Rejected;
+    }
 
     /// <summary>
     /// Reconstructs an order from snapshot data. For persistence recovery

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -56,6 +56,145 @@ public class ExecutionReportProcessorTests
         Assert.Empty(sink.Events);
     }
 
+    // -------- Idempotency / replay safety (Phase 3/1a) --------
+
+    [Fact]
+    public void Fill_DuplicateEr_BooksPositionOnce()
+    {
+        var (proc, ownership, book, positions, sink) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+        // Same ER replayed (FIXP retransmit after reconnect / WAL cold-start replay).
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(100, positions.GetOrCreate(owner, "PETR4").NetQuantity);
+        Assert.Equal(100, order.CumulativeQuantity);
+        Assert.Equal(OrderStatus.Filled, order.Status);
+        // Duplicate ER short-circuits before publish — downstream subscribers
+        // (UI / event sink) don't re-emit a phantom fill on FIXP retransmit.
+        Assert.Single(sink.Events);
+    }
+
+    [Fact]
+    public void Fill_OutOfOrderArrival_AppliesCumulativeDelta()
+    {
+        var (proc, ownership, book, positions, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 200, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        // ER B arrives first: cumQty jumps to 150 (it implicitly subsumes the
+        // missed ER A at cumQty=50). Position must book the full 150 at 30m.
+        proc.Apply(1UL, ExecKind.PartialFill, leaves: 50, cumQty: 150, lastQty: 100, lastPx: 30m, rejectReason: null);
+        // ER A arrives late: cumQty=50 is now stale and must be dropped, NOT
+        // double-applied (the dangerous regression flagged by rubber-duck).
+        proc.Apply(1UL, ExecKind.PartialFill, leaves: 150, cumQty: 50, lastQty: 50, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(150, order.CumulativeQuantity);
+        Assert.Equal(50, order.LeavesQuantity);
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+        Assert.Equal(150, positions.GetOrCreate(owner, "PETR4").NetQuantity);
+    }
+
+    [Fact]
+    public void Fill_AfterCancelled_BooksPositionAndKeepsTerminalStatus()
+    {
+        var (proc, ownership, book, positions, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        // Cancel ack arrives first.
+        proc.Apply(1UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null);
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+
+        // Late fill that actually happened pre-cancel arrives now. Exchange's
+        // cumulative-quantity is the source of truth — must NOT throw and
+        // must book the position; status stays Cancelled (no regression).
+        proc.Apply(1UL, ExecKind.PartialFill, leaves: 60, cumQty: 40, lastQty: 40, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(40, order.CumulativeQuantity);
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+        Assert.Equal(40, positions.GetOrCreate(owner, "PETR4").NetQuantity);
+    }
+
+    [Fact]
+    public void Cancel_AfterFilled_DoesNotRegressStatus()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+        Assert.Equal(OrderStatus.Filled, order.Status);
+
+        // A stale cancel arrives after the final fill. Must NOT regress to Cancelled.
+        proc.Apply(1UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null);
+
+        Assert.Equal(OrderStatus.Filled, order.Status);
+    }
+
+    [Fact]
+    public void Reject_AfterPartialFill_DoesNotRegressStatus()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.PartialFill, leaves: 60, cumQty: 40, lastQty: 40, lastPx: 30m, rejectReason: null);
+        proc.Apply(1UL, ExecKind.Rejected, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: "stale");
+
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+    }
+
+    [Fact]
+    public void New_Replayed_DoesNotRegressFromWorking()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.New, 100, 0, 0, 0m, null);
+        proc.Apply(1UL, ExecKind.PartialFill, 60, 40, 40, 30m, null);
+        // New ER replayed after reconnect — must not undo the partial fill state.
+        proc.Apply(1UL, ExecKind.New, 100, 0, 0, 0m, null);
+
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+        Assert.Equal(40, order.CumulativeQuantity);
+    }
+
+    [Fact]
+    public void Overfill_DoesNotThrow_AndCapsLeavesAtZero()
+    {
+        // Overfill (cumQty > order.Quantity) is a wire-side bug, but Apply must
+        // never throw on a replay-realistic input — that would poison WAL
+        // recovery. Position books the reported delta; leaves clamps at 0.
+        var (proc, ownership, book, positions, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 150, lastQty: 150, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(150, order.CumulativeQuantity);
+        Assert.Equal(0, order.LeavesQuantity);
+        Assert.Equal(OrderStatus.Filled, order.Status);
+        Assert.Equal(150, positions.GetOrCreate(owner, "PETR4").NetQuantity);
+    }
+
     private sealed class RecordingSink : IExecutionEventSink
     {
         public readonly List<ExecutionEvent> Events = new();

--- a/backend/tests/B3.Trading.Domain.Tests/OrderTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderTests.cs
@@ -26,4 +26,85 @@ public class OrderTests
         var order = new Order(2UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Sell, OrderType.Limit, 10, 30m);
         Assert.Throws<InvalidOperationException>(() => order.ApplyFill(11));
     }
+
+    // -------- ApplyCumulativeFill (Phase 3/1a) --------
+
+    [Fact]
+    public void ApplyCumulativeFill_ForwardProgress_ReturnsDelta()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+
+        Assert.Equal(40, order.ApplyCumulativeFill(40));
+        Assert.Equal(40, order.CumulativeQuantity);
+        Assert.Equal(60, order.LeavesQuantity);
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+
+        Assert.Equal(60, order.ApplyCumulativeFill(100));
+        Assert.Equal(0, order.LeavesQuantity);
+        Assert.Equal(OrderStatus.Filled, order.Status);
+    }
+
+    [Fact]
+    public void ApplyCumulativeFill_StaleOrDuplicate_ReturnsZero()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyCumulativeFill(60);
+
+        Assert.Equal(0, order.ApplyCumulativeFill(60)); // duplicate
+        Assert.Equal(0, order.ApplyCumulativeFill(40)); // stale (out-of-order)
+        Assert.Equal(60, order.CumulativeQuantity);
+        Assert.Equal(40, order.LeavesQuantity);
+    }
+
+    [Fact]
+    public void ApplyCumulativeFill_PreservesTerminalStatus()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.MarkCancelled();
+
+        // Late fill against a cancelled order — must book delta, keep status.
+        var delta = order.ApplyCumulativeFill(40);
+        Assert.Equal(40, delta);
+        Assert.Equal(40, order.CumulativeQuantity);
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+    }
+
+    [Fact]
+    public void ApplyCumulativeFill_Overfill_DoesNotThrow()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        var delta = order.ApplyCumulativeFill(150);
+        Assert.Equal(150, delta);
+        Assert.Equal(150, order.CumulativeQuantity);
+        Assert.Equal(0, order.LeavesQuantity);
+        Assert.Equal(OrderStatus.Filled, order.Status);
+    }
+
+    [Fact]
+    public void MarkCancelled_AfterFilled_NoOp()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyFill(100);
+        order.MarkCancelled();
+        Assert.Equal(OrderStatus.Filled, order.Status);
+    }
+
+    [Fact]
+    public void MarkRejected_AfterPartialFill_NoOp()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyFill(40);
+        order.MarkRejected();
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+    }
+
+    [Fact]
+    public void MarkWorking_AfterPartialFill_NoOp()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.MarkWorking();
+        order.ApplyFill(40);
+        order.MarkWorking(); // replayed New ER
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+    }
 }


### PR DESCRIPTION
## What

Pre-requisite for auto-reconnect (phase-3/1b → next PR). Makes the inbound ER pipeline tolerant of replay and out-of-order delivery so that:
- the FIXP retransmit that follows `EntryPointClient.ReconnectAsync` doesn't double-book positions or regress order status;
- the WAL replay at cold start can re-apply a duplicated ER stream without poisoning recovery (a throw post-append would be a permanent recovery blocker — `EventDispatcher.Dispatch` writes to WAL **before** running the mutation closure).

Closes the "ER processor idempotent + ordered" half of `p3-er-replay`. The reconnect / `SessionVerId` persistence half is `p3-1b-reconnect` and lands separately.

## Approach (informed by rubber-duck critique)

The first-cut plan was to dedup fills by `CumulativeQuantity` and book position at `LastQuantity`. The rubber-duck flagged that **this breaks under out-of-order delivery**: if ER B (cumQty=200, lastQty=50) arrives before ER A (cumQty=150, lastQty=50), booking lastQty for B and dropping A as stale leaves the position short by 50.

The fix is to make fills **cumulative-driven**:
- `Order.ApplyCumulativeFill(newCumQty)` returns the forward delta (`newCumQty - currentCumQty`, or 0 for stale/duplicate).
- `PositionKeeper` is booked at the **computed delta**, not at the ER's `lastQty`.
- `delta != lastQty` is normal under loss/reorder and is surfaced as `trading.er.fill_delta_mismatch{kind}` for operators.

Plus all the smaller correctness rules:
- `Apply` is now **total** — no replay-realistic input throws.
- Late fill against a Cancelled order: book the delta, **keep** the terminal status (no regression). Surfaced as `trading.er.late_fill_after_terminal{kind}`.
- Stale Cancel after Fill / stale Reject after PartialFill / replayed New after PartialFill — all dropped quietly with `trading.er.replay_dedup{kind}` and a debug log.
- Overfill (cumQty > order.Quantity): leaves clamps at 0, field still advances. Doesn't throw — recovery wins.

Backward-compat: `Order.ApplyFill(qty)` is kept for existing call sites (tests + any code that already enforces ordering at its own layer).

## Tests

- **+7 ExecutionReportProcessor cases**: duplicate fill, out-of-order fill (newer-then-older), late fill after Cancelled, stale Cancel after Filled, stale Reject after PartialFill, replayed New after PartialFill, overfill.
- **+7 Order cases**: `ApplyCumulativeFill` forward / stale / preserves-terminal / overfill, plus `Mark{Cancelled,Rejected,Working}` no-op guards.
- All 122 existing tests still green (12 Domain + 50 Application + 60 Api).

## Out of scope (next PR — phase-3/1b)

- Per-firm reconnect loop on `Terminated`
- Event-loop restart after `ReconnectAsync` (today `_eventLoop ??=` would never restart)
- `SessionVerId` persistence (today read from config — survives crash/restart only by chance)
- `FileSessionStateStore` wire-up so the SDK warm-restart path is active
- Skip-reconnect on client-initiated termination (so shutdown drain isn't fighting a reconnect loop)

Refs: roadmap todos `p3-er-replay`, `p3-1b-reconnect`.
