### PR TITLE
phase-3/1b: auto-reconnect + warm-restart for the FIXP gateway

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -89,43 +89,43 @@ public sealed class ExecutionReportProcessor
                 break;
             case ExecKind.PartialFill:
             case ExecKind.Fill:
-            {
-                var wasTerminal = order.Status is OrderStatus.Cancelled or OrderStatus.Rejected;
-                var delta = order.ApplyCumulativeFill(cumQty);
-                if (delta == 0)
                 {
-                    // Stale or duplicate fill (cumQty didn't advance). Expected
-                    // after FIXP retransmit; harmless because we book nothing.
-                    MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
-                    _logger.LogDebug(
-                        "Dropping stale fill for {ClOrdId}: ER cumQty={ErCum} <= order cumQty={OrderCum}.",
-                        lookupId, cumQty, order.CumulativeQuantity);
-                    return;
+                    var wasTerminal = order.Status is OrderStatus.Cancelled or OrderStatus.Rejected;
+                    var delta = order.ApplyCumulativeFill(cumQty);
+                    if (delta == 0)
+                    {
+                        // Stale or duplicate fill (cumQty didn't advance). Expected
+                        // after FIXP retransmit; harmless because we book nothing.
+                        MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
+                        _logger.LogDebug(
+                            "Dropping stale fill for {ClOrdId}: ER cumQty={ErCum} <= order cumQty={OrderCum}.",
+                            lookupId, cumQty, order.CumulativeQuantity);
+                        return;
+                    }
+                    if (wasTerminal)
+                    {
+                        // Late fill against a terminal order — exchange's truth
+                        // wins for position keeping; order keeps its terminal
+                        // status (preserved by ApplyCumulativeFill).
+                        MetricsRegistry.ExecutionReportsLateFillAfterTerminal.Add(1, KindTag(kind));
+                        _logger.LogWarning(
+                            "Late fill after terminal status for {ClOrdId}: status={Status}, delta={Delta}, lastPx={LastPx}.",
+                            lookupId, order.Status, delta, lastPx);
+                    }
+                    if (delta != lastQty)
+                    {
+                        // Cumulative advanced by an amount that disagrees with the
+                        // ER's own LastQuantity — most often because an
+                        // intermediate fill ER was lost or arrived out of order.
+                        // Position is booked at the observed delta @ lastPx.
+                        MetricsRegistry.ExecutionReportsFillDeltaMismatch.Add(1, KindTag(kind));
+                        _logger.LogWarning(
+                            "Fill delta mismatch for {ClOrdId}: ER lastQty={LastQty}, computed delta={Delta}.",
+                            lookupId, lastQty, delta);
+                    }
+                    _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
+                    break;
                 }
-                if (wasTerminal)
-                {
-                    // Late fill against a terminal order — exchange's truth
-                    // wins for position keeping; order keeps its terminal
-                    // status (preserved by ApplyCumulativeFill).
-                    MetricsRegistry.ExecutionReportsLateFillAfterTerminal.Add(1, KindTag(kind));
-                    _logger.LogWarning(
-                        "Late fill after terminal status for {ClOrdId}: status={Status}, delta={Delta}, lastPx={LastPx}.",
-                        lookupId, order.Status, delta, lastPx);
-                }
-                if (delta != lastQty)
-                {
-                    // Cumulative advanced by an amount that disagrees with the
-                    // ER's own LastQuantity — most often because an
-                    // intermediate fill ER was lost or arrived out of order.
-                    // Position is booked at the observed delta @ lastPx.
-                    MetricsRegistry.ExecutionReportsFillDeltaMismatch.Add(1, KindTag(kind));
-                    _logger.LogWarning(
-                        "Fill delta mismatch for {ClOrdId}: ER lastQty={LastQty}, computed delta={Delta}.",
-                        lookupId, lastQty, delta);
-                }
-                _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
-                break;
-            }
             case ExecKind.Canceled:
                 if (order.Status is OrderStatus.Cancelled or OrderStatus.Filled or OrderStatus.Rejected)
                 {

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -87,6 +87,21 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.entrypoint.events_received");
     public static readonly Counter<long> EntryPointReconnectAttempts =
         Meter.CreateCounter<long>("trading.entrypoint.reconnect_attempts");
+    public static readonly Counter<long> EntryPointReconnectSucceeded =
+        Meter.CreateCounter<long>("trading.entrypoint.reconnect_succeeded");
+    public static readonly Counter<long> EntryPointReconnectFailed =
+        Meter.CreateCounter<long>("trading.entrypoint.reconnect_failed");
+    // Last SessionVerId successfully Established for the firm. Reported as
+    // an observable gauge so a stuck reconnect (gauge frozen while attempts
+    // counter climbs) is visible at a glance.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, uint> _sessionVerIdByFirm = new();
+    public static readonly ObservableGauge<long> EntryPointSessionVerId =
+        Meter.CreateObservableGauge<long>(
+            "trading.entrypoint.session_ver_id",
+            () => _sessionVerIdByFirm.Select(kv =>
+                new Measurement<long>(kv.Value, new KeyValuePair<string, object?>("firm", kv.Key))));
+    public static void RecordSessionVerId(string firmId, uint verId) =>
+        _sessionVerIdByFirm[firmId] = verId;
     public static readonly Counter<long> EntryPointTranslationErrors =
         Meter.CreateCounter<long>("trading.entrypoint.translation_errors");
     public static readonly Counter<long> EntryPointBusinessRejects =

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -178,25 +178,49 @@ if (earlyIsReal)
         if (opts.Firms.Count == 0)
             throw new InvalidOperationException("Trading:Exchange:Mode is Real but no Firms[] configured. Set Mode=Unavailable for an honest no-broker host.");
         var lf = sp.GetRequiredService<ILoggerFactory>();
+        var persistence = sp.GetRequiredService<IOptions<PersistenceOptions>>().Value;
+        var stateRoot = Path.Combine(persistence.DataDirectory, "entrypoint-state");
         var gateways = opts.Firms.Select(firm =>
         {
             FirmConfigValidation.ValidateFirm(firm);
             var ep = FirmConfigValidation.ParseEndpoint(firm.Endpoint);
+
+            // Wire the SDK's file-backed warm-restart store + resolve the
+            // next SessionVerId from the persisted snapshot. Without this,
+            // a process restart would replay the configured SessionVerId
+            // and the gateway would terminate with InvalidSessionVerId.
+            var stateDir = Path.Combine(stateRoot, firm.FirmId);
+            Directory.CreateDirectory(stateDir);
+            var stateStore = new B3.EntryPoint.Client.State.FileSessionStateStore(stateDir);
+            uint? persistedVerId = null;
+            try
+            {
+                var snap = stateStore.LoadAsync(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+                if (snap is not null) persistedVerId = snap.SessionVerId;
+            }
+            catch (Exception ex)
+            {
+                lf.CreateLogger("FirmGatewayConnector").LogWarning(ex,
+                    "Failed to load persisted SessionStateStore for firm {Firm}; starting from configured SessionVerId.", firm.FirmId);
+            }
+            var resolvedVerId = SessionVerIdResolver.Resolve(firm.SessionVerId, persistedVerId);
+
             var clientOpts = new B3.EntryPoint.Client.EntryPointClientOptions
             {
                 Endpoint = ep,
                 SessionId = firm.SessionId,
-                SessionVerId = firm.SessionVerId,
+                SessionVerId = resolvedVerId,
                 EnteringFirm = firm.EnteringFirm,
                 Credentials = B3.EntryPoint.Client.EntryPointClientOptions.AccessKey(firm.AccessKey),
                 KeepAliveIntervalMs = firm.KeepAliveIntervalMs,
                 SenderLocation = firm.SenderLocation,
                 EnteringTrader = firm.EnteringTrader,
+                SessionStateStore = stateStore,
                 Logger = lf.CreateLogger($"B3.EntryPoint.Client[{firm.FirmId}]"),
             };
             var upstream = new B3.EntryPoint.Client.EntryPointClient(clientOpts);
             var gwLogger = lf.CreateLogger<B3EntryPointClientGateway>();
-            return new B3EntryPointClientGateway(upstream, firm.FirmId, gwLogger);
+            return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger);
         });
         return new FirmGatewayRegistry(gateways);
     });
@@ -325,8 +349,9 @@ internal sealed class EntryPointRouterStarter : Microsoft.Extensions.Hosting.IHo
 /// startup and tears them down on shutdown. Connection errors are logged
 /// but do not abort host start — failed firms surface via the
 /// <c>trading.entrypoint.connected</c> gauge and via gateway-unavailable
-/// rejections at submit time. Phase-2 follow-up (issue #7): readiness gate
-/// + automated reconnect with bumped SessionVerId.
+/// rejections at submit time. Subsequent peer-initiated terminations
+/// drive the gateway's own auto-reconnect loop (Phase 3/1b); this hosted
+/// service only owns the cold-start connect.
 /// </summary>
 internal sealed class FirmGatewayConnector : Microsoft.Extensions.Hosting.IHostedService
 {

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -28,16 +28,31 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private readonly Up.EntryPointClient _client;
     private readonly string _firmId;
     private readonly ILogger<B3EntryPointClientGateway> _logger;
-    private readonly CancellationTokenSource _eventLoopCts = new();
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly SemaphoreSlim _reconnectLock = new(1, 1);
+    private readonly TimeSpan _initialReconnectDelay;
+    private readonly TimeSpan _maxReconnectDelay;
     private Task? _eventLoop;
+    private uint _currentSessionVerId;
     private int _connectedState; // 0 = disconnected, 1 = connected (matches UpDownCounter increments)
+    private volatile bool _disposed;
 
-    public B3EntryPointClientGateway(Up.EntryPointClient client, string firmId, ILogger<B3EntryPointClientGateway> logger)
+    public B3EntryPointClientGateway(
+        Up.EntryPointClient client,
+        string firmId,
+        uint initialSessionVerId,
+        ILogger<B3EntryPointClientGateway> logger,
+        TimeSpan? initialReconnectDelay = null,
+        TimeSpan? maxReconnectDelay = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
         _logger = logger;
+        _currentSessionVerId = initialSessionVerId;
+        _initialReconnectDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(1);
+        _maxReconnectDelay = maxReconnectDelay ?? TimeSpan.FromSeconds(30);
         _client.Terminated += OnTerminated;
+        MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
     }
 
     public string FirmId => _firmId;
@@ -51,9 +66,29 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        OnConnected();
+    }
+
+    private void OnConnected()
+    {
         if (Interlocked.Exchange(ref _connectedState, 1) == 0)
             MetricsRegistry.EntryPointConnected.Add(1, FirmTag());
-        _eventLoop ??= Task.Run(() => RunEventLoopAsync(_eventLoopCts.Token));
+        MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
+        StartEventLoop();
+    }
+
+    /// <summary>
+    /// Spawn the inbound event-loop task. Re-enters after a successful
+    /// reconnect — the previous task completed when the underlying
+    /// <c>Events()</c> enumeration drained on Terminate, so a fresh
+    /// <c>Task.Run</c> is required (the original <c>??=</c> was a bug:
+    /// once completed, the loop would never restart and ER replay after
+    /// reconnect would land in /dev/null).
+    /// </summary>
+    private void StartEventLoop()
+    {
+        if (_eventLoop is { IsCompleted: false }) return;
+        _eventLoop = Task.Run(() => RunEventLoopAsync(_shutdownCts.Token));
     }
 
     public Task SubmitAsync(Order order, CancellationToken cancellationToken)
@@ -243,20 +278,104 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             MetricsRegistry.EntryPointConnected.Add(-1, FirmTag());
         _logger.LogWarning("EntryPoint session terminated for firm {Firm}: code={Code} reason={Reason} byClient={ByClient}",
             _firmId, e.Code, e.Reason, e.InitiatedByClient);
+
+        // Don't fight a graceful shutdown or a client-initiated terminate
+        // (e.g. our own DisposeAsync sending Terminate). Peer-initiated
+        // terminations are the only ones that warrant a reconnect attempt.
+        if (e.InitiatedByClient || _disposed || _shutdownCts.IsCancellationRequested) return;
+
+        // Detach from the inbound thread so the event-loop can drain
+        // cleanly; the reconnect loop owns its own lifecycle.
+        _ = Task.Run(() => ReconnectLoopAsync(_shutdownCts.Token));
+    }
+
+    /// <summary>
+    /// Singleflight reconnect loop. Bumps <c>SessionVerId</c> on every
+    /// attempt (the gateway requires strict-greater) and applies
+    /// exponential backoff with jitter. Exits cleanly on shutdown CT.
+    /// On success the inbound event-loop is restarted via
+    /// <see cref="StartEventLoop"/> so ER replay (FIXP retransmit) lands
+    /// on the existing <c>ExecutionReportReceived</c> subscribers.
+    /// </summary>
+    private async Task ReconnectLoopAsync(CancellationToken ct)
+    {
+        if (!await _reconnectLock.WaitAsync(0, ct).ConfigureAwait(false))
+            return; // already reconnecting
+        try
+        {
+            var attempt = 0;
+            while (!ct.IsCancellationRequested && !_disposed)
+            {
+                attempt++;
+                uint nextVerId;
+                try { nextVerId = checked(_currentSessionVerId + 1); }
+                catch (OverflowException)
+                {
+                    _logger.LogError("SessionVerId overflow for firm {Firm}; giving up.", _firmId);
+                    return;
+                }
+                MetricsRegistry.EntryPointReconnectAttempts.Add(1,
+                    new KeyValuePair<string, object?>("firm", _firmId),
+                    new KeyValuePair<string, object?>("attempt", attempt));
+                try
+                {
+                    await _client.ReconnectAsync(nextVerId, ct).ConfigureAwait(false);
+                    _currentSessionVerId = nextVerId;
+                    MetricsRegistry.EntryPointReconnectSucceeded.Add(1, FirmTag());
+                    _logger.LogInformation("EntryPoint reconnect ok for firm {Firm} on attempt {N} (sessionVerId={Ver}).",
+                        _firmId, attempt, nextVerId);
+                    OnConnected();
+                    return;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    MetricsRegistry.EntryPointReconnectFailed.Add(1,
+                        new KeyValuePair<string, object?>("firm", _firmId),
+                        new KeyValuePair<string, object?>("reason", ex.GetType().Name));
+                    _logger.LogWarning(ex, "EntryPoint reconnect failed for firm {Firm} (attempt {N}, sessionVerId={Ver}); will retry.",
+                        _firmId, attempt, nextVerId);
+                    // Bump the in-memory version even on failure: if the
+                    // failure was anything past Negotiate, the gateway has
+                    // already burned the value. Cheap to skip a few.
+                    _currentSessionVerId = nextVerId;
+                    var delay = ComputeBackoff(attempt);
+                    try { await Task.Delay(delay, ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
+                }
+            }
+        }
+        finally
+        {
+            _reconnectLock.Release();
+        }
+    }
+
+    private TimeSpan ComputeBackoff(int attempt)
+    {
+        var basisMs = Math.Min(_maxReconnectDelay.TotalMilliseconds,
+            _initialReconnectDelay.TotalMilliseconds * Math.Pow(2, Math.Min(attempt - 1, 16)));
+        var jitterMs = Random.Shared.NextDouble() * 0.25 * basisMs;
+        return TimeSpan.FromMilliseconds(basisMs + jitterMs);
     }
 
     private KeyValuePair<string, object?> FirmTag() => new("firm", _firmId);
 
     public async ValueTask DisposeAsync()
     {
-        try { _eventLoopCts.Cancel(); } catch { /* ignore */ }
+        _disposed = true;
+        try { _shutdownCts.Cancel(); } catch { /* ignore */ }
         if (_eventLoop is not null)
         {
             try { await _eventLoop.ConfigureAwait(false); } catch { /* event loop swallows, but be defensive */ }
         }
         _client.Terminated -= OnTerminated;
         await _client.DisposeAsync().ConfigureAwait(false);
-        _eventLoopCts.Dispose();
+        _shutdownCts.Dispose();
+        _reconnectLock.Dispose();
         if (Interlocked.Exchange(ref _connectedState, 0) == 1)
             MetricsRegistry.EntryPointConnected.Add(-1, FirmTag());
     }

--- a/backend/src/B3.Trading.Infrastructure/SessionVerIdResolver.cs
+++ b/backend/src/B3.Trading.Infrastructure/SessionVerIdResolver.cs
@@ -1,0 +1,31 @@
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Computes the next FIXP <c>SessionVerId</c> to advertise on
+/// <c>EntryPointClientOptions</c> at gateway construction.
+///
+/// <para>
+/// The B3 gateway rejects a Negotiate whose <c>SessionVerId</c> is not
+/// strictly greater than any previously seen value for the same
+/// <c>SessionId</c> (terminates with <c>InvalidSessionVerId</c>). After
+/// a process crash, the SDK's <see cref="B3.EntryPoint.Client.State.FileSessionStateStore"/>
+/// holds the last persisted version; we bump from that value rather
+/// than re-reading the (likely stale) configured value, otherwise the
+/// host can wedge in a permanent reconnect-loop after restart.
+/// </para>
+///
+/// <para>
+/// Returned value is <c>max(configured, persisted + 1)</c>: the
+/// configured value still wins when it has been bumped externally
+/// (operator override) but the persisted floor is always honoured.
+/// </para>
+/// </summary>
+public static class SessionVerIdResolver
+{
+    public static uint Resolve(uint configured, uint? persisted)
+    {
+        if (persisted is null) return configured;
+        var floor = checked(persisted.Value + 1);
+        return configured > floor ? configured : floor;
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/SessionVerIdResolverTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SessionVerIdResolverTests.cs
@@ -1,0 +1,41 @@
+using B3.Trading.Infrastructure;
+
+namespace B3.Trading.Application.Tests;
+
+public class SessionVerIdResolverTests
+{
+    [Fact]
+    public void NoPersisted_ReturnsConfigured()
+    {
+        Assert.Equal(7u, SessionVerIdResolver.Resolve(7u, null));
+    }
+
+    [Fact]
+    public void PersistedAhead_ReturnsPersistedPlusOne()
+    {
+        // Persisted snapshot wins after a crash so the gateway doesn't reject
+        // with InvalidSessionVerId.
+        Assert.Equal(11u, SessionVerIdResolver.Resolve(configured: 1u, persisted: 10u));
+    }
+
+    [Fact]
+    public void ConfiguredAhead_StillUsedAsOperatorOverride()
+    {
+        // Operator manually bumped the configured value past anything seen
+        // on disk — honour it (e.g. recovery from a corrupted state dir).
+        Assert.Equal(50u, SessionVerIdResolver.Resolve(configured: 50u, persisted: 5u));
+    }
+
+    [Fact]
+    public void PersistedEqualsConfigured_ReturnsPersistedPlusOne()
+    {
+        // Both at 5: the gateway already saw 5, so we MUST advance.
+        Assert.Equal(6u, SessionVerIdResolver.Resolve(configured: 5u, persisted: 5u));
+    }
+
+    [Fact]
+    public void PersistedAtMax_Overflows()
+    {
+        Assert.Throws<OverflowException>(() => SessionVerIdResolver.Resolve(0u, uint.MaxValue));
+    }
+}


### PR DESCRIPTION
## What

Builds on phase-3/1a (#16, idempotent ER processor): now that replayed ERs are safe to apply, the gateway can actually drive a reconnect — and the SDK's FIXP retransmit fans the missed ER batch back through the existing pipeline without double-booking positions.

Closes `p3-1b-reconnect`. Also closes the legacy "Phase-2 follow-up: readiness gate + automated reconnect with bumped SessionVerId" debt called out in `FirmGatewayConnector`'s docstring.

## Changes

### `B3EntryPointClientGateway`

- **OnTerminated** schedules `ReconnectLoopAsync` unless the termination was client-initiated (`InitiatedByClient` — our own `DisposeAsync` sending Terminate) or the shutdown CT has already fired. No more "session terminated → silently dead" state.
- **`ReconnectLoopAsync`** is singleflight (`SemaphoreSlim` with `WaitAsync(0)`), bumps `SessionVerId` on every attempt (gateway requires strict-greater on Negotiate), exponential backoff capped at 30 s with ±25% jitter, cancellable on shutdown.
- **In-memory `SessionVerId` is bumped even on failed attempts**: if the failure happened past Negotiate, the gateway has already burned the value and reusing it would loop forever on `InvalidSessionVerId`.
- **`StartEventLoop()` replaces the original `_eventLoop ??= Task.Run(...)` bug** — once the inbound enumeration drained on Terminate, the task was completed and `??=` would never restart it, so post-reconnect ER replay would have landed in `/dev/null`. Now we restart whenever the previous task is completed.
- Dispose path tightened: `_disposed` flag prevents re-entrancy from a Terminated event firing during shutdown.

### Warm restart across process crash (SessionVerId persistence)

- New `SessionVerIdResolver.Resolve(configured, persisted)` — returns `max(configured, persisted+1)`. Persisted floor wins so the gateway doesn't reject after a crash; configured wins as an operator override (e.g. recovery from a corrupted state dir).
- `Program.cs` Real-mode wiring constructs a per-firm `FileSessionStateStore` at `{DataDirectory}/entrypoint-state/{firmId}/`, peeks the snapshot **synchronously** at startup, and feeds the resolved `SessionVerId` both to `EntryPointClientOptions.SessionVerId` AND into the gateway constructor so the in-memory bump-counter starts in the right place. The SDK uses the same store to persist outbound / inbound seqnums + outstanding orders for FIXP-level warm restart.

### Metrics

| name | type | tags | when |
|---|---|---|---|
| `trading.entrypoint.reconnect_attempts` | counter | `firm`, `attempt` | each ReconnectAsync call (existing — kept) |
| `trading.entrypoint.reconnect_succeeded` | counter | `firm` | reconnect handshake completed |
| `trading.entrypoint.reconnect_failed` | counter | `firm`, `reason` | reconnect attempt threw |
| `trading.entrypoint.session_ver_id` | observable gauge | `firm` | last successfully Established version |

Operator signal: a frozen `session_ver_id` gauge alongside a climbing `reconnect_attempts` counter = the host is stuck reconnecting (probably an `InvalidSessionVerId` or wire-level reject).

## Tests

- **+5 `SessionVerIdResolver` cases**: no-persisted, persisted-ahead-of-configured, configured-override, equal values (must still bump), overflow guard.
- All **140 existing tests still green** (12 Domain + 66 Application + 62 Api + 1 Conformance skip).

A direct end-to-end test of the reconnect loop is **not** included: the SDK's `EntryPointClient.RaiseTerminated` is `internal`, so triggering a synthetic Terminated event from outside requires a TestPeer that forces a wire-level Terminate. Left as a Phase-7 conformance addition once TestPeer 0.9.0 (real ER replay) lands.

Refs: phase-3/1a (#16), roadmap todos `p3-er-replay` (done), `p3-1b-reconnect`.
