### PR TITLE
WorkingOrderBook: firm-scoped enumeration (closes #19)

### DIFF
--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -12,7 +12,21 @@ public sealed class WorkingOrderBook
 {
     private readonly ConcurrentDictionary<ulong, Order> _orders = new();
 
-    public bool TryAdd(Order order) => _orders.TryAdd(order.ClOrdId, order);
+    // Secondary index: firmId -> set of ClOrdIDs. Maintained on TryAdd / Restore.
+    // Built on top of ConcurrentDictionary so enumeration is lock-free; the inner
+    // dictionary's value byte is irrelevant — we only use the keys as a set.
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byFirm =
+        new(StringComparer.Ordinal);
+
+    public bool TryAdd(Order order)
+    {
+        if (!_orders.TryAdd(order.ClOrdId, order))
+            return false;
+
+        var firmSet = _byFirm.GetOrAdd(order.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
+        firmSet.TryAdd(order.ClOrdId, 0);
+        return true;
+    }
 
     public bool TryGet(ulong clOrdId, out Order? order) => _orders.TryGetValue(clOrdId, out order);
 
@@ -26,6 +40,41 @@ public sealed class WorkingOrderBook
         }
         return list;
     }
+
+    /// <summary>
+    /// Snapshots the orders associated with <paramref name="firmId"/>. By default
+    /// only non-terminal orders are returned (PendingNew / Working / PartiallyFilled),
+    /// which matches the FIXP "outstanding orders" semantics used to reconcile
+    /// against <c>SessionSnapshot.OutstandingOrders</c> after warm restart or
+    /// gap-recovery reconnect.
+    /// </summary>
+    /// <remarks>
+    /// Snapshot semantics: callers receive a stable list captured at call time;
+    /// concurrent <see cref="TryAdd"/> or status mutations after the call do not
+    /// affect the returned collection. Index-driven, so cost is O(orders for firm)
+    /// rather than O(total orders).
+    /// </remarks>
+    public IReadOnlyCollection<Order> EnumerateForFirm(string firmId, bool includeTerminal = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+
+        if (!_byFirm.TryGetValue(firmId, out var firmSet))
+            return Array.Empty<Order>();
+
+        var list = new List<Order>(firmSet.Count);
+        foreach (var clOrdId in firmSet.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order))
+                continue;
+            if (!includeTerminal && IsTerminal(order.Status))
+                continue;
+            list.Add(order);
+        }
+        return list;
+    }
+
+    private static bool IsTerminal(OrderStatus s) =>
+        s is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
 
     /// <summary>
     /// Captures the current set of working orders for snapshotting.
@@ -51,6 +100,7 @@ public sealed class WorkingOrderBook
     {
         ArgumentNullException.ThrowIfNull(snaps);
         _orders.Clear();
+        _byFirm.Clear();
         foreach (var s in snaps)
         {
             var owner = new EndClientId(s.EndClientId);
@@ -59,6 +109,8 @@ public sealed class WorkingOrderBook
             var status = Enum.Parse<OrderStatus>(s.Status);
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId);
+            var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
+            firmSet.TryAdd(s.ClOrdId, 0);
         }
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/WorkingOrderBookFirmEnumerationTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/WorkingOrderBookFirmEnumerationTests.cs
@@ -1,0 +1,108 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+public class WorkingOrderBookFirmEnumerationTests
+{
+    private static Order MakeOrder(ulong clOrdId, string firmId, string owner = "alice") =>
+        new(clOrdId, new EndClientId(owner), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 10, 1m, firmId);
+
+    [Fact]
+    public void EnumerateForFirm_ReturnsOnlyMatchingFirm()
+    {
+        var book = new WorkingOrderBook();
+        Assert.True(book.TryAdd(MakeOrder(1UL, "FIRM_A")));
+        Assert.True(book.TryAdd(MakeOrder(2UL, "FIRM_A")));
+        Assert.True(book.TryAdd(MakeOrder(3UL, "FIRM_B")));
+
+        var a = book.EnumerateForFirm("FIRM_A");
+        var b = book.EnumerateForFirm("FIRM_B");
+
+        Assert.Equal(new ulong[] { 1, 2 }, a.Select(o => o.ClOrdId).OrderBy(x => x));
+        Assert.Equal(new ulong[] { 3 }, b.Select(o => o.ClOrdId));
+    }
+
+    [Fact]
+    public void EnumerateForFirm_UnknownFirm_ReturnsEmpty()
+    {
+        var book = new WorkingOrderBook();
+        book.TryAdd(MakeOrder(1UL, "FIRM_A"));
+
+        Assert.Empty(book.EnumerateForFirm("FIRM_X"));
+    }
+
+    [Fact]
+    public void EnumerateForFirm_ExcludesTerminalByDefault_IncludesWhenRequested()
+    {
+        var book = new WorkingOrderBook();
+        var working = MakeOrder(1UL, "FIRM_A");
+        var filled = MakeOrder(2UL, "FIRM_A");
+        var cancelled = MakeOrder(3UL, "FIRM_A");
+        var rejected = MakeOrder(4UL, "FIRM_A");
+        book.TryAdd(working);
+        book.TryAdd(filled);
+        book.TryAdd(cancelled);
+        book.TryAdd(rejected);
+
+        filled.ApplyFill(10);     // -> Filled
+        cancelled.MarkCancelled();
+        rejected.MarkRejected();
+
+        var active = book.EnumerateForFirm("FIRM_A");
+        var all = book.EnumerateForFirm("FIRM_A", includeTerminal: true);
+
+        Assert.Equal(new ulong[] { 1 }, active.Select(o => o.ClOrdId));
+        Assert.Equal(4, all.Count);
+    }
+
+    [Fact]
+    public void Restore_RebuildsFirmIndex()
+    {
+        var book = new WorkingOrderBook();
+        // Pre-populate something to ensure Restore clears the index too.
+        book.TryAdd(MakeOrder(99UL, "STALE_FIRM"));
+
+        var snaps = new[]
+        {
+            new OrderSnapshot(10UL, "alice", "PETR4", 4321UL, "Buy", "Limit", 5, 1m, 5, 0, "Working", "FIRM_A"),
+            new OrderSnapshot(11UL, "bob",   "PETR4", 4321UL, "Sell","Limit", 7, 2m, 7, 0, "PendingNew", "FIRM_B"),
+        };
+        book.Restore(snaps);
+
+        Assert.Empty(book.EnumerateForFirm("STALE_FIRM"));
+        Assert.Equal(new ulong[] { 10 }, book.EnumerateForFirm("FIRM_A").Select(o => o.ClOrdId));
+        Assert.Equal(new ulong[] { 11 }, book.EnumerateForFirm("FIRM_B").Select(o => o.ClOrdId));
+    }
+
+    [Fact]
+    public void EnumerateForFirm_StableUnderConcurrentAdds()
+    {
+        var book = new WorkingOrderBook();
+        for (ulong i = 1; i <= 100; i++)
+            book.TryAdd(MakeOrder(i, "FIRM_A"));
+
+        // Snapshot, then add more. Snapshot must not throw and must not include
+        // post-snapshot additions deterministically — but at minimum, enumeration
+        // should never throw and the snapshot should be reasonable.
+        var snapshot = book.EnumerateForFirm("FIRM_A");
+        Parallel.For(101, 201, i => book.TryAdd(MakeOrder((ulong)i, "FIRM_A")));
+
+        // The snapshot returned earlier is a materialized list, so its count is fixed.
+        Assert.Equal(100, snapshot.Count);
+
+        // A fresh enumeration after the parallel adds sees all 200.
+        var after = book.EnumerateForFirm("FIRM_A");
+        Assert.Equal(200, after.Count);
+    }
+
+    [Fact]
+    public void EnumerateForFirm_NullOrEmpty_Throws()
+    {
+        var book = new WorkingOrderBook();
+        Assert.Throws<ArgumentException>(() => book.EnumerateForFirm(""));
+        Assert.Throws<ArgumentException>(() => book.EnumerateForFirm("   "));
+        Assert.Throws<ArgumentNullException>(() => book.EnumerateForFirm(null!));
+    }
+}


### PR DESCRIPTION
Closes #19.

## What

Adds `WorkingOrderBook.EnumerateForFirm(firmId, includeTerminal = false)` backed by a secondary `firmId → ClOrdID-set` index maintained on `TryAdd` / `Restore`.

By default returns only **non-terminal** orders (`PendingNew` / `Working` / `PartiallyFilled`) — matches the FIXP "outstanding orders" semantics used to reconcile against `SessionSnapshot.OutstandingOrders` after warm restart or gap-recovery reconnect (the upcoming #18 work).

## Why a secondary index (not linear scan)

Issue #19 left this open. Picked the index because:
- It's O(orders for firm), and on a busy multi-firm host the total book can be much larger than any single firm's outstanding set.
- `ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>>` is lock-free for reads under concurrent writes — important for the reconcile path that runs on the gateway's reconnect thread without blocking order entry.
- Memory cost is trivial (one byte per order in the inner dict).

`Restore` now clears `_byFirm` in addition to `_orders` so a snapshot-load doesn't leak stale firm entries from a previous run.

## Tests

+6 in `WorkingOrderBookFirmEnumerationTests.cs`:
1. Matching-firm filter.
2. Unknown firm → empty.
3. Terminal-status filtering (default vs `includeTerminal: true`).
4. `Restore` rebuilds index + clears stale entries.
5. Concurrent-add stability — snapshot is materialised, post-snapshot adds visible only on a fresh enumeration.
6. Input validation (null/empty/whitespace firmId).

All **146 tests green** (140 existing + 6 new).

## Out of scope

- Actually wiring the reconcile call against `SessionSnapshot.OutstandingOrders` — that lives in #18 (FIXP state machine).
