### PR TITLE
phase-3: explicit FIXP session-state observability + gap detection (closes #18)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -102,6 +102,53 @@ public static class MetricsRegistry
                 new Measurement<long>(kv.Value, new KeyValuePair<string, object?>("firm", kv.Key))));
     public static void RecordSessionVerId(string firmId, uint verId) =>
         _sessionVerIdByFirm[firmId] = verId;
+
+    // Per-firm FIXP wire-protocol state, sourced from the SDK's FixpClientState.
+    // Emitted as a one-hot gauge: for each firm, exactly one row has value 1
+    // (the current state) and the rest are 0. Source callbacks are pull-based
+    // so the metric always reflects the live SDK state on each scrape rather
+    // than a stale push from the last transition.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string,
+        Func<IEnumerable<KeyValuePair<string, int>>>> _sessionStateSources = new();
+    public static readonly ObservableGauge<int> EntryPointSessionState =
+        Meter.CreateObservableGauge<int>(
+            "trading.entrypoint.session_state",
+            () => _sessionStateSources.SelectMany(firm =>
+                firm.Value().Select(row => new Measurement<int>(
+                    row.Value,
+                    new KeyValuePair<string, object?>("firm", firm.Key),
+                    new KeyValuePair<string, object?>("state", row.Key)))));
+    public static void RegisterSessionStateSource(string firmId, Func<IEnumerable<KeyValuePair<string, int>>> source) =>
+        _sessionStateSources[firmId] = source;
+    public static void UnregisterSessionStateSource(string firmId) =>
+        _sessionStateSources.TryRemove(firmId, out _);
+
+    // Per-firm "is the gateway currently inside its reconnect loop" flag.
+    // Combined with session_state, this distinguishes "SDK terminated and
+    // we're actively trying to bring it back" (reconnecting=1) from
+    // "SDK terminated, gave up / no peer" (reconnecting=0).
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Func<int>> _reconnectingByFirm = new();
+    public static readonly ObservableGauge<int> EntryPointReconnecting =
+        Meter.CreateObservableGauge<int>(
+            "trading.entrypoint.reconnecting",
+            () => _reconnectingByFirm.Select(kv =>
+                new Measurement<int>(kv.Value(), new KeyValuePair<string, object?>("firm", kv.Key))));
+    public static void RegisterReconnectingSource(string firmId, Func<int> source) =>
+        _reconnectingByFirm[firmId] = source;
+    public static void UnregisterReconnectingSource(string firmId) =>
+        _reconnectingByFirm.TryRemove(firmId, out _);
+
+    // Inbound seqnum gap detected by our defensive check on top of the SDK's
+    // own retransmit handling. A non-zero rate indicates the SDK delivered an
+    // out-of-order or skipped batch — not necessarily fatal (SDK may still
+    // recover internally) but worth alerting on.
+    public static readonly Counter<long> EntryPointGapDetected =
+        Meter.CreateCounter<long>("trading.entrypoint.gap_detected");
+    // Companion to gap_detected — a duplicate / out-of-order replay we
+    // dropped (or the ER processor will idempotently dedup).
+    public static readonly Counter<long> EntryPointDuplicateInbound =
+        Meter.CreateCounter<long>("trading.entrypoint.duplicate_inbound");
+
     public static readonly Counter<long> EntryPointTranslationErrors =
         Meter.CreateCounter<long>("trading.entrypoint.translation_errors");
     public static readonly Counter<long> EntryPointBusinessRejects =

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -35,6 +35,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private Task? _eventLoop;
     private uint _currentSessionVerId;
     private int _connectedState; // 0 = disconnected, 1 = connected (matches UpDownCounter increments)
+    private int _reconnectingState; // 0 = idle, 1 = reconnect loop active (observable gauge)
+    private ulong _lastInboundSeqNum;
     private volatile bool _disposed;
 
     public B3EntryPointClientGateway(
@@ -53,6 +55,14 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _maxReconnectDelay = maxReconnectDelay ?? TimeSpan.FromSeconds(30);
         _client.Terminated += OnTerminated;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
+        // Pull-based observable gauges: read SDK state + our reconnect flag on
+        // every scrape rather than pushing on every transition. Avoids both
+        // a stale dashboard and a dropped-update race against fast Terminated
+        // → Reconnecting → Established cycles.
+        MetricsRegistry.RegisterSessionStateSource(_firmId,
+            () => FixpStateGaugeProjector.Project(_client.State));
+        MetricsRegistry.RegisterReconnectingSource(_firmId,
+            () => Volatile.Read(ref _reconnectingState));
     }
 
     public string FirmId => _firmId;
@@ -171,6 +181,26 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
                 MetricsRegistry.EntryPointEventsReceived.Add(1,
                     new KeyValuePair<string, object?>("firm", _firmId),
                     new KeyValuePair<string, object?>("event_type", ev.GetType().Name));
+
+                // Defensive gap detection on top of the SDK's own
+                // IRetransmitRequestHandler. The SDK normally hides gaps via
+                // automatic retransmit; if a gap nevertheless surfaces here,
+                // the metric flags it for ops and the ER processor's
+                // idempotency (#16) makes any subsequent replay safe.
+                switch (FixpGapDetector.Observe(ev.SeqNum, ref _lastInboundSeqNum))
+                {
+                    case GapObservation.Gap:
+                        MetricsRegistry.EntryPointGapDetected.Add(1, FirmTag());
+                        _logger.LogWarning("Inbound seqnum gap on firm {Firm}: got {Got} after {Last}; SDK retransmit should follow.",
+                            _firmId, ev.SeqNum, _lastInboundSeqNum);
+                        break;
+                    case GapObservation.Duplicate:
+                        MetricsRegistry.EntryPointDuplicateInbound.Add(1, FirmTag());
+                        // Don't continue — let translation + idempotent ER
+                        // processor drop it. Duplicates are expected during
+                        // FIXP retransmit.
+                        break;
+                }
 
                 ExecutionReportEnvelope? envelope;
                 try
@@ -301,6 +331,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     {
         if (!await _reconnectLock.WaitAsync(0, ct).ConfigureAwait(false))
             return; // already reconnecting
+        Interlocked.Exchange(ref _reconnectingState, 1);
         try
         {
             var attempt = 0;
@@ -350,6 +381,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         }
         finally
         {
+            Interlocked.Exchange(ref _reconnectingState, 0);
             _reconnectLock.Release();
         }
     }
@@ -368,6 +400,10 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     {
         _disposed = true;
         try { _shutdownCts.Cancel(); } catch { /* ignore */ }
+        // Stop emitting per-firm gauges before tearing down the SDK so the
+        // observable callbacks don't race with _client disposal.
+        MetricsRegistry.UnregisterSessionStateSource(_firmId);
+        MetricsRegistry.UnregisterReconnectingSource(_firmId);
         if (_eventLoop is not null)
         {
             try { await _eventLoop.ConfigureAwait(false); } catch { /* event loop swallows, but be defensive */ }

--- a/backend/src/B3.Trading.Infrastructure/FixpGapDetector.cs
+++ b/backend/src/B3.Trading.Infrastructure/FixpGapDetector.cs
@@ -1,0 +1,69 @@
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Result of a single inbound seqnum observation.
+/// </summary>
+public enum GapObservation
+{
+    /// <summary>First event since the last reset; nothing to compare against.</summary>
+    First,
+    /// <summary>Strictly +1 from the previous seqnum — happy path.</summary>
+    InOrder,
+    /// <summary>Incoming &lt; (last+1). Either a duplicate or out-of-order replay.</summary>
+    Duplicate,
+    /// <summary>Incoming &gt; (last+1). At least one inbound message was lost.</summary>
+    Gap,
+}
+
+/// <summary>
+/// Pure function over inbound FIXP message seqnums. Independent of the SDK so
+/// it can be unit-tested without driving <c>EntryPointClient</c>.
+///
+/// <para>
+/// The SDK runs its own gap-recovery via <c>IRetransmitRequestHandler</c>;
+/// this detector is a defensive "did the SDK actually deliver everything in
+/// order?" check feeding the <c>trading.entrypoint.gap_detected</c> metric.
+/// We do <i>not</i> drive a reconnect from here — the SDK owns retransmit
+/// and our reconnect engine should not race with it.
+/// </para>
+/// </summary>
+public static class FixpGapDetector
+{
+    /// <summary>
+    /// Updates <paramref name="last"/> in-place to reflect the highest
+    /// in-order seqnum seen and returns what was observed about
+    /// <paramref name="incoming"/>.
+    /// </summary>
+    /// <remarks>
+    /// FIXP seqnums are 1-based; a sentinel <c>0</c> means "no message yet".
+    /// On <see cref="GapObservation.Gap"/> we still advance <paramref name="last"/>
+    /// to <paramref name="incoming"/> so the next message is judged against
+    /// the new high-water mark (otherwise every subsequent in-order message
+    /// would also be flagged as a gap).
+    /// On <see cref="GapObservation.Duplicate"/> we leave <paramref name="last"/>
+    /// untouched; the caller can drop the message.
+    /// </remarks>
+    public static GapObservation Observe(ulong incoming, ref ulong last)
+    {
+        if (last == 0)
+        {
+            last = incoming;
+            return GapObservation.First;
+        }
+
+        var expected = last + 1;
+        if (incoming == expected)
+        {
+            last = incoming;
+            return GapObservation.InOrder;
+        }
+        if (incoming < expected)
+        {
+            // duplicate or out-of-order replay; do NOT regress last.
+            return GapObservation.Duplicate;
+        }
+        // incoming > expected → gap of (incoming - expected) messages.
+        last = incoming;
+        return GapObservation.Gap;
+    }
+}

--- a/backend/src/B3.Trading.Infrastructure/FixpStateGaugeProjector.cs
+++ b/backend/src/B3.Trading.Infrastructure/FixpStateGaugeProjector.cs
@@ -1,0 +1,44 @@
+using B3.EntryPoint.Client.Fixp;
+
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Projects an SDK <see cref="FixpClientState"/> into one-hot
+/// <c>(state-name, 0|1)</c> rows suitable for an OpenTelemetry observable
+/// gauge tagged by state. Callers iterate the result and emit one
+/// <c>Measurement</c> per row, with the <c>firm</c> tag added on top.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Always emits one row per known <see cref="FixpClientState"/> value so
+/// dashboards see a stable cardinality and can graph "is the firm in
+/// state X right now?" cleanly. Exactly one row per call has value 1,
+/// the rest are 0.
+/// </para>
+/// <para>
+/// State names are emitted in lower-case-with-underscores form
+/// (e.g. <c>tcp_connected</c>) to match the convention used by other
+/// metric tags in this project.
+/// </para>
+/// </summary>
+public static class FixpStateGaugeProjector
+{
+    private static readonly (FixpClientState State, string Tag)[] _states =
+    {
+        (FixpClientState.Disconnected, "disconnected"),
+        (FixpClientState.TcpConnected, "tcp_connected"),
+        (FixpClientState.Negotiating,  "negotiating"),
+        (FixpClientState.Negotiated,   "negotiated"),
+        (FixpClientState.Establishing, "establishing"),
+        (FixpClientState.Established,  "established"),
+        (FixpClientState.Suspended,    "suspended"),
+        (FixpClientState.Terminating,  "terminating"),
+        (FixpClientState.Terminated,   "terminated"),
+    };
+
+    public static IEnumerable<KeyValuePair<string, int>> Project(FixpClientState current)
+    {
+        foreach (var (state, tag) in _states)
+            yield return new KeyValuePair<string, int>(tag, state == current ? 1 : 0);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/FixpGapDetectorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/FixpGapDetectorTests.cs
@@ -1,0 +1,55 @@
+using B3.Trading.Infrastructure;
+
+namespace B3.Trading.Application.Tests;
+
+public class FixpGapDetectorTests
+{
+    [Fact]
+    public void First_Observation_AdoptsIncomingAsHighWater()
+    {
+        ulong last = 0;
+        var result = FixpGapDetector.Observe(42UL, ref last);
+
+        Assert.Equal(GapObservation.First, result);
+        Assert.Equal(42UL, last);
+    }
+
+    [Fact]
+    public void Sequential_InOrder_AdvancesHighWater()
+    {
+        ulong last = 10UL;
+        Assert.Equal(GapObservation.InOrder, FixpGapDetector.Observe(11UL, ref last));
+        Assert.Equal(11UL, last);
+        Assert.Equal(GapObservation.InOrder, FixpGapDetector.Observe(12UL, ref last));
+        Assert.Equal(12UL, last);
+    }
+
+    [Fact]
+    public void Gap_AdvancesHighWaterToIncomingSoSubsequentInOrderIsAccepted()
+    {
+        ulong last = 10UL;
+        Assert.Equal(GapObservation.Gap, FixpGapDetector.Observe(15UL, ref last));
+        Assert.Equal(15UL, last);
+        // The next in-order message (16) must NOT be flagged as another gap.
+        Assert.Equal(GapObservation.InOrder, FixpGapDetector.Observe(16UL, ref last));
+    }
+
+    [Fact]
+    public void Duplicate_DoesNotRegressHighWater()
+    {
+        ulong last = 10UL;
+        Assert.Equal(GapObservation.Duplicate, FixpGapDetector.Observe(10UL, ref last));
+        Assert.Equal(10UL, last);
+        Assert.Equal(GapObservation.Duplicate, FixpGapDetector.Observe(5UL, ref last));
+        Assert.Equal(10UL, last);
+    }
+
+    [Fact]
+    public void DuplicateThenInOrder_StillAdvancesAsExpected()
+    {
+        ulong last = 10UL;
+        FixpGapDetector.Observe(10UL, ref last); // duplicate
+        Assert.Equal(GapObservation.InOrder, FixpGapDetector.Observe(11UL, ref last));
+        Assert.Equal(11UL, last);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/FixpStateGaugeProjectorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/FixpStateGaugeProjectorTests.cs
@@ -1,0 +1,52 @@
+using B3.EntryPoint.Client.Fixp;
+using B3.Trading.Infrastructure;
+
+namespace B3.Trading.Application.Tests;
+
+public class FixpStateGaugeProjectorTests
+{
+    [Fact]
+    public void Project_EmitsExactlyOneRowAtOneAndAllOthersAtZero()
+    {
+        var rows = FixpStateGaugeProjector.Project(FixpClientState.Established).ToArray();
+
+        Assert.Equal(9, rows.Length);
+        Assert.Single(rows, r => r.Value == 1);
+        Assert.Equal("established", rows.Single(r => r.Value == 1).Key);
+    }
+
+    [Fact]
+    public void Project_DisconnectedDefault()
+    {
+        var rows = FixpStateGaugeProjector.Project(FixpClientState.Disconnected).ToArray();
+        Assert.Equal("disconnected", rows.Single(r => r.Value == 1).Key);
+    }
+
+    [Theory]
+    [InlineData(FixpClientState.Disconnected, "disconnected")]
+    [InlineData(FixpClientState.TcpConnected, "tcp_connected")]
+    [InlineData(FixpClientState.Negotiating, "negotiating")]
+    [InlineData(FixpClientState.Negotiated, "negotiated")]
+    [InlineData(FixpClientState.Establishing, "establishing")]
+    [InlineData(FixpClientState.Established, "established")]
+    [InlineData(FixpClientState.Suspended, "suspended")]
+    [InlineData(FixpClientState.Terminating, "terminating")]
+    [InlineData(FixpClientState.Terminated, "terminated")]
+    public void Project_StateTagsMatch(FixpClientState state, string expectedTag)
+    {
+        var rows = FixpStateGaugeProjector.Project(state).ToArray();
+        Assert.Equal(expectedTag, rows.Single(r => r.Value == 1).Key);
+    }
+
+    [Fact]
+    public void Project_AllStatesCovered()
+    {
+        // Every value in the SDK enum must appear in the projection so a new
+        // SDK release adding a state surfaces this test as a failure.
+        var sdkStates = Enum.GetValues<FixpClientState>().ToHashSet();
+        var projectedTags = FixpStateGaugeProjector.Project(FixpClientState.Disconnected)
+            .Select(r => r.Key)
+            .ToHashSet();
+        Assert.Equal(sdkStates.Count, projectedTags.Count);
+    }
+}


### PR DESCRIPTION
Closes #18.

## Design pivot from the issue spec

The original issue proposed an **explicit state machine class** in our gateway. While probing SDK 0.8.0 for this work I found:

- `EntryPointClient.State` already exposes a 9-state `FixpClientState` enum: `Disconnected → TcpConnected → Negotiating → Negotiated → Establishing → Established → Suspended → Terminating → Terminated`.
- `EntryPointClient.Retransmit` is a full `IRetransmitRequestHandler` with `RequestRetransmitAsync` + 4 events.

Mirroring the SDK's state into a metric is strictly better than building a parallel state machine — single source of truth, and we don't have to keep our enum in sync with the SDK's protocol. The original issue was written before this surface was visible. This PR takes the slimmer path; user pre-approved the design pivot.

## What landed

| Metric | Type | Tags | Meaning |
|---|---|---|---|
| `trading.entrypoint.session_state` | Observable gauge (one-hot) | `firm`, `state` | `1` for current `FixpClientState`, `0` for the other 8. Pull-based — each scrape reads the live SDK state. |
| `trading.entrypoint.reconnecting` | Observable gauge | `firm` | `1` whenever the gateway is inside `ReconnectLoopAsync`, else `0`. Combined with `session_state` it distinguishes "actively trying to recover" from "gave up / no peer". |
| `trading.entrypoint.gap_detected` | Counter | `firm` | Defensive seqnum-tracking pass on top of the SDK's own `IRetransmitRequestHandler`. Logs a warning when triggered. |
| `trading.entrypoint.duplicate_inbound` | Counter | `firm` | Companion to `gap_detected` — replayed/duplicate seqnum dropped or deduped by the ER processor. |

We do **not** trigger our own reconnect from the gap detector — the SDK owns retransmit and our reconnect engine should not race with it. The metric is a defense-in-depth signal for ops; the idempotent ER processor (#16) ensures any subsequent replay is safe.

## New types

- **`FixpGapDetector`** (Infrastructure, static) — pure `Observe(incoming, ref last) → GapObservation { First | InOrder | Duplicate | Gap }`. Tested in isolation.
- **`FixpStateGaugeProjector`** (Infrastructure, static) — projects `FixpClientState` into the one-hot row set the metric emits. Tested in isolation, with a coverage assertion that fails the build if the SDK adds a new state.

## Gateway wiring

- New `_lastInboundSeqNum` + `_reconnectingState` fields.
- Constructor registers pull-based source callbacks via `MetricsRegistry.RegisterSessionStateSource` / `RegisterReconnectingSource`.
- `DisposeAsync` unregisters them **before** disposing the SDK so the observable callbacks don't race with `_client` teardown.
- `RunEventLoopAsync` runs `FixpGapDetector.Observe` per event; `Gap` logs a warning + bumps `gap_detected`, `Duplicate` bumps `duplicate_inbound`.
- `ReconnectLoopAsync` toggles `_reconnectingState` 0 → 1 on entry, back to 0 in `finally`.

## Tests

**163 green** (146 existing + 17 new):
- 5 × `FixpGapDetector`: first observation, sequential, gap-then-recovery (key invariant: high-water advances on Gap so subsequent in-order isn't re-flagged), duplicate, dup-then-in-order.
- 12 × `FixpStateGaugeProjector`: one-hot shape, all 9 SDK enum values mapped, build-fails-on-new-SDK-state coverage check.

Format clean.

## Out of scope (deferred)

- Reconciling SDK's `SessionSnapshot.OutstandingOrders` against `WorkingOrderBook` — now feasible thanks to #19/#23 firm-scoped enumeration. Will open a follow-up issue if useful.
- Wiring `_client.Retransmit.*` events to dedicated metrics. SDK already drives retransmit transparently; `gap_detected` is sufficient for now.
