### PR TITLE
phase-7: multi-firm config validator + /admin/firms (closes #21)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -4,10 +4,12 @@ using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
+using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Api;
@@ -46,6 +48,33 @@ public static class AdminEndpoints
                 return Results.Conflict(new { error = "persistence_disabled" });
             var report = eod.Materialise(DateOnly.FromDateTime(DateTime.UtcNow));
             return Results.Ok(report);
+        });
+
+        // Per-firm operator visibility. In Real mode the response folds in
+        // live FIXP state from the FirmGatewayRegistry; in other modes it
+        // returns the configured shape only (state fields are null) — useful
+        // both as a config sanity check and as a stable schema for dashboards.
+        group.MapGet("/firms", (IOptions<ExchangeOptions> opts, IServiceProvider sp) =>
+        {
+            var mode = opts.Value.ResolveMode();
+            // Optional injection: FirmGatewayRegistry is only registered in Real mode.
+            var registry = sp.GetService<FirmGatewayRegistry>();
+            var firms = opts.Value.Firms.Select(cfg =>
+            {
+                B3EntryPointClientGateway? live = null;
+                if (registry is not null && registry.TryGet(cfg.FirmId, out var gw))
+                    live = gw;
+                return new
+                {
+                    firmId = cfg.FirmId,
+                    endpoint = cfg.Endpoint,
+                    sessionId = cfg.SessionId,
+                    sessionState = live?.SessionStateTag,
+                    sessionVerId = live?.CurrentSessionVerId,
+                    reconnecting = live?.IsReconnecting,
+                };
+            }).ToArray();
+            return Results.Ok(new { mode = mode.ToString(), firms });
         });
 
         return app;

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -19,8 +19,10 @@ using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.Configure<ExchangeOptions>(
-    builder.Configuration.GetSection(ExchangeOptions.SectionName));
+builder.Services.AddOptions<ExchangeOptions>()
+    .Bind(builder.Configuration.GetSection(ExchangeOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<ExchangeOptions>, ExchangeOptionsValidator>();
 builder.Services.Configure<AuthOptions>(
     builder.Configuration.GetSection(AuthOptions.SectionName));
 builder.Services.Configure<RiskOptions>(
@@ -182,7 +184,9 @@ if (earlyIsReal)
         var stateRoot = Path.Combine(persistence.DataDirectory, "entrypoint-state");
         var gateways = opts.Firms.Select(firm =>
         {
-            FirmConfigValidation.ValidateFirm(firm);
+            // Shape + uniqueness validation happened at startup via
+            // ExchangeOptionsValidator (ValidateOnStart). Endpoint DNS
+            // resolution is deferred to here because it requires network.
             var ep = FirmConfigValidation.ParseEndpoint(firm.Endpoint);
 
             // Wire the SDK's file-backed warm-restart store + resolve the
@@ -384,15 +388,13 @@ internal sealed class FirmGatewayConnector : Microsoft.Extensions.Hosting.IHoste
 
 internal static class FirmConfigValidation
 {
-    public static void ValidateFirm(FirmConfig f)
-    {
-        if (string.IsNullOrWhiteSpace(f.FirmId)) throw new InvalidOperationException("FirmConfig.FirmId required.");
-        if (string.IsNullOrWhiteSpace(f.Endpoint)) throw new InvalidOperationException($"FirmConfig.Endpoint required for firm '{f.FirmId}'.");
-        if (string.IsNullOrEmpty(f.AccessKey)) throw new InvalidOperationException($"FirmConfig.AccessKey required for firm '{f.FirmId}'.");
-        if (f.SenderLocation.Length is 0 or > 10) throw new InvalidOperationException($"FirmConfig.SenderLocation must be 1..10 chars for firm '{f.FirmId}'.");
-        if (f.EnteringTrader.Length is 0 or > 5) throw new InvalidOperationException($"FirmConfig.EnteringTrader must be 1..5 chars for firm '{f.FirmId}'.");
-    }
-
+    /// <summary>
+    /// DNS-resolves <paramref name="endpoint"/> in <c>host:port</c> form into
+    /// an <see cref="System.Net.IPEndPoint"/>. Shape validation lives in
+    /// <see cref="ExchangeOptionsValidator"/>; this helper is invoked at first
+    /// DI resolution by the Real-mode factory because it needs network access
+    /// and shouldn't block <c>ValidateOnStart</c>.
+    /// </summary>
     public static System.Net.IPEndPoint ParseEndpoint(string endpoint)
     {
         var parts = endpoint.Split(':', 2);

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -67,6 +67,21 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
 
     public string FirmId => _firmId;
 
+    /// <summary>
+    /// Lower-snake-case tag of the live SDK <c>FixpClientState</c> (e.g.
+    /// <c>established</c>, <c>terminated</c>). Mirrors the
+    /// <c>trading.entrypoint.session_state</c> metric and is the canonical
+    /// per-firm status read by the <c>/admin/firms</c> endpoint.
+    /// </summary>
+    public string SessionStateTag =>
+        FixpStateGaugeProjector.Project(_client.State).Single(r => r.Value == 1).Key;
+
+    /// <summary>Last <c>SessionVerId</c> the gateway has tried to use (in-memory; persisted via SDK's <c>SessionStateStore</c>).</summary>
+    public uint CurrentSessionVerId => Volatile.Read(ref _currentSessionVerId);
+
+    /// <summary>True when the auto-reconnect loop is currently running for this firm.</summary>
+    public bool IsReconnecting => Volatile.Read(ref _reconnectingState) == 1;
+
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/ExchangeOptionsValidator.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeOptionsValidator.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Eager-fail validation for <see cref="ExchangeOptions"/>. Replaces the
+/// previous ad-hoc <c>FirmConfigValidation</c> helper that was only invoked
+/// from the Real-mode service factory at first DI resolution — too late to
+/// give operators a clean startup error.
+///
+/// <para>
+/// Validation only fires when <see cref="ExchangeOptions.ResolveMode"/>
+/// returns <see cref="ExchangeMode.Real"/>; the Stub / Mock / Unavailable
+/// modes don't open FIXP sessions so a partially-filled <see cref="FirmConfig"/>
+/// is harmless and intentionally tolerated (test fixtures rely on this).
+/// </para>
+///
+/// Wire via:
+/// <code>
+/// services.AddOptions&lt;ExchangeOptions&gt;()
+///         .Bind(config.GetSection(ExchangeOptions.SectionName))
+///         .ValidateOnStart();
+/// services.AddSingleton&lt;IValidateOptions&lt;ExchangeOptions&gt;, ExchangeOptionsValidator&gt;();
+/// </code>
+/// </summary>
+public sealed class ExchangeOptionsValidator : IValidateOptions<ExchangeOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ExchangeOptions options)
+    {
+        if (options is null)
+            return ValidateOptionsResult.Fail("ExchangeOptions is null.");
+
+        if (options.ResolveMode() != ExchangeMode.Real)
+            return ValidateOptionsResult.Success;
+
+        if (options.Firms.Count == 0)
+            return ValidateOptionsResult.Fail(
+                "Trading:Exchange:Mode is Real but no Firms[] configured. Set Mode=Unavailable for an honest no-broker host.");
+
+        var failures = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < options.Firms.Count; i++)
+        {
+            var f = options.Firms[i];
+            ValidateFirm(i, f, failures);
+            if (!string.IsNullOrWhiteSpace(f.FirmId) && !seen.Add(f.FirmId))
+                failures.Add($"Trading:Exchange:Firms[{i}].FirmId='{f.FirmId}' is duplicated; FirmId must be unique across firms.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void ValidateFirm(int index, FirmConfig f, List<string> failures)
+    {
+        var p = $"Trading:Exchange:Firms[{index}]";
+
+        if (string.IsNullOrWhiteSpace(f.FirmId))
+            failures.Add($"{p}.FirmId is required.");
+        if (string.IsNullOrWhiteSpace(f.Endpoint))
+            failures.Add($"{p}.Endpoint is required (host:port).");
+        else if (!TryParseEndpointShape(f.Endpoint))
+            failures.Add($"{p}.Endpoint='{f.Endpoint}' must be 'host:port' with a numeric port.");
+        if (string.IsNullOrEmpty(f.AccessKey))
+            failures.Add($"{p}.AccessKey is required.");
+        if (f.SessionId == 0)
+            failures.Add($"{p}.SessionId must be > 0 (assigned by B3 per firm).");
+        if (f.SessionVerId == 0)
+            failures.Add($"{p}.SessionVerId must be >= 1; the FIXP gateway requires strict-greater on each Negotiate.");
+        if (f.EnteringFirm == 0)
+            failures.Add($"{p}.EnteringFirm must be > 0 (assigned by B3).");
+        if (string.IsNullOrEmpty(f.SenderLocation) || f.SenderLocation.Length > 10)
+            failures.Add($"{p}.SenderLocation must be 1..10 chars.");
+        if (string.IsNullOrEmpty(f.EnteringTrader) || f.EnteringTrader.Length > 5)
+            failures.Add($"{p}.EnteringTrader must be 1..5 chars.");
+        if (f.KeepAliveIntervalMs is < 100u or > 60_000u)
+            failures.Add($"{p}.KeepAliveIntervalMs={f.KeepAliveIntervalMs} is out of range; expected 100..60000.");
+    }
+
+    /// <summary>
+    /// Cheap shape check ("does it look like host:port?"). Real DNS resolution
+    /// is deferred to the gateway factory because it requires network and
+    /// shouldn't block startup validation.
+    /// </summary>
+    private static bool TryParseEndpointShape(string endpoint)
+    {
+        var parts = endpoint.Split(':', 2);
+        return parts.Length == 2
+            && !string.IsNullOrWhiteSpace(parts[0])
+            && int.TryParse(parts[1], out var port)
+            && port is > 0 and <= 65535;
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/AdminFirmsEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminFirmsEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+public class AdminFirmsEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public AdminFirmsEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task AdminFirms_RequiresAdminRole()
+    {
+        using var userClient = await _factory.CreateAuthedClientAsync(); // alice (user role)
+        var resp = await userClient.GetAsync("/admin/firms");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminFirms_ReturnsConfiguredShapeInMockMode()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/firms");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<FirmsResponse>(JsonOptions);
+        Assert.NotNull(body);
+        // TestAppFactory configures one firm: { FirmId = "TEST" }; live state
+        // fields are null because Mock mode doesn't register FirmGatewayRegistry.
+        Assert.Equal("Mock", body!.Mode);
+        var firm = Assert.Single(body.Firms);
+        Assert.Equal("TEST", firm.FirmId);
+        Assert.Null(firm.SessionState);
+        Assert.Null(firm.SessionVerId);
+        Assert.Null(firm.Reconnecting);
+    }
+
+    private sealed record FirmsResponse(string Mode, FirmEntry[] Firms);
+    private sealed record FirmEntry(
+        string FirmId,
+        string Endpoint,
+        uint SessionId,
+        string? SessionState,
+        uint? SessionVerId,
+        bool? Reconnecting);
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExchangeOptionsValidatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExchangeOptionsValidatorTests.cs
@@ -1,0 +1,167 @@
+using B3.Trading.Infrastructure;
+
+namespace B3.Trading.Application.Tests;
+
+public class ExchangeOptionsValidatorTests
+{
+    private static FirmConfig ValidFirm(string firmId = "FIRM_A") => new()
+    {
+        FirmId = firmId,
+        Endpoint = "broker.example.com:9000",
+        SessionId = 100,
+        SessionVerId = 1,
+        EnteringFirm = 200,
+        AccessKey = "secret",
+        SenderLocation = "BR-SP",
+        EnteringTrader = "TR1",
+        KeepAliveIntervalMs = 1000,
+    };
+
+    private static ExchangeOptions Real(params FirmConfig[] firms) => new()
+    {
+        Mode = ExchangeMode.Real,
+        Firms = firms.ToList(),
+    };
+
+    private static ExchangeOptionsValidator Sut() => new();
+
+    [Fact]
+    public void NonRealMode_TolaratesPartialFirmConfig()
+    {
+        var opts = new ExchangeOptions
+        {
+            Mode = ExchangeMode.Mock,
+            Firms = { new FirmConfig { FirmId = "TEST" } }, // missing everything else
+        };
+
+        Assert.True(Sut().Validate(null, opts).Succeeded);
+    }
+
+    [Fact]
+    public void Real_NoFirms_Fails()
+    {
+        var result = Sut().Validate(null, new ExchangeOptions { Mode = ExchangeMode.Real });
+        Assert.False(result.Succeeded);
+        Assert.Contains("no Firms[]", string.Join(";", result.Failures!));
+    }
+
+    [Fact]
+    public void Real_SingleValidFirm_Succeeds()
+    {
+        Assert.True(Sut().Validate(null, Real(ValidFirm())).Succeeded);
+    }
+
+    [Fact]
+    public void Real_DuplicateFirmId_Fails()
+    {
+        var result = Sut().Validate(null, Real(ValidFirm("DUP"), ValidFirm("DUP")));
+        Assert.False(result.Succeeded);
+        Assert.Contains("duplicated", string.Join(";", result.Failures!));
+    }
+
+    [Fact]
+    public void Real_MissingFirmId_Fails()
+    {
+        var f = ValidFirm();
+        f.FirmId = "";
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        Assert.Contains("FirmId is required", string.Join(";", r.Failures!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("nohostport")]
+    [InlineData("host:notaport")]
+    [InlineData("host:0")]
+    [InlineData("host:99999")]
+    [InlineData(":9000")]
+    public void Real_InvalidEndpoint_Fails(string endpoint)
+    {
+        var f = ValidFirm();
+        f.Endpoint = endpoint;
+        Assert.False(Sut().Validate(null, Real(f)).Succeeded);
+    }
+
+    [Fact]
+    public void Real_ZeroSessionVerId_Fails()
+    {
+        var f = ValidFirm();
+        f.SessionVerId = 0;
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        Assert.Contains("SessionVerId", string.Join(";", r.Failures!));
+    }
+
+    [Fact]
+    public void Real_ZeroSessionId_Fails()
+    {
+        var f = ValidFirm();
+        f.SessionId = 0;
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        Assert.Contains("SessionId", string.Join(";", r.Failures!));
+    }
+
+    [Fact]
+    public void Real_ZeroEnteringFirm_Fails()
+    {
+        var f = ValidFirm();
+        f.EnteringFirm = 0;
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        Assert.Contains("EnteringFirm", string.Join(";", r.Failures!));
+    }
+
+    [Fact]
+    public void Real_MissingAccessKey_Fails()
+    {
+        var f = ValidFirm();
+        f.AccessKey = "";
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        Assert.Contains("AccessKey", string.Join(";", r.Failures!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("12345678901")] // 11 chars
+    public void Real_InvalidSenderLocation_Fails(string sl)
+    {
+        var f = ValidFirm();
+        f.SenderLocation = sl;
+        Assert.False(Sut().Validate(null, Real(f)).Succeeded);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("ABCDEF")] // 6 chars
+    public void Real_InvalidEnteringTrader_Fails(string et)
+    {
+        var f = ValidFirm();
+        f.EnteringTrader = et;
+        Assert.False(Sut().Validate(null, Real(f)).Succeeded);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(50u)]
+    [InlineData(60_001u)]
+    public void Real_KeepAliveOutOfRange_Fails(uint ka)
+    {
+        var f = ValidFirm();
+        f.KeepAliveIntervalMs = ka;
+        Assert.False(Sut().Validate(null, Real(f)).Succeeded);
+    }
+
+    [Fact]
+    public void Real_AllFailuresAggregated()
+    {
+        var f = new FirmConfig(); // entirely empty
+        var r = Sut().Validate(null, Real(f));
+        Assert.False(r.Succeeded);
+        // Should report multiple distinct failures, not just the first one.
+        Assert.True(r.Failures!.Count() >= 5,
+            $"Expected aggregate of multiple failures, got: {string.Join(" | ", r.Failures!)}");
+    }
+}


### PR DESCRIPTION
Closes #21.

## What

- `ExchangeOptionsValidator` (`IValidateOptions<ExchangeOptions>`) wired via `AddOptions<>().Bind().ValidateOnStart()` so misconfigured Real-mode firms fail at boot, not at first connect.
- Validation is **mode-conditional**: skipped for `Mock`/`Stub`/`Unavailable` so test fixtures and the no-broker default keep working with partial config.
- `GET /admin/firms` (admin role) returns a stable shape across every mode: `{ mode, firms[] }` with per-firm `{ firmId, endpoint, sessionId, sessionState?, sessionVerId?, reconnecting? }`. Live state is populated only in Real mode where `FirmGatewayRegistry` exists.

## Validation rules (Real mode only)

| Field | Rule |
| --- | --- |
| `FirmId` | required, unique across array |
| `Endpoint` | `host:port`, port in (0, 65535] |
| `AccessKey` | required (non-empty) |
| `SessionId` | > 0 |
| `SessionVerId` | >= 1 |
| `EnteringFirm` | > 0 |
| `SenderLocation` | length 1..10 |
| `EnteringTrader` | length 1..5 |
| `KeepAliveIntervalMs` | [100, 60000] |

Failures are aggregated, so a misconfigured deployment sees every problem at once.

## Gateway accessors

`B3EntryPointClientGateway` exposes:
- `SessionStateTag` — projects `FixpClientState` (from #24).
- `CurrentSessionVerId` — warm-restart counter from #17 via `Volatile.Read`.
- `IsReconnecting` — flag from #17 via `Volatile.Read`.

Used by `/admin/firms` to sample without locking.

## Tests

- +17 validator unit tests covering each rule, the non-Real skip, and failure aggregation.
- +2 endpoint tests covering the admin-role gate and the Mock-mode shape.
- 188 tests green; `dotnet format` clean.

## Deferred

Per-firm credential file abstraction is deferred — env-override via `Trading__Exchange__Firms__N__AccessKey` already covers the operational need; richer secret-store layering can come once we have a deployment that needs it.
