### PR TITLE
phase-7: order-entry latency probes (closes #20)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -149,6 +149,25 @@ public static class MetricsRegistry
     public static readonly Counter<long> EntryPointDuplicateInbound =
         Meter.CreateCounter<long>("trading.entrypoint.duplicate_inbound");
 
+    // Order-entry latency probes. Two histograms tagged by firm + op
+    // (submit/cancel/replace) so dashboards can isolate cancel-side from
+    // submit-side wire performance:
+    //
+    //   * order_entry_call_ms — duration of the local SDK await (network
+    //     write + SDK serialization). Only successful calls are recorded;
+    //     failures are already tracked by OrdersGatewayFailed.
+    //   * order_entry_to_ack_ms — submit-to-first-ER round trip. The probe
+    //     starts the timer BEFORE the SDK await to avoid losing samples
+    //     when the ER arrives before the await completes (full-duplex).
+    //
+    // BusinessReject is not surfaced to the probe because it lacks the
+    // ClOrdID needed for correlation; those rejections are still counted
+    // by EntryPointBusinessRejects.
+    public static readonly Histogram<double> OrderEntryCallMs =
+        Meter.CreateHistogram<double>("trading.entrypoint.order_entry_call_ms");
+    public static readonly Histogram<double> OrderEntryToAckMs =
+        Meter.CreateHistogram<double>("trading.entrypoint.order_entry_to_ack_ms");
+
     public static readonly Counter<long> EntryPointTranslationErrors =
         Meter.CreateCounter<long>("trading.entrypoint.translation_errors");
     public static readonly Counter<long> EntryPointBusinessRejects =

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -32,6 +32,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private readonly SemaphoreSlim _reconnectLock = new(1, 1);
     private readonly TimeSpan _initialReconnectDelay;
     private readonly TimeSpan _maxReconnectDelay;
+    private readonly TimeProvider _clock;
+    private readonly OrderEntryLatencyProbe _latencyProbe;
     private Task? _eventLoop;
     private uint _currentSessionVerId;
     private int _connectedState; // 0 = disconnected, 1 = connected (matches UpDownCounter increments)
@@ -45,7 +47,9 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         uint initialSessionVerId,
         ILogger<B3EntryPointClientGateway> logger,
         TimeSpan? initialReconnectDelay = null,
-        TimeSpan? maxReconnectDelay = null)
+        TimeSpan? maxReconnectDelay = null,
+        TimeProvider? clock = null,
+        OrderEntryLatencyProbe? latencyProbe = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -53,6 +57,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _currentSessionVerId = initialSessionVerId;
         _initialReconnectDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(1);
         _maxReconnectDelay = maxReconnectDelay ?? TimeSpan.FromSeconds(30);
+        _clock = clock ?? TimeProvider.System;
+        _latencyProbe = latencyProbe ?? new OrderEntryLatencyProbe(_clock);
         _client.Terminated += OnTerminated;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
         // Pull-based observable gauges: read SDK state + our reconnect flag on
@@ -133,7 +139,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             TimeInForce = UpModels.TimeInForce.Day,
         };
 
-        return _client.SubmitAsync(req, cancellationToken);
+        return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
+            ct => _client.SubmitAsync(req, ct), cancellationToken);
     }
 
     public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken)
@@ -150,7 +157,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             Side = order.Side == OrderSide.Buy ? UpModels.Side.Buy : UpModels.Side.Sell,
         };
 
-        return _client.CancelAsync(req, cancellationToken);
+        return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpCancel,
+            ct => _client.CancelAsync(req, ct), cancellationToken);
     }
 
     public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
@@ -173,7 +181,38 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             TimeInForce = UpModels.TimeInForce.Day,
         };
 
-        return _client.ReplaceAsync(req, cancellationToken);
+        return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
+            ct => _client.ReplaceAsync(req, ct), cancellationToken);
+    }
+
+    /// <summary>
+    /// Common send pipeline: register the pending latency probe BEFORE the
+    /// SDK await (the matching ER can race ahead of the await on a fast
+    /// wire, so a post-await registration would lose samples), record the
+    /// SDK call duration on success, and forget the pending entry on
+    /// synchronous failure (no ER will follow). Failed-call duration is
+    /// intentionally not histogrammed — failures are tracked by
+    /// <see cref="MetricsRegistry.OrdersGatewayFailed"/>; mixing failure
+    /// timings would corrupt the p99 of successful sends.
+    /// </summary>
+    private async Task SendAsync(ulong clOrdId, string op, Func<CancellationToken, Task> sdkCall, CancellationToken ct)
+    {
+        var start = _clock.GetTimestamp();
+        _latencyProbe.OnSubmitted(clOrdId, _firmId, op);
+        try
+        {
+            await sdkCall(ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            _latencyProbe.Forget(clOrdId);
+            throw;
+        }
+
+        MetricsRegistry.OrderEntryCallMs.Record(
+            _clock.GetElapsedTime(start).TotalMilliseconds,
+            new KeyValuePair<string, object?>("firm", _firmId),
+            new KeyValuePair<string, object?>("op", op));
     }
 
     // The IEntryPointClient submit-side surface is unused on the real adapter
@@ -231,6 +270,10 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
 
                 if (envelope is null)
                     continue;
+
+                // Record latency before subscriber fan-out so a misbehaving
+                // subscriber can't lose the sample.
+                _latencyProbe.OnExecutionReport(envelope.ClOrdId);
 
                 try
                 {

--- a/backend/src/B3.Trading.Infrastructure/OrderEntryLatencyProbe.cs
+++ b/backend/src/B3.Trading.Infrastructure/OrderEntryLatencyProbe.cs
@@ -1,0 +1,155 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Observability;
+
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Tracks pending order-entry operations (submit/cancel/replace) by their
+/// outbound <c>ClOrdID</c> and records submit-to-first-ER latency to the
+/// <c>trading.entrypoint.order_entry_to_ack_ms</c> histogram on the matching
+/// inbound <see cref="ExecutionReportEnvelope"/>.
+///
+/// <para>
+/// Designed to be wired into <see cref="B3EntryPointClientGateway"/>:
+/// <see cref="OnSubmitted"/> is called <em>before</em> the SDK await (the
+/// ER can race ahead of the await on a fast wire) and
+/// <see cref="OnExecutionReport"/> is called as soon as a translated envelope
+/// is available, before fan-out to subscribers — so a misbehaving subscriber
+/// can't lose latency samples.
+/// </para>
+///
+/// <para>
+/// Pending entries are bounded by both <see cref="MaxPending"/> (cap-based
+/// eviction of oldest) and <see cref="Ttl"/> (timestamp-based sweep). The
+/// sweep runs at most every <see cref="SweepInterval"/> off the
+/// <c>OnSubmitted</c> path, so an order rate of millions/sec doesn't trigger
+/// O(N) work on every call.
+/// </para>
+///
+/// <para>
+/// Thread-safe. <see cref="OnExecutionReport"/> is idempotent — only the
+/// first ER for a given <c>ClOrdID</c> records a sample.
+/// </para>
+/// </summary>
+public sealed class OrderEntryLatencyProbe
+{
+    public const string OpSubmit = "submit";
+    public const string OpCancel = "cancel";
+    public const string OpReplace = "replace";
+
+    private readonly TimeProvider _clock;
+    private readonly ConcurrentDictionary<ulong, Pending> _pending = new();
+    private long _nextSweepTicks;
+    private int _approxCount;
+
+    public int MaxPending { get; }
+    public TimeSpan Ttl { get; }
+    public TimeSpan SweepInterval { get; }
+
+    public OrderEntryLatencyProbe(
+        TimeProvider? clock = null,
+        int maxPending = 50_000,
+        TimeSpan? ttl = null,
+        TimeSpan? sweepInterval = null)
+    {
+        _clock = clock ?? TimeProvider.System;
+        MaxPending = maxPending;
+        Ttl = ttl ?? TimeSpan.FromMinutes(5);
+        SweepInterval = sweepInterval ?? TimeSpan.FromSeconds(10);
+    }
+
+    /// <summary>
+    /// Approximate number of entries awaiting their first ER. Maintained via
+    /// <see cref="Interlocked"/> to avoid the cost of
+    /// <c>ConcurrentDictionary.Count</c> on the hot path.
+    /// </summary>
+    public int ApproxPending => Volatile.Read(ref _approxCount);
+
+    /// <summary>
+    /// Register a freshly-issued order-entry operation. Must be called BEFORE
+    /// awaiting the SDK send to avoid losing samples to ER-before-await
+    /// races. Idempotent — re-issuing the same ClOrdID overwrites the start
+    /// timestamp (only the latest send is timed).
+    /// </summary>
+    public void OnSubmitted(ulong clOrdId, string firm, string op)
+    {
+        var now = _clock.GetTimestamp();
+        var fresh = new Pending(now, firm, op);
+        _pending.AddOrUpdate(
+            clOrdId,
+            _ => { Interlocked.Increment(ref _approxCount); return fresh; },
+            (_, _) => fresh);
+
+        MaybeSweep(now);
+        if (Volatile.Read(ref _approxCount) > MaxPending)
+            EvictOldest();
+    }
+
+    /// <summary>
+    /// Drop a pending entry without recording a sample. Use for synchronous
+    /// SDK failures where no ER will follow.
+    /// </summary>
+    public void Forget(ulong clOrdId)
+    {
+        if (_pending.TryRemove(clOrdId, out _))
+            Interlocked.Decrement(ref _approxCount);
+    }
+
+    /// <summary>
+    /// Match a translated ER's <c>ClOrdID</c> against any pending entry and,
+    /// if found, record the elapsed time and remove the entry. Subsequent
+    /// ERs for the same <c>ClOrdID</c> are ignored — only the first one is
+    /// the ack the operator cares about.
+    /// </summary>
+    public void OnExecutionReport(ulong clOrdId)
+    {
+        if (!_pending.TryRemove(clOrdId, out var pending))
+            return;
+
+        Interlocked.Decrement(ref _approxCount);
+        var elapsedMs = _clock.GetElapsedTime(pending.StartTicks).TotalMilliseconds;
+        MetricsRegistry.OrderEntryToAckMs.Record(elapsedMs,
+            new KeyValuePair<string, object?>("firm", pending.Firm),
+            new KeyValuePair<string, object?>("op", pending.Op));
+    }
+
+    private void MaybeSweep(long now)
+    {
+        var next = Volatile.Read(ref _nextSweepTicks);
+        if (now < next) return;
+        var nextNext = now + (long)(SweepInterval.TotalSeconds * _clock.TimestampFrequency);
+        // Only one sweeper at a time; if another caller already advanced the
+        // gate, skip — the entries will be picked up on the following tick.
+        if (Interlocked.CompareExchange(ref _nextSweepTicks, nextNext, next) != next)
+            return;
+
+        var ttlTicks = (long)(Ttl.TotalSeconds * _clock.TimestampFrequency);
+        foreach (var kv in _pending)
+        {
+            if (now - kv.Value.StartTicks > ttlTicks &&
+                _pending.TryRemove(kv.Key, out _))
+            {
+                Interlocked.Decrement(ref _approxCount);
+            }
+        }
+    }
+
+    private void EvictOldest()
+    {
+        // Cap-based fallback for environments where TTL hasn't kicked in
+        // yet but pending entries are growing unbounded (silent broker, test
+        // harnesses). Keeps the dictionary bounded; precision of "oldest"
+        // doesn't matter much here.
+        var target = MaxPending - (MaxPending / 10); // free up ~10%
+        var snapshot = _pending.ToArray();
+        Array.Sort(snapshot, static (a, b) => a.Value.StartTicks.CompareTo(b.Value.StartTicks));
+        var toRemove = snapshot.Length - target;
+        for (var i = 0; i < toRemove && i < snapshot.Length; i++)
+        {
+            if (_pending.TryRemove(snapshot[i].Key, out _))
+                Interlocked.Decrement(ref _approxCount);
+        }
+    }
+
+    private readonly record struct Pending(long StartTicks, string Firm, string Op);
+}

--- a/backend/tests/B3.Trading.Application.Tests/OrderEntryLatencyProbeTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderEntryLatencyProbeTests.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application.Observability;
+using B3.Trading.Infrastructure;
+
+namespace B3.Trading.Application.Tests;
+
+public class OrderEntryLatencyProbeTests
+{
+    private sealed class TestClock : TimeProvider
+    {
+        private long _ticks;
+        public long FrequencyOverride { get; init; } = TimeSpan.TicksPerSecond;
+        public override long TimestampFrequency => FrequencyOverride;
+        public override long GetTimestamp() => Volatile.Read(ref _ticks);
+        public void Advance(TimeSpan dt) =>
+            Interlocked.Add(ref _ticks, (long)(dt.TotalSeconds * FrequencyOverride));
+    }
+
+    private static (List<Measurement<double>> samples, IDisposable subscription) CaptureToAck()
+    {
+        var samples = new List<Measurement<double>>();
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Meter.Name == "B3.Trading" &&
+                    instr.Name == "trading.entrypoint.order_entry_to_ack_ms")
+                    l.EnableMeasurementEvents(instr);
+            },
+        };
+        listener.SetMeasurementEventCallback<double>((_, value, tags, _) =>
+        {
+            lock (samples) samples.Add(new Measurement<double>(value, tags.ToArray()));
+        });
+        listener.Start();
+        return (samples, listener);
+    }
+
+    [Fact]
+    public void OnExecutionReport_RecordsElapsedMs_WithFirmAndOpTags()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var clock = new TestClock();
+        var probe = new OrderEntryLatencyProbe(clock);
+
+        probe.OnSubmitted(42, "FIRM_A", OrderEntryLatencyProbe.OpSubmit);
+        clock.Advance(TimeSpan.FromMilliseconds(7.5));
+        probe.OnExecutionReport(42);
+
+        var sample = Assert.Single(samples);
+        Assert.Equal(7.5, sample.Value, precision: 3);
+        var tags = sample.Tags.ToArray().ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal("FIRM_A", tags["firm"]);
+        Assert.Equal("submit", tags["op"]);
+    }
+
+    [Fact]
+    public void OnExecutionReport_IsIdempotent_OnlyFirstErRecords()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var clock = new TestClock();
+        var probe = new OrderEntryLatencyProbe(clock);
+
+        probe.OnSubmitted(7, "F", OrderEntryLatencyProbe.OpSubmit);
+        clock.Advance(TimeSpan.FromMilliseconds(2));
+        probe.OnExecutionReport(7);
+        clock.Advance(TimeSpan.FromMilliseconds(50));
+        probe.OnExecutionReport(7); // second ER for same ClOrdID — no-op
+
+        Assert.Single(samples);
+    }
+
+    [Fact]
+    public void OnExecutionReport_UnknownClOrdId_NoRecord()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var probe = new OrderEntryLatencyProbe(new TestClock());
+
+        probe.OnExecutionReport(999);
+
+        Assert.Empty(samples);
+        Assert.Equal(0, probe.ApproxPending);
+    }
+
+    [Fact]
+    public void Forget_DropsPendingWithoutRecording()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var probe = new OrderEntryLatencyProbe(new TestClock());
+
+        probe.OnSubmitted(5, "F", OrderEntryLatencyProbe.OpSubmit);
+        Assert.Equal(1, probe.ApproxPending);
+        probe.Forget(5);
+        Assert.Equal(0, probe.ApproxPending);
+
+        // Subsequent ER should not fire — probe was forgotten.
+        probe.OnExecutionReport(5);
+        Assert.Empty(samples);
+    }
+
+    [Fact]
+    public void OnSubmitted_OverwritesExistingPending()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var clock = new TestClock();
+        var probe = new OrderEntryLatencyProbe(clock);
+
+        probe.OnSubmitted(1, "F", OrderEntryLatencyProbe.OpSubmit);
+        clock.Advance(TimeSpan.FromMilliseconds(100));
+        probe.OnSubmitted(1, "F", OrderEntryLatencyProbe.OpSubmit); // re-issue resets timer
+        clock.Advance(TimeSpan.FromMilliseconds(3));
+        probe.OnExecutionReport(1);
+
+        Assert.Equal(1, probe.ApproxPending + samples.Count); // 0 pending + 1 sample
+        Assert.Equal(3, samples[0].Value, precision: 1);
+    }
+
+    [Fact]
+    public void Sweep_EvictsEntriesOlderThanTtl()
+    {
+        var clock = new TestClock();
+        var probe = new OrderEntryLatencyProbe(
+            clock,
+            ttl: TimeSpan.FromSeconds(2),
+            sweepInterval: TimeSpan.FromMilliseconds(1));
+
+        probe.OnSubmitted(1, "F", OrderEntryLatencyProbe.OpSubmit);
+        clock.Advance(TimeSpan.FromSeconds(3));
+
+        // A subsequent OnSubmitted triggers MaybeSweep which evicts ClOrdID=1.
+        probe.OnSubmitted(2, "F", OrderEntryLatencyProbe.OpSubmit);
+
+        // ClOrdID=1 was swept; only ClOrdID=2 remains.
+        Assert.Equal(1, probe.ApproxPending);
+    }
+
+    [Fact]
+    public void EvictOldest_BoundsDictionaryWhenCapExceeded()
+    {
+        var clock = new TestClock();
+        var probe = new OrderEntryLatencyProbe(
+            clock,
+            maxPending: 10,
+            ttl: TimeSpan.FromHours(1),       // disable TTL eviction
+            sweepInterval: TimeSpan.FromHours(1));
+
+        for (ulong i = 1; i <= 20; i++)
+        {
+            probe.OnSubmitted(i, "F", OrderEntryLatencyProbe.OpSubmit);
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+        }
+
+        // After overflow, eviction frees ~10% headroom; pending is at-or-below cap.
+        Assert.True(probe.ApproxPending <= 10,
+            $"Expected pending <= 10 after eviction, got {probe.ApproxPending}");
+        // Newest entry (ClOrdID=20) should still be present; record an ER and
+        // expect it to be measured.
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        probe.OnExecutionReport(20);
+        Assert.Single(samples);
+    }
+
+    [Fact]
+    public async Task ConcurrentSubmitAndAck_ProducesOneSamplePerClOrdId()
+    {
+        var (samples, sub) = CaptureToAck();
+        using var _ = sub;
+        var probe = new OrderEntryLatencyProbe(); // real clock OK — small N
+
+        const int n = 500;
+        var tasks = new List<Task>();
+        for (var i = 0; i < n; i++)
+        {
+            var id = (ulong)i + 1;
+            tasks.Add(Task.Run(() =>
+            {
+                probe.OnSubmitted(id, "F", OrderEntryLatencyProbe.OpSubmit);
+                probe.OnExecutionReport(id);
+                probe.OnExecutionReport(id); // duplicate — must not double-record
+            }));
+        }
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(n, samples.Count);
+        Assert.Equal(0, probe.ApproxPending);
+    }
+}


### PR DESCRIPTION
Closes #20.

## What

Two new histograms on the order-entry side, tagged by `firm` + `op` (`submit` / `cancel` / `replace`):

| Metric | Meaning |
| --- | --- |
| `trading.entrypoint.order_entry_call_ms` | Local SDK await duration — network write + serialization. |
| `trading.entrypoint.order_entry_to_ack_ms` | Submit-to-first-ER round trip. |

`order_entry_call_ms` records **successful** sends only; mixing failed-call timings would corrupt the p99 of healthy traffic, and `OrdersGatewayFailed` already counts the failures.

## How

- `OrderEntryLatencyProbe` keys pending entries by **outbound `ClOrdID`** in a `ConcurrentDictionary`. For cancel/replace the broker's ER carries the request's new ClOrdID, so one keying scheme covers all three ops.
- `OnExecutionReport` uses `TryRemove` → only the **first** ER for a given ClOrdID records a sample, matching the operator-visible "ack".
- The probe registers the pending entry **before the SDK await** because the matching ER can race ahead of the await on a fast/full-duplex wire — post-await registration would drop samples.
- TTL sweep gated by `Interlocked.CompareExchange` on `_nextSweepTicks` so the O(N) sweep runs at most every 10s, never on every order. `EvictOldest` is a cap-based fallback (default 50k) for environments where traffic stays below sweep cadence but pending grows.
- `ApproxPending` is maintained via `Interlocked` to avoid `ConcurrentDictionary.Count` on the hot path.
- `BusinessReject` is excluded — it lacks ClOrdID; those rejections stay tracked by `EntryPointBusinessRejects`.

## Wiring

`B3EntryPointClientGateway`:
- Constructor takes optional `TimeProvider` + `OrderEntryLatencyProbe` so tests can inject deterministic clocks.
- Submit / Cancel / CancelReplace now funnel through a shared `SendAsync` (register → await → record-or-forget) so the three paths can't drift.
- Event loop fires `probe.OnExecutionReport(envelope.ClOrdId)` **before** subscriber fan-out so a misbehaving subscriber can't lose samples.

## Tests

+8 probe unit tests covering: record-with-tags, ER idempotency, unknown ClOrdID, `Forget`, `OnSubmitted` overwrite, TTL sweep, cap-based eviction, concurrent submit/ack with duplicate ER. 196 tests green; `dotnet format` clean.

## Critique addressed

Rubber-duck flagged the ACK-before-pending race, the TTL-only-on-overflow gap, hot-path `Count` cost, ambiguous failed-call semantics, and metric naming for cancel/replace — all addressed before opening this PR.
