### PR TITLE
phase-7: expand conformance suite — auth negatives + /admin/firms shape (#22)

### DIFF
--- a/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
@@ -18,22 +18,35 @@ public sealed class ConformanceFactAttribute : FactAttribute
 {
     public const string EnvRequireConfigured = "B3T_REQUIRE_CONFIGURED";
 
+    /// <summary>
+    /// When true, the scenario also requires admin-role credentials
+    /// (B3T_ADMIN_USER / B3T_ADMIN_PASS). Skipped at discovery time when
+    /// only the basic user creds are configured, so deployments that
+    /// don't surface an admin role still get the rest of the suite.
+    /// </summary>
+    public bool RequiresAdmin { get; init; }
+
     public ConformanceFactAttribute()
     {
-        if (PlatformEndpoint.TryResolve() is not null)
-            return;
-
-        var require = Environment.GetEnvironmentVariable(EnvRequireConfigured);
-        if (string.Equals(require, "true", StringComparison.OrdinalIgnoreCase) ||
-            require == "1")
+        var peer = PlatformEndpoint.TryResolve();
+        if (peer is null)
         {
-            // Throwing here makes xUnit surface a discovery error instead of
-            // a skip. The CI pipeline fails loudly rather than passing with
-            // zero executed tests.
-            throw new InvalidOperationException(
-                $"{EnvRequireConfigured}=true but {PlatformEndpoint.SkipReason}");
+            var require = Environment.GetEnvironmentVariable(EnvRequireConfigured);
+            if (string.Equals(require, "true", StringComparison.OrdinalIgnoreCase) ||
+                require == "1")
+            {
+                // Throwing here makes xUnit surface a discovery error instead of
+                // a skip. The CI pipeline fails loudly rather than passing with
+                // zero executed tests.
+                throw new InvalidOperationException(
+                    $"{EnvRequireConfigured}=true but {PlatformEndpoint.SkipReason}");
+            }
+
+            Skip = PlatformEndpoint.SkipReason;
+            return;
         }
 
-        Skip = PlatformEndpoint.SkipReason;
+        if (RequiresAdmin && !peer.HasAdminCredentials)
+            Skip = PlatformEndpoint.AdminSkipReason;
     }
 }

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/LoginHelper.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/LoginHelper.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace B3.Trading.Conformance.Infrastructure;
+
+/// <summary>
+/// Small helper: <c>POST /auth/login</c> against the configured platform
+/// and return an authorization header ready to apply to any request. Lets
+/// individual conformance specs stay focused on the contract they're
+/// asserting instead of re-implementing the login dance.
+/// </summary>
+internal static class LoginHelper
+{
+    public static async Task<AuthenticationHeaderValue> LoginAsync(
+        HttpClient http, string username, string password)
+    {
+        var resp = await http.PostAsJsonAsync("/auth/login", new { username, password });
+        Assert.True(resp.IsSuccessStatusCode,
+            $"login failed for '{username}': {(int)resp.StatusCode} {await resp.Content.ReadAsStringAsync()}");
+        var payload = await resp.Content.ReadFromJsonAsync<LoginResponse>();
+        Assert.NotNull(payload);
+        Assert.False(string.IsNullOrWhiteSpace(payload!.Token));
+        return new AuthenticationHeaderValue("Bearer", payload.Token);
+    }
+
+    public sealed record LoginResponse(string Token, DateTimeOffset ExpiresAt);
+}

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
@@ -21,11 +21,18 @@ namespace B3.Trading.Conformance.Infrastructure;
 /// <c>tests/B3.Trading.Api.Tests</c>.
 /// </para>
 /// </remarks>
-public sealed record PlatformEndpoint(Uri BaseUrl, string Username, string Password)
+public sealed record PlatformEndpoint(
+    Uri BaseUrl,
+    string Username,
+    string Password,
+    string? AdminUsername = null,
+    string? AdminPassword = null)
 {
     public const string EnvBaseUrl = "B3T_BASE_URL";
     public const string EnvUsername = "B3T_AUTH_USER";
     public const string EnvPassword = "B3T_AUTH_PASS";
+    public const string EnvAdminUsername = "B3T_ADMIN_USER";
+    public const string EnvAdminPassword = "B3T_ADMIN_PASS";
 
     public static PlatformEndpoint? TryResolve()
     {
@@ -43,9 +50,24 @@ public sealed record PlatformEndpoint(Uri BaseUrl, string Username, string Passw
         if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
             return null;
 
-        return new PlatformEndpoint(uri, user, pass);
+        // Admin creds are optional — scenarios that need them skip
+        // individually via HasAdminCredentials.
+        var adminUser = Environment.GetEnvironmentVariable(EnvAdminUsername);
+        var adminPass = Environment.GetEnvironmentVariable(EnvAdminPassword);
+        var hasAdmin = !string.IsNullOrWhiteSpace(adminUser) && !string.IsNullOrWhiteSpace(adminPass);
+
+        return new PlatformEndpoint(
+            uri, user, pass,
+            hasAdmin ? adminUser : null,
+            hasAdmin ? adminPass : null);
     }
+
+    public bool HasAdminCredentials =>
+        !string.IsNullOrWhiteSpace(AdminUsername) && !string.IsNullOrWhiteSpace(AdminPassword);
 
     public const string SkipReason =
         "Conformance platform not configured. Set B3T_BASE_URL, B3T_AUTH_USER, B3T_AUTH_PASS to run.";
+
+    public const string AdminSkipReason =
+        "Admin scenario skipped: B3T_ADMIN_USER / B3T_ADMIN_PASS not configured.";
 }

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Admin/AdminFirmsSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Admin/AdminFirmsSpecTests.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Admin;
+
+/// <summary>
+/// Spec — Admin. <c>GET /admin/firms</c> is the operator-facing
+/// inventory of configured exchange firms. Its shape is part of the
+/// platform's public contract because dashboards and ops scripts depend
+/// on it; this scenario locks in <c>{ mode, firms[] }</c> with the
+/// per-firm field set documented for each entry.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class AdminFirmsSpecTests
+{
+    [ConformanceFact(RequiresAdmin = true)]
+    public async Task AdminFirms_ReturnsModeAndFirmsArrayShape()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+        var auth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/admin/firms");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+
+        // Parse as JsonElement to assert on the wire shape, not on a DTO
+        // that only the suite knows about. The dashboard side will do
+        // the same: pluck `.mode` and `.firms[].firmId`.
+        var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.String, json.GetProperty("mode").ValueKind);
+        var firms = json.GetProperty("firms");
+        Assert.Equal(JsonValueKind.Array, firms.ValueKind);
+
+        // Every firm entry — if any — must carry the documented keys.
+        // The default compose stack runs Mode=Unavailable with no firms,
+        // so the array can be empty; if a deployment configures firms
+        // they must conform to the shape.
+        foreach (var firm in firms.EnumerateArray())
+        {
+            Assert.Equal(JsonValueKind.String, firm.GetProperty("firmId").ValueKind);
+            Assert.True(firm.TryGetProperty("endpoint", out _),
+                "firm entry missing 'endpoint'");
+            Assert.True(firm.TryGetProperty("sessionId", out _),
+                "firm entry missing 'sessionId'");
+            // sessionState/sessionVerId/reconnecting are optional in semantics
+            // (null when no live registry attached for Mock/Stub/Unavailable
+            // modes) but the keys must be present so the schema is stable.
+            Assert.True(firm.TryGetProperty("sessionState", out _));
+            Assert.True(firm.TryGetProperty("sessionVerId", out _));
+            Assert.True(firm.TryGetProperty("reconnecting", out _));
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Auth/AuthRejectionTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Auth/AuthRejectionTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Headers;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Auth;
+
+/// <summary>
+/// Spec — Auth (negative paths). The platform's Authorization contract
+/// must reject anonymous, malformed, and insufficient-scope requests
+/// before they reach business logic. Each scenario asserts the surface
+/// status code, not internal behaviour, so the tests survive refactors
+/// of the underlying handlers.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class AuthRejectionTests
+{
+    [ConformanceFact]
+    public async Task ProtectedHttp_WithoutToken_Returns401()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var resp = await http.GetAsync("/orders");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [ConformanceFact]
+    public async Task ProtectedHttp_WithGarbageBearer_Returns401()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/orders");
+        // Looks superficially like a JWT (3 base64url segments) but the
+        // signature won't validate against the platform's signing key.
+        req.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJoYWNrZXIifQ.notavalidsignature");
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [ConformanceFact]
+    public async Task WebSocketUpgrade_WithoutToken_IsRejected()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        // Plain HTTP GET with an Upgrade hint: ASP.NET Core's auth
+        // middleware runs before the WS handshake, so an unauthenticated
+        // request should short-circuit with 401 (not the 101 Switching
+        // Protocols an authenticated peer would see).
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/ws");
+        req.Headers.Add("Upgrade", "websocket");
+        req.Headers.Add("Connection", "Upgrade");
+        req.Headers.Add("Sec-WebSocket-Version", "13");
+        req.Headers.Add("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [ConformanceFact]
+    public async Task AdminEndpoint_WithUserRole_Returns403()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+        var auth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/admin/firms");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+
+        // Authenticated but lacking the admin role: must surface as 403,
+        // not 401 (which would indicate a missing/invalid token instead
+        // of an authorization decision).
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+}

--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -16,6 +16,19 @@
 # always invoked explicitly via `run --rm`.
 
 services:
+  # Add an admin-role seed user so the conformance suite can hit /admin/*.
+  # Reuses alice's hash/salt (PBKDF2 is deterministic on plaintext+salt)
+  # under a different username + role=admin, so no extra secret-management
+  # is required.
+  trading-host:
+    environment:
+      Trading__Auth__Users__1__Username: ${TRADING_ADMIN_USER:-carol}
+      Trading__Auth__Users__1__PasswordHash: ${TRADING_SEED_PASSWORD_HASH:?Set TRADING_SEED_PASSWORD_HASH in .env (PBKDF2 base64)}
+      Trading__Auth__Users__1__Salt: ${TRADING_SEED_PASSWORD_SALT:?Set TRADING_SEED_PASSWORD_SALT in .env (base64)}
+      Trading__Auth__Users__1__Iterations: "600000"
+      Trading__Auth__Users__1__Role: admin
+      Trading__Auth__Users__1__Firm: default
+
   conformance:
     build:
       context: ..
@@ -33,5 +46,10 @@ services:
       # _SALT. Default `wonderland` matches the seeds committed in
       # .env.example. Override in .env when rotating.
       B3T_AUTH_PASS: ${TRADING_SEED_PASSWORD:-wonderland}
+      # Admin user for /admin/* coverage. Reuses the same PBKDF2 hash/salt
+      # because PBKDF2 is deterministic for a given plaintext+salt — same
+      # password material, different username + admin role.
+      B3T_ADMIN_USER: ${TRADING_ADMIN_USER:-carol}
+      B3T_ADMIN_PASS: ${TRADING_SEED_PASSWORD:-wonderland}
     networks:
       - b3-net


### PR DESCRIPTION
Lands the unblocked half of #22. Gap-recovery + multi-firm-isolation + synthetic-Terminate scenarios are still gated on TestPeer 0.9.0 — to be picked up when the dependency lands.

## New scenarios (5)

| Spec | What it locks in |
| --- | --- |
| `ProtectedHttp_WithoutToken_Returns401` | Bare `GET /orders` is rejected. |
| `ProtectedHttp_WithGarbageBearer_Returns401` | Well-shaped JWT with invalid signature → 401. Catches "the platform only checks the token shape" regressions. |
| `WebSocketUpgrade_WithoutToken_IsRejected` | Auth middleware short-circuits the `/ws` handshake to 401 instead of letting it upgrade. |
| `AdminEndpoint_WithUserRole_Returns403` | `alice` (user role) hitting `/admin/firms` must be **403**, not 401 — distinguishes "unauthorized" from "unauthenticated". |
| `AdminFirms_ReturnsModeAndFirmsArrayShape` | `/admin/firms` contract: `{ mode, firms[] }` with per-firm `{ firmId, endpoint, sessionId, sessionState, sessionVerId, reconnecting }` keys always present (values may be null). |

## Infrastructure

- **`LoginHelper`** — centralises the `POST /auth/login` → `AuthenticationHeaderValue` dance.
- **`ConformanceFactAttribute.RequiresAdmin`** — when the deployment didn't surface admin creds (`B3T_ADMIN_USER` / `B3T_ADMIN_PASS`), admin-scoped scenarios skip cleanly at discovery time. When `B3T_REQUIRE_CONFIGURED=true` (set by the conformance Docker image) the basic-creds gate still hard-fails as before.
- **`PlatformEndpoint`** — optional `AdminUsername` / `AdminPassword` + `HasAdminCredentials`.

## Compose

- `docker-compose.conformance.yml` seeds a second user (`carol`, role `admin`) on `trading-host`, reusing `alice`'s PBKDF2 hash/salt because PBKDF2 is deterministic for plaintext+salt — no extra secret-management needed.
- The `conformance` service gets `B3T_ADMIN_USER` / `B3T_ADMIN_PASS` so the admin-shape scenario can run.

## Validated locally

```
6/6 conformance scenarios PASS against docker compose
196/196 unit tests PASS
dotnet format --verify-no-changes clean
```

## Still blocked (tracked on #22)

- Synthetic peer-side `Terminate` → asserts `session_state` gauge transitions through Reconnecting → Establishing → Established.
- Peer skips a SeqNum → asserts `gap_detected` counter + automatic reconnect.
- Multi-firm isolation: ER for firm A doesn't leak to firm B's stream.
- Warm-restart: `SessionVerId` resumes from disk after process restart.

These need TestPeer 0.9.0's outbound-frame injection. Will land in a follow-up once the dep is published.
