### PR TITLE
frontend: operability badges (in-flight, reconnect countdown, firms health)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -179,3 +179,24 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
   padding: .35rem .8rem; font-weight: 600; cursor: pointer; align-self: flex-start;
 }
 .market-data h2 { display: flex; align-items: center; gap: .55rem; }
+
+/* ---------- Operability badges (added in frontend hardening pass) ---------- */
+.reconnect-countdown {
+  font-size: .7rem; color: var(--warn); font-variant-numeric: tabular-nums;
+}
+.role-badge {
+  background: rgba(79,158,255,.15); color: var(--accent);
+  padding: .1rem .45rem; border-radius: 999px; font-size: .65rem;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.firms-health {
+  padding: .15rem .55rem; border-radius: 999px; font-size: .7rem;
+  border: 1px solid var(--border); cursor: help;
+}
+.firms-health-ok    { background: rgba(54,196,111,.12); color: var(--green); border-color: rgba(54,196,111,.35); }
+.firms-health-warn  { background: rgba(245,166,35,.12); color: var(--warn);  border-color: rgba(245,166,35,.35); }
+.firms-health-muted { background: var(--panel-2); color: var(--muted); }
+.inflight {
+  margin: .25rem 0 0; font-size: .75rem; color: var(--warn);
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,8 +34,11 @@
     <header class="topbar">
       <div class="brand">B3TradingPlatform <span class="pill">trader</span></div>
       <div class="status">
+        <span id="firms-health" class="firms-health" hidden></span>
         <span id="ws-status" class="status-pill status-disconnected" title="WebSocket connection">disconnected</span>
+        <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
         <span id="user-label" class="user-label"></span>
+        <span id="user-role" class="role-badge" hidden></span>
         <button id="logout" class="link-button" type="button">Logout</button>
       </div>
     </header>
@@ -76,6 +79,7 @@
             </label>
           </div>
           <button type="submit" id="ticket-submit">Submit</button>
+          <p id="ticket-inflight" class="inflight" hidden></p>
           <p id="ticket-feedback" class="feedback" hidden></p>
         </form>
       </section>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,18 +1,21 @@
 // App entry point: wires login → worker → state → UI together.
 
-import { defaultBackend, login, submitOrder, cancelOrder } from "./protocol.js";
+import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms } from "./protocol.js";
+import { claimsFromToken } from "./jwt.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
 
 const SESSION_KEY = "b3tp.session";
 const MD_KEY = "b3tp.md";
 const DEFAULT_WATCHLIST = ["PETR4", "VALE3"];
+const FIRMS_POLL_INTERVAL_MS = 5_000;
 
 let worker = null;
 let mdWorker = null;
-let session = null;          // { token, expiresAt, username, backend }
+let session = null;          // { token, expiresAt, username, backend, role, firm }
 let mdConfig = null;         // { url, symbols }
 let expiryTimer = null;
+let firmsPollTimer = null;
 
 function init() {
   document.getElementById("login-backend").placeholder = defaultBackend();
@@ -38,7 +41,15 @@ async function onLogin(e) {
   const password = document.getElementById("login-password").value;
   try {
     const resp = await login(backend, username, password);
-    const next = { token: resp.token, expiresAt: resp.expiresAt, username, backend };
+    const claims = claimsFromToken(resp.token);
+    const next = {
+      token: resp.token,
+      expiresAt: resp.expiresAt,
+      username,
+      backend,
+      role: claims.role,
+      firm: claims.firm,
+    };
     writeSession(next);
     startSession(next);
   } catch (err) {
@@ -47,14 +58,29 @@ async function onLogin(e) {
 }
 
 function startSession(next) {
+  // Backfill claims for sessions persisted before this field existed.
+  if (next.role == null || next.firm == null) {
+    const claims = claimsFromToken(next.token);
+    next = { ...next, role: next.role ?? claims.role, firm: next.firm ?? claims.firm };
+  }
   session = next;
-  state.setUser({ username: next.username, expiresAt: next.expiresAt, backend: next.backend });
+  state.setUser({
+    username: next.username,
+    expiresAt: next.expiresAt,
+    backend: next.backend,
+    role: next.role,
+    firm: next.firm,
+  });
   state.clearAll();
   state.setStatus("connecting");
+  state.setSubmitInflight(null);
+  state.setWsReconnect(null);
+  state.setFirmsHealth(null);
   ui.showTrader();
 
   startWorker();
   startMdWorker();
+  startFirmsPoll();
   scheduleExpiry();
 }
 
@@ -172,6 +198,9 @@ function onMdWorkerMessage(msg) {
 function onWorkerMessage(msg) {
   switch (msg.type) {
     case "status":              state.setStatus(msg.value); break;
+    case "reconnect.scheduled":
+      state.setWsReconnect(msg.nextAt ? { nextAt: msg.nextAt } : null);
+      break;
     case "clear":               state.clearAll(); break;
     case "orders.snapshot":     state.applyOrdersSnapshot(msg.data); break;
     case "orders.delta":        state.applyOrdersDelta(msg.data); break;
@@ -197,6 +226,7 @@ async function handleSubmitOrder(payload) {
 
   ui.setTicketSubmitting(true);
   ui.setTicketFeedback(null);
+  state.setSubmitInflight({ startedAt: Date.now() });
   try {
     const resp = await submitOrder(session.backend, session.token, payload);
     ui.setTicketFeedback(`accepted: ${resp.clOrdId}${resp.status ? ` (${resp.status})` : ""}`, "ok");
@@ -206,6 +236,7 @@ async function handleSubmitOrder(payload) {
     ui.setTicketFeedback(err.message || "submit failed", "error");
   } finally {
     ui.setTicketSubmitting(false);
+    state.setSubmitInflight(null);
   }
 }
 
@@ -221,6 +252,7 @@ async function handleCancelOrder(clOrdId) {
 
 function logout() {
   if (expiryTimer) { clearTimeout(expiryTimer); expiryTimer = null; }
+  stopFirmsPoll();
   if (worker) {
     try { worker.postMessage({ type: "stop" }); } catch { /* swallow */ }
     worker.terminate();
@@ -238,10 +270,43 @@ function logout() {
   state.setUser(null);
   state.setStatus("disconnected");
   state.setMarketDataStatus("disconnected");
+  state.setSubmitInflight(null);
+  state.setWsReconnect(null);
+  state.setFirmsHealth(null);
   state.clearAll();
   state.clearMarketData();
   state.setWatchlist([]);
   ui.showLogin();
+}
+
+// ── Admin firms poll ───────────────────────────────────────────────
+// Only admins can hit /admin/firms (backend returns 403 otherwise).
+// We gate the call client-side too so the network panel stays clean.
+
+function startFirmsPoll() {
+  stopFirmsPoll();
+  if (!session || session.role !== "admin") return;
+  // Fire once immediately so the badge shows up without waiting a tick.
+  pollFirmsOnce();
+  firmsPollTimer = setInterval(pollFirmsOnce, FIRMS_POLL_INTERVAL_MS);
+}
+
+function stopFirmsPoll() {
+  if (firmsPollTimer) { clearInterval(firmsPollTimer); firmsPollTimer = null; }
+}
+
+async function pollFirmsOnce() {
+  if (!session) return;
+  try {
+    const resp = await getAdminFirms(session.backend, session.token);
+    state.setFirmsHealth({ ...resp, fetchedAt: Date.now() });
+  } catch (err) {
+    if (err.status === 401) { logout(); return; }
+    // 403 here means the JWT role drifted; stop polling so we don't
+    // hammer the endpoint with rejected calls.
+    if (err.status === 403) { stopFirmsPoll(); return; }
+    console.warn("[admin/firms]", err);
+  }
 }
 
 function readSession() {

--- a/frontend/js/jwt.js
+++ b/frontend/js/jwt.js
@@ -1,0 +1,27 @@
+// Tiny JWT helper. We do NOT verify the signature here — the backend
+// is the source of truth for authorization. The decoded payload is
+// used only for cosmetic UX decisions (showing/hiding admin areas,
+// labelling the user). Treat any value derived from this as untrusted.
+
+export function decodeJwt(token) {
+  if (typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
+    const json = atob(padded);
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function claimsFromToken(token) {
+  const payload = decodeJwt(token) ?? {};
+  return {
+    role: typeof payload.role === "string" ? payload.role : null,
+    firm: typeof payload.firm === "string" ? payload.firm : null,
+    sub:  typeof payload.sub  === "string" ? payload.sub  : null,
+  };
+}

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -47,3 +47,13 @@ export async function cancelOrder(backend, token, clOrdId) {
   if (resp.status === 204 || resp.status === 404) return null;
   return jsonOrThrow(resp);
 }
+
+// Admin-only: per-firm operator visibility. Returns 403 for non-admin
+// callers — the UI must gate the call by inspecting the JWT role
+// before invoking this. Schema mirrors AdminEndpoints.MapAdmin /firms.
+export async function getAdminFirms(backend, token) {
+  const resp = await fetch(`${backend}/admin/firms`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -10,10 +10,14 @@ const state = {
   positions: new Map(),    // Symbol  -> PositionDto
   executions: [],          // bounded ring of ExecutionDto
   status: "disconnected",  // disconnected | connecting | connected
-  user: null,              // { username, expiresAt, token, backend, firm }
+  user: null,              // { username, expiresAt, token, backend, firm, role }
   marketData: new Map(),   // Symbol -> { lastPrice, lastQty, lastTradeId, updatedAt, info }
   marketDataStatus: "disconnected", // disconnected | connecting | connected | not_ready
   watchlist: [],           // [string] symbols (UPPERCASE)
+  // UX-only slices added in the operability pass.
+  submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
+  wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
+  firmsHealth: null,       // { mode, firms, fetchedAt } | null — admin-only poll of /admin/firms
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -127,4 +131,21 @@ export function setWatchlist(symbols) {
 
 export function isTerminalOrderStatus(status) {
   return TERMINAL_ORDER_STATUSES.has(status);
+}
+
+// ── UX-only slices (operability pass) ──────────────────────────────
+
+export function setSubmitInflight(value) {
+  state.submitInflight = value;
+  notify("submitInflight");
+}
+
+export function setWsReconnect(value) {
+  state.wsReconnect = value;
+  notify("wsReconnect");
+}
+
+export function setFirmsHealth(value) {
+  state.firmsHealth = value;
+  notify("firmsHealth");
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -125,16 +125,90 @@ export function setStatusPill(status) {
 
 export function setUserLabel(user) {
   $("user-label").textContent = user ? `${user.username}` : "";
+  const roleEl = $("user-role");
+  if (!roleEl) return;
+  if (user?.role && user.role !== "user") {
+    roleEl.textContent = user.role;
+    roleEl.hidden = false;
+  } else {
+    roleEl.textContent = "";
+    roleEl.hidden = true;
+  }
+}
+
+// Periodic UI tick for time-based elements (in-flight elapsed, reconnect
+// countdown). Started lazily on first render so SSR / non-browser hosts
+// stay quiet.
+let tickTimer = null;
+function ensureTicker() {
+  if (tickTimer) return;
+  tickTimer = setInterval(() => {
+    renderInflight();
+    renderReconnect();
+  }, 250);
+}
+
+function renderInflight() {
+  const el = $("ticket-inflight");
+  if (!el) return;
+  const inflight = getState().submitInflight;
+  if (!inflight) { el.hidden = true; el.textContent = ""; return; }
+  const elapsed = Math.max(0, Date.now() - inflight.startedAt);
+  el.hidden = false;
+  el.textContent = `awaiting ACK… ${elapsed} ms`;
+}
+
+function renderReconnect() {
+  const el = $("ws-reconnect");
+  if (!el) return;
+  const r = getState().wsReconnect;
+  if (!r || !r.nextAt) { el.hidden = true; el.textContent = ""; return; }
+  const remaining = Math.max(0, r.nextAt - Date.now());
+  el.hidden = false;
+  el.textContent = `retry in ${(remaining / 1000).toFixed(1)}s`;
+}
+
+function renderFirmsHealth() {
+  const el = $("firms-health");
+  if (!el) return;
+  const fh = getState().firmsHealth;
+  if (!fh || !Array.isArray(fh.firms) || fh.firms.length === 0) {
+    el.hidden = true;
+    el.textContent = "";
+    el.title = "";
+    return;
+  }
+  // Pick the worst-state firm to drive the badge colour, but show the
+  // full list in the tooltip so an admin sees per-firm state at a glance.
+  const ranked = fh.firms.map(f => ({
+    firmId: f.firmId,
+    state: f.sessionState ?? "unknown",
+    reconnecting: !!f.reconnecting,
+  }));
+  const anyReconnecting = ranked.some(r => r.reconnecting);
+  const allEstablished = ranked.every(r => r.state === "Established");
+  const tone = anyReconnecting ? "warn" : (allEstablished ? "ok" : "muted");
+  const summary = `${ranked.length} firm${ranked.length === 1 ? "" : "s"}`;
+  el.hidden = false;
+  el.className = `firms-health firms-health-${tone}`;
+  el.textContent = `${summary} · ${fh.mode}`;
+  el.title = ranked.map(r => `${r.firmId}: ${r.state}${r.reconnecting ? " (reconnecting)" : ""}`).join("\n");
 }
 
 function renderForSlice(slice) {
   if (slice === "orders" || slice === "all") renderBlotter();
   if (slice === "positions" || slice === "all") renderPositions();
   if (slice === "executions" || slice === "all") renderExecutions();
-  if (slice === "status") setStatusPill(getState().status);
+  if (slice === "status") {
+    setStatusPill(getState().status);
+    renderReconnect(); // pill change usually correlates with countdown reset
+  }
   if (slice === "user")   setUserLabel(getState().user);
   if (slice === "marketData" || slice === "all") renderMarketData();
   if (slice === "marketDataStatus") setMdStatusPill(getState().marketDataStatus);
+  if (slice === "submitInflight") renderInflight();
+  if (slice === "wsReconnect") renderReconnect();
+  if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
 }
 
 function renderAll() {
@@ -145,6 +219,10 @@ function renderAll() {
   setUserLabel(getState().user);
   renderMarketData();
   setMdStatusPill(getState().marketDataStatus);
+  renderInflight();
+  renderReconnect();
+  renderFirmsHealth();
+  ensureTicker();
 }
 
 function setMdStatusPill(status) {

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -34,6 +34,8 @@ function scheduleReconnect() {
   const delay = Math.min(15_000, 500 * Math.pow(2, attempt++));
   reconnectTimer = setTimeout(connect, delay);
   post({ type: "status", value: "connecting" });
+  // Surface the next attempt timestamp so the UI can show a countdown.
+  post({ type: "reconnect.scheduled", nextAt: Date.now() + delay });
 }
 
 function wsUrl() {
@@ -66,6 +68,7 @@ function connect() {
   socket.onopen = () => {
     attempt = 0;
     post({ type: "status", value: "connected" });
+    post({ type: "reconnect.scheduled", nextAt: null });
     send({ type: "subscribe", channels: CHANNELS });
   };
 


### PR DESCRIPTION
First slice of the frontend hardening pass tracked in #30 — section 1 (visibilidade operacional). Pure UX, no backend / protocol / dependency changes.

## What this adds

- **JWT client-side decode** (`frontend/js/jwt.js`) — cosmetic only. Backend stays the authorization source of truth; the decoded role is used purely to show/hide UI affordances.
- **Role pill** in the topbar for non-default roles, so admin sessions are visually obvious.
- **Firms-health badge** in the topbar — polls `/admin/firms` every 5s for admin users, colours ok/warn/muted based on the worst firm, lists per-firm `sessionState` + `reconnecting` flag in the tooltip. Non-admin users never see it and never issue the request.
- **WS reconnect countdown** next to the status pill — worker now posts `reconnect.scheduled` with the next attempt timestamp (cleared on successful open); UI ticks at 250ms to render `retry in X.Xs`.
- **Order ticket in-flight indicator** — shows live ms elapsed between POST `/orders` and the response, complementing the server-side `order_entry_call_ms` histogram from #26.

## What this does NOT change

- No new endpoints or backend wiring (uses existing `/admin/firms` from #25).
- No new dependencies, no build step introduced (still vanilla JS + Web Workers).
- No backend tests modified — all 196 still green.
- Format check verified clean.

## Out of scope (deferred to next PRs against #30)

- Section 2: admin view (firms grid + EOD button + per-firm killswitch toggle).
- Section 3: blotter filter/search, fat-finger guard, keyboard shortcuts.
- Section 4: CSP and security headers, proactive token refresh.
- Section 5: ARIA pass and headless smoke test.

## Validation

- `dotnet format --verify-no-changes` — clean.
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 196 passed (6 conformance skipped, expected without the docker stack).
- `node --check` on every JS file — all parse.

Manual UX validation requires the docker stack; recommend smoke-checking the badge against a `Real`-mode firm + a `Mock`-mode firm to confirm the warn/muted variants render correctly.

Closes part of #30.
