### PR TITLE
frontend: admin view (firms grid, killswitch toggles, EOD trigger)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -200,3 +200,49 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
   margin: .25rem 0 0; font-size: .75rem; color: var(--warn);
   font-variant-numeric: tabular-nums;
 }
+
+/* ---------- View toggle + admin view ---------- */
+.view-toggle {
+  display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden;
+}
+.view-toggle button {
+  background: transparent; color: var(--muted); border: 0; padding: .25rem .75rem;
+  font: inherit; cursor: pointer; font-size: .75rem;
+}
+.view-toggle button.active { background: var(--accent); color: #0b1320; }
+.view-toggle button:not(.active):hover { color: var(--text); }
+
+.admin-view { display: flex; flex-direction: column; height: 100vh; overflow: auto; padding: 1rem; gap: 1rem; }
+.admin-subbar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: .5rem 0; border-bottom: 1px solid var(--border);
+}
+.admin-subbar h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+.admin-subbar #admin-mode { color: var(--accent); font-weight: 600; }
+.admin-panel { background: var(--panel); border: 1px solid var(--border); border-radius: 6px; padding: .75rem 1rem; }
+.admin-panel h3 { margin: 0 0 .6rem; font-size: .9rem; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+.admin-inline-form { display: flex; gap: .5rem; margin-bottom: .6rem; }
+.admin-inline-form input {
+  flex: 1; background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: .35rem .5rem; font: inherit;
+}
+.admin-eod-output {
+  margin: .6rem 0 0; padding: .5rem; background: var(--panel-2); border: 1px solid var(--border);
+  border-radius: 4px; font: 11px/1.4 ui-monospace, Menlo, Consolas, monospace;
+  white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow: auto;
+}
+.danger-btn {
+  border: 0; padding: .35rem .75rem; border-radius: 4px; cursor: pointer; font: inherit; font-size: .75rem;
+  text-transform: uppercase; letter-spacing: .04em; font-weight: 600;
+}
+.danger-btn.engage { background: rgba(239,83,80,.18); color: var(--red); }
+.danger-btn.engage:hover { background: rgba(239,83,80,.32); }
+.danger-btn.revive { background: rgba(54,196,111,.18); color: var(--green); }
+.danger-btn.revive:hover { background: rgba(54,196,111,.32); }
+.killed-tag {
+  display: inline-block; padding: .05rem .4rem; border-radius: 3px;
+  background: rgba(239,83,80,.18); color: var(--red);
+  font-size: .65rem; text-transform: uppercase; letter-spacing: .04em;
+  margin-right: .35rem;
+}
+.muted { color: var(--muted); text-align: center; padding: .8rem; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,10 @@
     <header class="topbar">
       <div class="brand">B3TradingPlatform <span class="pill">trader</span></div>
       <div class="status">
+        <span id="view-toggle" class="view-toggle" hidden>
+          <button type="button" data-view="trader" class="active">Trader</button>
+          <button type="button" data-view="admin">Admin</button>
+        </span>
         <span id="firms-health" class="firms-health" hidden></span>
         <span id="ws-status" class="status-pill status-disconnected" title="WebSocket connection">disconnected</span>
         <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
@@ -154,6 +158,52 @@
         </div>
       </section>
     </main>
+  </section>
+
+  <!-- ADMIN VIEW ------------------------------------------------------- -->
+  <section id="admin-view" class="view admin-view" hidden>
+    <header class="admin-subbar">
+      <h2>Operator console — mode: <span id="admin-mode">—</span></h2>
+      <div class="admin-actions">
+        <button id="admin-refresh" type="button" class="link-button">Refresh</button>
+      </div>
+    </header>
+    <p id="admin-feedback" class="feedback" hidden></p>
+
+    <section class="panel admin-panel">
+      <h3>Firms</h3>
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Firm</th><th>Endpoint</th><th>SessionId</th>
+              <th>State</th><th class="num">VerId</th><th>Reconn</th><th></th>
+            </tr>
+          </thead>
+          <tbody id="admin-firms-body"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel admin-panel">
+      <h3>End-clients (killed)</h3>
+      <form id="admin-add-ec-form" class="admin-inline-form">
+        <input id="admin-add-ec-id" type="text" placeholder="end-client id" maxlength="64" />
+        <button type="submit" class="danger-btn engage">Engage killswitch</button>
+      </form>
+      <div class="table-scroll">
+        <table>
+          <thead><tr><th>EndClient</th><th></th></tr></thead>
+          <tbody id="admin-endclient-body"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel admin-panel">
+      <h3>EOD materialisation</h3>
+      <button id="admin-eod-btn" type="button">Run EOD now</button>
+      <pre id="admin-eod-output" class="admin-eod-output" hidden></pre>
+    </section>
   </section>
 
   <script type="module" src="js/app.js"></script>

--- a/frontend/js/adminUi.js
+++ b/frontend/js/adminUi.js
@@ -1,0 +1,184 @@
+// Admin view: firms grid, killswitch toggles, EOD trigger.
+// Visible only when the JWT role is "admin"; the DOM is mounted but
+// hidden for non-admin sessions and the network calls are gated in
+// app.js as well so 403s don't pollute logs if the role drifts.
+
+import { getState, subscribe } from "./state.js";
+
+const $ = (id) => document.getElementById(id);
+
+let onToggleFirm = () => {};
+let onToggleEndClient = () => {};
+let onAddEndClient = () => {};
+let onRunEod = () => {};
+let onRefresh = () => {};
+
+export function setAdminHandlers(handlers) {
+  onToggleFirm      = handlers.onToggleFirm      ?? onToggleFirm;
+  onToggleEndClient = handlers.onToggleEndClient ?? onToggleEndClient;
+  onAddEndClient    = handlers.onAddEndClient    ?? onAddEndClient;
+  onRunEod          = handlers.onRunEod          ?? onRunEod;
+  onRefresh         = handlers.onRefresh         ?? onRefresh;
+}
+
+export function bindAdminUi() {
+  $("admin-refresh").addEventListener("click", () => onRefresh());
+
+  $("admin-firms-body").addEventListener("click", (e) => {
+    const btn = e.target.closest(".firm-toggle");
+    if (!btn) return;
+    const firmId = btn.dataset.firm;
+    const engage = btn.dataset.action === "engage";
+    if (!confirmTwice(
+      `Killswitch ${engage ? "ENGAGE" : "REVIVE"} for firm ${firmId}?`,
+      `Confirm: ${engage ? "engage" : "revive"} ${firmId}. This affects ALL traders in the firm.`,
+    )) return;
+    onToggleFirm({ firmId, engage });
+  });
+
+  $("admin-endclient-body").addEventListener("click", (e) => {
+    const btn = e.target.closest(".ec-revive");
+    if (!btn) return;
+    const id = btn.dataset.ec;
+    if (!confirmTwice(
+      `Revive end-client ${id}?`,
+      `Confirm: revive ${id}. They will be allowed to send orders again.`,
+    )) return;
+    onToggleEndClient({ id, engage: false });
+  });
+
+  $("admin-add-ec-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const id = $("admin-add-ec-id").value.trim();
+    if (!id) return;
+    if (!confirmTwice(
+      `ENGAGE killswitch for end-client ${id}?`,
+      `Confirm: engage ${id}. They will be unable to send orders.`,
+    )) return;
+    onAddEndClient({ id });
+    $("admin-add-ec-id").value = "";
+  });
+
+  $("admin-eod-btn").addEventListener("click", () => {
+    if (!confirmTwice(
+      "Run EOD materialisation now?",
+      "Confirm: run EOD against today's WAL. This is normally scheduled.",
+    )) return;
+    onRunEod();
+  });
+
+  subscribe(renderForSlice);
+}
+
+function confirmTwice(first, second) {
+  return window.confirm(first) && window.confirm(second);
+}
+
+function renderForSlice(slice) {
+  if (slice === "firmsHealth" || slice === "killStatus" || slice === "all") renderFirms();
+  if (slice === "killStatus"  || slice === "all") renderEndClients();
+  if (slice === "eodReport"   || slice === "all") renderEod();
+  if (slice === "currentView") onViewChanged();
+}
+
+function onViewChanged() {
+  // No-op hook for now; app.js drives view show/hide. Kept so the admin
+  // panel re-renders when first revealed (state may have arrived while
+  // the trader view was on top).
+  if (getState().currentView === "admin") {
+    renderFirms();
+    renderEndClients();
+    renderEod();
+  }
+}
+
+export function renderAdminAll() {
+  renderFirms();
+  renderEndClients();
+  renderEod();
+}
+
+function renderFirms() {
+  const body = $("admin-firms-body");
+  if (!body) return;
+  const fh = getState().firmsHealth;
+  const ks = getState().killStatus;
+  if (!fh || !Array.isArray(fh.firms)) {
+    body.innerHTML = `<tr><td colspan="6" class="muted">awaiting /admin/firms…</td></tr>`;
+    setText("admin-mode", "—");
+    return;
+  }
+  setText("admin-mode", fh.mode ?? "—");
+  const killedFirms = new Set(ks?.firms ?? []);
+  body.innerHTML = fh.firms.map(f => {
+    const killed = killedFirms.has(f.firmId);
+    const stateLabel = f.sessionState ?? "—";
+    const verId = f.sessionVerId ?? "—";
+    const reconn = f.reconnecting ? "yes" : "no";
+    const action = killed ? "revive" : "engage";
+    const btnLabel = killed ? "Revive" : "Killswitch";
+    const btnClass = killed ? "danger-btn revive" : "danger-btn engage";
+    return `<tr>
+      <td><code>${escapeHtml(f.firmId)}</code></td>
+      <td>${escapeHtml(f.endpoint ?? "—")}</td>
+      <td>${escapeHtml(f.sessionId ?? "—")}</td>
+      <td>${escapeHtml(stateLabel)}</td>
+      <td class="num">${escapeHtml(String(verId))}</td>
+      <td>${reconn}</td>
+      <td>${killed ? `<span class="killed-tag">KILLED</span>` : ""}
+        <button type="button" class="firm-toggle ${btnClass}"
+                data-firm="${escapeHtml(f.firmId)}" data-action="${action}">
+          ${btnLabel}
+        </button></td>
+    </tr>`;
+  }).join("");
+}
+
+function renderEndClients() {
+  const body = $("admin-endclient-body");
+  if (!body) return;
+  const ks = getState().killStatus;
+  if (!ks) {
+    body.innerHTML = `<tr><td colspan="2" class="muted">awaiting /admin/kill…</td></tr>`;
+    return;
+  }
+  const list = ks.endClients ?? [];
+  if (list.length === 0) {
+    body.innerHTML = `<tr><td colspan="2" class="muted">no killed end-clients</td></tr>`;
+    return;
+  }
+  body.innerHTML = list.map(id => `<tr>
+    <td><code>${escapeHtml(id)}</code></td>
+    <td><button type="button" class="ec-revive danger-btn revive" data-ec="${escapeHtml(id)}">Revive</button></td>
+  </tr>`).join("");
+}
+
+function renderEod() {
+  const el = $("admin-eod-output");
+  if (!el) return;
+  const r = getState().eodReport;
+  if (!r) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false;
+  const ts = new Date(r.ranAt).toISOString().slice(11, 19);
+  el.textContent = `[${ts}] ${JSON.stringify(r.report, null, 2)}`;
+}
+
+export function setAdminFeedback(message, kind) {
+  const el = $("admin-feedback");
+  if (!el) return;
+  if (!message) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false;
+  el.textContent = message;
+  el.className = `feedback ${kind === "ok" ? "ok" : "error"}`;
+}
+
+function setText(id, text) {
+  const el = $(id);
+  if (el) el.textContent = text;
+}
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[c]
+  ));
+}

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,9 +1,12 @@
 // App entry point: wires login → worker → state → UI together.
 
-import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms } from "./protocol.js";
+import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms,
+         getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
+         runEod } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
+import * as adminUi from "./adminUi.js";
 
 const SESSION_KEY = "b3tp.session";
 const MD_KEY = "b3tp.md";
@@ -21,11 +24,20 @@ function init() {
   document.getElementById("login-backend").placeholder = defaultBackend();
   document.getElementById("login-form").addEventListener("submit", onLogin);
   ui.bindUi();
+  adminUi.bindAdminUi();
   ui.setHandlers({
     onSubmitOrder: handleSubmitOrder,
     onCancelOrder: handleCancelOrder,
     onLogout: logout,
     onApplyMd: handleApplyMd,
+    onSwitchView: handleSwitchView,
+  });
+  adminUi.setAdminHandlers({
+    onToggleFirm:      handleToggleFirm,
+    onToggleEndClient: handleToggleEndClient,
+    onAddEndClient:    handleAddEndClient,
+    onRunEod:          handleRunEod,
+    onRefresh:         refreshAdminData,
   });
 
   const stored = readSession();
@@ -76,6 +88,9 @@ function startSession(next) {
   state.setSubmitInflight(null);
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
+  state.setKillStatus(null);
+  state.setEodReport(null);
+  state.setCurrentView("trader");
   ui.showTrader();
 
   startWorker();
@@ -273,6 +288,9 @@ function logout() {
   state.setSubmitInflight(null);
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
+  state.setKillStatus(null);
+  state.setEodReport(null);
+  state.setCurrentView("trader");
   state.clearAll();
   state.clearMarketData();
   state.setWatchlist([]);
@@ -298,14 +316,78 @@ function stopFirmsPoll() {
 async function pollFirmsOnce() {
   if (!session) return;
   try {
-    const resp = await getAdminFirms(session.backend, session.token);
-    state.setFirmsHealth({ ...resp, fetchedAt: Date.now() });
+    const [firms, kill] = await Promise.all([
+      getAdminFirms(session.backend, session.token),
+      getKillStatus(session.backend, session.token),
+    ]);
+    state.setFirmsHealth({ ...firms, fetchedAt: Date.now() });
+    state.setKillStatus({
+      firms: kill?.Firms ?? [],
+      endClients: kill?.EndClients ?? [],
+      fetchedAt: Date.now(),
+    });
   } catch (err) {
     if (err.status === 401) { logout(); return; }
     // 403 here means the JWT role drifted; stop polling so we don't
     // hammer the endpoint with rejected calls.
     if (err.status === 403) { stopFirmsPoll(); return; }
-    console.warn("[admin/firms]", err);
+    console.warn("[admin/poll]", err);
+  }
+}
+
+// ── Admin view + actions ───────────────────────────────────────────
+
+function handleSwitchView(view) {
+  if (view === "admin" && session?.role !== "admin") return; // safety
+  state.setCurrentView(view);
+  if (view === "admin") refreshAdminData();
+}
+
+async function refreshAdminData() {
+  await pollFirmsOnce();
+}
+
+async function withAdminCall(fn, okMessage) {
+  try {
+    await fn();
+    adminUi.setAdminFeedback(okMessage, "ok");
+    await pollFirmsOnce();
+  } catch (err) {
+    if (err.status === 401) { logout(); return; }
+    if (err.status === 403) { adminUi.setAdminFeedback("forbidden — role lost?", "error"); return; }
+    if (err.status === 503) { adminUi.setAdminFeedback("WAL backpressure — retry shortly", "error"); return; }
+    if (err.status === 409) { adminUi.setAdminFeedback(err.message || "conflict", "error"); return; }
+    adminUi.setAdminFeedback(err.message || "request failed", "error");
+  }
+}
+
+function handleToggleFirm({ firmId, engage }) {
+  withAdminCall(
+    () => (engage ? killFirm : reviveFirm)(session.backend, session.token, firmId),
+    `firm ${firmId}: ${engage ? "killed" : "revived"}`,
+  );
+}
+
+function handleToggleEndClient({ id, engage }) {
+  withAdminCall(
+    () => (engage ? killEndClient : reviveEndClient)(session.backend, session.token, id),
+    `end-client ${id}: ${engage ? "killed" : "revived"}`,
+  );
+}
+
+function handleAddEndClient({ id }) {
+  handleToggleEndClient({ id, engage: true });
+}
+
+async function handleRunEod() {
+  try {
+    const report = await runEod(session.backend, session.token);
+    state.setEodReport({ ranAt: Date.now(), report });
+    adminUi.setAdminFeedback("EOD report generated", "ok");
+  } catch (err) {
+    if (err.status === 401) { logout(); return; }
+    if (err.status === 409) { adminUi.setAdminFeedback("persistence disabled — EOD unavailable", "error"); return; }
+    adminUi.setAdminFeedback(err.message || "EOD failed", "error");
   }
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -57,3 +57,40 @@ export async function getAdminFirms(backend, token) {
   });
   return jsonOrThrow(resp);
 }
+
+// Admin-only: current killswitch state (lists of killed firms /
+// end-clients). Backend: GET /admin/kill -> { EndClients, Firms }.
+export async function getKillStatus(backend, token) {
+  const resp = await fetch(`${backend}/admin/kill`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}
+
+// Admin-only: toggle killswitch. POST = engage, DELETE = revive.
+// Returns 204 on success, 503 on WAL backpressure.
+async function toggleKill(backend, token, scope, id, engage) {
+  const resp = await fetch(
+    `${backend}/admin/kill/${scope}/${encodeURIComponent(id)}`,
+    {
+      method: engage ? "POST" : "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  if (resp.status === 204) return null;
+  return jsonOrThrow(resp);
+}
+
+export const killFirm        = (b, t, id) => toggleKill(b, t, "firm",       id, true);
+export const reviveFirm      = (b, t, id) => toggleKill(b, t, "firm",       id, false);
+export const killEndClient   = (b, t, id) => toggleKill(b, t, "end-client", id, true);
+export const reviveEndClient = (b, t, id) => toggleKill(b, t, "end-client", id, false);
+
+// Admin-only: trigger EOD materialisation. Returns the report or 409
+// when persistence is disabled.
+export async function runEod(backend, token) {
+  const resp = await fetch(`${backend}/admin/eod`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -18,6 +18,9 @@ const state = {
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
   firmsHealth: null,       // { mode, firms, fetchedAt } | null — admin-only poll of /admin/firms
+  killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
+  eodReport: null,         // { ranAt, report } | null — last EOD response in this session
+  currentView: "trader",   // "trader" | "admin" — which view is mounted
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -148,4 +151,20 @@ export function setWsReconnect(value) {
 export function setFirmsHealth(value) {
   state.firmsHealth = value;
   notify("firmsHealth");
+}
+
+export function setKillStatus(value) {
+  state.killStatus = value;
+  notify("killStatus");
+}
+
+export function setEodReport(value) {
+  state.eodReport = value;
+  notify("eodReport");
+}
+
+export function setCurrentView(view) {
+  if (state.currentView === view) return;
+  state.currentView = view;
+  notify("currentView");
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -11,22 +11,36 @@ let onSubmitOrder = () => {};
 let onCancelOrder = () => {};
 let onLogout      = () => {};
 let onApplyMd     = () => {};
+let onSwitchView  = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder = handlers.onSubmitOrder ?? onSubmitOrder;
   onCancelOrder = handlers.onCancelOrder ?? onCancelOrder;
   onLogout      = handlers.onLogout      ?? onLogout;
   onApplyMd     = handlers.onApplyMd     ?? onApplyMd;
+  onSwitchView  = handlers.onSwitchView  ?? onSwitchView;
 }
 
 export function showLogin() {
   $("login-view").hidden = false;
   $("trader-view").hidden = true;
+  $("admin-view").hidden = true;
+  setViewToggleVisible(false, "trader");
 }
 
 export function showTrader() {
   $("login-view").hidden = true;
   $("trader-view").hidden = false;
+  $("admin-view").hidden = true;
+}
+
+function setViewToggleVisible(visible, current) {
+  const wrap = $("view-toggle");
+  if (!wrap) return;
+  wrap.hidden = !visible;
+  for (const btn of wrap.querySelectorAll("button[data-view]")) {
+    btn.classList.toggle("active", btn.dataset.view === current);
+  }
 }
 
 export function setLoginError(message) {
@@ -81,6 +95,17 @@ export function bindUi() {
     onApplyMd({ url, symbols });
   });
 
+  // View toggle (trader / admin) — only wired here, visibility is
+  // gated in app.js based on the JWT role claim.
+  const toggle = $("view-toggle");
+  if (toggle) {
+    toggle.addEventListener("click", (e) => {
+      const btn = e.target.closest("button[data-view]");
+      if (!btn) return;
+      onSwitchView(btn.dataset.view);
+    });
+  }
+
   subscribe(renderForSlice);
   renderAll();
 }
@@ -126,14 +151,32 @@ export function setStatusPill(status) {
 export function setUserLabel(user) {
   $("user-label").textContent = user ? `${user.username}` : "";
   const roleEl = $("user-role");
-  if (!roleEl) return;
-  if (user?.role && user.role !== "user") {
-    roleEl.textContent = user.role;
-    roleEl.hidden = false;
-  } else {
-    roleEl.textContent = "";
-    roleEl.hidden = true;
+  if (roleEl) {
+    if (user?.role && user.role !== "user") {
+      roleEl.textContent = user.role;
+      roleEl.hidden = false;
+    } else {
+      roleEl.textContent = "";
+      roleEl.hidden = true;
+    }
   }
+  // Toggle visibility of the trader/admin view switch based on role.
+  const isAdmin = user?.role === "admin";
+  setViewToggleVisible(isAdmin, getState().currentView);
+}
+
+function applyCurrentView(view) {
+  const trader = $("trader-view");
+  const admin = $("admin-view");
+  if (!trader || !admin) return;
+  if (view === "admin") {
+    trader.hidden = true;
+    admin.hidden = false;
+  } else {
+    trader.hidden = false;
+    admin.hidden = true;
+  }
+  setViewToggleVisible(getState().user?.role === "admin", view);
 }
 
 // Periodic UI tick for time-based elements (in-flight elapsed, reconnect
@@ -209,6 +252,7 @@ function renderForSlice(slice) {
   if (slice === "submitInflight") renderInflight();
   if (slice === "wsReconnect") renderReconnect();
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
+  if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
 }
 
 function renderAll() {


### PR DESCRIPTION
Section 2 of the frontend hardening tracked in #30 — admin-only view that fronts the operator surface (killswitch + EOD) which previously had no UI.

## What this adds

- **Trader / Admin view toggle** in the topbar (cosmetic switch, only visible when the JWT role is `admin`). Server-side authorization is unchanged — the toggle does not grant anything.
- **Firms grid** consuming `/admin/firms` + `/admin/kill`: endpoint, sessionId, sessionState, sessionVerId, reconnecting flag, KILLED badge, and a contextual engage/revive button per row. Polled every 5s.
- **End-clients section** listing currently-killed ids with revive buttons, plus an inline form to engage a new id.
- **EOD section**: button to trigger `POST /admin/eod` with the JSON report rendered inline. Persistence-disabled returns 409 (surfaced); WAL backpressure returns 503 (surfaced).
- **Destructive actions** are gated behind two `window.confirm()` prompts so a stray click cannot disrupt a live firm.

## Endpoints exercised (no protocol changes)

| Method | Path |
|---|---|
| GET    | `/admin/firms` |
| GET    | `/admin/kill` |
| POST   | `/admin/kill/firm/{id}` |
| DELETE | `/admin/kill/firm/{id}` |
| POST   | `/admin/kill/end-client/{id}` |
| DELETE | `/admin/kill/end-client/{id}` |
| POST   | `/admin/eod` |

All already exist on the backend (`AdminEndpoints.cs`); no backend changes in this PR.

## Implementation notes

- `adminUi.js` is a new module mirroring `ui.js`'s pattern (handlers registered by `app.js`, rendering driven by state slices) so `ui.js` stays focused on the trader workspace.
- State gains `killStatus` / `eodReport` / `currentView` slices with thin setters consistent with the existing slice/notify pattern.
- Polling now fetches `/admin/firms` + `/admin/kill` in parallel; gating rules (role check + 401 logout + 403 stop) apply to both.
- Logout resets `currentView` to `trader` and clears all admin state so a follow-up non-admin login does not see stale data.

## Validation

- `dotnet format --verify-no-changes` — clean.
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 184 passed, 6 conformance skipped (expected without docker stack).
- `node --check` on every JS file — all parse.

## Out of scope

- Section 3: blotter filter/search, fat-finger guard, keyboard shortcuts.
- Section 4: CSP and security headers, proactive token refresh.
- Section 5: ARIA pass and headless smoke test.

Closes part of #30.
