### PR TITLE
frontend: blotter+ticket UX (filter, fat-finger, keyboard shortcuts)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -246,3 +246,24 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
   margin-right: .35rem;
 }
 .muted { color: var(--muted); text-align: center; padding: .8rem; }
+
+/* ---------- Blotter filter + row UX (section 3 of #30) ---------- */
+.blotter-filter {
+  display: flex; gap: .4rem; margin-bottom: .4rem;
+}
+.blotter-filter input, .blotter-filter select {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: .25rem .45rem; font: inherit; font-size: .8rem;
+}
+.blotter-filter input { flex: 1; }
+@keyframes row-fresh-fade {
+  0%   { background: rgba(79,158,255,.32); }
+  100% { background: transparent; }
+}
+tr.row-fresh > td { animation: row-fresh-fade 2s ease-out forwards; }
+tr.row-selected > td {
+  outline: 1px solid var(--accent); outline-offset: -1px;
+}
+tr[data-clordid] { cursor: pointer; }
+tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
+.feedback.warn { color: var(--warn); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,6 +91,17 @@
       <!-- BLOTTER ---------------------------------------------------- -->
       <section class="panel blotter">
         <h2>Working orders <span id="blotter-count" class="count">0</span></h2>
+        <div class="blotter-filter">
+          <input id="blotter-filter-text" type="search" placeholder="filter by symbol or ClOrdID" maxlength="32" />
+          <select id="blotter-filter-status">
+            <option value="">all statuses</option>
+            <option value="New">New</option>
+            <option value="PartiallyFilled">PartiallyFilled</option>
+            <option value="Filled">Filled</option>
+            <option value="Cancelled">Cancelled</option>
+            <option value="Rejected">Rejected</option>
+          </select>
+        </div>
         <div class="table-scroll">
           <table id="blotter-table">
             <thead>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4,12 +4,14 @@ import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          runEod } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
+import { validateOrder, fatFingerCheck, payloadKey } from "./validation.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
 import * as adminUi from "./adminUi.js";
 
 const SESSION_KEY = "b3tp.session";
 const MD_KEY = "b3tp.md";
+const BLOTTER_FILTER_KEY = "b3tp.blotter.filter";
 const DEFAULT_WATCHLIST = ["PETR4", "VALE3"];
 const FIRMS_POLL_INTERVAL_MS = 5_000;
 
@@ -31,6 +33,9 @@ function init() {
     onLogout: logout,
     onApplyMd: handleApplyMd,
     onSwitchView: handleSwitchView,
+    onBlotterFilter: handleBlotterFilter,
+    onSelectOrder: handleSelectOrder,
+    onKeyboardCancel: handleKeyboardCancel,
   });
   adminUi.setAdminHandlers({
     onToggleFirm:      handleToggleFirm,
@@ -233,11 +238,28 @@ function onWorkerMessage(msg) {
 
 async function handleSubmitOrder(payload) {
   if (!session) return;
-  if (!payload.symbol)               return ui.setTicketFeedback("symbol required", "error");
-  if (!Number.isFinite(payload.quantity) || payload.quantity <= 0)
-    return ui.setTicketFeedback("quantity must be positive", "error");
-  if (payload.type === "Limit" && (!Number.isFinite(payload.price) || payload.price <= 0))
-    return ui.setTicketFeedback("limit price required", "error");
+
+  const error = validateOrder(payload);
+  if (error) return ui.setTicketFeedback(error.message, "error");
+
+  // Fat-finger guard: first attempt with a >threshold deviation from
+  // the last observed trade is rejected with a warning; the same exact
+  // payload submitted again within the pending window goes through.
+  const lastPrice = state.getState().marketData.get(payload.symbol)?.lastPrice;
+  const ff = fatFingerCheck(payload, lastPrice);
+  const key = payloadKey(payload);
+  const pending = state.getState().pendingFatFinger;
+  if (ff && (!pending || pending.key !== key)) {
+    state.setPendingFatFinger(payload, key);
+    const pct = (ff.deviation * 100).toFixed(1);
+    ui.setTicketFeedback(
+      `fat-finger guard: price deviates ${pct}% from last trade ${ff.lastPrice}. Click Submit again to override.`,
+      "warn",
+    );
+    return;
+  }
+  // Clear pending guard once the user confirms or moves on.
+  state.setPendingFatFinger(null);
 
   ui.setTicketSubmitting(true);
   ui.setTicketFeedback(null);
@@ -265,6 +287,39 @@ async function handleCancelOrder(clOrdId) {
   }
 }
 
+// ── Blotter UX ─────────────────────────────────────────────────────
+
+function handleBlotterFilter(filter) {
+  state.setBlotterFilter(filter);
+  writeBlotterFilter(filter);
+}
+
+function handleSelectOrder(clOrdId) {
+  state.setSelectedOrder(clOrdId);
+}
+
+function handleKeyboardCancel() {
+  const id = state.getState().selectedClOrdId;
+  if (!id) return;
+  const order = state.getState().orders.get(id);
+  if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) return;
+  if (!window.confirm(`Cancel order ${id}?`)) return;
+  handleCancelOrder(id);
+}
+
+function readBlotterFilter() {
+  try {
+    const raw = sessionStorage.getItem(BLOTTER_FILTER_KEY);
+    if (!raw) return { text: "", status: "" };
+    const parsed = JSON.parse(raw);
+    return {
+      text:   typeof parsed?.text   === "string" ? parsed.text   : "",
+      status: typeof parsed?.status === "string" ? parsed.status : "",
+    };
+  } catch { return { text: "", status: "" }; }
+}
+function writeBlotterFilter(f) { sessionStorage.setItem(BLOTTER_FILTER_KEY, JSON.stringify(f)); }
+
 function logout() {
   if (expiryTimer) { clearTimeout(expiryTimer); expiryTimer = null; }
   stopFirmsPoll();
@@ -291,6 +346,9 @@ function logout() {
   state.setKillStatus(null);
   state.setEodReport(null);
   state.setCurrentView("trader");
+  state.setBlotterFilter(readBlotterFilter());
+  state.setSelectedOrder(null);
+  state.setPendingFatFinger(null);
   state.clearAll();
   state.clearMarketData();
   state.setWatchlist([]);

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -21,6 +21,11 @@ const state = {
   killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
   eodReport: null,         // { ranAt, report } | null — last EOD response in this session
   currentView: "trader",   // "trader" | "admin" — which view is mounted
+  // Blotter UX (section 3 of #30).
+  blotterFilter: { text: "", status: "" }, // { text: substring, status: "" | <OrderStatus> }
+  ordersHighlight: new Map(),              // ClOrdID -> Date.now() of last delta
+  selectedClOrdId: null,                   // currently selected blotter row (for keyboard cancel)
+  pendingFatFinger: null,                  // { payload, key } — set when a submit needs override
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -45,6 +50,9 @@ export function applyOrdersSnapshot(rows) {
 }
 export function applyOrdersDelta(row) {
   state.orders.set(row.clOrdId, row);
+  // Mark this row as freshly updated so the UI can flash it; the
+  // highlight expires naturally — readers compare against now.
+  state.ordersHighlight.set(row.clOrdId, Date.now());
   notify("orders");
 }
 
@@ -78,6 +86,9 @@ export function clearAll() {
   state.orders.clear();
   state.positions.clear();
   state.executions = [];
+  state.ordersHighlight.clear();
+  state.selectedClOrdId = null;
+  state.pendingFatFinger = null;
   notify("all");
 }
 
@@ -167,4 +178,24 @@ export function setCurrentView(view) {
   if (state.currentView === view) return;
   state.currentView = view;
   notify("currentView");
+}
+
+// ── Blotter UX slices (section 3 of #30) ───────────────────────────
+
+export function setBlotterFilter(filter) {
+  state.blotterFilter = {
+    text:   typeof filter?.text   === "string" ? filter.text   : "",
+    status: typeof filter?.status === "string" ? filter.status : "",
+  };
+  notify("blotterFilter");
+}
+
+export function setSelectedOrder(clOrdId) {
+  state.selectedClOrdId = clOrdId ?? null;
+  notify("selectedOrder");
+}
+
+export function setPendingFatFinger(payload, key) {
+  state.pendingFatFinger = payload ? { payload, key } : null;
+  notify("pendingFatFinger");
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -12,13 +12,19 @@ let onCancelOrder = () => {};
 let onLogout      = () => {};
 let onApplyMd     = () => {};
 let onSwitchView  = () => {};
+let onBlotterFilter  = () => {};
+let onSelectOrder    = () => {};
+let onKeyboardCancel = () => {};
 
 export function setHandlers(handlers) {
-  onSubmitOrder = handlers.onSubmitOrder ?? onSubmitOrder;
-  onCancelOrder = handlers.onCancelOrder ?? onCancelOrder;
-  onLogout      = handlers.onLogout      ?? onLogout;
-  onApplyMd     = handlers.onApplyMd     ?? onApplyMd;
-  onSwitchView  = handlers.onSwitchView  ?? onSwitchView;
+  onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
+  onCancelOrder    = handlers.onCancelOrder    ?? onCancelOrder;
+  onLogout         = handlers.onLogout         ?? onLogout;
+  onApplyMd        = handlers.onApplyMd        ?? onApplyMd;
+  onSwitchView     = handlers.onSwitchView     ?? onSwitchView;
+  onBlotterFilter  = handlers.onBlotterFilter  ?? onBlotterFilter;
+  onSelectOrder    = handlers.onSelectOrder    ?? onSelectOrder;
+  onKeyboardCancel = handlers.onKeyboardCancel ?? onKeyboardCancel;
 }
 
 export function showLogin() {
@@ -76,13 +82,28 @@ export function bindUi() {
 
   $("logout").addEventListener("click", () => onLogout());
 
-  // Event delegation for per-row Cancel buttons in the blotter.
+  // Event delegation for per-row Cancel buttons in the blotter,
+  // plus row selection (clicking anywhere outside the cancel button).
   $("blotter-body").addEventListener("click", (e) => {
     const btn = e.target.closest(".cancel-btn");
-    if (!btn) return;
-    const clOrdId = btn.dataset.clordid;
-    if (clOrdId) onCancelOrder(clOrdId);
+    if (btn) {
+      const clOrdId = btn.dataset.clordid;
+      if (clOrdId) onCancelOrder(clOrdId);
+      return;
+    }
+    const row = e.target.closest("tr[data-clordid]");
+    if (row) onSelectOrder(row.dataset.clordid);
   });
+
+  // Blotter filter: text + status select. Persisted via app.js.
+  const filterText = $("blotter-filter-text");
+  const filterStatus = $("blotter-filter-status");
+  const fireFilter = () => onBlotterFilter({
+    text:   filterText.value,
+    status: filterStatus.value,
+  });
+  if (filterText)   filterText.addEventListener("input",  fireFilter);
+  if (filterStatus) filterStatus.addEventListener("change", fireFilter);
 
   // Market data form: apply WS URL + watchlist atomically.
   $("md-form").addEventListener("submit", (e) => {
@@ -106,8 +127,46 @@ export function bindUi() {
     });
   }
 
+  // Global keyboard shortcuts:
+  //   F2  → focus the order-ticket symbol input
+  //   Esc → clear the ticket form (when focus is inside it)
+  //   Del → cancel the currently-selected blotter row
+  // We deliberately ignore key events when the user is typing into a
+  // text input to avoid stealing keystrokes.
+  document.addEventListener("keydown", onGlobalKeydown);
+
   subscribe(renderForSlice);
   renderAll();
+}
+
+function onGlobalKeydown(e) {
+  if (getState().currentView !== "trader") return;
+  const target = e.target;
+  const inEditable = target && (
+    target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT" ||
+    target.isContentEditable
+  );
+
+  if (e.key === "F2" && !e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+    const sym = $("ticket-symbol");
+    if (sym) sym.focus();
+    return;
+  }
+  if (e.key === "Escape") {
+    // Esc inside the ticket form clears it; outside, clear blotter selection.
+    if (target?.closest && target.closest("#ticket-form")) {
+      clearTicket();
+    } else {
+      onSelectOrder(null);
+    }
+    return;
+  }
+  if ((e.key === "Delete" || e.key === "Backspace") && !inEditable) {
+    if (!getState().selectedClOrdId) return;
+    e.preventDefault();
+    onKeyboardCancel();
+  }
 }
 
 export function setMdInputs({ url, symbols }) {
@@ -128,7 +187,8 @@ export function setTicketFeedback(message, kind) {
   if (!message) { el.hidden = true; el.textContent = ""; return; }
   el.hidden = false;
   el.textContent = message;
-  el.className = `feedback ${kind === "ok" ? "ok" : "error"}`;
+  const cls = kind === "ok" ? "ok" : kind === "warn" ? "warn" : "error";
+  el.className = `feedback ${cls}`;
 }
 
 export function setTicketSubmitting(submitting) {
@@ -239,7 +299,7 @@ function renderFirmsHealth() {
 }
 
 function renderForSlice(slice) {
-  if (slice === "orders" || slice === "all") renderBlotter();
+  if (slice === "orders" || slice === "all" || slice === "blotterFilter" || slice === "selectedOrder") renderBlotter();
   if (slice === "positions" || slice === "all") renderPositions();
   if (slice === "executions" || slice === "all") renderExecutions();
   if (slice === "status") {
@@ -306,16 +366,30 @@ function renderMarketData() {
 
 function renderBlotter() {
   const body = $("blotter-body");
-  const orders = [...getState().orders.values()]
+  const st = getState();
+  const filter = st.blotterFilter ?? { text: "", status: "" };
+  syncFilterInputs(filter);
+  const search = filter.text.trim().toUpperCase();
+  const wantStatus = filter.status;
+  const all = [...st.orders.values()];
+  const orders = all
+    .filter(o => !search || o.symbol.toUpperCase().includes(search) || o.clOrdId.toUpperCase().includes(search))
+    .filter(o => !wantStatus || o.status === wantStatus)
     .sort((a, b) => a.clOrdId.localeCompare(b.clOrdId));
-  $("blotter-count").textContent = orders.length.toString();
-  body.innerHTML = orders.map(orderRow).join("");
+  $("blotter-count").textContent = `${orders.length}/${all.length}`;
+  body.innerHTML = orders.map(o => orderRow(o, st)).join("");
 }
 
-function orderRow(o) {
+const HIGHLIGHT_MS = 2000;
+
+function orderRow(o, st) {
   const terminal = isTerminalOrderStatus(o.status);
   const price = o.price == null ? "—" : Number(o.price).toFixed(2);
-  return `<tr>
+  const highlightAt = st.ordersHighlight?.get(o.clOrdId);
+  const fresh = highlightAt && (Date.now() - highlightAt) < HIGHLIGHT_MS;
+  const selected = st.selectedClOrdId === o.clOrdId;
+  const cls = [fresh ? "row-fresh" : "", selected ? "row-selected" : ""].filter(Boolean).join(" ");
+  return `<tr data-clordid="${escapeHtml(o.clOrdId)}"${cls ? ` class="${cls}"` : ""}>
     <td><code>${escapeHtml(o.clOrdId)}</code></td>
     <td>${escapeHtml(o.symbol)}</td>
     <td>${escapeHtml(o.side)}</td>
@@ -327,6 +401,13 @@ function orderRow(o) {
     <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}</td>
     <td><button class="cancel-btn" data-clordid="${escapeHtml(o.clOrdId)}" ${terminal ? "disabled" : ""}>Cancel</button></td>
   </tr>`;
+}
+
+function syncFilterInputs(filter) {
+  const t = $("blotter-filter-text");
+  const s = $("blotter-filter-status");
+  if (t && document.activeElement !== t) t.value = filter.text;
+  if (s && s.value !== filter.status) s.value = filter.status;
 }
 
 function renderPositions() {

--- a/frontend/js/validation.js
+++ b/frontend/js/validation.js
@@ -1,0 +1,82 @@
+// Pre-trade validation helpers. These are advisory client-side checks;
+// the backend is still the source of truth for risk and exchange rules.
+
+const DEFAULTS = {
+  tickSize: 0.01,
+  lotSize: 100,
+  fatFingerThreshold: 0.10, // 10% deviation from last trade
+};
+
+// Per-symbol overrides — populated as the platform grows. Until then
+// the defaults serve PETR4 / VALE3 / etc adequately (lot=100, tick=0.01).
+const PER_SYMBOL = {
+  // Example: "BOVA11": { tickSize: 0.01, lotSize: 10 }
+};
+
+export function rulesFor(symbol) {
+  const o = PER_SYMBOL[symbol?.toUpperCase()] ?? {};
+  return {
+    tickSize:           o.tickSize           ?? DEFAULTS.tickSize,
+    lotSize:            o.lotSize            ?? DEFAULTS.lotSize,
+    fatFingerThreshold: o.fatFingerThreshold ?? DEFAULTS.fatFingerThreshold,
+  };
+}
+
+// Return null if valid, else { code, message } — caller decides how
+// to render. Callers must pass `lastPrice` from market data when the
+// fat-finger check is wanted; pass null/undefined to skip it.
+export function validateOrder(payload, lastPrice) {
+  if (!payload.symbol) return { code: "symbol_required", message: "symbol required" };
+
+  const qty = Number(payload.quantity);
+  if (!Number.isFinite(qty) || qty <= 0)
+    return { code: "qty_invalid", message: "quantity must be positive" };
+
+  const rules = rulesFor(payload.symbol);
+
+  if (qty % rules.lotSize !== 0)
+    return {
+      code: "lot_size",
+      message: `quantity must be a multiple of ${rules.lotSize} for ${payload.symbol}`,
+    };
+
+  if (payload.type === "Limit") {
+    const px = Number(payload.price);
+    if (!Number.isFinite(px) || px <= 0)
+      return { code: "price_required", message: "limit price required" };
+
+    // Tick alignment: avoid floating-point drift by comparing
+    // (price / tick) to its rounded integer within a small epsilon.
+    const ratio = px / rules.tickSize;
+    const rounded = Math.round(ratio);
+    if (Math.abs(ratio - rounded) > 1e-6)
+      return {
+        code: "tick_size",
+        message: `price must be a multiple of ${rules.tickSize.toFixed(2)} for ${payload.symbol}`,
+      };
+  }
+
+  return null;
+}
+
+// Returns { warn: true, deviation: n } when the limit price strays by
+// more than the threshold from the last observed trade. Returns null
+// otherwise (no warning, OR not a limit order, OR no reference price).
+export function fatFingerCheck(payload, lastPrice) {
+  if (payload.type !== "Limit") return null;
+  if (!Number.isFinite(lastPrice) || lastPrice <= 0) return null;
+
+  const px = Number(payload.price);
+  if (!Number.isFinite(px) || px <= 0) return null;
+
+  const rules = rulesFor(payload.symbol);
+  const deviation = Math.abs(px - lastPrice) / lastPrice;
+  if (deviation <= rules.fatFingerThreshold) return null;
+  return { warn: true, deviation, lastPrice, threshold: rules.fatFingerThreshold };
+}
+
+// Stable key for a payload so the UI can detect "same submission"
+// when the user clicks Submit a second time to override the warning.
+export function payloadKey(payload) {
+  return [payload.symbol, payload.side, payload.type, payload.quantity, payload.price ?? ""].join("|");
+}


### PR DESCRIPTION
Section 3 of the frontend hardening tracked in #30 — blotter and order-ticket UX. Pure UX, zero backend changes.

## What this adds

### Blotter
- Filter inputs above the table: text search across symbol/ClOrdID + status select. Persisted in `sessionStorage` so a refresh keeps the operator's view.
- Header count flips from `N` to `visible/total`.
- Recent-update highlight: every `orders.delta` flashes the row briefly via CSS animation.
- Row selection: click a row to select it (visual outline); Esc clears.

### Keyboard shortcuts (trader view only, ignored when typing)
| Key | Action |
|---|---|
| F2  | focus the ticket symbol input |
| Esc | clear ticket form (when focused inside it), else clear blotter selection |
| Del | cancel the selected order (single confirm) |

### Pre-trade validation (`frontend/js/validation.js`, advisory; backend remains source of truth)
- Lot size: quantity must be a multiple of the per-symbol lot (default 100).
- Tick size: limit price must be a multiple of the per-symbol tick (default 0.01), with epsilon-based comparison to dodge float drift.
- Fat-finger guard: when the limit price deviates >10% from the last observed trade in `marketData`, the first submit is rejected with a yellow warning; clicking Submit a second time with the **exact same payload** overrides. Skipped when no live price exists (so bootstrapping a fresh market is unaffected).
- Ticket feedback gains a `warn` tone so advisory messages don't masquerade as hard errors.

## Implementation notes

- State gains four slices: `blotterFilter`, `ordersHighlight` (Map), `selectedClOrdId`, `pendingFatFinger`. All cleared on logout/clearAll.
- Per-symbol overrides are centralised in `validation.js` so reference-data wiring later has one place to plug into.
- Highlight uses a CSS @keyframes animation — no JS timer needed; freshness recomputed on each render.
- Filter input syncing avoids clobbering the user's text while they're typing.

## Validation

- `dotnet format --verify-no-changes` — clean.
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — all passing (196 backend, 6 conformance skipped as expected without docker stack).
- `node --check` on every JS file.

## Out of scope (next PRs against #30)

- Section 4: CSP and security headers, proactive token refresh.
- Section 5: ARIA pass and headless smoke test.

Closes part of #30.
