### PR TITLE
frontend: security headers, token renewal, remember-me

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -267,3 +267,30 @@ tr.row-selected > td {
 tr[data-clordid] { cursor: pointer; }
 tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 .feedback.warn { color: var(--warn); }
+
+/* ---------- Session-expiry modal + helpers (section 4 of #30) ---------- */
+.muted-cell { color: var(--muted); }
+.muted-line { color: var(--muted); margin: 0 0 .4rem; font-size: .8rem; }
+.login-card label.remember { flex-direction: row; align-items: center; gap: .5rem; font-size: .8rem; color: var(--muted); }
+.login-card label.remember input { width: auto; }
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(8,11,16,.65);
+  display: grid; place-items: center; z-index: 1000;
+}
+.modal-card {
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  padding: 1.25rem 1.5rem; width: min(360px, 90vw);
+  display: flex; flex-direction: column; gap: .8rem;
+}
+.modal-card h2 { margin: 0; font-size: 1rem; }
+.modal-card label { display: grid; gap: .25rem; font-size: .8rem; color: var(--muted); }
+.modal-card input {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: .45rem .55rem; font: inherit;
+}
+.modal-actions { display: flex; justify-content: space-between; align-items: center; gap: .5rem; }
+.modal-actions button[type="submit"] {
+  background: var(--accent); color: #0b1320; border: 0; padding: .45rem .9rem;
+  border-radius: 4px; font-weight: 600; cursor: pointer; font: inherit;
+}
+.modal-actions button[type="submit"]:hover { filter: brightness(1.1); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,10 @@
         <span>Backend</span>
         <input id="login-backend" type="url" placeholder="http://localhost:5000" />
       </label>
+      <label class="row remember">
+        <input id="login-remember" type="checkbox" />
+        <span>Remember me on this device</span>
+      </label>
       <button type="submit" id="login-submit">Sign in</button>
       <p id="login-error" class="error" hidden></p>
     </form>
@@ -216,6 +220,23 @@
       <pre id="admin-eod-output" class="admin-eod-output" hidden></pre>
     </section>
   </section>
+
+  <!-- SESSION-EXPIRY MODAL -------------------------------------------- -->
+  <div id="session-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="session-modal-title">
+    <form id="session-modal-form" class="modal-card">
+      <h2 id="session-modal-title">Session expiring</h2>
+      <p id="session-modal-msg" class="muted-line">Re-enter your password to extend the session.</p>
+      <label>
+        <span>Password</span>
+        <input id="session-modal-password" type="password" autocomplete="current-password" required />
+      </label>
+      <p id="session-modal-error" class="error" hidden></p>
+      <div class="modal-actions">
+        <button type="button" id="session-modal-logout" class="link-button">Logout</button>
+        <button type="submit" id="session-modal-submit">Renew session</button>
+      </div>
+    </form>
+  </div>
 
   <script type="module" src="js/app.js"></script>
 </body>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -15,11 +15,30 @@ const BLOTTER_FILTER_KEY = "b3tp.blotter.filter";
 const DEFAULT_WATCHLIST = ["PETR4", "VALE3"];
 const FIRMS_POLL_INTERVAL_MS = 5_000;
 
+// ─────────────────────────────────────────────────────────────────
+// Session storage strategy:
+//   - sessionStorage (default): cleared when the tab/window closes,
+//     mitigates token theft if the workstation walks away.
+//   - localStorage ("Remember me" checkbox): persists across browser
+//     restarts, so a refresh after coffee keeps the operator logged
+//     in. Trade-off: a token sitting in localStorage is reachable by
+//     any later XSS bug for as long as the JWT TTL allows.
+//   We always read from both and prefer the freshest valid record so
+//   a logout from one tab doesn't leave stale state in the other.
+// ─────────────────────────────────────────────────────────────────
+
+let sessionStore = sessionStorage; // mutates if "remember me" was selected at login
+let renewInflight = false;
+let warningShown = false;
+
+const SESSION_WARNING_LEAD_MS = 60_000;
+
 let worker = null;
 let mdWorker = null;
-let session = null;          // { token, expiresAt, username, backend, role, firm }
+let session = null;          // { token, expiresAt, username, backend, role, firm, remember }
 let mdConfig = null;         // { url, symbols }
 let expiryTimer = null;
+let warningTimer = null;
 let firmsPollTimer = null;
 
 function init() {
@@ -56,6 +75,7 @@ async function onLogin(e) {
   const backend = (document.getElementById("login-backend").value || defaultBackend()).replace(/\/+$/, "");
   const username = document.getElementById("login-username").value.trim();
   const password = document.getElementById("login-password").value;
+  const remember = !!document.getElementById("login-remember")?.checked;
   try {
     const resp = await login(backend, username, password);
     const claims = claimsFromToken(resp.token);
@@ -66,7 +86,9 @@ async function onLogin(e) {
       backend,
       role: claims.role,
       firm: claims.firm,
+      remember,
     };
+    sessionStore = remember ? localStorage : sessionStorage;
     writeSession(next);
     startSession(next);
   } catch (err) {
@@ -105,17 +127,80 @@ function startSession(next) {
 }
 
 function scheduleExpiry() {
-  if (expiryTimer) clearTimeout(expiryTimer);
+  if (expiryTimer) { clearTimeout(expiryTimer); expiryTimer = null; }
+  if (warningTimer) { clearTimeout(warningTimer); warningTimer = null; }
   if (!session?.expiresAt) return;
   const remaining = new Date(session.expiresAt).getTime() - Date.now();
   if (remaining <= 0) { logout(); return; }
-  expiryTimer = setTimeout(logout, Math.max(1_000, remaining));
+
+  // Warning fires SESSION_WARNING_LEAD_MS before the hard expiry. If
+  // the lead time has already passed (short-lived tokens), fire it
+  // immediately. The hard expiry timer is kept so logout always wins
+  // even if the user walks away from the warning prompt.
+  const warnIn = Math.max(0, remaining - SESSION_WARNING_LEAD_MS);
+  warningTimer = setTimeout(showSessionWarning, warnIn);
+  expiryTimer  = setTimeout(logout, Math.max(1_000, remaining));
+}
+
+function showSessionWarning() {
+  if (!session || warningShown) return;
+  warningShown = true;
+  ui.openSessionModal({
+    onRenew: handleRenewSession,
+    onLogout: logout,
+  });
+}
+
+async function handleRenewSession(password) {
+  if (!session || renewInflight) return;
+  renewInflight = true;
+  try {
+    const resp = await login(session.backend, session.username, password);
+    const claims = claimsFromToken(resp.token);
+    session = {
+      ...session,
+      token: resp.token,
+      expiresAt: resp.expiresAt,
+      role: claims.role ?? session.role,
+      firm: claims.firm ?? session.firm,
+    };
+    writeSession(session);
+    state.setUser({
+      username: session.username,
+      expiresAt: session.expiresAt,
+      backend:   session.backend,
+      role:      session.role,
+      firm:      session.firm,
+    });
+    // Restart the WS worker so subsequent reconnects use the new token
+    // (the existing socket keeps working until the OLD JWT is rejected
+    // server-side; restart guarantees the next reconnect is clean).
+    restartWorker();
+    warningShown = false;
+    scheduleExpiry();
+    ui.closeSessionModal();
+  } catch (err) {
+    ui.setSessionModalError(err.message || "renew failed");
+  } finally {
+    renewInflight = false;
+  }
 }
 
 function startWorker() {
   worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
   worker.onmessage = (ev) => onWorkerMessage(ev.data);
   worker.postMessage({ type: "start", backend: session.backend, token: session.token });
+}
+
+function restartWorker() {
+  if (worker) {
+    try { worker.postMessage({ type: "stop" }); } catch { /* swallow */ }
+    worker.terminate();
+    worker = null;
+  }
+  state.setStatus("connecting");
+  state.setWsReconnect(null);
+  startWorker();
 }
 
 function defaultMdUrl() {
@@ -322,6 +407,9 @@ function writeBlotterFilter(f) { sessionStorage.setItem(BLOTTER_FILTER_KEY, JSON
 
 function logout() {
   if (expiryTimer) { clearTimeout(expiryTimer); expiryTimer = null; }
+  if (warningTimer) { clearTimeout(warningTimer); warningTimer = null; }
+  warningShown = false;
+  ui.closeSessionModal();
   stopFirmsPoll();
   if (worker) {
     try { worker.postMessage({ type: "stop" }); } catch { /* swallow */ }
@@ -450,16 +538,35 @@ async function handleRunEod() {
 }
 
 function readSession() {
-  try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (!parsed.token || !parsed.expiresAt) return null;
-    if (new Date(parsed.expiresAt).getTime() <= Date.now()) return null;
-    return parsed;
-  } catch { return null; }
+  // Read both stores; pick the freshest non-expired one. If "remember
+  // me" was used, it lives in localStorage. Otherwise, sessionStorage.
+  const candidates = [];
+  for (const store of [localStorage, sessionStorage]) {
+    try {
+      const raw = store.getItem(SESSION_KEY);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw);
+      if (!parsed.token || !parsed.expiresAt) continue;
+      if (new Date(parsed.expiresAt).getTime() <= Date.now()) continue;
+      candidates.push({ store, parsed });
+    } catch { /* fall through */ }
+  }
+  if (!candidates.length) return null;
+  candidates.sort((a, b) =>
+    new Date(b.parsed.expiresAt).getTime() - new Date(a.parsed.expiresAt).getTime());
+  const winner = candidates[0];
+  sessionStore = winner.store;
+  return winner.parsed;
 }
-function writeSession(s) { sessionStorage.setItem(SESSION_KEY, JSON.stringify(s)); }
-function clearSession()  { sessionStorage.removeItem(SESSION_KEY); }
+function writeSession(s) {
+  sessionStore.setItem(SESSION_KEY, JSON.stringify(s));
+  // Make sure the other store doesn't shadow our write.
+  const other = sessionStore === localStorage ? sessionStorage : localStorage;
+  try { other.removeItem(SESSION_KEY); } catch { /* swallow */ }
+}
+function clearSession() {
+  try { localStorage.removeItem(SESSION_KEY); } catch { /* swallow */ }
+  try { sessionStorage.removeItem(SESSION_KEY); } catch { /* swallow */ }
+}
 
 init();

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -55,6 +55,51 @@ export function setLoginError(message) {
   el.hidden = false; el.textContent = message;
 }
 
+// ── Session-expiry modal ───────────────────────────────────────────
+let sessionModalSubmit = null;
+let sessionModalLogout = null;
+
+export function openSessionModal({ onRenew, onLogout }) {
+  const modal = $("session-modal");
+  const form  = $("session-modal-form");
+  const pwd   = $("session-modal-password");
+  const logoutBtn = $("session-modal-logout");
+  if (!modal || !form || !pwd) return;
+  setSessionModalError(null);
+  pwd.value = "";
+  modal.hidden = false;
+  // Replace handlers (idempotent across multiple opens).
+  if (sessionModalSubmit) form.removeEventListener("submit", sessionModalSubmit);
+  if (sessionModalLogout) logoutBtn?.removeEventListener("click", sessionModalLogout);
+  sessionModalSubmit = (e) => {
+    e.preventDefault();
+    const value = pwd.value;
+    if (!value) { setSessionModalError("password required"); return; }
+    onRenew?.(value);
+  };
+  sessionModalLogout = () => onLogout?.();
+  form.addEventListener("submit", sessionModalSubmit);
+  logoutBtn?.addEventListener("click", sessionModalLogout);
+  // Defer focus to the next frame so backdrop transitions don't steal it.
+  requestAnimationFrame(() => pwd.focus());
+}
+
+export function closeSessionModal() {
+  const modal = $("session-modal");
+  if (!modal) return;
+  modal.hidden = true;
+  setSessionModalError(null);
+  const pwd = $("session-modal-password");
+  if (pwd) pwd.value = "";
+}
+
+export function setSessionModalError(message) {
+  const el = $("session-modal-error");
+  if (!el) return;
+  if (!message) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false; el.textContent = message;
+}
+
 export function bindUi() {
   // Order ticket: enable/disable price field by type.
   const typeEl = $("ticket-type");
@@ -345,13 +390,13 @@ function renderMarketData() {
   // subscriptions even before the first trade arrives.
   const rows = watch.length > 0 ? watch : [...md.keys()];
   if (rows.length === 0) {
-    body.innerHTML = `<tr><td colspan="5" style="color:var(--muted);text-align:center;padding:1rem">No subscriptions</td></tr>`;
+    body.innerHTML = `<tr><td colspan="5" class="muted">No subscriptions</td></tr>`;
     return;
   }
   body.innerHTML = rows.map(symbol => {
     const e = md.get(symbol);
     if (!e || e.lastPrice == null) {
-      return `<tr><td>${escapeHtml(symbol)}</td><td colspan="4" style="color:var(--muted)">awaiting data…</td></tr>`;
+      return `<tr><td>${escapeHtml(symbol)}</td><td colspan="4" class="muted-cell">awaiting data…</td></tr>`;
     }
     const ts = e.updatedAt ? new Date(e.updatedAt).toISOString().slice(11, 19) : "—";
     return `<tr>
@@ -416,7 +461,7 @@ function renderPositions() {
     .filter(p => p.netQuantity !== 0)
     .sort((a, b) => a.symbol.localeCompare(b.symbol));
   body.innerHTML = positions.length === 0
-    ? `<tr><td colspan="3" style="color:var(--muted);text-align:center;padding:1rem">No positions</td></tr>`
+    ? `<tr><td colspan="3" class="muted">No positions</td></tr>`
     : positions.map(p => `<tr>
         <td>${escapeHtml(p.symbol)}</td>
         <td class="num">${p.netQuantity}</td>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -47,6 +47,23 @@ http {
         listen 80 default_server;
         server_name _;
 
+        # ── Security headers (section 4 of #30) ──────────────────────
+        # Applied to ALL responses (static + proxied) via add_header at
+        # the server level. CSP is intentionally strict:
+        #   - no inline scripts (we use ES modules served as files)
+        #   - no inline styles (refactored to CSS classes)
+        #   - connect-src allows ws:/wss: anywhere because the trader
+        #     can configure a market-data endpoint on a different port
+        #     (8081) which 'self' wouldn't cover; HTTP fetches stay on
+        #     'self' (proxied via nginx).
+        # Operators that lock down the market-data origin can tighten
+        # connect-src further.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; worker-src 'self'; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "same-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
         # Static frontend
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
Section 4 of frontend hardening (#30) — security pass.

## Changes

**`frontend/nginx.conf`** — add headers on the server block:
- `Content-Security-Policy` strict (`default-src 'self'`; no inline
  scripts/styles; `connect-src 'self' ws: wss:` to allow the trader's
  market-data worker to point at a separately deployed
  `B3MarketDataPlatform`; `frame-ancestors 'none'`)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: same-origin`
- `Permissions-Policy: geolocation=(), microphone=(), camera=()`

**`frontend/js/ui.js`** — refactor 3 inline `style="color:var(--muted)"`
spots to `.muted` / `.muted-cell` classes so strict `style-src` doesn't
blank the workspace tables. Add `openSessionModal` / `closeSessionModal`
/ `setSessionModalError` helpers.

**`frontend/js/app.js`** — token-renewal flow:
- 60 s before JWT expiry a warning timer fires the re-auth modal.
- On success the session is rewritten, WS worker restarted so the next
  reconnect uses the fresh token, expiry timers re-scheduled.
- Hard expiry still triggers logout if the operator ignores the prompt.

Remember-me checkbox: when checked the session goes to `localStorage`
instead of `sessionStorage`. `readSession()` reads both and picks the
freshest valid record so a logout in one tab isn't undone by stale
state elsewhere. Trade-off documented inline.

**`frontend/index.html` / `frontend/css/styles.css`** — modal markup,
remember-me checkbox, modal styling using existing tokens.

## Validation
- `dotnet format --verify-no-changes`: clean
- `dotnet build`: 0 warnings
- `dotnet test`: 196 passing (6 conformance skipped — no docker)
- `node --check` every module under `frontend/js/`

Closes part of #30 (section 4). Section 5 (a11y + smoke E2E) is the
last remaining slice.
