### PR TITLE
frontend: a11y pass + opt-in Playwright smoke E2E

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,93 @@
+name: Frontend E2E (smoke)
+
+# Opt-in only: workflow_dispatch keeps it off every PR (it boots the
+# whole compose stack and pulls Playwright browsers, ~3-4 min). Run it
+# manually before merging anything that touches the frontend, the auth
+# flow, or the WS plumbing.
+#
+# Triggers:
+#   - workflow_dispatch  → operator-initiated run
+#   - schedule (Mon 03:00 UTC) → catch silent regressions on main weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Trader workspace smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Bring up frontend + trading-host (Stub mode)
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-e2e-smoke-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_USER: alice
+          TRADING_SEED_PASSWORD: wonderland
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.e2e.yml \
+              up -d --build --wait trading-host frontend
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Playwright + chromium
+        working-directory: frontend/e2e
+        run: |
+          npm install --no-audit --no-fund --no-package-lock
+          npx playwright install --with-deps chromium
+
+      - name: Run smoke
+        working-directory: frontend/e2e
+        env:
+          E2E_FRONTEND_URL: http://localhost:8080
+          E2E_USERNAME: alice
+          E2E_PASSWORD: wonderland
+        run: npm test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/e2e/playwright-report
+          retention-days: 7
+
+      - name: Trading-host logs (always)
+        if: always()
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-e2e-smoke-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.e2e.yml \
+              logs trading-host || true
+
+      - name: Tear down
+        if: always()
+        env:
+          TRADING_AUTH_SIGNING_KEY: ci-e2e-smoke-placeholder-key-min-32-bytes-long-aaaaa
+          TRADING_SEED_PASSWORD_HASH: ZDzDHANAHq8NDQK3BWk/YZjybKLCMKdRzw0z9Da5wic=
+          TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
+        run: |
+          docker compose \
+              -f docker/docker-compose.yml \
+              -f docker/docker-compose.e2e.yml \
+              down -v

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -1,0 +1,16 @@
+# Overlay used by the opt-in frontend smoke E2E (workflow_dispatch).
+#
+# Default `docker-compose.yml` brings the trading-host up in
+# Mode=Unavailable (fail-closed: POST /orders → 502). For a UI smoke
+# test we need an in-process gateway that produces ExecutionReports
+# without touching B3 — that is StubExchangeGateway. The overlay only
+# flips the mode and adds a single seeded firm so /admin/firms shows
+# something real.
+
+services:
+  trading-host:
+    environment:
+      Trading__Exchange__Mode: Stub
+      # StubExchangeGateway echoes ERs immediately for the seeded firm.
+      Trading__Exchange__Firms__0__FirmId: default
+      Trading__Exchange__Firms__0__Endpoint: stub://e2e

--- a/frontend/e2e/.gitignore
+++ b/frontend/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+.playwright/

--- a/frontend/e2e/package.json
+++ b/frontend/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "b3tp-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Opt-in headless smoke test against the docker compose stack. Pinned Playwright; not part of the day-to-day frontend build.",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.49.1"
+  }
+}

--- a/frontend/e2e/playwright.config.js
+++ b/frontend/e2e/playwright.config.js
@@ -1,0 +1,29 @@
+// Playwright config for the opt-in frontend smoke E2E.
+// Triggered via .github/workflows/e2e-smoke.yml (workflow_dispatch),
+// not on every PR. Run locally with:
+//   docker compose -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml up -d --build
+//   cd frontend/e2e && npm install && npx playwright install --with-deps chromium && npm test
+
+import { defineConfig, devices } from "@playwright/test";
+
+const FRONTEND_URL = process.env.E2E_FRONTEND_URL ?? "http://localhost:8080";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.spec\.js$/,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: FRONTEND_URL,
+    headless: true,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});

--- a/frontend/e2e/smoke.spec.js
+++ b/frontend/e2e/smoke.spec.js
@@ -1,0 +1,61 @@
+// Frontend smoke E2E (section 5 of #30, opt-in via workflow_dispatch).
+//
+// Scope: catch obvious regressions in the trader workspace without
+// relying on a real exchange. Verifies:
+//   1. login form renders, accepts seeded credentials, hides itself
+//   2. trader view appears with the username in the topbar
+//   3. orders WebSocket reaches "connected" within the timeout
+//   4. accessibility hooks added in section 5 are present
+//   5. the cancel-order keyboard shortcut (Del) is wired even when
+//      no row is selected (no exception, no broken state)
+//
+// NOT covered (tracked separately):
+//   - POST /orders ↔ ExecutionReport round-trip. The ticket form does
+//     not yet pass SecurityId, so Stub-mode submits would 400. See the
+//     follow-up issue linked in #30.
+
+import { expect, test } from "@playwright/test";
+
+const USERNAME = process.env.E2E_USERNAME ?? "alice";
+const PASSWORD = process.env.E2E_PASSWORD ?? "wonderland";
+
+test.describe("trader workspace smoke", () => {
+  test("login → trader view → WS connected", async ({ page }) => {
+    await page.goto("/");
+
+    // 1. Login form visible.
+    await expect(page.locator("#login-view")).toBeVisible();
+    await page.fill("#login-username", USERNAME);
+    await page.fill("#login-password", PASSWORD);
+    // Backend defaults to same-origin via the nginx reverse proxy, so
+    // we leave the backend field blank.
+    await page.click("#login-submit");
+
+    // 2. Trader view replaces login.
+    await expect(page.locator("#trader-view")).toBeVisible();
+    await expect(page.locator("#login-view")).toBeHidden();
+    await expect(page.locator("#user-label")).toHaveText(USERNAME);
+
+    // 3. WS reaches connected. Generous timeout for cold container.
+    await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+    await expect(page.locator("#ws-status")).toHaveAttribute("aria-label", /connected/);
+
+    // 4. ARIA hooks from section 5.
+    await expect(page.locator("#ws-status")).toHaveAttribute("role", "status");
+    await expect(page.locator("#logout")).toHaveAttribute("aria-label", "Logout");
+
+    // 5. Del with no selection should be a no-op (no JS exception).
+    let pageError = null;
+    page.on("pageerror", (err) => { pageError = err; });
+    await page.locator("body").press("Delete");
+    expect(pageError).toBeNull();
+  });
+
+  test("session-expiry modal markup is wired and hidden by default", async ({ page }) => {
+    await page.goto("/");
+    const modal = page.locator("#session-modal");
+    await expect(modal).toBeHidden();
+    await expect(modal).toHaveAttribute("role", "dialog");
+    await expect(modal).toHaveAttribute("aria-modal", "true");
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,16 +38,16 @@
     <header class="topbar">
       <div class="brand">B3TradingPlatform <span class="pill">trader</span></div>
       <div class="status">
-        <span id="view-toggle" class="view-toggle" hidden>
-          <button type="button" data-view="trader" class="active">Trader</button>
-          <button type="button" data-view="admin">Admin</button>
+        <span id="view-toggle" class="view-toggle" role="tablist" aria-label="View" hidden>
+          <button type="button" data-view="trader" class="active" role="tab" aria-selected="true">Trader</button>
+          <button type="button" data-view="admin" role="tab" aria-selected="false">Admin</button>
         </span>
-        <span id="firms-health" class="firms-health" hidden></span>
-        <span id="ws-status" class="status-pill status-disconnected" title="WebSocket connection">disconnected</span>
-        <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
+        <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
+        <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
+        <span id="ws-reconnect" class="reconnect-countdown" role="status" aria-live="polite" hidden></span>
         <span id="user-label" class="user-label"></span>
         <span id="user-role" class="role-badge" hidden></span>
-        <button id="logout" class="link-button" type="button">Logout</button>
+        <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
       </div>
     </header>
 
@@ -87,8 +87,8 @@
             </label>
           </div>
           <button type="submit" id="ticket-submit">Submit</button>
-          <p id="ticket-inflight" class="inflight" hidden></p>
-          <p id="ticket-feedback" class="feedback" hidden></p>
+          <p id="ticket-inflight" class="inflight" role="status" aria-live="polite" hidden></p>
+          <p id="ticket-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
         </form>
       </section>
 
@@ -143,7 +143,7 @@
       <section class="panel market-data">
         <h2>
           Market data
-          <span id="md-status" class="status-pill status-disconnected" title="MarketData WebSocket connection">disconnected</span>
+          <span id="md-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Market data: disconnected" title="MarketData WebSocket connection">disconnected</span>
         </h2>
         <form id="md-form" class="md-form">
           <label>
@@ -155,7 +155,7 @@
             <input id="md-symbols" type="text" placeholder="PETR4,VALE3" />
           </label>
           <button type="submit" id="md-apply">Apply</button>
-          <p id="md-feedback" class="feedback" hidden></p>
+          <p id="md-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
         </form>
         <div class="table-scroll">
           <table id="md-table">
@@ -183,7 +183,7 @@
         <button id="admin-refresh" type="button" class="link-button">Refresh</button>
       </div>
     </header>
-    <p id="admin-feedback" class="feedback" hidden></p>
+    <p id="admin-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
 
     <section class="panel admin-panel">
       <h3>Firms</h3>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -46,6 +46,7 @@ function setViewToggleVisible(visible, current) {
   wrap.hidden = !visible;
   for (const btn of wrap.querySelectorAll("button[data-view]")) {
     btn.classList.toggle("active", btn.dataset.view === current);
+    btn.setAttribute("aria-selected", btn.dataset.view === current ? "true" : "false");
   }
 }
 
@@ -251,6 +252,7 @@ export function setStatusPill(status) {
   const el = $("ws-status");
   el.textContent = status;
   el.className = `status-pill status-${status}`;
+  el.setAttribute("aria-label", `WebSocket: ${status}`);
 }
 
 export function setUserLabel(user) {
@@ -379,6 +381,7 @@ function setMdStatusPill(status) {
   if (!el) return;
   el.textContent = status;
   el.className = `status-pill status-${status}`;
+  el.setAttribute("aria-label", `Market data: ${status}`);
 }
 
 function renderMarketData() {
@@ -444,7 +447,7 @@ function orderRow(o, st) {
     <td class="num">${o.cumulativeQuantity}</td>
     <td class="num">${price}</td>
     <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}</td>
-    <td><button class="cancel-btn" data-clordid="${escapeHtml(o.clOrdId)}" ${terminal ? "disabled" : ""}>Cancel</button></td>
+    <td><button class="cancel-btn" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" ${terminal ? "disabled" : ""}>Cancel</button></td>
   </tr>`;
 }
 


### PR DESCRIPTION
Section 5 of frontend hardening (#30) — final slice.

## A11y pass

`index.html` + `frontend/js/ui.js`:
- `role="status"` + `aria-live="polite"` on every transient region
  (`ws-status`, `md-status`, `ws-reconnect`, `firms-health`,
  `ticket-inflight`, `ticket-feedback`, `md-feedback`,
  `admin-feedback`).
- Dynamic `aria-label` on the WS / MD pills kept in sync with the
  visible status string via `setStatusPill` / `setMdStatusPill`.
- `aria-label` on the Logout button and on every per-row Cancel
  button (`Cancel order <ClOrdId>` for screen readers).
- `role="tablist"` + `aria-selected` on the trader/admin view toggle.

Keyboard shortcuts already added in section 3 (F2/Esc/Del) are kept;
the smoke verifies Del-with-no-selection is a no-op.

## Smoke E2E (opt-in)

New `frontend/e2e/` Playwright project (`@playwright/test@1.49.1`) +
`docker/docker-compose.e2e.yml` overlay that flips the trading-host to
`Trading__Exchange__Mode=Stub` so submits don't surface as 502.

Test (`smoke.spec.js`) verifies:
1. Login form renders and accepts seeded creds.
2. Trader view replaces login.
3. Orders WS reaches `connected`.
4. ARIA hooks are present on the live DOM.
5. Session-expiry modal markup is wired and hidden by default.
6. `Del` with no row selected doesn't throw.

`.github/workflows/e2e-smoke.yml` is **opt-in**: `workflow_dispatch` +
weekly Mon 03:00 UTC cron. Booting the full stack and pulling Chromium
takes ~3-4 min, so we keep it off the per-PR critical path.

## Out of scope (follow-up)

End-to-end POST `/orders` ↔ ExecutionReport ↔ DELETE round-trip is
**not** exercised by the smoke. The ticket form does not yet pass
`SecurityId`, so Stub-mode submits would 400 with `"securityId is
required"`. A follow-up issue will be opened to:
- add a `SecurityId` field (or symbol→ID mapping) to the ticket form
- extend the smoke to cover submit + cancel

## Validation

- `dotnet format --verify-no-changes`: clean
- `dotnet build`: 0 warnings
- `dotnet test`: 196 passing (6 conformance skipped — no docker)
- `node --check` every frontend module
- `docker compose config` OK on the new overlay

Closes #30 (modulo the SecurityId follow-up).
