### PR TITLE
backend: SymbolDirectory resolves Symbol → SecurityId for UI submits (closes #36)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -42,6 +42,7 @@ public static class OrdersEndpoints
             IMarginProvider margin,
             EventDispatcher dispatcher,
             DrainState drain,
+            SymbolDirectory symbols,
             ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
@@ -60,13 +61,22 @@ public static class OrdersEndpoints
                 return Results.BadRequest(new { error = $"invalid type '{req.Type}'" });
             if (req.Quantity <= 0)
                 return Results.BadRequest(new { error = "quantity must be positive" });
-            if (req.SecurityId == 0)
+
+            // SecurityId resolution: explicit non-zero in the payload
+            // wins (preserves the conformance contract). Otherwise look
+            // up the directory by symbol — that is the path the trader
+            // UI takes, since the ticket form does not expose the
+            // numeric SecurityId.
+            var securityId = req.SecurityId;
+            if (securityId == 0 && symbols.TryResolve(req.Symbol, out var resolved))
+                securityId = resolved;
+            if (securityId == 0)
                 return Results.BadRequest(new { error = "securityId is required" });
 
             var owner = ResolveOwner(ctx, registry);
             var firm = ResolveFirm(ctx);
             var clOrdId = clOrdIds.Generate(owner);
-            var order = new Order(clOrdId, owner, req.Symbol, req.SecurityId, side, type, req.Quantity, req.Price, firm);
+            var order = new Order(clOrdId, owner, req.Symbol, securityId, side, type, req.Quantity, req.Price, firm);
 
             // Persist order intent + register ownership atomically. The
             // dispatcher serialises this with snapshot capture so a crash
@@ -82,7 +92,7 @@ public static class OrdersEndpoints
                         EndClientId = owner.Value,
                         FirmId = firm,
                         Symbol = req.Symbol,
-                        SecurityId = req.SecurityId,
+                        SecurityId = securityId,
                         Side = side.ToString(),
                         Type = type.ToString(),
                         Quantity = req.Quantity,

--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -1,0 +1,74 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Static symbol → SecurityId map bound from
+/// <c>Trading:SymbolDirectory:SecurityIds</c>. The trader UI submits
+/// orders by symbol because that is what end-clients understand;
+/// B3 wire (BinaryEntryPoint / SBE) addresses instruments by their
+/// numeric SecurityId. Without a directory, every UI submit is
+/// rejected with <c>securityId is required</c>.
+/// </summary>
+/// <remarks>
+/// Resolution rules (see <see cref="OrdersEndpoints.MapPost"/> in
+/// <c>B3.Trading.Api</c>):
+/// <list type="number">
+///   <item>If the request payload carries a non-zero
+///   <c>SecurityId</c>, that wins (preserves the conformance suite
+///   contract — explicit values are never overridden).</item>
+///   <item>Otherwise the directory is consulted by symbol; case
+///   does not matter (<see cref="StringComparer.OrdinalIgnoreCase"/>).</item>
+///   <item>If neither path yields an id, the endpoint still returns
+///   a 400 with the same message. The directory is additive, not a
+///   silent fallback.</item>
+/// </list>
+/// The directory is intentionally simple in v1 (in-process, read at
+/// startup). When the participant on-boards instruments dynamically
+/// (e.g. via a real B3 Security Definition feed), a hot-reload or
+/// service-backed implementation will replace this class behind the
+/// same <see cref="TryResolve(string, out ulong)"/> API.
+/// </remarks>
+public sealed class SymbolDirectory
+{
+    private readonly IReadOnlyDictionary<string, ulong> _byName;
+
+    public SymbolDirectory(SymbolDirectoryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        // Always copy to enforce case-insensitive comparison even if
+        // the binder produced a culture-sensitive dictionary.
+        var copy = new Dictionary<string, ulong>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in options.SecurityIds)
+        {
+            if (string.IsNullOrWhiteSpace(kv.Key) || kv.Value == 0) continue;
+            copy[kv.Key] = kv.Value;
+        }
+        _byName = copy;
+    }
+
+    public int Count => _byName.Count;
+
+    public bool TryResolve(string? symbol, out ulong securityId)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            securityId = 0;
+            return false;
+        }
+        return _byName.TryGetValue(symbol, out securityId);
+    }
+}
+
+/// <summary>
+/// Bound from <c>Trading:SymbolDirectory</c>.
+/// </summary>
+public sealed class SymbolDirectoryOptions
+{
+    public const string SectionName = "Trading:SymbolDirectory";
+
+    /// <summary>
+    /// Symbol → SecurityId. Symbols with a zero or empty SecurityId
+    /// are dropped at construction time (see <see cref="SymbolDirectory"/>).
+    /// </summary>
+    public Dictionary<string, ulong> SecurityIds { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -27,6 +27,10 @@ builder.Services.Configure<AuthOptions>(
     builder.Configuration.GetSection(AuthOptions.SectionName));
 builder.Services.Configure<RiskOptions>(
     builder.Configuration.GetSection(RiskOptions.SectionName));
+builder.Services.Configure<SymbolDirectoryOptions>(
+    builder.Configuration.GetSection(SymbolDirectoryOptions.SectionName));
+builder.Services.AddSingleton(sp =>
+    new SymbolDirectory(sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value));
 builder.Services.Configure<PersistenceOptions>(
     builder.Configuration.GetSection(PersistenceOptions.SectionName));
 

--- a/backend/src/B3.Trading.Host/appsettings.json
+++ b/backend/src/B3.Trading.Host/appsettings.json
@@ -54,6 +54,9 @@
       "Symbols": [],
       "MaxStaleness": "00:05:00"
     },
+    "SymbolDirectory": {
+      "SecurityIds": {}
+    },
     "Cors": {
       "AllowedOrigins": [ "http://localhost:8080", "http://127.0.0.1:8080" ]
     },

--- a/backend/tests/B3.Trading.Api.Tests/SymbolDirectoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SymbolDirectoryEndpointTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Validates that POST /orders accepts a payload without an explicit
+/// SecurityId when a <c>Trading:SymbolDirectory</c> mapping covers the
+/// symbol. This is the contract that lets the trader UI submit by
+/// symbol; the conformance suite (which always sends explicit
+/// SecurityId) must keep working unchanged.
+/// </summary>
+public class SymbolDirectoryEndpointTests
+{
+    private static TestAppFactory NewFactoryWithDirectory(bool register = true)
+    {
+        var overrides = new Dictionary<string, string?>();
+        if (register)
+        {
+            overrides["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321";
+        }
+        return TestAppFactory.WithOverrides(overrides);
+    }
+
+    [Fact]
+    public async Task Submit_WithoutSecurityId_KnownSymbol_Resolves()
+    {
+        using var factory = NewFactoryWithDirectory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/orders/", new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+            // SecurityId omitted on purpose — this is the trader-UI path.
+        });
+
+        // The default test factory uses Mock mode, which routes through
+        // the EntryPointClientGateway. Without a real exchange behind
+        // it the gateway throws → 502. That is fine for THIS test; we
+        // only need to prove we got past the SecurityId validator
+        // (which would have returned 400 before this PR).
+        Assert.NotEqual(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Submit_WithoutSecurityId_UnknownSymbol_Returns400()
+    {
+        using var factory = NewFactoryWithDirectory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/orders/", new
+        {
+            Symbol = "UNKNOWN",
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("securityId", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Submit_ExplicitSecurityId_TakesPrecedence_OverDirectory()
+    {
+        // Even when the directory has a mapping, an explicit non-zero
+        // SecurityId in the payload wins. This protects callers that
+        // know what they are doing (conformance, integration scripts)
+        // from a misconfigured directory silently rerouting orders.
+        using var factory = NewFactoryWithDirectory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/orders/", new
+        {
+            Symbol = "PETR4",
+            SecurityId = 99999UL, // ≠ directory entry 4321
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+        });
+
+        Assert.NotEqual(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Submit_WithoutSecurityId_NoDirectoryConfigured_Returns400()
+    {
+        using var factory = NewFactoryWithDirectory(register: false);
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/orders/", new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
@@ -1,0 +1,101 @@
+using B3.Trading.Application;
+
+namespace B3.Trading.Application.Tests;
+
+public class SymbolDirectoryTests
+{
+    [Fact]
+    public void TryResolve_KnownSymbol_ReturnsId()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+        });
+
+        Assert.True(sut.TryResolve("PETR4", out var id));
+        Assert.Equal(4321UL, id);
+    }
+
+    [Fact]
+    public void TryResolve_IsCaseInsensitive()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+        });
+
+        Assert.True(sut.TryResolve("petr4", out var id));
+        Assert.Equal(4321UL, id);
+    }
+
+    [Fact]
+    public void TryResolve_UnknownSymbol_ReturnsFalse()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+        });
+
+        Assert.False(sut.TryResolve("VALE3", out var id));
+        Assert.Equal(0UL, id);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryResolve_NullOrBlank_ReturnsFalse(string? input)
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+        });
+
+        Assert.False(sut.TryResolve(input, out var id));
+        Assert.Equal(0UL, id);
+    }
+
+    [Fact]
+    public void Constructor_DropsZeroIds()
+    {
+        // Defensive: zero would silently mean "unresolved" downstream
+        // and produce confusing 400s after a successful TryResolve.
+        // The directory drops these at construction so the contract
+        // "TryResolve returns true ⇒ id != 0" always holds.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds =
+            {
+                ["PETR4"] = 4321UL,
+                ["BAD"]   = 0UL,
+            },
+        });
+
+        Assert.Equal(1, sut.Count);
+        Assert.False(sut.TryResolve("BAD", out _));
+    }
+
+    [Fact]
+    public void Constructor_DropsBlankKeys()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds =
+            {
+                [" "] = 9UL,
+                ["PETR4"] = 4321UL,
+            },
+        });
+
+        Assert.Equal(1, sut.Count);
+    }
+
+    [Fact]
+    public void Empty_ReturnsFalseForEverything()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions());
+
+        Assert.Equal(0, sut.Count);
+        Assert.False(sut.TryResolve("PETR4", out _));
+    }
+}

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -14,3 +14,7 @@ services:
       # StubExchangeGateway echoes ERs immediately for the seeded firm.
       Trading__Exchange__Firms__0__FirmId: default
       Trading__Exchange__Firms__0__Endpoint: stub://e2e
+      # Smoke E2E posts orders by symbol; SymbolDirectory turns the
+      # symbol into a SecurityId so the validator does not 400.
+      Trading__SymbolDirectory__SecurityIds__PETR4: "4321"
+      Trading__SymbolDirectory__SecurityIds__VALE3: "1234"

--- a/frontend/e2e/smoke.spec.js
+++ b/frontend/e2e/smoke.spec.js
@@ -8,43 +8,42 @@
 //   4. accessibility hooks added in section 5 are present
 //   5. the cancel-order keyboard shortcut (Del) is wired even when
 //      no row is selected (no exception, no broken state)
-//
-// NOT covered (tracked separately):
-//   - POST /orders ↔ ExecutionReport round-trip. The ticket form does
-//     not yet pass SecurityId, so Stub-mode submits would 400. See the
-//     follow-up issue linked in #30.
+//   6. submit limit order → row appears in the blotter (#36 closed)
+//   7. cancel from the blotter → DELETE 204, button disables on
+//      terminal status
 
 import { expect, test } from "@playwright/test";
 
 const USERNAME = process.env.E2E_USERNAME ?? "alice";
 const PASSWORD = process.env.E2E_PASSWORD ?? "wonderland";
 
+// Symbol that the e2e overlay (docker/docker-compose.e2e.yml) maps
+// in the SymbolDirectory so the backend can resolve it without an
+// explicit SecurityId from the ticket form.
+const SYMBOL = "PETR4";
+
+async function login(page) {
+  await page.goto("/");
+  await expect(page.locator("#login-view")).toBeVisible();
+  await page.fill("#login-username", USERNAME);
+  await page.fill("#login-password", PASSWORD);
+  await page.click("#login-submit");
+  await expect(page.locator("#trader-view")).toBeVisible();
+  await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+}
+
 test.describe("trader workspace smoke", () => {
   test("login → trader view → WS connected", async ({ page }) => {
-    await page.goto("/");
-
-    // 1. Login form visible.
-    await expect(page.locator("#login-view")).toBeVisible();
-    await page.fill("#login-username", USERNAME);
-    await page.fill("#login-password", PASSWORD);
-    // Backend defaults to same-origin via the nginx reverse proxy, so
-    // we leave the backend field blank.
-    await page.click("#login-submit");
-
-    // 2. Trader view replaces login.
-    await expect(page.locator("#trader-view")).toBeVisible();
+    await login(page);
     await expect(page.locator("#login-view")).toBeHidden();
     await expect(page.locator("#user-label")).toHaveText(USERNAME);
 
-    // 3. WS reaches connected. Generous timeout for cold container.
-    await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+    // ARIA hooks from section 5.
     await expect(page.locator("#ws-status")).toHaveAttribute("aria-label", /connected/);
-
-    // 4. ARIA hooks from section 5.
     await expect(page.locator("#ws-status")).toHaveAttribute("role", "status");
     await expect(page.locator("#logout")).toHaveAttribute("aria-label", "Logout");
 
-    // 5. Del with no selection should be a no-op (no JS exception).
+    // Del with no selection should be a no-op (no JS exception).
     let pageError = null;
     page.on("pageerror", (err) => { pageError = err; });
     await page.locator("body").press("Delete");
@@ -58,4 +57,49 @@ test.describe("trader workspace smoke", () => {
     await expect(modal).toHaveAttribute("role", "dialog");
     await expect(modal).toHaveAttribute("aria-modal", "true");
   });
+
+  test("submit limit order → blotter row → cancel → DELETE 204", async ({ page }) => {
+    await login(page);
+
+    // Capture the DELETE response status independently of any UI
+    // change so the test still proves the cancel round-trip even if
+    // the stub gateway never produces a terminal ER.
+    const deleteResponses = [];
+    page.on("response", (resp) => {
+      if (resp.request().method() === "DELETE" && resp.url().includes("/orders/")) {
+        deleteResponses.push(resp.status());
+      }
+    });
+
+    // Fill the ticket: PETR4, Buy, Limit, qty 100 (lot multiple),
+    // price 25.00 (tick multiple). With no MD price observed the
+    // fat-finger guard is skipped (validation.js:fatFingerCheck
+    // returns null when lastPrice is unknown).
+    await page.fill("#ticket-symbol", SYMBOL);
+    await page.selectOption("#ticket-side", "Buy");
+    await page.selectOption("#ticket-type", "Limit");
+    await page.fill("#ticket-qty", "100");
+    await page.fill("#ticket-price", "25.00");
+    await page.click("#ticket-submit");
+
+    // The accepted ClOrdId is shown in the ticket-feedback line and
+    // the order arrives in the blotter via the WS push.
+    await expect(page.locator("#ticket-feedback")).toContainText(/accepted/i, { timeout: 15_000 });
+    const row = page.locator("#blotter-body tr[data-clordid]").first();
+    await expect(row).toBeVisible({ timeout: 15_000 });
+
+    // Click the row's cancel button. The button is per-row with an
+    // aria-label of "Cancel order <ClOrdId>".
+    await row.locator(".cancel-btn").click();
+
+    // The Stub gateway never echoes ERs, so the row may stay around
+    // in PendingCancel. What we care about is that the DELETE made
+    // it to the backend and returned 204.
+    await expect.poll(
+      () => deleteResponses.length,
+      { timeout: 10_000, message: "expected at least one DELETE /orders/<id> response" },
+    ).toBeGreaterThan(0);
+    expect(deleteResponses[0]).toBe(204);
+  });
 });
+


### PR DESCRIPTION
Closes #36.

## Problem

The trader UI ticket form submits orders by symbol only — it has no
view of the numeric `SecurityId` the FIXP wire requires. Until now
the backend rejected every UI submit with `400 securityId is
required`, which is exactly what the issue reports.

## Approach

A small, config-driven `SymbolDirectory` in `B3.Trading.Application`
(bound from `Trading:SymbolDirectory:SecurityIds`). `OrdersEndpoints`
uses it to resolve a missing `SecurityId` from the incoming `Symbol`.

Resolution rules (the contract this PR establishes):

1. If `req.SecurityId != 0` → use as-is. **Explicit payloads are
   never silently overridden.** This keeps the conformance suite
   (and any integration script that knows what it is doing) working
   unchanged even if the directory has a different mapping.
2. Else `symbols.TryResolve(req.Symbol, out resolved)` → use it.
3. Else `400 "securityId is required"` (same message as before;
   additive directory, no silent fallback).

The directory drops zero-valued ids and blank keys at construction
so `TryResolve == true` is guaranteed to return a non-zero id.

## Tests

- `SymbolDirectoryTests` (Application, 9 cases) — hit /
  case-insensitive / miss / null / blank / zero-drop /
  blank-key-drop / empty.
- `SymbolDirectoryEndpointTests` (Api, 4 cases) — known symbol
  resolves, unknown symbol 400, explicit SecurityId wins, no
  directory configured 400.
- `frontend/e2e/smoke.spec.js` — third test now exercises the full
  UI loop: ticket → "accepted" feedback → row in the blotter →
  click Cancel → DELETE 204. The Stub gateway never echoes ERs, so
  the assertion is on the DELETE response code rather than on a
  terminal status badge.

Suite: `dotnet format --verify-no-changes` clean,
`dotnet build` 0 warnings, **209 tests** passing
(196 prior + 13 new). `node --check` clean on the smoke spec.

## Compose / config

- `docker/docker-compose.e2e.yml` registers `PETR4=4321` and
  `VALE3=1234` so the smoke E2E has known-good symbols.
- Base `appsettings.json` ships with an empty `SymbolDirectory`
  section as documentation; **no production mapping is committed**.

## Out of scope

- Frontend ticket form remains symbol-only (no SecurityId field).
- Real exchange-side symbol catalogue (will land with the live
  market data integration; until then the directory is the
  pragmatic seam).
