### PR TITLE
backend: per-firm risk limits (slice 2 of #38)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
@@ -12,7 +12,7 @@ public sealed class MaxQuantityCheck : IRiskCheck
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.Symbol, l => l.MaxQuantity);
+        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxQuantity);
         if (max.HasValue && ctx.Quantity > max.Value)
             return RiskDecision.Reject($"quantity {ctx.Quantity} exceeds max {max.Value}");
         return RiskDecision.Approve;
@@ -29,7 +29,7 @@ public sealed class MaxNotionalCheck : IRiskCheck
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.Symbol, l => l.MaxNotional);
+        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxNotional);
         if (!max.HasValue || !ctx.Price.HasValue)
             return RiskDecision.Approve; // no cap, or market order — let venue handle
         var notional = ctx.Price.Value * ctx.Quantity;

--- a/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
@@ -19,7 +19,7 @@ public sealed class PositionLimitCheck : IRiskCheck
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var limit = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.Symbol, l => l.PositionLimit);
+        var limit = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PositionLimit);
         if (!limit.HasValue) return RiskDecision.Approve;
 
         var current = _positions.GetOrCreate(ctx.Owner, ctx.Symbol).NetQuantity;

--- a/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
@@ -19,7 +19,7 @@ public sealed class PriceCollarCheck : IRiskCheck
     public RiskDecision Check(RiskContext ctx)
     {
         if (!ctx.Price.HasValue) return RiskDecision.Approve; // market order
-        var collarPct = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.Symbol, l => l.PriceCollarPercent);
+        var collarPct = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarPercent);
         if (!collarPct.HasValue) return RiskDecision.Approve;
         if (!_refPrice.TryGet(ctx.Symbol, out var refPx) || refPx <= 0m)
             return RiskDecision.Approve; // no reference; can't enforce

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -2,8 +2,8 @@ namespace B3.Trading.Application.Risk;
 
 /// <summary>
 /// Risk configuration. Bound from <c>Trading:Risk</c>. Resolution order
-/// when computing limits for an order: per-end-client → per-symbol →
-/// default. First non-null wins per field.
+/// when computing limits for an order: per-end-client → per-firm →
+/// per-symbol → default. First non-null wins per field.
 /// </summary>
 public sealed class RiskOptions
 {
@@ -11,6 +11,8 @@ public sealed class RiskOptions
 
     public RiskLimits Default { get; set; } = new();
     public Dictionary<string, RiskLimits> PerEndClient { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, RiskLimits> PerFirm { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
     public Dictionary<string, RiskLimits> PerSymbol { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
@@ -28,11 +30,27 @@ public sealed class RiskLimits
 
 public static class RiskLimitsResolver
 {
-    public static T? Resolve<T>(RiskOptions opts, string endClient, string symbol, Func<RiskLimits, T?> selector)
+    /// <summary>
+    /// Resolves a single risk-limit field by walking the precedence
+    /// chain <c>per-end-client → per-firm → per-symbol → default</c>
+    /// and returning the first non-null value. <paramref name="firmId"/>
+    /// may be null/blank when the caller has no firm context (legacy
+    /// callers); the per-firm slot is then skipped.
+    /// </summary>
+    public static T? Resolve<T>(
+        RiskOptions opts,
+        string endClient,
+        string? firmId,
+        string symbol,
+        Func<RiskLimits, T?> selector)
         where T : struct
     {
         if (opts.PerEndClient.TryGetValue(endClient, out var ec) && selector(ec).HasValue)
             return selector(ec);
+        if (!string.IsNullOrWhiteSpace(firmId)
+            && opts.PerFirm.TryGetValue(firmId, out var fi)
+            && selector(fi).HasValue)
+            return selector(fi);
         if (opts.PerSymbol.TryGetValue(symbol, out var sy) && selector(sy).HasValue)
             return selector(sy);
         return selector(opts.Default);

--- a/backend/src/B3.Trading.Host/appsettings.json
+++ b/backend/src/B3.Trading.Host/appsettings.json
@@ -46,6 +46,7 @@
         "PositionLimit": 500000
       },
       "PerEndClient": {},
+      "PerFirm": {},
       "PerSymbol": {},
       "ReferencePrices": {}
     },

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -92,6 +92,69 @@ public class RiskPipelineTests
     }
 
     [Fact]
+    public void MaxQuantity_PerFirm_AppliesWhenEndClientNotConfigured()
+    {
+        var opts = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { MaxQuantity = 1000 },
+            PerFirm = { ["broker-a"] = new RiskLimits { MaxQuantity = 25 } },
+        });
+        var check = new MaxQuantityCheck(opts);
+        Assert.False(check.Check(Ctx(firm: "broker-a", qty: 26)).Approved);
+        Assert.True(check.Check(Ctx(firm: "broker-a", qty: 25)).Approved);
+        // A firm without a per-firm cap falls back to default.
+        Assert.True(check.Check(Ctx(firm: "broker-b", qty: 999)).Approved);
+    }
+
+    [Fact]
+    public void MaxQuantity_PerEndClient_BeatsPerFirm()
+    {
+        var opts = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { MaxQuantity = 1000 },
+            PerFirm = { ["broker-a"] = new RiskLimits { MaxQuantity = 25 } },
+            PerEndClient = { ["alice"] = new RiskLimits { MaxQuantity = 5 } },
+        });
+        var check = new MaxQuantityCheck(opts);
+        // Alice is capped at 5, even though her firm allows 25.
+        Assert.False(check.Check(Ctx(firm: "broker-a", qty: 10)).Approved);
+        // Bob has no per-end-client cap, so the firm limit applies.
+        Assert.True(check.Check(Ctx(owner: "bob", firm: "broker-a", qty: 25)).Approved);
+        Assert.False(check.Check(Ctx(owner: "bob", firm: "broker-a", qty: 26)).Approved);
+    }
+
+    [Fact]
+    public void MaxQuantity_PerFirm_BeatsPerSymbol()
+    {
+        var opts = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { MaxQuantity = 1000 },
+            PerFirm = { ["broker-a"] = new RiskLimits { MaxQuantity = 25 } },
+            PerSymbol = { ["PETR4"] = new RiskLimits { MaxQuantity = 50 } },
+        });
+        var check = new MaxQuantityCheck(opts);
+        // Firm wins over symbol on the same field.
+        Assert.False(check.Check(Ctx(firm: "broker-a", qty: 26)).Approved);
+        // A different firm with no per-firm entry falls through to symbol.
+        Assert.True(check.Check(Ctx(firm: "broker-b", qty: 50)).Approved);
+        Assert.False(check.Check(Ctx(firm: "broker-b", qty: 51)).Approved);
+    }
+
+    [Fact]
+    public void Resolver_SkipsPerFirm_WhenFirmIdIsBlank()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { MaxQuantity = 999 },
+            PerFirm = { ["broker-a"] = new RiskLimits { MaxQuantity = 1 } },
+        };
+        // Blank firm id should NOT match any per-firm entry.
+        var resolved = RiskLimitsResolver.Resolve(
+            opts, endClient: "x", firmId: "", symbol: "PETR4", l => l.MaxQuantity);
+        Assert.Equal(999, resolved);
+    }
+
+    [Fact]
     public void MaxNotional_RejectsOverNotional()
     {
         var opts = Wrap(new RiskOptions { Default = new RiskLimits { MaxNotional = 1000m } });


### PR DESCRIPTION
First implementation slice of pre-trade risk v2 (refs #38).

## What changes

Extends the risk-limit resolution chain with a new **PerFirm** slot:

```
Old: PerEndClient → PerSymbol → Default
New: PerEndClient → PerFirm → PerSymbol → Default
```

The resolver still picks first-non-null per field, so a per-symbol
cap can coexist with a per-firm cap on a different field.

**Why PerFirm sits between PerEndClient and PerSymbol** (from the
RFC): a firm-level cap is the broker's operational ceiling. It
should override symbol defaults but defer to anything an ops engineer
set explicitly for one end-client.

## Changes

- `RiskOptions.PerFirm` (case-insensitive `Dictionary`, defaults
  empty — fully backward compatible).
- `RiskLimitsResolver.Resolve` takes a new `string? firmId`
  parameter. Blank/null firm ids skip the per-firm slot.
- All four checks (`MaxQuantity`, `MaxNotional`, `PositionLimit`,
  `PriceCollar`) thread `ctx.FirmId` through the resolver. The
  context already carried `FirmId`, so no plumbing change.
- `appsettings.json` gains an empty `"PerFirm": {}` section as
  documentation; no production mapping committed.

## Tests

Four new cases in `RiskPipelineTests`:

- per-firm applies when the end-client has no explicit cap
- per-end-client beats per-firm on the same field
- per-firm beats per-symbol on the same field
- blank `firmId` skips the per-firm slot (legacy callers safe)

Suite: `dotnet format` clean, build 0 warnings, **213 tests** green
(209 prior + 4 new).

## Out of scope

The other 7 slices from the RFC roadmap land in their own PRs:
hot-reload + admin/risk debug endpoints, MarginCheck, live
reference prices, fat-finger server-side, rate limits, conformance,
Grafana panel.
