### PR TITLE
backend: hot-reload risk limits + admin/risk endpoints (slice 3 of #38)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -77,6 +77,47 @@ public static class AdminEndpoints
             return Results.Ok(new { mode = mode.ToString(), firms });
         });
 
+        // Debug helper for ops: surface the *effective* RiskLimits the
+        // resolver picks for a given (endClient, firm, symbol) tuple.
+        // Pure read — no side effects. The caller passes whatever
+        // dimension(s) they care about; missing values default to a
+        // sentinel that matches no entry so the resolver falls through
+        // to per-symbol/default for that slot.
+        group.MapGet("/risk/limits", (IOptionsMonitor<RiskOptions> opts, string? endClient, string? firmId, string? symbol) =>
+        {
+            var resolved = RiskLimitsResolver.ResolveAll(
+                opts.CurrentValue,
+                endClient ?? string.Empty,
+                firmId,
+                symbol ?? string.Empty);
+            return Results.Ok(new
+            {
+                query = new { endClient, firmId, symbol },
+                limits = new
+                {
+                    maxQuantity = resolved.MaxQuantity,
+                    maxNotional = resolved.MaxNotional,
+                    priceCollarPercent = resolved.PriceCollarPercent,
+                    positionLimit = resolved.PositionLimit,
+                },
+            });
+        });
+
+        // Reload hook for non-appsettings configuration providers.
+        // The default appsettings provider already watches the file
+        // and pushes IOptionsMonitor.OnChange notifications, so this
+        // endpoint is a no-op there. When a future provider (file/DB
+        // adapter from the persistence spike) ships, it can plug in
+        // an IRiskOptionsReloader and have the body trigger an
+        // out-of-band reload. Returns 204 either way; the caller can
+        // immediately re-query /admin/risk/limits to verify.
+        group.MapPost("/risk/reload", (IServiceProvider sp) =>
+        {
+            var reloader = sp.GetService<IRiskOptionsReloader>();
+            reloader?.Reload();
+            return Results.NoContent();
+        });
+
         return app;
     }
 

--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
@@ -4,15 +4,16 @@ namespace B3.Trading.Application.Risk.Checks;
 
 public sealed class MaxQuantityCheck : IRiskCheck
 {
-    private readonly RiskOptions _options;
-    public MaxQuantityCheck(IOptions<RiskOptions> options) => _options = options.Value;
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    public MaxQuantityCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
 
     public int Order => 100;
     public string Name => "max_quantity";
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxQuantity);
+        var opts = _options.CurrentValue;
+        var max = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxQuantity);
         if (max.HasValue && ctx.Quantity > max.Value)
             return RiskDecision.Reject($"quantity {ctx.Quantity} exceeds max {max.Value}");
         return RiskDecision.Approve;
@@ -21,15 +22,16 @@ public sealed class MaxQuantityCheck : IRiskCheck
 
 public sealed class MaxNotionalCheck : IRiskCheck
 {
-    private readonly RiskOptions _options;
-    public MaxNotionalCheck(IOptions<RiskOptions> options) => _options = options.Value;
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    public MaxNotionalCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
 
     public int Order => 100;
     public string Name => "max_notional";
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var max = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxNotional);
+        var opts = _options.CurrentValue;
+        var max = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxNotional);
         if (!max.HasValue || !ctx.Price.HasValue)
             return RiskDecision.Approve; // no cap, or market order — let venue handle
         var notional = ctx.Price.Value * ctx.Quantity;

--- a/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
@@ -5,12 +5,12 @@ namespace B3.Trading.Application.Risk.Checks;
 
 public sealed class PositionLimitCheck : IRiskCheck
 {
-    private readonly RiskOptions _options;
+    private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly PositionKeeper _positions;
 
-    public PositionLimitCheck(IOptions<RiskOptions> options, PositionKeeper positions)
+    public PositionLimitCheck(IOptionsMonitor<RiskOptions> options, PositionKeeper positions)
     {
-        _options = options.Value;
+        _options = options;
         _positions = positions;
     }
 
@@ -19,7 +19,8 @@ public sealed class PositionLimitCheck : IRiskCheck
 
     public RiskDecision Check(RiskContext ctx)
     {
-        var limit = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PositionLimit);
+        var opts = _options.CurrentValue;
+        var limit = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PositionLimit);
         if (!limit.HasValue) return RiskDecision.Approve;
 
         var current = _positions.GetOrCreate(ctx.Owner, ctx.Symbol).NetQuantity;

--- a/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
@@ -4,12 +4,12 @@ namespace B3.Trading.Application.Risk.Checks;
 
 public sealed class PriceCollarCheck : IRiskCheck
 {
-    private readonly RiskOptions _options;
+    private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly IReferencePrice _refPrice;
 
-    public PriceCollarCheck(IOptions<RiskOptions> options, IReferencePrice refPrice)
+    public PriceCollarCheck(IOptionsMonitor<RiskOptions> options, IReferencePrice refPrice)
     {
-        _options = options.Value;
+        _options = options;
         _refPrice = refPrice;
     }
 
@@ -19,7 +19,8 @@ public sealed class PriceCollarCheck : IRiskCheck
     public RiskDecision Check(RiskContext ctx)
     {
         if (!ctx.Price.HasValue) return RiskDecision.Approve; // market order
-        var collarPct = RiskLimitsResolver.Resolve(_options, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarPercent);
+        var opts = _options.CurrentValue;
+        var collarPct = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarPercent);
         if (!collarPct.HasValue) return RiskDecision.Approve;
         if (!_refPrice.TryGet(ctx.Symbol, out var refPx) || refPx <= 0m)
             return RiskDecision.Approve; // no reference; can't enforce

--- a/backend/src/B3.Trading.Application/Risk/IReferencePrice.cs
+++ b/backend/src/B3.Trading.Application/Risk/IReferencePrice.cs
@@ -13,10 +13,10 @@ public interface IReferencePrice
 
 public sealed class ConfigReferencePrice : IReferencePrice
 {
-    private readonly RiskOptions _options;
-    public ConfigReferencePrice(Microsoft.Extensions.Options.IOptions<RiskOptions> options) =>
-        _options = options.Value;
+    private readonly Microsoft.Extensions.Options.IOptionsMonitor<RiskOptions> _options;
+    public ConfigReferencePrice(Microsoft.Extensions.Options.IOptionsMonitor<RiskOptions> options) =>
+        _options = options;
 
     public bool TryGet(string symbol, out decimal price) =>
-        _options.ReferencePrices.TryGetValue(symbol, out price);
+        _options.CurrentValue.ReferencePrices.TryGetValue(symbol, out price);
 }

--- a/backend/src/B3.Trading.Application/Risk/IRiskOptionsReloader.cs
+++ b/backend/src/B3.Trading.Application/Risk/IRiskOptionsReloader.cs
@@ -1,0 +1,15 @@
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Optional seam that lets non-appsettings configuration providers
+/// (file/DB adapters from the persistence spike) be told to refresh.
+/// The default ASP.NET Core appsettings provider already watches the
+/// file and pushes <see cref="Microsoft.Extensions.Options.IOptionsMonitor{T}"/>
+/// notifications, so it does not need to register an implementation
+/// — the <c>POST /admin/risk/reload</c> endpoint becomes a no-op
+/// returning 204.
+/// </summary>
+public interface IRiskOptionsReloader
+{
+    void Reload();
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -55,4 +55,20 @@ public static class RiskLimitsResolver
             return selector(sy);
         return selector(opts.Default);
     }
+
+    /// <summary>
+    /// Convenience: resolve every <see cref="RiskLimits"/> field in
+    /// one pass. Used by <c>GET /admin/risk/limits</c> to surface
+    /// what the system actually thinks the cap is for a given
+    /// (endClient, firm, symbol) tuple.
+    /// </summary>
+    public static RiskLimits ResolveAll(
+        RiskOptions opts, string endClient, string? firmId, string symbol) =>
+        new()
+        {
+            MaxQuantity = Resolve(opts, endClient, firmId, symbol, l => l.MaxQuantity),
+            MaxNotional = Resolve(opts, endClient, firmId, symbol, l => l.MaxNotional),
+            PriceCollarPercent = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarPercent),
+            PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),
+        };
 }

--- a/backend/tests/B3.Trading.Api.Tests/AdminRiskEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminRiskEndpointsTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+public class AdminRiskEndpointsTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public AdminRiskEndpointsTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task GetLimits_RequiresAdminRole()
+    {
+        using var user = await _factory.CreateAuthedClientAsync(); // role=user
+        var resp = await user.GetAsync("/admin/risk/limits?symbol=PETR4");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLimits_ReturnsResolvedDefaults_WhenOnlyDefaultIsConfigured()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/risk/limits?symbol=PETR4");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var limits = body.GetProperty("limits");
+        Assert.Equal(1000, limits.GetProperty("maxQuantity").GetInt64());
+        Assert.Equal(1000000m, limits.GetProperty("maxNotional").GetDecimal());
+        Assert.Equal(10m, limits.GetProperty("priceCollarPercent").GetDecimal());
+        Assert.Equal(5000, limits.GetProperty("positionLimit").GetInt64());
+    }
+
+    [Fact]
+    public async Task GetLimits_PerEndClientWinsOverDefault()
+    {
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Risk:PerEndClient:alice:MaxQuantity"] = "7",
+        });
+        using var admin = await f.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/risk/limits?endClient=alice&symbol=PETR4");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(7, body.GetProperty("limits").GetProperty("maxQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task GetLimits_PerFirmAppliesWhenEndClientHasNoEntry()
+    {
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Risk:PerFirm:broker-a:MaxQuantity"] = "42",
+        });
+        using var admin = await f.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/risk/limits?endClient=bob&firmId=broker-a&symbol=PETR4");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(42, body.GetProperty("limits").GetProperty("maxQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task PostReload_RequiresAdminRole()
+    {
+        using var user = await _factory.CreateAuthedClientAsync();
+        var resp = await user.PostAsync("/admin/risk/reload", content: null);
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostReload_NoOpForAppsettingsProvider_Returns204()
+    {
+        // No IRiskOptionsReloader is registered in the default test
+        // host (we rely on the appsettings file watcher), so the
+        // endpoint short-circuits to 204 without doing anything.
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsync("/admin/risk/reload", content: null);
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -8,7 +8,7 @@ namespace B3.Trading.Application.Tests;
 
 public class RiskPipelineTests
 {
-    private static IOptions<RiskOptions> Wrap(RiskOptions o) => Options.Create(o);
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
 
     private static RiskContext Ctx(
         string owner = "alice", string firm = "default", string symbol = "PETR4",
@@ -152,6 +152,42 @@ public class RiskPipelineTests
         var resolved = RiskLimitsResolver.Resolve(
             opts, endClient: "x", firmId: "", symbol: "PETR4", l => l.MaxQuantity);
         Assert.Equal(999, resolved);
+    }
+
+    [Fact]
+    public void HotReload_NewLimitsTakeEffectOnNextCheck()
+    {
+        // Start permissive, then tighten. With IOptionsMonitor the
+        // change is observed on the very next Check call — no rebuild
+        // of the check or the pipeline required.
+        var monitor = new StaticOptionsMonitor<RiskOptions>(
+            new RiskOptions { Default = new RiskLimits { MaxQuantity = 1000 } });
+        var check = new MaxQuantityCheck(monitor);
+
+        Assert.True(check.Check(Ctx(qty: 500)).Approved);
+
+        monitor.Set(new RiskOptions { Default = new RiskLimits { MaxQuantity = 100 } });
+        Assert.False(check.Check(Ctx(qty: 500)).Approved);
+    }
+
+    [Fact]
+    public void ResolveAll_FoldsAllFieldsAcrossPrecedence()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { MaxQuantity = 1000, MaxNotional = 999_999m, PriceCollarPercent = 10m, PositionLimit = 5000 },
+            PerFirm = { ["broker-a"] = new RiskLimits { MaxQuantity = 50 } },
+            PerEndClient = { ["alice"] = new RiskLimits { PositionLimit = 100 } },
+            PerSymbol = { ["PETR4"] = new RiskLimits { PriceCollarPercent = 2m } },
+        };
+
+        var resolved = RiskLimitsResolver.ResolveAll(
+            opts, endClient: "alice", firmId: "broker-a", symbol: "PETR4");
+
+        Assert.Equal(50, resolved.MaxQuantity);                // from PerFirm
+        Assert.Equal(999_999m, resolved.MaxNotional);          // from Default
+        Assert.Equal(2m, resolved.PriceCollarPercent);         // from PerSymbol
+        Assert.Equal(100, resolved.PositionLimit);             // from PerEndClient
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/StaticOptionsMonitor.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StaticOptionsMonitor.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Minimal <see cref="IOptionsMonitor{T}"/> for unit tests that need
+/// to drive hot-reload behavior without spinning up the full
+/// configuration system. Subscribers registered via
+/// <see cref="OnChange"/> are invoked synchronously when
+/// <see cref="Set(T)"/> is called.
+/// </summary>
+internal sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T> where T : class
+{
+    private T _current;
+    private readonly List<Action<T, string?>> _listeners = new();
+
+    public StaticOptionsMonitor(T initial) => _current = initial;
+
+    public T CurrentValue => _current;
+
+    public T Get(string? name) => _current;
+
+    public IDisposable OnChange(Action<T, string?> listener)
+    {
+        _listeners.Add(listener);
+        return new Subscription(() => _listeners.Remove(listener));
+    }
+
+    public void Set(T value)
+    {
+        _current = value;
+        foreach (var l in _listeners.ToArray()) l(value, null);
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _onDispose;
+        public Subscription(Action onDispose) => _onDispose = onDispose;
+        public void Dispose() => _onDispose();
+    }
+}


### PR DESCRIPTION
Second implementation slice of pre-trade risk v2 (refs #38).

## Hot-reload

Switch every `RiskOptions` consumer from `IOptions<RiskOptions>` to
`IOptionsMonitor<RiskOptions>` and read `.CurrentValue` per request.
The default ASP.NET Core configuration provider already watches the
appsettings file and pushes the change notification, so editing a
limit no longer requires a redeploy.

Affected consumers (all 5):

- `MaxQuantityCheck`, `MaxNotionalCheck`
- `PositionLimitCheck`, `PriceCollarCheck`
- `ConfigReferencePrice`

## New admin endpoints (role=admin)

- `GET /admin/risk/limits?endClient=&firmId=&symbol=` — returns the
  effective `RiskLimits` resolved for the given tuple. **Pure read,
  no side effects.** Lets ops verify what the system actually thinks
  the cap is for any combination.
- `POST /admin/risk/reload` — triggers an out-of-band reload via an
  optional `IRiskOptionsReloader` seam. **No-op (returns 204)** when
  no implementation is registered, which is the case today (the
  appsettings provider self-watches). The seam is in place so the
  file/DB provider from the persistence spike (#29) can plug in
  later without API churn.

## Helpers

- `RiskLimitsResolver.ResolveAll` folds all four fields in one pass
  for the debug endpoint.
- `IRiskOptionsReloader` interface in
  `B3.Trading.Application/Risk`.
- Test-only `StaticOptionsMonitor<T>` to drive hot-reload behavior
  in unit tests without spinning up the full configuration system.

## Tests (+8)

Unit:
- `HotReload_NewLimitsTakeEffectOnNextCheck` — mutate the monitor,
  next `Check` call sees the new cap.
- `ResolveAll_FoldsAllFieldsAcrossPrecedence` — one resolution per
  field, mixing all four scopes.

Integration (`AdminRiskEndpointsTests`):
- GET requires admin role (`Forbidden` for user role)
- GET returns resolved defaults when only `Default` is configured
- GET — `PerEndClient` wins over `Default`
- GET — `PerFirm` applies when the end-client has no entry
- POST requires admin role
- POST returns `204` no-op when no `IRiskOptionsReloader` is
  registered

Suite: `dotnet format` clean, build 0 warnings, **221 tests** green
(213 prior + 8 new).
