### PR TITLE
backend: reserve-on-submit margin check (slice 4 of #38)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -117,16 +117,19 @@ public static class OrdersEndpoints
                 new KeyValuePair<string, object?>("symbol", req.Symbol),
                 new KeyValuePair<string, object?>("side", side.ToString()));
 
-            // Pre-trade risk: synchronous pipeline + async margin provider.
+            // Pre-trade risk: synchronous pipeline + async margin reservation.
             // Rejection synthesizes an ER through the same sink real
             // exchange rejections use, so the WS client can't tell them
-            // apart structurally.
+            // apart structurally. Margin runs LAST so that a reject
+            // from any earlier check leaves the ledger untouched.
             var riskCtx = new RiskContext(owner, firm, req.Symbol, side, type, req.Quantity, req.Price);
             var decision = risk.Evaluate(riskCtx);
+            var marginReserved = false;
             if (decision.Approved)
             {
-                var marginDecision = await margin.CheckAsync(riskCtx, ct);
-                if (!marginDecision.Approved) decision = marginDecision;
+                var marginDecision = await margin.TryReserveAsync(clOrdId, riskCtx, ct);
+                if (marginDecision.Approved) marginReserved = true;
+                else decision = marginDecision;
             }
             if (!decision.Approved)
             {
@@ -146,6 +149,9 @@ public static class OrdersEndpoints
                 MetricsRegistry.OrdersGatewayFailed.Add(1);
                 loggerFactory.CreateLogger("OrdersEndpoints")
                     .LogError(ex, "Gateway submit failed for {ClOrdId}; synthesizing rejection.", clOrdId);
+                // Roll back the margin reservation: the order will never
+                // reach the exchange, so no ER will arrive to release it.
+                if (marginReserved) margin.ReleaseReservation(clOrdId);
                 PublishSyntheticRejection(dispatcher, sink, order, owner, "gateway_unavailable");
                 return Results.Json(
                     new { error = "gateway unavailable", clOrdId = clOrdId.ToString() },

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -30,6 +30,7 @@ public sealed class ExecutionReportProcessor
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
     private readonly IExecutionEventSink _sink;
+    private readonly Risk.IMarginProvider _margin;
     private readonly ILogger<ExecutionReportProcessor> _logger;
 
     public ExecutionReportProcessor(
@@ -37,12 +38,14 @@ public sealed class ExecutionReportProcessor
         WorkingOrderBook orders,
         PositionKeeper positions,
         IExecutionEventSink sink,
+        Risk.IMarginProvider margin,
         ILogger<ExecutionReportProcessor> logger)
     {
         _ownership = ownership;
         _orders = orders;
         _positions = positions;
         _sink = sink;
+        _margin = margin;
         _logger = logger;
     }
 
@@ -124,6 +127,10 @@ public sealed class ExecutionReportProcessor
                             lookupId, lastQty, delta);
                     }
                     _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
+                    // Release reserved margin against the actual booked
+                    // delta — not the wire lastQty — so a lost
+                    // intermediate ER can't leave the ledger under-released.
+                    _margin.OnExecution(lookupId, kind, delta);
                     break;
                 }
             case ExecKind.Canceled:
@@ -134,6 +141,7 @@ public sealed class ExecutionReportProcessor
                     return;
                 }
                 order.MarkCancelled();
+                _margin.OnExecution(lookupId, kind, 0);
                 break;
             case ExecKind.Rejected:
                 if (order.Status is OrderStatus.Rejected or OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Cancelled)
@@ -143,6 +151,7 @@ public sealed class ExecutionReportProcessor
                     return;
                 }
                 order.MarkRejected();
+                _margin.OnExecution(lookupId, kind, 0);
                 break;
             case ExecKind.Replaced:
                 // Re-issuance: the gateway is responsible for calling

--- a/backend/src/B3.Trading.Application/Risk/IMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/IMarginProvider.cs
@@ -1,18 +1,59 @@
 namespace B3.Trading.Application.Risk;
 
 /// <summary>
-/// Pluggable margin / collateral check. Real providers would query an
-/// external risk-management system; v1 ships <see cref="NoOpMarginProvider"/>
-/// so the rest of the pipeline can compose without forcing operators to
-/// stand up the real integration on day one.
+/// Pluggable margin / collateral check.
+///
+/// <para>
+/// <b>Contract:</b> implementations may be stateful — the contract for
+/// <see cref="TryReserveAsync"/> is "atomically check available
+/// collateral and reserve the order's notional if the check passes".
+/// Reservations are released via <see cref="OnExecution"/> as
+/// ExecutionReports flow back from the exchange (partial fill releases
+/// proportionally; terminal status releases the rest). The
+/// <see cref="NoOpMarginProvider"/> default implementation makes both
+/// methods harmless no-ops so deployments can opt out by simply not
+/// registering a real provider.
+/// </para>
+///
+/// <para>
+/// The model assumed by v2 (see <c>docs/rfcs/pre-trade-risk-v2.md</c>
+/// §3.1) is reserve-on-submit / release-on-fill, mirroring a crypto
+/// spot exchange. Derivatives-style margin (initial/maintenance,
+/// greeks) and T+N cash settlement are deliberately out-of-scope and
+/// require a different provider behind this interface.
+/// </para>
 /// </summary>
 public interface IMarginProvider
 {
-    Task<RiskDecision> CheckAsync(RiskContext ctx, CancellationToken ct);
+    /// <summary>
+    /// Atomically check available collateral for the order and, if
+    /// sufficient, reserve the order's notional under
+    /// <paramref name="clOrdId"/>. Returns
+    /// <see cref="RiskDecision.Approve"/> on success or a
+    /// <see cref="RiskDecision.Reject"/> with a human-readable reason
+    /// otherwise. The reservation is released by <see cref="OnExecution"/>
+    /// when matching ERs arrive.
+    /// </summary>
+    Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct);
+
+    /// <summary>
+    /// Release reserved collateral as ERs arrive. Default: no-op.
+    /// Implementations that hold reservations override this to release
+    /// the unfilled portion on fills/cancels/rejects. <paramref name="lastQty"/>
+    /// is the per-ER fill quantity (0 for non-fill ERs).
+    /// </summary>
+    void OnExecution(ulong clOrdId, ExecKind kind, long lastQty) { }
+
+    /// <summary>
+    /// Synchronous release used by the order-submit path when the
+    /// downstream gateway throws after a successful reservation.
+    /// Default: no-op.
+    /// </summary>
+    void ReleaseReservation(ulong clOrdId) { }
 }
 
 public sealed class NoOpMarginProvider : IMarginProvider
 {
-    public Task<RiskDecision> CheckAsync(RiskContext ctx, CancellationToken ct) =>
+    public Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct) =>
         Task.FromResult(RiskDecision.Approve);
 }

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -1,0 +1,184 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// In-process reserve-on-submit margin provider.
+///
+/// <para>
+/// Implements the v2 margin model documented in
+/// <c>docs/rfcs/pre-trade-risk-v2.md</c> §3.1 — a synchronous
+/// reservation ledger inspired by crypto spot exchanges:
+/// </para>
+/// <list type="bullet">
+///   <item>On submit: <c>available -= price · qty</c> for the owner.</item>
+///   <item>On partial fill: release <c>fillQty · price</c>.</item>
+///   <item>On terminal status (Filled/Canceled/Rejected): release the
+///     remaining reservation.</item>
+/// </list>
+///
+/// <para>
+/// Only Buy + Limit + non-null price orders consume cash. Sell orders
+/// release inventory (no cash margin in the spot model) and Market
+/// orders are sized at the venue, so we cannot reserve up-front
+/// without a live reference price — both paths short-circuit to
+/// <see cref="RiskDecision.Approve"/> here. Out-of-scope work in the
+/// RFC: a Market-order path that uses a live reference price (slice
+/// 5) and short-sale collateral (future RFC).
+/// </para>
+///
+/// <para>
+/// State is in-process, ephemeral, and not concurrency-safe across
+/// processes — same posture as <see cref="PositionKeeper"/>. ER replay
+/// after reconnect rebuilds positions; reservations for in-flight
+/// orders that crossed a restart are abandoned with the order itself
+/// (no orphaned holds because the reservation lives only as long as
+/// the working order).
+/// </para>
+/// </summary>
+public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly ILogger<ReserveOnSubmitMarginProvider> _logger;
+
+    private readonly ConcurrentDictionary<ulong, ReservationEntry> _reservations = new();
+    private readonly ConcurrentDictionary<string, decimal> _reserved =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _gate = new();
+
+    public ReserveOnSubmitMarginProvider(
+        IOptionsMonitor<RiskOptions> options,
+        ILogger<ReserveOnSubmitMarginProvider> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct)
+    {
+        // Spot model: only Buys consume cash. Sells release inventory
+        // (handled separately by the position keeper) and don't touch
+        // the cash ledger here.
+        if (ctx.Side != OrderSide.Buy)
+            return Task.FromResult(RiskDecision.Approve);
+
+        // Market orders are sized at the venue — without a live
+        // reference price we can't reserve up-front. Slice 5 of the
+        // RFC will revisit this once MarketDataReferencePrice lands.
+        if (!ctx.Price.HasValue)
+            return Task.FromResult(RiskDecision.Approve);
+
+        var notional = ctx.Price.Value * ctx.Quantity;
+        if (notional <= 0m)
+            return Task.FromResult(RiskDecision.Approve);
+
+        var owner = ctx.Owner.Value;
+        var initial = ResolveInitial(owner);
+
+        // Atomic check+reserve: take the gate, snapshot reserved,
+        // verify capacity, mutate. The provider is a singleton so the
+        // gate scope covers all races for the same owner.
+        lock (_gate)
+        {
+            var reserved = _reserved.GetValueOrDefault(owner, 0m);
+            var available = initial - reserved;
+            if (notional > available)
+            {
+                return Task.FromResult(RiskDecision.Reject(
+                    $"insufficient margin: notional {notional} exceeds available {available} for end-client '{owner}'"));
+            }
+            _reserved[owner] = reserved + notional;
+            _reservations[clOrdId] = new ReservationEntry(owner, ctx.Price.Value, ctx.Quantity, notional);
+        }
+
+        return Task.FromResult(RiskDecision.Approve);
+    }
+
+    public void OnExecution(ulong clOrdId, ExecKind kind, long lastQty)
+    {
+        if (!_reservations.TryGetValue(clOrdId, out var entry))
+            return; // unknown order (Sell, Market, or never reserved here)
+
+        switch (kind)
+        {
+            case ExecKind.PartialFill:
+                if (lastQty > 0) ReleasePartial(clOrdId, entry, lastQty);
+                break;
+
+            case ExecKind.Fill:
+                if (lastQty > 0) ReleasePartial(clOrdId, entry, lastQty);
+                ReleaseRemaining(clOrdId);
+                break;
+
+            case ExecKind.Canceled:
+            case ExecKind.Rejected:
+                ReleaseRemaining(clOrdId);
+                break;
+
+                // New / Replaced: nothing to release. Replaced is handled
+                // by the gateway re-issuing under a fresh ClOrdID; the
+                // original reservation stays with the original ID.
+        }
+    }
+
+    public void ReleaseReservation(ulong clOrdId) => ReleaseRemaining(clOrdId);
+
+    private void ReleasePartial(ulong clOrdId, ReservationEntry entry, long lastQty)
+    {
+        var amount = entry.Price * lastQty;
+        if (amount <= 0m) return;
+        lock (_gate)
+        {
+            // Update the per-clordid entry so a subsequent partial
+            // releases against the still-reserved remainder, never the
+            // original.
+            var newRemaining = entry.RemainingNotional - amount;
+            if (newRemaining < 0m)
+            {
+                // Should not happen if the exchange respects our qty,
+                // but defend against a misbehaving venue rather than
+                // letting reserved go negative.
+                _logger.LogWarning(
+                    "Margin partial-release for {ClOrdId} would exceed remaining ({Amount} > {Remaining}); clamping.",
+                    clOrdId, amount, entry.RemainingNotional);
+                amount = entry.RemainingNotional;
+                newRemaining = 0m;
+            }
+            DecrementReserved(entry.Owner, amount);
+            _reservations[clOrdId] = entry with { RemainingNotional = newRemaining };
+        }
+    }
+
+    private void ReleaseRemaining(ulong clOrdId)
+    {
+        if (!_reservations.TryRemove(clOrdId, out var entry)) return;
+        if (entry.RemainingNotional <= 0m) return;
+        lock (_gate)
+        {
+            DecrementReserved(entry.Owner, entry.RemainingNotional);
+        }
+    }
+
+    private void DecrementReserved(string owner, decimal amount)
+    {
+        var reserved = _reserved.GetValueOrDefault(owner, 0m);
+        var next = reserved - amount;
+        if (next < 0m) next = 0m;
+        _reserved[owner] = next;
+    }
+
+    private decimal ResolveInitial(string owner) =>
+        _options.CurrentValue.Margin.Initial.GetValueOrDefault(owner, 0m);
+
+    /// <summary>Test/observability helper: returns the currently reserved amount for an owner.</summary>
+    internal decimal ReservedForTesting(string owner) => _reserved.GetValueOrDefault(owner, 0m);
+
+    /// <summary>Test/observability helper: returns the currently available amount for an owner.</summary>
+    internal decimal AvailableForTesting(string owner) =>
+        ResolveInitial(owner) - ReservedForTesting(owner);
+
+    private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional);
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -18,6 +18,27 @@ public sealed class RiskOptions
         new(StringComparer.OrdinalIgnoreCase);
     public Dictionary<string, decimal> ReferencePrices { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
+    public MarginOptions Margin { get; set; } = new();
+}
+
+/// <summary>
+/// Reserve-on-submit margin configuration. Disabled by default —
+/// <see cref="NoOpMarginProvider"/> stays in place until an operator
+/// opts in. See <c>docs/rfcs/pre-trade-risk-v2.md</c> §3.1 for the
+/// model assumed by v2 (crypto-spot ledger; not T+N, not derivatives).
+/// </summary>
+public sealed class MarginOptions
+{
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Per-end-client opening balance (in the single accounting
+    /// currency v2 assumes). Missing entries are treated as zero, so
+    /// unrecognized end-clients cannot place buy orders when margin
+    /// is enabled — fail-closed by default.
+    /// </summary>
+    public Dictionary<string, decimal> Initial { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
 }
 
 public sealed class RiskLimits

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -93,7 +93,15 @@ builder.Services.AddSingleton<EventDispatcher>();
 // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.
 builder.Services.AddSingleton<KillSwitchService>();
 builder.Services.AddTradingMarketData(builder.Configuration);
-builder.Services.AddSingleton<IMarginProvider, NoOpMarginProvider>();
+builder.Services.AddSingleton<IMarginProvider>(sp =>
+{
+    var opts = sp.GetRequiredService<IOptionsMonitor<RiskOptions>>().CurrentValue;
+    return opts.Margin.Enabled
+        ? new ReserveOnSubmitMarginProvider(
+            sp.GetRequiredService<IOptionsMonitor<RiskOptions>>(),
+            sp.GetRequiredService<ILogger<ReserveOnSubmitMarginProvider>>())
+        : new NoOpMarginProvider();
+});
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxNotionalCheck>();

--- a/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the reserve-on-submit margin provider
+/// (slice 4 of pre-trade risk v2). Verifies that when margin is
+/// enabled via config, buy orders consume an end-client's available
+/// balance, are rejected when depleted, and that releasing a prior
+/// reservation (admin cancel via DELETE /orders/{clOrdId}) frees the
+/// balance for new submissions.
+/// </summary>
+public class MarginCheckIntegrationTests
+{
+    private static IDictionary<string, string?> EnabledFor(string endClient, decimal initial) =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Risk:Margin:Enabled"] = "true",
+            [$"Trading:Risk:Margin:Initial:{endClient}"] = initial.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            // Push other limits high so margin is the only gate that matters.
+            ["Trading:Risk:Default:MaxQuantity"] = "1000000",
+            ["Trading:Risk:Default:MaxNotional"] = "999999999",
+        };
+
+    [Fact]
+    public async Task SubmitsUntilBalanceDepleted_ThenSecondIsRejected()
+    {
+        // alice's initial balance covers exactly 100 @ 30 = 3000.
+        using var f = TestAppFactory.WithOverrides(EnabledFor("alice", 3_000m));
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var first = await PostOrder(http, token, qty: 100, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+        var firstBody = await first.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.NotEqual("Rejected", firstBody!.Status);
+
+        var second = await PostOrder(http, token, qty: 1, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
+        var body = await second.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.Equal("Rejected", body!.Status);
+        Assert.Contains("margin", body.Reason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SellsAndUnknownOwnersBypassMargin()
+    {
+        // Margin enabled but alice is not in the Initial map (treated as 0 balance).
+        using var f = TestAppFactory.WithOverrides(EnabledFor("nobody", 0m));
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http); // alice -> not configured
+
+        // Sell ignores margin even with zero balance.
+        var sell = await PostOrder(http, token, qty: 10, price: 30m, side: "Sell");
+        Assert.Equal(HttpStatusCode.Accepted, sell.StatusCode);
+        var sellBody = await sell.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.NotEqual("Rejected", sellBody!.Status);
+
+        // Buy with 0 balance must be rejected with the margin reason.
+        var buy = await PostOrder(http, token, qty: 1, price: 30m, side: "Buy");
+        var buyBody = await buy.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.Equal("Rejected", buyBody!.Status);
+        Assert.Contains("margin", buyBody.Reason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DisabledByDefault_NoOpAlwaysApproves()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var resp = await PostOrder(http, token, qty: 100, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.NotEqual("Rejected", body!.Status);
+    }
+
+    private static async Task<HttpResponseMessage> PostOrder(
+        HttpClient http, string token, int qty, decimal price, string side = "Buy")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = side,
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+            })
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private sealed record OrderAck(string ClOrdId, string Status, string? Reason);
+}

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayTranslationTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayTranslationTests.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Risk;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -166,7 +167,7 @@ public class B3EntryPointClientGatewayTranslationTests
         ownership.Register(42UL, owner);
 
         var sink = new CapturingSink();
-        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, NullLogger<ExecutionReportProcessor>.Instance);
+        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
 
         // ER carries the cancel-side ClOrdID 99 plus OrigClOrdId 42.
         proc.Apply(clOrdId: 99UL, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: 42UL);

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Risk;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -57,7 +58,7 @@ public class EntryPointGatewayAndRouterTests
         ownership.Register(1UL, owner);
 
         var sink = new TestSink();
-        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, NullLogger<ExecutionReportProcessor>.Instance);
+        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         var client = new MockEntryPointClient();
         var dispatcher = new EventDispatcher(new NullEventStore());
         using var router = new EntryPointExecutionReportRouter(client, proc, dispatcher);

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Risk;
 using B3.Trading.Application;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,7 +13,7 @@ public class ExecutionReportProcessorTests
         var book = new WorkingOrderBook();
         var positions = new PositionKeeper();
         var sink = new RecordingSink();
-        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, NullLogger<ExecutionReportProcessor>.Instance);
+        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         return (proc, ownership, book, positions, sink);
     }
 

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -163,7 +163,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var clOrdIds = new ClOrdIdPrefixRegistry();
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
-            NullLogger<ExecutionReportProcessor>.Instance);
+            new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership);
         var dispatcher = new EventDispatcher(store);
         return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink);

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
@@ -1,0 +1,141 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+public class ReserveOnSubmitMarginProviderTests
+{
+    private static (ReserveOnSubmitMarginProvider provider, StaticOptionsMonitor<RiskOptions> monitor) Build(
+        decimal initial = 100_000m, string owner = "alice")
+    {
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial[owner] = initial;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var provider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        return (provider, monitor);
+    }
+
+    private static RiskContext Buy(string owner, decimal price, long qty, OrderType type = OrderType.Limit) =>
+        new(new EndClientId(owner), "FIRM", "PETR4", OrderSide.Buy, type, qty, type == OrderType.Market ? null : price);
+
+    [Fact]
+    public async Task Approves_until_balance_depleted_then_rejects()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 50), CancellationToken.None)).Approved);
+        Assert.True((await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None)).Approved);
+        var d3 = await p.TryReserveAsync(3, Buy("alice", 10m, 1), CancellationToken.None);
+        Assert.False(d3.Approved);
+        Assert.Contains("insufficient margin", d3.Reason);
+    }
+
+    [Fact]
+    public async Task Cancel_releases_reservation()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        Assert.False((await p.TryReserveAsync(2, Buy("alice", 10m, 1), CancellationToken.None)).Approved);
+        p.OnExecution(1, ExecKind.Canceled, 0);
+        Assert.True((await p.TryReserveAsync(3, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+    }
+
+    [Fact]
+    public async Task Reject_releases_reservation()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        p.OnExecution(1, ExecKind.Rejected, 0);
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task PartialFill_releases_proportionally()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        Assert.Equal(0m, p.AvailableForTesting("alice"));
+        p.OnExecution(1, ExecKind.PartialFill, 30);
+        Assert.Equal(300m, p.AvailableForTesting("alice"));
+        p.OnExecution(1, ExecKind.PartialFill, 20);
+        Assert.Equal(500m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Terminal_fill_releases_remaining()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        p.OnExecution(1, ExecKind.PartialFill, 30);
+        p.OnExecution(1, ExecKind.Fill, 70);
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Sells_skip_reservation()
+    {
+        var (p, _) = Build(initial: 100m);
+        var ctx = new RiskContext(new EndClientId("alice"), "F", "PETR4", OrderSide.Sell, OrderType.Limit, 10_000, 99m);
+        var d = await p.TryReserveAsync(1, ctx, CancellationToken.None);
+        Assert.True(d.Approved);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Markets_skip_reservation()
+    {
+        var (p, _) = Build(initial: 100m);
+        var d = await p.TryReserveAsync(1, Buy("alice", 0m, 10_000, OrderType.Market), CancellationToken.None);
+        Assert.True(d.Approved);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Unknown_owner_has_zero_balance_and_is_rejected()
+    {
+        var (p, _) = Build(initial: 1_000m, owner: "alice");
+        var d = await p.TryReserveAsync(1, Buy("bob", 1m, 1), CancellationToken.None);
+        Assert.False(d.Approved);
+    }
+
+    [Fact]
+    public async Task ReleaseReservation_is_idempotent()
+    {
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        p.ReleaseReservation(1);
+        p.ReleaseReservation(1);
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public void OnExecution_for_unknown_clordid_is_noop()
+    {
+        var (p, _) = Build();
+        p.OnExecution(999, ExecKind.Fill, 100);
+        Assert.Equal(100_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Hot_reload_of_initial_balance_is_observed()
+    {
+        var (p, monitor) = Build(initial: 100m);
+        Assert.False((await p.TryReserveAsync(1, Buy("alice", 10m, 50), CancellationToken.None)).Approved);
+        var newOpts = new RiskOptions();
+        newOpts.Margin.Enabled = true;
+        newOpts.Margin.Initial["alice"] = 1_000m;
+        monitor.Set(newOpts);
+        Assert.True((await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None)).Approved);
+    }
+
+    [Fact]
+    public async Task NoOpProvider_always_approves()
+    {
+        IMarginProvider noop = new NoOpMarginProvider();
+        var d = await noop.TryReserveAsync(1, Buy("alice", 999_999m, 999_999), CancellationToken.None);
+        Assert.True(d.Approved);
+        noop.OnExecution(1, ExecKind.Canceled, 0);
+        noop.ReleaseReservation(1);
+    }
+}


### PR DESCRIPTION
Slice 4 of pre-trade risk v2 (tracker #38). Implements the
reserve-on-submit margin model documented in
[`docs/rfcs/pre-trade-risk-v2.md` §3.1](../blob/main/docs/rfcs/pre-trade-risk-v2.md):
crypto-spot ledger, no derivatives, no T+N (per #42 addendum).

## Behaviour

| Event | Effect on the per-end-client ledger |
| --- | --- |
| Submit Buy + Limit + Price | `available -= price·qty` (atomic check+reserve) |
| Submit Sell or Market | no-op (sells release inventory; markets need a venue price — slice 5) |
| ER PartialFill | release `delta · entry.Price` (delta = booked, not wire `lastQty`) |
| ER Fill (terminal) | release remaining |
| ER Canceled / Rejected | release remaining |
| Gateway throw on submit | rollback via `ReleaseReservation(clOrdId)` |

Disabled by default. Operators opt in via:

```json
"Trading": { "Risk": { "Margin": { "Enabled": true,
  "Initial": { "alice": 100000, "bob": 50000 } } } }
```

`Initial` is read through `IOptionsMonitor`, so admin hot-reload of
balances takes effect on the next submit (mirrors the slice 3
hot-reload pattern).

## API surface change

`IMarginProvider.CheckAsync` → `TryReserveAsync(clOrdId, ctx, ct)` to
make the mutation explicit. Two new default-method members:

```csharp
void OnExecution(ulong clOrdId, ExecKind kind, long lastQty) { }
void ReleaseReservation(ulong clOrdId) { }
```

`NoOpMarginProvider` keeps the existing always-approve semantics so
deployments that don't enable margin see zero behavioural change.

## Wire-up

- `OrdersEndpoints` runs `TryReserveAsync` after the sync pipeline
  approves; on gateway throw, releases via `ReleaseReservation`.
- `ExecutionReportProcessor` now takes `IMarginProvider` and calls
  `OnExecution` after position bookings. Fills release against the
  **actual computed cumulative delta**, not the wire `lastQty`, so a
  missing intermediate ER cannot under-release the ledger.

## Tests

- **12 unit tests** in `ReserveOnSubmitMarginProviderTests`:
  deplete-then-reject, cancel/reject release, partial-fill proportional
  release, terminal full-release, sell/market bypass, unknown owner
  fail-closed, idempotent release, hot-reload of `Initial`,
  unknown-clOrdId no-op, `NoOp` passthrough.
- **3 API integration tests** in `MarginCheckIntegrationTests`:
  enabled-then-depleted, sells/zero-balance bypass, default-disabled.

Suite **221 → 247** (+26). `dotnet format` clean, 0 warnings.

## Out of scope

Documented in the RFC and reaffirmed here:

- Market-order reservation needs live reference price → slice 5.
- Short-sale collateral / inventory ledger → future RFC.
- Cross-process margin ledger → in-process only, ephemeral, same
  posture as `PositionKeeper`. ER replay rebuilds positions; in-flight
  reservations across a restart are abandoned with the orders themselves
  (no orphaned holds).
