### PR TITLE
backend: reference-price observability for price collar (slice 5 of #38)

### DIFF
--- a/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
@@ -56,6 +56,15 @@ public sealed class MarketDataReferencePrice : IReferencePrice, IHostedService
         _subscriber.InfoSnapshot += OnInfoSnapshot;
         _subscriber.ConnectionStateChanged += OnConnectionStateChanged;
         _subscriber.SubscribeError += OnSubscribeError;
+
+        // Push the per-symbol staleness source so the central observable
+        // gauge can report it on each scrape. Singleton lifetime — the
+        // provider lives as long as the host, so unregistration on
+        // shutdown is unnecessary (and would race with in-flight scrapes).
+        Observability.MetricsRegistry.RegisterRefPriceStalenessSource(
+            () => _cache.Select(kv => new KeyValuePair<string, double>(
+                kv.Key,
+                Math.Max(0d, (_clock.GetUtcNow() - kv.Value.UpdatedUtc).TotalSeconds))));
     }
 
     /// <summary>Exposed for tests / ops introspection. Snapshot, not live.</summary>
@@ -67,11 +76,15 @@ public sealed class MarketDataReferencePrice : IReferencePrice, IHostedService
 
     public bool TryGet(string symbol, out decimal price)
     {
+        var lookup = Lookup(symbol);
+        price = lookup.Price;
+        return lookup.Found;
+    }
+
+    public ReferencePriceLookup Lookup(string symbol)
+    {
         if (string.IsNullOrWhiteSpace(symbol))
-        {
-            price = 0m;
-            return false;
-        }
+            return ReferencePriceLookup.NotFound;
 
         if (_cache.TryGetValue(symbol, out var entry) && entry.Price > 0m)
         {
@@ -79,12 +92,11 @@ public sealed class MarketDataReferencePrice : IReferencePrice, IHostedService
             if (_options.MaxStaleness <= TimeSpan.Zero ||
                 _clock.GetUtcNow() - entry.UpdatedUtc <= _options.MaxStaleness)
             {
-                price = entry.Price;
-                return true;
+                return new ReferencePriceLookup(entry.Price, ReferencePriceSource.Live);
             }
         }
 
-        return _fallback.TryGet(symbol, out price);
+        return _fallback.Lookup(symbol);
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -178,4 +178,37 @@ public static class MetricsRegistry
     // MarketData consumer (B3.MarketData.WebSocketClient)
     public static readonly Counter<long> MarketDataSubscribeErrors =
         Meter.CreateCounter<long>("trading.marketdata.subscribe_errors");
+
+    // Reference-price observability for the price-collar check (slice 5).
+    //
+    // RefPriceLookups counts every IReferencePrice.Lookup made by the
+    // collar, tagged with (symbol, source) where source is one of
+    // "live" | "fallback" | "missing". A sustained drop in source=live
+    // (or rise in source=fallback) is the signal that the live MD feed
+    // has degraded and the collar is now leaning on the static config
+    // table — which is fail-open by design and worth alerting on.
+    public static readonly Counter<long> RefPriceLookups =
+        Meter.CreateCounter<long>("trading.risk.refprice.lookups");
+
+    // Counts the cases where PriceCollarCheck approved an order purely
+    // because it could not obtain any reference price for the symbol.
+    // These are unguarded orders from the collar's perspective; tag is
+    // the symbol so a single misconfigured ticker doesn't get lost in
+    // the aggregate.
+    public static readonly Counter<long> CollarBypassedNoReference =
+        Meter.CreateCounter<long>("trading.risk.collar.bypassed_no_reference");
+
+    // Per-symbol age (seconds) of the last live MD update held in the
+    // MarketDataReferencePrice cache. Sourced from a callback registered
+    // by the provider on construction (singleton). Symbols that have
+    // never been observed simply don't appear — no synthetic samples.
+    private static readonly System.Collections.Concurrent.ConcurrentBag<Func<IEnumerable<KeyValuePair<string, double>>>> _refPriceStalenessSources = new();
+    public static readonly ObservableGauge<double> RefPriceStalenessSeconds =
+        Meter.CreateObservableGauge<double>(
+            "trading.risk.refprice.staleness_seconds",
+            () => _refPriceStalenessSources.SelectMany(src => src()).Select(kv =>
+                new Measurement<double>(kv.Value, new KeyValuePair<string, object?>("symbol", kv.Key))));
+    public static void RegisterRefPriceStalenessSource(
+        Func<IEnumerable<KeyValuePair<string, double>>> source) =>
+        _refPriceStalenessSources.Add(source);
 }

--- a/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Observability;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Application.Risk.Checks;
@@ -22,9 +23,24 @@ public sealed class PriceCollarCheck : IRiskCheck
         var opts = _options.CurrentValue;
         var collarPct = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarPercent);
         if (!collarPct.HasValue) return RiskDecision.Approve;
-        if (!_refPrice.TryGet(ctx.Symbol, out var refPx) || refPx <= 0m)
-            return RiskDecision.Approve; // no reference; can't enforce
 
+        var lookup = _refPrice.Lookup(ctx.Symbol);
+        MetricsRegistry.RefPriceLookups.Add(1,
+            new KeyValuePair<string, object?>("symbol", ctx.Symbol),
+            new KeyValuePair<string, object?>("source", SourceTag(lookup.Source)));
+
+        if (!lookup.Found || lookup.Price <= 0m)
+        {
+            // Fail-open: a configured collar with no reference cannot be
+            // enforced. The counter below is the only signal ops gets
+            // that this happened — a steady non-zero rate is the cue to
+            // either seed the static table or fix the MD feed.
+            MetricsRegistry.CollarBypassedNoReference.Add(1,
+                new KeyValuePair<string, object?>("symbol", ctx.Symbol));
+            return RiskDecision.Approve;
+        }
+
+        var refPx = lookup.Price;
         var lower = refPx * (1m - collarPct.Value / 100m);
         var upper = refPx * (1m + collarPct.Value / 100m);
         if (ctx.Price.Value < lower || ctx.Price.Value > upper)
@@ -32,4 +48,11 @@ public sealed class PriceCollarCheck : IRiskCheck
                 $"price {ctx.Price.Value} outside collar [{lower:0.####}, {upper:0.####}] around ref {refPx}");
         return RiskDecision.Approve;
     }
+
+    private static string SourceTag(ReferencePriceSource source) => source switch
+    {
+        ReferencePriceSource.Live => "live",
+        ReferencePriceSource.Fallback => "fallback",
+        _ => "missing",
+    };
 }

--- a/backend/src/B3.Trading.Application/Risk/IReferencePrice.cs
+++ b/backend/src/B3.Trading.Application/Risk/IReferencePrice.cs
@@ -1,14 +1,55 @@
 namespace B3.Trading.Application.Risk;
 
 /// <summary>
-/// Reference price source for <see cref="Checks.PriceCollarCheck"/>. v1
-/// reads from <see cref="RiskOptions.ReferencePrices"/>; future
-/// implementations could subscribe to <c>B3MarketDataPlatform</c> last-trade
-/// or top-of-book ticks.
+/// Where a reference-price reading came from. Surfaced as a metric tag
+/// so ops can see whether the live MD feed is actually feeding the
+/// collar or whether it has degraded to the static config table.
+/// </summary>
+public enum ReferencePriceSource
+{
+    /// <summary>Fresh sample from the live market-data cache.</summary>
+    Live,
+    /// <summary>The live cache missed (or was stale) and we fell back to the static config table.</summary>
+    Fallback,
+    /// <summary>No source had a number for the symbol.</summary>
+    Missing,
+}
+
+/// <summary>
+/// Outcome of a reference-price lookup. <see cref="Found"/> is true
+/// for both Live and Fallback; only Missing returns false.
+/// </summary>
+public readonly record struct ReferencePriceLookup(decimal Price, ReferencePriceSource Source)
+{
+    public bool Found => Source != ReferencePriceSource.Missing;
+    public static ReferencePriceLookup NotFound { get; } = new(0m, ReferencePriceSource.Missing);
+}
+
+/// <summary>
+/// Reference price source for <see cref="Checks.PriceCollarCheck"/>.
+/// Implementations: <see cref="ConfigReferencePrice"/> (static config
+/// table) and
+/// <see cref="MarketData.MarketDataReferencePrice"/> (live B3 MD feed
+/// with config fallback).
 /// </summary>
 public interface IReferencePrice
 {
     bool TryGet(string symbol, out decimal price);
+
+    /// <summary>
+    /// Same lookup as <see cref="TryGet"/> but reports the source of
+    /// the reading (Live / Fallback / Missing) so the caller can emit
+    /// observability tags. Default impl wraps <see cref="TryGet"/> and
+    /// classifies hits as <see cref="ReferencePriceSource.Fallback"/>
+    /// (static — the safe assumption for any implementation that
+    /// hasn't opted into the richer contract).
+    /// </summary>
+    ReferencePriceLookup Lookup(string symbol)
+    {
+        if (TryGet(symbol, out var price))
+            return new ReferencePriceLookup(price, ReferencePriceSource.Fallback);
+        return ReferencePriceLookup.NotFound;
+    }
 }
 
 public sealed class ConfigReferencePrice : IReferencePrice
@@ -19,4 +60,9 @@ public sealed class ConfigReferencePrice : IReferencePrice
 
     public bool TryGet(string symbol, out decimal price) =>
         _options.CurrentValue.ReferencePrices.TryGetValue(symbol, out price);
+
+    public ReferencePriceLookup Lookup(string symbol) =>
+        TryGet(symbol, out var price)
+            ? new ReferencePriceLookup(price, ReferencePriceSource.Fallback)
+            : ReferencePriceLookup.NotFound;
 }

--- a/backend/tests/B3.Trading.Application.Tests/ReferencePriceMetricsTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReferencePriceMetricsTests.cs
@@ -1,0 +1,215 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Slice 5 wrap-up: verifies the observability hooks added to the
+/// reference-price path. The collar's behaviour is unchanged — these
+/// tests only assert that lookups are tagged with the correct source
+/// and that bypass-due-to-no-reference is counted, which is what ops
+/// will use to alert on a degraded MD feed.
+/// </summary>
+public class ReferencePriceMetricsTests : IDisposable
+{
+    private readonly MeterListener _listener;
+    private readonly object _gate = new();
+    private readonly List<(string Instrument, long Value, IDictionary<string, object?> Tags)> _samples = new();
+
+    public ReferencePriceMetricsTests()
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                // Only enable the two counters this fixture cares about.
+                // Other B3.Trading instruments would otherwise bleed in
+                // from xunit parallelism (other tests sharing the meter).
+                if (inst.Meter.Name == "B3.Trading" &&
+                    (inst.Name == "trading.risk.refprice.lookups" ||
+                     inst.Name == "trading.risk.collar.bypassed_no_reference"))
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((inst, v, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var t in tags) dict[t.Key] = t.Value;
+            lock (_gate) _samples.Add((inst.Name, v, dict));
+        });
+        _listener.Start();
+    }
+
+    public void Dispose() => _listener.Dispose();
+
+    private List<(string Instrument, long Value, IDictionary<string, object?> Tags)> Snapshot()
+    {
+        lock (_gate) return _samples.ToList();
+    }
+
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskContext Ctx(string symbol = "PETR4", decimal? price = 30m) =>
+        new(new EndClientId("alice"), "FIRM", symbol, OrderSide.Buy, OrderType.Limit, 100, price);
+
+    private static string? Tag(IDictionary<string, object?> tags, string key) =>
+        tags.TryGetValue(key, out var v) ? v as string : null;
+
+    [Fact]
+    public void Collar_LookupTaggedAsLive_WhenLiveCacheHitsFresh()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = BuildLiveRef(sub, new StaticFallback(), clock);
+        sub.RaiseTrade("PETR4", 30m, clock.GetUtcNow());
+
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { PriceCollarPercent = 10m } });
+        new PriceCollarCheck(opts, rp).Check(Ctx(price: 30m));
+
+        Assert.Contains(Snapshot(), s =>
+            s.Instrument == "trading.risk.refprice.lookups" &&
+            Tag(s.Tags, "source") == "live" &&
+            Tag(s.Tags, "symbol") == "PETR4");
+    }
+
+    [Fact]
+    public void Collar_LookupTaggedAsFallback_WhenLiveMissesAndConfigHits()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = BuildLiveRef(sub, new StaticFallback(("PETR4", 30m)), clock);
+        // No trade raised → live cache empty, falls through to static.
+
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { PriceCollarPercent = 10m } });
+        new PriceCollarCheck(opts, rp).Check(Ctx(price: 30m));
+
+        Assert.Contains(Snapshot(), s =>
+            s.Instrument == "trading.risk.refprice.lookups" &&
+            Tag(s.Tags, "source") == "fallback");
+    }
+
+    [Fact]
+    public void Collar_LookupTaggedAsMissing_AndBypassCounterFires_WhenNoReferenceAtAll()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = BuildLiveRef(sub, new StaticFallback(), clock);
+
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { PriceCollarPercent = 10m } });
+        new PriceCollarCheck(opts, rp).Check(Ctx(symbol: "VALE3", price: 30m));
+
+        Assert.Contains(Snapshot(), s =>
+            s.Instrument == "trading.risk.refprice.lookups" &&
+            Tag(s.Tags, "source") == "missing");
+        Assert.Contains(Snapshot(), s =>
+            s.Instrument == "trading.risk.collar.bypassed_no_reference" &&
+            Tag(s.Tags, "symbol") == "VALE3");
+    }
+
+    [Fact]
+    public void Collar_NoBypassCounter_WhenReferenceFoundAndOrderRejected()
+    {
+        var refPx = new StaticFallback(("PETR4", 30m));
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { PriceCollarPercent = 1m } });
+        var d = new PriceCollarCheck(opts, refPx).Check(Ctx(price: 35m));
+        Assert.False(d.Approved);
+        Assert.DoesNotContain(Snapshot(), s =>
+            s.Instrument == "trading.risk.collar.bypassed_no_reference");
+    }
+
+    [Fact]
+    public void Collar_NoBypassCounter_WhenCollarNotConfigured()
+    {
+        // No PriceCollarPercent on the resolved limits → check returns
+        // before doing any lookup; no metric should fire.
+        var opts = Wrap(new RiskOptions());
+        new PriceCollarCheck(opts, new StaticFallback()).Check(Ctx(price: 100m));
+        Assert.Empty(Snapshot());
+    }
+
+    [Fact]
+    public void ConfigReferencePrice_LookupReportsFallbackSource()
+    {
+        var monitor = new StaticOptionsMonitor<RiskOptions>(
+            new RiskOptions { ReferencePrices = { ["PETR4"] = 30m } });
+        var rp = new ConfigReferencePrice(monitor);
+
+        var hit = rp.Lookup("PETR4");
+        Assert.True(hit.Found);
+        Assert.Equal(ReferencePriceSource.Fallback, hit.Source);
+        Assert.Equal(30m, hit.Price);
+
+        var miss = rp.Lookup("VALE3");
+        Assert.False(miss.Found);
+        Assert.Equal(ReferencePriceSource.Missing, miss.Source);
+    }
+
+    [Fact]
+    public void MarketDataReferencePrice_LookupReportsLiveAndFallbackAndMissing()
+    {
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = BuildLiveRef(sub, new StaticFallback(("VALE3", 60m)), clock,
+            maxStaleness: TimeSpan.FromSeconds(10));
+        sub.RaiseTrade("PETR4", 28.5m, clock.GetUtcNow());
+
+        Assert.Equal(ReferencePriceSource.Live, rp.Lookup("PETR4").Source);
+        Assert.Equal(ReferencePriceSource.Fallback, rp.Lookup("VALE3").Source);
+        Assert.Equal(ReferencePriceSource.Missing, rp.Lookup("ITUB4").Source);
+
+        // Stale entry should also fall back, not stay live.
+        clock.Advance(TimeSpan.FromMinutes(1));
+        Assert.Equal(ReferencePriceSource.Missing, rp.Lookup("PETR4").Source);
+    }
+
+    [Fact]
+    public void StalenessGauge_PublishesPerSymbolAge()
+    {
+        var observed = new List<(string Symbol, double Seconds)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (inst.Name == "trading.risk.refprice.staleness_seconds")
+                    l.EnableMeasurementEvents(inst);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((inst, v, tags, _) =>
+        {
+            string? symbol = null;
+            foreach (var t in tags) if (t.Key == "symbol") symbol = (string?)t.Value;
+            if (symbol != null) observed.Add((symbol, v));
+        });
+        listener.Start();
+
+        var sub = new FakeMarketDataSubscriber();
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var rp = BuildLiveRef(sub, new StaticFallback(), clock);
+        sub.RaiseTrade("PETR4", 30m, clock.GetUtcNow());
+        clock.Advance(TimeSpan.FromSeconds(7));
+
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(observed, o => o.Symbol == "PETR4" && o.Seconds >= 7d);
+    }
+
+    private static MarketDataReferencePrice BuildLiveRef(
+        FakeMarketDataSubscriber sub, IReferencePrice fallback, TestClock clock,
+        TimeSpan? maxStaleness = null) =>
+        new(sub, fallback,
+            Options.Create(new MarketDataOptions
+            {
+                WsUrl = "ws://test",
+                MaxStaleness = maxStaleness ?? TimeSpan.FromMinutes(5),
+            }),
+            clock,
+            NullLogger<MarketDataReferencePrice>.Instance);
+}

--- a/docs/rfcs/pre-trade-risk-v2.md
+++ b/docs/rfcs/pre-trade-risk-v2.md
@@ -213,18 +213,26 @@ Two new admin endpoints (gated by `role=admin`):
 
 ### 4.6 Observability
 
-New metrics (Prometheus, via the existing OTel pipeline):
+New metrics (OTel via the existing pipeline; meter name `B3.Trading`):
 
-| Metric                                | Type      | Labels                  |
-| ------------------------------------- | --------- | ----------------------- |
-| `risk_check_total`                    | counter   | check, outcome          |
-| `risk_reject_total`                   | counter   | reason, firmId          |
-| `risk_pipeline_duration_ms`           | histogram | (none)                  |
-| `risk_margin_check_duration_ms`       | histogram | (none)                  |
-| `risk_reference_price_stale_total`    | counter   | symbol                  |
-| `risk_reference_price_missing_total`  | counter   | symbol                  |
+| Metric                                      | Type             | Tags              | Status       |
+| ------------------------------------------- | ---------------- | ----------------- | ------------ |
+| `trading.risk.refprice.lookups`             | counter          | symbol, source    | shipped (slice 5) |
+| `trading.risk.refprice.staleness_seconds`   | observable gauge | symbol            | shipped (slice 5) |
+| `trading.risk.collar.bypassed_no_reference` | counter          | symbol            | shipped (slice 5) |
 
-Grafana panel mirrors the FIXP panel's layout (rate / p95 / errors).
+`source` is one of `live` (live MD cache hit fresh under
+`Trading:MarketData:MaxStaleness`), `fallback` (live missed/stale,
+satisfied by the static `Trading:Risk:ReferencePrices` table), or
+`missing` (no source had a number). The `bypassed_no_reference`
+counter only increments when a configured collar approves an order
+purely because no reference was available — i.e. the fail-open
+escape hatch was exercised. A sustained non-zero rate is the cue for
+ops to either seed the static table or fix the live feed.
+
+Per-check `risk_check_total` / `risk_reject_total` / pipeline
+duration histograms remain on the slice 8 list (conformance + Grafana
+panel).
 
 ### 4.7 Conformance
 
@@ -285,14 +293,13 @@ brittle; the metric + ops paging is the compromise.
 Each PR is sequenced, autocontido, build/format/test green, with
 metrics + tests included.
 
-1. RFC (this document) — no code.
-2. `PerFirm` limits + resolver update.
+1. RFC (this document) — no code. **shipped (#39)**
+2. `PerFirm` limits + resolver update. **shipped (#40)**
 3. `IOptionsMonitor` switch + `GET /admin/risk/limits` + reload
-   endpoint.
-4. `MarginCheck` + `StaticMarginProvider` + cache + reject reason
-   wiring.
+   endpoint. **shipped (#41)**
+4. `MarginCheck` + reserve-on-submit ledger. **shipped (#43)**
 5. `IReferencePrice` indirection + `MarketDataReferencePrice` with
-   fallback + stale/missing metrics.
+   fallback + staleness/source/bypass metrics. **shipped (#44)**
 6. Fat-finger server-side: `MinTickSizeCheck`, `MinLotSizeCheck`,
    `MaxNotionalPerOrderCheck`, absolute collar in
    `PriceCollarCheck`.


### PR DESCRIPTION
Closes the slice 5 RFC item (tracker #38) by adding the missing
observability layer on top of the live `MarketDataReferencePrice`
that already shipped in the cross-stream MD work. Without these
signals, ops had no way to see whether the price collar was actually
being enforced against the live feed or silently degrading to the
static fallback.

## Surface

`IReferencePrice` gains a `Lookup(string symbol)` method returning a
struct that carries both the price and its source:

```csharp
public enum ReferencePriceSource { Live, Fallback, Missing }
public readonly record struct ReferencePriceLookup(decimal Price, ReferencePriceSource Source);
```

- `MarketDataReferencePrice.Lookup` → fresh cache hit = `Live`; stale
  / miss delegates to its fallback (which itself reports `Fallback`
  or `Missing`).
- `ConfigReferencePrice.Lookup` → hit = `Fallback`; miss = `Missing`.
- `TryGet` is preserved as a thin wrapper for back-compat.

## New metrics (meter `B3.Trading`)

| Metric | Type | Tags | When |
| --- | --- | --- | --- |
| `trading.risk.refprice.lookups` | counter | symbol, source | every collar lookup |
| `trading.risk.collar.bypassed_no_reference` | counter | symbol | fail-open path was taken |
| `trading.risk.refprice.staleness_seconds` | observable gauge | symbol | per-scrape |

`source` ∈ `live` / `fallback` / `missing`. A sustained drop in
`source=live` (or rise in `source=fallback`) is the alert signal that
the live MD feed has degraded. `bypassed_no_reference` only
increments when a configured collar approves an order purely because
no reference was available — i.e. the documented fail-open escape
hatch was exercised. Staleness is sourced from a callback registered
by `MarketDataReferencePrice` on construction; symbols never observed
don't emit synthetic samples.

## Wire-up

`PriceCollarCheck` switches from `TryGet` to `Lookup`, emits the
lookups counter on every check, and emits the bypass counter only
when the collar would have run but had no reference. Collar
decisions for the same inputs are byte-identical to before — only
observability is added.

## Tests (+8)

`ReferencePriceMetricsTests` covers:

- Lookup tagging across `live` / `fallback` / `missing` paths
- Bypass counter fires for the no-reference case but not for valid
  rejections, not when the collar is unconfigured
- Both `IReferencePrice` implementations surface the expected source
  on `Lookup`, including stale-entry → fallback
- Staleness gauge publishes per-symbol age via an isolated
  `MeterListener`

Fixture uses a per-instance lock + filtered `InstrumentPublished`
predicate so xunit parallelism on the shared `B3.Trading` meter
doesn't race assertions.

## RFC

§4.6 updated to reflect the metric names actually shipped (the
original table referenced placeholder Prometheus names that never
existed). §7 roadmap marks slices 1-5 as shipped with PR back-refs.

## Status

Suite 247 → 250 (244 passed + 6 skipped), 0 warnings, `dotnet format`
clean. **Slice 5 closed.** Slice 6 (fat-finger server-side:
`MinTickSize`, `MinLotSize`, `MaxNotionalPerOrder`, absolute collar)
is the next item in the RFC roadmap.
