### PR TITLE
backend: fat-finger server-side checks (slice 6 of #38)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -98,6 +98,7 @@ public static class AdminEndpoints
                     maxQuantity = resolved.MaxQuantity,
                     maxNotional = resolved.MaxNotional,
                     priceCollarPercent = resolved.PriceCollarPercent,
+                    priceCollarAbsolute = resolved.PriceCollarAbsolute,
                     positionLimit = resolved.PositionLimit,
                 },
             });

--- a/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
@@ -1,0 +1,76 @@
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Server-side fat-finger guard (slice 6 of pre-trade risk v2).
+///
+/// <para>
+/// Rejects orders whose limit price is not a whole multiple of the
+/// instrument's tick size. B3 enforces tick rules at the venue, but a
+/// client-side mistake (extra digit, wrong contract) routinely turns
+/// into a malformed order that the venue rejects with a generic
+/// reason; catching it here gives the trader a precise message and
+/// keeps a misconfigured UI from spamming the gateway.
+/// </para>
+///
+/// <para>
+/// <b>Fail-open:</b> symbols missing from
+/// <see cref="SymbolDirectory.TryGetSpec"/> approve. The fat-finger
+/// checks are additive — never blocking on a symbol whose spec wasn't
+/// loaded — so onboarding a new ticker doesn't silently halt trading
+/// while ops update the directory.
+/// </para>
+///
+/// <para>
+/// Market orders (no price) are skipped — the venue picks the price.
+/// </para>
+/// </summary>
+public sealed class MinTickSizeCheck : IRiskCheck
+{
+    private readonly SymbolDirectory _directory;
+    public MinTickSizeCheck(SymbolDirectory directory) => _directory = directory;
+
+    public int Order => 50; // run before max-quantity / collar so a malformed price fails fast
+    public string Name => "min_tick_size";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (!ctx.Price.HasValue) return RiskDecision.Approve;
+        if (!_directory.TryGetSpec(ctx.Symbol, out var spec) || spec.TickSize is not { } tick || tick <= 0m)
+            return RiskDecision.Approve;
+
+        // decimal arithmetic is exact for the values we care about
+        // (tick sizes are 0.01 / 0.001 etc., prices have at most 4-6
+        // decimals). decimal.Remainder avoids the FP precision trap
+        // that would bite a double-based modulus.
+        if (decimal.Remainder(ctx.Price.Value, tick) != 0m)
+            return RiskDecision.Reject(
+                $"price {ctx.Price.Value} is not a multiple of tick size {tick} for {ctx.Symbol}");
+        return RiskDecision.Approve;
+    }
+}
+
+/// <summary>
+/// Server-side fat-finger guard. Rejects orders whose quantity is not
+/// a whole multiple of the instrument's lot size (round lot for the
+/// equities cash market). Same fail-open posture as
+/// <see cref="MinTickSizeCheck"/>: an unconfigured symbol approves.
+/// </summary>
+public sealed class MinLotSizeCheck : IRiskCheck
+{
+    private readonly SymbolDirectory _directory;
+    public MinLotSizeCheck(SymbolDirectory directory) => _directory = directory;
+
+    public int Order => 50;
+    public string Name => "min_lot_size";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (!_directory.TryGetSpec(ctx.Symbol, out var spec) || spec.LotSize is not { } lot || lot <= 0)
+            return RiskDecision.Approve;
+
+        if (ctx.Quantity % lot != 0)
+            return RiskDecision.Reject(
+                $"quantity {ctx.Quantity} is not a multiple of lot size {lot} for {ctx.Symbol}");
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PriceCollarCheck.cs
@@ -22,7 +22,8 @@ public sealed class PriceCollarCheck : IRiskCheck
         if (!ctx.Price.HasValue) return RiskDecision.Approve; // market order
         var opts = _options.CurrentValue;
         var collarPct = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarPercent);
-        if (!collarPct.HasValue) return RiskDecision.Approve;
+        var collarAbs = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PriceCollarAbsolute);
+        if (!collarPct.HasValue && !collarAbs.HasValue) return RiskDecision.Approve;
 
         var lookup = _refPrice.Lookup(ctx.Symbol);
         MetricsRegistry.RefPriceLookups.Add(1,
@@ -41,8 +42,24 @@ public sealed class PriceCollarCheck : IRiskCheck
         }
 
         var refPx = lookup.Price;
-        var lower = refPx * (1m - collarPct.Value / 100m);
-        var upper = refPx * (1m + collarPct.Value / 100m);
+
+        // Effective band is the intersection of percent and absolute
+        // when both are set — narrower wins on each side. Either alone
+        // defines the full band; both unset short-circuited above.
+        decimal lower = decimal.MinValue, upper = decimal.MaxValue;
+        if (collarPct is { } pct)
+        {
+            lower = refPx * (1m - pct / 100m);
+            upper = refPx * (1m + pct / 100m);
+        }
+        if (collarAbs is { } abs && abs > 0m)
+        {
+            var absLower = refPx - abs;
+            var absUpper = refPx + abs;
+            if (absLower > lower) lower = absLower;
+            if (absUpper < upper) upper = absUpper;
+        }
+
         if (ctx.Price.Value < lower || ctx.Price.Value > upper)
             return RiskDecision.Reject(
                 $"price {ctx.Price.Value} outside collar [{lower:0.####}, {upper:0.####}] around ref {refPx}");

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -46,6 +46,15 @@ public sealed class RiskLimits
     public long? MaxQuantity { get; set; }
     public decimal? MaxNotional { get; set; }
     public decimal? PriceCollarPercent { get; set; }
+    /// <summary>
+    /// Optional absolute price band (in price units) around the
+    /// reference. When set together with <see cref="PriceCollarPercent"/>
+    /// the effective band is the **intersection** of the two —
+    /// whichever is narrower wins on each side. Useful for low-priced
+    /// or illiquid tickers where a percent-only collar is too coarse,
+    /// or as a conservative floor on top of an existing percent.
+    /// </summary>
+    public decimal? PriceCollarAbsolute { get; set; }
     public long? PositionLimit { get; set; }
 }
 
@@ -90,6 +99,7 @@ public static class RiskLimitsResolver
             MaxQuantity = Resolve(opts, endClient, firmId, symbol, l => l.MaxQuantity),
             MaxNotional = Resolve(opts, endClient, firmId, symbol, l => l.MaxNotional),
             PriceCollarPercent = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarPercent),
+            PriceCollarAbsolute = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarAbsolute),
             PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),
         };
 }

--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -30,6 +30,7 @@ namespace B3.Trading.Application;
 public sealed class SymbolDirectory
 {
     private readonly IReadOnlyDictionary<string, ulong> _byName;
+    private readonly IReadOnlyDictionary<string, InstrumentSpec> _specs;
 
     public SymbolDirectory(SymbolDirectoryOptions options)
     {
@@ -43,6 +44,21 @@ public sealed class SymbolDirectory
             copy[kv.Key] = kv.Value;
         }
         _byName = copy;
+
+        var specs = new Dictionary<string, InstrumentSpec>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in options.Specs)
+        {
+            if (string.IsNullOrWhiteSpace(kv.Key) || kv.Value is null) continue;
+            // Drop entries that wouldn't constrain anything — keeps
+            // TryGetSpec callers from having to special-case zero/negative.
+            var t = kv.Value.TickSize;
+            var l = kv.Value.LotSize;
+            if ((t is null or <= 0m) && (l is null or <= 0)) continue;
+            specs[kv.Key] = new InstrumentSpec(
+                t is > 0m ? t : null,
+                l is > 0 ? l : null);
+        }
+        _specs = specs;
     }
 
     public int Count => _byName.Count;
@@ -56,7 +72,33 @@ public sealed class SymbolDirectory
         }
         return _byName.TryGetValue(symbol, out securityId);
     }
+
+    /// <summary>
+    /// Returns the per-instrument tick/lot constraints for a symbol if
+    /// configured. Missing entries return false — fail-open is the
+    /// caller's responsibility (used by the fat-finger checks so that
+    /// an unconfigured symbol is not blocked by a non-existent tick).
+    /// </summary>
+    public bool TryGetSpec(string? symbol, out InstrumentSpec spec)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            spec = default;
+            return false;
+        }
+        return _specs.TryGetValue(symbol, out spec!);
+    }
 }
+
+/// <summary>
+/// Per-instrument trading constraints that don't fit in
+/// <see cref="Risk.RiskOptions"/> because they describe the
+/// instrument itself, not the firm/end-client risk policy. Both
+/// fields are optional — a null/missing value means "no constraint",
+/// so partial entries are valid (e.g. a TickSize-only spec for a
+/// symbol whose lot size is 1).
+/// </summary>
+public readonly record struct InstrumentSpec(decimal? TickSize, long? LotSize);
 
 /// <summary>
 /// Bound from <c>Trading:SymbolDirectory</c>.
@@ -71,4 +113,24 @@ public sealed class SymbolDirectoryOptions
     /// </summary>
     public Dictionary<string, ulong> SecurityIds { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Symbol → tick/lot constraints. Independent from
+    /// <see cref="SecurityIds"/>: a symbol can appear in one without
+    /// the other (e.g. the SecurityId is required for routing but
+    /// tick/lot are operator-supplied for the fat-finger checks).
+    /// </summary>
+    public Dictionary<string, InstrumentSpecOptions> Specs { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Mutable counterpart of <see cref="InstrumentSpec"/> used only by
+/// <c>Microsoft.Extensions.Configuration</c> binding (records with
+/// non-null parameters don't bind well from JSON sections).
+/// </summary>
+public sealed class InstrumentSpecOptions
+{
+    public decimal? TickSize { get; set; }
+    public long? LotSize { get; set; }
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -103,6 +103,8 @@ builder.Services.AddSingleton<IMarginProvider>(sp =>
         : new NoOpMarginProvider();
 });
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
+builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
+builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, PositionLimitCheck>();

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -227,6 +227,84 @@ public class RiskPipelineTests
     }
 
     [Fact]
+    public void PriceCollar_AbsoluteAlone_RejectsOutsideBand()
+    {
+        var refPx = new StubRef(("PETR4", 30m));
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { PriceCollarAbsolute = 0.50m } });
+        var check = new PriceCollarCheck(opts, refPx);
+        Assert.True(check.Check(Ctx(price: 30.50m)).Approved);   // upper boundary
+        Assert.True(check.Check(Ctx(price: 29.50m)).Approved);   // lower boundary
+        Assert.False(check.Check(Ctx(price: 30.51m)).Approved);
+        Assert.False(check.Check(Ctx(price: 29.49m)).Approved);
+    }
+
+    [Fact]
+    public void PriceCollar_PercentAndAbsolute_IntersectionWins()
+    {
+        // ref=30, pct=10% → [27, 33]; abs=0.50 → [29.50, 30.50].
+        // intersection [29.50, 30.50] — absolute is the narrower band.
+        var refPx = new StubRef(("PETR4", 30m));
+        var opts = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { PriceCollarPercent = 10m, PriceCollarAbsolute = 0.50m }
+        });
+        var check = new PriceCollarCheck(opts, refPx);
+        Assert.True(check.Check(Ctx(price: 30.50m)).Approved);
+        Assert.False(check.Check(Ctx(price: 31m)).Approved);   // inside pct, outside abs
+        Assert.False(check.Check(Ctx(price: 29m)).Approved);
+    }
+
+    [Fact]
+    public void MinTickSize_RejectsNonMultiple()
+    {
+        var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
+        var check = new MinTickSizeCheck(dir);
+        Assert.True(check.Check(Ctx(price: 30.01m)).Approved);
+        Assert.True(check.Check(Ctx(price: 30.00m)).Approved);
+        Assert.False(check.Check(Ctx(price: 30.001m)).Approved);
+    }
+
+    [Fact]
+    public void MinTickSize_NoSpec_Approves()
+    {
+        var dir = BuildDirectory();
+        Assert.True(new MinTickSizeCheck(dir).Check(Ctx(price: 30.001m)).Approved);
+    }
+
+    [Fact]
+    public void MinTickSize_MarketOrder_Approves()
+    {
+        var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
+        Assert.True(new MinTickSizeCheck(dir).Check(Ctx(price: null, type: OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void MinLotSize_RejectsNonMultiple()
+    {
+        var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { LotSize = 100L } });
+        var check = new MinLotSizeCheck(dir);
+        Assert.True(check.Check(Ctx(qty: 100)).Approved);
+        Assert.True(check.Check(Ctx(qty: 300)).Approved);
+        Assert.False(check.Check(Ctx(qty: 150)).Approved);
+        Assert.False(check.Check(Ctx(qty: 1)).Approved);
+    }
+
+    [Fact]
+    public void MinLotSize_NoSpec_Approves()
+    {
+        Assert.True(new MinLotSizeCheck(BuildDirectory()).Check(Ctx(qty: 7)).Approved);
+    }
+
+    private static SymbolDirectory BuildDirectory(
+        Dictionary<string, ulong>? securityIds = null,
+        Dictionary<string, InstrumentSpecOptions>? specs = null) =>
+        new(new SymbolDirectoryOptions
+        {
+            SecurityIds = securityIds ?? new(StringComparer.OrdinalIgnoreCase),
+            Specs = specs ?? new(StringComparer.OrdinalIgnoreCase),
+        });
+
+    [Fact]
     public void PositionLimit_RejectsWhenProjectedExceeds()
     {
         var positions = new PositionKeeper();

--- a/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
@@ -98,4 +98,81 @@ public class SymbolDirectoryTests
         Assert.Equal(0, sut.Count);
         Assert.False(sut.TryResolve("PETR4", out _));
     }
+
+    [Fact]
+    public void TryGetSpec_ReturnsConfiguredSpec()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100L },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.01m, spec.TickSize);
+        Assert.Equal(100L, spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_IsCaseInsensitive()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs = { ["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m } },
+        });
+
+        Assert.True(sut.TryGetSpec("petr4", out var spec));
+        Assert.Equal(0.01m, spec.TickSize);
+        Assert.Null(spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_UnknownSymbol_ReturnsFalse()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs = { ["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m } },
+        });
+
+        Assert.False(sut.TryGetSpec("VALE3", out var spec));
+        Assert.Equal(default, spec);
+    }
+
+    [Fact]
+    public void TryGetSpec_DropsEntriesWithNoConstraint()
+    {
+        // A spec where both tick and lot are missing (or non-positive)
+        // wouldn't constrain anything — treat it as "no spec" so the
+        // fail-open posture in MinTick/MinLot stays sharp.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["EMPTY"] = new InstrumentSpecOptions(),
+                ["BAD"]   = new InstrumentSpecOptions { TickSize = 0m, LotSize = 0L },
+            },
+        });
+
+        Assert.False(sut.TryGetSpec("EMPTY", out _));
+        Assert.False(sut.TryGetSpec("BAD", out _));
+    }
+
+    [Fact]
+    public void Specs_AreIndependentFromSecurityIds()
+    {
+        // A symbol can have a Spec without a SecurityId (or vice versa)
+        // — they're orthogonal lookups against the same directory.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+            Specs = { ["VALE3"] = new InstrumentSpecOptions { TickSize = 0.01m } },
+        });
+
+        Assert.True(sut.TryResolve("PETR4", out _));
+        Assert.False(sut.TryGetSpec("PETR4", out _));
+        Assert.False(sut.TryResolve("VALE3", out _));
+        Assert.True(sut.TryGetSpec("VALE3", out _));
+    }
 }

--- a/docs/rfcs/pre-trade-risk-v2.md
+++ b/docs/rfcs/pre-trade-risk-v2.md
@@ -301,8 +301,10 @@ metrics + tests included.
 5. `IReferencePrice` indirection + `MarketDataReferencePrice` with
    fallback + staleness/source/bypass metrics. **shipped (#44)**
 6. Fat-finger server-side: `MinTickSizeCheck`, `MinLotSizeCheck`,
-   `MaxNotionalPerOrderCheck`, absolute collar in
-   `PriceCollarCheck`.
+   absolute collar in `PriceCollarCheck`. **shipped** —
+   `MaxNotionalPerOrderCheck` was deduplicated against the existing
+   `MaxNotionalCheck` (slice 7's rolling-window variant remains
+   distinct).
 7. Notional cap by rolling window + order rate limit + max open
    orders.
 8. Conformance scenarios + Grafana panel + docs touch-up.


### PR DESCRIPTION
Slice 6 of the pre-trade risk v2 roadmap (#38). Adds the per-instrument fat-finger guards from RFC §4.3.

## What

- **`MinTickSizeCheck`** — rejects orders whose limit price isn't a multiple of the configured tick size. Uses `decimal.Remainder` (exact for the values we care about). Skips market orders.
- **`MinLotSizeCheck`** — rejects orders whose qty isn't a multiple of the configured lot size.
- Both **fail open** when the symbol has no spec configured. Onboarding a new ticker shouldn't silently halt trading while ops update the directory; these are additive guard rails, not gating policy.
- **`PriceCollarCheck` gains an absolute band** via `RiskLimits.PriceCollarAbsolute`. When both percent and absolute are set, the effective band is the **intersection** — narrower wins on each side. Either alone defines the full band; both unset short-circuits to Approve as before. Slice 5 metrics + reference-missing branch are unchanged.

## SymbolDirectory

Grows a `Specs: Dictionary<string, InstrumentSpec>` alongside `SecurityIds`. The two lookups are independent — a symbol can have one without the other. Bound from `Trading:SymbolDirectory:Specs:<symbol>` with `TickSize`/`LotSize` fields. **Backwards-compatible:** configs that only set `SecurityIds` keep working unchanged.

`GET /admin/risk/limits` surfaces the new `priceCollarAbsolute` field so ops can see the resolved cap.

## Dedup note

The roadmap originally listed `MaxNotionalPerOrderCheck` for this slice, but it already exists as `MaxNotionalCheck` (`Risk/Checks/MaxQuantityCheck.cs:23`). Slice 7's rolling-window variant remains distinct and tracked separately.

## Tests

- `+5` `SymbolDirectoryTests` covering `TryGetSpec` (resolution, case-insensitivity, drop-empty, independence from SecurityIds)
- `+2` `RiskPipelineTests` for the absolute-only and percent×absolute intersection collar paths
- `+5` `RiskPipelineTests` for the new tick/lot checks (boundary, no-spec fail-open, market-order skip)

Suite **244 → 256** passing (+ 6 skipped conformance, unchanged).

## Verified

- `dotnet format B3TradingPlatform.slnx --verify-no-changes` clean
- `dotnet build` 0 warnings
- `dotnet test` all green
