### PR TITLE
backend: rolling-notional + order-rate + max-open-orders (slice 7 of #38)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -100,6 +100,7 @@ public static class AdminEndpoints
                     priceCollarPercent = resolved.PriceCollarPercent,
                     priceCollarAbsolute = resolved.PriceCollarAbsolute,
                     positionLimit = resolved.PositionLimit,
+                    maxOpenOrders = resolved.MaxOpenOrders,
                 },
             });
         });

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -6,6 +6,7 @@ using B3.Trading.Application;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Domain;
 using B3.Trading.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
@@ -40,6 +41,7 @@ public static class OrdersEndpoints
             IExecutionEventSink sink,
             RiskPipeline risk,
             IMarginProvider margin,
+            CompositeRiskAccountant accountant,
             EventDispatcher dispatcher,
             DrainState drain,
             SymbolDirectory symbols,
@@ -139,6 +141,12 @@ public static class OrdersEndpoints
                 return Results.Accepted($"/orders/{clOrdId}",
                     new { ClOrdId = clOrdId.ToString(), Status = "Rejected", Reason = decision.Reason });
             }
+
+            // Slice 7: record the accepted submit on the rolling ledgers
+            // only after both the synchronous pipeline and the margin
+            // reservation approve. Recording earlier would charge the
+            // ledgers for orders the margin provider rejects.
+            accountant.RecordAccepted(riskCtx);
 
             try
             {

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -211,4 +211,61 @@ public static class MetricsRegistry
     public static void RegisterRefPriceStalenessSource(
         Func<IEnumerable<KeyValuePair<string, double>>> source) =>
         _refPriceStalenessSources.Add(source);
+
+    // Slice 7 — throttle/limit observability. All gauges are
+    // intentionally aggregate (no per-end-client tag) to keep
+    // observability cardinality bounded under tenant churn.
+    // Per-tenant detail is exposed via GET /admin/risk/throttle.
+
+    /// <summary>
+    /// Bumped when <see cref="Risk.Accounting.RollingNotionalAccountant"/>
+    /// cannot price a market order because no reference price exists
+    /// for the symbol — the order is recorded with notional 0
+    /// (fail-open). A sustained non-zero rate means the rolling cap
+    /// is being silently underestimated for those symbols.
+    /// </summary>
+    public static readonly Counter<long> RollingNotionalBypassedNoReference =
+        Meter.CreateCounter<long>("trading.risk.rolling_notional.bypassed_no_reference");
+
+    private static volatile Func<int>? _rollingNotionalActiveBucketsEc;
+    private static volatile Func<int>? _rollingNotionalActiveBucketsFirm;
+    public static readonly ObservableGauge<int> RollingNotionalActiveBuckets =
+        Meter.CreateObservableGauge<int>(
+            "trading.risk.rolling_notional.active_buckets",
+            () =>
+            {
+                var ec = _rollingNotionalActiveBucketsEc?.Invoke() ?? 0;
+                var fm = _rollingNotionalActiveBucketsFirm?.Invoke() ?? 0;
+                return new[]
+                {
+                    new Measurement<int>(ec, new KeyValuePair<string, object?>("scope", "end_client")),
+                    new Measurement<int>(fm, new KeyValuePair<string, object?>("scope", "firm")),
+                };
+            });
+    public static void RegisterRollingNotionalSources(Func<int> endClient, Func<int> firm)
+    {
+        _rollingNotionalActiveBucketsEc = endClient;
+        _rollingNotionalActiveBucketsFirm = firm;
+    }
+
+    private static volatile Func<int>? _orderRateActiveBucketsEc;
+    private static volatile Func<int>? _orderRateActiveBucketsFirm;
+    public static readonly ObservableGauge<int> OrderRateActiveBuckets =
+        Meter.CreateObservableGauge<int>(
+            "trading.risk.order_rate.active_buckets",
+            () =>
+            {
+                var ec = _orderRateActiveBucketsEc?.Invoke() ?? 0;
+                var fm = _orderRateActiveBucketsFirm?.Invoke() ?? 0;
+                return new[]
+                {
+                    new Measurement<int>(ec, new KeyValuePair<string, object?>("scope", "end_client")),
+                    new Measurement<int>(fm, new KeyValuePair<string, object?>("scope", "firm")),
+                };
+            });
+    public static void RegisterOrderRateSources(Func<int> endClient, Func<int> firm)
+    {
+        _orderRateActiveBucketsEc = endClient;
+        _orderRateActiveBucketsFirm = firm;
+    }
 }

--- a/backend/src/B3.Trading.Application/Risk/Accounting/IRiskAccountant.cs
+++ b/backend/src/B3.Trading.Application/Risk/Accounting/IRiskAccountant.cs
@@ -1,0 +1,43 @@
+namespace B3.Trading.Application.Risk.Accounting;
+
+/// <summary>
+/// Records that an order has been accepted by the synchronous risk
+/// pipeline <em>and</em> the async margin reservation, so the slice-7
+/// throttle ledgers can advance their state. Called by the order
+/// submit endpoint right before the gateway dispatch.
+/// </summary>
+///
+/// <remarks>
+/// Implementations are registered as singletons and fan out from the
+/// composite <see cref="CompositeRiskAccountant"/>. Recording must be
+/// quick and side-effect-free beyond ledger updates — the call is on
+/// the submit hot path.
+/// </remarks>
+public interface IRiskAccountant
+{
+    void RecordAccepted(RiskContext ctx);
+}
+
+/// <summary>
+/// Fans <see cref="IRiskAccountant.RecordAccepted"/> out to every
+/// registered accountant. A single composite is what the endpoint
+/// depends on, so adding a new accountant is a DI-only change.
+/// </summary>
+public sealed class CompositeRiskAccountant : IRiskAccountant
+{
+    private readonly IRiskAccountant[] _accountants;
+
+    public CompositeRiskAccountant(IEnumerable<IRiskAccountant> accountants)
+    {
+        // Materialise once so we don't re-enumerate the DI container
+        // on every submit.
+        _accountants = accountants
+            .Where(a => a is not CompositeRiskAccountant)
+            .ToArray();
+    }
+
+    public void RecordAccepted(RiskContext ctx)
+    {
+        foreach (var a in _accountants) a.RecordAccepted(ctx);
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Accounting/OrderRateAccountant.cs
+++ b/backend/src/B3.Trading.Application/Risk/Accounting/OrderRateAccountant.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Accounting;
+
+/// <summary>
+/// Holds the per-end-client and per-firm sliding ledgers used by
+/// <see cref="Checks.OrderRateLimitCheck"/>. Each accepted submit
+/// counts as a single entry of value 1 in both ledgers.
+/// </summary>
+public sealed class OrderRateAccountant : IRiskAccountant
+{
+    private readonly SlidingWindowLedger _perEndClient;
+    private readonly SlidingWindowLedger _perFirm;
+    private readonly IOptionsMonitor<RiskOptions> _options;
+
+    public OrderRateAccountant(IOptionsMonitor<RiskOptions> options, TimeProvider clock)
+    {
+        _options = options;
+        _perEndClient = new SlidingWindowLedger(clock);
+        _perFirm = new SlidingWindowLedger(clock);
+    }
+
+    public SlidingWindowLedger EndClientLedger => _perEndClient;
+    public SlidingWindowLedger FirmLedger => _perFirm;
+
+    public TimeSpan Window => TimeSpan.FromSeconds(
+        Math.Max(1, _options.CurrentValue.OrderRate.WindowSeconds));
+
+    public void RecordAccepted(RiskContext ctx)
+    {
+        _perEndClient.Append(ctx.Owner.Value, 1m);
+        if (!string.IsNullOrWhiteSpace(ctx.FirmId))
+            _perFirm.Append(ctx.FirmId, 1m);
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Accounting/RollingNotionalAccountant.cs
+++ b/backend/src/B3.Trading.Application/Risk/Accounting/RollingNotionalAccountant.cs
@@ -1,0 +1,65 @@
+using B3.Trading.Application.Observability;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Accounting;
+
+/// <summary>
+/// Holds the per-end-client and per-firm sliding ledgers used by
+/// <see cref="Checks.RollingNotionalCheck"/>. Implements
+/// <see cref="IRiskAccountant"/> so accepted submits feed both
+/// ledgers.
+/// </summary>
+public sealed class RollingNotionalAccountant : IRiskAccountant
+{
+    private readonly SlidingWindowLedger _perEndClient;
+    private readonly SlidingWindowLedger _perFirm;
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly IReferencePrice _refPrice;
+
+    public RollingNotionalAccountant(
+        IOptionsMonitor<RiskOptions> options,
+        IReferencePrice refPrice,
+        TimeProvider clock)
+    {
+        _options = options;
+        _refPrice = refPrice;
+        _perEndClient = new SlidingWindowLedger(clock);
+        _perFirm = new SlidingWindowLedger(clock);
+    }
+
+    public SlidingWindowLedger EndClientLedger => _perEndClient;
+    public SlidingWindowLedger FirmLedger => _perFirm;
+
+    /// <summary>
+    /// Computes the notional that will be charged to the rolling
+    /// ledger for an order. Limit orders use their own price; market
+    /// orders fall back to <see cref="IReferencePrice.Lookup"/>. When
+    /// no reference is available the notional is 0 and a bypass
+    /// metric is incremented — fail-open posture matching the
+    /// price-collar check.
+    /// </summary>
+    public decimal NotionalFor(RiskContext ctx)
+    {
+        if (ctx.Price is { } px) return px * ctx.Quantity;
+
+        var lookup = _refPrice.Lookup(ctx.Symbol);
+        if (lookup.Found && lookup.Price > 0m)
+            return lookup.Price * ctx.Quantity;
+
+        MetricsRegistry.RollingNotionalBypassedNoReference.Add(1,
+            new KeyValuePair<string, object?>("symbol", ctx.Symbol));
+        return 0m;
+    }
+
+    public TimeSpan Window => TimeSpan.FromSeconds(
+        Math.Max(1, _options.CurrentValue.RollingNotional.WindowSeconds));
+
+    public void RecordAccepted(RiskContext ctx)
+    {
+        var notional = NotionalFor(ctx);
+        if (notional <= 0m) return;
+        _perEndClient.Append(ctx.Owner.Value, notional);
+        if (!string.IsNullOrWhiteSpace(ctx.FirmId))
+            _perFirm.Append(ctx.FirmId, notional);
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Accounting/SlidingWindowLedger.cs
+++ b/backend/src/B3.Trading.Application/Risk/Accounting/SlidingWindowLedger.cs
@@ -1,0 +1,178 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.Risk.Accounting;
+
+/// <summary>
+/// Per-key sliding-window aggregate of <see cref="decimal"/> values
+/// over a configurable time horizon. Used by the slice-7 throttle
+/// checks (rolling notional, order rate). Each key owns a queue of
+/// timestamped entries plus a running sum/count so neither
+/// <see cref="Sum"/> nor <see cref="Append"/> need to walk the queue
+/// on every call — only the head is pruned.
+/// </summary>
+///
+/// <remarks>
+/// <para>
+/// <b>Concurrency.</b> Each bucket has its own lock (a plain
+/// <c>object</c>); cross-key contention is therefore the same as
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/>'s. <c>Sum</c> and
+/// <c>Append</c> both prune lazily, so reads are not free, but the
+/// hot path is bounded by the number of entries that actually fall
+/// outside the window since the last call.
+/// </para>
+///
+/// <para>
+/// <b>Check / record race.</b> The check (<c>Sum</c>) and the record
+/// (<c>Append</c>) are intentionally <em>not</em> a single atomic
+/// operation. Risk evaluation runs first and the accountant only
+/// records after both the synchronous pipeline <em>and</em> the async
+/// margin reservation approve — wrapping a lock around that span
+/// would serialize order entry. This is acceptable for an anti-runaway
+/// guard: under N concurrent submits, the cap can be overshot by up
+/// to N. Documented at <c>docs/rfcs/pre-trade-risk-v2.md</c> §4.4.
+/// </para>
+///
+/// <para>
+/// <b>Memory.</b> Empty buckets are removed by
+/// <see cref="SweepEmptyBuckets"/>, called periodically by a hosted
+/// service. Removal is reference-equality based so a racing Append
+/// that has already mutated the bucket cannot lose its entry.
+/// </para>
+/// </remarks>
+public sealed class SlidingWindowLedger
+{
+    private readonly ConcurrentDictionary<string, Bucket> _buckets =
+        new(StringComparer.Ordinal);
+    private readonly TimeProvider _clock;
+
+    public SlidingWindowLedger(TimeProvider clock)
+    {
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Sum of values whose timestamp is within
+    /// <c>(now - <paramref name="window"/>, now]</c>. Returns 0 for
+    /// unknown keys without allocating a bucket.
+    /// </summary>
+    public decimal Sum(string key, TimeSpan window)
+    {
+        if (!_buckets.TryGetValue(key, out var bucket)) return 0m;
+        var cutoff = _clock.GetUtcNow() - window;
+        return bucket.PruneAndSum(cutoff);
+    }
+
+    /// <summary>
+    /// Count of entries whose timestamp is within the window. Same
+    /// no-allocation behavior as <see cref="Sum"/>.
+    /// </summary>
+    public int Count(string key, TimeSpan window)
+    {
+        if (!_buckets.TryGetValue(key, out var bucket)) return 0;
+        var cutoff = _clock.GetUtcNow() - window;
+        return bucket.PruneAndCount(cutoff);
+    }
+
+    /// <summary>
+    /// Append a value at the current clock time. Creates the bucket
+    /// on first use.
+    /// </summary>
+    public void Append(string key, decimal value)
+    {
+        var bucket = _buckets.GetOrAdd(key, static _ => new Bucket());
+        bucket.Append(_clock.GetUtcNow(), value);
+    }
+
+    /// <summary>
+    /// Removes buckets whose pruned content is empty for the given
+    /// window. Intended to be called from a periodic background
+    /// sweeper to bound memory under tenant churn.
+    /// </summary>
+    public int SweepEmptyBuckets(TimeSpan window)
+    {
+        var cutoff = _clock.GetUtcNow() - window;
+        var removed = 0;
+        foreach (var kv in _buckets)
+        {
+            // Prune first so a long-idle bucket releases its inner
+            // queue capacity even when it would otherwise remain
+            // mapped.
+            kv.Value.PruneAndCount(cutoff);
+            if (kv.Value.IsEmpty)
+            {
+                // Reference-equality remove: a concurrent Append that
+                // raced past PruneAndCount has already mutated the
+                // bucket and made it non-empty, so the value
+                // comparison fails and we skip removal. The bucket
+                // stays mapped and the entry survives.
+                if (((ICollection<KeyValuePair<string, Bucket>>)_buckets)
+                    .Remove(new KeyValuePair<string, Bucket>(kv.Key, kv.Value)))
+                {
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+
+    public int ActiveBucketCount => _buckets.Count;
+
+    /// <summary>
+    /// Diagnostic-only enumeration of currently-tracked keys. Used by
+    /// admin endpoints; not on the hot path.
+    /// </summary>
+    public IEnumerable<string> Keys => _buckets.Keys;
+
+    private sealed class Bucket
+    {
+        private readonly object _lock = new();
+        private readonly Queue<Entry> _entries = new();
+        private decimal _runningSum;
+
+        public bool IsEmpty
+        {
+            get
+            {
+                lock (_lock) return _entries.Count == 0;
+            }
+        }
+
+        public void Append(DateTimeOffset ts, decimal value)
+        {
+            lock (_lock)
+            {
+                _entries.Enqueue(new Entry(ts, value));
+                _runningSum += value;
+            }
+        }
+
+        public decimal PruneAndSum(DateTimeOffset cutoff)
+        {
+            lock (_lock)
+            {
+                Prune(cutoff);
+                return _runningSum;
+            }
+        }
+
+        public int PruneAndCount(DateTimeOffset cutoff)
+        {
+            lock (_lock)
+            {
+                Prune(cutoff);
+                return _entries.Count;
+            }
+        }
+
+        private void Prune(DateTimeOffset cutoff)
+        {
+            while (_entries.Count > 0 && _entries.Peek().Timestamp <= cutoff)
+            {
+                var dropped = _entries.Dequeue();
+                _runningSum -= dropped.Value;
+            }
+        }
+
+        private readonly record struct Entry(DateTimeOffset Timestamp, decimal Value);
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxOpenOrdersCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxOpenOrdersCheck.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Caps the number of non-terminal (PendingNew / Working /
+/// PartiallyFilled) orders an end-client can have outstanding.
+/// </summary>
+///
+/// <remarks>
+/// <para>
+/// <b>Counting semantics.</b> The current order being submitted is
+/// already in <see cref="WorkingOrderBook"/> by the time the risk
+/// pipeline runs (<see cref="WorkingOrderBook.TryAdd"/> is called by
+/// the persistence dispatcher before
+/// <c>RiskPipeline.Evaluate</c>), so the check uses strict
+/// <c>&gt;</c> against the cap rather than <c>&gt;=</c>: a cap of N
+/// is reached exactly when the count after include-self is N+1.
+/// </para>
+///
+/// <para>
+/// <b>State lifetime.</b> The order book is currently in-memory and
+/// re-derived from ER replay on restart, so caps reset across
+/// restarts. Documented in the persistence spike (checkpoint 015) as
+/// an MVP limitation tied to the broader event-sourcing roadmap.
+/// </para>
+/// </remarks>
+public sealed class MaxOpenOrdersCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly WorkingOrderBook _book;
+
+    public MaxOpenOrdersCheck(IOptionsMonitor<RiskOptions> options, WorkingOrderBook book)
+    {
+        _options = options;
+        _book = book;
+    }
+
+    public int Order => 170;
+    public string Name => "max_open_orders";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var cap = RiskLimitsResolver.Resolve(
+            _options.CurrentValue, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxOpenOrders);
+        if (!cap.HasValue) return RiskDecision.Approve;
+
+        // The current order is already in the book — see XML doc.
+        var openIncludingSelf = _book.CountOpenForOwner(ctx.Owner);
+        if (openIncludingSelf > cap.Value)
+            return RiskDecision.Reject(
+                $"open orders {openIncludingSelf - 1} would exceed cap {cap.Value} for {ctx.Owner.Value}");
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Checks/ThrottleChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/ThrottleChecks.cs
@@ -1,0 +1,117 @@
+using B3.Trading.Application.Risk.Accounting;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Rejects orders whose notional, added to the rolling-window total
+/// already submitted by the same end-client (or firm), would exceed
+/// the configured cap. Anti-runaway-bot guard — see
+/// <see cref="Accounting.SlidingWindowLedger"/> for the
+/// non-atomic-by-design semantics.
+/// </summary>
+public sealed class RollingNotionalCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly RollingNotionalAccountant _accountant;
+
+    public RollingNotionalCheck(
+        IOptionsMonitor<RiskOptions> options,
+        RollingNotionalAccountant accountant)
+    {
+        _options = options;
+        _accountant = accountant;
+    }
+
+    public int Order => 150;
+    public string Name => "rolling_notional";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var rolling = _options.CurrentValue.RollingNotional;
+        var endClientCap = ResolveCap(rolling.PerEndClient, ctx.Owner.Value)
+                           ?? rolling.Default.Cap;
+        var firmCap = string.IsNullOrWhiteSpace(ctx.FirmId)
+            ? null
+            : ResolveCap(rolling.PerFirm, ctx.FirmId);
+
+        if (!endClientCap.HasValue && !firmCap.HasValue) return RiskDecision.Approve;
+
+        var notional = _accountant.NotionalFor(ctx);
+        if (notional <= 0m) return RiskDecision.Approve; // bypass already metered
+        var window = _accountant.Window;
+
+        if (endClientCap is { } ecCap)
+        {
+            var current = _accountant.EndClientLedger.Sum(ctx.Owner.Value, window);
+            if (current + notional > ecCap)
+                return RiskDecision.Reject(
+                    $"rolling notional {current + notional:0.##} would exceed end-client cap {ecCap:0.##} over last {window.TotalSeconds:0}s");
+        }
+        if (firmCap is { } fmCap)
+        {
+            var current = _accountant.FirmLedger.Sum(ctx.FirmId!, window);
+            if (current + notional > fmCap)
+                return RiskDecision.Reject(
+                    $"rolling notional {current + notional:0.##} would exceed firm cap {fmCap:0.##} over last {window.TotalSeconds:0}s");
+        }
+        return RiskDecision.Approve;
+    }
+
+    private static decimal? ResolveCap(IDictionary<string, RollingNotionalLimit> map, string key) =>
+        map.TryGetValue(key, out var entry) ? entry.Cap : null;
+}
+
+/// <summary>
+/// Rejects orders that would exceed an end-client's (or firm's) order
+/// submission rate over a rolling window. Both ledgers are checked
+/// when configured; the first cap exceeded wins.
+/// </summary>
+public sealed class OrderRateLimitCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly OrderRateAccountant _accountant;
+
+    public OrderRateLimitCheck(
+        IOptionsMonitor<RiskOptions> options,
+        OrderRateAccountant accountant)
+    {
+        _options = options;
+        _accountant = accountant;
+    }
+
+    public int Order => 160;
+    public string Name => "order_rate_limit";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var rate = _options.CurrentValue.OrderRate;
+        var endClientMax = ResolveMax(rate.PerEndClient, ctx.Owner.Value) ?? rate.Default.Max;
+        var firmMax = string.IsNullOrWhiteSpace(ctx.FirmId)
+            ? null
+            : ResolveMax(rate.PerFirm, ctx.FirmId);
+
+        if (!endClientMax.HasValue && !firmMax.HasValue) return RiskDecision.Approve;
+
+        var window = _accountant.Window;
+
+        if (endClientMax is { } ecMax)
+        {
+            var current = _accountant.EndClientLedger.Count(ctx.Owner.Value, window);
+            if (current + 1 > ecMax)
+                return RiskDecision.Reject(
+                    $"order rate {current + 1} would exceed end-client cap {ecMax}/{window.TotalSeconds:0}s");
+        }
+        if (firmMax is { } fmMax)
+        {
+            var current = _accountant.FirmLedger.Count(ctx.FirmId!, window);
+            if (current + 1 > fmMax)
+                return RiskDecision.Reject(
+                    $"order rate {current + 1} would exceed firm cap {fmMax}/{window.TotalSeconds:0}s");
+        }
+        return RiskDecision.Approve;
+    }
+
+    private static int? ResolveMax(IDictionary<string, OrderRateLimit> map, string key) =>
+        map.TryGetValue(key, out var entry) ? entry.Max : null;
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -19,6 +19,66 @@ public sealed class RiskOptions
     public Dictionary<string, decimal> ReferencePrices { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
     public MarginOptions Margin { get; set; } = new();
+
+    /// <summary>
+    /// Rolling-window notional cap (slice 7). Modeled as its own
+    /// section instead of a field on <see cref="RiskLimits"/> because
+    /// the underlying ledger is keyed per-end-client (and per-firm)
+    /// only — letting the per-symbol resolution slot participate
+    /// would mean the cap that applies to one order varies with the
+    /// symbol while the state being measured is global, which is the
+    /// inconsistency we want to avoid.
+    /// </summary>
+    public RollingNotionalOptions RollingNotional { get; set; } = new();
+
+    /// <summary>
+    /// Order rate limit (slice 7). Same scoping rationale as
+    /// <see cref="RollingNotional"/>: per-end-client and per-firm
+    /// only, no per-symbol override.
+    /// </summary>
+    public OrderRateOptions OrderRate { get; set; } = new();
+}
+
+/// <summary>
+/// Per-end-client / per-firm cap on the notional submitted within a
+/// rolling time window. Anti-runaway guard, not a regulatory boundary
+/// — the check/record cycle is not atomic, so under bursts the cap
+/// can be overshot by the number of concurrent in-flight submits.
+/// </summary>
+public sealed class RollingNotionalOptions
+{
+    public int WindowSeconds { get; set; } = 60;
+    public RollingNotionalLimit Default { get; set; } = new();
+    public Dictionary<string, RollingNotionalLimit> PerEndClient { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, RollingNotionalLimit> PerFirm { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+}
+
+public sealed class RollingNotionalLimit
+{
+    public decimal? Cap { get; set; }
+}
+
+/// <summary>
+/// Per-end-client / per-firm cap on the number of submitted orders
+/// within a rolling time window. Both ledgers (per-end-client and
+/// per-firm) are checked independently when configured; the order is
+/// rejected on the first cap exceeded.
+/// </summary>
+public sealed class OrderRateOptions
+{
+    public int WindowSeconds { get; set; } = 1;
+    public OrderRateLimit Default { get; set; } = new();
+    public Dictionary<string, OrderRateLimit> PerEndClient { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, OrderRateLimit> PerFirm { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+}
+
+public sealed class OrderRateLimit
+{
+    public int? Max { get; set; }
 }
 
 /// <summary>
@@ -56,6 +116,17 @@ public sealed class RiskLimits
     /// </summary>
     public decimal? PriceCollarAbsolute { get; set; }
     public long? PositionLimit { get; set; }
+
+    /// <summary>
+    /// Optional cap on the number of non-terminal orders an end-client
+    /// can have outstanding at once. Counted across all symbols by the
+    /// owner index — the per-symbol resolver slot is intentionally
+    /// orthogonal (a per-symbol cap would mean "no more than N
+    /// PETR4 orders open" but the underlying index is per-owner; we
+    /// resolve the field per-symbol but the count is global, same
+    /// trade-off as <see cref="PositionLimit"/>).
+    /// </summary>
+    public int? MaxOpenOrders { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -101,5 +172,6 @@ public static class RiskLimitsResolver
             PriceCollarPercent = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarPercent),
             PriceCollarAbsolute = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarAbsolute),
             PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),
+            MaxOpenOrders = Resolve(opts, endClient, firmId, symbol, l => l.MaxOpenOrders),
         };
 }

--- a/backend/src/B3.Trading.Application/Risk/ThrottleLedgerSweeper.cs
+++ b/backend/src/B3.Trading.Application/Risk/ThrottleLedgerSweeper.cs
@@ -1,0 +1,77 @@
+using B3.Trading.Application.Risk.Accounting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Periodically prunes empty buckets from the rolling-notional and
+/// order-rate ledgers. Keeps the in-memory dictionaries from growing
+/// unbounded under tenant churn (every distinct end-client/firm
+/// allocates a bucket on first submit). Runs on a fixed cadence
+/// (default 60s) — frequent enough to bound footprint, infrequent
+/// enough to avoid contention with the hot path.
+/// </summary>
+public sealed class ThrottleLedgerSweeper : BackgroundService
+{
+    private readonly RollingNotionalAccountant _notional;
+    private readonly OrderRateAccountant _rate;
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly ILogger<ThrottleLedgerSweeper> _logger;
+    private readonly TimeProvider _clock;
+
+    public ThrottleLedgerSweeper(
+        RollingNotionalAccountant notional,
+        OrderRateAccountant rate,
+        IOptionsMonitor<RiskOptions> options,
+        ILogger<ThrottleLedgerSweeper> logger,
+        TimeProvider clock)
+    {
+        _notional = notional;
+        _rate = rate;
+        _options = options;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public TimeSpan SweepInterval { get; init; } = TimeSpan.FromSeconds(60);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(SweepInterval, _clock);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken)) return;
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            // Window is read each tick so config reloads take effect
+            // without restarting the sweeper.
+            var notionalWindow = _notional.Window;
+            var rateWindow = _rate.Window;
+
+            try
+            {
+                var n1 = _notional.EndClientLedger.SweepEmptyBuckets(notionalWindow);
+                var n2 = _notional.FirmLedger.SweepEmptyBuckets(notionalWindow);
+                var n3 = _rate.EndClientLedger.SweepEmptyBuckets(rateWindow);
+                var n4 = _rate.FirmLedger.SweepEmptyBuckets(rateWindow);
+                if (n1 + n2 + n3 + n4 > 0)
+                    _logger.LogDebug(
+                        "Throttle ledger sweep removed {Count} empty buckets",
+                        n1 + n2 + n3 + n4);
+            }
+            catch (Exception ex)
+            {
+                // Sweeper failure must not take the host down.
+                _logger.LogWarning(ex, "Throttle ledger sweep failed; will retry next interval");
+            }
+        }
+    }
+}

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -18,6 +18,13 @@ public sealed class WorkingOrderBook
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byFirm =
         new(StringComparer.Ordinal);
 
+    // Secondary index: end-client -> set of ClOrdIDs. Used by the
+    // slice-7 MaxOpenOrders check so the hot path doesn't scan every
+    // historical order in _orders to count what's still open for one
+    // owner. Same lock-free shape as _byFirm.
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byOwner =
+        new(StringComparer.Ordinal);
+
     public bool TryAdd(Order order)
     {
         if (!_orders.TryAdd(order.ClOrdId, order))
@@ -25,6 +32,8 @@ public sealed class WorkingOrderBook
 
         var firmSet = _byFirm.GetOrAdd(order.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
         firmSet.TryAdd(order.ClOrdId, 0);
+        var ownerSet = _byOwner.GetOrAdd(order.Owner.Value, static _ => new ConcurrentDictionary<ulong, byte>());
+        ownerSet.TryAdd(order.ClOrdId, 0);
         return true;
     }
 
@@ -39,6 +48,30 @@ public sealed class WorkingOrderBook
                 list.Add(kv.Value);
         }
         return list;
+    }
+
+    /// <summary>
+    /// Counts an end-client's non-terminal orders (PendingNew /
+    /// Working / PartiallyFilled). Indexed via <see cref="_byOwner"/>
+    /// so the cost is O(orders for owner) rather than O(total orders)
+    /// — the v2 risk pipeline calls this on every submit.
+    /// </summary>
+    /// <remarks>
+    /// The current order being submitted is already in the book by
+    /// the time the risk pipeline runs (the persistence dispatcher
+    /// adds it before evaluation), so callers comparing to a cap
+    /// should use strict <c>&gt;</c>, not <c>&gt;=</c>.
+    /// </remarks>
+    public int CountOpenForOwner(EndClientId owner)
+    {
+        if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
+        var count = 0;
+        foreach (var clOrdId in set.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (!IsTerminal(order.Status)) count++;
+        }
+        return count;
     }
 
     /// <summary>
@@ -101,6 +134,7 @@ public sealed class WorkingOrderBook
         ArgumentNullException.ThrowIfNull(snaps);
         _orders.Clear();
         _byFirm.Clear();
+        _byOwner.Clear();
         foreach (var s in snaps)
         {
             var owner = new EndClientId(s.EndClientId);
@@ -111,6 +145,8 @@ public sealed class WorkingOrderBook
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
+            var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());
+            ownerSet.TryAdd(s.ClOrdId, 0);
         }
     }
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -9,12 +9,14 @@ using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Application.Risk.Checks;
 using B3.Trading.Host.Observability;
 using B3.Trading.Host.MarketData;
 using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -108,8 +110,22 @@ builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, PositionLimitCheck>();
+builder.Services.AddSingleton<IRiskCheck, RollingNotionalCheck>();
+builder.Services.AddSingleton<IRiskCheck, OrderRateLimitCheck>();
+builder.Services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
 builder.Services.AddSingleton<IRiskCheck, PriceCollarCheck>();
 builder.Services.AddSingleton<RiskPipeline>();
+
+// Throttle accountants (slice 7). TimeProvider is fetched from DI so
+// tests can substitute a FakeTimeProvider; production resolves to
+// TimeProvider.System via the registration below.
+builder.Services.TryAddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<RollingNotionalAccountant>();
+builder.Services.AddSingleton<OrderRateAccountant>();
+builder.Services.AddSingleton<IRiskAccountant>(sp => sp.GetRequiredService<RollingNotionalAccountant>());
+builder.Services.AddSingleton<IRiskAccountant>(sp => sp.GetRequiredService<OrderRateAccountant>());
+builder.Services.AddSingleton<CompositeRiskAccountant>();
+builder.Services.AddHostedService<ThrottleLedgerSweeper>();
 
 // Auth: JWT bearer with explicit claim mapping. We disable the legacy
 // inbound mapping so 'sub' stays 'sub' (not ClaimTypes.NameIdentifier),
@@ -306,6 +322,20 @@ builder.Services.AddSingleton<ExchangeStatus>(sp =>
 builder.Services.AddTradingObservability(builder.Configuration);
 
 var app = builder.Build();
+
+// Hook the slice-7 throttle ledgers into MetricsRegistry so the
+// observable gauges have a source. Done after Build so the singletons
+// are resolvable; safe to call multiple times (sources are last-write-wins).
+{
+    var rolling = app.Services.GetRequiredService<RollingNotionalAccountant>();
+    var rate = app.Services.GetRequiredService<OrderRateAccountant>();
+    B3.Trading.Application.Observability.MetricsRegistry.RegisterRollingNotionalSources(
+        () => rolling.EndClientLedger.ActiveBucketCount,
+        () => rolling.FirmLedger.ActiveBucketCount);
+    B3.Trading.Application.Observability.MetricsRegistry.RegisterOrderRateSources(
+        () => rate.EndClientLedger.ActiveBucketCount,
+        () => rate.FirmLedger.ActiveBucketCount);
+}
 
 // Fail-fast on weak / missing JWT signing key outside Development. The
 // default in appsettings.json is a known dev-only string; if it leaks

--- a/backend/tests/B3.Trading.Application.Tests/ThrottleChecksTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ThrottleChecksTests.cs
@@ -1,0 +1,323 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+public class ThrottleChecksTests
+{
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskContext Ctx(
+        string owner = "alice", string firm = "default", string symbol = "PETR4",
+        OrderSide side = OrderSide.Buy, OrderType type = OrderType.Limit,
+        long qty = 100, decimal? price = 30m) =>
+        new(new EndClientId(owner), firm, symbol, side, type, qty, price);
+
+    private sealed class StubRef : IReferencePrice
+    {
+        private readonly Dictionary<string, decimal> _prices;
+        public StubRef(params (string, decimal)[] entries) =>
+            _prices = entries.ToDictionary(e => e.Item1, e => e.Item2, StringComparer.OrdinalIgnoreCase);
+        public bool TryGet(string symbol, out decimal price) => _prices.TryGetValue(symbol, out price);
+    }
+
+    // ────────────────── SlidingWindowLedger ──────────────────
+
+    [Fact]
+    public void Ledger_SumIsZeroForUnknownKey()
+    {
+        var ledger = new SlidingWindowLedger(new TestClock(DateTimeOffset.UtcNow));
+        Assert.Equal(0m, ledger.Sum("missing", TimeSpan.FromSeconds(60)));
+        Assert.Equal(0, ledger.Count("missing", TimeSpan.FromSeconds(60)));
+        Assert.Equal(0, ledger.ActiveBucketCount); // no allocation
+    }
+
+    [Fact]
+    public void Ledger_PrunesEntriesOutsideWindow()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var ledger = new SlidingWindowLedger(clock);
+        ledger.Append("k", 100m);
+        clock.Advance(TimeSpan.FromSeconds(30));
+        ledger.Append("k", 50m);
+        Assert.Equal(150m, ledger.Sum("k", TimeSpan.FromSeconds(60)));
+        // Advance so the first entry falls out (it was at t0; cutoff = t0+61 - 60 = t0+1).
+        clock.Advance(TimeSpan.FromSeconds(31));
+        Assert.Equal(50m, ledger.Sum("k", TimeSpan.FromSeconds(60)));
+    }
+
+    [Fact]
+    public void Ledger_SweepRemovesEmptyBuckets()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var ledger = new SlidingWindowLedger(clock);
+        ledger.Append("k", 1m);
+        Assert.Equal(1, ledger.ActiveBucketCount);
+        clock.Advance(TimeSpan.FromSeconds(120));
+        var removed = ledger.SweepEmptyBuckets(TimeSpan.FromSeconds(60));
+        Assert.Equal(1, removed);
+        Assert.Equal(0, ledger.ActiveBucketCount);
+    }
+
+    [Fact]
+    public void Ledger_SweepLeavesActiveBuckets()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var ledger = new SlidingWindowLedger(clock);
+        ledger.Append("active", 1m);
+        ledger.Append("stale", 1m);
+        clock.Advance(TimeSpan.FromSeconds(120));
+        ledger.Append("active", 1m); // still active
+        var removed = ledger.SweepEmptyBuckets(TimeSpan.FromSeconds(60));
+        Assert.Equal(1, removed);
+        Assert.Equal(1, ledger.ActiveBucketCount);
+    }
+
+    // ────────────────── RollingNotionalCheck ──────────────────
+
+    [Fact]
+    public void RollingNotional_NoCap_Approves()
+    {
+        var (check, _, _) = BuildRollingNotional(new RiskOptions());
+        Assert.True(check.Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void RollingNotional_RejectsWhenCumulativeExceedsCap()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            RollingNotional = new RollingNotionalOptions
+            {
+                WindowSeconds = 60,
+                Default = new RollingNotionalLimit { Cap = 5_000m },
+            },
+        };
+        var (check, accountant, _) = BuildRollingNotional(opts, clock);
+
+        // First 100 @ 30 = 3000. Approve + record.
+        Assert.True(check.Check(Ctx(qty: 100)).Approved);
+        accountant.RecordAccepted(Ctx(qty: 100));
+
+        // Next 100 @ 30 = 3000 → cumulative 6000 > 5000 → reject.
+        Assert.False(check.Check(Ctx(qty: 100)).Approved);
+
+        // After window passes, the ledger is clear again.
+        clock.Advance(TimeSpan.FromSeconds(61));
+        Assert.True(check.Check(Ctx(qty: 100)).Approved);
+    }
+
+    [Fact]
+    public void RollingNotional_PerEndClientAndPerFirmAreIndependent()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            RollingNotional = new RollingNotionalOptions
+            {
+                WindowSeconds = 60,
+                PerEndClient = { ["alice"] = new RollingNotionalLimit { Cap = 10_000m } },
+                PerFirm = { ["acme"] = new RollingNotionalLimit { Cap = 1_000m } },
+            },
+        };
+        var (check, accountant, _) = BuildRollingNotional(opts, clock);
+
+        // 1500 notional > firm cap 1000 → reject even though end-client cap is 10000.
+        Assert.False(check.Check(Ctx(firm: "acme", qty: 50)).Approved);
+    }
+
+    [Fact]
+    public void RollingNotional_MarketOrderUsesReferencePrice()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            RollingNotional = new RollingNotionalOptions
+            {
+                WindowSeconds = 60,
+                Default = new RollingNotionalLimit { Cap = 1_000m },
+            },
+        };
+        var refPx = new StubRef(("PETR4", 30m));
+        var (check, accountant, _) = BuildRollingNotional(opts, clock, refPx);
+
+        // Market order 100 * ref 30 = 3000 > 1000 → reject.
+        Assert.False(check.Check(Ctx(qty: 100, price: null, type: OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void RollingNotional_MarketOrderApprovesWhenNoReference()
+    {
+        // Fail-open posture (mirrors PriceCollarCheck) — bypass metric is bumped
+        // by the accountant on its NotionalFor() path.
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            RollingNotional = new RollingNotionalOptions
+            {
+                Default = new RollingNotionalLimit { Cap = 1_000m },
+            },
+        };
+        var (check, _, _) = BuildRollingNotional(opts, clock, new StubRef());
+        Assert.True(check.Check(Ctx(qty: 100, price: null, type: OrderType.Market)).Approved);
+    }
+
+    // ────────────────── OrderRateLimitCheck ──────────────────
+
+    [Fact]
+    public void OrderRate_RejectsWhenRateExceeded()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            OrderRate = new OrderRateOptions
+            {
+                WindowSeconds = 1,
+                Default = new OrderRateLimit { Max = 2 },
+            },
+        };
+        var (check, accountant) = BuildOrderRate(opts, clock);
+
+        Assert.True(check.Check(Ctx()).Approved);
+        accountant.RecordAccepted(Ctx());
+        Assert.True(check.Check(Ctx()).Approved);
+        accountant.RecordAccepted(Ctx());
+        Assert.False(check.Check(Ctx()).Approved); // 3rd would exceed cap of 2
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.True(check.Check(Ctx()).Approved); // window cleared
+    }
+
+    [Fact]
+    public void OrderRate_PerFirmCapAppliesAcrossClients()
+    {
+        var clock = new TestClock(DateTimeOffset.UtcNow);
+        var opts = new RiskOptions
+        {
+            OrderRate = new OrderRateOptions
+            {
+                WindowSeconds = 1,
+                PerFirm = { ["acme"] = new OrderRateLimit { Max = 1 } },
+            },
+        };
+        var (check, accountant) = BuildOrderRate(opts, clock);
+
+        Assert.True(check.Check(Ctx(owner: "alice", firm: "acme")).Approved);
+        accountant.RecordAccepted(Ctx(owner: "alice", firm: "acme"));
+        // Different end-client, same firm — firm cap blocks it.
+        Assert.False(check.Check(Ctx(owner: "bob", firm: "acme")).Approved);
+    }
+
+    // ────────────────── MaxOpenOrdersCheck ──────────────────
+
+    [Fact]
+    public void MaxOpenOrders_RejectsWhenIncludeSelfExceedsCap()
+    {
+        // The order is added to the book *before* risk runs, so the
+        // count includes the current order. Cap=2 means we accept up
+        // to two open orders for this owner.
+        var book = new WorkingOrderBook();
+        AddOpen(book, "alice", clOrdId: 1);
+        AddOpen(book, "alice", clOrdId: 2);
+        AddOpen(book, "alice", clOrdId: 3); // current submit
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MaxOpenOrders = 2 } });
+        var check = new MaxOpenOrdersCheck(opts, book);
+
+        Assert.False(check.Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void MaxOpenOrders_ApprovesWhenAtCap()
+    {
+        var book = new WorkingOrderBook();
+        AddOpen(book, "alice", clOrdId: 1);
+        AddOpen(book, "alice", clOrdId: 2); // current submit, count == cap
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MaxOpenOrders = 2 } });
+        Assert.True(new MaxOpenOrdersCheck(opts, book).Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void MaxOpenOrders_NoCap_Approves()
+    {
+        var book = new WorkingOrderBook();
+        AddOpen(book, "alice", clOrdId: 1);
+        Assert.True(new MaxOpenOrdersCheck(Wrap(new RiskOptions()), book).Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void MaxOpenOrders_ExcludesTerminalOrders()
+    {
+        var book = new WorkingOrderBook();
+        var o1 = NewOrder("alice", 1);
+        book.TryAdd(o1);
+        o1.MarkRejected(); // terminal — should not count
+        AddOpen(book, "alice", clOrdId: 2); // current submit
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MaxOpenOrders = 1 } });
+        // Open count (excluding terminal) = 1 (only o2). Cap = 1, count > cap is false → approve.
+        Assert.True(new MaxOpenOrdersCheck(opts, book).Check(Ctx()).Approved);
+    }
+
+    // ────────────────── CompositeRiskAccountant ──────────────────
+
+    [Fact]
+    public void Composite_FansOutToAllAccountants()
+    {
+        var a = new CountingAccountant();
+        var b = new CountingAccountant();
+        var composite = new CompositeRiskAccountant(new IRiskAccountant[] { a, b });
+        composite.RecordAccepted(Ctx());
+        Assert.Equal(1, a.Count);
+        Assert.Equal(1, b.Count);
+    }
+
+    [Fact]
+    public void Composite_DoesNotIncludeItself()
+    {
+        // DI registers the composite as well; ensure the constructor
+        // filters it out so RecordAccepted doesn't recurse infinitely.
+        var inner = new CountingAccountant();
+        var composite = new CompositeRiskAccountant(Array.Empty<IRiskAccountant>());
+        var outer = new CompositeRiskAccountant(new IRiskAccountant[] { composite, inner });
+        outer.RecordAccepted(Ctx());
+        Assert.Equal(1, inner.Count);
+    }
+
+    private sealed class CountingAccountant : IRiskAccountant
+    {
+        public int Count;
+        public void RecordAccepted(RiskContext ctx) => Count++;
+    }
+
+    // ────────────────── helpers ──────────────────
+
+    private static (RollingNotionalCheck check, RollingNotionalAccountant accountant, IOptionsMonitor<RiskOptions> opts)
+        BuildRollingNotional(RiskOptions o, TestClock? clock = null, IReferencePrice? refPx = null)
+    {
+        clock ??= new TestClock(DateTimeOffset.UtcNow);
+        refPx ??= new StubRef();
+        var monitor = Wrap(o);
+        var accountant = new RollingNotionalAccountant(monitor, refPx, clock);
+        return (new RollingNotionalCheck(monitor, accountant), accountant, monitor);
+    }
+
+    private static (OrderRateLimitCheck check, OrderRateAccountant accountant)
+        BuildOrderRate(RiskOptions o, TestClock? clock = null)
+    {
+        clock ??= new TestClock(DateTimeOffset.UtcNow);
+        var monitor = Wrap(o);
+        var accountant = new OrderRateAccountant(monitor, clock);
+        return (new OrderRateLimitCheck(monitor, accountant), accountant);
+    }
+
+    private static void AddOpen(WorkingOrderBook book, string owner, ulong clOrdId) =>
+        book.TryAdd(NewOrder(owner, clOrdId));
+
+    private static Order NewOrder(string owner, ulong clOrdId) =>
+        new(clOrdId, new EndClientId(owner), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            quantity: 100, price: 30m, firmId: "default");
+}

--- a/docs/rfcs/pre-trade-risk-v2.md
+++ b/docs/rfcs/pre-trade-risk-v2.md
@@ -242,6 +242,41 @@ The synthetic-ER invariant — risk rejections flow through the same
 channel as exchange rejections — is asserted by reading from the same
 ER stream the existing tests use.
 
+### 4.8 Throttle ledgers (rolling notional + order rate)
+
+`SlidingWindowLedger` is the shared in-memory aggregate behind
+`RollingNotionalCheck` and `OrderRateLimitCheck`. Two design points
+worth fixing:
+
+- **Scope is end-client and firm only — no per-symbol slot.** The
+  ledgers are keyed per-end-client (and per-firm) globally, but
+  `RiskLimits` resolves caps via the per-symbol slot too. Letting the
+  per-symbol cap apply to a global ledger would mean the cap that
+  applies to one order varies with the symbol while the state being
+  measured is global, which is the inconsistency we want to avoid.
+  `RollingNotionalOptions` and `OrderRateOptions` therefore live as
+  their own top-level sections with `Default` / `PerEndClient` /
+  `PerFirm` only.
+- **Check + record is intentionally not atomic.** Risk evaluation
+  reads the ledger; the accountant only writes after the synchronous
+  pipeline *and* the async margin reservation approve. Wrapping a
+  lock around that span would serialise order entry. Trade-off: under
+  N concurrent in-flight submits the cap can be overshot by up to N.
+  Acceptable for an anti-runaway guard; if a strict throttle is ever
+  needed, that's a different check with reserve+release semantics
+  (out of scope for v2).
+
+`MaxOpenOrdersCheck` reads `WorkingOrderBook.CountOpenForOwner`,
+which uses a secondary owner→ClOrdId index built on TryAdd/Restore so
+the hot path doesn't scan all historical orders. The order being
+submitted is already in the book by the time the risk pipeline runs
+(persistence dispatcher adds it before evaluation), so the check
+compares with strict `>` against the cap, not `>=`.
+
+A `ThrottleLedgerSweeper` BackgroundService prunes empty buckets
+periodically (default 60s) so distinct end-client/firm churn doesn't
+leak unbounded memory.
+
 ## 5. Alternatives considered
 
 ### A. Persist limits in a database now
@@ -306,7 +341,15 @@ metrics + tests included.
    `MaxNotionalCheck` (slice 7's rolling-window variant remains
    distinct).
 7. Notional cap by rolling window + order rate limit + max open
-   orders.
+   orders. **shipped** — sliding-window queue ledger
+   (`SlidingWindowLedger`) shared by `RollingNotionalCheck` and
+   `OrderRateLimitCheck`; both have per-end-client and per-firm scopes
+   (no per-symbol — see §4.4 below). `MaxOpenOrdersCheck` reads an
+   indexed `WorkingOrderBook.CountOpenForOwner` so the hot path is
+   O(orders for owner). `IRiskAccountant` is fanned out from the
+   submit endpoint after both the synchronous pipeline and margin
+   approve. A periodic `ThrottleLedgerSweeper` removes empty buckets
+   to bound memory under tenant churn.
 8. Conformance scenarios + Grafana panel + docs touch-up.
 
 ## 8. Open questions
@@ -319,9 +362,11 @@ metrics + tests included.
 - **OQ-2:** Margin TTL default — 5s feels right for the stub but a
   real provider may want 30s+ to amortize back-office cost. Leaving
   it configurable; default revisits when the real adapter arrives.
-- **OQ-3:** Rate limit window — fixed-window vs sliding-log. Sliding
-  is more accurate but more memory; fixed is simpler. Lean fixed for
-  v2 unless the conformance scenarios show false negatives.
+- **OQ-3:** Rate limit window — fixed-window vs sliding-log. **Resolved:**
+  shipped sliding-log via `SlidingWindowLedger` (queue + running
+  aggregate). Memory is bounded by the periodic sweeper; the running
+  aggregate keeps `Sum`/`Count` O(entries-pruned-this-call) rather
+  than O(window-size).
 - **OQ-4:** Should `/admin/risk/reload` be per-firm or global?
   Starting global; per-firm only if a multi-firm config-source
   provider needs it.


### PR DESCRIPTION
Slice 7 of the pre-trade risk v2 roadmap (#38). Adds the three throttle checks from RFC §7. All ship in one PR — `RollingNotionalCheck` and `OrderRateLimitCheck` share infrastructure, and `MaxOpenOrdersCheck` is small enough not to warrant its own slice.

## What

### `SlidingWindowLedger` (shared)
- Per-key `Queue<Entry>` + running aggregate so `Sum`/`Count` are O(entries-pruned-this-call), not O(window-size).
- Per-bucket lock; cross-key contention matches `ConcurrentDictionary`.
- `ThrottleLedgerSweeper` (`BackgroundService`, 60s default) prunes empty buckets via reference-equality `TryRemove` so a racing `Append` never loses an entry.

### `RollingNotionalCheck` + `OrderRateLimitCheck`
- Per-end-client and per-firm scopes — **no per-symbol slot**. Letting a per-symbol cap apply to a globally-keyed ledger would mean the cap that applies to one order varies with the symbol while the state being measured is global. `RollingNotionalOptions` and `OrderRateOptions` live as their own top-level config sections (not fields on `RiskLimits`) to enforce that at the type level.
- Market orders use `IReferencePrice` for notional estimation (mirrors `PriceCollarCheck`), with a bypass counter when no reference is available.
- **Check + record is intentionally not atomic.** The accountant only records after the synchronous pipeline *and* the async margin reservation approve. Under N concurrent submits the cap can be overshot by up to N — acceptable for an anti-runaway guard, documented in RFC §4.8.

### `MaxOpenOrdersCheck`
- Reads `WorkingOrderBook.CountOpenForOwner`, backed by a new secondary owner→ClOrdId index (built on `TryAdd`/`Restore`, mirrors the existing `_byFirm` shape). Hot path is O(orders-for-owner) instead of scanning all historical orders.
- The order being submitted is already in the book when risk runs, so the check uses strict `>`, not `>=`. Terminal-state orders are excluded.

## Integration

- `CompositeRiskAccountant` fans `IRiskAccountant.RecordAccepted()` out to every registered accountant.
- `OrdersEndpoints` calls it after the synchronous pipeline **and** margin both approve, before gateway dispatch — so margin rejects don't consume the rolling/rate budget.
- Observability: aggregate gauges only (`active_buckets` tagged by `scope=end_client|firm`) — no per-end-client tag to keep cardinality bounded under tenant churn.
- `GET /admin/risk/limits` surfaces the new `maxOpenOrders` field.

## Rubber-duck blockers caught (and fixed)

- **Order is in book before risk runs** → use strict `>`, include `PendingNew` in "open".
- **Margin runs outside `RiskPipeline`** → `RecordAccepted` placed after both approvals.
- **Resolver vs global ledger inconsistency** → separate config sections, no `PerSymbol`.
- **`WorkingOrderBook.ForEndClient` is O(total)** → indexed `CountOpenForOwner`.
- **Sweeper race** → reference-equality `TryRemove`.
- **Metrics cardinality** → aggregate gauges only.

## Tests

17 new tests (4 SlidingWindowLedger, 5 RollingNotional, 2 OrderRate, 4 MaxOpenOrders, 2 CompositeRiskAccountant). Suite **256 → 273** (+ 6 skipped conformance, unchanged).

## Verified

- `dotnet format B3TradingPlatform.slnx --verify-no-changes` clean
- `dotnet build` 0 warnings
- `dotnet test` all green
