### PR TITLE
backend: conformance + risk dashboard + RFC closure (slice 8 of #38)

### DIFF
--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Risk/RiskRejectionShapeSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Risk/RiskRejectionShapeSpecTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Risk;
+
+/// <summary>
+/// Spec — Risk. Pre-trade risk rejections must surface to clients as
+/// HTTP 202 with a stable JSON envelope: <c>{ clOrdId, status:
+/// "Rejected", reason }</c>. The 202 (not 4xx) status matters because
+/// a risk reject is a synchronous outcome of an accepted submission,
+/// not an input-validation error — UIs and ops scripts treat the two
+/// classes differently. The reason string is opaque but must be
+/// non-empty so dashboards can group by it.
+///
+/// <para>
+/// The scenario discovers the configured cap via <c>GET
+/// /admin/risk/limits</c> instead of hardcoding values, so the same
+/// suite runs against any deployment whose admin happens to have
+/// tuned the caps differently. Skipped if no <c>MaxQuantity</c> is
+/// configured for the test user (deployments that disable v2 risk
+/// entirely have nothing to assert here).
+/// </para>
+/// </summary>
+[Trait("Category", "Conformance")]
+public class RiskRejectionShapeSpecTests
+{
+    [ConformanceFact(RequiresAdmin = true)]
+    public async Task RiskRejection_ReturnsAcceptedWithRejectedShape()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        // Two different identities: admin to query the resolved cap,
+        // user to actually submit the order. Mirrors how dashboards
+        // and trader UIs are wired in real deployments.
+        var adminAuth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
+        var userAuth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+
+        var cap = await ResolveMaxQuantityAsync(http, adminAuth, peer.Username);
+        if (cap is null)
+        {
+            // No configured cap → nothing to breach deterministically.
+            // Mirrors AdminFirmsSpecTests' "if firms are present, they
+            // must conform" stance: the assertion is conditional on
+            // the deployment actually having a v2 risk cap configured.
+            // xunit v2 has no in-test skip API, so we no-op and
+            // surface the decision via an Assert.True trace message.
+            Assert.True(true,
+                "No MaxQuantity configured for the test user — risk-rejection shape not asserted.");
+            return;
+        }
+
+        // Quantity strictly above the cap so any change in the cap
+        // resolution still produces a clean reject without overflow.
+        var quantity = checked(cap.Value + 1);
+
+        // Symbol/securityId: the submit pipeline accepts an explicit
+        // non-zero securityId in the payload regardless of the
+        // SymbolDirectory contents. Picking a synthetic id keeps the
+        // test independent of operator-provided directory data.
+        using var submit = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Headers = { Authorization = userAuth },
+            Content = JsonContent.Create(new
+            {
+                symbol = "PETR4",
+                securityId = 4321UL,
+                side = "Buy",
+                type = "Limit",
+                quantity,
+                price = 30m,
+            }),
+        };
+
+        var resp = await http.SendAsync(submit);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.String, body.GetProperty("clOrdId").ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(body.GetProperty("clOrdId").GetString()),
+            "clOrdId should echo back so clients can correlate with the synthetic ER.");
+
+        Assert.Equal("Rejected", body.GetProperty("status").GetString());
+
+        var reason = body.GetProperty("reason").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(reason),
+            "reason must be non-empty so observability can group by it.");
+    }
+
+    private static async Task<long?> ResolveMaxQuantityAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, string endClient)
+    {
+        // The admin endpoint resolves limits per (endClient, firm,
+        // symbol) — we leave firm/symbol unset so the resolver falls
+        // through to the per-end-client and Default slots. That
+        // matches what a trader from `endClient` would actually hit
+        // when no per-symbol override applies.
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get, $"/admin/risk/limits?endClient={Uri.EscapeDataString(endClient)}");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var limits = json.GetProperty("limits");
+        if (!limits.TryGetProperty("maxQuantity", out var prop) || prop.ValueKind == JsonValueKind.Null)
+            return null;
+        return prop.GetInt64();
+    }
+}

--- a/docker/observability/grafana/dashboards/risk.json
+++ b/docker/observability/grafana/dashboards/risk.json
@@ -1,0 +1,150 @@
+{
+  "annotations": { "list": [] },
+  "description": "Pre-trade risk dashboard for the B3 trading-host. Surfaces v2 risk-pipeline behaviour: rejection rates by reason, reference-price freshness/coverage, throttle ledger occupancy. Built from instruments verified to actually export — see docs/METRICS.md for the catalog.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate of pre-trade risk rejections, broken down by the resolved Reason tag. Each series is one risk-check name (max_quantity, max_notional, price_collar_percent, position_limit, max_open_orders, rolling_notional, order_rate, fat_finger_*). A non-zero baseline is normal in busy markets; sustained spikes suggest either misconfiguration or a misbehaving client.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (reason) (rate(trading_orders_rejected_by_risk_total[1m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Risk rejections rate (per reason)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Reference-price lookups by source: live (fresh MD), fallback (stale or static config), missing (no reference at all). A growing missing/fallback share means the MD subscription is degraded — checks that depend on a reference (price collar, rolling notional) silently bypass when there is no price, which is tracked separately below.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (source) (rate(trading_risk_refprice_lookups_total[1m]))",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reference price lookups (per source)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cumulative count of price-collar checks that bypassed because no reference price was available. A non-zero rate here is the smoking gun for the price-collar gap — orders that would have been rejected got through because the reference was missing.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null }, { "color": "orange", "value": 1 } ] }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "value_and_name" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(trading_risk_collar_bypassed_no_reference_total)",
+          "legendFormat": "collar bypassed",
+          "refId": "A"
+        }
+      ],
+      "title": "Collar bypassed (no reference)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cumulative count of rolling-notional checks that bypassed because no reference price was available. Same diagnostic role as the collar-bypass counter, for the slice-7 throttle.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null }, { "color": "orange", "value": 1 } ] }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 8 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "value_and_name" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(trading_risk_rolling_notional_bypassed_no_reference_total)",
+          "legendFormat": "rolling notional bypassed",
+          "refId": "A"
+        }
+      ],
+      "title": "Rolling notional bypassed (no reference)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Per-symbol staleness of the reference price feed (seconds since the last accepted MD update). Anything trending above the configured MaxStaleness window means the price-collar and rolling-notional checks are about to start bypassing for that symbol.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" } },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 8 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "trading_risk_refprice_staleness_seconds",
+          "legendFormat": "{{symbol}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reference price staleness (per symbol)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Active sliding-window buckets for the rolling-notional throttle, by scope (end_client / firm). Tracks how much state the SlidingWindowLedger is holding right now. A flat-line at 0 means no recent submits; sustained growth suggests a bucket-eviction bug or an end-client/firm cardinality explosion.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 14 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "trading_risk_rolling_notional_active_buckets",
+          "legendFormat": "{{scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rolling notional — active buckets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Active sliding-window buckets for the order-rate throttle, by scope (end_client / firm). Same ledger semantics as the rolling-notional gauge above, applied to the per-second order-count limiter.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 14 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "trading_risk_order_rate_active_buckets",
+          "legendFormat": "{{scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Order rate — active buckets",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["b3-trading", "risk"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "B3 Trading — Risk",
+  "uid": "b3-trading-risk",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -63,6 +63,18 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 | `trading.entrypoint.translation_errors` | Counter | `firm` |
 | `trading.entrypoint.business_rejects` | Counter | `firm`, `code` |
 | `trading.entrypoint.terminated` | Counter | `firm`, `cause` |
+| `trading.marketdata.subscribe_errors` | Counter | `symbol`, `reason` |
+| `trading.risk.refprice.lookups` | Counter | `source` (live/fallback/missing) |
+| `trading.risk.refprice.staleness_seconds` | Observable Gauge | `symbol` |
+| `trading.risk.collar.bypassed_no_reference` | Counter | `symbol` |
+| `trading.risk.rolling_notional.bypassed_no_reference` | Counter | `symbol` |
+| `trading.risk.rolling_notional.active_buckets` | Observable Gauge | `scope` (end_client/firm) |
+| `trading.risk.order_rate.active_buckets` | Observable Gauge | `scope` (end_client/firm) |
+
+The `trading.risk.*` series back the **B3 Trading — Risk** Grafana
+dashboard (`docker/observability/grafana/dashboards/risk.json`); the
+v2 risk pipeline is documented in
+[`docs/rfcs/pre-trade-risk-v2.md`](rfcs/pre-trade-risk-v2.md).
 
 ## Auto-instrumentation also exported
 

--- a/docs/rfcs/pre-trade-risk-v2.md
+++ b/docs/rfcs/pre-trade-risk-v2.md
@@ -2,7 +2,7 @@
 
 | Field    | Value                                          |
 | -------- | ---------------------------------------------- |
-| Status   | Draft                                          |
+| Status   | Implemented                                    |
 | Tracking | [#38](https://github.com/pedrosakuma/B3TradingPlatform/issues/38) |
 | Replaces | n/a (extends v1 in `B3.Trading.Application/Risk`) |
 
@@ -350,7 +350,20 @@ metrics + tests included.
    submit endpoint after both the synchronous pipeline and margin
    approve. A periodic `ThrottleLedgerSweeper` removes empty buckets
    to bound memory under tenant churn.
-8. Conformance scenarios + Grafana panel + docs touch-up.
+8. Conformance scenarios + Grafana panel + docs touch-up. **shipped** —
+   `Spec_HTTP_Risk/RiskRejectionShapeSpecTests.cs` discovers the
+   resolved `MaxQuantity` via `GET /admin/risk/limits` and asserts the
+   wire contract for risk rejections (`202 Accepted` + `{ clOrdId,
+   status: "Rejected", reason }`). Grafana dashboard
+   `dashboards/risk.json` ("B3 Trading — Risk") surfaces rejection
+   rates by reason, ref-price lookup mix and staleness, bypass
+   counters, and active throttle buckets per scope. `docs/METRICS.md`
+   gained the per-metric inventory for the `trading.risk.*` family.
+
+**RFC status: Implemented.** Future evolutions (PerFirm vs PerSymbol
+ordering — OQ-1, margin TTL — OQ-2, per-firm reload — OQ-4) will land
+as small follow-up PRs without a new RFC unless a behavioural
+contract changes.
 
 ## 8. Open questions
 


### PR DESCRIPTION
Closes the pre-trade risk v2 RFC (#38) by locking in the rejection
wire contract via conformance, surfacing the v2 metrics in Grafana,
and inventorying the `trading.risk.*` family in `docs/METRICS.md`.

## Conformance — `Spec_HTTP_Risk/RiskRejectionShapeSpecTests.cs`

One scenario, **discover-then-test**:

1. `GET /admin/risk/limits?endClient=<user>` (admin role) reads the
   resolved `MaxQuantity` for the test user — instead of hardcoding
   thresholds the suite would have to keep in sync with config.
2. Submit a limit order with `quantity = cap + 1`.
3. Assert the rejection envelope: HTTP `202 Accepted` + body
   `{ clOrdId, status: "Rejected", reason }` with non-empty `reason`.

If `MaxQuantity` is not configured for the deployment, the assertion
no-ops with an `Assert.True` trace (mirrors `AdminFirmsSpecTests`'
"if firms are present, they must conform" stance — xunit v2 has no
in-test skip API).

The `202` (not 4xx) is the load-bearing detail: a risk reject is a
synchronous outcome of an *accepted* submission. Trader UIs and ops
scripts treat input-validation 4xx and risk 202+Rejected as different
classes of event, and the conformance suite now defends that.

Verified end-to-end against the compose stack with the conformance
overlay (admin user `carol` seeded via `Trading__Auth__Users__1__*`).

## Grafana — `dashboards/risk.json`

New **B3 Trading — Risk** dashboard, auto-loaded by the existing
file provisioner. Seven panels, all using instruments verified
against `MetricsRegistry.cs`:

| Panel | Expression sketch |
| --- | --- |
| Risk rejections rate (per reason) | `sum by (reason) (rate(trading_orders_rejected_by_risk_total[1m]))` |
| Reference price lookups (per source) | `sum by (source) (rate(trading_risk_refprice_lookups_total[1m]))` |
| Collar bypassed (no reference) | `sum(trading_risk_collar_bypassed_no_reference_total)` |
| Rolling notional bypassed (no reference) | `sum(trading_risk_rolling_notional_bypassed_no_reference_total)` |
| Reference price staleness (per symbol) | `trading_risk_refprice_staleness_seconds` |
| Rolling notional — active buckets | `trading_risk_rolling_notional_active_buckets` |
| Order rate — active buckets | `trading_risk_order_rate_active_buckets` |

Sibling-created next to `process-up.json`; `process-up` stays the
home dashboard. No compose changes required.

## Docs

- **`docs/METRICS.md`** — adds the `trading.marketdata.*` and
  `trading.risk.*` rows to the per-metric inventory and points
  readers at the new dashboard + RFC.
- **`docs/rfcs/pre-trade-risk-v2.md`** — slice 8 marked shipped,
  status flipped `Draft → Implemented`. Future tweaks (open
  questions OQ-1/OQ-2/OQ-4) land as follow-ups without a new RFC.

## Validation

- `dotnet format B3TradingPlatform.slnx --verify-no-changes` ✅
- `dotnet build` 0 warns ✅
- `dotnet test` 273 → **274** (new conformance test discovered,
  skipped in CI without env vars) ✅
- Live conformance run against compose stack with overlay → green ✅

## Next

Pre-trade risk v2 (#38) is implemented end-to-end. The 8 risk checks
now follow the same template (ctor with `IOptionsMonitor` + maybe one
stateful service, simple Resolve+compare); a small
`RiskCheckBase`/`SimpleLimitCheck<T>` extraction would reduce
boilerplate. Will propose as a separate refactor PR after this lands.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
