### PR TITLE
feat(algo): slice 2 — Algo aggregate + AlgoBook + WAL/snapshot plumbing

### DIFF
--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -1,0 +1,161 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// In-memory aggregate of <see cref="Algo"/> parents, indexed by AlgoId
+/// with secondary indices by end-client and firm. Mirrors the shape of
+/// <see cref="WorkingOrderBook"/>: lock-free reads via
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/>, snapshot/restore for
+/// the persistence layer, and "current open parents for X" lookups for
+/// the API/engine side.
+///
+/// <para>
+/// Mutation of an individual <see cref="Algo"/> aggregate is the engine's
+/// responsibility under the per-parent lock described in RFC §4.3 — the
+/// book itself only synchronises the registration and de-registration.
+/// </para>
+/// </summary>
+public sealed class AlgoBook
+{
+    private readonly ConcurrentDictionary<ulong, Algo> _algos = new();
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byOwner =
+        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byFirm =
+        new(StringComparer.Ordinal);
+
+    public bool TryAdd(Algo algo)
+    {
+        ArgumentNullException.ThrowIfNull(algo);
+        if (!_algos.TryAdd(algo.AlgoId, algo))
+            return false;
+
+        var ownerSet = _byOwner.GetOrAdd(algo.Owner.Value, static _ => new ConcurrentDictionary<ulong, byte>());
+        ownerSet.TryAdd(algo.AlgoId, 0);
+        var firmSet = _byFirm.GetOrAdd(algo.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
+        firmSet.TryAdd(algo.AlgoId, 0);
+        return true;
+    }
+
+    public bool TryGet(ulong algoId, out Algo? algo) => _algos.TryGetValue(algoId, out algo);
+
+    public IReadOnlyCollection<Algo> EnumerateForOwner(EndClientId owner, bool includeTerminal = false)
+    {
+        if (!_byOwner.TryGetValue(owner.Value, out var set))
+            return Array.Empty<Algo>();
+        var list = new List<Algo>(set.Count);
+        foreach (var id in set.Keys)
+        {
+            if (!_algos.TryGetValue(id, out var a)) continue;
+            if (!includeTerminal && a.IsTerminal) continue;
+            list.Add(a);
+        }
+        return list;
+    }
+
+    public IReadOnlyCollection<Algo> EnumerateForFirm(string firmId, bool includeTerminal = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        if (!_byFirm.TryGetValue(firmId, out var set))
+            return Array.Empty<Algo>();
+        var list = new List<Algo>(set.Count);
+        foreach (var id in set.Keys)
+        {
+            if (!_algos.TryGetValue(id, out var a)) continue;
+            if (!includeTerminal && a.IsTerminal) continue;
+            list.Add(a);
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Captures every algo (terminal included) for a snapshot. Same
+    /// rationale as <see cref="WorkingOrderBook.Snapshot"/>: replay-from-WAL
+    /// and replay-from-snapshot must converge on the same in-memory state.
+    /// </summary>
+    public IEnumerable<Persistence.AlgoSnapshot> Snapshot()
+    {
+        foreach (var kv in _algos)
+        {
+            var a = kv.Value;
+            yield return ToSnapshot(a);
+        }
+    }
+
+    public void Restore(IEnumerable<Persistence.AlgoSnapshot> snaps)
+    {
+        ArgumentNullException.ThrowIfNull(snaps);
+        _algos.Clear();
+        _byOwner.Clear();
+        _byFirm.Clear();
+        foreach (var s in snaps)
+        {
+            var algo = FromSnapshot(s);
+            _algos[algo.AlgoId] = algo;
+            var ownerSet = _byOwner.GetOrAdd(algo.Owner.Value, static _ => new ConcurrentDictionary<ulong, byte>());
+            ownerSet.TryAdd(algo.AlgoId, 0);
+            var firmSet = _byFirm.GetOrAdd(algo.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
+            firmSet.TryAdd(algo.AlgoId, 0);
+        }
+    }
+
+    private static Persistence.AlgoSnapshot ToSnapshot(Algo a)
+    {
+        long? icebergDisplay = null;
+        decimal? icebergLimit = null;
+        DateTimeOffset? twapStart = null;
+        DateTimeOffset? twapEnd = null;
+        int? twapSliceCount = null;
+        string? twapChildType = null;
+        decimal? twapChildPrice = null;
+
+        switch (a.Parameters)
+        {
+            case IcebergParameters ip:
+                icebergDisplay = ip.DisplayQuantity;
+                icebergLimit = ip.LimitPrice;
+                break;
+            case TwapParameters tp:
+                twapStart = tp.StartUtc;
+                twapEnd = tp.EndUtc;
+                twapSliceCount = tp.SliceCount;
+                twapChildType = tp.ChildOrderType.ToString();
+                twapChildPrice = tp.ChildPrice;
+                break;
+        }
+
+        return new Persistence.AlgoSnapshot(
+            a.AlgoId, a.Owner.Value, a.FirmId, a.Symbol, a.SecurityId,
+            a.Side.ToString(), a.Type.ToString(), a.TotalQuantity, a.FilledQuantity,
+            a.Status.ToString(), a.TerminalReason.ToString(),
+            a.CreatedAtUtc, a.TerminalAtUtc,
+            icebergDisplay, icebergLimit,
+            twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice);
+    }
+
+    internal static Algo FromSnapshot(Persistence.AlgoSnapshot s)
+    {
+        var owner = new EndClientId(s.EndClientId);
+        var side = Enum.Parse<OrderSide>(s.Side);
+        var type = Enum.Parse<AlgoType>(s.Type);
+        var status = Enum.Parse<AlgoStatus>(s.Status);
+        var reason = Enum.Parse<AlgoTerminalReason>(s.TerminalReason);
+        AlgoParameters parameters = type switch
+        {
+            AlgoType.Iceberg => new IcebergParameters(
+                s.IcebergDisplayQuantity ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing IcebergDisplayQuantity."),
+                s.IcebergLimitPrice),
+            AlgoType.Twap => new TwapParameters(
+                s.TwapStartUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapStartUtc."),
+                s.TwapEndUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapEndUtc."),
+                s.TwapSliceCount ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapSliceCount."),
+                Enum.Parse<OrderType>(s.TwapChildOrderType ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapChildOrderType.")),
+                s.TwapChildPrice),
+            _ => throw new InvalidOperationException($"Unknown algo type: {s.Type}"),
+        };
+        return Algo.Hydrate(s.AlgoId, owner, s.FirmId, s.Symbol, s.SecurityId,
+            side, type, s.TotalQuantity, parameters, s.CreatedAtUtc,
+            s.FilledQuantity, status, reason, s.TerminalAtUtc);
+    }
+}

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -16,6 +16,7 @@ public sealed class PlatformSnapshot
     public List<string> KilledFirms { get; init; } = new();
     public ClOrdIdRegistrySnapshot ClOrdIds { get; init; } = new();
     public List<OwnershipMappingSnapshot> Ownership { get; init; } = new();
+    public List<AlgoSnapshot> Algos { get; init; } = new();
 }
 
 public sealed record OrderSnapshot(
@@ -30,7 +31,37 @@ public sealed record OrderSnapshot(
     long LeavesQuantity,
     long CumulativeQuantity,
     string Status,
-    string FirmId = "DEFAULT");
+    string FirmId = "DEFAULT",
+    ulong? ParentAlgoId = null,
+    int? AlgoSliceSeq = null);
+
+/// <summary>
+/// Captures an <see cref="B3.Trading.Domain.Algo"/> aggregate. Discriminated
+/// per-type fields mirror the <see cref="AlgoCreatedEvent"/> wire shape so
+/// that recovery via WAL-only and recovery via snapshot+tail produce
+/// byte-identical aggregates.
+/// </summary>
+public sealed record AlgoSnapshot(
+    ulong AlgoId,
+    string EndClientId,
+    string FirmId,
+    string Symbol,
+    ulong SecurityId,
+    string Side,
+    string Type,
+    long TotalQuantity,
+    long FilledQuantity,
+    string Status,
+    string TerminalReason,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? TerminalAtUtc,
+    long? IcebergDisplayQuantity = null,
+    decimal? IcebergLimitPrice = null,
+    DateTimeOffset? TwapStartUtc = null,
+    DateTimeOffset? TwapEndUtc = null,
+    int? TwapSliceCount = null,
+    string? TwapChildOrderType = null,
+    decimal? TwapChildPrice = null);
 
 public sealed record PositionSnapshot(
     string EndClientId,

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -19,6 +19,9 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(OrderSubmittedEvent), "order.submitted")]
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
+[JsonDerivedType(typeof(AlgoCreatedEvent), "algo.created")]
+[JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
+[JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -41,6 +44,17 @@ public sealed record OrderSubmittedEvent : WalEvent
     public required string Type { get; init; }
     public required long Quantity { get; init; }
     public decimal? Price { get; init; }
+
+    /// <summary>
+    /// When set, the order is a child slice of an <see cref="AlgoCreatedEvent"/>'s
+    /// parent. Both algo fields are set together or both <c>null</c>; manual
+    /// orders submitted via <c>POST /orders</c> emit <c>null</c>. Added in
+    /// algo orders v0 — older WAL segments without these fields deserialise
+    /// with <c>null</c> on both, which matches the manual-order semantics
+    /// they actually carried.
+    /// </summary>
+    public ulong? ParentAlgoId { get; init; }
+    public int? AlgoSliceSeq { get; init; }
 }
 
 /// <summary>
@@ -79,4 +93,63 @@ public sealed record KillSwitchToggledEvent : WalEvent
     public required string Target { get; init; }
     public required bool Killed { get; init; }    // true=kill, false=revive
     public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Captures the parent params at submit time. Authoritative source of
+/// truth for everything in the algo aggregate except the derived state
+/// (FilledQuantity / Status), which is reconstructed during replay from
+/// the child <see cref="OrderSubmittedEvent"/> + <see cref="ExecutionReportReceivedEvent"/>
+/// stream and the terminal events below. See RFC §4.5.
+/// </summary>
+public sealed record AlgoCreatedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string EndClientId { get; init; }
+    public required string FirmId { get; init; }
+    public required string Symbol { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required string Side { get; init; }
+    public required string Type { get; init; }   // "Iceberg" | "Twap"
+    public required long TotalQuantity { get; init; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+    /// <summary>
+    /// Iceberg-only: visible slice quantity. Mutually exclusive with
+    /// the Twap fields below. Validated by the engine, not the WAL —
+    /// the event mirrors whatever the submit pipeline accepted.
+    /// </summary>
+    public long? IcebergDisplayQuantity { get; init; }
+    public decimal? IcebergLimitPrice { get; init; }
+
+    public DateTimeOffset? TwapStartUtc { get; init; }
+    public DateTimeOffset? TwapEndUtc { get; init; }
+    public int? TwapSliceCount { get; init; }
+    public string? TwapChildOrderType { get; init; }   // "Limit" | "Market"
+    public decimal? TwapChildPrice { get; init; }
+}
+
+/// <summary>
+/// Recorded when <c>DELETE /algo/{id}</c> reaches the engine, before the
+/// child cancels are dispatched. Replay uses it to set the parent to
+/// <c>Cancelling</c>; the eventual <see cref="AlgoTerminalStateRecordedEvent"/>
+/// promotes it to <c>Cancelled</c>.
+/// </summary>
+public sealed record AlgoCancelRequestedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Recorded when the parent reaches a terminal state
+/// (<c>Completed</c>, <c>Cancelled</c>, <c>Expired</c>, <c>Suspended</c>).
+/// The <see cref="Reason"/> is the durable companion that distinguishes
+/// "user pulled it" from "venue rejected the third slice in a row".
+/// </summary>
+public sealed record AlgoTerminalStateRecordedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string Status { get; init; }    // AlgoStatus enum name
+    public required string Reason { get; init; }    // AlgoTerminalReason enum name
+    public required DateTimeOffset AtUtc { get; init; }
 }

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -125,7 +125,7 @@ public sealed class WorkingOrderBook
                 o.ClOrdId, o.Owner.Value, o.Symbol, o.SecurityId,
                 o.Side.ToString(), o.Type.ToString(),
                 o.Quantity, o.Price, o.LeavesQuantity, o.CumulativeQuantity,
-                o.Status.ToString(), o.FirmId);
+                o.Status.ToString(), o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq);
         }
     }
 
@@ -142,7 +142,8 @@ public sealed class WorkingOrderBook
             var type = Enum.Parse<OrderType>(s.Type);
             var status = Enum.Parse<OrderStatus>(s.Status);
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
-                s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId);
+                s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId,
+                s.ParentAlgoId, s.AlgoSliceSeq);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Domain/Algo.cs
+++ b/backend/src/B3.Trading.Domain/Algo.cs
@@ -1,0 +1,218 @@
+namespace B3.Trading.Domain;
+
+public enum AlgoType
+{
+    Iceberg,
+    Twap,
+}
+
+/// <summary>
+/// Lifecycle of an <see cref="Algo"/> parent. The state machine is enforced
+/// by <c>Algo</c>'s mutators; transitions outside the allowed graph throw.
+/// See RFC docs/rfcs/algo-orders-v0.md §4.4.
+/// </summary>
+public enum AlgoStatus
+{
+    PendingNew,
+    Working,
+    Cancelling,
+    Cancelled,
+    Suspended,
+    Expired,
+    Completed,
+}
+
+/// <summary>
+/// Durable companion to terminal/suspended states. Persisting the reason
+/// matters because the same <see cref="AlgoStatus.Cancelled"/> outcome
+/// means very different things to a UI/operator depending on whether the
+/// parent had partially filled. See RFC §4.1.
+/// </summary>
+public enum AlgoTerminalReason
+{
+    None = 0,
+    UserCancelled,
+    RiskRejected,
+    GatewayUnavailable,
+    VenueCancelled,
+    TwapWindowExpired,
+    RetriesExhausted,
+    Drained,
+}
+
+/// <summary>
+/// Per-type parameters carried by an <see cref="Algo"/>. Sealed-class-per-type
+/// keeps the discriminated shape explicit on the wire and at runtime; the
+/// abstract base lets consumers pattern-match without losing type safety.
+/// </summary>
+public abstract record AlgoParameters;
+
+public sealed record IcebergParameters(long DisplayQuantity, decimal? LimitPrice) : AlgoParameters;
+
+public sealed record TwapParameters(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    int SliceCount,
+    OrderType ChildOrderType,
+    decimal? ChildPrice) : AlgoParameters;
+
+/// <summary>
+/// Parent algo aggregate, sibling to <see cref="Order"/>. v0 stores only
+/// what the engine needs for state-machine decisions; child progress is
+/// derived from the order/ER stream during replay (RFC §4.5). The aggregate
+/// is mutated only by the algo engine under the per-parent lock described
+/// in RFC §4.3 — concurrent mutation from multiple threads is undefined.
+/// </summary>
+public sealed class Algo
+{
+    public Algo(
+        ulong algoId,
+        EndClientId owner,
+        string firmId,
+        string symbol,
+        ulong securityId,
+        OrderSide side,
+        AlgoType type,
+        long totalQuantity,
+        AlgoParameters parameters,
+        DateTimeOffset createdAtUtc)
+    {
+        if (algoId == 0)
+            throw new ArgumentOutOfRangeException(nameof(algoId), "AlgoId cannot be zero (reserved as null sentinel).");
+        if (string.IsNullOrWhiteSpace(firmId))
+            throw new ArgumentException("FirmId required.", nameof(firmId));
+        if (string.IsNullOrWhiteSpace(symbol))
+            throw new ArgumentException("Symbol required.", nameof(symbol));
+        if (totalQuantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(totalQuantity));
+        ArgumentNullException.ThrowIfNull(parameters);
+        ValidateParametersMatchType(type, parameters);
+
+        AlgoId = algoId;
+        Owner = owner;
+        FirmId = firmId;
+        Symbol = symbol;
+        SecurityId = securityId;
+        Side = side;
+        Type = type;
+        TotalQuantity = totalQuantity;
+        Parameters = parameters;
+        CreatedAtUtc = createdAtUtc;
+        Status = AlgoStatus.PendingNew;
+        TerminalReason = AlgoTerminalReason.None;
+    }
+
+    public ulong AlgoId { get; }
+    public EndClientId Owner { get; }
+    public string FirmId { get; }
+    public string Symbol { get; }
+    public ulong SecurityId { get; }
+    public OrderSide Side { get; }
+    public AlgoType Type { get; }
+    public long TotalQuantity { get; }
+    public AlgoParameters Parameters { get; }
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public long FilledQuantity { get; private set; }
+    public AlgoStatus Status { get; private set; }
+    public AlgoTerminalReason TerminalReason { get; private set; }
+    public DateTimeOffset? TerminalAtUtc { get; private set; }
+
+    public long RemainingQuantity => Math.Max(0, TotalQuantity - FilledQuantity);
+
+    public bool IsTerminal => Status is AlgoStatus.Cancelled or AlgoStatus.Completed
+        or AlgoStatus.Expired or AlgoStatus.Suspended;
+
+    /// <summary>
+    /// Engine-driven transition out of <see cref="AlgoStatus.PendingNew"/>
+    /// once the first child has been accepted by the submit pipeline. No-op
+    /// if the algo has already advanced (idempotent under replay).
+    /// </summary>
+    public void MarkWorking()
+    {
+        if (Status == AlgoStatus.PendingNew)
+            Status = AlgoStatus.Working;
+    }
+
+    /// <summary>
+    /// Records a fill against the parent. Idempotent only at the slice
+    /// level (slice 6 onwards); v0 callers must apply each fill exactly
+    /// once. Overfill is permitted (mirrors <see cref="Order"/>) so replay
+    /// of a venue-misbehaving stream stays total.
+    /// </summary>
+    public void RecordFill(long fillQty)
+    {
+        if (fillQty <= 0)
+            throw new ArgumentOutOfRangeException(nameof(fillQty));
+        FilledQuantity += fillQty;
+    }
+
+    /// <summary>
+    /// Operator cancel request. Allowed from any non-terminal state; the
+    /// engine arms outstanding child cancels and the parent moves to
+    /// <see cref="AlgoStatus.Cancelling"/>. From <see cref="AlgoStatus.Cancelling"/>
+    /// the call is a no-op (the operator can spam DELETE without harm).
+    /// </summary>
+    public void RequestCancel()
+    {
+        if (IsTerminal || Status == AlgoStatus.Cancelling)
+            return;
+        Status = AlgoStatus.Cancelling;
+    }
+
+    /// <summary>
+    /// Records a terminal outcome. Caller is responsible for ensuring the
+    /// reason matches the status (e.g. <see cref="AlgoTerminalReason.TwapWindowExpired"/>
+    /// only with <see cref="AlgoStatus.Expired"/>); the aggregate validates
+    /// the status is terminal but trusts the supplied reason. Idempotent
+    /// when called with the same status (replay-safe).
+    /// </summary>
+    public void RecordTerminal(AlgoStatus status, AlgoTerminalReason reason, DateTimeOffset atUtc)
+    {
+        if (status is not (AlgoStatus.Cancelled or AlgoStatus.Completed
+            or AlgoStatus.Expired or AlgoStatus.Suspended))
+        {
+            throw new ArgumentOutOfRangeException(nameof(status), $"Not a terminal status: {status}");
+        }
+        if (IsTerminal && Status == status)
+            return;
+        if (IsTerminal && Status != status)
+            throw new InvalidOperationException($"Algo {AlgoId} already terminal in {Status}; cannot move to {status}.");
+
+        Status = status;
+        TerminalReason = reason;
+        TerminalAtUtc = atUtc;
+    }
+
+    /// <summary>
+    /// Reconstructs an algo from snapshot data. Bypasses the state-machine
+    /// invariants because the snapshot was, by construction, produced from
+    /// a sequence of valid mutations. Mirrors <see cref="Order.Hydrate"/>.
+    /// </summary>
+    internal static Algo Hydrate(
+        ulong algoId, EndClientId owner, string firmId, string symbol, ulong securityId,
+        OrderSide side, AlgoType type, long totalQuantity, AlgoParameters parameters,
+        DateTimeOffset createdAtUtc, long filledQuantity, AlgoStatus status,
+        AlgoTerminalReason terminalReason, DateTimeOffset? terminalAtUtc)
+    {
+        var a = new Algo(algoId, owner, firmId, symbol, securityId, side, type,
+            totalQuantity, parameters, createdAtUtc);
+        a.FilledQuantity = filledQuantity;
+        a.Status = status;
+        a.TerminalReason = terminalReason;
+        a.TerminalAtUtc = terminalAtUtc;
+        return a;
+    }
+
+    private static void ValidateParametersMatchType(AlgoType type, AlgoParameters parameters)
+    {
+        var ok = type switch
+        {
+            AlgoType.Iceberg => parameters is IcebergParameters,
+            AlgoType.Twap => parameters is TwapParameters,
+            _ => false,
+        };
+        if (!ok)
+            throw new ArgumentException($"Parameters {parameters.GetType().Name} do not match algo type {type}.", nameof(parameters));
+    }
+}

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -37,12 +37,29 @@ public sealed class Order
     /// multiple firms. Default <c>"DEFAULT"</c> exists only to keep older
     /// unit tests terse; production call sites always pass an explicit firm.
     /// </summary>
-    public Order(ulong clOrdId, EndClientId owner, string symbol, ulong securityId, OrderSide side, OrderType type, long quantity, decimal? price, string firmId = "DEFAULT")
+    public Order(
+        ulong clOrdId,
+        EndClientId owner,
+        string symbol,
+        ulong securityId,
+        OrderSide side,
+        OrderType type,
+        long quantity,
+        decimal? price,
+        string firmId = "DEFAULT",
+        ulong? parentAlgoId = null,
+        int? algoSliceSeq = null)
     {
         if (clOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(clOrdId), "ClOrdID cannot be zero (reserved as null sentinel by EntryPoint).");
         if (string.IsNullOrWhiteSpace(firmId))
             throw new ArgumentException("FirmId required.", nameof(firmId));
+        if (parentAlgoId is 0)
+            throw new ArgumentOutOfRangeException(nameof(parentAlgoId), "ParentAlgoId cannot be zero (reserved as null sentinel).");
+        if ((parentAlgoId is null) != (algoSliceSeq is null))
+            throw new ArgumentException("ParentAlgoId and AlgoSliceSeq must be set together (both null = manual order; both set = algo child).");
+        if (algoSliceSeq is < 0)
+            throw new ArgumentOutOfRangeException(nameof(algoSliceSeq));
         ClOrdId = clOrdId;
         Owner = owner;
         Symbol = symbol;
@@ -52,6 +69,8 @@ public sealed class Order
         Quantity = quantity;
         Price = price;
         FirmId = firmId;
+        ParentAlgoId = parentAlgoId;
+        AlgoSliceSeq = algoSliceSeq;
         LeavesQuantity = quantity;
         Status = OrderStatus.PendingNew;
     }
@@ -65,6 +84,16 @@ public sealed class Order
     public OrderType Type { get; }
     public long Quantity { get; }
     public decimal? Price { get; }
+    /// <summary>
+    /// When set, this order is a child slice produced by an
+    /// <c>AlgoEngine</c> on behalf of the parent <see cref="Algo"/> with
+    /// id <see cref="ParentAlgoId"/> and slice index <see cref="AlgoSliceSeq"/>.
+    /// Manual orders submitted via <c>POST /orders</c> leave both fields
+    /// <c>null</c>. The pair is set together or both <c>null</c> — never
+    /// one without the other (RFC §4.2).
+    /// </summary>
+    public ulong? ParentAlgoId { get; }
+    public int? AlgoSliceSeq { get; }
     public long LeavesQuantity { get; private set; }
     public long CumulativeQuantity { get; private set; }
     public OrderStatus Status { get; private set; }
@@ -149,9 +178,10 @@ public sealed class Order
     /// </summary>
     internal static Order Hydrate(
         ulong clOrdId, EndClientId owner, string symbol, ulong securityId, OrderSide side, OrderType type,
-        long quantity, decimal? price, long leaves, long cumQty, OrderStatus status, string firmId = "DEFAULT")
+        long quantity, decimal? price, long leaves, long cumQty, OrderStatus status, string firmId = "DEFAULT",
+        ulong? parentAlgoId = null, int? algoSliceSeq = null)
     {
-        var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId);
+        var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddSingleton<EndClientRegistry>();
 builder.Services.AddSingleton<ClOrdIdPrefixRegistry>();
 builder.Services.AddSingleton<OrderOwnershipMap>();
 builder.Services.AddSingleton<WorkingOrderBook>();
+builder.Services.AddSingleton<AlgoBook>();
 builder.Services.AddSingleton<PositionKeeper>();
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -19,19 +19,22 @@ public sealed class StateSnapshotter
     private readonly KillSwitchService _killSwitch;
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly OrderOwnershipMap _ownership;
+    private readonly AlgoBook _algos;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
         PositionKeeper positions,
         KillSwitchService killSwitch,
         ClOrdIdPrefixRegistry clOrdIds,
-        OrderOwnershipMap ownership)
+        OrderOwnershipMap ownership,
+        AlgoBook algos)
     {
         _orders = orders;
         _positions = positions;
         _killSwitch = killSwitch;
         _clOrdIds = clOrdIds;
         _ownership = ownership;
+        _algos = algos;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -44,6 +47,7 @@ public sealed class StateSnapshotter
         KilledFirms = _killSwitch.ListKilledFirms().ToList(),
         ClOrdIds = _clOrdIds.Snapshot(),
         Ownership = _ownership.Snapshot().ToList(),
+        Algos = _algos.Snapshot().ToList(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -54,6 +58,7 @@ public sealed class StateSnapshotter
         _killSwitch.Restore(snap.KilledEndClients, snap.KilledFirms);
         _clOrdIds.Restore(snap.ClOrdIds);
         _ownership.Restore(snap.Ownership);
+        _algos.Restore(snap.Algos);
     }
 }
 
@@ -70,17 +75,20 @@ public sealed class EventReplayer
     private readonly OrderOwnershipMap _ownership;
     private readonly KillSwitchService _killSwitch;
     private readonly ExecutionReportProcessor _processor;
+    private readonly AlgoBook _algos;
 
     public EventReplayer(
         WorkingOrderBook orders,
         OrderOwnershipMap ownership,
         KillSwitchService killSwitch,
-        ExecutionReportProcessor processor)
+        ExecutionReportProcessor processor,
+        AlgoBook algos)
     {
         _orders = orders;
         _ownership = ownership;
         _killSwitch = killSwitch;
         _processor = processor;
+        _algos = algos;
     }
 
     public void Apply(WalEvent evt)
@@ -91,8 +99,13 @@ public sealed class EventReplayer
                 var owner = new EndClientId(o.EndClientId);
                 var side = Enum.Parse<OrderSide>(o.Side, ignoreCase: true);
                 var type = Enum.Parse<OrderType>(o.Type, ignoreCase: true);
-                _orders.TryAdd(new Order(o.ClOrdId, owner, o.Symbol, o.SecurityId, side, type, o.Quantity, o.Price, o.FirmId));
+                _orders.TryAdd(new Order(o.ClOrdId, owner, o.Symbol, o.SecurityId, side, type,
+                    o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq));
                 _ownership.Register(o.ClOrdId, owner);
+                // Parent state-machine progression on first child accept is
+                // engine-side (slice 5/6); replay only re-creates the order
+                // — the parent's Working/Filled state is reconstructed from
+                // the child ER stream through the processor below.
                 break;
             case ExecutionReportReceivedEvent er:
                 if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))
@@ -113,6 +126,43 @@ public sealed class EventReplayer
                     else _killSwitch.ReviveFirm(k.Target);
                 }
                 break;
+            case AlgoCreatedEvent ac:
+                ApplyAlgoCreated(ac);
+                break;
+            case AlgoCancelRequestedEvent acr:
+                if (_algos.TryGet(acr.AlgoId, out var cancelling) && cancelling is not null)
+                    cancelling.RequestCancel();
+                break;
+            case AlgoTerminalStateRecordedEvent at:
+                if (_algos.TryGet(at.AlgoId, out var algo) && algo is not null)
+                {
+                    var status = Enum.Parse<AlgoStatus>(at.Status, ignoreCase: true);
+                    var reason = Enum.Parse<AlgoTerminalReason>(at.Reason, ignoreCase: true);
+                    algo.RecordTerminal(status, reason, at.AtUtc);
+                }
+                break;
         }
+    }
+
+    private void ApplyAlgoCreated(AlgoCreatedEvent ac)
+    {
+        var owner = new EndClientId(ac.EndClientId);
+        var side = Enum.Parse<OrderSide>(ac.Side, ignoreCase: true);
+        var type = Enum.Parse<AlgoType>(ac.Type, ignoreCase: true);
+        AlgoParameters parameters = type switch
+        {
+            AlgoType.Iceberg => new IcebergParameters(
+                ac.IcebergDisplayQuantity ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing IcebergDisplayQuantity."),
+                ac.IcebergLimitPrice),
+            AlgoType.Twap => new TwapParameters(
+                ac.TwapStartUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapStartUtc."),
+                ac.TwapEndUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapEndUtc."),
+                ac.TwapSliceCount ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapSliceCount."),
+                Enum.Parse<OrderType>(ac.TwapChildOrderType ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapChildOrderType."), ignoreCase: true),
+                ac.TwapChildPrice),
+            _ => throw new InvalidOperationException($"Unknown algo type: {ac.Type}"),
+        };
+        _algos.TryAdd(new Algo(ac.AlgoId, owner, ac.FirmId, ac.Symbol, ac.SecurityId,
+            side, type, ac.TotalQuantity, parameters, ac.CreatedAtUtc));
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -1,0 +1,248 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Slice 2: parent algo aggregates persist via three new WAL events
+/// (<see cref="AlgoCreatedEvent"/>, <see cref="AlgoCancelRequestedEvent"/>,
+/// <see cref="AlgoTerminalStateRecordedEvent"/>) plus a new
+/// <see cref="AlgoSnapshot"/> array. These tests exercise the full
+/// recovery shape: WAL-only replay and snapshot+tail must both produce
+/// the same in-memory <see cref="AlgoBook"/>.
+/// </summary>
+public class AlgoRecoveryTests : IDisposable
+{
+    private readonly string _root;
+
+    public AlgoRecoveryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-algo-recovery-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private PersistenceOptions Opts() => new()
+    {
+        DataDirectory = _root,
+        FirmId = "test",
+        ChannelCapacity = 1024,
+        GroupCommitMaxRecords = 8,
+        GroupCommitWindow = TimeSpan.FromMilliseconds(5),
+        FsyncOnFlush = false,
+    };
+
+    [Fact]
+    public async Task AlgoEvents_ReplayedFromWal_ReproduceParentAggregate()
+    {
+        var createdAt = DateTimeOffset.UtcNow;
+        var terminalAt = createdAt.AddSeconds(5);
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+
+            // Iceberg created.
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 100UL,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Iceberg",
+                    TotalQuantity = 1000,
+                    CreatedAtUtc = createdAt,
+                    IcebergDisplayQuantity = 100,
+                    IcebergLimitPrice = 30m,
+                },
+                () => algos.TryAdd(new Algo(100UL, new EndClientId("alice"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Iceberg, 1000,
+                    new IcebergParameters(100, 30m), createdAt)));
+
+            // First child child submitted (manual orders pipeline reused).
+            dispatcher.Dispatch(
+                new OrderSubmittedEvent
+                {
+                    ClOrdId = 1UL,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Limit",
+                    Quantity = 100,
+                    Price = 30m,
+                    ParentAlgoId = 100UL,
+                    AlgoSliceSeq = 0,
+                },
+                () =>
+                {
+                    book.TryAdd(new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL,
+                        OrderSide.Buy, OrderType.Limit, 100, 30m, "TEST", 100UL, 0));
+                    ownership.Register(1UL, new EndClientId("alice"));
+                });
+
+            // Operator cancels.
+            dispatcher.Dispatch(
+                new AlgoCancelRequestedEvent { AlgoId = 100UL, ActorUserId = "carol" },
+                () => algos.TryGet(100UL, out var a).Then(() => a!.RequestCancel()));
+
+            // Engine records terminal.
+            dispatcher.Dispatch(
+                new AlgoTerminalStateRecordedEvent
+                {
+                    AlgoId = 100UL,
+                    Status = "Cancelled",
+                    Reason = "UserCancelled",
+                    AtUtc = terminalAt,
+                },
+                () => algos.TryGet(100UL, out var a).Then(() =>
+                    a!.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, terminalAt)));
+        }
+
+        // Cold boot — replay WAL only, no snapshot taken.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.True(algos.TryGet(100UL, out var algo) && algo is not null);
+            Assert.Equal(AlgoStatus.Cancelled, algo!.Status);
+            Assert.Equal(AlgoTerminalReason.UserCancelled, algo.TerminalReason);
+            Assert.Equal(terminalAt, algo.TerminalAtUtc);
+            Assert.Equal(AlgoType.Iceberg, algo.Type);
+            var ip = Assert.IsType<IcebergParameters>(algo.Parameters);
+            Assert.Equal(100, ip.DisplayQuantity);
+            Assert.Equal(30m, ip.LimitPrice);
+
+            // Child carries the algo linkage on the Order.
+            Assert.True(book.TryGet(1UL, out var child) && child is not null);
+            Assert.Equal(100UL, child!.ParentAlgoId);
+            Assert.Equal(0, child.AlgoSliceSeq);
+        }
+    }
+
+    [Fact]
+    public async Task TwapAlgo_RoundtripsThroughSnapshot()
+    {
+        var createdAt = new DateTimeOffset(2026, 5, 4, 13, 0, 0, TimeSpan.Zero);
+        var twapStart = createdAt;
+        var twapEnd = createdAt.AddMinutes(10);
+
+        PlatformSnapshot? snap;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, _, algos, dispatcher) = Build(store);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos);
+
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 200UL,
+                    EndClientId = "bob",
+                    FirmId = "TEST",
+                    Symbol = "VALE3",
+                    SecurityId = 1234UL,
+                    Side = "Sell",
+                    Type = "Twap",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    TwapStartUtc = twapStart,
+                    TwapEndUtc = twapEnd,
+                    TwapSliceCount = 5,
+                    TwapChildOrderType = "Market",
+                    TwapChildPrice = null,
+                },
+                () => algos.TryAdd(new Algo(200UL, new EndClientId("bob"), "TEST", "VALE3", 1234UL,
+                    OrderSide.Sell, AlgoType.Twap, 5000,
+                    new TwapParameters(twapStart, twapEnd, 5, OrderType.Market, null), createdAt)));
+
+            // Two slice fills of 1000 each.
+            algos.TryGet(200UL, out var live);
+            live!.MarkWorking();
+            live.RecordFill(1000);
+            live.RecordFill(1000);
+
+            snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+        }
+
+        Assert.NotNull(snap);
+        Assert.Single(snap!.Algos);
+
+        // Restore into a fresh book and verify shape.
+        var restored = new AlgoBook();
+        restored.Restore(snap.Algos);
+        Assert.True(restored.TryGet(200UL, out var rehydrated) && rehydrated is not null);
+        Assert.Equal(2000, rehydrated!.FilledQuantity);
+        Assert.Equal(3000, rehydrated.RemainingQuantity);
+        Assert.Equal(AlgoStatus.Working, rehydrated.Status);
+        var tp = Assert.IsType<TwapParameters>(rehydrated.Parameters);
+        Assert.Equal(twapStart, tp.StartUtc);
+        Assert.Equal(twapEnd, tp.EndUtc);
+        Assert.Equal(5, tp.SliceCount);
+        Assert.Equal(OrderType.Market, tp.ChildOrderType);
+        Assert.Null(tp.ChildPrice);
+    }
+
+    [Fact]
+    public void AlgoBook_EnumerateForOwner_ExcludesTerminalByDefault()
+    {
+        var algos = new AlgoBook();
+        var alice = new EndClientId("alice");
+        var live = new Algo(1UL, alice, "TEST", "PETR4", 4321UL, OrderSide.Buy, AlgoType.Iceberg,
+            100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+        var done = new Algo(2UL, alice, "TEST", "PETR4", 4321UL, OrderSide.Buy, AlgoType.Iceberg,
+            100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+        done.RecordTerminal(AlgoStatus.Completed, AlgoTerminalReason.None, DateTimeOffset.UtcNow);
+        algos.TryAdd(live);
+        algos.TryAdd(done);
+
+        Assert.Single(algos.EnumerateForOwner(alice));
+        Assert.Equal(2, algos.EnumerateForOwner(alice, includeTerminal: true).Count);
+    }
+
+    private static (WorkingOrderBook, OrderOwnershipMap, KillSwitchService, ExecutionReportProcessor, AlgoBook, EventDispatcher) Build(IEventStore store)
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var killSwitch = new KillSwitchService();
+        var ownership = new OrderOwnershipMap();
+        var algos = new AlgoBook();
+        var sink = new TestSink();
+        var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
+            new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var dispatcher = new EventDispatcher(store);
+        return (book, ownership, killSwitch, processor, algos, dispatcher);
+    }
+
+    private sealed class TestSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent evt) { }
+    }
+}
+
+internal static class TupleExt
+{
+    // Tiny helper so the dispatcher action stays inline-readable when we
+    // need to do "TryGet then call a method on the result" without a temp.
+    public static void Then(this bool found, Action a)
+    {
+        if (found) a();
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -44,7 +44,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         // Phase 1: live session — append events through the dispatcher, mutate state.
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
-            var (book, positions, killSwitch, ownership, _, dispatcher, processor, sink) = BuildState(store);
+            var (book, positions, killSwitch, ownership, _, dispatcher, processor, sink, _) = BuildState(store);
 
             // Submit two orders.
             DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "PETR4", OrderSide.Buy, 100, 30m);
@@ -65,8 +65,8 @@ public class RecoveryAndSnapshotTests : IDisposable
         // Phase 2: cold boot — fresh state objects, recovery replays the WAL.
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
-            var (book, positions, killSwitch, ownership, snapshotter, _, processor, _) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, processor);
+            var (book, positions, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
+            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
             var recovery = new PersistenceRecovery(store,
                 snapshotter,
                 replayer,
@@ -100,7 +100,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         long snapSeq;
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
-            var (book, _, _, ownership, snapshotter, dispatcher, _, _) = BuildState(store);
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) = BuildState(store);
             for (var i = 1UL; i <= 3UL; i++)
                 DispatchSubmit(dispatcher, book, ownership, i, "alice", "PETR4", OrderSide.Buy, 10, 30m);
 
@@ -119,8 +119,8 @@ public class RecoveryAndSnapshotTests : IDisposable
         // Phase 2: cold boot from snapshot+tail.
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
-            var (book, _, killSwitch, ownership, snapshotter, _, processor, _) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, processor);
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
+            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -135,7 +135,7 @@ public class RecoveryAndSnapshotTests : IDisposable
     public async Task Snapshot_DoesNotIncludeFlatPositions()
     {
         await using var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance);
-        var (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, _) = BuildState(store);
+        var (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, _, _) = BuildState(store);
         DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "PETR4", OrderSide.Buy, 100, 30m);
         DispatchEr(dispatcher, processor, 1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, lastPx: 30m);
         DispatchSubmit(dispatcher, book, ownership, 2UL, "alice", "PETR4", OrderSide.Sell, 100, 30m);
@@ -154,19 +154,21 @@ public class RecoveryAndSnapshotTests : IDisposable
         StateSnapshotter,
         EventDispatcher,
         ExecutionReportProcessor,
-        TestSink) BuildState(IEventStore store)
+        TestSink,
+        AlgoBook) BuildState(IEventStore store)
     {
         var book = new WorkingOrderBook();
         var positions = new PositionKeeper();
         var killSwitch = new KillSwitchService();
         var ownership = new OrderOwnershipMap();
         var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algos = new AlgoBook();
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
             new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
-        var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership);
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership, algos);
         var dispatcher = new EventDispatcher(store);
-        return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink);
+        return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
     }
 
     private static void DispatchSubmit(

--- a/backend/tests/B3.Trading.Domain.Tests/AlgoTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/AlgoTests.cs
@@ -1,0 +1,125 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+public class AlgoTests
+{
+    private static readonly EndClientId Alice = new("alice");
+    private const string Firm = "TEST";
+
+    private static Algo NewIceberg(ulong id = 1, long total = 1000, long display = 100, decimal? limit = 30m) =>
+        new(id, Alice, Firm, "PETR4", 4321UL, OrderSide.Buy, AlgoType.Iceberg,
+            total, new IcebergParameters(display, limit), DateTimeOffset.UtcNow);
+
+    private static Algo NewTwap(ulong id = 1, long total = 1000, int slices = 10) =>
+        new(id, Alice, Firm, "PETR4", 4321UL, OrderSide.Buy, AlgoType.Twap,
+            total,
+            new TwapParameters(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddMinutes(10), slices, OrderType.Market, null),
+            DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void Construction_AssignsFieldsAndStartsPendingNew()
+    {
+        var algo = NewIceberg();
+        Assert.Equal(AlgoStatus.PendingNew, algo.Status);
+        Assert.Equal(AlgoTerminalReason.None, algo.TerminalReason);
+        Assert.Equal(1000, algo.RemainingQuantity);
+        Assert.False(algo.IsTerminal);
+    }
+
+    [Fact]
+    public void Construction_RejectsZeroAlgoId()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Algo(0, Alice, Firm, "PETR4", 4321UL, OrderSide.Buy, AlgoType.Iceberg, 100,
+                new IcebergParameters(10, 30m), DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Construction_RejectsParametersOfWrongType()
+    {
+        // TwapParameters with AlgoType.Iceberg is a programming error.
+        var twap = new TwapParameters(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddMinutes(1), 5, OrderType.Limit, 30m);
+        Assert.Throws<ArgumentException>(() =>
+            new Algo(1, Alice, Firm, "PETR4", 4321UL, OrderSide.Buy, AlgoType.Iceberg, 100,
+                twap, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void MarkWorking_AdvancesOnceAndIsIdempotent()
+    {
+        var algo = NewIceberg();
+        algo.MarkWorking();
+        Assert.Equal(AlgoStatus.Working, algo.Status);
+        algo.MarkWorking();
+        Assert.Equal(AlgoStatus.Working, algo.Status);
+    }
+
+    [Fact]
+    public void RecordFill_AccumulatesAndUpdatesRemaining()
+    {
+        var algo = NewIceberg(total: 500);
+        algo.RecordFill(120);
+        algo.RecordFill(80);
+        Assert.Equal(200, algo.FilledQuantity);
+        Assert.Equal(300, algo.RemainingQuantity);
+    }
+
+    [Fact]
+    public void RequestCancel_TransitionsAnyNonTerminalToCancelling()
+    {
+        var algo = NewIceberg();
+        algo.MarkWorking();
+        algo.RequestCancel();
+        Assert.Equal(AlgoStatus.Cancelling, algo.Status);
+        // Idempotent — operator can spam DELETE.
+        algo.RequestCancel();
+        Assert.Equal(AlgoStatus.Cancelling, algo.Status);
+    }
+
+    [Fact]
+    public void RequestCancel_IsNoOpAfterTerminal()
+    {
+        var algo = NewIceberg();
+        algo.MarkWorking();
+        algo.RecordTerminal(AlgoStatus.Completed, AlgoTerminalReason.None, DateTimeOffset.UtcNow);
+        algo.RequestCancel();
+        Assert.Equal(AlgoStatus.Completed, algo.Status);
+    }
+
+    [Theory]
+    [InlineData(AlgoStatus.Completed, AlgoTerminalReason.None)]
+    [InlineData(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled)]
+    [InlineData(AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected)]
+    [InlineData(AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired)]
+    public void RecordTerminal_SetsStatusReasonAndTimestamp(AlgoStatus status, AlgoTerminalReason reason)
+    {
+        var algo = NewTwap();
+        var at = DateTimeOffset.UtcNow;
+        algo.RecordTerminal(status, reason, at);
+        Assert.Equal(status, algo.Status);
+        Assert.Equal(reason, algo.TerminalReason);
+        Assert.Equal(at, algo.TerminalAtUtc);
+        Assert.True(algo.IsTerminal);
+    }
+
+    [Fact]
+    public void RecordTerminal_RejectsNonTerminalStatus()
+    {
+        var algo = NewIceberg();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            algo.RecordTerminal(AlgoStatus.Working, AlgoTerminalReason.None, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void RecordTerminal_RejectsConflictingReentry()
+    {
+        var algo = NewIceberg();
+        algo.RecordTerminal(AlgoStatus.Completed, AlgoTerminalReason.None, DateTimeOffset.UtcNow);
+        // Replay-safe: same status is no-op.
+        algo.RecordTerminal(AlgoStatus.Completed, AlgoTerminalReason.None, DateTimeOffset.UtcNow);
+        // Different terminal must throw — would indicate a logic bug.
+        Assert.Throws<InvalidOperationException>(() =>
+            algo.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, DateTimeOffset.UtcNow));
+    }
+}

--- a/backend/tests/B3.Trading.Domain.Tests/OrderAlgoLinkageTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderAlgoLinkageTests.cs
@@ -1,0 +1,57 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+/// <summary>
+/// Slice 2: Order grew nullable <c>ParentAlgoId</c>/<c>AlgoSliceSeq</c>
+/// for algo-engine children. Manual orders must keep working with both
+/// fields null; the pair must be validated together.
+/// </summary>
+public class OrderAlgoLinkageTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    [Fact]
+    public void ManualOrder_DefaultsAlgoFieldsToNull()
+    {
+        var o = new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        Assert.Null(o.ParentAlgoId);
+        Assert.Null(o.AlgoSliceSeq);
+    }
+
+    [Fact]
+    public void AlgoChild_CarriesBothParentAndSlice()
+    {
+        var o = new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+            firmId: "F1", parentAlgoId: 42UL, algoSliceSeq: 0);
+        Assert.Equal(42UL, o.ParentAlgoId);
+        Assert.Equal(0, o.AlgoSliceSeq);
+    }
+
+    [Fact]
+    public void AlgoChild_RejectsHalfSetPair()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+                parentAlgoId: 42UL));
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+                algoSliceSeq: 0));
+    }
+
+    [Fact]
+    public void AlgoChild_RejectsZeroParentAlgoId()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+                parentAlgoId: 0UL, algoSliceSeq: 0));
+    }
+
+    [Fact]
+    public void AlgoChild_RejectsNegativeSliceSeq()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Order(1UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+                parentAlgoId: 42UL, algoSliceSeq: -1));
+    }
+}


### PR DESCRIPTION
First implementation slice for algo orders v0 (RFC \`docs/rfcs/algo-orders-v0.md\` §4.1, §4.2, §4.5). **No engine, no HTTP** — just the durable shape so the engine slices can land without snapshot-format churn.

## Domain (\`B3.Trading.Domain\`)

- **\`Algo\`** aggregate with state machine:
  \`PendingNew → Working → Cancelling → Cancelled / Suspended / Expired / Completed\`
- **\`AlgoStatus\`**, **\`AlgoTerminalReason\`** enums + sealed parameter records (\`IcebergParameters\`, \`TwapParameters\`) per algo type — discriminated shape stays explicit at runtime and on the wire.
- **\`Order\`** grows nullable \`ParentAlgoId\` + \`AlgoSliceSeq\`. Both null = manual order; both set = algo child. Half-set is a programming error (throws). Existing manual-order callsites need no change.

## Application

- **\`AlgoBook\`** — in-memory aggregate, owner/firm secondary indices, \`Snapshot\`/\`Restore\` mirroring \`WorkingOrderBook\`'s shape.
- **\`WalEvents\`** — three new derived types (RFC §4.5):
  - \`AlgoCreatedEvent\` — parent params at submit time.
  - \`AlgoCancelRequestedEvent\` — operator-driven \`DELETE /algo/{id}\` log entry.
  - \`AlgoTerminalStateRecordedEvent\` — terminal status + durable reason.
  - \`OrderSubmittedEvent\` extended with nullable \`ParentAlgoId\`/\`AlgoSliceSeq\`.
- **\`Snapshots\`** — \`AlgoSnapshot\` record + \`PlatformSnapshot.Algos\` array; \`OrderSnapshot\` extended with the same nullable algo fields.

## Infrastructure

- **\`StateSnapshotter\`** wires \`AlgoBook\` into \`Capture\`/\`Restore\`.
- **\`EventReplayer\`** dispatches the 3 algo events and propagates algo fields through \`OrderSubmittedEvent\` on replay.
- **DI**: \`AlgoBook\` registered as singleton next to \`WorkingOrderBook\`.

## Tests (+14)

- **\`AlgoTests\`** (Domain): state-machine transitions, idempotent \`MarkWorking\`, parameter-type validation, replay-safe \`RecordTerminal\`, conflicting terminal rejection.
- **\`OrderAlgoLinkageTests\`** (Domain): nullable-pair invariants, zero/negative rejections.
- **\`AlgoRecoveryTests\`** (Application): WAL-only replay rebuilds Iceberg parent + child linkage; TWAP parameters roundtrip through snapshot; \`AlgoBook.EnumerateForOwner\` honours \`includeTerminal\`.

## Backwards compatibility

- **Snapshots:** \`Algos\` defaults to \`new()\` and STJ web defaults skip missing properties, so old snapshots load with an empty algo list.
- **WAL:** new \`OrderSubmittedEvent\` fields are nullable; older records deserialize with \`null\` on both, which is exactly the manual-order semantics they carried.
- **Manual-order callsites** are unchanged (default-valued ctor parameters).

## Verification

- \`dotnet format --verify-no-changes\` ✓
- \`dotnet build\` ✓ (0 warnings)
- \`dotnet test\` ✓ (Domain 30 / Application 187 / Api 77 / Conformance 7 skipped)

## Out of scope (later slices)

- HTTP \`POST /algo\` and the trader UI (slice 3)
- Simulator gateway (slice 4)
- Iceberg engine (slice 5), TWAP engine (slice 6)
- Conformance + Grafana (slice 7)

Refs #48.