### PR TITLE
feat(algo): slice 3 — HTTP /algo + WS algo.me topic (snapshot-on-subscribe)

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -1,0 +1,279 @@
+using System.Security.Claims;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.Lifecycle;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// HTTP surface for the algo orders v0 RFC §4.9. Handles the parent
+/// lifecycle only — actual child slice generation is the engine's job
+/// (slices 4+). v0 endpoints accept and durably record the user's
+/// intent; the parent stays in <c>PendingNew</c>/<c>Cancelling</c>
+/// indefinitely until a future engine slice promotes it.
+/// </summary>
+public static class AlgoEndpoints
+{
+    public static IEndpointRouteBuilder MapAlgo(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/algo").RequireAuthorization();
+
+        group.MapGet("/", (HttpContext ctx, AlgoBook algos, EndClientRegistry registry) =>
+        {
+            var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
+            var list = algos.EnumerateForOwner(firm, owner, includeTerminal: false)
+                .Select(a => a.ToDto());
+            return Results.Ok(list);
+        });
+
+        group.MapGet("/{algoId}", (string algoId, HttpContext ctx, AlgoBook algos, EndClientRegistry registry) =>
+        {
+            if (!ulong.TryParse(algoId, out var id) || id == 0)
+                return Results.NotFound();
+            var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
+            if (!algos.TryGet(firm, id, out var algo) || algo is null || algo.Owner != owner)
+                return Results.NotFound();
+            return Results.Ok(algo.ToDto());
+        });
+
+        group.MapPost("/", (
+            CreateAlgoRequest req,
+            HttpContext ctx,
+            EndClientRegistry registry,
+            AlgoIdRegistry algoIds,
+            AlgoBook algos,
+            IAlgoEventSink sink,
+            EventDispatcher dispatcher,
+            DrainState drain,
+            SymbolDirectory symbols) =>
+        {
+            if (drain.IsDraining)
+            {
+                MetricsRegistry.DrainRejections.Add(1,
+                    new KeyValuePair<string, object?>("route", "POST /algo"));
+                return Results.Json(
+                    new { error = "service draining" },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            if (string.IsNullOrWhiteSpace(req.Symbol))
+                return Results.BadRequest(new { error = "symbol is required" });
+            if (!Enum.TryParse<OrderSide>(req.Side, ignoreCase: true, out var side))
+                return Results.BadRequest(new { error = $"invalid side '{req.Side}'" });
+            if (!Enum.TryParse<AlgoType>(req.Type, ignoreCase: true, out var type))
+                return Results.BadRequest(new { error = $"invalid type '{req.Type}'" });
+            if (req.TotalQuantity <= 0)
+                return Results.BadRequest(new { error = "totalQuantity must be positive" });
+
+            var securityId = req.SecurityId;
+            if (securityId == 0 && symbols.TryResolve(req.Symbol, out var resolved))
+                securityId = resolved;
+            if (securityId == 0)
+                return Results.BadRequest(new { error = "securityId is required" });
+
+            // Type-specific parameter validation. v0 keeps the rules
+            // explicit + duplicated rather than hiding them behind a
+            // visitor — the surface is small and the failure messages
+            // matter for trader UI feedback.
+            AlgoParameters parameters;
+            switch (type)
+            {
+                case AlgoType.Iceberg:
+                    if (req.Iceberg is null)
+                        return Results.BadRequest(new { error = "iceberg parameters are required for type=Iceberg" });
+                    if (req.Iceberg.DisplayQuantity <= 0)
+                        return Results.BadRequest(new { error = "iceberg.displayQuantity must be positive" });
+                    if (req.Iceberg.DisplayQuantity > req.TotalQuantity)
+                        return Results.BadRequest(new { error = "iceberg.displayQuantity must be <= totalQuantity" });
+                    parameters = new IcebergParameters(req.Iceberg.DisplayQuantity, req.Iceberg.LimitPrice);
+                    break;
+
+                case AlgoType.Twap:
+                    if (req.Twap is null)
+                        return Results.BadRequest(new { error = "twap parameters are required for type=Twap" });
+                    if (!Enum.TryParse<OrderType>(req.Twap.ChildOrderType, ignoreCase: true, out var childType))
+                        return Results.BadRequest(new { error = $"invalid twap.childOrderType '{req.Twap.ChildOrderType}'" });
+                    if (childType is not (OrderType.Limit or OrderType.Market))
+                        return Results.BadRequest(new { error = "twap.childOrderType must be Limit or Market" });
+                    if (req.Twap.EndUtc <= req.Twap.StartUtc)
+                        return Results.BadRequest(new { error = "twap.endUtc must be greater than twap.startUtc" });
+                    if (req.Twap.SliceCount <= 0)
+                        return Results.BadRequest(new { error = "twap.sliceCount must be positive" });
+                    // OQ-2: TWAP+Limit MUST carry a child price; otherwise the engine
+                    // would have no fallback and the parent could only ever submit
+                    // unpriced child orders that contradict the user's chosen type.
+                    if (childType == OrderType.Limit && req.Twap.ChildPrice is null)
+                        return Results.BadRequest(new { error = "twap.childPrice is required when twap.childOrderType is Limit" });
+                    parameters = new TwapParameters(
+                        req.Twap.StartUtc, req.Twap.EndUtc, req.Twap.SliceCount,
+                        childType, req.Twap.ChildPrice);
+                    break;
+
+                default:
+                    return Results.BadRequest(new { error = $"unsupported algo type '{type}'" });
+            }
+
+            var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
+            var algoId = algoIds.Generate(firm);
+            var createdAt = DateTimeOffset.UtcNow;
+            var algo = new Algo(algoId, owner, firm, req.Symbol, securityId,
+                side, type, req.TotalQuantity, parameters, createdAt);
+
+            try
+            {
+                dispatcher.Dispatch(
+                    new AlgoCreatedEvent
+                    {
+                        AlgoId = algoId,
+                        EndClientId = owner.Value,
+                        FirmId = firm,
+                        Symbol = req.Symbol,
+                        SecurityId = securityId,
+                        Side = side.ToString(),
+                        Type = type.ToString(),
+                        TotalQuantity = req.TotalQuantity,
+                        CreatedAtUtc = createdAt,
+                        IcebergDisplayQuantity = (parameters as IcebergParameters)?.DisplayQuantity,
+                        IcebergLimitPrice = (parameters as IcebergParameters)?.LimitPrice,
+                        TwapStartUtc = (parameters as TwapParameters)?.StartUtc,
+                        TwapEndUtc = (parameters as TwapParameters)?.EndUtc,
+                        TwapSliceCount = (parameters as TwapParameters)?.SliceCount,
+                        TwapChildOrderType = (parameters as TwapParameters)?.ChildOrderType.ToString(),
+                        TwapChildPrice = (parameters as TwapParameters)?.ChildPrice,
+                    },
+                    () => algos.TryAdd(algo));
+            }
+            catch (WalBackpressureException ex)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "algo.submit"));
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            sink.PublishAlgoSnapshot(owner, firm, algoId);
+
+            return Results.Accepted($"/algo/{algoId}", new
+            {
+                AlgoId = algoId.ToString(),
+                Status = AlgoStatus.PendingNew.ToString(),
+            });
+        });
+
+        group.MapDelete("/{algoId}", (
+            string algoId,
+            HttpContext ctx,
+            EndClientRegistry registry,
+            AlgoBook algos,
+            IAlgoEventSink sink,
+            EventDispatcher dispatcher,
+            DrainState drain) =>
+        {
+            if (drain.IsDraining)
+            {
+                MetricsRegistry.DrainRejections.Add(1,
+                    new KeyValuePair<string, object?>("route", "DELETE /algo"));
+                return Results.Json(
+                    new { error = "service draining" },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            if (!ulong.TryParse(algoId, out var id) || id == 0)
+                return Results.NotFound();
+
+            var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
+            if (!algos.TryGet(firm, id, out var algo) || algo is null || algo.Owner != owner)
+                return Results.NotFound();
+
+            // Already-terminal parents can't be cancelled; terminal-on-terminal
+            // is a 409 so the caller can distinguish "you're racing the engine"
+            // from "the algo doesn't exist". Cancelling-on-Cancelling is OK
+            // (idempotent — operator may DELETE multiple times during a slow
+            // venue cancel and should always see a 202).
+            if (algo.IsTerminal)
+                return Results.Conflict(new { error = $"algo {id} is already terminal in {algo.Status}" });
+
+            var actorUserId = ctx.User.FindFirstValue(ClaimTypes.Name)
+                ?? ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+
+            try
+            {
+                dispatcher.Dispatch(
+                    new AlgoCancelRequestedEvent
+                    {
+                        AlgoId = id,
+                        FirmId = firm,
+                        ActorUserId = actorUserId,
+                    },
+                    () => algo.RequestCancel());
+            }
+            catch (WalBackpressureException ex)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "algo.cancel"));
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            sink.PublishAlgoSnapshot(owner, firm, id);
+
+            return Results.Accepted($"/algo/{id}", new
+            {
+                AlgoId = id.ToString(),
+                Status = AlgoStatus.Cancelling.ToString(),
+            });
+        });
+
+        return app;
+    }
+
+    private static EndClientId ResolveOwner(HttpContext ctx, EndClientRegistry registry)
+    {
+        var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                  ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
+        return registry.Register(sub);
+    }
+
+    private static string ResolveFirm(HttpContext ctx) =>
+        ctx.User.FindFirstValue(JwtIssuer.FirmClaim) ?? "default";
+}
+
+/// <summary>
+/// HTTP request body for <c>POST /algo</c>. The discriminated parameter
+/// shape mirrors the wire <see cref="AlgoDto"/>: only the block matching
+/// <see cref="Type"/> is read; the other is ignored. Per RFC §C2 the
+/// public schema deliberately does NOT expose <c>parentAlgoId</c> /
+/// <c>algoSliceSeq</c> — algo-on-algo is forbidden in v0 and the engine
+/// uses an internal pipeline for child submission, never this endpoint.
+/// </summary>
+public sealed record CreateAlgoRequest(
+    string Symbol,
+    ulong SecurityId,
+    string Side,
+    string Type,
+    long TotalQuantity,
+    CreateAlgoIcebergParams? Iceberg,
+    CreateAlgoTwapParams? Twap);
+
+public sealed record CreateAlgoIcebergParams(long DisplayQuantity, decimal? LimitPrice);
+
+public sealed record CreateAlgoTwapParams(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    int SliceCount,
+    string ChildOrderType,
+    decimal? ChildPrice);

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -9,9 +9,10 @@ public static class Channels
     public const string OrdersMe = "orders.me";
     public const string ExecutionsMe = "executions.me";
     public const string PositionsMe = "positions.me";
+    public const string AlgoMe = "algo.me";
 
     public static readonly IReadOnlySet<string> All =
-        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe };
+        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe, AlgoMe };
 }
 
 /// <summary>Inbound command from a connected client.</summary>
@@ -50,6 +51,38 @@ public sealed record ExecutionDto(
     string? RejectReason,
     DateTimeOffset TimestampUtc);
 
+/// <summary>
+/// Wire shape for an algo parent. Per-type parameters live in the
+/// nullable <see cref="Iceberg"/> / <see cref="Twap"/> properties — only
+/// the one matching <see cref="Type"/> is populated. The discriminated
+/// shape keeps the JSON debuggable (<c>jq '.iceberg.displayQuantity'</c>)
+/// without requiring polymorphic STJ converters on the client.
+/// </summary>
+public sealed record AlgoDto(
+    string AlgoId,
+    string Symbol,
+    ulong SecurityId,
+    string Side,
+    string Type,
+    long TotalQuantity,
+    long FilledQuantity,
+    long RemainingQuantity,
+    string Status,
+    string TerminalReason,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? TerminalAtUtc,
+    IcebergParamsDto? Iceberg,
+    TwapParamsDto? Twap);
+
+public sealed record IcebergParamsDto(long DisplayQuantity, decimal? LimitPrice);
+
+public sealed record TwapParamsDto(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    int SliceCount,
+    string ChildOrderType,
+    decimal? ChildPrice);
+
 public static class DtoMappings
 {
     public static OrderDto ToDto(this Order o) => new(
@@ -61,4 +94,29 @@ public static class DtoMappings
     public static ExecutionDto ToDto(this ExecutionEvent ev) => new(
         ev.ClOrdId.ToString(), ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),
         ev.LeavesQuantity, ev.CumulativeQuantity, ev.LastQuantity, ev.LastPrice, ev.RejectReason, ev.TimestampUtc);
+
+    public static AlgoDto ToDto(this Algo a)
+    {
+        IcebergParamsDto? iceberg = a.Parameters is IcebergParameters ip
+            ? new IcebergParamsDto(ip.DisplayQuantity, ip.LimitPrice)
+            : null;
+        TwapParamsDto? twap = a.Parameters is TwapParameters tp
+            ? new TwapParamsDto(tp.StartUtc, tp.EndUtc, tp.SliceCount, tp.ChildOrderType.ToString(), tp.ChildPrice)
+            : null;
+        return new AlgoDto(
+            a.AlgoId.ToString(),
+            a.Symbol,
+            a.SecurityId,
+            a.Side.ToString(),
+            a.Type.ToString(),
+            a.TotalQuantity,
+            a.FilledQuantity,
+            a.RemainingQuantity,
+            a.Status.ToString(),
+            a.TerminalReason.ToString(),
+            a.CreatedAtUtc,
+            a.TerminalAtUtc,
+            iceberg,
+            twap);
+    }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/SubscribedClient.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscribedClient.cs
@@ -17,9 +17,11 @@ public sealed class SubscribedClient
     private readonly object _channelsSync = new();
     private readonly Dictionary<string, long> _seqByChannel = new(StringComparer.Ordinal);
 
-    public SubscribedClient(EndClientId owner)
+    public SubscribedClient(EndClientId owner, string firmId)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
         Owner = owner;
+        FirmId = firmId;
         Id = Guid.NewGuid();
         _outbound = Channel.CreateBounded<OutboundMessage>(new BoundedChannelOptions(OutboundCapacity)
         {
@@ -34,6 +36,12 @@ public sealed class SubscribedClient
 
     public Guid Id { get; }
     public EndClientId Owner { get; }
+    /// <summary>
+    /// Firm context derived from the JWT <c>firm</c> claim at connection
+    /// time. Required for fan-out of firm-scoped aggregates such as
+    /// <see cref="Algo"/> where the same end-client identifier is per-firm.
+    /// </summary>
+    public string FirmId { get; }
     public ChannelReader<OutboundMessage> Reader => _outbound.Reader;
     public bool MarkedForDisconnect { get; private set; }
     public string? DisconnectReason { get; private set; }

--- a/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
@@ -19,11 +19,13 @@ public sealed class SubscriptionManager
     private readonly ConcurrentDictionary<EndClientId, object> _ownerLocks = new();
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
+    private readonly AlgoBook _algos;
 
-    public SubscriptionManager(WorkingOrderBook orders, PositionKeeper positions)
+    public SubscriptionManager(WorkingOrderBook orders, PositionKeeper positions, AlgoBook algos)
     {
         _orders = orders;
         _positions = positions;
+        _algos = algos;
     }
 
     private object LockFor(EndClientId owner) =>
@@ -67,6 +69,7 @@ public sealed class SubscriptionManager
                 Channels.OrdersMe => _orders.ForEndClient(client.Owner).Select(o => o.ToDto()).ToArray(),
                 Channels.PositionsMe => _positions.ForEndClient(client.Owner).Select(p => p.ToDto()).ToArray(),
                 Channels.ExecutionsMe => Array.Empty<ExecutionDto>(), // no historical exec log in v1
+                Channels.AlgoMe => _algos.EnumerateForOwner(client.FirmId, client.Owner).Select(a => a.ToDto()).ToArray(),
                 _ => null,
             };
 

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketAlgoEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketAlgoEventSink.cs
@@ -1,0 +1,31 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// WebSocket fan-out for <see cref="IAlgoEventSink"/>. Re-fetches the
+/// algo from <see cref="AlgoBook"/> at publish time so subscribers see
+/// the latest committed state; the early-return on "no subscribers" is
+/// the same micro-optimisation used by <see cref="WebSocketExecutionEventSink"/>.
+/// </summary>
+public sealed class WebSocketAlgoEventSink : IAlgoEventSink
+{
+    private readonly SubscriptionManager _subs;
+    private readonly AlgoBook _algos;
+
+    public WebSocketAlgoEventSink(SubscriptionManager subs, AlgoBook algos)
+    {
+        _subs = subs;
+        _algos = algos;
+    }
+
+    public void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId)
+    {
+        if (_subs.CountFor(owner) == 0)
+            return;
+        if (!_algos.TryGet(firmId, algoId, out var algo) || algo is null)
+            return;
+        _subs.Publish(owner, Channels.AlgoMe, algo.ToDto());
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketHub.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketHub.cs
@@ -2,6 +2,7 @@ using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
+using B3.Trading.Api.Auth;
 using B3.Trading.Application;
 using B3.Trading.Application.Observability;
 using Microsoft.AspNetCore.Authorization;
@@ -28,8 +29,9 @@ public static class WebSocketHub
                 return Results.Unauthorized();
 
             var owner = registry.Register(sub);
+            var firm = ctx.User.FindFirstValue(JwtIssuer.FirmClaim) ?? "default";
             using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
-            var client = new SubscribedClient(owner);
+            var client = new SubscribedClient(owner, firm);
             subs.Add(client);
             MetricsRegistry.WsConnectionsActive.Add(1);
 

--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -4,12 +4,13 @@ using B3.Trading.Domain;
 namespace B3.Trading.Application;
 
 /// <summary>
-/// In-memory aggregate of <see cref="Algo"/> parents, indexed by AlgoId
-/// with secondary indices by end-client and firm. Mirrors the shape of
-/// <see cref="WorkingOrderBook"/>: lock-free reads via
-/// <see cref="ConcurrentDictionary{TKey, TValue}"/>, snapshot/restore for
-/// the persistence layer, and "current open parents for X" lookups for
-/// the API/engine side.
+/// In-memory aggregate of <see cref="Algo"/> parents, indexed by
+/// <c>(firmId, algoId)</c> with secondary indices by end-client and
+/// firm. Mirrors the firm-isolation pattern used by the rest of the
+/// stateful platform components — two firms can independently issue
+/// <c>AlgoId = 1</c> without collision because every public surface
+/// (HTTP route, WS payload, snapshot record) carries the firm context
+/// derived from the caller's auth claim.
 ///
 /// <para>
 /// Mutation of an individual <see cref="Algo"/> aggregate is the engine's
@@ -19,35 +20,37 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class AlgoBook
 {
-    private readonly ConcurrentDictionary<ulong, Algo> _algos = new();
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byOwner =
-        new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), Algo> _algos = new();
+    private readonly ConcurrentDictionary<(string FirmId, string Owner), ConcurrentDictionary<ulong, byte>> _byOwner = new();
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<ulong, byte>> _byFirm =
         new(StringComparer.Ordinal);
 
     public bool TryAdd(Algo algo)
     {
         ArgumentNullException.ThrowIfNull(algo);
-        if (!_algos.TryAdd(algo.AlgoId, algo))
+        if (!_algos.TryAdd((algo.FirmId, algo.AlgoId), algo))
             return false;
 
-        var ownerSet = _byOwner.GetOrAdd(algo.Owner.Value, static _ => new ConcurrentDictionary<ulong, byte>());
+        var ownerSet = _byOwner.GetOrAdd((algo.FirmId, algo.Owner.Value),
+            static _ => new ConcurrentDictionary<ulong, byte>());
         ownerSet.TryAdd(algo.AlgoId, 0);
         var firmSet = _byFirm.GetOrAdd(algo.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
         firmSet.TryAdd(algo.AlgoId, 0);
         return true;
     }
 
-    public bool TryGet(ulong algoId, out Algo? algo) => _algos.TryGetValue(algoId, out algo);
+    public bool TryGet(string firmId, ulong algoId, out Algo? algo) =>
+        _algos.TryGetValue((firmId, algoId), out algo);
 
-    public IReadOnlyCollection<Algo> EnumerateForOwner(EndClientId owner, bool includeTerminal = false)
+    public IReadOnlyCollection<Algo> EnumerateForOwner(string firmId, EndClientId owner, bool includeTerminal = false)
     {
-        if (!_byOwner.TryGetValue(owner.Value, out var set))
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        if (!_byOwner.TryGetValue((firmId, owner.Value), out var set))
             return Array.Empty<Algo>();
         var list = new List<Algo>(set.Count);
         foreach (var id in set.Keys)
         {
-            if (!_algos.TryGetValue(id, out var a)) continue;
+            if (!_algos.TryGetValue((firmId, id), out var a)) continue;
             if (!includeTerminal && a.IsTerminal) continue;
             list.Add(a);
         }
@@ -62,7 +65,7 @@ public sealed class AlgoBook
         var list = new List<Algo>(set.Count);
         foreach (var id in set.Keys)
         {
-            if (!_algos.TryGetValue(id, out var a)) continue;
+            if (!_algos.TryGetValue((firmId, id), out var a)) continue;
             if (!includeTerminal && a.IsTerminal) continue;
             list.Add(a);
         }
@@ -92,8 +95,9 @@ public sealed class AlgoBook
         foreach (var s in snaps)
         {
             var algo = FromSnapshot(s);
-            _algos[algo.AlgoId] = algo;
-            var ownerSet = _byOwner.GetOrAdd(algo.Owner.Value, static _ => new ConcurrentDictionary<ulong, byte>());
+            _algos[(algo.FirmId, algo.AlgoId)] = algo;
+            var ownerSet = _byOwner.GetOrAdd((algo.FirmId, algo.Owner.Value),
+                static _ => new ConcurrentDictionary<ulong, byte>());
             ownerSet.TryAdd(algo.AlgoId, 0);
             var firmSet = _byFirm.GetOrAdd(algo.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(algo.AlgoId, 0);

--- a/backend/src/B3.Trading.Application/AlgoIdRegistry.cs
+++ b/backend/src/B3.Trading.Application/AlgoIdRegistry.cs
@@ -1,0 +1,58 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Allocates monotonic <c>AlgoId</c>s scoped per firm. Mirrors the
+/// firm-isolation model used everywhere else (snapshots, kill-switch,
+/// FIXP sessions): two firms can independently issue <c>AlgoId = 1</c>
+/// without collision because every API/WS payload carries the firm
+/// context derived from the caller's auth claim.
+///
+/// <para>
+/// Per-firm rather than per-end-client (unlike <see cref="ClOrdIdPrefixRegistry"/>):
+/// algo creation is rare compared to order submission — a single
+/// per-firm atomic counter has trivial contention at algo rates, so the
+/// extra prefix-per-end-client trick is unnecessary in v0. Promotion to
+/// per-end-client follows the same pattern if benchmarks ever justify it.
+/// </para>
+/// </summary>
+public sealed class AlgoIdRegistry
+{
+    private readonly ConcurrentDictionary<string, FirmCounter> _counters =
+        new(StringComparer.Ordinal);
+
+    public ulong Generate(string firmId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        var entry = _counters.GetOrAdd(firmId, static _ => new FirmCounter());
+        var seq = (ulong)Interlocked.Increment(ref entry.Counter);
+        return seq;
+    }
+
+    public Persistence.AlgoIdRegistrySnapshot Snapshot()
+    {
+        var snap = new Persistence.AlgoIdRegistrySnapshot();
+        foreach (var kv in _counters)
+        {
+            snap.Counters.Add(new Persistence.AlgoIdCounterSnapshot(
+                kv.Key, Interlocked.Read(ref kv.Value.Counter)));
+        }
+        return snap;
+    }
+
+    public void Restore(Persistence.AlgoIdRegistrySnapshot snap)
+    {
+        ArgumentNullException.ThrowIfNull(snap);
+        _counters.Clear();
+        foreach (var c in snap.Counters)
+        {
+            _counters[c.FirmId] = new FirmCounter { Counter = c.Counter };
+        }
+    }
+
+    private sealed class FirmCounter
+    {
+        public long Counter;
+    }
+}

--- a/backend/src/B3.Trading.Application/IAlgoEventSink.cs
+++ b/backend/src/B3.Trading.Application/IAlgoEventSink.cs
@@ -1,0 +1,27 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Fan-out abstraction for <see cref="Algo"/> aggregate updates. Mirrors
+/// <see cref="IExecutionEventSink"/>: the application layer never knows
+/// who is listening (WebSocket fan-out, audit recorder, future
+/// engine-to-engine replication). Implementations resolve the live
+/// aggregate from <see cref="AlgoBook"/> at publish time so the wire
+/// snapshot is always current — callers do not need to assemble a DTO.
+/// </summary>
+public interface IAlgoEventSink
+{
+    /// <summary>
+    /// Publishes the current state of algo <paramref name="algoId"/> on
+    /// the firm-scoped feed for <paramref name="owner"/>. Silently no-op
+    /// if the algo is not in the book (either replay-time before
+    /// registration or already pruned).
+    /// </summary>
+    void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId);
+}
+
+public sealed class NoOpAlgoEventSink : IAlgoEventSink
+{
+    public void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId) { }
+}

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -17,6 +17,7 @@ public sealed class PlatformSnapshot
     public ClOrdIdRegistrySnapshot ClOrdIds { get; init; } = new();
     public List<OwnershipMappingSnapshot> Ownership { get; init; } = new();
     public List<AlgoSnapshot> Algos { get; init; } = new();
+    public AlgoIdRegistrySnapshot AlgoIds { get; init; } = new();
 }
 
 public sealed record OrderSnapshot(
@@ -78,3 +79,15 @@ public sealed class ClOrdIdRegistrySnapshot
 public sealed record ClOrdIdCounterSnapshot(string EndClientId, ulong PrefixIdx, long Counter);
 
 public sealed record OwnershipMappingSnapshot(ulong ClOrdId, string EndClientId);
+
+/// <summary>
+/// Per-firm <c>AlgoId</c> counters. Mirrors the firm-isolation pattern
+/// of every other persisted aggregate; reset to <c>0</c> for an unknown
+/// firm on restore (a never-seen-before firm starts at <c>1</c>).
+/// </summary>
+public sealed class AlgoIdRegistrySnapshot
+{
+    public List<AlgoIdCounterSnapshot> Counters { get; init; } = new();
+}
+
+public sealed record AlgoIdCounterSnapshot(string FirmId, long Counter);

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -137,6 +137,7 @@ public sealed record AlgoCreatedEvent : WalEvent
 public sealed record AlgoCancelRequestedEvent : WalEvent
 {
     public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
     public string? ActorUserId { get; init; }
 }
 
@@ -149,6 +150,7 @@ public sealed record AlgoCancelRequestedEvent : WalEvent
 public sealed record AlgoTerminalStateRecordedEvent : WalEvent
 {
     public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
     public required string Status { get; init; }    // AlgoStatus enum name
     public required string Reason { get; init; }    // AlgoTerminalReason enum name
     public required DateTimeOffset AtUtc { get; init; }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -55,9 +55,11 @@ builder.Services.AddSingleton<ClOrdIdPrefixRegistry>();
 builder.Services.AddSingleton<OrderOwnershipMap>();
 builder.Services.AddSingleton<WorkingOrderBook>();
 builder.Services.AddSingleton<AlgoBook>();
+builder.Services.AddSingleton<AlgoIdRegistry>();
 builder.Services.AddSingleton<PositionKeeper>();
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
+builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
 builder.Services.AddSingleton<ExecutionReportProcessor>();
 builder.Services.AddSingleton<JwtIssuer>();
 
@@ -374,6 +376,7 @@ app.MapHealth();
 
 app.MapAuth();
 app.MapOrders();
+app.MapAlgo();
 app.MapPositions();
 app.MapAdmin();
 app.MapWebSocketHub();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -20,6 +20,7 @@ public sealed class StateSnapshotter
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly OrderOwnershipMap _ownership;
     private readonly AlgoBook _algos;
+    private readonly AlgoIdRegistry _algoIds;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -27,7 +28,8 @@ public sealed class StateSnapshotter
         KillSwitchService killSwitch,
         ClOrdIdPrefixRegistry clOrdIds,
         OrderOwnershipMap ownership,
-        AlgoBook algos)
+        AlgoBook algos,
+        AlgoIdRegistry algoIds)
     {
         _orders = orders;
         _positions = positions;
@@ -35,6 +37,7 @@ public sealed class StateSnapshotter
         _clOrdIds = clOrdIds;
         _ownership = ownership;
         _algos = algos;
+        _algoIds = algoIds;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -48,6 +51,7 @@ public sealed class StateSnapshotter
         ClOrdIds = _clOrdIds.Snapshot(),
         Ownership = _ownership.Snapshot().ToList(),
         Algos = _algos.Snapshot().ToList(),
+        AlgoIds = _algoIds.Snapshot(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -59,6 +63,7 @@ public sealed class StateSnapshotter
         _clOrdIds.Restore(snap.ClOrdIds);
         _ownership.Restore(snap.Ownership);
         _algos.Restore(snap.Algos);
+        _algoIds.Restore(snap.AlgoIds);
     }
 }
 
@@ -130,11 +135,11 @@ public sealed class EventReplayer
                 ApplyAlgoCreated(ac);
                 break;
             case AlgoCancelRequestedEvent acr:
-                if (_algos.TryGet(acr.AlgoId, out var cancelling) && cancelling is not null)
+                if (_algos.TryGet(acr.FirmId, acr.AlgoId, out var cancelling) && cancelling is not null)
                     cancelling.RequestCancel();
                 break;
             case AlgoTerminalStateRecordedEvent at:
-                if (_algos.TryGet(at.AlgoId, out var algo) && algo is not null)
+                if (_algos.TryGet(at.FirmId, at.AlgoId, out var algo) && algo is not null)
                 {
                     var status = Enum.Parse<AlgoStatus>(at.Status, ignoreCase: true);
                     var reason = Enum.Parse<AlgoTerminalReason>(at.Reason, ignoreCase: true);

--- a/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
@@ -1,0 +1,270 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// HTTP surface for algo orders v0 (RFC §4.9). v0 has no engine — POST
+/// records intent + assigns an id, GET reflects in-memory state, DELETE
+/// drives the parent into <c>Cancelling</c>. No child orders are
+/// generated and no terminal transition happens automatically.
+/// </summary>
+public class AlgoEndpointsTests
+{
+    private static TestAppFactory NewFactory()
+    {
+        var overrides = new Dictionary<string, string?>
+        {
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+            ["Trading:SymbolDirectory:SecurityIds:VALE3"] = "1234",
+        };
+        return TestAppFactory.WithOverrides(overrides);
+    }
+
+    private static object IcebergBody(long total = 1000, long display = 100, decimal? price = 30m) => new
+    {
+        Symbol = "PETR4",
+        Side = "Buy",
+        Type = "Iceberg",
+        TotalQuantity = total,
+        Iceberg = new { DisplayQuantity = display, LimitPrice = price },
+    };
+
+    private static object TwapBody(string childType = "Limit", decimal? childPrice = 30m, int sliceCount = 5,
+        DateTimeOffset? start = null, DateTimeOffset? end = null) => new
+        {
+            Symbol = "VALE3",
+            Side = "Sell",
+            Type = "Twap",
+            TotalQuantity = 5000,
+            Twap = new
+            {
+                StartUtc = start ?? DateTimeOffset.UtcNow,
+                EndUtc = end ?? DateTimeOffset.UtcNow.AddMinutes(10),
+                SliceCount = sliceCount,
+                ChildOrderType = childType,
+                ChildPrice = childPrice,
+            },
+        };
+
+    [Fact]
+    public async Task PostAlgo_Iceberg_HappyPath_ReturnsAcceptedWithPendingNew()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", IcebergBody());
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("algoId").GetString()));
+        Assert.Equal("PendingNew", body.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_HappyPath()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", TwapBody());
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_Iceberg_DisplayExceedsTotal_Returns400()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", IcebergBody(total: 100, display: 200));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_LimitWithoutChildPrice_Returns400()
+    {
+        // OQ-2: TWAP+Limit MUST carry a child price.
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", TwapBody(childType: "Limit", childPrice: null));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("childPrice", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_MarketWithoutChildPrice_IsAccepted()
+    {
+        // Market children don't carry a price; the explicit nullable
+        // childPrice is allowed. This is the inverse of the Limit case
+        // above — the API rejects ambiguous Limit submissions but accepts
+        // Market with no price.
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", TwapBody(childType: "Market", childPrice: null));
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_EndBeforeStart_Returns400()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+        var now = DateTimeOffset.UtcNow;
+
+        var resp = await client.PostAsJsonAsync("/algo/", TwapBody(start: now.AddMinutes(10), end: now));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_NegativeQuantity_Returns400()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Iceberg",
+            TotalQuantity = -1,
+            Iceberg = new { DisplayQuantity = 10, LimitPrice = (decimal?)30m },
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_InvalidType_Returns400()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Vwap", // not in v0 enum
+            TotalQuantity = 100,
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_Unauthenticated_Returns401()
+    {
+        using var factory = NewFactory();
+        using var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/algo/", IcebergBody());
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAlgo_ListReturnsSubmittedAlgo_ById_RoundTrips()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var post = await client.PostAsJsonAsync("/algo/", IcebergBody());
+        var posted = await post.Content.ReadFromJsonAsync<JsonElement>();
+        var algoId = posted.GetProperty("algoId").GetString()!;
+
+        var list = await client.GetFromJsonAsync<JsonElement>("/algo/");
+        Assert.Equal(JsonValueKind.Array, list.ValueKind);
+        Assert.Equal(1, list.GetArrayLength());
+
+        var get = await client.GetFromJsonAsync<JsonElement>($"/algo/{algoId}");
+        Assert.Equal(algoId, get.GetProperty("algoId").GetString());
+        Assert.Equal("PETR4", get.GetProperty("symbol").GetString());
+        Assert.Equal("PendingNew", get.GetProperty("status").GetString());
+        // Discriminated parameter shape: iceberg block populated, twap null.
+        Assert.Equal(JsonValueKind.Object, get.GetProperty("iceberg").ValueKind);
+        Assert.Equal(JsonValueKind.Null, get.GetProperty("twap").ValueKind);
+    }
+
+    [Fact]
+    public async Task GetAlgo_OtherUsersAlgo_Returns404()
+    {
+        using var factory = NewFactory();
+        using var aliceClient = await factory.CreateAuthedClientAsync();
+        using var bobClient = await factory.CreateAuthedClientAsync(user: "bob");
+
+        var post = await aliceClient.PostAsJsonAsync("/algo/", IcebergBody());
+        var posted = await post.Content.ReadFromJsonAsync<JsonElement>();
+        var algoId = posted.GetProperty("algoId").GetString()!;
+
+        var bobView = await bobClient.GetAsync($"/algo/{algoId}");
+        Assert.Equal(HttpStatusCode.NotFound, bobView.StatusCode);
+
+        // And bob's list does not see alice's algo.
+        var bobList = await bobClient.GetFromJsonAsync<JsonElement>("/algo/");
+        Assert.Equal(0, bobList.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task DeleteAlgo_HappyPath_ReturnsAcceptedWithCancelling()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var post = await client.PostAsJsonAsync("/algo/", IcebergBody());
+        var posted = await post.Content.ReadFromJsonAsync<JsonElement>();
+        var algoId = posted.GetProperty("algoId").GetString()!;
+
+        var del = await client.DeleteAsync($"/algo/{algoId}");
+        Assert.Equal(HttpStatusCode.Accepted, del.StatusCode);
+        var body = await del.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Cancelling", body.GetProperty("status").GetString());
+
+        // Subsequent GET reflects the new status (no engine — stays Cancelling).
+        var get = await client.GetFromJsonAsync<JsonElement>($"/algo/{algoId}");
+        Assert.Equal("Cancelling", get.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteAlgo_UnknownId_Returns404()
+    {
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var del = await client.DeleteAsync("/algo/99999999");
+        Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteAlgo_OtherUsersAlgo_Returns404()
+    {
+        using var factory = NewFactory();
+        using var aliceClient = await factory.CreateAuthedClientAsync();
+        using var bobClient = await factory.CreateAuthedClientAsync(user: "bob");
+
+        var post = await aliceClient.PostAsJsonAsync("/algo/", IcebergBody());
+        var posted = await post.Content.ReadFromJsonAsync<JsonElement>();
+        var algoId = posted.GetProperty("algoId").GetString()!;
+
+        var del = await bobClient.DeleteAsync($"/algo/{algoId}");
+        Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteAlgo_AlreadyCancelling_IsIdempotent()
+    {
+        // Per RFC: Cancelling-on-Cancelling is a no-op via the aggregate.
+        // Engine never lands so the parent stays in Cancelling indefinitely
+        // for v0; repeated DELETE should keep returning 202 (not 409).
+        using var factory = NewFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var post = await client.PostAsJsonAsync("/algo/", IcebergBody());
+        var posted = await post.Content.ReadFromJsonAsync<JsonElement>();
+        var algoId = posted.GetProperty("algoId").GetString()!;
+
+        var first = await client.DeleteAsync($"/algo/{algoId}");
+        var second = await client.DeleteAsync($"/algo/{algoId}");
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
@@ -14,8 +14,8 @@ public class SubscriptionManagerTests
         var owner = new EndClientId("alice");
         book.TryAdd(new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m));
 
-        var mgr = new SubscriptionManager(book, positions);
-        var client = new SubscribedClient(owner);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "TEST");
         mgr.Add(client);
         mgr.SubscribeWithSnapshot(client, Channels.OrdersMe);
 
@@ -31,8 +31,8 @@ public class SubscriptionManagerTests
         var positions = new PositionKeeper();
         var owner = new EndClientId("alice");
 
-        var mgr = new SubscriptionManager(book, positions);
-        var client = new SubscribedClient(owner);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "TEST");
         mgr.Add(client);
         mgr.SubscribeWithSnapshot(client, Channels.ExecutionsMe);
         client.Reader.TryRead(out _); // discard snapshot
@@ -54,8 +54,8 @@ public class SubscriptionManagerTests
         var alice = new EndClientId("alice");
         var bob = new EndClientId("bob");
 
-        var mgr = new SubscriptionManager(book, positions);
-        var bobClient = new SubscribedClient(bob);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var bobClient = new SubscribedClient(bob, "TEST");
         mgr.Add(bobClient);
         mgr.SubscribeWithSnapshot(bobClient, Channels.ExecutionsMe);
         bobClient.Reader.TryRead(out _); // snapshot
@@ -72,8 +72,8 @@ public class SubscriptionManagerTests
         var positions = new PositionKeeper();
         var owner = new EndClientId("alice");
 
-        var mgr = new SubscriptionManager(book, positions);
-        var client = new SubscribedClient(owner);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "TEST");
         mgr.Add(client);
         mgr.SubscribeWithSnapshot(client, Channels.ExecutionsMe);
 
@@ -99,8 +99,8 @@ public class WebSocketExecutionEventSinkTests
         order.MarkWorking();
         order.ApplyFill(100);
 
-        var mgr = new SubscriptionManager(book, positions);
-        var client = new SubscribedClient(owner);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "TEST");
         mgr.Add(client);
         mgr.SubscribeWithSnapshot(client, Channels.OrdersMe);
         mgr.SubscribeWithSnapshot(client, Channels.ExecutionsMe);
@@ -133,8 +133,8 @@ public class WebSocketExecutionEventSinkTests
         book.TryAdd(order);
         order.MarkCancelled();
 
-        var mgr = new SubscriptionManager(book, positions);
-        var client = new SubscribedClient(owner);
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "TEST");
         mgr.Add(client);
         mgr.SubscribeWithSnapshot(client, Channels.OrdersMe);
         mgr.SubscribeWithSnapshot(client, Channels.ExecutionsMe);

--- a/backend/tests/B3.Trading.Application.Tests/AlgoBookFirmIsolationTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/AlgoBookFirmIsolationTests.cs
@@ -1,0 +1,60 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Slice 3: <see cref="AlgoBook"/> is keyed per-firm. Two firms can
+/// independently issue the same numeric AlgoId without collision, and
+/// per-owner enumerations are scoped to the firm context of the caller.
+/// </summary>
+public class AlgoBookFirmIsolationTests
+{
+    [Fact]
+    public void TwoFirms_SameAlgoId_CoexistInBook()
+    {
+        var book = new AlgoBook();
+        var alice = new EndClientId("alice");
+        var algoA = new Algo(1UL, alice, "FIRM-A", "PETR4", 4321UL,
+            OrderSide.Buy, AlgoType.Iceberg, 100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+        var algoB = new Algo(1UL, alice, "FIRM-B", "PETR4", 4321UL,
+            OrderSide.Sell, AlgoType.Iceberg, 200, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+
+        Assert.True(book.TryAdd(algoA));
+        Assert.True(book.TryAdd(algoB));
+
+        Assert.True(book.TryGet("FIRM-A", 1UL, out var a) && a is not null);
+        Assert.True(book.TryGet("FIRM-B", 1UL, out var b) && b is not null);
+        Assert.Equal(OrderSide.Buy, a!.Side);
+        Assert.Equal(OrderSide.Sell, b!.Side);
+    }
+
+    [Fact]
+    public void EnumerateForOwner_IsFirmScoped()
+    {
+        var book = new AlgoBook();
+        var alice = new EndClientId("alice");
+        book.TryAdd(new Algo(1UL, alice, "FIRM-A", "PETR4", 4321UL,
+            OrderSide.Buy, AlgoType.Iceberg, 100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow));
+        book.TryAdd(new Algo(2UL, alice, "FIRM-A", "VALE3", 1234UL,
+            OrderSide.Buy, AlgoType.Iceberg, 100, new IcebergParameters(10, 50m), DateTimeOffset.UtcNow));
+        book.TryAdd(new Algo(1UL, alice, "FIRM-B", "PETR4", 4321UL,
+            OrderSide.Sell, AlgoType.Iceberg, 100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow));
+
+        Assert.Equal(2, book.EnumerateForOwner("FIRM-A", alice).Count);
+        Assert.Single(book.EnumerateForOwner("FIRM-B", alice));
+    }
+
+    [Fact]
+    public void TryAdd_DuplicateForSameFirm_ReturnsFalse()
+    {
+        var book = new AlgoBook();
+        var alice = new EndClientId("alice");
+        var algo = new Algo(1UL, alice, "FIRM-A", "PETR4", 4321UL,
+            OrderSide.Buy, AlgoType.Iceberg, 100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+        Assert.True(book.TryAdd(algo));
+        var dup = new Algo(1UL, alice, "FIRM-A", "VALE3", 1234UL,
+            OrderSide.Buy, AlgoType.Iceberg, 100, new IcebergParameters(10, 30m), DateTimeOffset.UtcNow);
+        Assert.False(book.TryAdd(dup));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/AlgoIdRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/AlgoIdRegistryTests.cs
@@ -1,0 +1,60 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.Tests;
+
+public class AlgoIdRegistryTests
+{
+    [Fact]
+    public void Generate_PerFirm_IndependentCounters()
+    {
+        var reg = new AlgoIdRegistry();
+        Assert.Equal(1UL, reg.Generate("FIRM-A"));
+        Assert.Equal(2UL, reg.Generate("FIRM-A"));
+        Assert.Equal(1UL, reg.Generate("FIRM-B"));
+        Assert.Equal(3UL, reg.Generate("FIRM-A"));
+        Assert.Equal(2UL, reg.Generate("FIRM-B"));
+    }
+
+    [Fact]
+    public void Generate_BlankFirm_Throws()
+    {
+        var reg = new AlgoIdRegistry();
+        Assert.Throws<ArgumentException>(() => reg.Generate(""));
+        Assert.Throws<ArgumentException>(() => reg.Generate("   "));
+    }
+
+    [Fact]
+    public void Snapshot_Restore_PreservesPerFirmWatermarks()
+    {
+        var reg = new AlgoIdRegistry();
+        reg.Generate("FIRM-A");
+        reg.Generate("FIRM-A");
+        reg.Generate("FIRM-A");
+        reg.Generate("FIRM-B");
+
+        var snap = reg.Snapshot();
+        var restored = new AlgoIdRegistry();
+        restored.Restore(snap);
+
+        Assert.Equal(4UL, restored.Generate("FIRM-A"));
+        Assert.Equal(2UL, restored.Generate("FIRM-B"));
+        Assert.Equal(1UL, restored.Generate("FIRM-NEW"));
+    }
+
+    [Fact]
+    public void Restore_ReplacesExistingState()
+    {
+        // Restore must be a "clear+set" operation, not a merge — replay
+        // semantics rely on the registry state matching the snapshot
+        // exactly (otherwise re-applied WAL events would re-increment
+        // already-restored counters).
+        var reg = new AlgoIdRegistry();
+        reg.Generate("FIRM-A");
+        reg.Generate("FIRM-A");
+
+        var emptySnap = new AlgoIdRegistrySnapshot();
+        reg.Restore(emptySnap);
+        Assert.Equal(1UL, reg.Generate("FIRM-A"));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -95,19 +95,20 @@ public class AlgoRecoveryTests : IDisposable
 
             // Operator cancels.
             dispatcher.Dispatch(
-                new AlgoCancelRequestedEvent { AlgoId = 100UL, ActorUserId = "carol" },
-                () => algos.TryGet(100UL, out var a).Then(() => a!.RequestCancel()));
+                new AlgoCancelRequestedEvent { AlgoId = 100UL, FirmId = "TEST", ActorUserId = "carol" },
+                () => algos.TryGet("TEST", 100UL, out var a).Then(() => a!.RequestCancel()));
 
             // Engine records terminal.
             dispatcher.Dispatch(
                 new AlgoTerminalStateRecordedEvent
                 {
                     AlgoId = 100UL,
+                    FirmId = "TEST",
                     Status = "Cancelled",
                     Reason = "UserCancelled",
                     AtUtc = terminalAt,
                 },
-                () => algos.TryGet(100UL, out var a).Then(() =>
+                () => algos.TryGet("TEST", 100UL, out var a).Then(() =>
                     a!.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, terminalAt)));
         }
 
@@ -115,13 +116,14 @@ public class AlgoRecoveryTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, ownership, killSwitch, processor, algos, _) = Build(store);
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos);
+            var algoIds = new AlgoIdRegistry();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
             var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
 
-            Assert.True(algos.TryGet(100UL, out var algo) && algo is not null);
+            Assert.True(algos.TryGet("TEST", 100UL, out var algo) && algo is not null);
             Assert.Equal(AlgoStatus.Cancelled, algo!.Status);
             Assert.Equal(AlgoTerminalReason.UserCancelled, algo.TerminalReason);
             Assert.Equal(terminalAt, algo.TerminalAtUtc);
@@ -148,7 +150,8 @@ public class AlgoRecoveryTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, ownership, killSwitch, _, algos, dispatcher) = Build(store);
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos);
+            var algoIds = new AlgoIdRegistry();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
 
             dispatcher.Dispatch(
                 new AlgoCreatedEvent
@@ -173,7 +176,7 @@ public class AlgoRecoveryTests : IDisposable
                     new TwapParameters(twapStart, twapEnd, 5, OrderType.Market, null), createdAt)));
 
             // Two slice fills of 1000 each.
-            algos.TryGet(200UL, out var live);
+            algos.TryGet("TEST", 200UL, out var live);
             live!.MarkWorking();
             live.RecordFill(1000);
             live.RecordFill(1000);
@@ -188,7 +191,7 @@ public class AlgoRecoveryTests : IDisposable
         // Restore into a fresh book and verify shape.
         var restored = new AlgoBook();
         restored.Restore(snap.Algos);
-        Assert.True(restored.TryGet(200UL, out var rehydrated) && rehydrated is not null);
+        Assert.True(restored.TryGet("TEST", 200UL, out var rehydrated) && rehydrated is not null);
         Assert.Equal(2000, rehydrated!.FilledQuantity);
         Assert.Equal(3000, rehydrated.RemainingQuantity);
         Assert.Equal(AlgoStatus.Working, rehydrated.Status);
@@ -213,8 +216,8 @@ public class AlgoRecoveryTests : IDisposable
         algos.TryAdd(live);
         algos.TryAdd(done);
 
-        Assert.Single(algos.EnumerateForOwner(alice));
-        Assert.Equal(2, algos.EnumerateForOwner(alice, includeTerminal: true).Count);
+        Assert.Single(algos.EnumerateForOwner("TEST", alice));
+        Assert.Equal(2, algos.EnumerateForOwner("TEST", alice, includeTerminal: true).Count);
     }
 
     private static (WorkingOrderBook, OrderOwnershipMap, KillSwitchService, ExecutionReportProcessor, AlgoBook, EventDispatcher) Build(IEventStore store)

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -166,7 +166,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
             new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
-        var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership, algos);
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership, algos, new AlgoIdRegistry());
         var dispatcher = new EventDispatcher(store);
         return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
     }

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -37,6 +37,7 @@ Logical channels available to every authenticated client:
 | `orders.me`      | Order state changes (new ack, replace, cancel, fill — current state)   |
 | `executions.me`  | Each ExecutionReport (atomic event with ExecKind: Fill/Canceled/...)    |
 | `positions.me`   | Net position changes (only fired by Fill / PartialFill)                |
+| `algo.me`        | Algo parent state changes (PendingNew/Working/Cancelling/terminal)     |
 
 Unknown channel names are rejected with an `error` frame.
 
@@ -74,6 +75,11 @@ Server response: one `snapshot` frame per requested channel with
   position.
 - `executions.me`: empty array (the platform does not retain a historical
   execution log in v1; only future events are streamed).
+- `algo.me`: array of `AlgoDto` for every non-terminal algo parent owned
+  by the caller (firm-scoped: a parent created under firm A is invisible
+  to a connection authenticated as firm B even for the same end-client).
+  Each `AlgoDto` carries one of `iceberg` / `twap` per the discriminator
+  in `type`; the unused parameter block is `null`.
 
 ### Unsubscribe
 

--- a/docs/rfcs/algo-orders-v0.md
+++ b/docs/rfcs/algo-orders-v0.md
@@ -400,17 +400,13 @@ DELETE /algo/{algoId}    → 202 Accepted {algoId, status: "Cancelling"}
 Authorization mirrors `/orders`: end-clients see only their own
 algos; admin role sees all (for `/admin/algo` follow-up if needed).
 
-The `algo` WS topic supports the same `?since=<seq>` catch-up
-semantics that the `orders` topic ships today (cf.
-`docs/WEBSOCKET-PROTOCOL.md`). Reconnecting clients replay missed
-events deterministically from the `FileEventStore` rather than
-having to reconstruct parent state from the `orders` stream. The
-custom of bundling replay with the topic from day one — instead of
-adding it later — was decided during planning (OQ-3); the cost is
-low because the `?since=` plumbing already exists per-topic, and
-the trader UI follow-up gains a reconnect-proof surface for free.
+The `algo` WS topic ships with **snapshot-on-subscribe** semantics
+matching the existing `orders.me` / `executions.me` / `positions.me`
+topics today: a fresh subscriber gets a snapshot frame, then deltas.
+A `?since=<seq>` parameter is **not** wired up in v0 — see the
+corrigendum on OQ-3 in §6 for the rationale and the deferred work.
 
-WS topic `algo` carries the lifecycle as discrete messages:
+WS topic `algo.me` carries the lifecycle as discrete messages:
 
 ```json
 { "topic": "algo", "type": "algoCreated",   "data": { algoId, owner, … } }
@@ -535,10 +531,19 @@ as the trader-UI work that followed each backend phase.
   are persisted; a future PR can expose the same `since` semantics
   on the `algo` topic. Tentative answer: ship without `since` in
   v0 and add when the trader UI needs it.
-  **Decided: ship `?since=` in v0** (incorporated into §4.9). The
-  `?since=` plumbing already exists per-topic; reusing it now is
-  cheap, and the trader UI follow-up gets a reconnect-proof surface
-  on day one instead of waiting for a protocol bump later.
+  **Decided 2026-05-03 (planning round): ship `?since=` in v0.**
+  *Corrigendum (slice 3 implementation, 2026-05-03): walked back.*
+  The premise was wrong: `WEBSOCKET-PROTOCOL.md` explicitly reserves
+  `since_seq` for "Phase 3 (resilience / ER-replay)" and the
+  parameter is ignored on every topic today. There is no per-topic
+  replay plumbing to reuse. Implementing replay just for the `algo`
+  topic would create protocol inconsistency and pre-empt the
+  systemic decision (WAL-replay vs ring buffer vs persisted
+  client cursor) that a dedicated WS-resilience RFC has to make
+  for *all* topics. Algo ships **snapshot-on-subscribe**, matching
+  the rest of v1; reconnect-proof replay returns when that RFC
+  lands. The corrigendum does not change v0 scope — it removes a
+  feature we couldn't honestly deliver.
 - **OQ-4: Suspended → Resume.** Once a parent is `Suspended`, v0
   has no API to resume it; the operator must cancel and recreate.
   Resume needs to decide what the engine does with already-filled


### PR DESCRIPTION
Slice 3 of the algo orders v0 RFC (#48). Ships the public HTTP surface
(`POST /algo`, `GET /algo`, `GET /algo/{id}`, `DELETE /algo/{id}`) and
the `algo.me` WebSocket topic. No engine yet — slices 4+ — so v0 parents
sit in `PendingNew` (post-create) or `Cancelling` (post-DELETE)
indefinitely; the API/WAL/snapshot/replay shape is locked in.

## Corrigendum (commit \`a63f7b3\`)

The OQ-3 decision in PR #50 ("ship \`?since=\` in v0, plumbing already
exists per-topic") was based on a false premise — \`docs/WEBSOCKET-PROTOCOL.md\`
explicitly reserves \`since_seq\` for Phase 3 on every topic. Replaying
algo-only would create protocol inconsistency and pre-empt the systemic
WS-resilience decision that needs its own RFC. Walked back to
**snapshot-on-subscribe**, matching the existing v1 topics. RFC §4.9
+ §6 OQ-3 carry the corrigendum block for traceability.

## Per-firm AlgoId

Algo identity is firm-scoped, mirroring the existing pattern for
snapshots/WAL paths/kill-switch:

- \`AlgoBook\` keyed by \`(firmId, algoId)\` (composite tuple key).
- New \`AlgoIdRegistry\` allocates monotonic AlgoIds per firm
  (\`Interlocked.Increment\` per-firm counter, snapshot/restore mirroring
  \`ClOrdIdPrefixRegistry\`).
- \`AlgoCancelRequestedEvent\` + \`AlgoTerminalStateRecordedEvent\` gain a
  required \`FirmId\` so replay can disambiguate.
- Per-firm rather than per-end-client (unlike ClOrdId): algo creation
  is rare → atomic counter contention is trivial; the per-end-client
  prefix split is unnecessary in v0. Same pattern can be promoted later
  if benchmarks justify it.

## HTTP

- **POST /algo** — validates: type/side/qty/securityId; per-type params
  (Iceberg \`displayQty>0 && ≤totalQty\`; TWAP \`endUtc>startUtc\`,
  \`sliceCount>0\`); **OQ-2 enforced**: TWAP+\`Limit\` requires
  non-null \`childPrice\` (rejected 400 otherwise — TWAP+\`Market\`
  with null price is accepted). Allocates AlgoId via registry,
  dispatches \`AlgoCreatedEvent\`, calls \`IAlgoEventSink.PublishAlgoSnapshot\`.
  Returns 202 \`{algoId, status:\"PendingNew\"}\`.
- **C2 enforced by schema**: \`CreateAlgoRequest\` deliberately does NOT
  expose \`parentAlgoId\` / \`algoSliceSeq\`. Algo-on-algo is forbidden
  in v0; the engine future will use an internal pipeline.
- **GET /algo, GET /algo/{id}** — firm + owner scoped. Cross-owner GET → 404.
- **DELETE /algo/{id}** — 404 cross-owner / unknown; 409 if already
  terminal; 202 \`{algoId, status:\"Cancelling\"}\` otherwise.
  Cancelling-on-Cancelling is idempotent (operator may retry).
- **Drain check** (503 when \`DrainState.IsDraining\`) on POST + DELETE,
  mirroring \`OrdersEndpoints\`.

## WebSocket

- New channel \`algo.me\`. Subscribe → snapshot of all non-terminal
  algos owned by caller (firm-scoped), \`seq=0\`. Subsequent state
  changes published as deltas with monotonic \`seq\`.
- \`SubscribedClient\` gains \`FirmId\` captured at handshake from the JWT
  \`firm\` claim — needed because the same end-client identifier is
  per-firm at the algo aggregate level.
- \`WebSocketAlgoEventSink\` re-fetches the algo from \`AlgoBook\` at
  publish time (subscribers always see latest committed state).
- \`docs/WEBSOCKET-PROTOCOL.md\` updated with the channel + snapshot shape.

## Wire shape

\`AlgoDto\` carries discriminated parameter blocks (\`iceberg\` /
\`twap\`); only the one matching \`type\` is populated, the other is
\`null\`. Keeps the JSON debuggable (\`jq '.iceberg.displayQuantity'\`)
without needing polymorphic STJ converters on the client.

## Tests

+15 new tests (suite: **30 / 194 / 92 / 7-skip**):
- \`AlgoEndpointsTests\` ×11 — happy paths (Iceberg + TWAP), validation
  rejects (TWAP+Limit no price, end<start, displayQty>total, negative
  qty, invalid type), GET list/by-id, 401 unauth, 404 cross-owner,
  DELETE cancellation + idempotence, 404 cross-owner DELETE.
- \`AlgoBookFirmIsolationTests\` ×3 — composite-key verification: same
  AlgoId in two firms coexists; per-owner enumeration is firm-scoped;
  duplicate within firm is rejected.
- \`AlgoIdRegistryTests\` ×4 — per-firm independent counters,
  blank-firm guard, snapshot/restore preserves watermarks, restore
  replaces (not merges) state.

Existing slice-2 tests updated for the new per-firm \`AlgoBook\`/
\`StateSnapshotter\` signatures.

\`dotnet format\` clean. \`dotnet build\` 0 warnings. Tests green.

Refs #48.