### PR TITLE
feat(algo): slice 5a — extract OrderSubmissionService + AlgoSignal infra

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -3,6 +3,7 @@ using B3.Trading.Api.Auth;
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
+
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -55,7 +56,8 @@ public static class AlgoEndpoints
             IAlgoEventSink sink,
             EventDispatcher dispatcher,
             DrainState drain,
-            SymbolDirectory symbols) =>
+            SymbolDirectory symbols,
+            IAlgoSignalQueue signals) =>
         {
             if (drain.IsDraining)
             {
@@ -165,6 +167,12 @@ public static class AlgoEndpoints
 
             sink.PublishAlgoSnapshot(owner, firm, algoId);
 
+            if (!signals.TryEnqueue(new AlgoCreatedSignal { FirmId = firm, AlgoId = algoId }))
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "created"));
+            }
+
             return Results.Accepted($"/algo/{algoId}", new
             {
                 AlgoId = algoId.ToString(),
@@ -179,7 +187,8 @@ public static class AlgoEndpoints
             AlgoBook algos,
             IAlgoEventSink sink,
             EventDispatcher dispatcher,
-            DrainState drain) =>
+            DrainState drain,
+            IAlgoSignalQueue signals) =>
         {
             if (drain.IsDraining)
             {
@@ -230,6 +239,12 @@ public static class AlgoEndpoints
             }
 
             sink.PublishAlgoSnapshot(owner, firm, id);
+
+            if (!signals.TryEnqueue(new AlgoCancelRequestedSignal { FirmId = firm, AlgoId = id }))
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "cancel_requested"));
+            }
 
             return Results.Accepted($"/algo/{id}", new
             {

--- a/backend/src/B3.Trading.Api/Lifecycle/DrainState.cs
+++ b/backend/src/B3.Trading.Api/Lifecycle/DrainState.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.Observability;
 using Microsoft.Extensions.Hosting;
 
@@ -18,7 +19,7 @@ namespace B3.Trading.Api.Lifecycle;
 /// <c>/live</c> stays 200 throughout — the process is still healthy,
 /// just refusing new work.
 /// </summary>
-public sealed class DrainState
+public sealed class DrainState : IDrainGate
 {
     private readonly Stopwatch _uptime = Stopwatch.StartNew();
     private long _draining; // 0 = serving, 1 = draining

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -1,19 +1,12 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
-using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
 using B3.Trading.Application.Observability;
-using B3.Trading.Application.Persistence;
-using B3.Trading.Application.Risk;
-using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Domain;
-using B3.Trading.Infrastructure;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Api;
 
@@ -34,35 +27,14 @@ public static class OrdersEndpoints
             SubmitOrderRequest req,
             HttpContext ctx,
             EndClientRegistry registry,
-            ClOrdIdPrefixRegistry clOrdIds,
-            OrderOwnershipMap ownership,
-            WorkingOrderBook book,
-            IExchangeGateway gateway,
-            IExecutionEventSink sink,
-            RiskPipeline risk,
-            IMarginProvider margin,
-            CompositeRiskAccountant accountant,
-            EventDispatcher dispatcher,
-            DrainState drain,
+            OrderSubmissionService submitter,
             SymbolDirectory symbols,
-            ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
-            if (drain.IsDraining)
-            {
-                MetricsRegistry.DrainRejections.Add(1,
-                    new KeyValuePair<string, object?>("route", "POST /orders"));
-                return Results.Json(
-                    new { error = "service draining" },
-                    statusCode: StatusCodes.Status503ServiceUnavailable);
-            }
-
             if (!Enum.TryParse<OrderSide>(req.Side, ignoreCase: true, out var side))
                 return Results.BadRequest(new { error = $"invalid side '{req.Side}'" });
             if (!Enum.TryParse<OrderType>(req.Type, ignoreCase: true, out var type))
                 return Results.BadRequest(new { error = $"invalid type '{req.Type}'" });
-            if (req.Quantity <= 0)
-                return Results.BadRequest(new { error = "quantity must be positive" });
 
             // SecurityId resolution: explicit non-zero in the payload
             // wins (preserves the conformance contract). Otherwise look
@@ -72,101 +44,37 @@ public static class OrdersEndpoints
             var securityId = req.SecurityId;
             if (securityId == 0 && symbols.TryResolve(req.Symbol, out var resolved))
                 securityId = resolved;
-            if (securityId == 0)
-                return Results.BadRequest(new { error = "securityId is required" });
 
             var owner = ResolveOwner(ctx, registry);
             var firm = ResolveFirm(ctx);
-            var clOrdId = clOrdIds.Generate(owner);
-            var order = new Order(clOrdId, owner, req.Symbol, securityId, side, type, req.Quantity, req.Price, firm);
 
-            // Persist order intent + register ownership atomically. The
-            // dispatcher serialises this with snapshot capture so a crash
-            // mid-window cannot leave the book and the WAL out of sync.
-            // Backpressure surfaces here as 503 — disk lag becomes a
-            // visible reject, never silent latency creep.
-            try
-            {
-                dispatcher.Dispatch(
-                    new OrderSubmittedEvent
-                    {
-                        ClOrdId = clOrdId,
-                        EndClientId = owner.Value,
-                        FirmId = firm,
-                        Symbol = req.Symbol,
-                        SecurityId = securityId,
-                        Side = side.ToString(),
-                        Type = type.ToString(),
-                        Quantity = req.Quantity,
-                        Price = req.Price,
-                    },
-                    () =>
-                    {
-                        book.TryAdd(order);
-                        ownership.Register(clOrdId, owner);
-                    });
-            }
-            catch (WalBackpressureException ex)
-            {
-                MetricsRegistry.WalBackpressure.Add(1,
-                    new KeyValuePair<string, object?>("call_site", "orders.submit"));
-                return Results.Json(
-                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
-                    statusCode: StatusCodes.Status503ServiceUnavailable);
-            }
+            var result = await submitter.SubmitAsync(new OrderSubmissionRequest(
+                owner, firm, req.Symbol, securityId, side, type,
+                req.Quantity, req.Price, OrderSubmissionSource.Manual), ct);
 
-            MetricsRegistry.OrdersSubmitted.Add(1,
-                new KeyValuePair<string, object?>("symbol", req.Symbol),
-                new KeyValuePair<string, object?>("side", side.ToString()));
-
-            // Pre-trade risk: synchronous pipeline + async margin reservation.
-            // Rejection synthesizes an ER through the same sink real
-            // exchange rejections use, so the WS client can't tell them
-            // apart structurally. Margin runs LAST so that a reject
-            // from any earlier check leaves the ledger untouched.
-            var riskCtx = new RiskContext(owner, firm, req.Symbol, side, type, req.Quantity, req.Price);
-            var decision = risk.Evaluate(riskCtx);
-            var marginReserved = false;
-            if (decision.Approved)
+            return result.Kind switch
             {
-                var marginDecision = await margin.TryReserveAsync(clOrdId, riskCtx, ct);
-                if (marginDecision.Approved) marginReserved = true;
-                else decision = marginDecision;
-            }
-            if (!decision.Approved)
-            {
-                MetricsRegistry.OrdersRejectedByRisk.Add(1,
-                    new KeyValuePair<string, object?>("reason", decision.Reason ?? "risk_rejected"));
-                PublishSyntheticRejection(dispatcher, sink, order, owner, decision.Reason ?? "risk_rejected");
-                return Results.Accepted($"/orders/{clOrdId}",
-                    new { ClOrdId = clOrdId.ToString(), Status = "Rejected", Reason = decision.Reason });
-            }
-
-            // Slice 7: record the accepted submit on the rolling ledgers
-            // only after both the synchronous pipeline and the margin
-            // reservation approve. Recording earlier would charge the
-            // ledgers for orders the margin provider rejects.
-            accountant.RecordAccepted(riskCtx);
-
-            try
-            {
-                await gateway.SubmitAsync(order, ct);
-            }
-            catch (Exception ex)
-            {
-                MetricsRegistry.OrdersGatewayFailed.Add(1);
-                loggerFactory.CreateLogger("OrdersEndpoints")
-                    .LogError(ex, "Gateway submit failed for {ClOrdId}; synthesizing rejection.", clOrdId);
-                // Roll back the margin reservation: the order will never
-                // reach the exchange, so no ER will arrive to release it.
-                if (marginReserved) margin.ReleaseReservation(clOrdId);
-                PublishSyntheticRejection(dispatcher, sink, order, owner, "gateway_unavailable");
-                return Results.Json(
-                    new { error = "gateway unavailable", clOrdId = clOrdId.ToString() },
-                    statusCode: StatusCodes.Status502BadGateway);
-            }
-
-            return Results.Accepted($"/orders/{clOrdId}", new { ClOrdId = clOrdId.ToString() });
+                OrderSubmissionResultKind.Accepted =>
+                    Results.Accepted($"/orders/{result.ClOrdId}", new { ClOrdId = result.ClOrdId.ToString() }),
+                OrderSubmissionResultKind.Rejected =>
+                    Results.Accepted($"/orders/{result.ClOrdId}",
+                        new { ClOrdId = result.ClOrdId.ToString(), Status = "Rejected", Reason = result.Reason }),
+                OrderSubmissionResultKind.GatewayFailed =>
+                    Results.Json(
+                        new { error = "gateway unavailable", clOrdId = result.ClOrdId.ToString() },
+                        statusCode: StatusCodes.Status502BadGateway),
+                OrderSubmissionResultKind.WalBackpressure =>
+                    Results.Json(
+                        new { error = "system busy (WAL backpressure)", detail = result.Reason },
+                        statusCode: StatusCodes.Status503ServiceUnavailable),
+                OrderSubmissionResultKind.Drained =>
+                    Results.Json(
+                        new { error = "service draining" },
+                        statusCode: StatusCodes.Status503ServiceUnavailable),
+                OrderSubmissionResultKind.BadRequest =>
+                    Results.BadRequest(new { error = result.Reason }),
+                _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+            };
         });
 
         group.MapDelete("/{clOrdId}", async (
@@ -208,53 +116,6 @@ public static class OrdersEndpoints
 
     private static string ResolveFirm(HttpContext ctx) =>
         ctx.User.FindFirstValue(JwtIssuer.FirmClaim) ?? "default";
-
-    private static void PublishSyntheticRejection(
-        EventDispatcher dispatcher,
-        IExecutionEventSink sink,
-        Order order,
-        EndClientId owner,
-        string reason)
-    {
-        // Synthetic rejections (risk decline, gateway failure) flow through
-        // the same WAL+sink path as real exchange ERs: identical recovery
-        // and audit semantics, identical client-facing shape.
-        try
-        {
-            dispatcher.Dispatch(
-                new ExecutionReportReceivedEvent
-                {
-                    ClOrdId = order.ClOrdId,
-                    ExecKind = ExecKind.Rejected.ToString(),
-                    LeavesQuantity = order.LeavesQuantity,
-                    CumulativeQuantity = order.CumulativeQuantity,
-                    LastQuantity = 0,
-                    LastPrice = 0m,
-                    RejectReason = reason,
-                    Synthetic = true,
-                },
-                () =>
-                {
-                    order.MarkRejected();
-                    sink.Publish(new ExecutionEvent(
-                        owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
-                        order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
-                        reason, DateTimeOffset.UtcNow));
-                });
-        }
-        catch (WalBackpressureException)
-        {
-            // The order is already accepted in the WAL but the rejection
-            // can't be persisted. Mark + publish anyway so the client sees
-            // a terminal state; the missing audit entry is preferable to a
-            // ghost order. Surfaces in metrics as a backpressure event.
-            order.MarkRejected();
-            sink.Publish(new ExecutionEvent(
-                owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
-                order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
-                reason, DateTimeOffset.UtcNow));
-        }
-    }
 }
 
 public sealed record SubmitOrderRequest(

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1,0 +1,75 @@
+using B3.Trading.Application.Observability;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Single-consumer hosted service that reacts to <see cref="AlgoSignal"/>s
+/// queued by the API and the ER processor. RFC algo-orders-v0 §4.3:
+/// "one IHostedService, bounded Channel, single consumer in v0, per-parent
+/// serialisation via SemaphoreSlim".
+///
+/// <para>
+/// In slice 5a the consumer body is intentionally a no-op — it logs and
+/// counts signals so the wiring + back-pressure metric are observable end
+/// to end without behavioural change. Slice 5b plugs in the Iceberg
+/// state-machine reactor.
+/// </para>
+/// </summary>
+public sealed class AlgoEngine : BackgroundService
+{
+    private readonly AlgoSignalQueue _queue;
+    private readonly ILogger<AlgoEngine> _logger;
+
+    public AlgoEngine(AlgoSignalQueue queue, ILogger<AlgoEngine> logger)
+    {
+        _queue = queue;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AlgoEngine consumer task starting (slice 5a no-op reactor).");
+        try
+        {
+            await foreach (var signal in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                MetricsRegistry.AlgoSignalsConsumed.Add(1,
+                    new KeyValuePair<string, object?>("kind", SignalKind(signal)));
+                _logger.LogDebug("AlgoEngine received signal {Kind} for algo {AlgoId}/{Firm}",
+                    SignalKind(signal), AlgoIdOf(signal), signal.FirmId);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        finally
+        {
+            _logger.LogInformation("AlgoEngine consumer task stopped.");
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _queue.Complete();
+        return base.StopAsync(cancellationToken);
+    }
+
+    private static string SignalKind(AlgoSignal s) => s switch
+    {
+        AlgoCreatedSignal => "created",
+        AlgoCancelRequestedSignal => "cancel_requested",
+        ChildExecutionObservedSignal => "child_er",
+        _ => "unknown",
+    };
+
+    private static ulong AlgoIdOf(AlgoSignal s) => s switch
+    {
+        AlgoCreatedSignal c => c.AlgoId,
+        AlgoCancelRequestedSignal c => c.AlgoId,
+        ChildExecutionObservedSignal c => c.AlgoId,
+        _ => 0,
+    };
+}

--- a/backend/src/B3.Trading.Application/Algo/AlgoSignal.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoSignal.cs
@@ -1,0 +1,46 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Discriminated union of signals fed into the <see cref="AlgoEngine"/>'s
+/// reactive consumer. Each signal carries the minimum identity the engine
+/// needs to reload state from the books — full domain objects are not
+/// captured to avoid pinning stale references when a parent or child is
+/// mutated between enqueue and dequeue.
+/// </summary>
+public abstract record AlgoSignal
+{
+    /// <summary>Firm scope; required because the <see cref="AlgoBook"/> is keyed by <c>(firmId, algoId)</c>.</summary>
+    public required string FirmId { get; init; }
+}
+
+/// <summary>
+/// A new <see cref="Domain.Algo"/> parent has been persisted by the API
+/// (or rehydrated from snapshot/WAL during boot reconciliation) and may
+/// require the engine to submit its first child slice.
+/// </summary>
+public sealed record AlgoCreatedSignal : AlgoSignal
+{
+    public required ulong AlgoId { get; init; }
+}
+
+/// <summary>
+/// An operator has called <c>DELETE /algo/{id}</c>. The parent is
+/// already in <c>Cancelling</c>; the engine must cancel any live child
+/// and then mark the parent terminal.
+/// </summary>
+public sealed record AlgoCancelRequestedSignal : AlgoSignal
+{
+    public required ulong AlgoId { get; init; }
+}
+
+/// <summary>
+/// An execution report was just applied to a child order linked to an
+/// algo parent. Enqueued by <c>ExecutionReportProcessor</c> AFTER the
+/// dispatcher returns, so the engine consumer never holds the dispatcher
+/// lock when reacting (RFC §4.3 thread boundary).
+/// </summary>
+public sealed record ChildExecutionObservedSignal : AlgoSignal
+{
+    public required ulong AlgoId { get; init; }
+    public required ulong ChildClOrdId { get; init; }
+}

--- a/backend/src/B3.Trading.Application/Algo/AlgoSignalQueue.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoSignalQueue.cs
@@ -1,0 +1,56 @@
+using System.Threading.Channels;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Producer side of the algo engine's signal channel. The producer never
+/// blocks on a full queue: backpressure surfaces as a returned <c>false</c>
+/// so the caller can record metrics + log without back-pressuring the
+/// dispatcher thread.
+/// </summary>
+public interface IAlgoSignalQueue
+{
+    bool TryEnqueue(AlgoSignal signal);
+}
+
+/// <summary>
+/// Bounded MPSC channel feeding the single <see cref="AlgoEngine"/>
+/// consumer task (RFC §4.3 v0). Capacity is generous because algo flow is
+/// orders-of-magnitude lower than ER flow; a full queue indicates a
+/// pathological loop and should fail loud, not block producers.
+/// </summary>
+public sealed class AlgoSignalQueue : IAlgoSignalQueue
+{
+    private readonly Channel<AlgoSignal> _channel;
+
+    public const int DefaultCapacity = 4096;
+
+    public AlgoSignalQueue(int capacity = DefaultCapacity)
+    {
+        _channel = Channel.CreateBounded<AlgoSignal>(new BoundedChannelOptions(capacity)
+        {
+            // Wait + TryWrite: when full, TryWrite returns false rather than
+            // overwriting an in-flight signal. Producers (the dispatcher
+            // thread, the ER processor) MUST observe the drop and surface
+            // it as a metric — silently overwriting would lose engine
+            // intent (e.g. a cancel-requested behind a flood of child ERs).
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public bool TryEnqueue(AlgoSignal signal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        return _channel.Writer.TryWrite(signal);
+    }
+
+    /// <summary>
+    /// Async stream consumed by the engine's hosted-service loop. Completes
+    /// when <see cref="Complete"/> is called (host shutdown).
+    /// </summary>
+    public ChannelReader<AlgoSignal> Reader => _channel.Reader;
+
+    public void Complete() => _channel.Writer.TryComplete();
+}

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -1,3 +1,4 @@
+
 using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,7 @@ public sealed class ExecutionReportProcessor
     private readonly IExecutionEventSink _sink;
     private readonly Risk.IMarginProvider _margin;
     private readonly ILogger<ExecutionReportProcessor> _logger;
+    private readonly IAlgoSignalQueue? _algoSignals;
 
     public ExecutionReportProcessor(
         OrderOwnershipMap ownership,
@@ -39,7 +41,8 @@ public sealed class ExecutionReportProcessor
         PositionKeeper positions,
         IExecutionEventSink sink,
         Risk.IMarginProvider margin,
-        ILogger<ExecutionReportProcessor> logger)
+        ILogger<ExecutionReportProcessor> logger,
+        IAlgoSignalQueue? algoSignals = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -47,6 +50,7 @@ public sealed class ExecutionReportProcessor
         _sink = sink;
         _margin = margin;
         _logger = logger;
+        _algoSignals = algoSignals;
     }
 
     /// <summary>
@@ -174,6 +178,31 @@ public sealed class ExecutionReportProcessor
             lastPx,
             rejectReason,
             DateTimeOffset.UtcNow));
+
+        // Algo engine hook: signal AFTER fan-out so the engine reactor
+        // sees the same world the WS subscribers see, and so the dispatch
+        // path (which may be holding internal locks) is fully unwound
+        // before the engine's per-parent semaphore is acquired
+        // (RFC algo-orders-v0 §4.3).
+        if (_algoSignals is not null
+            && order.ParentAlgoId is { } parentAlgoId
+            && !string.IsNullOrEmpty(order.FirmId))
+        {
+            var enqueued = _algoSignals.TryEnqueue(new ChildExecutionObservedSignal
+            {
+                FirmId = order.FirmId,
+                AlgoId = parentAlgoId,
+                ChildClOrdId = lookupId,
+            });
+            if (!enqueued)
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "child_er"));
+                _logger.LogWarning(
+                    "Algo signal queue full; dropped child_er signal for parent {AlgoId} child {ClOrdId}.",
+                    parentAlgoId, lookupId);
+            }
+        }
     }
 
     private static KeyValuePair<string, object?> KindTag(ExecKind kind) =>

--- a/backend/src/B3.Trading.Application/Gateway/IExchangeGateway.cs
+++ b/backend/src/B3.Trading.Application/Gateway/IExchangeGateway.cs
@@ -1,12 +1,13 @@
 using B3.Trading.Domain;
 
-namespace B3.Trading.Infrastructure;
+namespace B3.Trading.Application;
 
 /// <summary>
 /// Boundary toward <c>B3.EntryPoint.Client</c> (the wire-puro FIXP/SBE
-/// library). Real implementation will adapt EntryPoint
-/// NewOrder/CancelReplace/Cancel + ExecutionReport to/from the domain;
-/// the interface lives in Infrastructure so Application stays wire-agnostic.
+/// library). The interface lives in Application — implementations live in
+/// Infrastructure (ports-and-adapters), so the algo engine and the
+/// HTTP submit pipeline can share the same abstraction without
+/// dragging in wire-library types.
 /// </summary>
 public interface IExchangeGateway
 {

--- a/backend/src/B3.Trading.Application/Lifecycle/IDrainGate.cs
+++ b/backend/src/B3.Trading.Application/Lifecycle/IDrainGate.cs
@@ -1,0 +1,13 @@
+namespace B3.Trading.Application.Lifecycle;
+
+/// <summary>
+/// Process-wide drain signal exposed to application-layer services. The
+/// concrete implementation lives in the API layer (it ties into
+/// <c>IHostApplicationLifetime.ApplicationStopping</c>); the application
+/// layer only sees the read-side flag so the dependency arrow stays
+/// Application → (nothing).
+/// </summary>
+public interface IDrainGate
+{
+    bool IsDraining { get; }
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -80,6 +80,19 @@ public static class MetricsRegistry
     public static readonly Counter<long> DrainRejections =
         Meter.CreateCounter<long>("trading.drain.rejections");
 
+    // Algo engine (RFC algo-orders-v0 §7 C1)
+    public static readonly Counter<long> AlgoSignalsConsumed =
+        Meter.CreateCounter<long>("trading.algo.signals_consumed");
+    // Producer-side back-pressure: the bounded signal channel rejected a
+    // write because it was full. Should be flat at zero in healthy
+    // operation; non-zero indicates a stuck consumer or a runaway loop.
+    public static readonly Counter<long> AlgoSignalsDropped =
+        Meter.CreateCounter<long>("trading.algo.signals_dropped");
+    // Child orders submitted by the engine on behalf of an algo parent.
+    // Tagged by algo type so iceberg vs twap are distinguishable.
+    public static readonly Counter<long> AlgoChildrenSubmitted =
+        Meter.CreateCounter<long>("trading.algo.children_submitted");
+
     /// <summary>
     /// 1 when the host booted with <c>ExchangeMode.Simulator</c> active, 0
     /// otherwise. Set once at startup and never decremented (mode is fixed

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -1,0 +1,268 @@
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// The "submit an order" pipeline extracted from <c>POST /orders</c> so it
+/// can be reused by the algo engine (RFC algo-orders-v0 §4.3). Manual
+/// submissions and engine-driven child slices share the same WAL writes,
+/// risk pipeline, margin reservation, gateway dispatch, and synthetic
+/// rejection plumbing — there must be exactly one path that orders take
+/// from intent to wire, otherwise audit/recovery semantics diverge.
+///
+/// <para>
+/// The service is stateless apart from its injected collaborators; all
+/// per-call mutable state lives on the returned <see cref="OrderSubmissionResult"/>
+/// or in the underlying books. Callers translate the result into their own
+/// transport (HTTP status + JSON body for endpoints, signal updates for
+/// the engine).
+/// </para>
+/// </summary>
+public sealed class OrderSubmissionService
+{
+    private readonly ClOrdIdPrefixRegistry _clOrdIds;
+    private readonly OrderOwnershipMap _ownership;
+    private readonly WorkingOrderBook _book;
+    private readonly IExchangeGateway _gateway;
+    private readonly IExecutionEventSink _sink;
+    private readonly RiskPipeline _risk;
+    private readonly IMarginProvider _margin;
+    private readonly CompositeRiskAccountant _accountant;
+    private readonly EventDispatcher _dispatcher;
+    private readonly Lifecycle.IDrainGate _drain;
+    private readonly ILogger<OrderSubmissionService> _logger;
+
+    public OrderSubmissionService(
+        ClOrdIdPrefixRegistry clOrdIds,
+        OrderOwnershipMap ownership,
+        WorkingOrderBook book,
+        IExchangeGateway gateway,
+        IExecutionEventSink sink,
+        RiskPipeline risk,
+        IMarginProvider margin,
+        CompositeRiskAccountant accountant,
+        EventDispatcher dispatcher,
+        Lifecycle.IDrainGate drain,
+        ILogger<OrderSubmissionService> logger)
+    {
+        _clOrdIds = clOrdIds;
+        _ownership = ownership;
+        _book = book;
+        _gateway = gateway;
+        _sink = sink;
+        _risk = risk;
+        _margin = margin;
+        _accountant = accountant;
+        _dispatcher = dispatcher;
+        _drain = drain;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Runs the full submit pipeline for one order. The caller is
+    /// responsible for parsing/validating the request shape; this method
+    /// validates business invariants (positive quantity, non-zero
+    /// SecurityId) and short-circuits with the appropriate result.
+    /// </summary>
+    public async Task<OrderSubmissionResult> SubmitAsync(OrderSubmissionRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+
+        if (_drain.IsDraining)
+        {
+            MetricsRegistry.DrainRejections.Add(1,
+                new KeyValuePair<string, object?>("route", req.Source == OrderSubmissionSource.Algo ? "algo.submit" : "POST /orders"));
+            return OrderSubmissionResult.Drained;
+        }
+
+        if (req.Quantity <= 0)
+            return OrderSubmissionResult.BadRequest("quantity must be positive");
+        if (req.SecurityId == 0)
+            return OrderSubmissionResult.BadRequest("securityId is required");
+        if (string.IsNullOrWhiteSpace(req.Symbol))
+            return OrderSubmissionResult.BadRequest("symbol is required");
+
+        var clOrdId = _clOrdIds.Generate(req.Owner);
+        var order = new Order(
+            clOrdId, req.Owner, req.Symbol, req.SecurityId, req.Side, req.Type,
+            req.Quantity, req.Price, req.FirmId,
+            parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq);
+
+        try
+        {
+            _dispatcher.Dispatch(
+                new OrderSubmittedEvent
+                {
+                    ClOrdId = clOrdId,
+                    EndClientId = req.Owner.Value,
+                    FirmId = req.FirmId,
+                    Symbol = req.Symbol,
+                    SecurityId = req.SecurityId,
+                    Side = req.Side.ToString(),
+                    Type = req.Type.ToString(),
+                    Quantity = req.Quantity,
+                    Price = req.Price,
+                    ParentAlgoId = req.ParentAlgoId,
+                    AlgoSliceSeq = req.AlgoSliceSeq,
+                },
+                () =>
+                {
+                    _book.TryAdd(order);
+                    _ownership.Register(clOrdId, req.Owner);
+                });
+        }
+        catch (WalBackpressureException ex)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site",
+                    req.Source == OrderSubmissionSource.Algo ? "algo.submit" : "orders.submit"));
+            return OrderSubmissionResult.WalBackpressure(ex.Message);
+        }
+
+        MetricsRegistry.OrdersSubmitted.Add(1,
+            new KeyValuePair<string, object?>("symbol", req.Symbol),
+            new KeyValuePair<string, object?>("side", req.Side.ToString()),
+            new KeyValuePair<string, object?>("source",
+                req.Source == OrderSubmissionSource.Algo ? "algo" : "manual"));
+
+        var riskCtx = new RiskContext(req.Owner, req.FirmId, req.Symbol, req.Side, req.Type, req.Quantity, req.Price);
+        var decision = _risk.Evaluate(riskCtx);
+        var marginReserved = false;
+        if (decision.Approved)
+        {
+            var marginDecision = await _margin.TryReserveAsync(clOrdId, riskCtx, ct);
+            if (marginDecision.Approved) marginReserved = true;
+            else decision = marginDecision;
+        }
+        if (!decision.Approved)
+        {
+            MetricsRegistry.OrdersRejectedByRisk.Add(1,
+                new KeyValuePair<string, object?>("reason", decision.Reason ?? "risk_rejected"));
+            PublishSyntheticRejection(order, decision.Reason ?? "risk_rejected");
+            return OrderSubmissionResult.Rejected(clOrdId, decision.Reason ?? "risk_rejected");
+        }
+
+        _accountant.RecordAccepted(riskCtx);
+
+        try
+        {
+            await _gateway.SubmitAsync(order, ct);
+        }
+        catch (Exception ex)
+        {
+            MetricsRegistry.OrdersGatewayFailed.Add(1);
+            _logger.LogError(ex, "Gateway submit failed for {ClOrdId}; synthesizing rejection.", clOrdId);
+            if (marginReserved) _margin.ReleaseReservation(clOrdId);
+            PublishSyntheticRejection(order, "gateway_unavailable");
+            return OrderSubmissionResult.GatewayFailed(clOrdId, ex);
+        }
+
+        return OrderSubmissionResult.Accepted(clOrdId);
+    }
+
+    private void PublishSyntheticRejection(Order order, string reason)
+    {
+        try
+        {
+            _dispatcher.Dispatch(
+                new ExecutionReportReceivedEvent
+                {
+                    ClOrdId = order.ClOrdId,
+                    ExecKind = ExecKind.Rejected.ToString(),
+                    LeavesQuantity = order.LeavesQuantity,
+                    CumulativeQuantity = order.CumulativeQuantity,
+                    LastQuantity = 0,
+                    LastPrice = 0m,
+                    RejectReason = reason,
+                    Synthetic = true,
+                },
+                () =>
+                {
+                    order.MarkRejected();
+                    _sink.Publish(new ExecutionEvent(
+                        order.Owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
+                        order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
+                        reason, DateTimeOffset.UtcNow));
+                });
+        }
+        catch (WalBackpressureException)
+        {
+            order.MarkRejected();
+            _sink.Publish(new ExecutionEvent(
+                order.Owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
+                order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
+                reason, DateTimeOffset.UtcNow));
+        }
+    }
+}
+
+public enum OrderSubmissionSource
+{
+    Manual,
+    Algo,
+}
+
+public sealed record OrderSubmissionRequest(
+    EndClientId Owner,
+    string FirmId,
+    string Symbol,
+    ulong SecurityId,
+    OrderSide Side,
+    OrderType Type,
+    long Quantity,
+    decimal? Price,
+    OrderSubmissionSource Source = OrderSubmissionSource.Manual,
+    ulong? ParentAlgoId = null,
+    int? AlgoSliceSeq = null);
+
+/// <summary>
+/// Outcome of <see cref="OrderSubmissionService.SubmitAsync"/>. The
+/// discriminator is the <see cref="Kind"/> property; callers branch on it
+/// to map to their transport (HTTP status / engine-side state transition).
+/// All terminal cases also carry the <see cref="ClOrdId"/> when one was
+/// allocated, so the caller can echo it to the user even when the order
+/// was rejected synthetically.
+/// </summary>
+public sealed class OrderSubmissionResult
+{
+    public OrderSubmissionResultKind Kind { get; }
+    public ulong ClOrdId { get; }
+    public string? Reason { get; }
+    public Exception? GatewayException { get; }
+
+    private OrderSubmissionResult(OrderSubmissionResultKind kind, ulong clOrdId, string? reason, Exception? ex)
+    {
+        Kind = kind;
+        ClOrdId = clOrdId;
+        Reason = reason;
+        GatewayException = ex;
+    }
+
+    public static OrderSubmissionResult Accepted(ulong clOrdId) =>
+        new(OrderSubmissionResultKind.Accepted, clOrdId, null, null);
+    public static OrderSubmissionResult Rejected(ulong clOrdId, string reason) =>
+        new(OrderSubmissionResultKind.Rejected, clOrdId, reason, null);
+    public static OrderSubmissionResult GatewayFailed(ulong clOrdId, Exception ex) =>
+        new(OrderSubmissionResultKind.GatewayFailed, clOrdId, "gateway_unavailable", ex);
+    public static OrderSubmissionResult WalBackpressure(string detail) =>
+        new(OrderSubmissionResultKind.WalBackpressure, 0, detail, null);
+    public static OrderSubmissionResult BadRequest(string reason) =>
+        new(OrderSubmissionResultKind.BadRequest, 0, reason, null);
+    public static OrderSubmissionResult Drained { get; } =
+        new(OrderSubmissionResultKind.Drained, 0, "service draining", null);
+}
+
+public enum OrderSubmissionResultKind
+{
+    Accepted,
+    Rejected,
+    GatewayFailed,
+    WalBackpressure,
+    BadRequest,
+    Drained,
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -61,12 +61,22 @@ builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
 builder.Services.AddSingleton<ExecutionReportProcessor>();
+builder.Services.AddSingleton<OrderSubmissionService>();
+
+// Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).
+// In slice 5a the consumer body is a no-op reactor; slice 5b plugs in the
+// Iceberg state machine.
+builder.Services.AddSingleton<AlgoSignalQueue>();
+builder.Services.AddSingleton<IAlgoSignalQueue>(sp => sp.GetRequiredService<AlgoSignalQueue>());
+builder.Services.AddHostedService<AlgoEngine>();
 builder.Services.AddSingleton<JwtIssuer>();
 
 // Lifecycle: drain flag flipped on SIGTERM /
 // IHostApplicationLifetime.ApplicationStopping. Read by /ready (503 when
 // draining) and POST /orders (refuses new orders so in-flight can finish).
 builder.Services.AddSingleton<DrainState>();
+builder.Services.AddSingleton<B3.Trading.Application.Lifecycle.IDrainGate>(
+    sp => sp.GetRequiredService<DrainState>());
 builder.Services.AddHostedService<DrainHostedService>();
 
 // Persistence: event-sourced WAL + periodic snapshot. The IEventStore

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging;
 using Up = B3.EntryPoint.Client;
 using UpModels = B3.EntryPoint.Client.Models;
 
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
@@ -1,5 +1,7 @@
 using B3.Trading.Domain;
 
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/ExchangeOptions.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeOptions.cs
@@ -1,3 +1,5 @@
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
+++ b/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
@@ -1,5 +1,7 @@
 using B3.Trading.Domain;
 
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/StubExchangeGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/StubExchangeGateway.cs
@@ -1,5 +1,7 @@
 using B3.Trading.Domain;
 
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/UnavailableExchangeGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/UnavailableExchangeGateway.cs
@@ -1,5 +1,7 @@
 using B3.Trading.Domain;
 
+using B3.Trading.Application;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSignalQueueTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSignalQueueTests.cs
@@ -1,0 +1,45 @@
+using B3.Trading.Application;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class AlgoSignalQueueTests
+{
+    [Fact]
+    public void TryEnqueue_AcceptsUntilCapacity_ThenDrops()
+    {
+        var q = new AlgoSignalQueue(capacity: 2);
+        Assert.True(q.TryEnqueue(new AlgoCreatedSignal { FirmId = "f", AlgoId = 1 }));
+        Assert.True(q.TryEnqueue(new AlgoCreatedSignal { FirmId = "f", AlgoId = 2 }));
+        // Bounded channel with DropWrite returns false instead of blocking
+        // when full — producers must observe the drop and surface it as a
+        // metric, not silently retry.
+        Assert.False(q.TryEnqueue(new AlgoCreatedSignal { FirmId = "f", AlgoId = 3 }));
+    }
+
+    [Fact]
+    public async Task Reader_DrainsInFifoOrder()
+    {
+        var q = new AlgoSignalQueue();
+        q.TryEnqueue(new AlgoCreatedSignal { FirmId = "f", AlgoId = 1 });
+        q.TryEnqueue(new ChildExecutionObservedSignal { FirmId = "f", AlgoId = 1, ChildClOrdId = 999 });
+        q.TryEnqueue(new AlgoCancelRequestedSignal { FirmId = "f", AlgoId = 1 });
+        q.Complete();
+
+        var seen = new List<AlgoSignal>();
+        await foreach (var s in q.Reader.ReadAllAsync())
+            seen.Add(s);
+
+        Assert.Collection(seen,
+            s => Assert.IsType<AlgoCreatedSignal>(s),
+            s => Assert.IsType<ChildExecutionObservedSignal>(s),
+            s => Assert.IsType<AlgoCancelRequestedSignal>(s));
+    }
+
+    [Fact]
+    public void TryEnqueue_NullArgument_Throws()
+    {
+        var q = new AlgoSignalQueue();
+        Assert.Throws<ArgumentNullException>(() => q.TryEnqueue(null!));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/ExecutionReportProcessorAlgoSignalTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/ExecutionReportProcessorAlgoSignalTests.cs
@@ -1,0 +1,107 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class ExecutionReportProcessorAlgoSignalTests
+{
+    [Fact]
+    public void ChildOrder_FillEr_EnqueuesChildExecutionObservedSignal()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new RecordingSink();
+        var queue = new AlgoSignalQueue();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink,
+            new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            queue);
+
+        var owner = new EndClientId("alice");
+        var child = new Order(
+            42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+            firmId: "default", parentAlgoId: 7UL, algoSliceSeq: 1);
+        book.TryAdd(child);
+        ownership.Register(42UL, owner);
+
+        proc.Apply(42UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        // Drain the queue and verify the engine got a signal that points
+        // back at the parent algo + the specific child that filled.
+        queue.Complete();
+        var seen = new List<AlgoSignal>();
+        foreach (var s in DrainSync(queue)) seen.Add(s);
+        var observed = Assert.Single(seen);
+        var child_er = Assert.IsType<ChildExecutionObservedSignal>(observed);
+        Assert.Equal(7UL, child_er.AlgoId);
+        Assert.Equal(42UL, child_er.ChildClOrdId);
+        Assert.Equal("default", child_er.FirmId);
+    }
+
+    [Fact]
+    public void ManualOrder_FillEr_DoesNotEnqueueAnySignal()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new RecordingSink();
+        var queue = new AlgoSignalQueue();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink,
+            new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            queue);
+
+        var owner = new EndClientId("alice");
+        var manual = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(manual);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        queue.Complete();
+        Assert.Empty(DrainSync(queue));
+    }
+
+    [Fact]
+    public void NullSignalQueue_IsTolerated_PreservesLegacyConstructorSemantics()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new RecordingSink();
+        // Older callers (and most existing unit tests) construct the
+        // processor without an algo queue; this overload must keep working.
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink,
+            new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance);
+
+        var owner = new EndClientId("alice");
+        var child = new Order(
+            42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m,
+            firmId: "default", parentAlgoId: 7UL, algoSliceSeq: 1);
+        book.TryAdd(child);
+        ownership.Register(42UL, owner);
+
+        // Should not throw despite the parent linkage and missing queue.
+        proc.Apply(42UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+        Assert.Equal(OrderStatus.Filled, child.Status);
+    }
+
+    private static IEnumerable<AlgoSignal> DrainSync(AlgoSignalQueue q)
+    {
+        while (q.Reader.TryRead(out var s)) yield return s;
+    }
+
+    private sealed class RecordingSink : IExecutionEventSink
+    {
+        public readonly List<ExecutionEvent> Events = new();
+        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+}


### PR DESCRIPTION
Pre-work for the iceberg engine (slice 5b plugs in the logic). **No behavioural change**: same WAL writes, same risk pipeline, same gateway dispatch, same synthetic-rejection shape.

## What's in

- **`OrderSubmissionService`** (Application): pulls the entire `POST /orders` body into one reusable service. Accepts `parentAlgoId`/`algoSliceSeq` so the engine can submit children through the *exact* same pipeline as manual orders — the RFC §4.3 invariant that audit/recovery semantics must not diverge between paths.
- **`IExchangeGateway` moved Infrastructure → Application** (Gateway/). It's the gateway port (ports-and-adapters); Infra implementations gain `using B3.Trading.Application;` and continue to implement it.
- **`IDrainGate` (Application.Lifecycle):** read-side abstraction so `OrderSubmissionService` can short-circuit on drain without leaking `Api.Lifecycle.DrainState` upward. `DrainState` implements it; DI wires both registrations.
- **`AlgoSignal` hierarchy + bounded MPSC `AlgoSignalQueue`** (`FullMode=Wait` so producers see `false` on full and surface drops as `trading.algo.signals_dropped{kind}` — silent overwrite would lose cancel intent behind a flood of child ERs).
- **`AlgoEngine` BackgroundService**: single-consumer task per RFC §4.3 v0. Slice-5a body is a no-op reactor that logs + counts; **slice 5b plugs in the iceberg state machine**.
- **`ExecutionReportProcessor`** enqueues `ChildExecutionObservedSignal` AFTER fan-out, only when `order.ParentAlgoId` is set. New ctor parameter is optional null so the 6 existing test callsites compile unchanged.
- **`AlgoEndpoints` POST/DELETE** enqueue `AlgoCreated`/`AlgoCancelRequested` signals after the dispatcher returns.
- **`OrdersEndpoints`** rewritten to call `OrderSubmissionService` and map the result discriminator to HTTP shape — zero logic moved, status codes + bodies preserved.

## Metrics

- `trading.orders.submitted` now carries `source=manual|algo` (RFC §7 C1).
- New: `trading.algo.signals_consumed{kind}`, `trading.algo.signals_dropped{kind}`, `trading.algo.children_submitted{type}` (counter exists; engine wires it in 5b).

## Tests

`30 / 200 / 114 / 8-skip`. New cases: `AlgoSignalQueue` capacity/FIFO/null-arg, `ExecutionReportProcessor` child-er enqueue + manual no-enqueue + null-queue tolerance. `dotnet format` clean.

## What's NOT in

- Iceberg refill logic, suspend transitions, retries, recovery, integration tests against simulator. Those are slice 5b.
- TWAP engine — slice 6.

Refs: RFC `docs/rfcs/algo-orders-v0.md` §4.2, §4.3, §7.