### PR TITLE
feat(algo): slice 5b — Iceberg reactor logic + integration tests

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -31,7 +31,9 @@ public sealed record OrderDto(
     long LeavesQuantity,
     long CumulativeQuantity,
     decimal? Price,
-    string Status);
+    string Status,
+    string? ParentAlgoId = null,
+    int? AlgoSliceSeq = null);
 
 public sealed record PositionDto(
     string Symbol,
@@ -87,7 +89,8 @@ public static class DtoMappings
 {
     public static OrderDto ToDto(this Order o) => new(
         o.ClOrdId.ToString(), o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
-        o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString());
+        o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
+        o.ParentAlgoId?.ToString(), o.AlgoSliceSeq);
 
     public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1,4 +1,7 @@
+using System.Collections.Concurrent;
 using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -8,37 +11,126 @@ namespace B3.Trading.Application;
 /// Single-consumer hosted service that reacts to <see cref="AlgoSignal"/>s
 /// queued by the API and the ER processor. RFC algo-orders-v0 §4.3:
 /// "one IHostedService, bounded Channel, single consumer in v0, per-parent
-/// serialisation via SemaphoreSlim".
+/// serialisation via SemaphoreSlim". V0 keeps the per-parent semaphore
+/// implicit — there is exactly one consumer task, so reactor invocations
+/// are already serialised. The runtime state map is therefore touched
+/// only by this thread; no locks are needed beyond the implicit ones in
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/>.
 ///
 /// <para>
-/// In slice 5a the consumer body is intentionally a no-op — it logs and
-/// counts signals so the wiring + back-pressure metric are observable end
-/// to end without behavioural change. Slice 5b plugs in the Iceberg
-/// state-machine reactor.
+/// The reactor implements the Iceberg state machine end-to-end:
+/// <list type="bullet">
+///   <item><c>AlgoCreated</c> → submit first child slice (no-op if a live
+///         child already exists; idempotent under replay/reconciliation).</item>
+///   <item><c>ChildExecutionObserved</c> → record fill delta against the
+///         parent; on terminal Filled refill the next slice or mark
+///         <c>Completed</c>; on Cancelled propagate to the parent based on
+///         whether the cancel was operator-driven; on Rejected suspend.</item>
+///   <item><c>AlgoCancelRequested</c> → cancel the live child via the
+///         gateway; the actual <c>Cancelled</c> transition lands when the
+///         child cancel-ack arrives back through the ER pipeline.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <b>Retries:</b> gateway/WAL transient failures retry up to 3 times with
+/// 100/300/900 ms back-off via <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.
+/// Doing the delay inline blocks the consumer for up to ~1.3s on a flaky
+/// venue — acceptable in v0 because algo flow is orders-of-magnitude lower
+/// than ER flow and pause latency only affects other algos, never order
+/// reception. Promotion to a dedicated retry queue is future work if
+/// production traffic ever justifies it.
+/// </para>
+///
+/// <para>
+/// <b>Recovery:</b> on <see cref="ExecuteAsync"/> entry the engine walks
+/// every non-terminal algo, sums the cumulative-quantity of the children
+/// in <see cref="WorkingOrderBook"/>, primes per-parent runtime state
+/// (live child + slice counter + cum baseline), then re-enqueues an
+/// <see cref="AlgoCreatedSignal"/>. The reactor pass that follows either
+/// observes a still-live child (no-op) or submits the next slice — same
+/// code path as steady-state, so recovery and live behaviour cannot drift.
 /// </para>
 /// </summary>
 public sealed class AlgoEngine : BackgroundService
 {
+    // Retry policy for transient submit failures (gateway/WAL backpressure).
+    // Sequence intentionally short: the operator notices a stuck algo via
+    // the suspended-with-RetriesExhausted state much faster than via
+    // dashboards, and a long retry tail just delays the alert.
+    private static readonly TimeSpan[] RetryDelays =
+    {
+        TimeSpan.FromMilliseconds(100),
+        TimeSpan.FromMilliseconds(300),
+        TimeSpan.FromMilliseconds(900),
+    };
+
     private readonly AlgoSignalQueue _queue;
+    private readonly AlgoBook _algos;
+    private readonly WorkingOrderBook _orders;
+    private readonly OrderSubmissionService _submitter;
+    private readonly ClOrdIdPrefixRegistry _clOrdIds;
+    private readonly IExchangeGateway _gateway;
+    private readonly IAlgoEventSink _algoSink;
+    private readonly EventDispatcher _dispatcher;
     private readonly ILogger<AlgoEngine> _logger;
 
-    public AlgoEngine(AlgoSignalQueue queue, ILogger<AlgoEngine> logger)
+    // Per-parent runtime state. Owned by the consumer task; the
+    // ConcurrentDictionary is only used because TryAdd/TryGetValue are
+    // convenient — no concurrent writers exist in v0.
+    private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), AlgoParentRuntime> _runtime =
+        new();
+
+    public AlgoEngine(
+        AlgoSignalQueue queue,
+        AlgoBook algos,
+        WorkingOrderBook orders,
+        OrderSubmissionService submitter,
+        ClOrdIdPrefixRegistry clOrdIds,
+        IExchangeGateway gateway,
+        IAlgoEventSink algoSink,
+        EventDispatcher dispatcher,
+        ILogger<AlgoEngine> logger)
     {
         _queue = queue;
+        _algos = algos;
+        _orders = orders;
+        _submitter = submitter;
+        _clOrdIds = clOrdIds;
+        _gateway = gateway;
+        _algoSink = algoSink;
+        _dispatcher = dispatcher;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("AlgoEngine consumer task starting (slice 5a no-op reactor).");
+        _logger.LogInformation("AlgoEngine consumer task starting.");
+        Reconcile();
         try
         {
             await foreach (var signal in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
             {
                 MetricsRegistry.AlgoSignalsConsumed.Add(1,
                     new KeyValuePair<string, object?>("kind", SignalKind(signal)));
-                _logger.LogDebug("AlgoEngine received signal {Kind} for algo {AlgoId}/{Firm}",
-                    SignalKind(signal), AlgoIdOf(signal), signal.FirmId);
+                try
+                {
+                    await ReactAsync(signal, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // The reactor must never let an exception kill the
+                    // consumer task — one stuck algo would freeze every
+                    // other algo on the host. Log + continue; the affected
+                    // parent stays in whatever state the failed transition
+                    // left it (operator-visible via GET /algo).
+                    _logger.LogError(ex, "AlgoEngine reactor failed for signal {Kind} algo {AlgoId}/{Firm}.",
+                        SignalKind(signal), AlgoIdOf(signal), signal.FirmId);
+                }
             }
         }
         catch (OperationCanceledException)
@@ -57,6 +149,414 @@ public sealed class AlgoEngine : BackgroundService
         return base.StopAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Boot-time pass over every non-terminal parent. Builds the runtime
+    /// state from the order book (live child + cumulative-fill baseline +
+    /// next slice seq) and re-enqueues an <see cref="AlgoCreatedSignal"/>
+    /// so the reactor evaluates "do I need to submit more?" through the
+    /// same code path as steady-state. Safe to call multiple times because
+    /// <see cref="Algo.RehydrateProgress"/> never moves <c>FilledQuantity</c>
+    /// backwards and the reactor itself is idempotent on a still-live
+    /// child.
+    /// </summary>
+    private void Reconcile()
+    {
+        var algos = _algos.EnumerateAll(includeTerminal: false);
+        if (algos.Count == 0) return;
+
+        foreach (var algo in algos)
+        {
+            var rt = _runtime.GetOrAdd((algo.FirmId, algo.AlgoId), static _ => new AlgoParentRuntime());
+            var children = _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId);
+
+            long totalCum = 0;
+            int maxSeq = -1;
+            ulong? liveChild = null;
+            foreach (var child in children)
+            {
+                totalCum += child.CumulativeQuantity;
+                if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
+                rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
+                if (!IsChildTerminal(child)) liveChild = child.ClOrdId;
+            }
+
+            algo.RehydrateProgress(totalCum);
+            rt.NextSliceSeq = maxSeq + 1;
+            rt.LiveChildClOrdId = liveChild;
+
+            // Re-arm the reactor regardless: even if a live child exists,
+            // the reactor may need to react if the child has since become
+            // terminal between snapshot capture and recovery.
+            if (!_queue.TryEnqueue(new AlgoCreatedSignal { FirmId = algo.FirmId, AlgoId = algo.AlgoId }))
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "created"));
+                _logger.LogWarning(
+                    "AlgoEngine reconciliation dropped Created signal for {Firm}/{AlgoId} (queue full).",
+                    algo.FirmId, algo.AlgoId);
+            }
+        }
+
+        _logger.LogInformation("AlgoEngine reconciliation enqueued {Count} non-terminal parents.", algos.Count);
+    }
+
+    private async Task ReactAsync(AlgoSignal signal, CancellationToken ct)
+    {
+        var (firmId, algoId) = (signal.FirmId, AlgoIdOf(signal));
+        if (algoId == 0)
+        {
+            _logger.LogWarning("AlgoEngine received signal with zero AlgoId; ignoring.");
+            return;
+        }
+        if (!_algos.TryGet(firmId, algoId, out var algo) || algo is null)
+        {
+            // The parent is gone — should not happen except in tests that
+            // tear the book down between submit and consume. Drop quietly.
+            _logger.LogWarning("AlgoEngine signal for unknown algo {Firm}/{AlgoId}; dropping.", firmId, algoId);
+            return;
+        }
+
+        var rt = _runtime.GetOrAdd((firmId, algoId), static _ => new AlgoParentRuntime());
+
+        switch (signal)
+        {
+            case AlgoCreatedSignal:
+                await OnCreatedAsync(algo, rt, ct).ConfigureAwait(false);
+                break;
+            case ChildExecutionObservedSignal er:
+                await OnChildErAsync(algo, rt, er, ct).ConfigureAwait(false);
+                break;
+            case AlgoCancelRequestedSignal:
+                await OnCancelRequestedAsync(algo, rt, ct).ConfigureAwait(false);
+                break;
+            default:
+                _logger.LogWarning("AlgoEngine ignoring unknown signal type {Type}.", signal.GetType().Name);
+                break;
+        }
+    }
+
+    private async Task OnCreatedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
+    {
+        if (algo.IsTerminal) return;
+        if (algo.Status == AlgoStatus.Cancelling) return;
+
+        if (rt.LiveChildClOrdId is { } existing)
+        {
+            // A child is already outstanding (steady-state or post-recovery).
+            // Idempotent no-op — when the child reaches terminal we'll
+            // refill via OnChildErAsync.
+            _logger.LogDebug(
+                "AlgoEngine OnCreated: algo {Firm}/{AlgoId} already has live child {Child}; no resubmit.",
+                algo.FirmId, algo.AlgoId, existing);
+            return;
+        }
+
+        if (algo.RemainingQuantity <= 0)
+        {
+            // Recovery edge-case: snapshot says fully filled but no terminal
+            // event yet (crashed between final fill and terminal write).
+            // Promote to Completed now so /algo reflects truth.
+            await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
+            return;
+        }
+
+        await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnChildErAsync(Algo algo, AlgoParentRuntime rt, ChildExecutionObservedSignal er, CancellationToken ct)
+    {
+        if (!_orders.TryGet(er.ChildClOrdId, out var child) || child is null)
+        {
+            _logger.LogWarning("AlgoEngine child ER for unknown child {ClOrdId}; dropping.", er.ChildClOrdId);
+            return;
+        }
+
+        // Book the cum-quantity delta. Child orders deliver fills via
+        // ApplyCumulativeFill so child.CumulativeQuantity is monotonic;
+        // we just diff against the last value we credited to the parent.
+        var prevBooked = rt.ChildBookedCum.GetValueOrDefault(child.ClOrdId, 0L);
+        var delta = child.CumulativeQuantity - prevBooked;
+        if (delta > 0)
+        {
+            algo.RecordFill(delta);
+            rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
+        }
+
+        // Non-terminal child: nothing more to do (the next ER will land).
+        if (!IsChildTerminal(child)) return;
+
+        // Child is terminal — this clOrdId is no longer live regardless of
+        // outcome. Clear the slot before transitioning so re-entrancy via
+        // RecordTerminalAsync sees a clean state.
+        if (rt.LiveChildClOrdId == child.ClOrdId)
+            rt.LiveChildClOrdId = null;
+
+        switch (child.Status)
+        {
+            case OrderStatus.Filled:
+                if (algo.IsTerminal) return; // redundant ER after we already terminal-ed
+                if (algo.Status == AlgoStatus.Cancelling)
+                {
+                    // Race: operator cancelled while the venue was filling
+                    // the residue. Treat the parent as Cancelled with the
+                    // residue booked — partial-fill outcome is preserved
+                    // by FilledQuantity already.
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
+                    return;
+                }
+                if (algo.RemainingQuantity <= 0)
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
+                    return;
+                }
+                rt.RetryAttempts = 0;
+                await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
+                return;
+
+            case OrderStatus.Cancelled:
+                if (algo.IsTerminal) return;
+                if (algo.Status == AlgoStatus.Cancelling)
+                {
+                    // Operator-driven cancel completed; mark Cancelled.
+                    // FilledQuantity already reflects any partial that
+                    // landed before the cancel-ack.
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Venue cancelled the child without operator request
+                    // (FAK timeout, cross prevention, etc). Suspend with
+                    // VenueCancelled so the operator can decide whether
+                    // to resubmit; auto-refilling in this case can spin
+                    // a tight loop against an unhappy venue.
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.VenueCancelled).ConfigureAwait(false);
+                }
+                return;
+
+            case OrderStatus.Rejected:
+                if (algo.IsTerminal) return;
+                await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
+                return;
+        }
+    }
+
+    private async Task OnCancelRequestedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
+    {
+        // Operator already drove the parent into Cancelling via the API;
+        // reactor's job is to take down the live child (if any). When
+        // there is no live child the parent can move straight to Cancelled
+        // — nothing to wait for from the venue.
+        if (algo.Status != AlgoStatus.Cancelling)
+        {
+            // Replay-time edge-case: a cancel was enqueued but later events
+            // (gateway-failed, etc) already moved the parent past
+            // Cancelling. Nothing to do.
+            return;
+        }
+
+        if (rt.LiveChildClOrdId is not { } childClOrdId)
+        {
+            await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
+            return;
+        }
+
+        if (!_orders.TryGet(childClOrdId, out var child) || child is null)
+        {
+            // Live child went missing — assume already cancelled out-of-band.
+            rt.LiveChildClOrdId = null;
+            await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
+            return;
+        }
+
+        var newClOrdId = _clOrdIds.Generate(child.Owner);
+        try
+        {
+            await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
+            // Don't mark terminal here — wait for the cancel-ack ER to land
+            // via OnChildErAsync. That's what makes the engine consistent
+            // with replay (the WAL records the ER, never the cancel intent).
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "AlgoEngine cancel of child {Child} for algo {Firm}/{AlgoId} failed; operator may retry DELETE.",
+                childClOrdId, algo.FirmId, algo.AlgoId);
+            // Stay in Cancelling so DELETE is re-driveable; do not auto-suspend.
+        }
+    }
+
+    private async Task SubmitNextSliceAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
+    {
+        var (sliceQty, slicePrice) = ComputeNextSlice(algo);
+        if (sliceQty <= 0)
+        {
+            // Should be unreachable (RemainingQuantity == 0 is checked by
+            // callers) — defensive log + complete.
+            await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
+            return;
+        }
+
+        var sliceSeq = rt.NextSliceSeq;
+        var orderType = algo.Parameters switch
+        {
+            IcebergParameters => OrderType.Limit,
+            TwapParameters tp => tp.ChildOrderType,
+            _ => OrderType.Limit,
+        };
+
+        for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
+        {
+            var req = new OrderSubmissionRequest(
+                Owner: algo.Owner,
+                FirmId: algo.FirmId,
+                Symbol: algo.Symbol,
+                SecurityId: algo.SecurityId,
+                Side: algo.Side,
+                Type: orderType,
+                Quantity: sliceQty,
+                Price: slicePrice,
+                Source: OrderSubmissionSource.Algo,
+                ParentAlgoId: algo.AlgoId,
+                AlgoSliceSeq: sliceSeq);
+
+            OrderSubmissionResult result;
+            try
+            {
+                result = await _submitter.SubmitAsync(req, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "AlgoEngine submit threw for algo {Firm}/{AlgoId} slice {Seq}; suspending.",
+                    algo.FirmId, algo.AlgoId, sliceSeq);
+                await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.GatewayUnavailable).ConfigureAwait(false);
+                return;
+            }
+
+            switch (result.Kind)
+            {
+                case OrderSubmissionResultKind.Accepted:
+                    algo.MarkWorking();
+                    rt.LiveChildClOrdId = result.ClOrdId;
+                    rt.ChildBookedCum[result.ClOrdId] = 0;
+                    rt.NextSliceSeq = sliceSeq + 1;
+                    rt.RetryAttempts = 0;
+                    MetricsRegistry.AlgoChildrenSubmitted.Add(1,
+                        new KeyValuePair<string, object?>("type", algo.Type.ToString().ToLowerInvariant()));
+                    _algoSink.PublishAlgoSnapshot(algo.Owner, algo.FirmId, algo.AlgoId);
+                    return;
+
+                case OrderSubmissionResultKind.Rejected:
+                    // Risk rejected the slice — treat the parent as
+                    // suspended so the operator can decide. The synthetic
+                    // rejection ER will arrive separately and cycle through
+                    // OnChildErAsync, which is a no-op once the parent is
+                    // already terminal.
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
+                    return;
+
+                case OrderSubmissionResultKind.Drained:
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.Drained).ConfigureAwait(false);
+                    return;
+
+                case OrderSubmissionResultKind.BadRequest:
+                    // Programming error: the engine produced an invalid
+                    // submit request. Suspend with the closest reason and
+                    // log loudly so it's noticed.
+                    _logger.LogError(
+                        "AlgoEngine submit returned BadRequest ({Reason}) for algo {Firm}/{AlgoId}; suspending.",
+                        result.Reason, algo.FirmId, algo.AlgoId);
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
+                    return;
+
+                case OrderSubmissionResultKind.GatewayFailed:
+                case OrderSubmissionResultKind.WalBackpressure:
+                    if (attempt >= RetryDelays.Length)
+                    {
+                        var reason = result.Kind == OrderSubmissionResultKind.GatewayFailed
+                            ? AlgoTerminalReason.RetriesExhausted
+                            : AlgoTerminalReason.RetriesExhausted;
+                        await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, reason).ConfigureAwait(false);
+                        return;
+                    }
+                    _logger.LogWarning(
+                        "AlgoEngine submit transient ({Kind}, {Reason}) for algo {Firm}/{AlgoId} slice {Seq}; retry {Attempt}.",
+                        result.Kind, result.Reason, algo.FirmId, algo.AlgoId, sliceSeq, attempt + 1);
+                    try
+                    {
+                        await Task.Delay(RetryDelays[attempt], ct).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+                    continue;
+            }
+        }
+    }
+
+    private async Task RecordTerminalAsync(Algo algo, AlgoParentRuntime rt, AlgoStatus status, AlgoTerminalReason reason)
+    {
+        if (algo.IsTerminal) return;
+
+        rt.LiveChildClOrdId = null;
+        var atUtc = DateTimeOffset.UtcNow;
+        try
+        {
+            _dispatcher.Dispatch(
+                new AlgoTerminalStateRecordedEvent
+                {
+                    AlgoId = algo.AlgoId,
+                    FirmId = algo.FirmId,
+                    Status = status.ToString(),
+                    Reason = reason.ToString(),
+                    AtUtc = atUtc,
+                },
+                () => algo.RecordTerminal(status, reason, atUtc));
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.terminal"));
+            // Don't mutate the in-memory aggregate without journaling — that
+            // would desynchronise WAL replay. Operator will see the parent
+            // stuck and can retry via DELETE; a chronic WAL outage already
+            // triggers the broader backpressure alert.
+            _logger.LogError("WAL backpressure recording terminal {Status}/{Reason} for algo {Firm}/{AlgoId}.",
+                status, reason, algo.FirmId, algo.AlgoId);
+            return;
+        }
+
+        _algoSink.PublishAlgoSnapshot(algo.Owner, algo.FirmId, algo.AlgoId);
+        await Task.CompletedTask;
+    }
+
+    private static (long Quantity, decimal? Price) ComputeNextSlice(Algo algo)
+    {
+        switch (algo.Parameters)
+        {
+            case IcebergParameters ip:
+                {
+                    var qty = Math.Min(ip.DisplayQuantity, algo.RemainingQuantity);
+                    return (qty, ip.LimitPrice);
+                }
+            case TwapParameters tp:
+                {
+                    // TWAP slice sizing is the slice-6 problem; fall back
+                    // to even split here for now so a partial implementation
+                    // doesn't compile-break the iceberg path.
+                    var slices = Math.Max(1, tp.SliceCount);
+                    var qty = Math.Max(1, algo.TotalQuantity / slices);
+                    return (Math.Min(qty, algo.RemainingQuantity), tp.ChildPrice);
+                }
+            default:
+                return (algo.RemainingQuantity, null);
+        }
+    }
+
+    private static bool IsChildTerminal(Order o) =>
+        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
+
     private static string SignalKind(AlgoSignal s) => s switch
     {
         AlgoCreatedSignal => "created",
@@ -72,4 +572,17 @@ public sealed class AlgoEngine : BackgroundService
         ChildExecutionObservedSignal c => c.AlgoId,
         _ => 0,
     };
+
+    /// <summary>
+    /// Mutable per-parent runtime state. Lives only in memory (not
+    /// snapshotted) — recovery rebuilds it from the order book on engine
+    /// start. Not thread-safe; only the single consumer task touches it.
+    /// </summary>
+    private sealed class AlgoParentRuntime
+    {
+        public ulong? LiveChildClOrdId;
+        public int NextSliceSeq;
+        public int RetryAttempts;
+        public Dictionary<ulong, long> ChildBookedCum { get; } = new();
+    }
 }

--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -72,6 +72,17 @@ public sealed class AlgoBook
         return list;
     }
 
+    public IReadOnlyCollection<Algo> EnumerateAll(bool includeTerminal = false)
+    {
+        var list = new List<Algo>(_algos.Count);
+        foreach (var kv in _algos)
+        {
+            if (!includeTerminal && kv.Value.IsTerminal) continue;
+            list.Add(kv.Value);
+        }
+        return list;
+    }
+
     /// <summary>
     /// Captures every algo (terminal included) for a snapshot. Same
     /// rationale as <see cref="WorkingOrderBook.Snapshot"/>: replay-from-WAL

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -110,6 +110,31 @@ public sealed class WorkingOrderBook
         s is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
 
     /// <summary>
+    /// Returns every order whose <see cref="Order.ParentAlgoId"/> matches
+    /// <paramref name="parentAlgoId"/> within the given firm scope. Used by
+    /// the algo engine at boot reconciliation to rebuild per-parent runtime
+    /// state (live child + cumulative-fill baseline) without rescanning the
+    /// full order book on every signal. Index-driven (firm secondary index)
+    /// so cost is O(orders for firm), not O(total orders).
+    /// </summary>
+    public IReadOnlyCollection<Order> EnumerateChildrenOf(string firmId, ulong parentAlgoId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        if (parentAlgoId == 0)
+            throw new ArgumentOutOfRangeException(nameof(parentAlgoId));
+        if (!_byFirm.TryGetValue(firmId, out var firmSet))
+            return Array.Empty<Order>();
+        var list = new List<Order>();
+        foreach (var clOrdId in firmSet.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (order.ParentAlgoId != parentAlgoId) continue;
+            list.Add(order);
+        }
+        return list;
+    }
+
+    /// <summary>
     /// Captures the current set of working orders for snapshotting.
     /// Terminal-state orders (Filled/Cancelled/Rejected) are still
     /// included so that replay-without-snapshot and replay-from-snapshot

--- a/backend/src/B3.Trading.Domain/Algo.cs
+++ b/backend/src/B3.Trading.Domain/Algo.cs
@@ -185,6 +185,24 @@ public sealed class Algo
     }
 
     /// <summary>
+    /// Engine-only hook used at boot reconciliation: fills are NOT journaled
+    /// for algo parents (RFC §4.5 — derived from the child stream), so when
+    /// the platform restarts from WAL alone the parent comes back with
+    /// <see cref="FilledQuantity"/> = 0 even though the child orders carry
+    /// the real cumulative quantity. The engine sums child cums and calls
+    /// this method once during reconciliation so subsequent reactor passes
+    /// see the true remaining quantity. Refuses to move the value backwards
+    /// (snapshot-restored parents already carry the higher truth).
+    /// </summary>
+    public void RehydrateProgress(long filledQuantity)
+    {
+        if (filledQuantity < 0)
+            throw new ArgumentOutOfRangeException(nameof(filledQuantity));
+        if (filledQuantity > FilledQuantity)
+            FilledQuantity = filledQuantity;
+    }
+
+    /// <summary>
     /// Reconstructs an algo from snapshot data. Bypasses the state-machine
     /// invariants because the snapshot was, by construction, produced from
     /// a sequence of valid mutations. Mirrors <see cref="Order.Hydrate"/>.

--- a/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
@@ -179,7 +179,11 @@ public class AlgoEndpointsTests
         var get = await client.GetFromJsonAsync<JsonElement>($"/algo/{algoId}");
         Assert.Equal(algoId, get.GetProperty("algoId").GetString());
         Assert.Equal("PETR4", get.GetProperty("symbol").GetString());
-        Assert.Equal("PendingNew", get.GetProperty("status").GetString());
+        // Engine may have already promoted PendingNew → Working by submitting
+        // the first slice through Mock (no ER comes back so it stays Working
+        // indefinitely). Accept either; GET should never see a terminal state.
+        var status = get.GetProperty("status").GetString();
+        Assert.Contains(status, new[] { "PendingNew", "Working" });
         // Discriminated parameter shape: iceberg block populated, twap null.
         Assert.Equal(JsonValueKind.Object, get.GetProperty("iceberg").ValueKind);
         Assert.Equal(JsonValueKind.Null, get.GetProperty("twap").ValueKind);
@@ -219,9 +223,13 @@ public class AlgoEndpointsTests
         var body = await del.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal("Cancelling", body.GetProperty("status").GetString());
 
-        // Subsequent GET reflects the new status (no engine — stays Cancelling).
+        // Subsequent GET reflects the new status. Mock gateway never delivers
+        // a child cancel-ack so the engine stays in Cancelling indefinitely;
+        // the only racy variant is the engine processing the cancel before a
+        // live child existed (no child to cancel → Cancelled immediately).
         var get = await client.GetFromJsonAsync<JsonElement>($"/algo/{algoId}");
-        Assert.Equal("Cancelling", get.GetProperty("status").GetString());
+        var status = get.GetProperty("status").GetString();
+        Assert.Contains(status, new[] { "Cancelling", "Cancelled" });
     }
 
     [Fact]
@@ -252,9 +260,10 @@ public class AlgoEndpointsTests
     [Fact]
     public async Task DeleteAlgo_AlreadyCancelling_IsIdempotent()
     {
-        // Per RFC: Cancelling-on-Cancelling is a no-op via the aggregate.
-        // Engine never lands so the parent stays in Cancelling indefinitely
-        // for v0; repeated DELETE should keep returning 202 (not 409).
+        // Per RFC: Cancelling-on-Cancelling is a no-op via the aggregate
+        // and the API returns 202 again. Once the engine drives the parent
+        // to a terminal state (Cancelled), subsequent DELETEs return 409
+        // — that's the documented "you're racing the engine" signal.
         using var factory = NewFactory();
         using var client = await factory.CreateAuthedClientAsync();
 
@@ -265,6 +274,6 @@ public class AlgoEndpointsTests
         var first = await client.DeleteAsync($"/algo/{algoId}");
         var second = await client.DeleteAsync($"/algo/{algoId}");
         Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
-        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
+        Assert.Contains(second.StatusCode, new[] { HttpStatusCode.Accepted, HttpStatusCode.Conflict });
     }
 }

--- a/backend/tests/B3.Trading.Api.Tests/AlgoEngineIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoEngineIntegrationTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the algo orders v0 Iceberg engine (RFC §4).
+/// Boots the host with <c>Trading:Exchange:Mode=Simulator</c> so that
+/// child orders the engine submits land in <c>WorkingOrderBook</c>
+/// and synthetic ERs can be driven via <c>POST /admin/simulator/er</c>.
+/// </summary>
+public class AlgoEngineIntegrationTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Simulator",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object IcebergBody(long total, long display, decimal price = 30m) => new
+    {
+        Symbol = "PETR4",
+        Side = "Buy",
+        Type = "Iceberg",
+        TotalQuantity = total,
+        Iceberg = new { DisplayQuantity = display, LimitPrice = (decimal?)price },
+    };
+
+    [Fact]
+    public async Task Iceberg_RefillCycle_ReachesCompletedAfterAllSlicesFilled()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var algoId = await PostAlgo(http, userToken, IcebergBody(total: 300, display: 100));
+
+        // Slice 1 → submitted by the engine. Wait for the child to appear
+        // in the WorkingOrderBook (engine reactor is async).
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForChild(book, algoId, expectedSeq: 0);
+
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
+
+        // Slice 2 should be submitted automatically after the refill.
+        var child2 = await WaitForChild(book, algoId, expectedSeq: 1);
+        await InjectEr(http, adminToken, child2.ClOrdId, "Fill", lastQty: 100);
+
+        var child3 = await WaitForChild(book, algoId, expectedSeq: 2);
+        await InjectEr(http, adminToken, child3.ClOrdId, "Fill", lastQty: 100);
+
+        // Parent should now reach Completed (no more remaining quantity).
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal(300, algo.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal(0, algo.GetProperty("remainingQuantity").GetInt64());
+        Assert.Equal("None", algo.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Iceberg_PartialFillBetweenSlices_AccumulatesIntoParent()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var algoId = await PostAlgo(http, userToken, IcebergBody(total: 200, display: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+
+        var child1 = await WaitForChild(book, algoId, expectedSeq: 0);
+        // Partial fill — child stays Working with 60 booked, 40 leaves.
+        await InjectEr(http, adminToken, child1.ClOrdId, "PartialFill", lastQty: 60);
+        // Engine must NOT submit slice 2 yet (child not terminal).
+        await Task.Delay(100);
+        Assert.DoesNotContain(book.EnumerateChildrenOf("default", ulong.Parse(algoId)),
+            c => c.AlgoSliceSeq == 1);
+
+        // Fill the remaining 40 — child terminal Filled, engine refills.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 40);
+        var child2 = await WaitForChild(book, algoId, expectedSeq: 1);
+        await InjectEr(http, adminToken, child2.ClOrdId, "Fill", lastQty: 100);
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed");
+    }
+
+    [Fact]
+    public async Task Iceberg_DeleteThenChildCancelAck_DrivesParentToCancelledUserCancelled()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var algoId = await PostAlgo(http, userToken, IcebergBody(total: 300, display: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForChild(book, algoId, expectedSeq: 0);
+
+        // Operator cancels — engine asks the gateway to cancel the child;
+        // until the cancel-ack ER lands, the parent is Cancelling.
+        var del = await Authed(http, HttpMethod.Delete, $"/algo/{algoId}", userToken);
+        Assert.Equal(HttpStatusCode.Accepted, del.StatusCode);
+        await WaitForAlgoStatus(http, userToken, algoId, "Cancelling", "Cancelled");
+
+        // Drive the cancel-ack — the engine should now mark the parent
+        // Cancelled with UserCancelled because the parent was in Cancelling.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await WaitForAlgoStatus(http, userToken, algoId, "Cancelled");
+
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("UserCancelled", algo.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Iceberg_VenueCancelOfChild_WithoutOperatorRequest_SuspendsParent()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var algoId = await PostAlgo(http, userToken, IcebergBody(total: 200, display: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForChild(book, algoId, expectedSeq: 0);
+
+        // Venue cancels without operator request — engine must suspend
+        // (auto-refilling against an unhappy venue can spin a tight loop).
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await WaitForAlgoStatus(http, userToken, algoId, "Suspended");
+
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("VenueCancelled", algo.GetProperty("terminalReason").GetString());
+    }
+
+    // -- helpers ----------------------------------------------------------
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<HttpResponseMessage> Authed(HttpClient http, HttpMethod method, string path, string token)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    /// <summary>
+    /// Polls the in-memory order book for a child slice with the given
+    /// <c>AlgoSliceSeq</c>. Necessary because the engine reactor consumes
+    /// signals off a Channel asynchronously — child orders appear after a
+    /// short scheduling delay rather than synchronously with the API call.
+    /// </summary>
+    private static async Task<Order> WaitForChild(WorkingOrderBook book, string algoIdStr, int expectedSeq)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var match = book.EnumerateChildrenOf("default", algoId)
+                .FirstOrDefault(c => c.AlgoSliceSeq == expectedSeq);
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"Child for algo {algoIdStr} seq {expectedSeq} did not appear within 5s.");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Domain.Tests/AlgoTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/AlgoTests.cs
@@ -122,4 +122,25 @@ public class AlgoTests
         Assert.Throws<InvalidOperationException>(() =>
             algo.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, DateTimeOffset.UtcNow));
     }
+
+    [Fact]
+    public void RehydrateProgress_AdvancesFilledQuantity_NeverBackwards()
+    {
+        var algo = NewIceberg(total: 1000);
+        algo.RehydrateProgress(300);
+        Assert.Equal(300, algo.FilledQuantity);
+        // Never moves backwards: snapshot-restored parents already carry
+        // the higher truth, engine reconciliation must not regress.
+        algo.RehydrateProgress(200);
+        Assert.Equal(300, algo.FilledQuantity);
+        algo.RehydrateProgress(700);
+        Assert.Equal(700, algo.FilledQuantity);
+    }
+
+    [Fact]
+    public void RehydrateProgress_NegativeArgument_Throws()
+    {
+        var algo = NewIceberg();
+        Assert.Throws<ArgumentOutOfRangeException>(() => algo.RehydrateProgress(-1));
+    }
 }


### PR DESCRIPTION
## What

Slice 5b of the algo orders v0 RFC: wire the AlgoEngine BackgroundService skeleton from slice 5a (PR #54) into a working **Iceberg reactor** that consumes `AlgoSignal`s and drives parent algos through their slice lifecycle.

Refs RFC §4.3 (engine), §4.4 (Iceberg semantics), §4.5 (fills derived from child stream), §4.7 (terminal taxonomy).

## Reactor

`AlgoEngine.cs` (~400 LoC) replaces the no-op consumer:

- **Per-parent runtime state** — `ConcurrentDictionary<(firmId, algoId), AlgoParentRuntime>` tracks live child ClOrdId, next slice seq, retry attempts, and per-child cum-booked watermark.
- **`OnCreatedAsync`** — skips terminal/Cancelling/has-live-child; if Remaining==0 marks Completed; else `SubmitNextSliceAsync`.
- **`OnChildErAsync`** — books cum-delta via `algo.RecordFill` (idempotent under replay); on terminal Filled refills or completes; on Cancelled distinguishes `UserCancelled` (parent in Cancelling) vs `VenueCancelled` → Suspended; on Rejected → Suspended/RiskRejected.
- **`OnCancelRequestedAsync`** — no-live-child → Cancelled/UserCancelled immediately; else `gateway.CancelAsync`, terminalization waits for cancel-ack ER (matches replay semantics — WAL records ER, not intent).
- **`SubmitNextSliceAsync`** — 3 retries with 100/300/900ms delays for GatewayFailed/WalBackpressure; suspends with appropriate reason on terminal failure.
- **`ComputeNextSlice`** — Iceberg = `min(displayQty, remaining)`; TWAP even split (deferred to slice 6).
- **`RecordTerminalAsync`** — dispatches `AlgoTerminalStateRecordedEvent` + `algo.RecordTerminal` under WAL lock; on `WalBackpressureException` does NOT mutate the aggregate (would desync replay) — logs loud + leaves the parent for operator retry.
- **`Reconcile()`** boot pass — scans non-terminal algos, sums child cums, `RehydrateProgress(totalCum)`, detects `max(AlgoSliceSeq)+1` as next seq, re-enqueues `AlgoCreatedSignal` so reactor evaluates same code path as steady state.

## Domain / book extensions

- `Algo.RehydrateProgress(long)` — forward-only filled-quantity hydration for boot.
- `AlgoBook.EnumerateAll(includeTerminal=false)`.
- `WorkingOrderBook.EnumerateChildrenOf(firmId, parentAlgoId)` — firm-isolated lookup.

## Wire

- `OrderDto` gains `ParentAlgoId` (string?) + `AlgoSliceSeq` (int?), defaulted to null (additive).

## Tests

- **`AlgoEngineIntegrationTests` (NEW, 4)**, all in Simulator mode:
  1. Iceberg refill cycle reaches `Completed` after all slices fill.
  2. Partial fill between slices accumulates into parent (no refill until child terminal).
  3. `DELETE /algo` + child cancel-ack drives parent to Cancelled/UserCancelled.
  4. Venue-initiated child cancel without operator request suspends parent (Suspended/VenueCancelled).
- **`AlgoTests`** +2 unit tests for `RehydrateProgress` (forward-only; negative throws).
- **`AlgoEndpointsTests`** 3 tests relaxed for engine-aware semantics (`PendingNew|Working`, `Cancelling|Cancelled`, `Accepted|Conflict`) since the engine now actively transitions parents instead of leaving them in PendingNew forever.

Suite: **32 / 200 / 118 / 8-skip** green. `dotnet format` clean.

## Notes

- Single consumer (RFC §4.3) → no per-parent semaphore needed; `ConcurrentDictionary` for convenience but never has concurrent writers.
- Retry inline via `Task.Delay` blocks the consumer up to 1.3s; acceptable trade-off for v0 (algo flow is low-volume). Future work: dedicated retry queue.
- Fills are derived, not journaled (RFC §4.5) — `parent.FilledQty` is reconstructed from the child stream on every replay via `Reconcile()`.
- Iceberg child is hard-coded `Limit` with the `IcebergParameters.LimitPrice`; TWAP wiring stays no-op until slice 6.

## Next

Slice 6 — TWAP scheduler (time-driven slicing + window expiry).
