### PR TITLE
feat(algo): slice 6 — TWAP scheduler + window expiry

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -116,6 +116,19 @@ public static class AlgoEndpoints
                     // unpriced child orders that contradict the user's chosen type.
                     if (childType == OrderType.Limit && req.Twap.ChildPrice is null)
                         return Results.BadRequest(new { error = "twap.childPrice is required when twap.childOrderType is Limit" });
+                    // RFC §4.8: reject when the implied per-slice quantity
+                    // rounds to zero. Echo the floor in the error body so
+                    // the caller can lower sliceCount or raise totalQuantity
+                    // without guessing.
+                    var floorQty = TwapPlan.FloorSliceQty(req.TotalQuantity, req.Twap.SliceCount);
+                    if (floorQty <= 0)
+                        return Results.BadRequest(new
+                        {
+                            error = "twap.sliceCount produces a per-slice quantity of zero",
+                            impliedSliceQuantity = floorQty,
+                            totalQuantity = req.TotalQuantity,
+                            sliceCount = req.Twap.SliceCount,
+                        });
                     parameters = new TwapParameters(
                         req.Twap.StartUtc, req.Twap.EndUtc, req.Twap.SliceCount,
                         childType, req.Twap.ChildPrice);

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -73,6 +73,7 @@ public sealed class AlgoEngine : BackgroundService
     private readonly IExchangeGateway _gateway;
     private readonly IAlgoEventSink _algoSink;
     private readonly EventDispatcher _dispatcher;
+    private readonly TimeProvider _clock;
     private readonly ILogger<AlgoEngine> _logger;
 
     // Per-parent runtime state. Owned by the consumer task; the
@@ -90,6 +91,7 @@ public sealed class AlgoEngine : BackgroundService
         IExchangeGateway gateway,
         IAlgoEventSink algoSink,
         EventDispatcher dispatcher,
+        TimeProvider clock,
         ILogger<AlgoEngine> logger)
     {
         _queue = queue;
@@ -100,6 +102,7 @@ public sealed class AlgoEngine : BackgroundService
         _gateway = gateway;
         _algoSink = algoSink;
         _dispatcher = dispatcher;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -109,7 +112,7 @@ public sealed class AlgoEngine : BackgroundService
         Reconcile();
         try
         {
-            await foreach (var signal in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            await foreach (var signal in _queue.ReadAllAsync(stoppingToken).ConfigureAwait(false))
             {
                 MetricsRegistry.AlgoSignalsConsumed.Add(1,
                     new KeyValuePair<string, object?>("kind", SignalKind(signal)));
@@ -244,7 +247,8 @@ public sealed class AlgoEngine : BackgroundService
         {
             // A child is already outstanding (steady-state or post-recovery).
             // Idempotent no-op — when the child reaches terminal we'll
-            // refill via OnChildErAsync.
+            // refill (Iceberg) or wait for the next scheduled tick (TWAP)
+            // via OnChildErAsync.
             _logger.LogDebug(
                 "AlgoEngine OnCreated: algo {Firm}/{AlgoId} already has live child {Child}; no resubmit.",
                 algo.FirmId, algo.AlgoId, existing);
@@ -258,6 +262,42 @@ public sealed class AlgoEngine : BackgroundService
             // Promote to Completed now so /algo reflects truth.
             await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
             return;
+        }
+
+        // TWAP: scheduling decisions for "is the next slice due?" and
+        // "has the window expired?" live here. The scheduler thread fires
+        // an AlgoCreatedSignal at every relevant transition; the engine
+        // re-evaluates from scratch using the deterministic plan so the
+        // two threads cannot drift.
+        if (algo.Type == AlgoType.Twap && algo.Parameters is TwapParameters tp)
+        {
+            var now = _clock.GetUtcNow();
+            if (now >= tp.EndUtc)
+            {
+                // Window passed (mid-execution OR during downtime). RFC
+                // §4.6: parent transitions to Expired with the residue
+                // preserved on FilledQuantity. If RemainingQuantity is
+                // zero the earlier branch above already routed to
+                // Completed.
+                await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
+                return;
+            }
+
+            if (rt.NextSliceSeq >= tp.SliceCount)
+            {
+                // Plan exhausted but residue remains and window still
+                // open — no slices left to submit; wait for window
+                // expiry to mark Expired.
+                return;
+            }
+
+            var dueAt = TwapPlan.PlannedAtUtc(tp.StartUtc, tp.EndUtc, tp.SliceCount, rt.NextSliceSeq);
+            if (now < dueAt)
+            {
+                // Not due yet — scheduler will re-fire when plannedAtUtc
+                // arrives. No-op (idempotent under tick storms).
+                return;
+            }
         }
 
         await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
@@ -310,6 +350,23 @@ public sealed class AlgoEngine : BackgroundService
                     return;
                 }
                 rt.RetryAttempts = 0;
+                if (algo.Type == AlgoType.Twap && algo.Parameters is TwapParameters tpFilled)
+                {
+                    // TWAP child finished but residue remains. The
+                    // scheduler — not the engine — drives the next slice:
+                    // the next AlgoCreatedSignal will arrive at
+                    // plannedAtUtc(NextSliceSeq) (or sooner if catch-up
+                    // is needed). RFC §4.6 forbids the engine from
+                    // bursting slices on its own. Window-expired-during-
+                    // child-fill is also handled here: if the window
+                    // already passed there is no point waiting for the
+                    // scheduler tick.
+                    if (_clock.GetUtcNow() >= tpFilled.EndUtc)
+                    {
+                        await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
+                    }
+                    return;
+                }
                 await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
                 return;
 
@@ -321,6 +378,16 @@ public sealed class AlgoEngine : BackgroundService
                     // FilledQuantity already reflects any partial that
                     // landed before the cancel-ack.
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
+                }
+                else if (IsTwapWindowExpired(algo))
+                {
+                    // RFC §4.6 "window passed during downtime AND child was
+                    // live": engine reconciles the child via the ordinary
+                    // ER path, then evaluates the parent — if not Completed,
+                    // mark Expired regardless of why the child terminated.
+                    // Window-expiry is the more specific signal here than
+                    // VenueCancelled.
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
                 }
                 else
                 {
@@ -335,10 +402,20 @@ public sealed class AlgoEngine : BackgroundService
 
             case OrderStatus.Rejected:
                 if (algo.IsTerminal) return;
+                if (IsTwapWindowExpired(algo))
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
+                    return;
+                }
                 await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
                 return;
         }
     }
+
+    private bool IsTwapWindowExpired(Algo algo) =>
+        algo.Type == AlgoType.Twap
+        && algo.Parameters is TwapParameters tp
+        && _clock.GetUtcNow() >= tp.EndUtc;
 
     private async Task OnCancelRequestedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
     {
@@ -531,7 +608,7 @@ public sealed class AlgoEngine : BackgroundService
         await Task.CompletedTask;
     }
 
-    private static (long Quantity, decimal? Price) ComputeNextSlice(Algo algo)
+    private (long Quantity, decimal? Price) ComputeNextSlice(Algo algo)
     {
         switch (algo.Parameters)
         {
@@ -542,12 +619,20 @@ public sealed class AlgoEngine : BackgroundService
                 }
             case TwapParameters tp:
                 {
-                    // TWAP slice sizing is the slice-6 problem; fall back
-                    // to even split here for now so a partial implementation
-                    // doesn't compile-break the iceberg path.
-                    var slices = Math.Max(1, tp.SliceCount);
-                    var qty = Math.Max(1, algo.TotalQuantity / slices);
-                    return (Math.Min(qty, algo.RemainingQuantity), tp.ChildPrice);
+                    // Deterministic per-slice quantity (RFC §4.8): floor on
+                    // slices 0..n-2 and the remainder on the last slice so
+                    // the parent total reconciles exactly. Recovery
+                    // re-derives the same numbers from the parameters
+                    // alone — no separate persisted plan.
+                    var rt = _runtime[(algo.FirmId, algo.AlgoId)];
+                    var seq = rt.NextSliceSeq;
+                    var planned = TwapPlan.SliceQty(algo.TotalQuantity, tp.SliceCount, seq);
+                    // Cap at remaining: fills from earlier slices may
+                    // partially-cancel a slice and shift residue forward,
+                    // so the planned quantity can exceed what's actually
+                    // outstanding.
+                    var qty = Math.Min(planned, algo.RemainingQuantity);
+                    return (qty, tp.ChildPrice);
                 }
             default:
                 return (algo.RemainingQuantity, null);

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -1,0 +1,224 @@
+using System.Diagnostics;
+using B3.Trading.Application.Observability;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Time-driven driver for TWAP parents (RFC algo-orders-v0 §4.6 + §4.11).
+/// Runs on its own hosted-service thread separate from the
+/// <see cref="AlgoEngine"/> consumer so slice-firing latency is bounded
+/// by the periodic tick interval and is never coupled to consumer-side
+/// work (iceberg refills, terminal-state recording).
+///
+/// <para>
+/// <b>Scheduling model.</b> A simple periodic 100ms tick. Each tick scans
+/// non-terminal TWAP parents and asks one question: "is the next due
+/// slice's <c>plannedAtUtc &lt;= now</c> AND there is no live child?" If
+/// yes, enqueue an <see cref="AlgoCreatedSignal"/> so the engine
+/// re-evaluates the same code path it uses at submit time. The engine —
+/// not the scheduler — is the sole writer of slice signals to keep the
+/// reactor's idempotency contract intact.
+/// </para>
+///
+/// <para>
+/// <b>No catch-up burst.</b> RFC §4.6 explicitly forbids dumping a backlog
+/// of skipped slices in one tick: at most one slice per parent per tick.
+/// A recovered host that was down for several minutes therefore catches
+/// up at 100ms granularity, which is "no faster than TWAP itself would
+/// have produced + one." This scheduler enforces it implicitly: it
+/// enqueues exactly one <see cref="AlgoCreatedSignal"/> per parent per
+/// tick, and the engine's per-parent serialisation guarantees the next
+/// slice does not fire until the previous child reports back terminal.
+/// </para>
+///
+/// <para>
+/// <b>Window expiry.</b> When <c>now &gt;= endUtc</c> the scheduler
+/// enqueues an <see cref="AlgoCreatedSignal"/> too — the engine handler
+/// recognises the expired-window case and transitions the parent to
+/// <c>Expired/TwapWindowExpired</c>. Doing the transition through the
+/// engine (rather than the scheduler directly) keeps WAL writes
+/// single-threaded and keeps the post-restart code path identical to
+/// steady state.
+/// </para>
+///
+/// <para>
+/// <b>Promotion plan.</b> RFC §4.11 deferred-B leaves periodic-tick →
+/// min-heap → time-wheel as future work, gated on benchmarks from the
+/// metrics this slice ships
+/// (<c>algo.scheduler.tick_duration</c>, <c>algo.twap.slice_fire_jitter</c>).
+/// </para>
+/// </summary>
+public sealed class AlgoScheduler : BackgroundService
+{
+    /// <summary>
+    /// Tick interval. 100ms is the RFC §4.11 v0 pick — large enough that
+    /// the periodic-tick scan stays trivially cheap on modest fleets,
+    /// small enough that slice-fire jitter is well below human-noticeable
+    /// latency. Tuneable via the constructor for tests that need a
+    /// faster clock.
+    /// </summary>
+    public static readonly TimeSpan DefaultTickInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly AlgoBook _algos;
+    private readonly WorkingOrderBook _orders;
+    private readonly IAlgoSignalQueue _signals;
+    private readonly TimeProvider _clock;
+    private readonly TimeSpan _tickInterval;
+    private readonly ILogger<AlgoScheduler> _logger;
+
+    public AlgoScheduler(
+        AlgoBook algos,
+        WorkingOrderBook orders,
+        IAlgoSignalQueue signals,
+        TimeProvider clock,
+        ILogger<AlgoScheduler> logger)
+        : this(algos, orders, signals, clock, DefaultTickInterval, logger)
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly constructor; production resolution uses the
+    /// <see cref="DefaultTickInterval"/> overload.
+    /// </summary>
+    public AlgoScheduler(
+        AlgoBook algos,
+        WorkingOrderBook orders,
+        IAlgoSignalQueue signals,
+        TimeProvider clock,
+        TimeSpan tickInterval,
+        ILogger<AlgoScheduler> logger)
+    {
+        if (tickInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tickInterval));
+        _algos = algos;
+        _orders = orders;
+        _signals = signals;
+        _clock = clock;
+        _tickInterval = tickInterval;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AlgoScheduler starting (tick={TickMs}ms).", _tickInterval.TotalMilliseconds);
+        // PeriodicTimer is the right primitive: it does not drift on slow
+        // ticks (next fire is still aligned to wall-clock interval) and
+        // releases the thread between ticks.
+        using var timer = new PeriodicTimer(_tickInterval, _clock);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                var sw = ValueStopwatch.StartNew();
+                try
+                {
+                    Tick();
+                }
+                catch (Exception ex)
+                {
+                    // Tick must never throw out — that would kill the
+                    // scheduler thread and silently freeze every TWAP
+                    // parent on the host. Log + carry on.
+                    _logger.LogError(ex, "AlgoScheduler tick failed; continuing.");
+                }
+                MetricsRegistry.AlgoSchedulerTickDuration.Record(sw.GetElapsedMilliseconds());
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        finally
+        {
+            _logger.LogInformation("AlgoScheduler stopped.");
+        }
+    }
+
+    /// <summary>
+    /// Single tick body. Public for tests so they can drive the scheduler
+    /// deterministically without spinning the timer.
+    /// </summary>
+    public void Tick()
+    {
+        var now = _clock.GetUtcNow();
+        var algos = _algos.EnumerateAll(includeTerminal: false);
+        foreach (var algo in algos)
+        {
+            if (algo.Type != AlgoType.Twap) continue;
+            if (algo.IsTerminal) continue;
+            if (algo.Status == AlgoStatus.Cancelling) continue;
+            if (algo.Parameters is not TwapParameters tp) continue;
+
+            // Window expiry is independent of slice progress: even if more
+            // slices are nominally scheduled, once endUtc has passed the
+            // engine must promote to Expired so the parent stops counting
+            // as "live work" everywhere.
+            if (now >= tp.EndUtc)
+            {
+                Enqueue(algo);
+                continue;
+            }
+
+            // Determine "is there a live child?" and "what's the next
+            // slice we owe?" by scanning the order book — the scheduler
+            // intentionally does not share state with the engine to keep
+            // the threads decoupled (RFC §4.11 commitment 1).
+            int maxSeq = -1;
+            bool hasLiveChild = false;
+            foreach (var child in _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId))
+            {
+                if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
+                if (!IsChildTerminal(child)) hasLiveChild = true;
+            }
+            if (hasLiveChild) continue;
+
+            var nextSeq = maxSeq + 1;
+            if (nextSeq >= tp.SliceCount) continue; // plan exhausted; wait for endUtc
+
+            var dueAt = TwapPlan.PlannedAtUtc(tp.StartUtc, tp.EndUtc, tp.SliceCount, nextSeq);
+            if (now < dueAt) continue;
+
+            // Slice fire: capture jitter as (now - plannedAtUtc) before
+            // the channel write so dropped signals still surface in the
+            // metric.
+            MetricsRegistry.AlgoTwapSliceFireJitter.Record((now - dueAt).TotalMilliseconds);
+            Enqueue(algo);
+        }
+    }
+
+    private void Enqueue(Algo algo)
+    {
+        if (!_signals.TryEnqueue(new AlgoCreatedSignal { FirmId = algo.FirmId, AlgoId = algo.AlgoId }))
+        {
+            MetricsRegistry.AlgoSignalsDropped.Add(1,
+                new KeyValuePair<string, object?>("kind", "scheduler"));
+            _logger.LogWarning(
+                "AlgoScheduler dropped signal for {Firm}/{AlgoId} (queue full).",
+                algo.FirmId, algo.AlgoId);
+        }
+    }
+
+    private static bool IsChildTerminal(Order o) =>
+        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
+
+    /// <summary>
+    /// Cheap stopwatch-equivalent that avoids allocating a Stopwatch per
+    /// tick. <see cref="Stopwatch"/>'s allocation overhead is negligible
+    /// in absolute terms but the scheduler ticks 10x/sec so it adds up.
+    /// </summary>
+    private readonly struct ValueStopwatch
+    {
+        private static readonly double TimestampToMs = 1000d / Stopwatch.Frequency;
+
+        private readonly long _start;
+
+        private ValueStopwatch(long start) => _start = start;
+
+        public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
+
+        public double GetElapsedMilliseconds() => (Stopwatch.GetTimestamp() - _start) * TimestampToMs;
+    }
+}

--- a/backend/src/B3.Trading.Application/Algo/AlgoSignalQueue.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoSignalQueue.cs
@@ -43,13 +43,35 @@ public sealed class AlgoSignalQueue : IAlgoSignalQueue
     public bool TryEnqueue(AlgoSignal signal)
     {
         ArgumentNullException.ThrowIfNull(signal);
-        return _channel.Writer.TryWrite(signal);
+        if (_channel.Writer.TryWrite(signal))
+        {
+            Observability.MetricsRegistry.AlgoSignalQueueDepth.Add(1);
+            return true;
+        }
+        return false;
     }
 
     /// <summary>
     /// Async stream consumed by the engine's hosted-service loop. Completes
-    /// when <see cref="Complete"/> is called (host shutdown).
+    /// when <see cref="Complete"/> is called (host shutdown). Wraps the raw
+    /// channel reader so the consumer's per-signal dequeue updates the
+    /// queue-depth gauge — keeping the metric symmetric with
+    /// <see cref="TryEnqueue"/>.
     /// </summary>
+    public IAsyncEnumerable<AlgoSignal> ReadAllAsync(CancellationToken ct) =>
+        ReadAllInternalAsync(ct);
+
+    private async IAsyncEnumerable<AlgoSignal> ReadAllInternalAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var signal in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        {
+            Observability.MetricsRegistry.AlgoSignalQueueDepth.Add(-1);
+            yield return signal;
+        }
+    }
+
+    /// <summary>Direct channel reader access (legacy call sites; new code should use <see cref="ReadAllAsync"/>).</summary>
     public ChannelReader<AlgoSignal> Reader => _channel.Reader;
 
     public void Complete() => _channel.Writer.TryComplete();

--- a/backend/src/B3.Trading.Application/Algo/TwapPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/TwapPlan.cs
@@ -1,0 +1,88 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pure helpers that produce the deterministic slice plan for a TWAP
+/// parent (RFC algo-orders-v0 §4.6 + §4.8).
+///
+/// <para>
+/// The plan is intentionally <b>not</b> persisted as a separate artefact —
+/// it is fully derivable from <c>(startUtc, endUtc, sliceCount,
+/// totalQuantity)</c>. Recovery just re-runs the same functions to
+/// reproduce the schedule, so engine and scheduler agree on slice timing
+/// and quantity by construction (no drift between the two threads).
+/// </para>
+///
+/// <para>
+/// <b>Spacing.</b> Slice <c>k</c> fires at <c>start + k * (end - start) / sliceCount</c>.
+/// Slice 0 fires at <c>startUtc</c>; the last slice (<c>sliceCount-1</c>)
+/// fires at <c>start + (sliceCount-1)/sliceCount * window</c>. Window
+/// expiry is checked separately at <c>endUtc</c> — no slice is scheduled
+/// at or after <c>endUtc</c>.
+/// </para>
+///
+/// <para>
+/// <b>Quantity rounding.</b> Slices 0..n-2 each carry <c>floor(total/n)</c>
+/// and slice n-1 carries the remainder, so the parent total matches
+/// exactly. Lot-size rounding (RFC §4.8) is deferred until the lot-size
+/// table lands; v0 treats the floor as both the rounded and the unrounded
+/// value.
+/// </para>
+/// </summary>
+public static class TwapPlan
+{
+    /// <summary>
+    /// UTC instant at which slice <paramref name="sliceSeq"/> is due to
+    /// fire. Pure function of the parent parameters; no clock side effect.
+    /// </summary>
+    public static DateTimeOffset PlannedAtUtc(
+        DateTimeOffset startUtc, DateTimeOffset endUtc, int sliceCount, int sliceSeq)
+    {
+        if (sliceCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sliceCount), "sliceCount must be positive.");
+        if (sliceSeq < 0 || sliceSeq >= sliceCount)
+            throw new ArgumentOutOfRangeException(nameof(sliceSeq),
+                $"sliceSeq must be in [0,{sliceCount}).");
+        if (endUtc <= startUtc)
+            throw new ArgumentException("endUtc must be after startUtc.", nameof(endUtc));
+
+        // Compute the offset in ticks to avoid floating-point drift across
+        // recoveries. The plan must be byte-identical between scheduler
+        // ticks and post-restart reconciliation.
+        var windowTicks = (endUtc - startUtc).Ticks;
+        var offsetTicks = windowTicks * sliceSeq / sliceCount;
+        return startUtc.AddTicks(offsetTicks);
+    }
+
+    /// <summary>
+    /// Quantity for slice <paramref name="sliceSeq"/>. All but the last
+    /// slice get <c>floor(total/sliceCount)</c>; the last slice carries
+    /// the remainder so the parent total reconciles exactly.
+    /// </summary>
+    public static long SliceQty(long totalQuantity, int sliceCount, int sliceSeq)
+    {
+        if (totalQuantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(totalQuantity), "totalQuantity must be positive.");
+        if (sliceCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sliceCount), "sliceCount must be positive.");
+        if (sliceSeq < 0 || sliceSeq >= sliceCount)
+            throw new ArgumentOutOfRangeException(nameof(sliceSeq),
+                $"sliceSeq must be in [0,{sliceCount}).");
+
+        var floorQty = totalQuantity / sliceCount;
+        if (sliceSeq < sliceCount - 1)
+            return floorQty;
+
+        // Last slice: pick up whatever the floor-rounding left on the
+        // table so sum-of-slices == totalQuantity exactly.
+        var prior = floorQty * (sliceCount - 1);
+        return totalQuantity - prior;
+    }
+
+    /// <summary>
+    /// Per-slice floor quantity (RFC §4.8); echoed in the
+    /// <c>POST /algo</c> error body when validation rejects the
+    /// parameters because the implied per-slice quantity is zero.
+    /// </summary>
+    public static long FloorSliceQty(long totalQuantity, int sliceCount) =>
+        sliceCount <= 0 ? 0 : totalQuantity / sliceCount;
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -93,6 +93,31 @@ public static class MetricsRegistry
     public static readonly Counter<long> AlgoChildrenSubmitted =
         Meter.CreateCounter<long>("trading.algo.children_submitted");
 
+    // TWAP scheduler observability (RFC §4.11). Jitter is the wall-clock
+    // delay between the deterministic plannedAtUtc and the moment the
+    // scheduler actually enqueued the slice signal — captures both
+    // scheduler-tick granularity (~100ms) and consumer back-pressure.
+    public static readonly Histogram<double> AlgoTwapSliceFireJitter =
+        Meter.CreateHistogram<double>(
+            "trading.algo.twap.slice_fire_jitter",
+            unit: "ms",
+            description: "now − plannedAtUtc at the moment the scheduler fires a TWAP slice.");
+    // How long a single scheduler tick takes end-to-end. Surfaces "the
+    // scheduler is starting to spend non-trivial time in its tick" before
+    // tick interval starts to slip.
+    public static readonly Histogram<double> AlgoSchedulerTickDuration =
+        Meter.CreateHistogram<double>(
+            "trading.algo.scheduler.tick_duration",
+            unit: "ms",
+            description: "Wall-clock duration of a single AlgoScheduler tick.");
+    // Live depth of the algo signal channel. Healthy operation has this
+    // close to zero; a sustained climb means the consumer is falling
+    // behind the scheduler/ER hot path.
+    public static readonly UpDownCounter<long> AlgoSignalQueueDepth =
+        Meter.CreateUpDownCounter<long>(
+            "trading.algo.signal_queue_depth",
+            description: "Estimated number of signals queued for the AlgoEngine consumer.");
+
     /// <summary>
     /// 1 when the host booted with <c>ExchangeMode.Simulator</c> active, 0
     /// otherwise. Set once at startup and never decremented (mode is fixed

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -64,11 +64,13 @@ builder.Services.AddSingleton<ExecutionReportProcessor>();
 builder.Services.AddSingleton<OrderSubmissionService>();
 
 // Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).
-// In slice 5a the consumer body is a no-op reactor; slice 5b plugs in the
-// Iceberg state machine.
+// In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the
+// Iceberg state machine; slice 6 adds the AlgoScheduler hosted service that
+// drives TWAP slice firing on a separate thread (RFC §4.11 commitment 1).
 builder.Services.AddSingleton<AlgoSignalQueue>();
 builder.Services.AddSingleton<IAlgoSignalQueue>(sp => sp.GetRequiredService<AlgoSignalQueue>());
 builder.Services.AddHostedService<AlgoEngine>();
+builder.Services.AddHostedService<AlgoScheduler>();
 builder.Services.AddSingleton<JwtIssuer>();
 
 // Lifecycle: drain flag flipped on SIGTERM /

--- a/backend/tests/B3.Trading.Api.Tests/AlgoTwapIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoTwapIntegrationTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the algo orders v0 TWAP engine (RFC §4.6 +
+/// §4.8). Boots the host with <c>Trading:Exchange:Mode=Simulator</c> so
+/// the scheduler-driven child orders land in <c>WorkingOrderBook</c> and
+/// synthetic ERs can be driven via <c>POST /admin/simulator/er</c>.
+///
+/// <para>
+/// These tests use real wall-clock time deliberately. Tightly-bounded
+/// TWAP windows (sub-second) keep them fast; the scheduler ticks every
+/// 100ms in the host so a slice typically fires within ~150ms of becoming
+/// due. Generous polling timeouts (5s) absorb CI scheduling jitter.
+/// </para>
+/// </summary>
+public class AlgoTwapIntegrationTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Simulator",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object TwapBody(long total, int sliceCount, DateTimeOffset start, DateTimeOffset end,
+        string childType = "Limit", decimal? childPrice = 30m) => new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Twap",
+            TotalQuantity = total,
+            Twap = new
+            {
+                StartUtc = start,
+                EndUtc = end,
+                SliceCount = sliceCount,
+                ChildOrderType = childType,
+                ChildPrice = childPrice,
+            },
+        };
+
+    [Fact]
+    public async Task Twap_AllSlicesDueAtSubmit_FiresOnePerTickUntilCompleted()
+    {
+        // Window opens 5s in the past and closes 5s in the future:
+        // every slice's plannedAtUtc is already <= now, so the
+        // scheduler immediately starts firing slices. The "no catch-up
+        // burst" rule (RFC §4.6) means slices fire one-at-a-time at
+        // tick granularity; the engine's per-parent serialisation
+        // (one in-flight child) keeps them strictly sequential.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            TwapBody(total: 300, sliceCount: 3,
+                start: now.AddSeconds(-5), end: now.AddSeconds(5)));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+
+        // Slices 0..2 each carry 100 (300/3 even split).
+        var s0 = await WaitForChild(book, algoId, expectedSeq: 0);
+        Assert.Equal(100, s0.Quantity);
+        await InjectEr(http, adminToken, s0.ClOrdId, "Fill", lastQty: 100);
+
+        var s1 = await WaitForChild(book, algoId, expectedSeq: 1);
+        Assert.Equal(100, s1.Quantity);
+        await InjectEr(http, adminToken, s1.ClOrdId, "Fill", lastQty: 100);
+
+        var s2 = await WaitForChild(book, algoId, expectedSeq: 2);
+        Assert.Equal(100, s2.Quantity);
+        await InjectEr(http, adminToken, s2.ClOrdId, "Fill", lastQty: 100);
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal(300, algo.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal("None", algo.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Twap_LastSliceCarriesRemainder()
+    {
+        // 1003 / 3 = 334 floor → slices 0,1 = 334 each, slice 2 = 335.
+        // Verifies §4.8 last-slice-remainder rule end-to-end.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            TwapBody(total: 1003, sliceCount: 3,
+                start: now.AddSeconds(-15), end: now.AddSeconds(5)));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var s0 = await WaitForChild(book, algoId, expectedSeq: 0);
+        Assert.Equal(334, s0.Quantity);
+        await InjectEr(http, adminToken, s0.ClOrdId, "Fill", lastQty: 334);
+
+        var s1 = await WaitForChild(book, algoId, expectedSeq: 1);
+        Assert.Equal(334, s1.Quantity);
+        await InjectEr(http, adminToken, s1.ClOrdId, "Fill", lastQty: 334);
+
+        var s2 = await WaitForChild(book, algoId, expectedSeq: 2);
+        Assert.Equal(335, s2.Quantity); // remainder lands on the last slice
+        await InjectEr(http, adminToken, s2.ClOrdId, "Fill", lastQty: 335);
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal(1003, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task Twap_WindowExpiresWithoutFill_ParentBecomesExpired()
+    {
+        // Tight window: slice 0 fires immediately, then we let the
+        // window pass without injecting any fill on the live child.
+        // Eventually we cancel the child via the simulator; engine
+        // observes child terminalize past endUtc and routes the
+        // parent to Expired/TwapWindowExpired (RFC §4.6 "window
+        // passed during downtime AND child was live").
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            TwapBody(total: 100, sliceCount: 1,
+                start: now.AddSeconds(-1), end: now.AddMilliseconds(500)));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var s0 = await WaitForChild(book, algoId, expectedSeq: 0);
+
+        // Wait past the window end so the scheduler's expiry path is
+        // armed by the time the child terminalizes.
+        await Task.Delay(800);
+
+        // Cancel the live child so the engine can re-evaluate the
+        // parent. Per the engine's window-aware cancel handling, this
+        // routes the parent to Expired (not VenueCancelled) because
+        // endUtc < now at the moment the child terminalizes.
+        await InjectEr(http, adminToken, s0.ClOrdId, "Canceled");
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("TwapWindowExpired", algo.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Twap_NoChildSubmitted_WindowExpires_SchedulerDrivesExpired()
+    {
+        // Edge case: a TWAP submitted with the entire window already in
+        // the past (clock-skew or operator-replay scenario). No child
+        // is — or can be — submitted; the engine's first reactor pass
+        // (driven by the immediate AlgoCreatedSignal POST emits) sees
+        // now >= endUtc with no live child and routes to Expired.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            TwapBody(total: 100, sliceCount: 1,
+                start: now.AddSeconds(-2), end: now.AddSeconds(-1)));
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("TwapWindowExpired", algo.GetProperty("terminalReason").GetString());
+        Assert.Equal(0, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    // ───────────────────────── helpers (parallel to AlgoEngineIntegrationTests) ─────────────────────────
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<Order> WaitForChild(WorkingOrderBook book, string algoIdStr, int expectedSeq)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var match = book.EnumerateChildrenOf("default", algoId)
+                .FirstOrDefault(c => c.AlgoSliceSeq == expectedSeq);
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"Child for algo {algoIdStr} seq {expectedSeq} did not appear within 5s.");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class AlgoSchedulerTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset End = new(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+    private const string Firm = "TEST";
+
+    /// <summary>Minimal mutable clock so tests can step time forward deterministically.</summary>
+    private sealed class MutableClock : TimeProvider
+    {
+        public DateTimeOffset Now;
+        public MutableClock(DateTimeOffset now) => Now = now;
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private static (AlgoBook algos, WorkingOrderBook orders, AlgoSignalQueue queue, MutableClock clock, AlgoScheduler scheduler) Build(DateTimeOffset now)
+    {
+        var algos = new AlgoBook();
+        var orders = new WorkingOrderBook();
+        var queue = new AlgoSignalQueue();
+        var clock = new MutableClock(now);
+        var scheduler = new AlgoScheduler(algos, orders, queue, clock,
+            AlgoScheduler.DefaultTickInterval, NullLogger<AlgoScheduler>.Instance);
+        return (algos, orders, queue, clock, scheduler);
+    }
+
+    private static Algo NewTwap(ulong id, int sliceCount = 4) =>
+        new(id, new EndClientId("alice"), Firm, "PETR4", 4321UL, OrderSide.Buy, AlgoType.Twap,
+            totalQuantity: 1000,
+            new TwapParameters(Start, End, sliceCount, OrderType.Limit, 30m),
+            createdAtUtc: Start);
+
+    private static Order NewChild(ulong clOrdId, ulong parentAlgoId, int sliceSeq,
+        long qty, OrderStatus status = OrderStatus.Working)
+    {
+        var o = new Order(clOrdId, new EndClientId("alice"), "PETR4", 4321UL,
+            OrderSide.Buy, OrderType.Limit, qty, 30m, Firm, parentAlgoId, sliceSeq);
+        o.MarkWorking();
+        switch (status)
+        {
+            case OrderStatus.Filled:
+                o.ApplyCumulativeFill(qty);
+                break;
+            case OrderStatus.Cancelled:
+                o.MarkCancelled();
+                break;
+            case OrderStatus.Rejected:
+                o.MarkRejected();
+                break;
+        }
+        return o;
+    }
+
+    private static List<AlgoSignal> Drain(AlgoSignalQueue q)
+    {
+        q.Complete();
+        var seen = new List<AlgoSignal>();
+        while (q.Reader.TryRead(out var s)) seen.Add(s);
+        return seen;
+    }
+
+    // ───────────────────────── Slice firing ─────────────────────────
+
+    [Fact]
+    public void Tick_BeforeStart_DoesNotEnqueue()
+    {
+        var (algos, _, queue, _, scheduler) = Build(now: Start.AddSeconds(-1));
+        algos.TryAdd(NewTwap(1));
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_AtStart_EnqueuesFirstSlice()
+    {
+        // Slice 0's plannedAtUtc == startUtc; at exactly startUtc the
+        // scheduler must fire it.
+        var (algos, _, queue, _, scheduler) = Build(now: Start);
+        algos.TryAdd(NewTwap(1));
+        scheduler.Tick();
+        var signals = Drain(queue);
+        var s = Assert.Single(signals);
+        Assert.Equal(1UL, ((AlgoCreatedSignal)s).AlgoId);
+    }
+
+    [Fact]
+    public void Tick_WithLiveChild_DoesNotEnqueue()
+    {
+        // Engine invariant: only one in-flight child per parent. Scheduler
+        // must observe the live child and stay quiet until the engine
+        // (via OnChildErAsync) clears it.
+        var (algos, orders, queue, _, scheduler) = Build(now: Start.AddMinutes(20));
+        algos.TryAdd(NewTwap(1));
+        orders.TryAdd(NewChild(clOrdId: 100, parentAlgoId: 1, sliceSeq: 0, qty: 250));
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_AfterFirstChildFilled_EnqueuesSecondSliceWhenDue()
+    {
+        // Slice 1 plannedAt = start + 15min. At t=20min slice 1 is overdue.
+        var (algos, orders, queue, _, scheduler) = Build(now: Start.AddMinutes(20));
+        algos.TryAdd(NewTwap(1));
+        orders.TryAdd(NewChild(100, 1, sliceSeq: 0, qty: 250, status: OrderStatus.Filled));
+        scheduler.Tick();
+        Assert.Single(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_NotYetDue_DoesNotEnqueue()
+    {
+        // Slice 1 plannedAt = start + 15min. At t=10min slice 1 is not
+        // due yet, slice 0 is already filled — scheduler must wait.
+        var (algos, orders, queue, _, scheduler) = Build(now: Start.AddMinutes(10));
+        algos.TryAdd(NewTwap(1));
+        orders.TryAdd(NewChild(100, 1, sliceSeq: 0, qty: 250, status: OrderStatus.Filled));
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_AfterWindowEnd_StillEnqueuesSoEngineCanExpire()
+    {
+        // RFC §4.6: window-passed parents need an engine pass to mark
+        // Expired. Scheduler enqueues a Created signal; the engine
+        // recognises now>=endUtc and transitions terminal.
+        var (algos, _, queue, _, scheduler) = Build(now: End.AddMinutes(1));
+        algos.TryAdd(NewTwap(1));
+        scheduler.Tick();
+        Assert.Single(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_PlanExhaustedBeforeWindow_DoesNotEnqueue()
+    {
+        // 4 slices already submitted; window still open. Scheduler has
+        // nothing more to do until endUtc — no spurious signals.
+        var (algos, orders, queue, _, scheduler) = Build(now: Start.AddMinutes(50));
+        algos.TryAdd(NewTwap(1, sliceCount: 4));
+        for (var seq = 0; seq < 4; seq++)
+            orders.TryAdd(NewChild(clOrdId: (ulong)(100 + seq), parentAlgoId: 1, sliceSeq: seq,
+                qty: 250, status: OrderStatus.Filled));
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_IgnoresIcebergParents()
+    {
+        // Iceberg refills happen entirely in the engine's OnChildErAsync;
+        // the scheduler must never inject extra signals for them.
+        var (algos, _, queue, _, scheduler) = Build(now: Start);
+        var ice = new Algo(2UL, new EndClientId("alice"), Firm, "PETR4", 4321UL,
+            OrderSide.Buy, AlgoType.Iceberg, 1000,
+            new IcebergParameters(100, 30m), Start);
+        algos.TryAdd(ice);
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_IgnoresCancellingParents()
+    {
+        // Operator already drove the parent into Cancelling — the engine
+        // owns the next transition. Scheduler stays out.
+        var (algos, _, queue, _, scheduler) = Build(now: Start.AddMinutes(20));
+        var twap = NewTwap(1);
+        twap.RequestCancel();
+        algos.TryAdd(twap);
+        scheduler.Tick();
+        Assert.Empty(Drain(queue));
+    }
+
+    [Fact]
+    public void Tick_CatchUp_OnlyOneSignalPerTickPerParent()
+    {
+        // RFC §4.6: no catch-up burst. Even if many slices are overdue
+        // (host was down for 40min, slices 0..2 all due), the scheduler
+        // must enqueue at most ONE signal per parent per tick. The engine
+        // submits one slice; subsequent ticks then submit the next.
+        var (algos, _, queue, _, scheduler) = Build(now: Start.AddMinutes(40));
+        algos.TryAdd(NewTwap(1, sliceCount: 4));
+        scheduler.Tick();
+        Assert.Single(Drain(queue));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/TwapPlanTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/TwapPlanTests.cs
@@ -1,0 +1,146 @@
+using B3.Trading.Application;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class TwapPlanTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset End = new(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+
+    // ───────────────────────── PlannedAtUtc ─────────────────────────
+
+    [Fact]
+    public void PlannedAtUtc_FirstSliceFiresAtStart()
+    {
+        var t = TwapPlan.PlannedAtUtc(Start, End, sliceCount: 4, sliceSeq: 0);
+        Assert.Equal(Start, t);
+    }
+
+    [Fact]
+    public void PlannedAtUtc_LastSliceFiresStrictlyBeforeEnd()
+    {
+        // Plan must reserve endUtc as the expiry boundary — no slice
+        // should be scheduled at endUtc itself, otherwise the
+        // window-expiry path and the slice-fire path race.
+        var t = TwapPlan.PlannedAtUtc(Start, End, sliceCount: 4, sliceSeq: 3);
+        Assert.True(t < End, $"expected last slice < end ({End}), got {t}");
+    }
+
+    [Fact]
+    public void PlannedAtUtc_EvenSpacing_4Slices_Each15Minutes()
+    {
+        Assert.Equal(Start, TwapPlan.PlannedAtUtc(Start, End, 4, 0));
+        Assert.Equal(Start.AddMinutes(15), TwapPlan.PlannedAtUtc(Start, End, 4, 1));
+        Assert.Equal(Start.AddMinutes(30), TwapPlan.PlannedAtUtc(Start, End, 4, 2));
+        Assert.Equal(Start.AddMinutes(45), TwapPlan.PlannedAtUtc(Start, End, 4, 3));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_DeterministicAcrossInvocations()
+    {
+        // The plan is recomputed at each scheduler tick AND at every
+        // recovery — drift between calls would split-brain the
+        // engine/scheduler. Hammer the helper to assert byte-equality.
+        for (var seq = 0; seq < 10; seq++)
+        {
+            var a = TwapPlan.PlannedAtUtc(Start, End, 10, seq);
+            var b = TwapPlan.PlannedAtUtc(Start, End, 10, seq);
+            Assert.Equal(a, b);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void PlannedAtUtc_RejectsNonPositiveSliceCount(int sliceCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            TwapPlan.PlannedAtUtc(Start, End, sliceCount, 0));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void PlannedAtUtc_RejectsOutOfRangeSliceSeq(int sliceSeq)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            TwapPlan.PlannedAtUtc(Start, End, 4, sliceSeq));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_RejectsNonPositiveWindow()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            TwapPlan.PlannedAtUtc(Start, Start, 4, 0));
+        Assert.Throws<ArgumentException>(() =>
+            TwapPlan.PlannedAtUtc(End, Start, 4, 0));
+    }
+
+    // ───────────────────────── SliceQty ─────────────────────────
+
+    [Fact]
+    public void SliceQty_EvenDivision_AllSlicesEqual()
+    {
+        Assert.Equal(250, TwapPlan.SliceQty(1000, 4, 0));
+        Assert.Equal(250, TwapPlan.SliceQty(1000, 4, 1));
+        Assert.Equal(250, TwapPlan.SliceQty(1000, 4, 2));
+        Assert.Equal(250, TwapPlan.SliceQty(1000, 4, 3));
+    }
+
+    [Fact]
+    public void SliceQty_UnevenDivision_LastSliceCarriesRemainder()
+    {
+        // 1003 / 3 = 334, remainder 1 → slices 0,1 = 334 each, slice 2 = 335.
+        Assert.Equal(334, TwapPlan.SliceQty(1003, 3, 0));
+        Assert.Equal(334, TwapPlan.SliceQty(1003, 3, 1));
+        Assert.Equal(335, TwapPlan.SliceQty(1003, 3, 2));
+        Assert.Equal(1003,
+            TwapPlan.SliceQty(1003, 3, 0)
+            + TwapPlan.SliceQty(1003, 3, 1)
+            + TwapPlan.SliceQty(1003, 3, 2));
+    }
+
+    [Fact]
+    public void SliceQty_SingleSlice_TakesAll()
+    {
+        Assert.Equal(1000, TwapPlan.SliceQty(1000, 1, 0));
+    }
+
+    [Fact]
+    public void SliceQty_SumAlwaysMatchesTotal()
+    {
+        // Property test: across plausible combinations the sum of all
+        // slice quantities must reconcile to totalQuantity (RFC §4.8
+        // exact-match invariant).
+        var totals = new long[] { 1, 100, 999, 1000, 12_345, 1_000_000 };
+        var sliceCounts = new[] { 1, 2, 3, 7, 10, 100 };
+        foreach (var total in totals)
+        {
+            foreach (var count in sliceCounts)
+            {
+                if (count > total) continue; // would produce zero floor
+                long sum = 0;
+                for (var seq = 0; seq < count; seq++)
+                    sum += TwapPlan.SliceQty(total, count, seq);
+                Assert.Equal(total, sum);
+            }
+        }
+    }
+
+    [Fact]
+    public void SliceQty_RejectsNonPositiveTotal()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => TwapPlan.SliceQty(0, 4, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => TwapPlan.SliceQty(-1, 4, 0));
+    }
+
+    [Fact]
+    public void FloorSliceQty_ReturnsPlannedFloor()
+    {
+        Assert.Equal(250, TwapPlan.FloorSliceQty(1000, 4));
+        Assert.Equal(0, TwapPlan.FloorSliceQty(3, 4));
+        Assert.Equal(0, TwapPlan.FloorSliceQty(100, 0));
+    }
+}


### PR DESCRIPTION
Implements RFC `algo-orders-v0` §4.6 (TWAP scheduling/recovery), §4.8 (quantity rounding) and §4.11 (scheduler/consumer thread separation). Builds on slice 5b (#55).

## What

- **`TwapPlan`** (`backend/src/B3.Trading.Application/Algo/TwapPlan.cs`) — pure helpers:
  - `PlannedAtUtc(start, end, sliceCount, sliceSeq)` uses ticks arithmetic for byte-deterministic recovery.
  - `SliceQty(total, count, seq)` floors on slices `0..n-2`, last slice carries remainder.
  - `FloorSliceQty(total, count)` for §4.8 validation.
- **`AlgoScheduler`** (`AlgoScheduler.cs`, new `BackgroundService`) — `PeriodicTimer(100ms, TimeProvider)`. Per tick, scans non-terminal TWAPs and enqueues at most one `AlgoCreatedSignal` per parent (no catch-up burst). Window-expired check fires first.
- **`AlgoEngine`** TWAP-aware:
  - `OnCreatedAsync`: defers when not yet due; routes to `Expired/TwapWindowExpired` when `now >= endUtc`.
  - `OnChildErAsync` Filled branch: records fill + checks expiry but does **not** auto-refill (scheduler owns the next slice).
  - `OnChildErAsync` Cancelled/Rejected branches: when window already past → `Expired/TwapWindowExpired` instead of `Suspended/VenueCancelled`/`Suspended/RiskRejected`.
  - `ComputeNextSlice` for TWAP uses `TwapPlan.SliceQty(total, sliceCount, NextSliceSeq)`.
- **`POST /algo`** TWAP validator rejects when `floor(total/sliceCount) <= 0` (echoes `impliedSliceQuantity`, `totalQuantity`, `sliceCount`).
- **Metrics** (`MetricsRegistry`): `AlgoTwapSliceFireJitter` (Histogram, ms), `AlgoSchedulerTickDuration` (Histogram, ms), `AlgoSignalQueueDepth` (UpDownCounter). Queue gauge inc on `TryEnqueue`, dec via new `AlgoSignalQueue.ReadAllAsync` wrapper consumed by the engine.
- **DI**: `AddHostedService<AlgoScheduler>()` next to `AlgoEngine` in `Program.cs`.

## Why this shape

- **Separate scheduler thread** (RFC §4.11 commitment 1): scheduler enqueues; engine remains the sole writer to algo state. Slice-fire latency decoupled from consumer-side work.
- **Deterministic plan, not persisted**: recovery re-derives slice times from parameters alone — no extra WAL event.
- **Last slice carries remainder**: avoids drift; sum-equals-total property test verifies across many combos.
- **Slice n-1 plannedAt strictly before `endUtc`**: window-expiry path and slice-fire path never race.
- **Window-expired-during-child-terminal**: per RFC §4.6, after live child reconciles via ER → if remaining > 0 and `now >= endUtc` → parent goes `Expired/TwapWindowExpired` regardless of child's outcome.
- **Iceberg unchanged**: `OnCreatedAsync` falls through to `SubmitNextSliceAsync`; Filled branch still auto-refills.

## Tests

- `TwapPlanTests` — 12 tests (spacing, last-slice-strictly-before-end, deterministic, even/uneven division, sum-equals-total property, validation).
- `AlgoSchedulerTests` — 10 tests with inline `MutableClock : TimeProvider` (before-start, at-start, with-live-child no-op, after-fill enqueue, not-due, after-window-end enqueue, plan-exhausted, ignores Iceberg, ignores Cancelling, no-catch-up-burst).
- `AlgoTwapIntegrationTests` — 4 integration tests, Simulator mode + real wall-clock (all-slices-due path, last-slice-remainder, window-expires-without-fill, scheduler-drives-expired).

Suite: **32 / 226 / 122 / 8-skip green** (Application +26, Api +4 vs slice-5b baseline). `dotnet format` clean.

## Deferred (called out for slice 7)

- `algo_signal_dispatch_latency_ms` and `algo_per_parent_lock_wait_ms` (RFC §4.11) — would need timestamping on every signal.
- Lot-size rounding (RFC §4.8) — pending lot-size table.

Closes part of #48.

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli)