### PR TITLE
feat(algo): slice 7 — algo conformance + Grafana dashboard

### DIFF
--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/AlgoValidationSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/AlgoValidationSpecTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Algo;
+
+/// <summary>
+/// Spec — POST /algo validation contract (RFC algo-orders-v0 §4.8).
+/// The §4.8 quantity-rounding rule is part of the public contract: a
+/// TWAP whose <c>floor(totalQuantity / sliceCount)</c> rounds to zero
+/// MUST be rejected at submit time (before the engine ever sees it),
+/// and the error body MUST echo <c>impliedSliceQuantity</c>,
+/// <c>totalQuantity</c>, and <c>sliceCount</c> so callers can fix
+/// either input without guessing.
+///
+/// <para>
+/// No <c>RequiresSimulator</c> gate — this is a pure validation path
+/// that does not depend on the exchange mode.
+/// </para>
+/// </summary>
+[Trait("Category", "Conformance")]
+public class AlgoValidationSpecTests
+{
+    [ConformanceFact]
+    public async Task PostAlgoTwap_ImpliedSliceZero_Returns400WithEcho()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+        var auth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+
+        // 2 / 5 = 0 (floor) → MUST be rejected. The window is well-formed
+        // (1-minute, in the future) so the §4.8 check is the only path
+        // that can fire.
+        var now = DateTimeOffset.UtcNow;
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Twap",
+                TotalQuantity = 2,
+                Twap = new
+                {
+                    StartUtc = now,
+                    EndUtc = now.AddMinutes(1),
+                    SliceCount = 5,
+                    ChildOrderType = "Limit",
+                    ChildPrice = 30m,
+                },
+            }),
+        };
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(0, body.GetProperty("impliedSliceQuantity").GetInt64());
+        Assert.Equal(2, body.GetProperty("totalQuantity").GetInt64());
+        Assert.Equal(5, body.GetProperty("sliceCount").GetInt32());
+    }
+}

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/AlgoValidationSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/AlgoValidationSpecTests.cs
@@ -39,6 +39,7 @@ public class AlgoValidationSpecTests
             Content = JsonContent.Create(new
             {
                 Symbol = "PETR4",
+                SecurityId = 4321UL,
                 Side = "Buy",
                 Type = "Twap",
                 TotalQuantity = 2,

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/IcebergLifecycleSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/IcebergLifecycleSpecTests.cs
@@ -1,0 +1,179 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Algo;
+
+/// <summary>
+/// Spec — Iceberg engine end-to-end (RFC algo-orders-v0 §4.5). Covers the
+/// reactor's three contract points against a deployed peer:
+/// (1) Created → first child sliced at <c>displayQuantity</c>;
+/// (2) Filled child → next child auto-refilled by the engine;
+/// (3) <c>DELETE /algo/{id}</c> + cancel ER on the live child →
+///     parent terminalises to <c>Cancelled/UserRequested</c>.
+///
+/// Skipped unless the peer is in <c>Mode=Simulator</c>
+/// (<c>B3T_SIMULATOR_MODE=true</c>) and admin credentials are configured
+/// (<c>B3T_ADMIN_USER</c>/<c>B3T_ADMIN_PASS</c>) — the synthetic ER
+/// injection is the admin-only seam from slice 4.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class IcebergLifecycleSpecTests
+{
+    [ConformanceFact(RequiresAdmin = true, RequiresSimulator = true)]
+    public async Task Iceberg_FirstChild_ThenRefill_ThenCancel()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var userAuth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+        var adminAuth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
+
+        // 1. Create the parent: total=300, display=100. The engine must
+        //    submit slice 0 immediately and refill on terminal-fill.
+        var algoId = await CreateIcebergAsync(http, userAuth, total: 300, display: 100, price: 30m);
+
+        // 2. Slice 0 should appear on /orders for the same end-client,
+        //    tagged with the parent algoId + sliceSeq=0.
+        var slice0 = await WaitForChildAsync(http, userAuth, algoId, expectedSeq: 0);
+        Assert.Equal(100, slice0.Quantity);
+
+        // 3. Fully fill slice 0 via the simulator. Engine reactor sees
+        //    the terminal fill and submits slice 1.
+        await InjectErAsync(http, adminAuth, slice0.ClOrdId, "Fill", lastQty: 100, lastPx: 30m);
+
+        var slice1 = await WaitForChildAsync(http, userAuth, algoId, expectedSeq: 1);
+        Assert.Equal(100, slice1.Quantity);
+
+        // 4. Cancel the parent while slice 1 is still live. The reactor
+        //    flips parent to Cancelling and waits for a terminal ER on
+        //    the live child before terminalising — without an explicit
+        //    Canceled ER the parent stays in Cancelling forever.
+        var cancelResp = await SendAsync(http, HttpMethod.Delete, $"/algo/{algoId}", userAuth);
+        Assert.True(cancelResp.StatusCode == HttpStatusCode.Accepted ||
+                    cancelResp.StatusCode == HttpStatusCode.NoContent,
+            $"DELETE /algo expected 202/204, got {(int)cancelResp.StatusCode}");
+
+        // 5. Drive the simulator to ack the cancel on slice 1.
+        await InjectErAsync(http, adminAuth, slice1.ClOrdId, "Canceled");
+
+        // 6. Parent should now report Cancelled with the user-requested
+        //    terminal reason; remaining quantity is 100 (only slice 0 filled).
+        await WaitForAlgoStatusAsync(http, userAuth, algoId, "Cancelled");
+        var algo = await GetAlgoAsync(http, userAuth, algoId);
+        Assert.Equal("UserRequested", algo.GetProperty("terminalReason").GetString());
+        Assert.Equal(100, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    // ----- Helpers (kept inline to avoid leaking algo HTTP shape into
+    // shared infrastructure; the simulator spec uses the same pattern). -----
+
+    private static async Task<string> CreateIcebergAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, long total, long display, decimal price)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Iceberg",
+                TotalQuantity = total,
+                Iceberg = new { DisplayQuantity = display, LimitPrice = price },
+            }),
+        };
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<(ulong ClOrdId, long Quantity)> WaitForChildAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, string algoId, int expectedSeq)
+    {
+        // Conformance polls 15s — UAT peers can carry HTTP/scheduler/WAL
+        // latency well above the in-process integration baseline.
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "/orders/");
+            req.Headers.Authorization = auth;
+            var resp = await http.SendAsync(req);
+            resp.EnsureSuccessStatusCode();
+            var orders = await resp.Content.ReadFromJsonAsync<JsonElement[]>();
+            foreach (var o in orders!)
+            {
+                if (o.TryGetProperty("parentAlgoId", out var pid) &&
+                    pid.ValueKind == JsonValueKind.String &&
+                    pid.GetString() == algoId &&
+                    o.TryGetProperty("algoSliceSeq", out var seq) &&
+                    seq.ValueKind == JsonValueKind.Number &&
+                    seq.GetInt32() == expectedSeq)
+                {
+                    var clOrdId = ulong.Parse(o.GetProperty("clOrdId").GetString()!);
+                    var qty = o.GetProperty("quantity").GetInt64();
+                    return (clOrdId, qty);
+                }
+            }
+            await Task.Delay(150);
+        }
+        throw new TimeoutException(
+            $"Algo {algoId} child slice {expectedSeq} did not appear in /orders within 15s.");
+    }
+
+    private static async Task InjectErAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, ulong clOrdId, string type,
+        long? lastQty = null, decimal? lastPx = null)
+    {
+        object body = (lastQty, lastPx) switch
+        {
+            (long q, decimal p) => new { ClOrdId = clOrdId, Type = type, LastQty = q, LastPx = p },
+            (long q, null) => new { ClOrdId = clOrdId, Type = type, LastQty = q },
+            _ => new { ClOrdId = clOrdId, Type = type },
+        };
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    private static async Task WaitForAlgoStatusAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, string algoId, string expectedStatus)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        string? observed = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            var algo = await GetAlgoAsync(http, auth, algoId);
+            observed = algo.GetProperty("status").GetString();
+            if (observed == expectedStatus) return;
+            await Task.Delay(150);
+        }
+        throw new TimeoutException(
+            $"Algo {algoId} did not reach status={expectedStatus} within 15s (last observed={observed}).");
+    }
+
+    private static async Task<JsonElement> GetAlgoAsync(
+        HttpClient http, System.Net.Http.Headers.AuthenticationHeaderValue auth, string algoId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpClient http, HttpMethod method, string path, System.Net.Http.Headers.AuthenticationHeaderValue auth)
+    {
+        using var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = auth;
+        return await http.SendAsync(req);
+    }
+}

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/IcebergLifecycleSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/IcebergLifecycleSpecTests.cs
@@ -78,6 +78,7 @@ public class IcebergLifecycleSpecTests
             Content = JsonContent.Create(new
             {
                 Symbol = "PETR4",
+                SecurityId = 4321UL,
                 Side = "Buy",
                 Type = "Iceberg",
                 TotalQuantity = total,

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/TwapLifecycleSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/TwapLifecycleSpecTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Algo;
+
+/// <summary>
+/// Spec — TWAP scheduler end-to-end (RFC algo-orders-v0 §4.6 + §4.8).
+/// Submits a 2-slice TWAP whose window opens in the recent past so both
+/// slices are immediately due, fills them sequentially via the simulator,
+/// and asserts the parent reaches <c>Completed</c> with the full quantity.
+///
+/// <para>
+/// The window is intentionally minute-scale (<c>start = now-3m</c>,
+/// <c>end = now+1m</c>) instead of seconds: client/server clock skew on
+/// a UAT/staging peer can erase a sub-second margin and either expire the
+/// parent mid-test or push slice 1's <c>plannedAtUtc</c> into the future.
+/// 60s of headroom before <c>endUtc</c> tolerates realistic NTP drift and
+/// HTTP latency without giving up determinism.
+/// </para>
+/// </summary>
+[Trait("Category", "Conformance")]
+public class TwapLifecycleSpecTests
+{
+    [ConformanceFact(RequiresAdmin = true, RequiresSimulator = true)]
+    public async Task Twap_TwoSlices_FillsSequentially_ParentCompletes()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var userAuth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+        var adminAuth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
+
+        // 2 slices over [now-3m, now+1m]:
+        //   slice 0 plannedAt = start             = now-3m
+        //   slice 1 plannedAt = start + window/2  = now-1m
+        // Both already due → engine fires slice 0 immediately; after we
+        // fill it, the scheduler's next tick fires slice 1. Window
+        // remains open for ≥60s, far above any realistic conformance
+        // latency budget.
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await CreateTwapAsync(http, userAuth,
+            total: 200, sliceCount: 2,
+            start: now.AddMinutes(-3), end: now.AddMinutes(1),
+            childPrice: 30m);
+
+        // Engine enforces one live child per parent: slice 1 cannot
+        // appear until slice 0 reaches a terminal state.
+        var slice0 = await WaitForChildAsync(http, userAuth, algoId, expectedSeq: 0);
+        Assert.Equal(100, slice0.Quantity);
+        await InjectErAsync(http, adminAuth, slice0.ClOrdId, "Fill", lastQty: 100, lastPx: 30m);
+
+        var slice1 = await WaitForChildAsync(http, userAuth, algoId, expectedSeq: 1);
+        Assert.Equal(100, slice1.Quantity); // even split, no remainder
+        await InjectErAsync(http, adminAuth, slice1.ClOrdId, "Fill", lastQty: 100, lastPx: 30m);
+
+        await WaitForAlgoStatusAsync(http, userAuth, algoId, "Completed");
+        var algo = await GetAlgoAsync(http, userAuth, algoId);
+        Assert.Equal(200, algo.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal("None", algo.GetProperty("terminalReason").GetString());
+    }
+
+    // ----- Helpers (deliberately duplicated from IcebergLifecycleSpecTests
+    // to keep each conformance scenario self-contained — the spec files
+    // are the contract, not a shared test utility library). -----
+
+    private static async Task<string> CreateTwapAsync(
+        HttpClient http, AuthenticationHeaderValue auth,
+        long total, int sliceCount, DateTimeOffset start, DateTimeOffset end, decimal? childPrice)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Twap",
+                TotalQuantity = total,
+                Twap = new
+                {
+                    StartUtc = start,
+                    EndUtc = end,
+                    SliceCount = sliceCount,
+                    ChildOrderType = "Limit",
+                    ChildPrice = childPrice,
+                },
+            }),
+        };
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<(ulong ClOrdId, long Quantity)> WaitForChildAsync(
+        HttpClient http, AuthenticationHeaderValue auth, string algoId, int expectedSeq)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "/orders/");
+            req.Headers.Authorization = auth;
+            var resp = await http.SendAsync(req);
+            resp.EnsureSuccessStatusCode();
+            var orders = await resp.Content.ReadFromJsonAsync<JsonElement[]>();
+            foreach (var o in orders!)
+            {
+                if (o.TryGetProperty("parentAlgoId", out var pid) &&
+                    pid.ValueKind == JsonValueKind.String &&
+                    pid.GetString() == algoId &&
+                    o.TryGetProperty("algoSliceSeq", out var seq) &&
+                    seq.ValueKind == JsonValueKind.Number &&
+                    seq.GetInt32() == expectedSeq)
+                {
+                    return (
+                        ulong.Parse(o.GetProperty("clOrdId").GetString()!),
+                        o.GetProperty("quantity").GetInt64());
+                }
+            }
+            await Task.Delay(150);
+        }
+        throw new TimeoutException(
+            $"TWAP {algoId} child slice {expectedSeq} did not appear in /orders within 15s.");
+    }
+
+    private static async Task InjectErAsync(
+        HttpClient http, AuthenticationHeaderValue auth, ulong clOrdId, string type,
+        long? lastQty = null, decimal? lastPx = null)
+    {
+        object body = (lastQty, lastPx) switch
+        {
+            (long q, decimal p) => new { ClOrdId = clOrdId, Type = type, LastQty = q, LastPx = p },
+            (long q, null) => new { ClOrdId = clOrdId, Type = type, LastQty = q },
+            _ => new { ClOrdId = clOrdId, Type = type },
+        };
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    private static async Task WaitForAlgoStatusAsync(
+        HttpClient http, AuthenticationHeaderValue auth, string algoId, string expectedStatus)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        string? observed = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            var algo = await GetAlgoAsync(http, auth, algoId);
+            observed = algo.GetProperty("status").GetString();
+            if (observed == expectedStatus) return;
+            await Task.Delay(150);
+        }
+        throw new TimeoutException(
+            $"TWAP {algoId} did not reach status={expectedStatus} within 15s (last observed={observed}).");
+    }
+
+    private static async Task<JsonElement> GetAlgoAsync(
+        HttpClient http, AuthenticationHeaderValue auth, string algoId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+}

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/TwapLifecycleSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Algo/TwapLifecycleSpecTests.cs
@@ -75,6 +75,7 @@ public class TwapLifecycleSpecTests
             Content = JsonContent.Create(new
             {
                 Symbol = "PETR4",
+                SecurityId = 4321UL,
                 Side = "Buy",
                 Type = "Twap",
                 TotalQuantity = total,

--- a/docker/observability/grafana/dashboards/algo.json
+++ b/docker/observability/grafana/dashboards/algo.json
@@ -1,0 +1,174 @@
+{
+  "annotations": { "list": [] },
+  "description": "Algo orders v0 dashboard for the B3 trading-host. Surfaces engine reactor + scheduler health: child-submission throughput, signal queue depth/back-pressure, scheduler tick duration, and TWAP slice fire jitter. Built from instruments verified to actually export — see docs/METRICS.md for the catalog. Per RFC algo-orders-v0 §7 C1, parentAlgoId is intentionally NOT a metric tag (logs/traces only); per-algo drill-down lives there.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate of child orders the engine reactor submits on behalf of algo parents, broken down by algo type (iceberg / twap). The slice-7 source-tag panel below cross-checks this against POST /orders submissions tagged source=algo — they should agree.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (type) (rate(trading_algo_children_submitted_total[1m]))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Algo children submitted (per type)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate at which the AlgoEngine consumer pulls signals off the bounded channel, broken down by signal kind (created / cancel_requested / child_execution_observed). A flat zero with parents in PendingNew suggests the consumer is stuck.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (kind) (rate(trading_algo_signals_consumed_total[1m]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Algo signals consumed (per kind)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Signals dropped because the bounded channel rejected the write (5-minute window). Healthy operation is flat zero. Non-zero means a stuck engine consumer or a runaway producer (scheduler / ER processor / endpoint enqueue) — the bounded channel is the producer-side back-pressure boundary.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "value_and_name" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(increase(trading_algo_signals_dropped_total[5m]))",
+          "legendFormat": "dropped (5m)",
+          "refId": "A"
+        }
+      ],
+      "title": "Algo signals dropped (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Live depth of the algo signal channel (UpDownCounter). Increments on enqueue, decrements on dequeue. Healthy: hovers near zero. A sustained climb means the consumer is falling behind producers — the dropped-signals stat above is the smoking gun once back-pressure tips into rejection.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" } },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "trading_algo_signal_queue_depth",
+          "legendFormat": "queue depth",
+          "refId": "A"
+        }
+      ],
+      "title": "Algo signal queue depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Orders submitted via POST /orders broken down by source: manual (trader-typed) vs algo (engine-generated child). Cross-check: the algo series should track 'Algo children submitted' panel above. Divergence means the source tag is wrong somewhere in the submission path.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 8 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (source) (rate(trading_orders_submitted_total[1m]))",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Orders submitted (per source)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Wall-clock duration of a single AlgoScheduler tick, p50/p95/p99 over a 5-minute window. The scheduler ticks every 100ms; a tick should comfortably finish in ≪10ms. Sustained p99 climbing toward the tick interval means the scheduler is starting to slip and slice fires will bunch up on subsequent ticks.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(trading_algo_scheduler_tick_duration_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(trading_algo_scheduler_tick_duration_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(trading_algo_scheduler_tick_duration_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduler tick duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "TWAP slice fire jitter — wall-clock delay between the deterministic plannedAtUtc and the moment the scheduler actually enqueued the slice signal. Captures both scheduler-tick granularity (~100ms) and consumer back-pressure. p95 < 200ms is healthy for a 100ms scheduler interval.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(trading_algo_twap_slice_fire_jitter_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(trading_algo_twap_slice_fire_jitter_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(trading_algo_twap_slice_fire_jitter_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "TWAP slice fire jitter (p50 / p95 / p99)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["b3-trading", "algo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "B3 Trading — Algo",
+  "uid": "b3-trading-algo",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -41,7 +41,7 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 
 | OTel name | Type | Tags |
 |---|---|---|
-| `trading.orders.submitted` | Counter | (none, planned: firm/symbol) |
+| `trading.orders.submitted` | Counter | `symbol`, `side`, `source` (manual/algo) |
 | `trading.orders.rejected_by_risk` | Counter | `check` |
 | `trading.orders.gateway_failed` | Counter | (none) |
 | `trading.orders.cancel_requested` | Counter | (none) |
@@ -70,11 +70,26 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 | `trading.risk.rolling_notional.bypassed_no_reference` | Counter | `symbol` |
 | `trading.risk.rolling_notional.active_buckets` | Observable Gauge | `scope` (end_client/firm) |
 | `trading.risk.order_rate.active_buckets` | Observable Gauge | `scope` (end_client/firm) |
+| `trading.algo.signals_consumed` | Counter | `kind` (created/cancel_requested/child_execution_observed) |
+| `trading.algo.signals_dropped` | Counter | `kind` |
+| `trading.algo.children_submitted` | Counter | `type` (iceberg/twap) |
+| `trading.algo.twap.slice_fire_jitter` | Histogram (ms) | (none) |
+| `trading.algo.scheduler.tick_duration` | Histogram (ms) | (none) |
+| `trading.algo.signal_queue_depth` | UpDownCounter | (none) |
 
 The `trading.risk.*` series back the **B3 Trading — Risk** Grafana
 dashboard (`docker/observability/grafana/dashboards/risk.json`); the
 v2 risk pipeline is documented in
 [`docs/rfcs/pre-trade-risk-v2.md`](rfcs/pre-trade-risk-v2.md).
+
+The `trading.algo.*` series (plus the `source` tag on
+`trading.orders.submitted`) back the **B3 Trading — Algo** Grafana
+dashboard (`docker/observability/grafana/dashboards/algo.json`); the
+v0 algo pipeline is documented in
+[`docs/rfcs/algo-orders-v0.md`](rfcs/algo-orders-v0.md). Per RFC §7
+C1, `parentAlgoId` is intentionally **not** a metric tag (cardinality
+would explode); per-algo drill-down lives in structured logs and
+traces.
 
 ## Auto-instrumentation also exported
 

--- a/docs/rfcs/algo-orders-v0.md
+++ b/docs/rfcs/algo-orders-v0.md
@@ -2,7 +2,7 @@
 
 | Field    | Value                                                              |
 | -------- | ------------------------------------------------------------------ |
-| Status   | Accepted                                                           |
+| Status   | Implemented                                                        |
 | Tracking | [#48](https://github.com/pedrosakuma/B3TradingPlatform/issues/48)  |
 | Replaces | n/a (new capability on top of `B3.Trading.Application`)            |
 
@@ -494,11 +494,31 @@ engines from conformance.
    refuse-to-boot in Production unless `Trading:Exchange:AllowSimulatorInProduction=true`),
    `SimulatorEndpointTests` + `SimulatorBootGuardTests`, and a
    `RequiresSimulator`-gated conformance smoke (`Spec_HTTP_Simulator`).
-5. **Iceberg engine** — first reactive engine. Submits the first
-   child, refills on terminal-fill, suspends on terminal-cancel.
-6. **TWAP engine** — scheduler + recovery. Largest PR; the
-   scheduling model in §4.6 is the contract.
+5. **Iceberg engine** — first reactive engine. ✅ Implemented (slices
+   5a + 5b). 5a extracted `OrderSubmissionService` and shipped the
+   `AlgoSignalQueue` / no-op `AlgoEngine` skeleton; 5b lit up the
+   reactor with per-parent serialisation, refill on terminal-fill,
+   and `Suspended/VenueCancelled` on terminal-cancel.
+6. **TWAP engine** — scheduler + recovery. ✅ Implemented. Adds the
+   deterministic `TwapPlan` (ticks-based `plannedAtUtc` + last-slice
+   remainder), `AlgoScheduler` `BackgroundService` (PeriodicTimer
+   100ms, no catch-up burst), TWAP-aware engine paths
+   (defer/expire on create, no auto-refill on filled, window-expired
+   routing on cancelled/rejected), §4.8 validator on `POST /algo`,
+   and the scheduler observability metrics
+   (`trading.algo.twap.slice_fire_jitter`,
+   `trading.algo.scheduler.tick_duration`,
+   `trading.algo.signal_queue_depth`).
 7. **Conformance scenarios + Grafana panel** for algo metrics.
+   ✅ Implemented. Adds three `Spec_HTTP_Algo` scenarios (iceberg
+   lifecycle including cancel-ack, TWAP two-slice fills-to-completion,
+   `POST /algo` §4.8 validator echo) plus a **B3 Trading — Algo**
+   Grafana dashboard
+   (`docker/observability/grafana/dashboards/algo.json`) covering
+   children-submitted rate by type, signals consumed/dropped/queue
+   depth, scheduler tick duration, TWAP slice fire jitter, and
+   manual-vs-algo `POST /orders` source split. Per §7 C1 there is no
+   `parentAlgoId` metric tag.
 
 The frontend follow-up is intentionally *not* numbered here. It
 lands as its own RFC once the engine is proven, on the same posture


### PR DESCRIPTION
Final slice of RFC `algo-orders-v0`. Adds external-contract proof against a deployed peer plus the operator-facing dashboard, then flips the RFC to **Implemented**. Builds on slice 6 (#56).

Closes #48.

## What

### Conformance (`Spec_HTTP_Algo`, `RequiresSimulator` + `RequiresAdmin`)

- **`IcebergLifecycleSpecTests`** — POST `/algo` iceberg(total=300, display=100) → wait child slice 0 → fill via `POST /admin/simulator/er` → wait child slice 1 → DELETE `/algo/{id}` → cancel-ack ER on slice 1 → assert `Cancelled/UserRequested` with `filledQuantity=100`.
- **`TwapLifecycleSpecTests`** — POST `/algo` twap(total=200, sliceCount=2, start=now-3m, end=now+1m) → fill both slices sequentially → assert `Completed/None`.
- **`AlgoValidationSpecTests`** (no `RequiresSimulator`) — POST `/algo` twap(total=2, sliceCount=5) → assert 400 with body echoing `impliedSliceQuantity=0`, `totalQuantity=2`, `sliceCount=5` (RFC §4.8 contract).

Conformance polling timeouts bumped to **15s** (vs 5s in-process integration baseline) to absorb HTTP/scheduler/WAL latency on remote peers.

### Grafana — `docker/observability/grafana/dashboards/algo.json`

Picked up by the existing provisioning (`provisioning/dashboards/dashboards.yaml` watches the dashboards folder; no extra wiring).

| Panel | Query shape |
|---|---|
| Children submitted (per type) | `sum by(type) (rate(trading_algo_children_submitted_total[1m]))` |
| Signals consumed (per kind) | `sum by(kind) (rate(trading_algo_signals_consumed_total[1m]))` |
| Signals dropped (5m) — red threshold | `sum(increase(trading_algo_signals_dropped_total[5m]))` |
| Signal queue depth | `trading_algo_signal_queue_depth` |
| Orders submitted (per source) | `sum by(source) (rate(trading_orders_submitted_total[1m]))` |
| Scheduler tick duration p50/p95/p99 | `histogram_quantile(q, sum by(le) (rate(trading_algo_scheduler_tick_duration_bucket[5m])))` |
| TWAP slice fire jitter p50/p95/p99 | `histogram_quantile(q, sum by(le) (rate(trading_algo_twap_slice_fire_jitter_bucket[5m])))` |

Per RFC §7 C1, **no `parentAlgoId` metric tag** — cardinality concern; per-algo drill-down is a logs/traces concern.

### Docs

- **`docs/METRICS.md`** — adds 6 `trading.algo.*` rows + corrects the `trading.orders.submitted` row to declare the `symbol`/`side`/`source` tags it actually emits + cross-references the new dashboard.
- **`docs/rfcs/algo-orders-v0.md`** — flips `Status: Accepted` → `Implemented`; rewrites §5 entries 5/6/7 with concrete summaries of what each slice shipped.

## Why this shape

- **Iceberg cancel scenario must inject a `Canceled` ER on the live child.** The reactor flips parent to `Cancelling` on DELETE but waits for a terminal ER on the live child before terminalising — without the ER, the parent stays in `Cancelling` forever. The conformance scenario exercises the full path.
- **TWAP scenario uses a minute-scale window** (`start=now-3m`, `end=now+1m`). Sub-second windows reserved for in-process integration tests where client/server clock skew is zero by construction; on a UAT peer NTP drift + HTTP latency can push slice 1's `plannedAtUtc` into the future or expire the parent mid-test.
- **TWAP fills are sequential** because the engine enforces one live child per parent (RFC §4.6); the spec mirrors that.
- **`signals_dropped` panel uses `increase()` over 5m** instead of lifetime `sum()` so the stat returns to blue once back-pressure clears — a single historical drop shouldn't keep operators staring at a red panel forever.
- **Helpers duplicated across the three spec files** instead of factored into `Conformance.Infrastructure`. The spec files *are* the contract; sharing a helper between specs would invite "let me just tweak the helper" drive-by changes that break the spec posture.

## Tests

- Suite **32 / 226 / 122 / 11-skip** (Conformance +3 vs slice-6 baseline 8-skip; the 3 new specs skip locally because there's no peer configured — they run when `B3T_BASE_URL`/`B3T_AUTH_USER`/`B3T_AUTH_PASS` (+ `B3T_ADMIN_USER`/`B3T_ADMIN_PASS` + `B3T_SIMULATOR_MODE=true` for the lifecycle specs) are set).
- `dotnet format` clean.

## Out of scope (deferred)

- `algo_signal_dispatch_latency_ms` and `algo_per_parent_lock_wait_ms` from RFC §4.11 — would need timestamping every signal; pulled forward into a future algo-engine perf RFC if measured contention justifies it.
- Lot-size rounding (RFC §4.8) — pending lot-size table.
- Algo-driven **WS topic** conformance (`algo.me` snapshot-on-subscribe) — covered by integration tests in slice 3; conformance can pick it up alongside the future WS-resilience RFC.

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli)