### PR TITLE
feat(docker): integration-real-stack-v1 — reinstate marketdata leg

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -204,11 +204,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Bring up real stack (matching-platform + trading-host)
-        # docker-compose.real.yml flips trading-host to Mode=Real and adds
-        # the matching-platform service. Conformance overlay still piles
-        # on the carol admin seed. --wait blocks until matching's healthcheck
-        # passes AND trading-host reports healthy (FIXP Negotiate
+      - name: Bring up real stack (matching-platform + marketdata + trading-host)
+        # docker-compose.real.yml flips trading-host to Mode=Real, adds
+        # the matching-platform service, and (since v1) the marketdata-live
+        # service consuming matching's UMDF unicast — so trading-host's
+        # IReferencePrice is wired through MarketDataReferencePrice end-to-end
+        # instead of falling back to the static map. Conformance overlay still
+        # piles on the carol admin seed. --wait blocks until matching's
+        # healthcheck passes AND trading-host reports healthy (FIXP Negotiate
         # succeeded against matching).
         run: |
           docker compose \
@@ -231,7 +234,7 @@ jobs:
       - name: Logs (always)
         if: always()
         run: |
-          for svc in trading-host matching-platform; do
+          for svc in trading-host matching-platform marketdata-live; do
             echo "::group::$svc"
             docker compose \
                 -f docker/docker-compose.yml \

--- a/docker/conformance/Dockerfile
+++ b/docker/conformance/Dockerfile
@@ -17,11 +17,15 @@
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0.201
 
-# curl is used by the entrypoint to wait for /ready before invoking
-# dotnet test. ca-certificates so https targets work too.
-RUN apt-get update \
- && apt-get install --no-install-recommends -y curl ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+# The SDK image (Ubuntu noble base) already ships /usr/bin/curl and
+# /etc/ssl/certs/ca-certificates.crt — no apt-get install needed. We
+# used to run `apt-get update && apt-get install -y curl ca-certificates`
+# here, but the GitHub-hosted runners' archive.ubuntu.com mirror
+# regularly times out (5+ min `Ign:` per package, eventual exit 100
+# "Mirror sync in progress?") and the conformance job hits the
+# 15-minute step timeout — flaky in a way that has nothing to do with
+# what we're testing. Skipping the apt step entirely removes the only
+# external network dependency from this image build.
 
 WORKDIR /src
 

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -1,9 +1,17 @@
-# Real-stack overlay: matching-platform + trading-host(Mode=Real).
+# Real-stack overlay: matching-platform + marketdata + trading-host(Mode=Real).
 #
-# Brings up the only existing service in the family that can speak real
-# B3 EntryPoint wire to a trading-host running in Mode=Real. The overlay
+# Brings up the only services in the family that can drive the real
+# B3 EntryPoint wire (matching) and the live UMDF reference-price WS
+# (marketdata) against a trading-host running in Mode=Real. The overlay
 # is opt-in — `docker compose up` (no -f overlay) keeps the honest
 # Mode=Unavailable default.
+#
+# Topology (all on b3-net):
+#
+#   matching-platform ──FIXP TCP 9876──> trading-host ──> frontend
+#         │
+#         └──UMDF unicast UDP──> marketdata ──WS 8080──> trading-host
+#                                                       (IReferencePrice)
 #
 # Usage:
 #   docker compose \
@@ -27,14 +35,12 @@
 #       -f docker/docker-compose.conformance.yml \
 #       run --rm conformance
 #
-# The marketdata service stays profile-gated under the base compose.
-# Per RFC integration-real-stack-v0 §4.4 R1.b, the upstream b3-marketdata
-# consumer cannot bind unicast UDP via its existing JSON config (its
-# MulticastPacketSource always issues SetMulticastOption, which fails
-# EINVAL on a non-multicast group). Until that gap is closed upstream
-# the matching → marketdata UMDF leg is out of scope; matching's own
-# UMDF emissions are sunk to its loopback (see
-# docker/real/exchange-simulator.bridge.json).
+# v1 (this file) reinstates the marketdata leg after upstream
+# B3MarketDataPlatform#10 (PR #11) shipped the unicast bridge transport.
+# The marketdata service in docker-compose.yml is profile-gated under the
+# PCAP-replay configuration; here we redefine it to consume matching's
+# UMDF over the bridge and clear the profile so it boots with the overlay.
+# See RFC docs/rfcs/integration-real-stack-v0.md § v1 amendment.
 
 services:
   matching-platform:
@@ -50,6 +56,14 @@ services:
       - ./real/exchange-simulator.bridge.json:/app/config/exchange-simulator.bridge.json:ro
       - ./real/instruments-eqt.json:/app/config/instruments-eqt.json:ro
     command: ["/app/config/exchange-simulator.bridge.json"]
+    depends_on:
+      # The UnicastUdpPacketSink resolves the "marketdata" hostname at
+      # startup via DNS (B3.Exchange.Core.UnicastUdpPacketSink:36). If
+      # marketdata-live is not up, matching aborts with "Name or service
+      # not known". service_started is enough — we don't need the WS to
+      # be ready before matching opens its UDP sockets.
+      marketdata-live:
+        condition: service_started
     healthcheck:
       # Matching ships /metrics + /sessions on its HTTP port (no /health).
       # /metrics returning 200 is a sufficient readiness signal: the HTTP
@@ -61,10 +75,54 @@ services:
       retries: 12
       start_period: 5s
 
+  marketdata-live:
+    # Live UMDF unicast variant for the real-stack overlay. Defined as a
+    # separate service from the profile-gated PCAP-replay `marketdata` in
+    # the base compose so the two never conflict (volumes are
+    # additively-merged in compose, which would force a phantom PCAP bind
+    # here). Resolves to the hostname `marketdata` on b3-net via the
+    # network alias below — that name is hard-coded into
+    # docker/real/exchange-simulator.bridge.json (matching's UMDF sink)
+    # and into trading-host's Trading__MarketData__WsUrl below.
+    image: ghcr.io/pedrosakuma/b3-marketdata:${MARKETDATA_TAG:-latest}
+    container_name: b3-marketdata
+    restart: unless-stopped
+    environment:
+      UMDF_WS_PORT: "8080"
+      UMDF_MULTICAST_CONFIG: /app/config/transport.json
+    volumes:
+      - ./real/marketdata-transport.json:/app/config/transport.json:ro
+    networks:
+      b3-net:
+        aliases:
+          - marketdata
+    expose:
+      - "8080"     # WebSocket fanout consumed by trading-host
+      - "30084/udp"  # IncrementalA  (matching → marketdata)
+      - "30085/udp"  # IncrementalB  (silent in v1; matching only emits A)
+      - "30184/udp"  # SnapshotRecovery
+      - "31084/udp"  # InstrumentDefinition
+    ports:
+      # Host port for direct WS smoke (browser / debug). Not required
+      # for the in-bridge trading-host → marketdata WS hop.
+      - "${MARKETDATA_PORT:-8081}:8080"
+    healthcheck:
+      # The image is distroless-ish (no curl/wget). Use dotnet --info as
+      # a liveness probe — proves the runtime is alive and the container
+      # hasn't crashed silently. The trading-host's WS subscriber retries
+      # on its own if the WS server isn't yet accepting.
+      test: ["CMD", "/usr/bin/dotnet", "--info"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+
   trading-host:
     depends_on:
       matching-platform:
         condition: service_healthy
+      marketdata-live:
+        condition: service_started
     environment:
       Trading__Exchange__Mode: Real
       # Single firm wired to matching's pre-#42 default session, matching
@@ -89,6 +147,12 @@ services:
       # mapping is documentation more than enforcement.
       Trading__SymbolDirectory__SecurityIds__PETR4: "4321"
       Trading__SymbolDirectory__SecurityIds__VALE3: "1234"
-      # Reference-price WS deliberately left unset (D3 deferred to v1
-      # per R1.b — see overlay header). The trading-host falls back to
-      # the static Trading:Risk:ReferencePrices map.
+      # Live reference price via the marketdata WS leg (RFC §4.5 D3).
+      # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
+      # cache misses fall back to Trading:Risk:ReferencePrices map. The
+      # subscription is best-effort: marketdata being slow to come up
+      # doesn't block trading-host startup.
+      Trading__MarketData__WsUrl: ws://marketdata:8080/ws
+      Trading__MarketData__Symbols__0: PETR4
+      Trading__MarketData__Symbols__1: VALE3
+      Trading__MarketData__Symbols__2: ITUB4

--- a/docker/real/exchange-simulator.bridge.json
+++ b/docker/real/exchange-simulator.bridge.json
@@ -13,15 +13,13 @@
   // Differences from upstream config/exchange-simulator.bridge.json
   // (https://github.com/pedrosakuma/B3MatchingPlatform):
   //
-  // 1. UMDF unicast targets point at 127.0.0.1 (matching's own loopback)
-  //    instead of "marketdata". Per RFC integration-real-stack-v0 §4.4
-  //    R1.b, the upstream b3-marketdata consumer cannot bind unicast UDP
-  //    via its existing JSON config (MulticastPacketSource always issues
-  //    SetMulticastOption, which fails EINVAL on a non-multicast group).
-  //    Until that gap is closed upstream, marketdata stays out of the
-  //    real overlay and matching's UMDF emissions are sunk to /dev/null.
-  //    The FIXP TCP listener (port 9876) is what the trading-host needs,
-  //    and it's unaffected.
+  // 1. UMDF unicast targets point at "marketdata" (the docker compose
+  //    service alias on b3-net). Resolved at startup by
+  //    B3.Exchange.Core.UnicastUdpPacketSink via DNS. The matching ports
+  //    here MUST match docker/real/marketdata-transport.json EQT group
+  //    verbatim (incremental 30084, instrument-def 31084, snapshot 30184).
+  //    Closes RFC integration-real-stack-v0 §4.4 R1.b after upstream
+  //    B3MarketDataPlatform#10 (PR #11) shipped the unicast transport.
   //
   // 2. firms[0] / sessions[0] pinned to FIRM01 / 10101 / dev-key-1 so
   //    docker-compose.real.yml's trading-host overlay can hard-code
@@ -49,24 +47,25 @@
   "channels": [
     {
       "channelNumber": 84,
-      // transport=unicast: each "*.group" below is a DNS name (or IP)
-      // resolved at startup. We point at 127.0.0.1 so the UDP sink writes
-      // to matching's own loopback and the kernel drops the datagrams —
-      // there is no UMDF consumer on the bridge in v0 (see header).
+      // transport=unicast: each "*.group" below is the docker compose
+      // service alias of the marketdata consumer on b3-net. matching's
+      // B3.Exchange.Core.UnicastUdpPacketSink resolves the alias via DNS
+      // at startup, so it MUST match the service name in
+      // docker-compose.real.yml (`marketdata`).
       "transport": "unicast",
-      "incrementalGroup": "127.0.0.1",
+      "incrementalGroup": "marketdata",
       "incrementalPort": 30084,
       "selfTradePrevention": "none",
       "instruments": "config/instruments-eqt.json",
       "snapshot": {
-        "group": "127.0.0.1",
+        "group": "marketdata",
         "port": 30184,
         "cadenceMs": 1000,
         "maxEntriesPerChunk": 30
       },
       "instrumentDefinition": {
         "channelNumber": 184,
-        "group": "127.0.0.1",
+        "group": "marketdata",
         "port": 31084,
         "cadenceMs": 5000
       }

--- a/docker/real/marketdata-transport.json
+++ b/docker/real/marketdata-transport.json
@@ -1,0 +1,54 @@
+{
+  // Marketdata consumer transport for the real-stack overlay.
+  //
+  // Mounted into b3-marketdata as /app/config/transport.json and selected via
+  // UMDF_MULTICAST_CONFIG. Loaded by B3.Umdf.Transport.MulticastFeedConfig.
+  //
+  // Wire-format note: with `transport: "unicast"` the consumer skips the
+  // IGMP join entirely and binds `multicastGroup`:`port` as a plain UDP
+  // socket. We use `0.0.0.0` (all interfaces) — the docker bridge takes
+  // care of routing matching's UDP datagrams to the marketdata container.
+  // See B3MarketDataPlatform/docs/CONFIGURATION.md § Example — unicast
+  // (Docker Compose bridge).
+  //
+  // Channel layout:
+  //
+  // - EQT (channelId 84) — real channel, ports match
+  //   docker/real/exchange-simulator.bridge.json verbatim. matching emits
+  //   InstrumentDefinition + SnapshotRecovery + Incremental on these ports;
+  //   the consumer transitions WaitInstrumentDefinition → Streaming and
+  //   serves Trade/Info frames over WS to the trading-host.
+  //
+  // - DRV (channelId 72) — phantom channel on unused ports (40072/40073/
+  //   41072/40172). Pure workaround for the upstream guard at
+  //   B3.Umdf.ConsoleApp/Program.cs:500 ("Single-group live multicast mode
+  //   is not supported; use multiple groups") which fires regardless of
+  //   transport mode. Tracked upstream at
+  //   https://github.com/pedrosakuma/B3MarketDataPlatform/issues/13.
+  //   The DRV sockets sit in WaitInstrumentDefinition forever; no impact
+  //   on EQT throughput.
+  //
+  // matching's bridge config only emits one of the two redundant
+  // Incremental feeds (A); B is intentionally not configured. UMDF arbitration
+  // tolerates a silent peer (the SDK only needs A to advance the sequence).
+  "channelGroups": [
+    {
+      "name": "EQT",
+      "channels": [
+        { "channelId":  84, "type": "IncrementalA",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30084 },
+        { "channelId":  84, "type": "IncrementalB",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30085 },
+        { "channelId": 184, "type": "InstrumentDefinition", "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 31084 },
+        { "channelId":  84, "type": "SnapshotRecovery",     "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30184 }
+      ]
+    },
+    {
+      "name": "DRV",
+      "channels": [
+        { "channelId":  72, "type": "IncrementalA",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 40072 },
+        { "channelId":  72, "type": "IncrementalB",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 40073 },
+        { "channelId": 172, "type": "InstrumentDefinition", "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 41072 },
+        { "channelId":  72, "type": "SnapshotRecovery",     "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 40172 }
+      ]
+    }
+  ]
+}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -47,15 +47,27 @@ docker compose \
     up
 ```
 
-Brings up `matching-platform` (`ghcr.io/pedrosakuma/b3-matching:latest`)
-and flips `trading-host` into `Mode=Real` against matching's FIXP
-listener over the existing `b3-net` bridge. Use this overlay when you
-need to see the real `B3.EntryPoint.Client` path drive end-to-end —
-gap detection, latency probes, multi-firm registry — instead of the
-in-process mock.
+Brings up the real-wire trio against the trading-host:
 
-The `marketdata` leg of the topology stays out of this overlay in
-v0; see RFC `docs/rfcs/integration-real-stack-v0.md` §4.4 R1.b.
+| Service | Image | What it does |
+|---|---|---|
+| `matching-platform` | `ghcr.io/pedrosakuma/b3-matching:latest` | FIXP TCP listener (`:9876`) + UMDF unicast publisher |
+| `marketdata-live` | `ghcr.io/pedrosakuma/b3-marketdata:latest` | UMDF consumer (binds `30084/30184/31084 udp`) + WebSocket fanout (`:8080`, hostname `marketdata` on `b3-net`) |
+| `trading-host` | (this repo) | `Mode=Real`, FIRM01 session against matching, `IReferencePrice` wired through `marketdata-live` WS |
+
+The overlay is opt-in — `docker compose up` (no `-f`) keeps the honest
+`Mode=Unavailable` default.
+
+Use this overlay when you need to see the real `B3.EntryPoint.Client`
+path drive end-to-end (gap detection, latency probes, multi-firm
+registry) and the live reference-price WS pipeline (versus the in-process
+mock + static-map fallback).
+
+The base compose's profile-gated `marketdata` (PCAP-replay) is unrelated
+and stays dormant under this overlay; the live variant is a separate
+service named `marketdata-live` with a network alias `marketdata` so the
+hostnames in `docker/real/exchange-simulator.bridge.json` and the
+trading-host `Trading__MarketData__WsUrl` resolve.
 
 ## Honest no-broker mode
 

--- a/docs/rfcs/integration-real-stack-v0.md
+++ b/docs/rfcs/integration-real-stack-v0.md
@@ -2,7 +2,7 @@
 
 | Field    | Value                                                                  |
 | -------- | ---------------------------------------------------------------------- |
-| Status   | Implemented                                                            |
+| Status   | Implemented (v1)                                                       |
 | Tracking | [#58](https://github.com/pedrosakuma/B3TradingPlatform/issues/58)      |
 | Replaces | n/a (additive overlay on top of the family `docker-compose.yml`)       |
 
@@ -468,3 +468,110 @@ from the base compose header and from `docs/DOCKER.md`'s introduction.
   WS endpoint to point at. The static-map fallback in the host
   remains. v1 (gated by upstream marketdata bridge support)
   reinstates the WS wire.
+
+## 8. v1 amendment — marketdata leg reinstated (2026-05-04)
+
+### What changed upstream
+
+- [`pedrosakuma/B3MarketDataPlatform#10`](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/10)
+  closed (PR #11 merged 2026-05-04). The consumer's
+  `MulticastPacketSource` now honours a `transport: "unicast"` flag per
+  channel: when set, the socket binds `multicastGroup`:`port` as a
+  plain UDP listener and skips `SetMulticastOption` entirely. New
+  schema documented under upstream `docs/CONFIGURATION.md` §
+  *Example — unicast (Docker Compose bridge)*.
+- New GHCR build `sha-2a252af` published; `:latest` updated.
+
+### What this slice does
+
+Reinstates the marketdata leg in the real overlay so the topology
+finally matches the diagram users have been promised:
+
+```
+matching-platform ──FIXP TCP 9876──> trading-host ──> frontend
+        │
+        └──UMDF unicast UDP──> marketdata-live ──WS 8080──> trading-host
+                               (alias: marketdata)         (IReferencePrice)
+```
+
+Concretely:
+
+1. `docker/real/marketdata-transport.json` (new) — consumer config with
+   the EQT group on matching's emit ports (30084/30085/31084/30184),
+   all `transport: "unicast"` bound on `0.0.0.0`. A second `DRV` group
+   on unused ports (40072/40073/41072/40172) satisfies the `Program.cs`
+   guard described in the next section.
+2. `docker/real/exchange-simulator.bridge.json` — UMDF unicast targets
+   flipped from `127.0.0.1` to `marketdata` (DNS-resolved on `b3-net`).
+3. `docker/docker-compose.real.yml` — adds a `marketdata-live` service
+   (separate name from the PCAP-replay `marketdata` profile-gated in the
+   base compose, with a `marketdata` alias on `b3-net` so DNS resolution
+   from matching and from trading-host works unchanged) and flips
+   `Trading__MarketData__WsUrl` to `ws://marketdata:8080/ws`,
+   subscribing PETR4/VALE3/ITUB4. The base PCAP variant stays dormant.
+4. `.github/workflows/docker.yml` — `real-stack-conformance` now
+   captures `marketdata-live` logs in the always-run logs step.
+5. `docs/DOCKER.md` § *Real-stack overlay* refreshed with the three-row
+   service table.
+
+### Local verification (2026-05-04)
+
+```
+docker compose -f docker-compose.yml -f docker-compose.real.yml up -d --wait trading-host
+# Container b3-marketdata Healthy
+# Container b3-matching-platform Healthy
+# Container b3-trading-host Healthy
+
+curl http://localhost:5000/health
+# {"status":"ready", … "exchange":{"mode":"Real","readyForOrders":true,"firmCount":1}}
+
+docker logs b3-trading-host | grep MarketData
+# MarketData subscribed: PETR4
+# MarketData subscribed: VALE3
+# MarketData subscribed: ITUB4
+# MarketData connection state: Connected
+
+docker compose … -f docker-compose.conformance.yml run --rm conformance
+# Test Run Successful. Total tests: 6 (5 Auth + 1 AdminFirms).
+```
+
+The marketdata consumer reaches `G0:Streaming` with 3 instruments / 3
+books / 3 symbols. Trade frames have not been observed yet because no
+order has crossed in this stack (matching has only one connected firm
+in the real overlay; `IReferencePrice` cache misses keep falling back
+to the static map until a real trade prints). v2 will exercise the
+crossed-order path and assert that `MarketDataReferencePrice` displaces
+the static fallback.
+
+### Findings filed upstream (non-blocking)
+
+- [`B3MarketDataPlatform#13`](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/13)
+  — the single-channel-group guard at `B3.Umdf.ConsoleApp/Program.cs:500`
+  fires regardless of transport. Workaround: phantom DRV group in
+  `marketdata-transport.json`. Suggested fix: make the guard
+  transport-aware (allow when every channel in the only group is
+  `transport: "unicast"`).
+- [`B3MarketDataPlatform#12`](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/12)
+  — `SecurityDefinition_12.SecurityDesc` parsing throws
+  `ArgumentOutOfRangeException` on every InstrumentDefinition cycle
+  emitted by `b3-matching:latest`. Cosmetic — books are still created
+  and the consumer transitions to `Streaming` — but the warn is loud
+  and probably points at a real interop gap (matching emitter vs.
+  marketdata generated SBE reader).
+
+### Q1 update (R1)
+
+Resolved as **R1.a (with one footnote)** post-upstream-fix. Unicast bind
+works; the only deviation from the original R1.a sketch is the JSON key
+shape (`channelGroups` instead of the `feeds` placeholder used in the
+draft) and the workaround for the multi-group guard. D3 (reference-price
+WS) is now **enabled by default in the real overlay**.
+
+### v0 scoping items now retired
+
+- "matching → marketdata UMDF leg is out of scope" — **closed**.
+- "Trading__MarketData__WsUrl deliberately left unset" — **closed**;
+  set to `ws://marketdata:8080/ws` in the overlay.
+- "static-map fallback is the only reference-price path in the real
+  stack" — **partially closed**; fallback still serves cache misses
+  until trades print, but the live path is wired and connecting.


### PR DESCRIPTION
Closes #61. Continuation of #60 (v0) now that upstream [B3MarketDataPlatform#10](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/10) shipped `transport: "unicast"` per channel (PR #11, merged 2026-05-04).

## What this does

Re-enables the marketdata leg in the real-stack overlay so the topology finally matches the diagram users have been promised:

```
matching-platform ──FIXP TCP 9876──> trading-host ──> frontend
        │
        └──UMDF unicast UDP──> marketdata-live ──WS 8080──> trading-host
                               (alias: marketdata)         (IReferencePrice)
```

| File | Change |
|---|---|
| `docker/real/marketdata-transport.json` | **new** — EQT group on matching's emit ports + phantom DRV group to satisfy upstream multi-group guard |
| `docker/real/exchange-simulator.bridge.json` | UMDF unicast targets flipped `127.0.0.1` → `marketdata` (DNS) |
| `docker/docker-compose.real.yml` | adds `marketdata-live` service (alias `marketdata`); enables D3 — sets `Trading__MarketData__WsUrl` + Symbols__0..2 |
| `.github/workflows/docker.yml` | `real-stack-conformance` collects marketdata-live logs |
| `docs/DOCKER.md` | refreshed real-stack overlay section |
| `docs/rfcs/integration-real-stack-v0.md` | appended § 8 v1 amendment; Status → "Implemented (v1)" |

## Why `marketdata-live` (not just override `marketdata`)

Compose merges `volumes:` and `profiles:` *additively* across overlay files. Reusing the base service name forces a phantom PCAP bind mount and requires `--profile marketdata` on the user's CLI. A separate service name with a network alias avoids both — DNS resolution from matching and from trading-host stays unchanged because both look up `marketdata`.

## Local verification

```
docker compose -f docker-compose.yml -f docker-compose.real.yml up -d --wait trading-host
# 4 containers Healthy

curl http://localhost:5000/health
# {"exchange":{"mode":"Real","readyForOrders":true,"firmCount":1}}

docker logs b3-trading-host | grep MarketData
# MarketData subscribed: PETR4 / VALE3 / ITUB4
# MarketData connection state: Connected

docker compose ... -f docker-compose.conformance.yml run --rm conformance
# Test Run Successful. Total tests: 6 (5 Auth + 1 AdminFirms).
```

Marketdata reaches `G0:Streaming` with 3 instruments / 3 books / 3 symbols. No trade has crossed yet (matching has only one connected firm in the real overlay), so `IReferencePrice` cache misses still fall back to the static map until a trade prints — v2 will exercise the crossed-order path.

## Cross-issues filed (non-blocking)

- [`B3MarketDataPlatform#13`](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/13) — single-channel-group guard at `Program.cs:500`. Workaround = phantom DRV group. Suggested fix = make guard transport-aware.
- [`B3MarketDataPlatform#12`](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/12) — recurring `SecurityDefinition_12.SecurityDesc` parse `ArgumentOutOfRangeException` on InstrumentDefinition packets from b3-matching. Cosmetic (books still create, state reaches Streaming) but loud in logs.

## Out of scope

- Crossed-order path that prints a trade.
- sha-pinning of upstream images (`:latest` everywhere).
- HA / multi-region (`ha-resilience-backlog` #29 still blocked).

🤖 Co-authored-by: Copilot