### PR TITLE
feat(api): admin diagnostics endpoint for reference-price plumbing

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
@@ -120,6 +121,82 @@ public static class AdminEndpoints
             return Results.NoContent();
         });
 
+        // GET /admin/marketdata/reference-prices?symbols=ITUB4,VALE3
+        // Operator/diagnostics view of the reference-price plumbing.
+        // Surfaces three independent readings per symbol so the caller
+        // can disambiguate "live deslocou fallback?" without inferring
+        // it from the metric tags alone:
+        //   - effective : what IReferencePrice.Lookup currently returns
+        //                 (Live | Fallback | Missing) — the single value
+        //                 the price-collar check actually consumes.
+        //   - live      : raw entry from MarketDataReferencePrice's cache
+        //                 (price + updatedUtc), independent of staleness.
+        //                 Null when MD feature is off or the symbol has
+        //                 never been observed on the WS feed.
+        //   - fallback  : raw entry from the static config table.
+        //                 Null when the symbol has no static reference.
+        // When `symbols` is omitted, returns the union of MD-subscribed
+        // symbols (Trading:MarketData:Symbols) and statically-configured
+        // ones (Trading:Risk:ReferencePrices), de-duplicated.
+        group.MapGet("/marketdata/reference-prices", (
+            string? symbols,
+            ConfigReferencePrice fallback,
+            IServiceProvider sp,
+            IOptions<MarketDataOptions> mdOpts,
+            IOptionsMonitor<RiskOptions> riskOpts,
+            IOptions<ExchangeOptions> exchangeOpts) =>
+        {
+            // MarketDataReferencePrice is registered only when the WsUrl
+            // gate is set (see MarketDataRegistration.cs). When absent,
+            // IReferencePrice resolves to ConfigReferencePrice — same as
+            // the fallback we already inject here, so the endpoint
+            // gracefully degrades to a "fallback only" view.
+            var mdRef = sp.GetService<MarketDataReferencePrice>();
+            var liveSnapshot = mdRef?.Snapshot();
+            var effective = (IReferencePrice?)mdRef ?? fallback;
+
+            var requested = ParseSymbolList(symbols);
+            if (requested.Count == 0)
+            {
+                var union = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var s in mdOpts.Value.Symbols)
+                    if (!string.IsNullOrWhiteSpace(s)) union.Add(s.Trim());
+                foreach (var s in riskOpts.CurrentValue.ReferencePrices.Keys)
+                    if (!string.IsNullOrWhiteSpace(s)) union.Add(s);
+                requested = union.OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
+            }
+
+            var items = requested.Select(sym =>
+            {
+                var eff = effective.Lookup(sym);
+                var fb = fallback.Lookup(sym);
+                object? liveBlock = null;
+                if (liveSnapshot is not null && liveSnapshot.TryGetValue(sym, out var entry))
+                {
+                    liveBlock = new
+                    {
+                        price = entry.Price,
+                        updatedUtc = entry.UpdatedUtc,
+                    };
+                }
+                return new
+                {
+                    symbol = sym,
+                    effectivePrice = eff.Found ? eff.Price : (decimal?)null,
+                    effectiveSource = eff.Source.ToString(),
+                    live = liveBlock,
+                    fallbackPrice = fb.Found ? fb.Price : (decimal?)null,
+                };
+            }).ToArray();
+
+            return Results.Ok(new
+            {
+                mode = exchangeOpts.Value.ResolveMode().ToString(),
+                marketDataEnabled = mdRef is not null,
+                symbols = items,
+            });
+        });
+
         // POST /admin/simulator/er — synthetic ER injection for slice-4
         // simulator mode (RFC algo-orders-v0 §4.10/§7-B3). Only mapped
         // when Mode=Simulator at boot, so the route is invisible to other
@@ -133,6 +210,20 @@ public static class AdminEndpoints
         }
 
         return app;
+    }
+
+    private static List<string> ParseSymbolList(string? csv)
+    {
+        if (string.IsNullOrWhiteSpace(csv))
+            return new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>();
+        foreach (var raw in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (seen.Add(raw))
+                ordered.Add(raw);
+        }
+        return ordered;
     }
 
     private static IResult ToggleKill(

--- a/backend/tests/B3.Trading.Api.Tests/AdminMarketDataEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminMarketDataEndpointTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Coverage for <c>GET /admin/marketdata/reference-prices</c> — the
+/// diagnostics surface that lets ops introspect the reference-price
+/// plumbing without deriving it from metric tags. Slice A of
+/// real-stack v2: this endpoint is the contract the v2 conformance
+/// spec will assert against.
+/// </summary>
+public class AdminMarketDataEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public AdminMarketDataEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task ReferencePrices_RequiresAdminRole()
+    {
+        using var user = await _factory.CreateAuthedClientAsync(); // role=user
+        var resp = await user.GetAsync("/admin/marketdata/reference-prices?symbols=PETR4");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReferencePrices_DefaultFactory_NoMarketData_ReportsFallbackOnly()
+    {
+        // The default test factory leaves Trading:MarketData:WsUrl unset,
+        // so MarketDataReferencePrice is not registered and the endpoint
+        // gracefully degrades to a fallback-only view.
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Risk:ReferencePrices:PETR4"] = "32.50",
+        });
+        using var admin = await f.CreateAuthedClientAsync("admin");
+
+        var resp = await admin.GetAsync("/admin/marketdata/reference-prices?symbols=PETR4");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.False(body.GetProperty("marketDataEnabled").GetBoolean());
+
+        var entries = body.GetProperty("symbols");
+        Assert.Equal(1, entries.GetArrayLength());
+        var entry = entries[0];
+        Assert.Equal("PETR4", entry.GetProperty("symbol").GetString());
+        Assert.Equal("Fallback", entry.GetProperty("effectiveSource").GetString());
+        Assert.Equal(32.50m, entry.GetProperty("effectivePrice").GetDecimal());
+        Assert.Equal(JsonValueKind.Null, entry.GetProperty("live").ValueKind);
+        Assert.Equal(32.50m, entry.GetProperty("fallbackPrice").GetDecimal());
+    }
+
+    [Fact]
+    public async Task ReferencePrices_UnknownSymbol_ReportsMissing()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+
+        var resp = await admin.GetAsync("/admin/marketdata/reference-prices?symbols=NEVERHEARD");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var entry = body.GetProperty("symbols")[0];
+        Assert.Equal("NEVERHEARD", entry.GetProperty("symbol").GetString());
+        Assert.Equal("Missing", entry.GetProperty("effectiveSource").GetString());
+        Assert.Equal(JsonValueKind.Null, entry.GetProperty("effectivePrice").ValueKind);
+        Assert.Equal(JsonValueKind.Null, entry.GetProperty("live").ValueKind);
+        Assert.Equal(JsonValueKind.Null, entry.GetProperty("fallbackPrice").ValueKind);
+    }
+
+    [Fact]
+    public async Task ReferencePrices_NoSymbolsQuery_ReturnsUnionOfConfigured()
+    {
+        // With no `symbols` query param, the endpoint should enumerate
+        // everything it knows about: MD-subscribed symbols ∪ static
+        // fallback keys, de-duplicated. Default factory has no MD
+        // subscriptions, so this exercises just the static keys.
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Risk:ReferencePrices:PETR4"] = "32.50",
+            ["Trading:Risk:ReferencePrices:VALE3"] = "65.00",
+        });
+        using var admin = await f.CreateAuthedClientAsync("admin");
+
+        var resp = await admin.GetAsync("/admin/marketdata/reference-prices");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var symbols = body.GetProperty("symbols")
+            .EnumerateArray()
+            .Select(e => e.GetProperty("symbol").GetString())
+            .ToHashSet();
+        Assert.Contains("PETR4", symbols);
+        Assert.Contains("VALE3", symbols);
+    }
+
+    [Fact]
+    public async Task ReferencePrices_DuplicateSymbolsInQuery_AreDeduped()
+    {
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Risk:ReferencePrices:PETR4"] = "32.50",
+        });
+        using var admin = await f.CreateAuthedClientAsync("admin");
+
+        var resp = await admin.GetAsync("/admin/marketdata/reference-prices?symbols=PETR4,PETR4,petr4");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Equal(1, body.GetProperty("symbols").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ReferencePrices_ReportsExchangeMode()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/marketdata/reference-prices?symbols=PETR4");
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        var mode = body.GetProperty("mode").GetString();
+        Assert.False(string.IsNullOrEmpty(mode));
+    }
+}


### PR DESCRIPTION
## Resumo

Slice A do real-stack v2 (split conforme rubber-duck). Adiciona `GET /admin/marketdata/reference-prices` — surface de diagnóstico que expõe as três leituras independentes do plumbing de reference-price, sem inferir do tag de métricas.

## Contrato

```
GET /admin/marketdata/reference-prices?symbols=ITUB4,VALE3
```

Resposta:
```json
{
  "mode": "Real",
  "marketDataEnabled": true,
  "symbols": [
    {
      "symbol": "ITUB4",
      "effectivePrice": 31.23,
      "effectiveSource": "Live",
      "live": { "price": 31.23, "updatedUtc": "2026-05-04T..." },
      "fallbackPrice": 30.00
    }
  ]
}
```

- **effective**: o que `IReferencePrice.Lookup` retorna (Live/Fallback/Missing)
- **live**: entry raw do cache do `MarketDataReferencePrice` (price + updatedUtc), null quando MD off ou símbolo nunca observado
- **fallback**: entry raw da tabela estática
- Sem query `symbols`: união de MD-subscribed ∪ static fallback keys, dedup.

## Por que separados

A Slice B vai precisar asserir "trade deslocou fallback" em real-stack conformance. A revisão do rubber-duck mostrou que asserir "initial Fallback" é race (InfoSnapshot pode pré-popular). A solução determinística é capturar `liveUpdatedUtc` baseline, postar cross com price diferente do fallback, e asserir `updatedUtc > baseline` + `price == cross`. Esse contrato exige expor live + fallback separados — daí a slice.

## Testes

6 novos em `AdminMarketDataEndpointTests`:
- gate de admin (403 pra user)
- degrada graciosamente quando MD off (`marketDataEnabled: false`)
- símbolo desconhecido → `Missing` + nulls
- query vazia retorna união de configurados
- dedupe case-insensitive
- reporta `mode`

128/128 verde no `B3.Trading.Api.Tests`.

## Próximos passos

Slice B (follow-up): firm/símbolo wiring no overlay real, novo `RequiresSandboxMatching` flag, e o spec de crossed-order usando esse endpoint pra asserções determinísticas.

Co-authored-by: Copilot