### PR TITLE
feat(conformance): real-stack v2 — crossed-order prints displace live ref-price

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,7 +160,7 @@ jobs:
           docker compose \
               -f docker/docker-compose.yml \
               -f docker/docker-compose.conformance.yml \
-              run --rm conformance
+              run --rm --no-deps conformance
 
       - name: Trading-host logs (always)
         if: always()
@@ -224,12 +224,18 @@ jobs:
         # Per RFC integration-real-stack-v0 §4.7: auth + admin/firms +
         # risk-rejection-shape exercise the real wire; simulator + algo
         # specs auto-skip on RequiresSimulator (no Mode=Simulator).
+        # `--no-deps` is critical: without it, `docker compose run` will
+        # recreate trading-host (and its FIXP session) between the
+        # `up --wait` step and conformance execution, which leaves the
+        # SDK trying to reuse SessionVerId=1 against a matching that
+        # already saw last-seen=1, producing a permanent negotiate-reject
+        # loop and the spec timing out at `sessionState=terminating`.
         run: |
           docker compose \
               -f docker/docker-compose.yml \
               -f docker/docker-compose.real.yml \
               -f docker/docker-compose.conformance.yml \
-              run --rm conformance
+              run --rm --no-deps conformance
 
       - name: Logs (always)
         if: always()

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
@@ -33,6 +33,16 @@ public sealed class ConformanceFactAttribute : FactAttribute
     /// </summary>
     public bool RequiresSimulator { get; init; }
 
+    /// <summary>
+    /// When true, the scenario is gated to the dedicated docker-compose
+    /// real-stack sandbox (operator opts in via
+    /// <c>B3T_REAL_STACK_CONFORMANCE=true</c>). Used for destructive
+    /// active-flow tests that submit crossed orders and expect real
+    /// trade prints — those would be unsafe to run against any
+    /// non-sandbox deployment even when the wires happen to reach.
+    /// </summary>
+    public bool RequiresSandboxMatching { get; init; }
+
     public ConformanceFactAttribute()
     {
         var peer = PlatformEndpoint.TryResolve();
@@ -74,6 +84,8 @@ public sealed class ConformanceFactAttribute : FactAttribute
                 return PlatformEndpoint.AdminSkipReason;
             if (RequiresSimulator && !PlatformEndpoint.IsSimulatorMode())
                 return PlatformEndpoint.SimulatorSkipReason;
+            if (RequiresSandboxMatching && !PlatformEndpoint.IsRealStackConformance())
+                return PlatformEndpoint.RealStackConformanceSkipReason;
             return null;
         }
         set => base.Skip = value;

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
@@ -34,6 +34,7 @@ public sealed record PlatformEndpoint(
     public const string EnvAdminUsername = "B3T_ADMIN_USER";
     public const string EnvAdminPassword = "B3T_ADMIN_PASS";
     public const string EnvSimulatorMode = "B3T_SIMULATOR_MODE";
+    public const string EnvRealStackConformance = "B3T_REAL_STACK_CONFORMANCE";
 
     public static PlatformEndpoint? TryResolve()
     {
@@ -79,6 +80,20 @@ public sealed record PlatformEndpoint(
         return string.Equals(v, "true", StringComparison.OrdinalIgnoreCase) || v == "1";
     }
 
+    /// <summary>
+    /// True when the operator declared this is the dedicated docker-compose
+    /// real-stack sandbox (env var <c>B3T_REAL_STACK_CONFORMANCE=true</c>).
+    /// Gates destructive scenarios that submit live crossed orders and
+    /// expect them to print real trades — running those against
+    /// staging/prod-like infrastructure would be unsafe even if the
+    /// matching+marketdata wires happened to be reachable.
+    /// </summary>
+    public static bool IsRealStackConformance()
+    {
+        var v = Environment.GetEnvironmentVariable(EnvRealStackConformance);
+        return string.Equals(v, "true", StringComparison.OrdinalIgnoreCase) || v == "1";
+    }
+
     public const string SkipReason =
         "Conformance platform not configured. Set B3T_BASE_URL, B3T_AUTH_USER, B3T_AUTH_PASS to run.";
 
@@ -87,4 +102,7 @@ public sealed record PlatformEndpoint(
 
     public const string SimulatorSkipReason =
         "Simulator scenario skipped: B3T_SIMULATOR_MODE=true not set (host is not in Mode=Simulator).";
+
+    public const string RealStackConformanceSkipReason =
+        "Real-stack scenario skipped: B3T_REAL_STACK_CONFORMANCE=true not set (host is not the docker-compose real-stack sandbox).";
 }

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs
@@ -63,6 +63,16 @@ public class ReferencePriceLiveSpecTests
         var adminAuth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
         var userAuth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
 
+        // Preflight: the trading-host's /ready turns green as soon as
+        // the HTTP listener is up — it does NOT wait for FIXP to finish
+        // negotiating with matching. On slower CI runners that delta is
+        // multi-second, long enough for the spec to fire its first
+        // POST /orders before the FirmGateway is `established`, in
+        // which case the host short-circuits to 502 gateway-unavailable.
+        // Block here until /admin/firms reports the alice-firm session
+        // is established (or fail loudly with the last-seen state).
+        await WaitForFirmEstablishedAsync(http, adminAuth);
+
         // Baseline — capture (and log) but do not assert source. The
         // live cache may already be primed by an InfoSnapshot from the
         // matching emitter's startup cycle, in which case effectiveSource
@@ -111,6 +121,41 @@ public class ReferencePriceLiveSpecTests
         Assert.Fail(
             $"Timed out after {PollTimeout.TotalSeconds:F0}s waiting for {Symbol} live ref-price=={CrossPrice} updated after {submitStartUtc:o}. " +
             $"Baseline: {Format(baseline)}. Last seen: {Format(lastSeen)}.");
+    }
+
+    private static async Task WaitForFirmEstablishedAsync(
+        HttpClient http, AuthenticationHeaderValue auth)
+    {
+        // 60s budget covers cold-CI timing (image load, EPC SDK
+        // negotiate+establish, FIXP auth handshake). On a warm local
+        // stack it returns in <1s.
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(60);
+        string? lastState = null;
+        int? lastFirmCount = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, "/admin/firms");
+            req.Headers.Authorization = auth;
+            var resp = await http.SendAsync(req);
+            if (resp.IsSuccessStatusCode)
+            {
+                var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
+                var firms = json.GetProperty("firms");
+                lastFirmCount = firms.GetArrayLength();
+                if (lastFirmCount > 0)
+                {
+                    var state = firms[0].TryGetProperty("sessionState", out var s) && s.ValueKind == JsonValueKind.String
+                        ? s.GetString()
+                        : null;
+                    lastState = state;
+                    if (string.Equals(state, "established", StringComparison.OrdinalIgnoreCase))
+                        return;
+                }
+            }
+            await Task.Delay(PollInterval);
+        }
+        Assert.Fail(
+            $"Timed out waiting for FirmGateway to reach 'established' (last sessionState={lastState ?? "<none>"}, firmCount={lastFirmCount?.ToString() ?? "<none>"}).");
     }
 
     private static async Task SubmitOrderAndAssertAcceptedAsync(

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_MarketData;
+
+/// <summary>
+/// Spec — MarketData. A trade that prints on the matching engine must
+/// reach the trading-host through the live UMDF + WS leg and displace
+/// the static fallback in <c>MarketDataReferencePrice</c>. This spec
+/// proves the end-to-end loop: matching → marketdata UMDF → marketdata
+/// WS → trading-host cache → <c>IReferencePrice</c> diagnostics.
+///
+/// <para>
+/// Gate: <see cref="ConformanceFactAttribute.RequiresSandboxMatching"/>.
+/// The scenario submits a real crossed-pair (buy + sell at the same
+/// price/qty) and expects matching to print a trade — destructive in
+/// any non-sandbox environment, so it stays skipped unless the
+/// operator explicitly opts in via
+/// <c>B3T_REAL_STACK_CONFORMANCE=true</c>. The docker-compose
+/// real-stack overlay sets the flag; nothing else does.
+/// </para>
+///
+/// <para>
+/// Design notes (rubber-duck'd):
+/// <list type="bullet">
+/// <item>Pre-cross baseline is captured but NOT asserted to be
+///       <c>Fallback</c> — <c>InfoSnapshot.TradingReferencePrice</c>
+///       could pre-populate the live cache before this test runs. The
+///       deterministic invariant is "after the cross, live.price equals
+///       the cross price AND live.updatedUtc advanced past the moment
+///       we started submitting", regardless of pre-warmed state.</item>
+/// <item>Cross price is chosen distinct from the configured static
+///       fallback (30.00) so a coincidental fallback->live transition
+///       at the wrong price would still fail the assertion.</item>
+/// <item>Quantity 100 / price 31.00 respects matching's lot/tick
+///       constraints (lot=100, tick=0.01 in instruments-eqt.json) and
+///       sits well inside the default ±10% collar around the static
+///       fallback (range [27.00, 33.00]).</item>
+/// <item>30s timeout covers the multi-hop async path (FIXP submit →
+///       matching execute → UMDF UDP → marketdata WS → trading-host
+///       cache update). 250ms poll keeps the failure window tight.</item>
+/// </list>
+/// </para>
+/// </summary>
+[Trait("Category", "Conformance")]
+public class ReferencePriceLiveSpecTests
+{
+    private const string Symbol = "ITUB4";
+    private const decimal CrossPrice = 31.00m;
+    private const long CrossQuantity = 100;
+    private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+
+    [ConformanceFact(RequiresAdmin = true, RequiresSandboxMatching = true)]
+    public async Task CrossedTrade_DisplacesFallback_ReachesLiveCacheWithCrossPrice()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var adminAuth = await LoginHelper.LoginAsync(http, peer.AdminUsername!, peer.AdminPassword!);
+        var userAuth = await LoginHelper.LoginAsync(http, peer.Username, peer.Password);
+
+        // Baseline — capture (and log) but do not assert source. The
+        // live cache may already be primed by an InfoSnapshot from the
+        // matching emitter's startup cycle, in which case effectiveSource
+        // is already Live before any trade has actually printed. The
+        // deterministic step is the post-cross assertion below.
+        var baseline = await GetReferencePriceAsync(http, adminAuth, Symbol);
+        Assert.Equal(Symbol, baseline.Symbol);
+        // Static fallback must be configured for this symbol — otherwise
+        // we couldn't prove "live displaced fallback", we'd only prove
+        // "live filled a hole". The real overlay seeds it explicitly.
+        Assert.NotNull(baseline.FallbackPrice);
+
+        // Mark the moment we start submitting; the live cache update
+        // for the trade we're about to print MUST arrive after this.
+        var submitStartUtc = DateTimeOffset.UtcNow;
+
+        // Cross pair from the same authenticated end-client. The
+        // matching bridge is configured with selfTradePrevention=none
+        // (docker/real/exchange-simulator.bridge.json), so opposite
+        // sides at the same price/qty will execute against each other.
+        await SubmitOrderAndAssertAcceptedAsync(http, userAuth, side: "Buy");
+        await SubmitOrderAndAssertAcceptedAsync(http, userAuth, side: "Sell");
+
+        // Poll the diagnostics endpoint until the live cache reports the
+        // cross price OR we exhaust the budget. On timeout, dump every
+        // observation we can to make the failure debuggable.
+        var deadline = DateTimeOffset.UtcNow + PollTimeout;
+        ReferencePriceDiagnostic? lastSeen = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var current = await GetReferencePriceAsync(http, adminAuth, Symbol);
+            lastSeen = current;
+            if (current.Live is { } live &&
+                live.Price == CrossPrice &&
+                live.UpdatedUtc > submitStartUtc)
+            {
+                // Bonus invariant: with the live cache hit, the effective
+                // resolution must reflect Live (not Fallback / Missing).
+                Assert.Equal("Live", current.EffectiveSource);
+                Assert.Equal(CrossPrice, current.EffectivePrice);
+                return;
+            }
+            await Task.Delay(PollInterval);
+        }
+
+        Assert.Fail(
+            $"Timed out after {PollTimeout.TotalSeconds:F0}s waiting for {Symbol} live ref-price=={CrossPrice} updated after {submitStartUtc:o}. " +
+            $"Baseline: {Format(baseline)}. Last seen: {Format(lastSeen)}.");
+    }
+
+    private static async Task SubmitOrderAndAssertAcceptedAsync(
+        HttpClient http, AuthenticationHeaderValue auth, string side)
+    {
+        // SymbolDirectory in the real overlay maps ITUB4 → 900000000003
+        // (matching the instruments file the matching-platform loads),
+        // so we can omit securityId and let the host resolve.
+        using var submit = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Headers = { Authorization = auth },
+            Content = JsonContent.Create(new
+            {
+                symbol = Symbol,
+                side,
+                type = "Limit",
+                quantity = CrossQuantity,
+                price = CrossPrice,
+            }),
+        };
+
+        var resp = await http.SendAsync(submit);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.True(resp.StatusCode == HttpStatusCode.Accepted,
+            $"{side} POST /orders expected 202 Accepted, got {(int)resp.StatusCode}: {body}");
+
+        // 202 Accepted is also returned for risk-rejected orders (with
+        // status="Rejected" in the body — see RiskRejectionShapeSpec).
+        // For this scenario, we need actual acceptance through to the
+        // gateway; assert the status field is absent or != "Rejected".
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            var json = JsonDocument.Parse(body).RootElement;
+            if (json.TryGetProperty("status", out var statusProp))
+            {
+                var status = statusProp.GetString();
+                Assert.True(!string.Equals(status, "Rejected", StringComparison.OrdinalIgnoreCase),
+                    $"{side} POST /orders was risk-rejected before reaching matching: {body}");
+            }
+        }
+    }
+
+    private static async Task<ReferencePriceDiagnostic> GetReferencePriceAsync(
+        HttpClient http, AuthenticationHeaderValue auth, string symbol)
+    {
+        using var req = new HttpRequestMessage(
+            HttpMethod.Get, $"/admin/marketdata/reference-prices?symbols={Uri.EscapeDataString(symbol)}");
+        req.Headers.Authorization = auth;
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var entry = json.GetProperty("symbols")[0];
+
+        LiveBlock? live = null;
+        if (entry.TryGetProperty("live", out var liveProp) && liveProp.ValueKind == JsonValueKind.Object)
+        {
+            live = new LiveBlock(
+                liveProp.GetProperty("price").GetDecimal(),
+                liveProp.GetProperty("updatedUtc").GetDateTimeOffset());
+        }
+
+        return new ReferencePriceDiagnostic(
+            Symbol: entry.GetProperty("symbol").GetString()!,
+            EffectivePrice: entry.GetProperty("effectivePrice").ValueKind == JsonValueKind.Null
+                ? null : entry.GetProperty("effectivePrice").GetDecimal(),
+            EffectiveSource: entry.GetProperty("effectiveSource").GetString()!,
+            Live: live,
+            FallbackPrice: entry.GetProperty("fallbackPrice").ValueKind == JsonValueKind.Null
+                ? null : entry.GetProperty("fallbackPrice").GetDecimal());
+    }
+
+    private static string Format(ReferencePriceDiagnostic? d) => d is null
+        ? "<none>"
+        : $"{{ source={d.EffectiveSource}, effective={d.EffectivePrice?.ToString() ?? "null"}, live={(d.Live is { } l ? $"{l.Price}@{l.UpdatedUtc:o}" : "null")}, fallback={d.FallbackPrice?.ToString() ?? "null"} }}";
+
+    private sealed record ReferencePriceDiagnostic(
+        string Symbol,
+        decimal? EffectivePrice,
+        string EffectiveSource,
+        LiveBlock? Live,
+        decimal? FallbackPrice);
+
+    private sealed record LiveBlock(decimal Price, DateTimeOffset UpdatedUtc);
+}

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -134,19 +134,38 @@ services:
       Trading__Exchange__Firms__0__SessionId: "10101"
       Trading__Exchange__Firms__0__SessionVerId: "1"
       Trading__Exchange__Firms__0__EnteringFirm: "100"
-      Trading__Exchange__Firms__0__AccessKey: dev-key-1
+      # Matching's FixpSession parses Credentials as JSON expecting
+      # { auth_type, username, access_key }. devMode disables enforcement
+      # but the parse still requires the schema. Pre-this-fix, the raw
+      # "dev-key-1" string was rejected with "'d' is an invalid start of
+      # a value", and a too-thin {"accessKey":...} was rejected with
+      # "missing required field (auth_type/username/access_key)".
+      Trading__Exchange__Firms__0__AccessKey: '{"auth_type":"basic","username":"10101","access_key":"dev-key-1"}'
       Trading__Exchange__Firms__0__SenderLocation: SP
       Trading__Exchange__Firms__0__EnteringTrader: ALICE
-      # Map the conformance/test SecurityIds onto the symbols matching
-      # advertises in instruments-eqt.json. Conformance specs that POST
-      # to /orders or /algo with an explicit SecurityId still resolve
-      # against the host-side directory; the upstream id (900000000001
-      # for PETR4) is what matching matches on if the order ever reaches
-      # the gateway. v0's covered specs (auth/admin/risk) either skip
-      # the gateway entirely or get rejected by risk first, so the
-      # mapping is documentation more than enforcement.
-      Trading__SymbolDirectory__SecurityIds__PETR4: "4321"
-      Trading__SymbolDirectory__SecurityIds__VALE3: "1234"
+      # alice's firm is `default` in the base compose for back-compat with
+      # Mock/Simulator mode, but in Real mode every order routed by JWT
+      # firm claim has to find a registered FirmGateway. Override here so
+      # the seeded user actually reaches matching instead of bouncing as
+      # a gateway-routing miss.
+      Trading__Auth__Users__0__Firm: FIRM01
+      # Map the conformance-driven symbols onto the SecurityIds matching
+      # advertises in instruments-eqt.json. v1 used placeholder ids that
+      # would have been silently rejected by matching had any order ever
+      # reached the gateway; v2 corrects them so /orders submissions for
+      # PETR4/VALE3/ITUB4 hit a real instrument and can print trades.
+      Trading__SymbolDirectory__SecurityIds__PETR4: "900000000001"
+      Trading__SymbolDirectory__SecurityIds__VALE3: "900000000002"
+      Trading__SymbolDirectory__SecurityIds__ITUB4: "900000000003"
+      # Static fallback prices for the price-collar check. Required so the
+      # collar accepts the v2 cross prices below the live cache warms up,
+      # AND so the v2 conformance spec can deterministically prove that a
+      # live trade observation displaces this static value (ITUB4 baseline
+      # = 30.00; cross prints at a different price; live block updatedUtc
+      # has to advance past baseline).
+      Trading__Risk__ReferencePrices__PETR4: "32.50"
+      Trading__Risk__ReferencePrices__VALE3: "65.00"
+      Trading__Risk__ReferencePrices__ITUB4: "30.00"
       # Live reference price via the marketdata WS leg (RFC §4.5 D3).
       # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
       # cache misses fall back to Trading:Risk:ReferencePrices map. The
@@ -156,3 +175,13 @@ services:
       Trading__MarketData__Symbols__0: PETR4
       Trading__MarketData__Symbols__1: VALE3
       Trading__MarketData__Symbols__2: ITUB4
+
+  # When the conformance overlay is also stacked on top, opt this run into
+  # the destructive real-stack scenarios. RequiresSandboxMatching specs
+  # (e.g. ReferencePriceLiveSpec) will only execute when this flag is set;
+  # any non-real conformance run keeps skipping them at discovery time.
+  # The conformance service is defined in docker-compose.conformance.yml;
+  # we just merge an env var into it from this overlay.
+  conformance:
+    environment:
+      B3T_REAL_STACK_CONFORMANCE: "true"

--- a/docs/rfcs/integration-real-stack-v0.md
+++ b/docs/rfcs/integration-real-stack-v0.md
@@ -2,7 +2,7 @@
 
 | Field    | Value                                                                  |
 | -------- | ---------------------------------------------------------------------- |
-| Status   | Implemented (v1)                                                       |
+| Status   | Implemented (v2)                                                       |
 | Tracking | [#58](https://github.com/pedrosakuma/B3TradingPlatform/issues/58)      |
 | Replaces | n/a (additive overlay on top of the family `docker-compose.yml`)       |
 
@@ -589,3 +589,98 @@ default in the real overlay**.
 - "static-map fallback is the only reference-price path in the real
   stack" — **partially closed**; fallback still serves cache misses
   until trades print, but the live path is wired and connecting.
+
+## 9. v2 amendment — destructive cross-pair conformance (2026-05-04)
+
+§8/v1 wired the live marketdata leg but left the live → trading-host
+ref-price cache unverifiable end-to-end: nothing in the real stack
+actually printed a trade, so `MarketDataReferencePrice` lived on
+`InfoSnapshot` data only and the static fallback could never be proven
+to be displaced by a real execution. v2 closes that gap with a
+destructive conformance scenario gated behind a dedicated env flag.
+
+### What ships
+
+- **New gate** `ConformanceFactAttribute.RequiresSandboxMatching` +
+  `B3T_REAL_STACK_CONFORMANCE` env (resolved by `PlatformEndpoint`).
+  Pattern matches the existing `RequiresAdmin` / `RequiresSimulator`
+  flags. Tests carrying the flag skip at discovery time unless the
+  env reads `true`/`1`.
+- **Compose plumbing** — `docker-compose.real.yml` now stacks a
+  `conformance:` service stanza that injects
+  `B3T_REAL_STACK_CONFORMANCE=true` into the conformance one-shot.
+  Compose merges environment maps additively, so:
+  - base + conformance → flag absent → spec auto-skips.
+  - base + real + conformance → flag present → spec runs.
+  This is exactly what the real-stack-conformance CI job (and only
+  that job) stacks.
+- **Real-overlay corrections required by the destructive path**:
+  - `Trading__Auth__Users__0__Firm: FIRM01` so alice's JWT firm claim
+    actually resolves to the registered FirmGateway (was `default` for
+    Mock back-compat; orders never reached the gateway).
+  - `Trading__SymbolDirectory__SecurityIds__{PETR4,VALE3,ITUB4}` set
+    to `900000000001/2/3`, the actual ids matching publishes via
+    `instruments-eqt.json`. v1's placeholders (4321/1234) would have
+    been silently mis-routed had any order arrived.
+  - `Trading__Risk__ReferencePrices__{PETR4,VALE3,ITUB4}` seeded so
+    the price-collar accepts cross prices before the live cache warms,
+    and so the v2 spec has a deterministic baseline (ITUB4=30.00) for
+    "live displaced this static value".
+  - `Trading__Exchange__Firms__0__AccessKey` reformatted as the JSON
+    envelope matching's `FixpSession` parses:
+    `{"auth_type":"basic","username":"<sessionId>","access_key":"..."}`.
+    Raw-string accessKey was rejected at Negotiate
+    (`'d' is an invalid start of a value`).
+- **New spec** `Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs`:
+  1. admin login → GET `/admin/marketdata/reference-prices?symbols=ITUB4`
+     → capture baseline (don't assert source — `InfoSnapshot` may
+     pre-populate the cache).
+  2. user login → POST `/orders` ITUB4 BUY 100 @ 31.00 + SELL 100 @
+     31.00. Assert both 202 with no `Rejected` status (failure mode
+     `gateway unavailable` would surface as 502 with body).
+  3. Poll diagnostics endpoint every 250ms up to 30s for
+     `live.price == 31.00` AND `live.updatedUtc > submitStartUtc`.
+  4. Bonus: assert `effectiveSource == "Live"` and
+     `effectivePrice == 31.00`.
+- Cross price (31.00) is chosen distinct from the configured fallback
+  (30.00) so a coincidental fallback→live transition at the wrong
+  price would still fail. Within the default ±10% collar
+  ([27.00, 33.00]) and respects matching's lot/tick (100 / 0.01).
+
+### Verification
+
+```
+$ docker compose -f docker-compose.yml -f docker-compose.real.yml \
+                 -f docker-compose.conformance.yml run --rm conformance
+Passed B3.Trading.Conformance.Spec_HTTP_MarketData.ReferencePriceLiveSpecTests
+       .CrossedTrade_DisplacesFallback_ReachesLiveCacheWithCrossPrice [973 ms]
+Total tests: 12  Passed: 9  Skipped: 3 (simulator-only)
+```
+
+End-to-end latency `POST /orders → live cache update` < 1s on the local
+real stack.
+
+### Upstream interop bugs surfaced en route
+
+The v2 implementation was blocked three times in sequence by upstream
+interop issues that no other downstream had hit. All three closed
+within the same window:
+
+- `B3MatchingPlatform#236` — FIXP `NewOrderSingle` template=102 v6 from
+  EPC 0.8.0 rejected as `UnsupportedTemplate`.
+- `B3MatchingPlatform#239` — `varData has 2 trailing byte(s) after
+  declared fields` on the first business message.
+- `B3MatchingPlatform#241` — `business reject (unsupported feature)
+  RoutingInstruction=0 not supported`. EPC 0.8.0 doesn't expose
+  `RoutingInstruction` on its public submit API; matching now accepts
+  the SBE default.
+
+The pattern (each interop discovered downstream via this exact spec)
+suggests a CI gap on the matching repo. Recommended in #241 that
+matching add a submit-and-execute path via EPC to its own CI.
+
+### Status
+
+- "static-map fallback is the only reference-price path in the real
+  stack" — **fully closed**: live cache verifiably displaces the
+  fallback under a real cross-pair execution.


### PR DESCRIPTION
Closes the v1 gap on RFC integration-real-stack-v0: nothing in the real stack was actually printing trades, so `MarketDataReferencePrice` could only ever be filled by `InfoSnapshot` — the "live displaces fallback" invariant was never proven. v2 proves it.

## What ships

- **New conformance spec** `Spec_HTTP_MarketData/ReferencePriceLiveSpecTests.cs`: admin login → baseline GET → user login → POST `/orders` ITUB4 BUY 100 @ 31.00 + SELL 100 @ 31.00 (both 202) → poll `/admin/marketdata/reference-prices` (Slice A, #64) every 250ms up to 30s → assert `live.price == 31.00` AND `live.updatedUtc > submitStartUtc` AND `effectiveSource == "Live"`.
- **New gate** `ConformanceFactAttribute.RequiresSandboxMatching` + `B3T_REAL_STACK_CONFORMANCE` env. Pattern matches existing `RequiresAdmin` / `RequiresSimulator`. The destructive scenario only runs when the env is set.
- **Compose overlay merge** in `docker-compose.real.yml`: a `conformance:` stanza additively injects `B3T_REAL_STACK_CONFORMANCE=true` into the conformance one-shot. Plain conformance run (no real overlay) → flag absent → spec auto-skips at discovery.
- **Real-overlay corrections** required for the destructive path to actually reach matching:
  - alice's firm overridden to `FIRM01` (was `default` for Mock back-compat — orders never reached the gateway).
  - `SymbolDirectory.SecurityIds` set to the actual ids matching publishes via `instruments-eqt.json` (`PETR4=900000000001/VALE3=900000000002/ITUB4=900000000003`); v1's placeholders would have been silently mis-routed.
  - `Risk.ReferencePrices` seeded so the price-collar accepts cross prices before live cache warms, and so the spec has a deterministic baseline (ITUB4=30.00).
  - `Trading__Exchange__Firms__0__AccessKey` reformatted as the JSON envelope matching's FixpSession parses: `{auth_type:"basic", username:"<sessionId>", access_key:"..."}`. Raw string was rejected at Negotiate.
- **RFC §9** documents the v2 amendment: design, gate semantics, verification transcript, and the three upstream interop bugs surfaced en route.

## Verification

```
$ docker compose -f docker-compose.yml -f docker-compose.real.yml \
                 -f docker-compose.conformance.yml run --rm conformance
Passed B3.Trading.Conformance.Spec_HTTP_MarketData.ReferencePriceLiveSpecTests
       .CrossedTrade_DisplacesFallback_ReachesLiveCacheWithCrossPrice [973 ms]
Total tests: 12  Passed: 9  Skipped: 3 (simulator-only)
```

`Api.Tests`: 128/128 green.

End-to-end latency `POST /orders → live cache update` measured < 1s on the local real stack.

## Upstream interop bugs surfaced en route

The implementation was blocked three times in sequence by interop bugs no other downstream had hit. All three closed within the same window:

- B3MatchingPlatform#236 — FIXP NewOrderSingle template=102 v6 from EPC 0.8.0 rejected as `UnsupportedTemplate`.
- B3MatchingPlatform#239 — `varData has 2 trailing byte(s) after declared fields` on the first business message.
- B3MatchingPlatform#241 — `business reject (unsupported feature) RoutingInstruction=0 not supported`. EPC 0.8.0 doesn't expose the field on its public submit API; matching now accepts the SBE default.

Recommended in #241 that matching add a submit-and-execute path via EPC to its own CI, to cut the discover-via-downstream cycle.

## CI expectations

- `real-stack-conformance` job runs the new spec (env present) and now reports 9 passed.
- `conformance` (plain) job continues to skip it at discovery (env absent), no behavior change.