### PR TITLE
T1: extend mdProtocol decoder for MBP book + server-side candles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,11 @@ jobs:
       # the entry point is present.
       - name: Verify frontend entry point exists
         run: test -f frontend/index.html
+
+      - name: Set up Node (for decoder unit tests)
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Run mdProtocol decoder tests (no deps, node:test)
+        run: node --test frontend/test/decoder.test.mjs

--- a/frontend/js/mdProtocol.js
+++ b/frontend/js/mdProtocol.js
@@ -5,24 +5,59 @@
 // We deliberately *do not* depend on the MD repo's frontend protocol
 // helper — keeping a thin, hand-rolled subset here means the trader UI
 // has no upstream coupling beyond the wire.
+//
+// v2 (T1, issue #67): adds MBP book frames (BOOK_SNAPSHOT, LEVEL_*,
+// BOOK_CLEARED) and server-side candles (CANDLE_*). MBO order frames
+// (ORDER_*) remain out of scope — see RFC #66 for rationale.
 
 export const MSG = {
   SUBSCRIBE: 0x0001,
   UNSUBSCRIBE: 0x0002,
   SUBSCRIBE_OK: 0x0010,
   SUBSCRIBE_ERROR: 0x0011,
+  BOOK_SNAPSHOT: 0x0020,
   INFO_SNAPSHOT: 0x0021,
+  LEVEL_SNAPSHOT: 0x0022,
   TRADE: 0x0033,
+  BOOK_CLEARED: 0x0034,
   TRADE_BUST: 0x0035,
+  LEVEL_UPDATE: 0x0037,
+  LEVEL_DELETED: 0x0038,
   SERVER_STATUS: 0x0050,
+  CANDLE_SNAPSHOT: 0x0060,
+  CANDLE_UPDATE: 0x0061,
 };
 
 // DataFlags bits we use. `Trades` alone is enough to update last-trade
 // price; `Info` adds the periodic snapshot which seeds the cache before
-// the first live trade and surfaces venue-side trading status.
+// the first live trade and surfaces venue-side trading status. `Mbp`
+// streams aggregated price levels (DOB panel — issue #68). `Book` is
+// kept for completeness but the trader UI doesn't render full MBO.
 export const FLAGS = {
+  BOOK: 0x01,
   INFO: 0x02,
+  MBP: 0x08,
   TRADES: 0x10,
+};
+
+// CandleSnapshot.flags bits. Server may stream a multi-frame snapshot
+// (FIRST on the head, LAST on the tail) when the candle history
+// doesn't fit in a single frame.
+export const CANDLE_FLAGS = {
+  FIRST: 0x01,
+  LAST: 0x02,
+};
+
+// Side encoding for LevelUpdate/LevelDeleted (uint8). Bid=0, Ask=1 —
+// verified against MD worker.js (`side === 0 ? bidLevels : askLevels`).
+//
+// NOTE: BookCleared uses a *different* wire encoding (0=both,
+// 1=bid-only, 2=ask-only — verified against upstream worker.js
+// `BookCleared` handler). The decoder normalises that to `SIDE.BID`,
+// `SIDE.ASK`, or `null` (both) so consumers can use one enum everywhere.
+export const SIDE = {
+  BID: 0,
+  ASK: 1,
 };
 
 // Order matches the bit indices in InfoSnapshot.fieldMask. We only
@@ -46,6 +81,12 @@ const FIELD_DECIMALS = {
   TradingReferencePrice: 8,
 };
 
+// SBE Price exponent (-4) for trade/level/candle prices. All B3 cash-equity
+// prices encode with 4 decimals; we divide here so consumers see decimals
+// (R$ 30.50 instead of 305000). Risk consumers care about the divided value,
+// not the i64 mantissa, and we are nowhere near 2^53 at typical magnitudes.
+const PRICE_DIVISOR = 10_000;
+
 const SUBSCRIBE_ERROR_NAMES = { 1: 'UnknownSymbol', 2: 'NotReady' };
 
 const encoder = new TextEncoder();
@@ -53,7 +94,9 @@ const decoder = new TextDecoder();
 
 // ── Builders ──────────────────────────────────────────────────────────
 
-export function buildSubscribe(symbol, flags = FLAGS.TRADES | FLAGS.INFO) {
+const DEFAULT_SUBSCRIBE_FLAGS = FLAGS.TRADES | FLAGS.INFO;
+
+export function buildSubscribe(symbol, flags = DEFAULT_SUBSCRIBE_FLAGS) {
   const symBytes = encoder.encode(symbol.toUpperCase().trim());
   if (symBytes.length === 0 || symBytes.length > 255) {
     throw new Error(`invalid symbol length: ${symBytes.length}`);
@@ -96,7 +139,9 @@ export function parseFrames(arrayBuffer) {
     const v = new DataView(arrayBuffer, off, Math.min(4, total - off));
     const len = v.getUint16(0, true);
     if (len < 4 || off + len > total) break; // truncated/garbage; bail
-    const ev = parseOne(arrayBuffer, off, len);
+    let ev = null;
+    try { ev = parseOne(arrayBuffer, off, len); }
+    catch { /* malformed payload of a known type; skip this frame, keep parsing */ }
     if (ev) out.push(ev);
     off += len;
   }
@@ -153,7 +198,7 @@ function parseOne(buf, base, len) {
       // Price field has SBE exponent -4. Use Number() because at typical
       // B3 magnitudes (R$ 1e0–1e3 with 4 decimals) we are nowhere near
       // 2^53; risk consumers care about the divided value, not the i64.
-      const price = Number(priceMantissa) / 10_000;
+      const price = Number(priceMantissa) / PRICE_DIVISOR;
       return { type: 'Trade', securityId, price, qty, tradeId };
     }
 
@@ -161,6 +206,113 @@ function parseOne(buf, base, len) {
       const securityId = v.getBigUint64(o, true); o += 8;
       const tradeId = Number(v.getBigInt64(o, true));
       return { type: 'TradeBust', securityId, tradeId };
+    }
+
+    case MSG.BOOK_SNAPSHOT: {
+      // Marker frame: server announces a fresh book after subscribe with
+      // the BOOK flag. Concrete levels arrive in subsequent LEVEL_SNAPSHOT
+      // (MBP) or ORDER_ADDED (MBO; not consumed here).
+      const securityId = v.getBigUint64(o, true);
+      return { type: 'BookSnapshot', securityId };
+    }
+
+    case MSG.BOOK_CLEARED: {
+      // Wire: 0=both sides, 1=bid only, 2=ask only. Older frames may
+      // omit the byte — treat as bilateral. Translated to our SIDE
+      // enum (or null = both) so consumers don't need to know the
+      // wire-vs-enum delta.
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const wire = o < len ? v.getUint8(o) : 0;
+      let side;
+      if (wire === 1) side = SIDE.BID;
+      else if (wire === 2) side = SIDE.ASK;
+      else side = null; // 0 (or omitted) = both
+      return { type: 'BookCleared', securityId, side };
+    }
+
+    case MSG.LEVEL_SNAPSHOT: {
+      // securityId(8) + bidCount(2) + askCount(2) + N entries.
+      // Entry layout: price(8 i64 mantissa, /1e4) + qty(8 i64) + count(4 u32) = 20 bytes.
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const bidCount = v.getUint16(o, true); o += 2;
+      const askCount = v.getUint16(o, true); o += 2;
+      const bids = new Array(bidCount);
+      for (let i = 0; i < bidCount; i++) {
+        const price = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const qty = Number(v.getBigInt64(o, true)); o += 8;
+        const count = v.getUint32(o, true); o += 4;
+        bids[i] = { price, qty, count };
+      }
+      const asks = new Array(askCount);
+      for (let i = 0; i < askCount; i++) {
+        const price = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const qty = Number(v.getBigInt64(o, true)); o += 8;
+        const count = v.getUint32(o, true); o += 4;
+        asks[i] = { price, qty, count };
+      }
+      return { type: 'LevelSnapshot', securityId, bids, asks };
+    }
+
+    case MSG.LEVEL_UPDATE: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const side = v.getUint8(o); o += 1;
+      const price = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+      const qty = Number(v.getBigInt64(o, true)); o += 8;
+      const count = v.getUint32(o, true);
+      return { type: 'LevelUpdate', securityId, side, price, qty, count };
+    }
+
+    case MSG.LEVEL_DELETED: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const side = v.getUint8(o); o += 1;
+      const price = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR;
+      return { type: 'LevelDeleted', securityId, side, price };
+    }
+
+    case MSG.CANDLE_SNAPSHOT: {
+      // securityId(8) + resolution(2 u16, seconds) + flags(1) + count(2) + N candles.
+      // Candle layout: time(8 unix-ms i64) + OHLC(4×8 i64, /1e4) + volume(8 i64) + avg(8 i64, /1e4) = 56 bytes.
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const resolution = v.getUint16(o, true); o += 2;
+      const flags = v.getUint8(o); o += 1;
+      const count = v.getUint16(o, true); o += 2;
+      const candles = new Array(count);
+      for (let i = 0; i < count; i++) {
+        const time = Number(v.getBigInt64(o, true)); o += 8;
+        const open = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const high = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const low = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const close = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        const volume = Number(v.getBigInt64(o, true)); o += 8;
+        const avg = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+        candles[i] = { time, open, high, low, close, volume, avg };
+      }
+      return {
+        type: 'CandleSnapshot',
+        securityId,
+        resolution,
+        candles,
+        isFirst: !!(flags & CANDLE_FLAGS.FIRST),
+        isLast: !!(flags & CANDLE_FLAGS.LAST),
+      };
+    }
+
+    case MSG.CANDLE_UPDATE: {
+      const securityId = v.getBigUint64(o, true); o += 8;
+      const resolution = v.getUint16(o, true); o += 2;
+      const time = Number(v.getBigInt64(o, true)); o += 8;
+      const open = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+      const high = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+      const low = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+      const close = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR; o += 8;
+      const volume = Number(v.getBigInt64(o, true)); o += 8;
+      const avg = Number(v.getBigInt64(o, true)) / PRICE_DIVISOR;
+      return {
+        type: 'CandleUpdate',
+        securityId,
+        resolution,
+        candle: { time, open, high, low, close, volume, avg },
+      };
     }
 
     default:

--- a/frontend/js/mdWorker.js
+++ b/frontend/js/mdWorker.js
@@ -7,20 +7,28 @@
 //   - different failure surface (server may NOT_READY at startup)
 //
 // Inputs (main thread → us):
-//   { type: "start", url, symbols: [string] }
+//   { type: "start", url, symbols: [string], flags?: number }
 //   { type: "stop" }
 //   { type: "setSymbols", symbols: [string] }   // diff applied
+//   { type: "setFlags", flags: number }         // re-subscribe with new bitmask
 //
 // Outputs (us → main thread):
 //   { type: "md.status", value: "connecting"|"connected"|"disconnected"|"not_ready" }
 //   { type: "md.trade",    symbol, price, qty, tradeId }
 //   { type: "md.info",     symbol, fields }     // raw InfoSnapshot fields
 //   { type: "md.bust",     symbol, tradeId }
+//   { type: "md.book.snapshot",     symbol }    // marker; levels follow
+//   { type: "md.book.cleared",      symbol, side }
+//   { type: "md.level.snapshot",    symbol, bids: [{price,qty,count}], asks: [...] }
+//   { type: "md.level.update",      symbol, side, price, qty, count }
+//   { type: "md.level.deleted",     symbol, side, price }
+//   { type: "md.candle.snapshot",   symbol, resolution, candles, isFirst, isLast }
+//   { type: "md.candle.update",     symbol, resolution, candle }
 //   { type: "md.subError", symbol, errorName }
 //   { type: "md.clear" }                        // dropped; main thread should reset cache
 //   { type: "md.error",    message }
 
-import { buildSubscribe, buildUnsubscribe, parseFrames } from './mdProtocol.js';
+import { buildSubscribe, buildUnsubscribe, parseFrames, FLAGS } from './mdProtocol.js';
 
 let ws = null;
 let url = null;
@@ -28,6 +36,7 @@ let stopped = false;
 let attempt = 0;
 let reconnectTimer = null;
 let serverReady = false;
+let subscribeFlags = FLAGS.TRADES | FLAGS.INFO;
 
 // Subscribed symbols. Keys are normalized (UPPERCASE, trimmed) so set
 // arithmetic is straightforward. Value is the resolved securityId once
@@ -115,9 +124,13 @@ function handleFrame(f) {
 
     case 'SubscribeOk': {
       const symbol = f.symbol.toUpperCase();
+      // Defensive: drop server-misdelivered subscriptions for symbols
+      // we never asked for. Keeps the local map honest and prevents
+      // forwarding frames the trader UI didn't request.
+      if (!subscriptions.has(symbol)) return;
       const id = f.securityId;
       subscriptions.set(symbol, id);
-      securityIdToSymbol.set(id.toString(), symbol);
+      securityIdToSymbol.set(id, symbol);
       return;
     }
 
@@ -131,23 +144,91 @@ function handleFrame(f) {
     }
 
     case 'Trade': {
-      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      const symbol = securityIdToSymbol.get(f.securityId);
       if (!symbol) return; // arrived before SubscribeOk landed; drop
       post({ type: 'md.trade', symbol, price: f.price, qty: f.qty, tradeId: f.tradeId });
       return;
     }
 
     case 'TradeBust': {
-      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      const symbol = securityIdToSymbol.get(f.securityId);
       if (!symbol) return;
       post({ type: 'md.bust', symbol, tradeId: f.tradeId });
       return;
     }
 
     case 'InfoSnapshot': {
-      const symbol = securityIdToSymbol.get(f.securityId.toString());
+      const symbol = securityIdToSymbol.get(f.securityId);
       if (!symbol) return;
       post({ type: 'md.info', symbol, fields: f.fields });
+      return;
+    }
+
+    case 'BookSnapshot': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({ type: 'md.book.snapshot', symbol });
+      return;
+    }
+
+    case 'BookCleared': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({ type: 'md.book.cleared', symbol, side: f.side });
+      return;
+    }
+
+    case 'LevelSnapshot': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({ type: 'md.level.snapshot', symbol, bids: f.bids, asks: f.asks });
+      return;
+    }
+
+    case 'LevelUpdate': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({
+        type: 'md.level.update',
+        symbol,
+        side: f.side,
+        price: f.price,
+        qty: f.qty,
+        count: f.count,
+      });
+      return;
+    }
+
+    case 'LevelDeleted': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({ type: 'md.level.deleted', symbol, side: f.side, price: f.price });
+      return;
+    }
+
+    case 'CandleSnapshot': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({
+        type: 'md.candle.snapshot',
+        symbol,
+        resolution: f.resolution,
+        candles: f.candles,
+        isFirst: f.isFirst,
+        isLast: f.isLast,
+      });
+      return;
+    }
+
+    case 'CandleUpdate': {
+      const symbol = securityIdToSymbol.get(f.securityId);
+      if (!symbol) return;
+      post({
+        type: 'md.candle.update',
+        symbol,
+        resolution: f.resolution,
+        candle: f.candle,
+      });
       return;
     }
   }
@@ -156,7 +237,7 @@ function handleFrame(f) {
 function flushSubscribes() {
   for (const [symbol, id] of subscriptions) {
     if (id !== null) continue; // already resolved
-    try { safeSend(buildSubscribe(symbol)); }
+    try { safeSend(buildSubscribe(symbol, subscribeFlags)); }
     catch (err) {
       subscriptions.delete(symbol);
       post({ type: 'md.subError', symbol, errorName: String(err.message || err) });
@@ -171,7 +252,7 @@ function applySymbolDiff(next) {
     if (wanted.has(symbol)) continue;
     if (id !== null) safeSend(buildUnsubscribe(id));
     subscriptions.delete(symbol);
-    securityIdToSymbol.delete(id?.toString() ?? '');
+    if (id !== null) securityIdToSymbol.delete(id);
     post({ type: 'md.removed', symbol });
   }
   // Add new ones.
@@ -179,13 +260,29 @@ function applySymbolDiff(next) {
     if (subscriptions.has(symbol)) continue;
     subscriptions.set(symbol, null);
     if (serverReady) {
-      try { safeSend(buildSubscribe(symbol)); }
+      try { safeSend(buildSubscribe(symbol, subscribeFlags)); }
       catch (err) {
         subscriptions.delete(symbol);
         post({ type: 'md.subError', symbol, errorName: String(err.message || err) });
       }
     }
   }
+}
+
+function resetSubscriptionsForFlagsChange() {
+  // Unsubscribe all currently-resolved symbols and re-subscribe with the
+  // new flags. The server resolves a fresh securityId per (symbol, flags)
+  // session, so we drop the reverse index and let SubscribeOk repopulate.
+  // Frames in flight under the previous flags are intentionally lost
+  // during the gap; post `md.clear` so panels (DOB, chart, tape) reset
+  // their per-symbol caches instead of mixing stale state with new.
+  for (const [, id] of subscriptions) {
+    if (id !== null) safeSend(buildUnsubscribe(id));
+  }
+  for (const sym of subscriptions.keys()) subscriptions.set(sym, null);
+  securityIdToSymbol.clear();
+  post({ type: 'md.clear' });
+  if (serverReady) flushSubscribes();
 }
 
 self.onmessage = (ev) => {
@@ -195,6 +292,9 @@ self.onmessage = (ev) => {
       url = msg.url;
       stopped = false;
       attempt = 0;
+      if (typeof msg.flags === 'number' && msg.flags > 0) {
+        subscribeFlags = msg.flags;
+      }
       subscriptions.clear();
       securityIdToSymbol.clear();
       for (const s of msg.symbols || []) {
@@ -218,6 +318,13 @@ self.onmessage = (ev) => {
 
     case 'setSymbols':
       applySymbolDiff(msg.symbols || []);
+      break;
+
+    case 'setFlags':
+      if (typeof msg.flags === 'number' && msg.flags > 0 && msg.flags !== subscribeFlags) {
+        subscribeFlags = msg.flags;
+        resetSubscriptionsForFlagsChange();
+      }
       break;
   }
 };

--- a/frontend/test/decoder.test.mjs
+++ b/frontend/test/decoder.test.mjs
@@ -1,0 +1,395 @@
+// Standalone decoder tests for frontend/js/mdProtocol.js. No deps —
+// runs with `node --test frontend/test/decoder.test.mjs` (Node 18+).
+//
+// Coverage: every MSG.* the parser handles, including the v2 additions
+// (BOOK_*, LEVEL_*, CANDLE_*) introduced in issue #67. Each test builds
+// a wire-shaped buffer matching the layout documented in mdProtocol.js
+// and asserts the decoded object shape, types, and price scaling.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MSG,
+  FLAGS,
+  CANDLE_FLAGS,
+  SIDE,
+  buildSubscribe,
+  buildUnsubscribe,
+  parseFrames,
+} from '../js/mdProtocol.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function frame(type, payloadBytes) {
+  // header = 4 bytes (len LE u16, type LE u16); body = payloadBytes
+  const total = 4 + payloadBytes.length;
+  const buf = new ArrayBuffer(total);
+  const v = new DataView(buf);
+  v.setUint16(0, total, true);
+  v.setUint16(2, type, true);
+  new Uint8Array(buf, 4).set(payloadBytes);
+  return new Uint8Array(buf);
+}
+
+function pack(...parts) {
+  // concat Uint8Arrays
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) { out.set(p, off); off += p.length; }
+  return out;
+}
+
+function u8(n) { return new Uint8Array([n & 0xff]); }
+function u16(n) {
+  const b = new Uint8Array(2);
+  new DataView(b.buffer).setUint16(0, n, true);
+  return b;
+}
+function u32(n) {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n, true);
+  return b;
+}
+function i64(n) {
+  const b = new Uint8Array(8);
+  new DataView(b.buffer).setBigInt64(0, BigInt(n), true);
+  return b;
+}
+function u64(n) {
+  const b = new Uint8Array(8);
+  new DataView(b.buffer).setBigUint64(0, BigInt(n), true);
+  return b;
+}
+function strLen8(s) {
+  // u8 length prefix + utf8 bytes
+  const bytes = new TextEncoder().encode(s);
+  return pack(u8(bytes.length), bytes);
+}
+
+function parseSingle(frameBytes) {
+  // parseFrames takes ArrayBuffer; strip Uint8Array view safely.
+  const ab = frameBytes.buffer.slice(
+    frameBytes.byteOffset,
+    frameBytes.byteOffset + frameBytes.byteLength
+  );
+  const events = parseFrames(ab);
+  assert.equal(events.length, 1, 'expected exactly one decoded event');
+  return events[0];
+}
+
+// ── flag/constant exports ────────────────────────────────────────────
+
+test('FLAGS exposes BOOK and MBP for issue #67', () => {
+  assert.equal(FLAGS.BOOK, 0x01);
+  assert.equal(FLAGS.INFO, 0x02);
+  assert.equal(FLAGS.MBP, 0x08);
+  assert.equal(FLAGS.TRADES, 0x10);
+});
+
+test('CANDLE_FLAGS exposes FIRST and LAST', () => {
+  assert.equal(CANDLE_FLAGS.FIRST, 0x01);
+  assert.equal(CANDLE_FLAGS.LAST, 0x02);
+});
+
+test('SIDE.BID is 0 and SIDE.ASK is 1', () => {
+  assert.equal(SIDE.BID, 0);
+  assert.equal(SIDE.ASK, 1);
+});
+
+// ── builders ─────────────────────────────────────────────────────────
+
+test('buildSubscribe defaults to TRADES|INFO', () => {
+  const buf = buildSubscribe('PETR4');
+  const v = new DataView(buf);
+  assert.equal(v.getUint16(0, true), buf.byteLength); // total length
+  assert.equal(v.getUint16(2, true), MSG.SUBSCRIBE);
+  assert.equal(v.getUint8(4), FLAGS.TRADES | FLAGS.INFO);
+  assert.equal(v.getUint8(5), 5); // 'PETR4' length
+});
+
+test('buildSubscribe accepts custom flags (e.g. INFO|TRADES|MBP)', () => {
+  const buf = buildSubscribe('VALE3', FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP);
+  const v = new DataView(buf);
+  assert.equal(v.getUint8(4), FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP);
+});
+
+test('buildSubscribe normalises symbol to uppercase', () => {
+  const buf = buildSubscribe('  petr4  ');
+  const sym = new TextDecoder().decode(new Uint8Array(buf, 6));
+  assert.equal(sym, 'PETR4');
+});
+
+test('buildUnsubscribe encodes 12-byte frame with securityId', () => {
+  const buf = buildUnsubscribe(900_000_000_001n);
+  assert.equal(buf.byteLength, 12);
+  const v = new DataView(buf);
+  assert.equal(v.getUint16(2, true), MSG.UNSUBSCRIBE);
+  assert.equal(v.getBigUint64(4, true), 900_000_000_001n);
+});
+
+// ── existing frames (regression) ─────────────────────────────────────
+
+test('ServerStatus(ready=1) decodes', () => {
+  const ev = parseSingle(frame(MSG.SERVER_STATUS, u8(1)));
+  assert.deepEqual(ev, { type: 'ServerStatus', ready: true });
+});
+
+test('SubscribeOk decodes securityId, flags, symbol', () => {
+  const ev = parseSingle(frame(
+    MSG.SUBSCRIBE_OK,
+    pack(u64(900_000_000_003n), u8(FLAGS.TRADES | FLAGS.INFO), strLen8('ITUB4'))
+  ));
+  assert.equal(ev.type, 'SubscribeOk');
+  assert.equal(ev.securityId, 900_000_000_003n);
+  assert.equal(ev.flags, FLAGS.TRADES | FLAGS.INFO);
+  assert.equal(ev.symbol, 'ITUB4');
+});
+
+test('SubscribeError maps known code to name', () => {
+  const ev = parseSingle(frame(MSG.SUBSCRIBE_ERROR, pack(u8(2), strLen8('FOO'))));
+  assert.equal(ev.type, 'SubscribeError');
+  assert.equal(ev.errorCode, 2);
+  assert.equal(ev.errorName, 'NotReady');
+  assert.equal(ev.symbol, 'FOO');
+});
+
+test('Trade divides price by 1e4', () => {
+  // 32.50 → 325000 mantissa
+  const ev = parseSingle(frame(
+    MSG.TRADE,
+    pack(u64(900_000_000_001n), i64(325000), i64(100), i64(7777))
+  ));
+  assert.equal(ev.type, 'Trade');
+  assert.equal(ev.price, 32.5);
+  assert.equal(ev.qty, 100);
+  assert.equal(ev.tradeId, 7777);
+});
+
+test('TradeBust decodes', () => {
+  const ev = parseSingle(frame(MSG.TRADE_BUST, pack(u64(900_000_000_001n), i64(7777))));
+  assert.deepEqual(ev, { type: 'TradeBust', securityId: 900_000_000_001n, tradeId: 7777 });
+});
+
+test('InfoSnapshot decodes selected fields with SBE exponents', () => {
+  // mask: bit 4 (LastTradePrice, /1e4), bit 17 (TradingReferencePrice, /1e8)
+  const mask = (1 << 4) | (1 << 17);
+  const ev = parseSingle(frame(
+    MSG.INFO_SNAPSHOT,
+    pack(u64(900_000_000_001n), u32(mask), i64(305000), i64(3050000000n))
+  ));
+  assert.equal(ev.type, 'InfoSnapshot');
+  assert.equal(ev.fields.LastTradePrice, 30.5);
+  assert.equal(ev.fields.TradingReferencePrice, 30.5);
+});
+
+// ── new frames (issue #67) ───────────────────────────────────────────
+
+test('BookSnapshot is a marker frame with only securityId', () => {
+  const ev = parseSingle(frame(MSG.BOOK_SNAPSHOT, u64(900_000_000_001n)));
+  assert.deepEqual(ev, { type: 'BookSnapshot', securityId: 900_000_000_001n });
+});
+
+test('BookCleared wire 0 = both sides (null)', () => {
+  const ev = parseSingle(frame(MSG.BOOK_CLEARED, pack(u64(900n), u8(0))));
+  assert.deepEqual(ev, { type: 'BookCleared', securityId: 900n, side: null });
+});
+
+test('BookCleared wire 1 = bid only', () => {
+  const ev = parseSingle(frame(MSG.BOOK_CLEARED, pack(u64(900n), u8(1))));
+  assert.equal(ev.side, SIDE.BID);
+});
+
+test('BookCleared wire 2 = ask only', () => {
+  const ev = parseSingle(frame(MSG.BOOK_CLEARED, pack(u64(900n), u8(2))));
+  assert.equal(ev.side, SIDE.ASK);
+});
+
+test('BookCleared with side byte omitted = both (null)', () => {
+  const ev = parseSingle(frame(MSG.BOOK_CLEARED, u64(900n)));
+  assert.equal(ev.side, null);
+});
+
+test('LevelSnapshot decodes bid/ask arrays with prices /1e4', () => {
+  // 2 bids: (30.50, 100, 1), (30.49, 200, 3)
+  // 1 ask:  (30.51, 50, 2)
+  const ev = parseSingle(frame(MSG.LEVEL_SNAPSHOT, pack(
+    u64(900n),
+    u16(2), u16(1),
+    i64(305000), i64(100), u32(1),
+    i64(304900), i64(200), u32(3),
+    i64(305100), i64(50), u32(2),
+  )));
+  assert.equal(ev.type, 'LevelSnapshot');
+  assert.equal(ev.bids.length, 2);
+  assert.equal(ev.asks.length, 1);
+  assert.deepEqual(ev.bids[0], { price: 30.5, qty: 100, count: 1 });
+  assert.deepEqual(ev.bids[1], { price: 30.49, qty: 200, count: 3 });
+  assert.deepEqual(ev.asks[0], { price: 30.51, qty: 50, count: 2 });
+});
+
+test('LevelSnapshot with zero counts decodes empty arrays', () => {
+  const ev = parseSingle(frame(MSG.LEVEL_SNAPSHOT, pack(u64(900n), u16(0), u16(0))));
+  assert.equal(ev.bids.length, 0);
+  assert.equal(ev.asks.length, 0);
+});
+
+test('LevelSnapshot asymmetric: bid-only', () => {
+  const ev = parseSingle(frame(MSG.LEVEL_SNAPSHOT, pack(
+    u64(900n), u16(1), u16(0),
+    i64(305000), i64(100), u32(1),
+  )));
+  assert.equal(ev.bids.length, 1);
+  assert.equal(ev.asks.length, 0);
+  assert.deepEqual(ev.bids[0], { price: 30.5, qty: 100, count: 1 });
+});
+
+test('LevelSnapshot asymmetric: ask-only', () => {
+  const ev = parseSingle(frame(MSG.LEVEL_SNAPSHOT, pack(
+    u64(900n), u16(0), u16(1),
+    i64(305100), i64(50), u32(2),
+  )));
+  assert.equal(ev.bids.length, 0);
+  assert.equal(ev.asks.length, 1);
+  assert.deepEqual(ev.asks[0], { price: 30.51, qty: 50, count: 2 });
+});
+
+test('LevelUpdate decodes side, price, qty, count', () => {
+  const ev = parseSingle(frame(MSG.LEVEL_UPDATE, pack(
+    u64(900n), u8(SIDE.BID), i64(305000), i64(150), u32(2)
+  )));
+  assert.deepEqual(ev, {
+    type: 'LevelUpdate',
+    securityId: 900n,
+    side: SIDE.BID,
+    price: 30.5,
+    qty: 150,
+    count: 2,
+  });
+});
+
+test('LevelDeleted decodes side and price', () => {
+  const ev = parseSingle(frame(MSG.LEVEL_DELETED, pack(
+    u64(900n), u8(SIDE.ASK), i64(305100)
+  )));
+  assert.deepEqual(ev, {
+    type: 'LevelDeleted',
+    securityId: 900n,
+    side: SIDE.ASK,
+    price: 30.51,
+  });
+});
+
+test('CandleSnapshot decodes OHLC/volume/avg with price scaling', () => {
+  // 1 candle: 1m resolution, FIRST|LAST flags, OHLC ~30.5, vol 1000, avg 30.45
+  const ev = parseSingle(frame(MSG.CANDLE_SNAPSHOT, pack(
+    u64(900n),
+    u16(60),                                         // resolution (seconds)
+    u8(CANDLE_FLAGS.FIRST | CANDLE_FLAGS.LAST),
+    u16(1),                                          // count
+    i64(1_700_000_000_000),                          // time (unix ms)
+    i64(305000), i64(305500), i64(304500), i64(305200), // OHLC
+    i64(1000), i64(304500),                          // volume, avg
+  )));
+  assert.equal(ev.type, 'CandleSnapshot');
+  assert.equal(ev.resolution, 60);
+  assert.equal(ev.isFirst, true);
+  assert.equal(ev.isLast, true);
+  assert.equal(ev.candles.length, 1);
+  const c = ev.candles[0];
+  assert.equal(c.time, 1_700_000_000_000);
+  assert.equal(c.open, 30.5);
+  assert.equal(c.high, 30.55);
+  assert.equal(c.low, 30.45);
+  assert.equal(c.close, 30.52);
+  assert.equal(c.volume, 1000);
+  assert.equal(c.avg, 30.45);
+});
+
+test('CandleSnapshot streams: only FIRST flag on head, only LAST on tail', () => {
+  const head = parseSingle(frame(MSG.CANDLE_SNAPSHOT, pack(
+    u64(900n), u16(60), u8(CANDLE_FLAGS.FIRST), u16(0)
+  )));
+  const tail = parseSingle(frame(MSG.CANDLE_SNAPSHOT, pack(
+    u64(900n), u16(60), u8(CANDLE_FLAGS.LAST), u16(0)
+  )));
+  assert.equal(head.isFirst, true);
+  assert.equal(head.isLast, false);
+  assert.equal(tail.isFirst, false);
+  assert.equal(tail.isLast, true);
+});
+
+test('CandleSnapshot intermediate frame has neither FIRST nor LAST', () => {
+  const mid = parseSingle(frame(MSG.CANDLE_SNAPSHOT, pack(
+    u64(900n), u16(60), u8(0), u16(0)
+  )));
+  assert.equal(mid.isFirst, false);
+  assert.equal(mid.isLast, false);
+});
+
+test('CandleUpdate decodes single in-progress candle', () => {
+  const ev = parseSingle(frame(MSG.CANDLE_UPDATE, pack(
+    u64(900n),
+    u16(60),
+    i64(1_700_000_060_000),
+    i64(305200), i64(305800), i64(305000), i64(305700),
+    i64(500), i64(305400),
+  )));
+  assert.equal(ev.type, 'CandleUpdate');
+  assert.equal(ev.resolution, 60);
+  assert.deepEqual(ev.candle, {
+    time: 1_700_000_060_000,
+    open: 30.52,
+    high: 30.58,
+    low: 30.5,
+    close: 30.57,
+    volume: 500,
+    avg: 30.54,
+  });
+});
+
+// ── multi-frame coalescing ───────────────────────────────────────────
+
+test('parseFrames decodes multiple coalesced frames in one buffer', () => {
+  const f1 = frame(MSG.TRADE, pack(u64(900n), i64(305000), i64(100), i64(1)));
+  const f2 = frame(MSG.LEVEL_UPDATE, pack(u64(900n), u8(SIDE.BID), i64(304900), i64(50), u32(1)));
+  const merged = pack(f1, f2);
+  const ab = merged.buffer.slice(0);
+  const events = parseFrames(ab);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].type, 'Trade');
+  assert.equal(events[1].type, 'LevelUpdate');
+});
+
+test('parseFrames skips unknown message types (forward-compat)', () => {
+  // Use a message type the decoder doesn't recognise (0x00FF, reserved).
+  const unknown = frame(0x00FF, u64(900n));
+  const known = frame(MSG.TRADE, pack(u64(900n), i64(305000), i64(100), i64(1)));
+  const ab = pack(unknown, known).buffer.slice(0);
+  const events = parseFrames(ab);
+  // Unknown is skipped (returns null), known still decodes.
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'Trade');
+});
+
+test('parseFrames bails on truncated buffer (no throw)', () => {
+  // Frame claims length=20 but buffer only has 8 bytes.
+  const bad = new Uint8Array(8);
+  new DataView(bad.buffer).setUint16(0, 20, true);
+  new DataView(bad.buffer).setUint16(2, MSG.TRADE, true);
+  const events = parseFrames(bad.buffer);
+  assert.equal(events.length, 0);
+});
+
+test('parseFrames skips a malformed known-type frame and keeps parsing', () => {
+  // LEVEL_UPDATE declares its full length but its payload is truncated
+  // to just securityId — DataView reads past the end will throw. The
+  // wrapper must catch, drop only that frame, and keep parsing the
+  // following valid Trade frame in the same coalesced buffer.
+  const malformed = frame(MSG.LEVEL_UPDATE, u64(900n)); // payload too short
+  const good = frame(MSG.TRADE, pack(u64(900n), i64(305000), i64(100), i64(1)));
+  const ab = pack(malformed, good).buffer.slice(0);
+  const events = parseFrames(ab);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'Trade');
+});


### PR DESCRIPTION
Closes #67. Sub-task of #66 (Trader UI v2 meta).

## What

Pure plumbing slice. The `B3MarketDataPlatform` WS already publishes `BOOK_SNAPSHOT`, `LEVEL_SNAPSHOT/UPDATE/DELETED`, `BOOK_CLEARED`, and `CANDLE_SNAPSHOT/UPDATE`; the trader UI's hand-rolled subset `mdProtocol.js` only consumed `Trade` + `InfoSnapshot`. T1 extends decoder + worker so T2 (DOB), T3 (candle chart), and T4 (trade tape) can land without re-touching the wire layer.

## Changes

- **`frontend/js/mdProtocol.js`** — 7 new frame parsers, `FLAGS.BOOK`/`FLAGS.MBP`, `CANDLE_FLAGS`, `SIDE` constants. All SBE Price (-4) mantissas divided by 1e4 for consistency with existing `Trade`. `BookCleared` wire `0/1/2` normalised to `null`/`SIDE.BID`/`SIDE.ASK` (verified against upstream `worker.js`; wire encoding differs from `LEVEL_*`'s side enum and is easy to misread). `parseFrames` now wraps `parseOne` in try/catch — malformed payload of a known type drops only that frame, keeps parsing the rest of the coalesced WS message.
- **`frontend/js/mdWorker.js`** — forwards new frames as `md.book.snapshot/cleared`, `md.level.snapshot/update/deleted`, `md.candle.snapshot/update`. Optional `flags` on `start` (defaults to `TRADES|INFO` — back-compat). New `setFlags` message: re-subscribe entire watchlist with new bitmask, posts `md.clear` so panels reset stale state. Defensive: drop `SubscribeOk` for symbols we never asked for. Use BigInt `securityId` directly as Map key (no per-frame `.toString()`).
- **`frontend/test/decoder.test.mjs`** — 32 standalone Node tests, no deps, run via `node --test`. Covers every `MSG.*`, builders, multi-frame coalescing, unknown-type skip, truncated buffer, malformed-known-frame skip, `BookCleared` wire 0/1/2/omitted, asymmetric `LevelSnapshot` (bid-only/ask-only), intermediate `CandleSnapshot` stream frame.
- **`.github/workflows/ci.yml`** — `node --test frontend/test/decoder.test.mjs` step in the existing `frontend` job (Node 20).

## Quality

- 32/32 decoder tests green locally.
- `dotnet build B3TradingPlatform.slnx -c Release` clean (no .NET changes).
- Behavior unchanged for existing trader UI flows: default subscribe flags identical, message-out shapes for `Trade`/`Info`/`Bust` byte-for-byte preserved.

## Rubber-duck pass

Critique caught a real bug (`BookCleared` wire 0/1/2 → must remap, not pass through), missing tests (asymmetric snapshots, malformed known-frame skip, `SubscribeOk` for unrequested symbol), and noted two architectural follow-ups deferred to T2/T3 with explanatory comments on those issues:
- #68 (T2): per-symbol vs global flags trade-off when DOB needs MBP only on the active symbol.
- #69 (T3): empirically confirm whether candles arrive under `MBP` or require `BOOK` before assuming the subscribe shape.

## Out of scope

- MBO `ORDER_*` frames (#66 — high volume, separate RFC).
- Render — no UI panels yet (those are T2/T3/T4).