### PR TITLE
feat(demo-driver): D1 — laptop demo overlay (closes #72)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,6 +121,7 @@ jobs:
           docker compose -f docker/docker-compose.yml config --quiet
           docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml config --quiet
           docker compose -f docker/docker-compose.yml -f docker/docker-compose.conformance.yml config --quiet
+          docker compose -f docker/docker-compose.yml -f docker/docker-compose.demo.yml config --quiet
 
   conformance:
     name: Run conformance suite against compose stack

--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -12,4 +12,7 @@
     <Project Path="backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj" />
   </Folder>
+  <Folder Name="/backend/tools/">
+    <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />
+  </Folder>
 </Solution>

--- a/backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj
+++ b/backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Trading.DemoDriver</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tools/B3.Trading.DemoDriver/BotSubmitterWorker.cs
+++ b/backend/tools/B3.Trading.DemoDriver/BotSubmitterWorker.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// One per user bot. Logs in, then submits random buy/sell limit orders
+/// around each symbol's reference price at the configured rate. Caps the
+/// number of in-flight (working) orders per bot to keep the WorkingOrderBook
+/// bounded during long demos.
+/// </summary>
+internal sealed class BotSubmitterWorker : BackgroundService
+{
+    private readonly TradingClient _client;
+    private readonly DemoOrderRegistry _registry;
+    private readonly DemoDriverOptions _options;
+    private readonly DemoModeState _modeState;
+    private readonly ILogger<BotSubmitterWorker> _log;
+    private readonly Random _rng;
+
+    public BotSubmitterWorker(
+        TradingClient client,
+        DemoOrderRegistry registry,
+        DemoDriverOptions options,
+        DemoModeState modeState,
+        ILogger<BotSubmitterWorker> log)
+    {
+        _client = client;
+        _registry = registry;
+        _options = options;
+        _modeState = modeState;
+        _log = log;
+        _rng = new Random(HashCode.Combine(client.Username, Environment.TickCount));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _modeState.WaitReadyAsync(stoppingToken);
+        if (!_modeState.SubmitsEnabled)
+        {
+            _log.LogWarning("[bot {User}] submit disabled (exchange mode {Mode}); idling.",
+                _client.Username, _modeState.ExchangeMode);
+            return;
+        }
+
+        var period = TimeSpan.FromSeconds(1.0 / Math.Max(0.01, _options.SubmitRateHz));
+        _log.LogInformation("[bot {User}] starting; period={Period}", _client.Username, period);
+
+        try
+        {
+            await _client.EnsureAuthenticatedAsync(stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "[bot {User}] login failed; aborting.", _client.Username);
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_registry.CountFor(_client.Username) >= _options.MaxOpenOrdersPerBot)
+                {
+                    // Backpressure: pause submission until injector drains some.
+                    await Task.Delay(period, stoppingToken);
+                    continue;
+                }
+
+                if (_options.Symbols.Count == 0)
+                {
+                    _log.LogWarning("[bot {User}] no symbols configured; sleeping 5s.", _client.Username);
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                    continue;
+                }
+
+                var sym = _options.Symbols[_rng.Next(_options.Symbols.Count)];
+                var side = _rng.Next(2) == 0 ? "Buy" : "Sell";
+                long qty = 100L * (1L + _rng.Next(10)); // 100..1000
+                // ±0.5% around ref, rounded to 0.01.
+                var spread = (decimal)((_rng.NextDouble() - 0.5) * 0.01);
+                var raw = sym.ReferencePrice * (1m + spread);
+                var price = Math.Round(raw, 2, MidpointRounding.AwayFromZero);
+
+                var result = await _client.SubmitOrderAsync(sym.Symbol, side, qty, price, stoppingToken);
+                switch (result.Kind)
+                {
+                    case SubmitResultKind.Accepted:
+                        _registry.Register(new BotOrder(
+                            ClOrdId: result.ClOrdId,
+                            OwnerUsername: _client.Username,
+                            Symbol: sym.Symbol,
+                            Side: side,
+                            Price: price,
+                            Quantity: qty,
+                            LeavesQuantity: qty,
+                            CumulativeQuantity: 0));
+                        break;
+                    case SubmitResultKind.Rejected:
+                        _log.LogDebug("[bot {User}] rejected: {Reason}", _client.Username, result.Reason);
+                        break;
+                    case SubmitResultKind.Failed:
+                        _log.LogWarning("[bot {User}] submit failed: {Reason}", _client.Username, result.Reason);
+                        await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+                        break;
+                }
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "[bot {User}] submit cycle error", _client.Username);
+                await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+            }
+
+            await Task.Delay(period, stoppingToken);
+        }
+    }
+}

--- a/backend/tools/B3.Trading.DemoDriver/DemoDriverOptions.cs
+++ b/backend/tools/B3.Trading.DemoDriver/DemoDriverOptions.cs
@@ -1,0 +1,86 @@
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// Configuration for the demo-driver process. All values come from environment
+/// variables (DEMO_*). Defaults are tuned to "looks alive in the trader UI
+/// without tripping any risk limits at default settings".
+/// </summary>
+internal sealed class DemoDriverOptions
+{
+    public string BackendUrl { get; init; } = "http://trading-host:5000";
+
+    /// <summary>Bots that submit orders. Format: "username:password" CSV.</summary>
+    public IReadOnlyList<BotCredential> UserBots { get; init; } = Array.Empty<BotCredential>();
+
+    /// <summary>Single admin used by the InjectorWorker. Required when Mode == Simulator.</summary>
+    public BotCredential? Admin { get; init; }
+
+    /// <summary>Symbols + reference prices the bots quote around. Format: "SYMBOL:px" CSV.</summary>
+    public IReadOnlyList<SymbolRef> Symbols { get; init; } = Array.Empty<SymbolRef>();
+
+    /// <summary>Per-bot order submission rate.</summary>
+    public double SubmitRateHz { get; init; } = 0.5;
+
+    /// <summary>Inject (Fill / PartialFill) rate across all bots.</summary>
+    public double InjectRateHz { get; init; } = 0.3;
+
+    /// <summary>auto-detect | simulator-inject | submit-only.</summary>
+    public string Mode { get; init; } = "auto-detect";
+
+    /// <summary>Cap working orders per bot — pause submitting once reached.</summary>
+    public int MaxOpenOrdersPerBot { get; init; } = 50;
+
+    public static DemoDriverOptions FromEnvironment()
+    {
+        return new DemoDriverOptions
+        {
+            BackendUrl = GetEnv("DEMO_BACKEND_URL", "http://trading-host:5000"),
+            UserBots = ParseBots(GetEnv("DEMO_USER_BOTS", "bot-clientA:demopass,bot-clientB:demopass")),
+            Admin = ParseBot(GetEnv("DEMO_ADMIN", "demo-admin:demopass")),
+            Symbols = ParseSymbols(GetEnv("DEMO_SYMBOLS", "PETR4:32.50,VALE3:65.00,ITUB4:30.00")),
+            SubmitRateHz = double.Parse(GetEnv("DEMO_SUBMIT_RATE_HZ", "0.5"), System.Globalization.CultureInfo.InvariantCulture),
+            InjectRateHz = double.Parse(GetEnv("DEMO_INJECT_RATE_HZ", "0.3"), System.Globalization.CultureInfo.InvariantCulture),
+            Mode = GetEnv("DEMO_MODE", "auto-detect"),
+            MaxOpenOrdersPerBot = int.Parse(GetEnv("DEMO_MAX_OPEN_ORDERS", "50"), System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+
+    private static string GetEnv(string key, string fallback)
+        => Environment.GetEnvironmentVariable(key) is { Length: > 0 } v ? v : fallback;
+
+    private static IReadOnlyList<BotCredential> ParseBots(string csv)
+    {
+        var list = new List<BotCredential>();
+        foreach (var raw in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parsed = ParseBot(raw);
+            if (parsed is not null) list.Add(parsed);
+        }
+        return list;
+    }
+
+    private static BotCredential? ParseBot(string raw)
+    {
+        var parts = raw.Split(':', 2);
+        if (parts.Length != 2) return null;
+        return new BotCredential(parts[0].Trim(), parts[1].Trim());
+    }
+
+    private static IReadOnlyList<SymbolRef> ParseSymbols(string csv)
+    {
+        var list = new List<SymbolRef>();
+        foreach (var raw in csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = raw.Split(':', 2);
+            if (parts.Length != 2) continue;
+            if (!decimal.TryParse(parts[1].Trim(), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var px))
+                continue;
+            list.Add(new SymbolRef(parts[0].Trim().ToUpperInvariant(), px));
+        }
+        return list;
+    }
+}
+
+internal sealed record BotCredential(string Username, string Password);
+
+internal sealed record SymbolRef(string Symbol, decimal ReferencePrice);

--- a/backend/tools/B3.Trading.DemoDriver/DemoModeState.cs
+++ b/backend/tools/B3.Trading.DemoDriver/DemoModeState.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// Hosted resolution of the trading-host's exchange mode + readiness, shared
+/// between the submitter and injector workers. Polls /health until the host
+/// is ready (or until cancellation), then exposes derived flags.
+///
+/// The mode determines behavior per the rubber-duck design review:
+///   Simulator   → submits enabled, injects enabled (target mode).
+///   Mock        → submits enabled, injects disabled (orders sit working).
+///   Stub        → submits enabled but will get 502; we let the bots try
+///                 anyway, so the operator sees the failure mode honestly.
+///   Real        → submits enabled, injects disabled (cross requires real
+///                 cross-firm setup; out of D1 scope).
+///   Unavailable → submits disabled (loud warning); host explicitly refuses
+///                 orders. Bots would just spam 502s.
+/// </summary>
+internal sealed class DemoModeState
+{
+    private readonly TaskCompletionSource _ready = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly DemoDriverOptions _options;
+    private readonly ILogger<DemoModeState> _log;
+
+    public DemoModeState(DemoDriverOptions options, ILogger<DemoModeState> log)
+    {
+        _options = options;
+        _log = log;
+    }
+
+    public string ExchangeMode { get; private set; } = "unknown";
+    public bool SubmitsEnabled { get; private set; }
+    public bool InjectsEnabled { get; private set; }
+
+    public Task WaitReadyAsync(CancellationToken ct)
+    {
+        if (_ready.Task.IsCompleted) return Task.CompletedTask;
+        return _ready.Task.WaitAsync(ct);
+    }
+
+    public async Task BootstrapAsync(TradingClient probeClient, CancellationToken ct)
+    {
+        // Wait for /health to return ready (or at least respond) — gives
+        // trading-host time to come up if compose started us in parallel.
+        var deadline = DateTime.UtcNow.AddMinutes(2);
+        HealthResponse? health = null;
+        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try
+            {
+                health = await probeClient.GetHealthAsync(ct);
+                if (health is not null) break;
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "[mode] /health probe failed; retrying");
+            }
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+        }
+
+        if (health is null)
+        {
+            _log.LogError("[mode] /health never became reachable; assuming Unavailable.");
+            ExchangeMode = "Unavailable";
+        }
+        else
+        {
+            ExchangeMode = health.Exchange?.Mode ?? "unknown";
+        }
+
+        var explicitMode = _options.Mode?.ToLowerInvariant() ?? "auto-detect";
+        switch (explicitMode)
+        {
+            case "submit-only":
+                SubmitsEnabled = true;
+                InjectsEnabled = false;
+                break;
+            case "simulator-inject":
+                SubmitsEnabled = true;
+                InjectsEnabled = true;
+                break;
+            default: // auto-detect
+                ApplyAutoDetect();
+                break;
+        }
+
+        _log.LogInformation("[mode] resolved exchange={Mode} submits={Submits} injects={Injects} (DEMO_MODE={Demo})",
+            ExchangeMode, SubmitsEnabled, InjectsEnabled, explicitMode);
+        _ready.TrySetResult();
+    }
+
+    private void ApplyAutoDetect()
+    {
+        switch (ExchangeMode)
+        {
+            case "Simulator":
+                SubmitsEnabled = true;
+                InjectsEnabled = true;
+                break;
+            case "Mock":
+            case "Real":
+                SubmitsEnabled = true;
+                InjectsEnabled = false;
+                break;
+            case "Stub":
+                _log.LogWarning("[mode] exchange=Stub — orders will return 502; bots will keep trying.");
+                SubmitsEnabled = true;
+                InjectsEnabled = false;
+                break;
+            case "Unavailable":
+                _log.LogWarning("[mode] exchange=Unavailable — demo requires Mode=Simulator. Configure docker-compose.demo.yml overlay.");
+                SubmitsEnabled = false;
+                InjectsEnabled = false;
+                break;
+            default:
+                _log.LogWarning("[mode] unknown exchange mode '{Mode}'; defaulting to submits-only.", ExchangeMode);
+                SubmitsEnabled = true;
+                InjectsEnabled = false;
+                break;
+        }
+    }
+}

--- a/backend/tools/B3.Trading.DemoDriver/DemoOrderRegistry.cs
+++ b/backend/tools/B3.Trading.DemoDriver/DemoOrderRegistry.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// In-process registry of orders submitted by demo bots that the
+/// <see cref="InjectorWorker"/> may target with synthetic ER injections.
+///
+/// Per the rubber-duck design review (D1 plan): only orders accepted by the
+/// trading-host (i.e., 202 with no terminal Status) are tracked. The injector
+/// updates leaves/cum from the response of POST /admin/simulator/er and evicts
+/// entries when the order reaches a terminal state (Filled, Cancelled, Rejected).
+/// </summary>
+internal sealed class DemoOrderRegistry
+{
+    private readonly ConcurrentDictionary<string, BotOrder> _orders = new(StringComparer.Ordinal);
+
+    public int Count => _orders.Count;
+
+    public int CountFor(string ownerUsername)
+    {
+        var n = 0;
+        foreach (var kv in _orders)
+            if (string.Equals(kv.Value.OwnerUsername, ownerUsername, StringComparison.Ordinal))
+                n++;
+        return n;
+    }
+
+    public void Register(BotOrder order) => _orders[order.ClOrdId] = order;
+
+    public bool TryEvict(string clOrdId) => _orders.TryRemove(clOrdId, out _);
+
+    /// <summary>Update leaves/cum after an injection. If leaves==0 the entry is evicted.</summary>
+    public void OnInjected(string clOrdId, long leaves, long cum)
+    {
+        if (leaves <= 0)
+        {
+            _orders.TryRemove(clOrdId, out _);
+            return;
+        }
+        if (_orders.TryGetValue(clOrdId, out var existing))
+        {
+            _orders[clOrdId] = existing with { LeavesQuantity = leaves, CumulativeQuantity = cum };
+        }
+    }
+
+    public BotOrder? PickRandomWorking(Random rng)
+    {
+        // Snapshot for stability across the random pick — registry can mutate
+        // concurrently. ConcurrentDictionary.ToArray is consistent.
+        var snapshot = _orders.ToArray();
+        if (snapshot.Length == 0) return null;
+        var pick = snapshot[rng.Next(snapshot.Length)];
+        return pick.Value;
+    }
+}
+
+internal sealed record BotOrder(
+    string ClOrdId,
+    string OwnerUsername,
+    string Symbol,
+    string Side,
+    decimal Price,
+    long Quantity,
+    long LeavesQuantity,
+    long CumulativeQuantity);

--- a/backend/tools/B3.Trading.DemoDriver/Dockerfile
+++ b/backend/tools/B3.Trading.DemoDriver/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+#
+# Demo-driver console — exercises the trading-host with synthetic order flow
+# so the trader UI looks alive without manual interaction. NEVER run against
+# anything other than a Simulator/Mock-mode trading-host.
+
+# ---------- build ----------
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201 AS build
+WORKDIR /src
+
+COPY global.json Directory.Build.props ./
+COPY backend/tools/B3.Trading.DemoDriver ./backend/tools/B3.Trading.DemoDriver
+
+WORKDIR /src/backend/tools/B3.Trading.DemoDriver
+RUN dotnet restore --use-current-runtime
+RUN dotnet publish \
+        --configuration Release \
+        --use-current-runtime \
+        --no-restore \
+        --output /app/publish \
+        -p:PublishSingleFile=false \
+        -p:UseAppHost=false
+
+# ---------- runtime ----------
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+RUN groupadd --system --gid 10001 demo \
+ && useradd  --system --uid 10001 --gid demo --home /app demo
+
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+ENV DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_EnableDiagnostics=0
+
+USER demo
+ENTRYPOINT ["dotnet", "B3.Trading.DemoDriver.dll"]

--- a/backend/tools/B3.Trading.DemoDriver/InjectorWorker.cs
+++ b/backend/tools/B3.Trading.DemoDriver/InjectorWorker.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// Single instance. Logs in as the configured admin and periodically picks a
+/// random working order from <see cref="DemoOrderRegistry"/> to inject either
+/// a PartialFill or a Fill into via <c>POST /admin/simulator/er</c>.
+///
+/// Only runs in Simulator mode. In other modes the worker exits early (the
+/// bots will still submit; orders just sit working in Mock or fail gracefully
+/// in Stub/Unavailable).
+/// </summary>
+internal sealed class InjectorWorker : BackgroundService
+{
+    private readonly TradingClient _admin;
+    private readonly DemoOrderRegistry _registry;
+    private readonly DemoDriverOptions _options;
+    private readonly DemoModeState _modeState;
+    private readonly ILogger<InjectorWorker> _log;
+    private readonly Random _rng = new();
+
+    public InjectorWorker(
+        TradingClient admin,
+        DemoOrderRegistry registry,
+        DemoDriverOptions options,
+        DemoModeState modeState,
+        ILogger<InjectorWorker> log)
+    {
+        _admin = admin;
+        _registry = registry;
+        _options = options;
+        _modeState = modeState;
+        _log = log;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _modeState.WaitReadyAsync(stoppingToken);
+        if (!_modeState.InjectsEnabled)
+        {
+            _log.LogInformation("[injector] disabled (exchange mode {Mode}); idling.", _modeState.ExchangeMode);
+            return;
+        }
+
+        try
+        {
+            await _admin.EnsureAuthenticatedAsync(stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "[injector] admin login failed; aborting.");
+            return;
+        }
+
+        var period = TimeSpan.FromSeconds(1.0 / Math.Max(0.01, _options.InjectRateHz));
+        _log.LogInformation("[injector] starting; period={Period} actor={Actor}", period, _admin.Username);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var order = _registry.PickRandomWorking(_rng);
+                if (order is null)
+                {
+                    await Task.Delay(period, stoppingToken);
+                    continue;
+                }
+
+                // Decide: full fill (30%) or partial (70%). Fill quantity is
+                // bounded by remaining leaves so we never overfill.
+                var leaves = order.LeavesQuantity;
+                var lastQty = _rng.NextDouble() < 0.3
+                    ? leaves
+                    : Math.Max(1L, (long)Math.Round(leaves * (0.2 + _rng.NextDouble() * 0.5)));
+                lastQty = Math.Min(lastQty, leaves);
+                var lastPx = order.Price; // synthetic — at the resting price.
+                var execType = lastQty >= leaves ? "Fill" : "PartialFill";
+
+                var inject = await _admin.InjectErAsync(order.ClOrdId, execType, lastQty, lastPx, stoppingToken);
+                if (inject.Success)
+                {
+                    _registry.OnInjected(order.ClOrdId, inject.LeavesQuantity, inject.CumulativeQuantity);
+                    _log.LogDebug("[injector] {Type} {ClOrdId} owner={Owner} qty={Qty} leaves={Leaves}",
+                        execType, order.ClOrdId, order.OwnerUsername, lastQty, inject.LeavesQuantity);
+                }
+                else
+                {
+                    // 404/400 = stale or overfill; evict and move on.
+                    _registry.TryEvict(order.ClOrdId);
+                    _log.LogDebug("[injector] evict stale {ClOrdId}: {Reason}", order.ClOrdId, inject.Reason);
+                }
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "[injector] cycle error");
+                await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken);
+            }
+
+            await Task.Delay(period, stoppingToken);
+        }
+    }
+}

--- a/backend/tools/B3.Trading.DemoDriver/Program.cs
+++ b/backend/tools/B3.Trading.DemoDriver/Program.cs
@@ -1,0 +1,99 @@
+using B3.Trading.DemoDriver;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var options = DemoDriverOptions.FromEnvironment();
+if (options.UserBots.Count == 0)
+{
+    Console.Error.WriteLine("[demo-driver] DEMO_USER_BOTS is empty; nothing to do.");
+    return 64; // EX_USAGE
+}
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
+builder.Logging.AddSimpleConsole(o =>
+{
+    o.SingleLine = true;
+    o.TimestampFormat = "HH:mm:ss ";
+});
+
+var services = builder.Services;
+services.AddSingleton(options);
+services.AddSingleton<DemoOrderRegistry>();
+services.AddSingleton<DemoModeState>();
+
+// One typed HttpClient per bot. Named clients so each gets its own JWT
+// header and its own DefaultRequestHeaders without bleeding across bots.
+foreach (var bot in options.UserBots)
+{
+    services.AddHttpClient($"bot:{bot.Username}", c => c.BaseAddress = new Uri(options.BackendUrl));
+}
+if (options.Admin is not null)
+    services.AddHttpClient($"admin:{options.Admin.Username}", c => c.BaseAddress = new Uri(options.BackendUrl));
+services.AddHttpClient("probe", c => c.BaseAddress = new Uri(options.BackendUrl));
+
+services.AddHostedService<BootstrapHostedService>();
+
+foreach (var bot in options.UserBots)
+{
+    var captured = bot;
+    services.AddSingleton<IHostedService>(sp =>
+    {
+        var http = sp.GetRequiredService<IHttpClientFactory>().CreateClient($"bot:{captured.Username}");
+        var client = new TradingClient(http, captured);
+        return new BotSubmitterWorker(
+            client,
+            sp.GetRequiredService<DemoOrderRegistry>(),
+            sp.GetRequiredService<DemoDriverOptions>(),
+            sp.GetRequiredService<DemoModeState>(),
+            sp.GetRequiredService<ILogger<BotSubmitterWorker>>());
+    });
+}
+
+if (options.Admin is not null)
+{
+    var captured = options.Admin;
+    services.AddSingleton<IHostedService>(sp =>
+    {
+        var http = sp.GetRequiredService<IHttpClientFactory>().CreateClient($"admin:{captured.Username}");
+        var client = new TradingClient(http, captured);
+        return new InjectorWorker(
+            client,
+            sp.GetRequiredService<DemoOrderRegistry>(),
+            sp.GetRequiredService<DemoDriverOptions>(),
+            sp.GetRequiredService<DemoModeState>(),
+            sp.GetRequiredService<ILogger<InjectorWorker>>());
+    });
+}
+
+await builder.Build().RunAsync();
+return 0;
+
+// Mode probe runs once before the workers wake up. Workers await
+// DemoModeState.WaitReadyAsync().
+internal sealed class BootstrapHostedService : IHostedService
+{
+    private readonly DemoModeState _mode;
+    private readonly IHttpClientFactory _http;
+    private readonly DemoDriverOptions _options;
+
+    public BootstrapHostedService(DemoModeState mode, IHttpClientFactory http, DemoDriverOptions options)
+    {
+        _mode = mode;
+        _http = http;
+        _options = options;
+    }
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        // Use the first user bot as the probe identity. /health is unauthenticated
+        // so the credential never gets used in the probe path; we just need a
+        // TradingClient instance.
+        var probeBot = _options.UserBots[0];
+        var probe = new TradingClient(_http.CreateClient("probe"), probeBot);
+        await _mode.BootstrapAsync(probe, ct);
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/backend/tools/B3.Trading.DemoDriver/TradingClient.cs
+++ b/backend/tools/B3.Trading.DemoDriver/TradingClient.cs
@@ -1,0 +1,131 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.Trading.DemoDriver;
+
+/// <summary>
+/// Thin HTTP client over the trading-host REST surface used by both the
+/// submitter and injector workers. Caches the JWT internally and refreshes
+/// transparently when /auth/login responses surface an expiresAt within the
+/// next minute.
+/// </summary>
+internal sealed class TradingClient
+{
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _http;
+    private readonly BotCredential _creds;
+    private string? _token;
+    private DateTimeOffset _expiresAt = DateTimeOffset.MinValue;
+
+    public TradingClient(HttpClient http, BotCredential creds)
+    {
+        _http = http;
+        _creds = creds;
+    }
+
+    public string Username => _creds.Username;
+
+    public async Task EnsureAuthenticatedAsync(CancellationToken ct)
+    {
+        if (_token is not null && DateTimeOffset.UtcNow < _expiresAt - TimeSpan.FromMinutes(1))
+            return;
+
+        var resp = await _http.PostAsJsonAsync("/auth/login",
+            new LoginRequest(_creds.Username, _creds.Password), JsonOpts, ct);
+        resp.EnsureSuccessStatusCode();
+        var payload = await resp.Content.ReadFromJsonAsync<LoginResponse>(JsonOpts, ct)
+            ?? throw new InvalidOperationException("Empty /auth/login response");
+        _token = payload.Token;
+        _expiresAt = payload.ExpiresAt;
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+    }
+
+    public async Task<HealthResponse?> GetHealthAsync(CancellationToken ct)
+    {
+        var resp = await _http.GetAsync("/health", ct);
+        if (!resp.IsSuccessStatusCode) return null;
+        return await resp.Content.ReadFromJsonAsync<HealthResponse>(JsonOpts, ct);
+    }
+
+    public async Task<SubmitResult> SubmitOrderAsync(string symbol, string side, long qty, decimal price, CancellationToken ct)
+    {
+        await EnsureAuthenticatedAsync(ct);
+        var resp = await _http.PostAsJsonAsync("/orders", new SubmitOrderRequest(
+            Symbol: symbol,
+            SecurityId: 0,
+            Side: side,
+            Type: "Limit",
+            Quantity: qty,
+            Price: price), JsonOpts, ct);
+
+        if (resp.StatusCode == System.Net.HttpStatusCode.Accepted)
+        {
+            var body = await resp.Content.ReadFromJsonAsync<SubmitOrderResponse>(JsonOpts, ct);
+            if (body is null) return SubmitResult.Failed("empty response");
+            // The OrdersEndpoints surface returns 202 on both Accepted and
+            // server-side Rejected paths (includes Status=Rejected). Don't
+            // register rejected orders — late inject would be a bogus fill.
+            if (string.Equals(body.Status, "Rejected", StringComparison.OrdinalIgnoreCase))
+                return SubmitResult.Rejected(body.ClOrdId, body.Reason ?? "rejected");
+            return SubmitResult.Accepted(body.ClOrdId);
+        }
+
+        return SubmitResult.Failed($"status={(int)resp.StatusCode}");
+    }
+
+    public async Task<InjectResult> InjectErAsync(string clOrdId, string type, long? lastQty, decimal? lastPx, CancellationToken ct)
+    {
+        await EnsureAuthenticatedAsync(ct);
+        if (!ulong.TryParse(clOrdId, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var clOrdIdNum))
+            return InjectResult.Failed($"non-numeric clOrdId '{clOrdId}'");
+
+        var resp = await _http.PostAsJsonAsync("/admin/simulator/er",
+            new InjectErRequest(clOrdIdNum, type, lastQty, lastPx, RejectReason: null), JsonOpts, ct);
+
+        if (resp.StatusCode == System.Net.HttpStatusCode.Accepted)
+        {
+            var body = await resp.Content.ReadFromJsonAsync<InjectErResponse>(JsonOpts, ct);
+            if (body is null) return InjectResult.Failed("empty response");
+            return InjectResult.Ok(body.LeavesQuantity, body.CumulativeQuantity);
+        }
+
+        // 404 = unknown clOrdId (race or already evicted). 400 = overfill /
+        // bad request. Both are caller-evict signals.
+        return InjectResult.Failed($"status={(int)resp.StatusCode}");
+    }
+
+    private sealed record LoginRequest(string Username, string Password);
+    private sealed record LoginResponse(string Token, DateTimeOffset ExpiresAt);
+    private sealed record SubmitOrderRequest(string Symbol, uint SecurityId, string Side, string Type, long Quantity, decimal? Price);
+    private sealed record SubmitOrderResponse(string ClOrdId, string? Status, string? Reason);
+    // ClOrdId is serialized as a JSON number on the simulator endpoint
+    // (server-side type is ulong, no ToString() roundtrip), so the typed
+    // request/response use ulong rather than string.
+    private sealed record InjectErRequest(ulong ClOrdId, string Type, long? LastQty, decimal? LastPx, string? RejectReason);
+    private sealed record InjectErResponse(ulong ClOrdId, string ExecType, long LeavesQuantity, long CumulativeQuantity);
+    public sealed record ExchangeBlock(string Mode, bool ReadyForOrders, int FirmCount);
+}
+
+internal sealed record HealthResponse(string Status, TradingClient.ExchangeBlock? Exchange);
+
+internal readonly record struct SubmitResult(SubmitResultKind Kind, string ClOrdId, string? Reason)
+{
+    public static SubmitResult Accepted(string clOrdId) => new(SubmitResultKind.Accepted, clOrdId, null);
+    public static SubmitResult Rejected(string clOrdId, string reason) => new(SubmitResultKind.Rejected, clOrdId, reason);
+    public static SubmitResult Failed(string reason) => new(SubmitResultKind.Failed, string.Empty, reason);
+}
+
+internal enum SubmitResultKind { Accepted, Rejected, Failed }
+
+internal readonly record struct InjectResult(bool Success, long LeavesQuantity, long CumulativeQuantity, string? Reason)
+{
+    public static InjectResult Ok(long leaves, long cum) => new(true, leaves, cum, null);
+    public static InjectResult Failed(string reason) => new(false, 0, 0, reason);
+}
+

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -47,3 +47,22 @@ REPLAY_SPEED=2
 #   TRADING_MARKETDATA_WS_URL=ws://marketdata:8080/ws
 TRADING_MARKETDATA_WS_URL=
 TRADING_MARKETDATA_SYMBOL_0=PETR4
+
+# --- demo overlay (opt-in, laptop demos only) ---
+# Bring up with:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.demo.yml up -d
+# Flips the trading-host to Mode=Simulator and starts the demo-driver
+# console which submits + injects fills continuously so the trader UI
+# looks alive. NEVER enable on a host reachable beyond your laptop.
+# Defaults below are committed in docker-compose.demo.yml — override
+# only if rotating the demo credentials.
+# DEMO_BOT_A_USER=bot-clientA
+# DEMO_BOT_A_PASSWORD=demopass
+# DEMO_BOT_B_USER=bot-clientB
+# DEMO_BOT_B_PASSWORD=demopass
+# DEMO_ADMIN_USER=demo-admin
+# DEMO_ADMIN_PASSWORD=demopass
+# DEMO_SUBMIT_RATE_HZ=0.5
+# DEMO_INJECT_RATE_HZ=0.3
+# DEMO_MAX_OPEN_ORDERS=50
+# DEMO_MODE=auto-detect

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -1,0 +1,92 @@
+# Demo overlay for the family stack. Brings the trading-host up in
+# Mode=Simulator (synthetic ER injection enabled, NOT FOR PRODUCTION),
+# seeds three additional users (one admin + two user bots), and starts
+# the demo-driver process that hammers the trader UI with continuous
+# order/fill activity.
+#
+# Usage (laptop demos only):
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.demo.yml \
+#       up -d
+#
+# Open http://localhost:8080 and log in as bot-clientA / demopass (or
+# bot-clientB / demopass) to see that bot's blotter, executions and
+# positions evolve in real time. Logging in as alice (the original
+# seed) shows the empty view since alice does not submit orders.
+#
+# Hashes below are PBKDF2-HMAC-SHA256 (600k iterations) of the literal
+# password "demopass". Both the password and the hashes are public —
+# DO NOT enable this overlay against a host reachable beyond your
+# laptop. The trading-host refuses to boot in Production with
+# Mode=Simulator unless AllowSimulatorInProduction=true is also set.
+
+services:
+  trading-host:
+    environment:
+      # Flip to Simulator so the InjectorWorker can POST /admin/simulator/er.
+      Trading__Exchange__Mode: Simulator
+
+      # User-bot 1 (default seed; submits orders).
+      Trading__Auth__Users__1__Username: ${DEMO_BOT_A_USER:-bot-clientA}
+      Trading__Auth__Users__1__PasswordHash: ${DEMO_BOT_A_HASH:-jCdJniZgt0YyP/cJa5ehORTMcdxEUaesnzTTZtNKYFg=}
+      Trading__Auth__Users__1__Salt: ${DEMO_BOT_A_SALT:-MKxchosZRRVTRQZe4u4Ykw==}
+      Trading__Auth__Users__1__Iterations: "600000"
+      Trading__Auth__Users__1__Role: user
+      Trading__Auth__Users__1__Firm: default
+
+      # User-bot 2 (default seed; submits orders).
+      Trading__Auth__Users__2__Username: ${DEMO_BOT_B_USER:-bot-clientB}
+      Trading__Auth__Users__2__PasswordHash: ${DEMO_BOT_B_HASH:-kPDXUUV7Bf0Qy1ryGVncXv88gi3hglccO2pcgU/VODs=}
+      Trading__Auth__Users__2__Salt: ${DEMO_BOT_B_SALT:-Bj20VGNiURA5SHsRHKWsUw==}
+      Trading__Auth__Users__2__Iterations: "600000"
+      Trading__Auth__Users__2__Role: user
+      Trading__Auth__Users__2__Firm: default
+
+      # Admin used exclusively by the demo-driver injector. Kept distinct
+      # from carol (conformance overlay) so the two overlays can coexist
+      # without slot collisions.
+      Trading__Auth__Users__3__Username: ${DEMO_ADMIN_USER:-demo-admin}
+      Trading__Auth__Users__3__PasswordHash: ${DEMO_ADMIN_HASH:-Xs/FcCBkBNEKbRKQCVR8YIQXGN/53Gxj01DBCCWl7Mk=}
+      Trading__Auth__Users__3__Salt: ${DEMO_ADMIN_SALT:-wtrNdBpmiH7nWtMwM6v9cA==}
+      Trading__Auth__Users__3__Iterations: "600000"
+      Trading__Auth__Users__3__Role: admin
+      Trading__Auth__Users__3__Firm: default
+
+      # Static reference prices the bots quote around. Mirrors the defaults
+      # the demo-driver bakes in via DEMO_SYMBOLS so the price collar (10%
+      # default) never trips on the random ±0.5% spread.
+      Trading__Risk__ReferencePrices__PETR4: "32.50"
+      Trading__Risk__ReferencePrices__VALE3: "65.00"
+      Trading__Risk__ReferencePrices__ITUB4: "30.00"
+
+      # SecurityId mapping so POST /orders can resolve symbol → SecurityId
+      # (the demo-driver leaves SecurityId=0 in the request payload — the
+      # ResolveOwner path looks the symbol up in this directory). Same IDs
+      # used by the real-stack overlay so a host that is later flipped to
+      # Mode=Real keeps consistent identifiers.
+      Trading__SymbolDirectory__SecurityIds__PETR4: "900000000001"
+      Trading__SymbolDirectory__SecurityIds__VALE3: "900000000002"
+      Trading__SymbolDirectory__SecurityIds__ITUB4: "900000000003"
+
+  demo-driver:
+    build:
+      context: ..
+      dockerfile: backend/tools/B3.Trading.DemoDriver/Dockerfile
+    image: ${DEMO_DRIVER_IMAGE:-b3-trading-demo-driver:dev}
+    container_name: b3-trading-demo-driver
+    restart: unless-stopped
+    depends_on:
+      trading-host:
+        condition: service_healthy
+    environment:
+      DEMO_BACKEND_URL: http://trading-host:5000
+      DEMO_USER_BOTS: "${DEMO_BOT_A_USER:-bot-clientA}:${DEMO_BOT_A_PASSWORD:-demopass},${DEMO_BOT_B_USER:-bot-clientB}:${DEMO_BOT_B_PASSWORD:-demopass}"
+      DEMO_ADMIN: "${DEMO_ADMIN_USER:-demo-admin}:${DEMO_ADMIN_PASSWORD:-demopass}"
+      DEMO_SYMBOLS: "PETR4:32.50,VALE3:65.00,ITUB4:30.00"
+      DEMO_SUBMIT_RATE_HZ: "${DEMO_SUBMIT_RATE_HZ:-0.5}"
+      DEMO_INJECT_RATE_HZ: "${DEMO_INJECT_RATE_HZ:-0.3}"
+      DEMO_MAX_OPEN_ORDERS: "${DEMO_MAX_OPEN_ORDERS:-50}"
+      DEMO_MODE: "${DEMO_MODE:-auto-detect}"
+    networks:
+      - b3-net

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -69,6 +69,72 @@ service named `marketdata-live` with a network alias `marketdata` so the
 hostnames in `docker/real/exchange-simulator.bridge.json` and the
 trading-host `Trading__MarketData__WsUrl` resolve.
 
+## Demo overlay (opt-in, laptop-only)
+
+```bash
+docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.demo.yml \
+    up -d --build
+# open http://localhost:8080 and log in as bot-clientA / demopass
+```
+
+Flips the trading-host to `Mode=Simulator` (synthetic ER injection
+enabled) and starts the **demo-driver** console
+([`backend/tools/B3.Trading.DemoDriver`](../backend/tools/B3.Trading.DemoDriver))
+which:
+
+- logs in as `bot-clientA` and `bot-clientB` (role=user),
+- submits random buy/sell limit orders around the configured reference
+  prices at `DEMO_SUBMIT_RATE_HZ` (default 0.5 Hz per bot),
+- logs in as `demo-admin` (role=admin) and POSTs `/admin/simulator/er`
+  to inject synthetic Fill / PartialFill ERs at `DEMO_INJECT_RATE_HZ`
+  (default 0.3 Hz across the registry).
+
+Result: the trader UI's blotter, executions and positions panels move
+on their own. **Log in as one of the bots** to see that bot's view —
+`alice` does not submit orders so her view stays empty.
+
+| Service | What it does |
+|---|---|
+| `trading-host` | flipped to `Mode=Simulator`; seeds 3 extra users (`bot-clientA`, `bot-clientB`, `demo-admin`) |
+| `demo-driver` | hosts the submit + inject loops; logs to stdout |
+
+### Safety
+
+`Mode=Simulator` MUST NOT be enabled against a host reachable beyond
+your laptop — anyone with admin creds (default `demo-admin/demopass`,
+public in this repo) can mint synthetic fills. The trading-host
+**refuses to boot** in `ASPNETCORE_ENVIRONMENT=Production` with
+`Mode=Simulator` unless `Trading:Exchange:AllowSimulatorInProduction=true`
+is also set; do not flip that switch.
+
+The demo passwords are PBKDF2-hashed and committed in
+`docker/docker-compose.demo.yml` so the overlay works zero-config.
+Override via `DEMO_BOT_A_HASH` / `DEMO_BOT_A_SALT` (and `_B_`, `_ADMIN_`)
++ matching `DEMO_BOT_A_PASSWORD` etc. when rotating credentials.
+
+### Tuning
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `DEMO_SUBMIT_RATE_HZ` | 0.5 | Per-bot submission rate |
+| `DEMO_INJECT_RATE_HZ` | 0.3 | Global inject rate (admin → registry) |
+| `DEMO_MAX_OPEN_ORDERS` | 50 | Per-bot cap; submitter pauses once reached |
+| `DEMO_MODE` | auto-detect | `auto-detect` \| `simulator-inject` \| `submit-only` |
+
+### Out of scope (D1)
+
+- No MD ticks: this overlay does not include `--profile marketdata`,
+  so the MD panel stays static. Combine with the marketdata profile
+  (PCAP) to also see trades on the tape.
+- No `Mode=Real` cross-firm bots: real-stack cross requires multiple
+  firm sessions wired through the `docker-compose.real.yml` overlay;
+  tracked as a follow-up to issue #72.
+- No order cancellation cycle: bots submit + injector fills; bounded
+  via `DEMO_MAX_OPEN_ORDERS`, but stale working orders accumulate
+  during long runs.
+
 ## Honest no-broker mode
 
 The trading-host has four exchange modes, configured via


### PR DESCRIPTION
Closes #72.

## What

`docker compose -f docker/docker-compose.yml -f docker/docker-compose.demo.yml up -d` brings the trader UI to life:
- trading-host flipped to **Mode=Simulator**;
- two user bots (\`bot-clientA\`, \`bot-clientB\`) submit random buy/sell limit orders around configured ref prices;
- one admin (\`demo-admin\`) injects synthetic Fill / PartialFill ERs against working orders via \`POST /admin/simulator/er\`.

Log in as either bot at http://localhost:8080 to see the blotter, executions and positions panels evolve on their own. Default rates: 0.5 Hz/bot submit, 0.3 Hz inject, 50 max open orders/bot.

## Process layout

- \`backend/tools/B3.Trading.DemoDriver\` — .NET 10 console, \`Microsoft.Extensions.Hosting\`-based.
- \`DemoModeState\` (\`BootstrapHostedService\`) probes \`/health\` first; resolves submit/inject flags from \`exchange.mode\` + \`DEMO_MODE\` env.
- \`BotSubmitterWorker[]\` (one per user bot) loops submits.
- \`InjectorWorker\` (admin) picks random working order from in-process \`DemoOrderRegistry\` and injects.

## Rubber-duck design findings adopted (before implementation)

- **Demo overlay, not a profile** — needs to set \`Mode=Simulator\` explicitly; base \`docker compose up\` default stays \`Unavailable\`.
- **Demo creds in overlay only** — never in base \`appsettings.json\`. Hashes (PBKDF2-HMAC-SHA256, 600k iters) for \`demo-admin\` / \`bot-clientA\` / \`bot-clientB\` (all password \`demopass\`) are committed in the overlay so it works zero-config.
- **Track leaves/cum from inject responses** — \`DemoOrderRegistry\` evicts on \`Fill\`/0-leaves/404/400 so the injector never overfills.
- **Drop \`Status=Rejected\` responses** — \`POST /orders\` returns 202 even on server-side rejections; not registering them avoids the injector minting bogus fills against rejected ClOrdIds.
- **\`MaxOpenOrdersPerBot\` cap** — bounds the working book during long runs.
- **\`Mode=Unavailable\` detected** — bots log loudly and idle (vs. spamming 502s).

## Out of scope (D1)

- MD ticks (combine with \`--profile marketdata\` for that).
- Real-stack cross-firm (requires multi-firm wiring through \`docker-compose.real.yml\`).
- Order cancellation cycle (covered by \`MaxOpenOrdersPerBot\`).

## Verification

- \`dotnet build B3TradingPlatform.slnx -c Release\` clean (0 warns).
- \`dotnet format --verify-no-changes\` clean.
- \`dotnet test\` 32+226+128 passing, 12 skip (conformance — discovery-time skip outside compose).
- Local smoke: stack up, bot-clientA blotter showed 44 orders in 60s with mix of Filled/PartiallyFilled/PendingNew, positions evolving.
- \`docker compose config\` clean for the new overlay; CI \`compose-validate\` job extended.

## Files

- \`backend/tools/B3.Trading.DemoDriver/\` (new project: csproj, Program, Options, Registry, ModeState, TradingClient, BotSubmitterWorker, InjectorWorker, Dockerfile)
- \`docker/docker-compose.demo.yml\` (new overlay)
- \`docker/.env.example\` (commented demo block)
- \`docs/DOCKER.md\` (\"Demo overlay (opt-in, laptop-only)\" section)
- \`B3TradingPlatform.slnx\` (added tools project)
- \`.github/workflows/docker.yml\` (compose-validate covers new overlay)

D2 (README \"Quick demo\" + DOCKER polish) follows next per the planned sequence.