### PR TITLE
feat(trader-ui): T2 — depth-of-book panel

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -77,11 +77,12 @@ body {
   flex: 1;
   display: grid;
   grid-template-columns: 280px 1fr 240px;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto 1fr auto auto;
   grid-template-areas:
     "ticket  blotter   positions"
     "ticket  blotter   positions"
-    "md      execs     positions";
+    "md      execs     positions"
+    "dob     dob       positions";
   gap: 8px; padding: 8px; min-height: 0;
 }
 .panel {
@@ -103,6 +104,22 @@ body {
 .executions { grid-area: execs; min-height: 0; }
 .market-data{ grid-area: md; }
 .market-data .empty { color: var(--muted); font-size: .8rem; }
+.dob { grid-area: dob; }
+.dob h2 select {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: .15rem .3rem; font: inherit; font-size: .8rem;
+}
+.dob-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; min-height: 0;
+}
+.dob-grid table { width: 100%; border-collapse: collapse; font-size: .8rem; }
+.dob-grid th { color: var(--muted); font-weight: 500; padding: .15rem .35rem; }
+.dob-grid td { padding: .12rem .35rem; }
+.dob-grid .num { text-align: right; font-variant-numeric: tabular-nums; }
+.dob-bid td:last-child { color: #1f9d55; font-weight: 600; } /* bid price */
+.dob-ask td:first-child { color: #c53030; font-weight: 600; } /* ask price */
+.dob-grid .muted-cell { color: var(--muted); text-align: center; padding: .8rem; }
 
 /* ---------- Order ticket ---------- */
 .ticket-form { display: flex; flex-direction: column; gap: .55rem; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -172,6 +172,39 @@
           </table>
         </div>
       </section>
+
+      <!-- DEPTH OF BOOK ---------------------------------------------- -->
+      <section class="panel dob">
+        <h2>
+          Depth of book
+          <select id="dob-symbol" aria-label="DOB symbol">
+            <option value="">— select symbol —</option>
+          </select>
+        </h2>
+        <p id="dob-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
+        <div class="dob-grid">
+          <table id="dob-bids" class="dob-side dob-bid">
+            <thead>
+              <tr>
+                <th class="num">Cum</th>
+                <th class="num">Qty</th>
+                <th class="num">Bid</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <table id="dob-asks" class="dob-side dob-ask">
+            <thead>
+              <tr>
+                <th class="num">Ask</th>
+                <th class="num">Qty</th>
+                <th class="num">Cum</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
     </main>
   </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -8,6 +8,7 @@ import { validateOrder, fatFingerCheck, payloadKey } from "./validation.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
 import * as adminUi from "./adminUi.js";
+import { FLAGS } from "./mdProtocol.js";
 
 const SESSION_KEY = "b3tp.session";
 const MD_KEY = "b3tp.md";
@@ -55,6 +56,7 @@ function init() {
     onBlotterFilter: handleBlotterFilter,
     onSelectOrder: handleSelectOrder,
     onKeyboardCancel: handleKeyboardCancel,
+    onSelectDobSymbol: handleSelectDobSymbol,
   });
   adminUi.setAdminHandlers({
     onToggleFirm:      handleToggleFirm,
@@ -268,6 +270,8 @@ function handleApplyMd({ url, symbols }) {
       mdWorker = null;
     }
     state.clearMarketData();
+    state.clearAllBooks();
+    mbpEnabled = false;
     startMdWorker();
   } else {
     mdWorker.postMessage({ type: "setSymbols", symbols });
@@ -280,10 +284,27 @@ function handleApplyMd({ url, symbols }) {
   ui.setMdFeedback(`watching ${symbols.length} symbol(s)`, "ok");
 }
 
+// MBP is sticky: once enabled in a session, we leave the flag on even
+// if the trader closes the DOB panel. Toggling MBP re-subscribes every
+// symbol (server allocates fresh securityIds per flag set), which would
+// briefly blank market-data and trade-tape — not worth it.
+let mbpEnabled = false;
+
+function handleSelectDobSymbol(symbol) {
+  state.setDobSymbol(symbol || null);
+  if (!symbol || !mdWorker || mbpEnabled) return;
+  const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
+  mdWorker.postMessage({ type: "setFlags", flags });
+  mbpEnabled = true;
+}
+
 function onMdWorkerMessage(msg) {
   switch (msg.type) {
     case "md.status":   state.setMarketDataStatus(msg.value); break;
-    case "md.clear":    state.clearMarketData(); break;
+    case "md.clear":
+      state.clearMarketData();
+      state.clearAllBooks();
+      break;
     case "md.trade":    state.applyMdTrade(msg); break;
     case "md.info":     state.applyMdInfo(msg); break;
     case "md.bust":
@@ -294,8 +315,19 @@ function onMdWorkerMessage(msg) {
     case "md.subError":
       ui.setMdFeedback(`subscribe ${msg.symbol}: ${msg.errorName}`, "error");
       state.removeMdSymbol(msg.symbol);
+      state.removeBookSymbol(msg.symbol);
       break;
-    case "md.removed":  state.removeMdSymbol(msg.symbol); break;
+    case "md.removed":
+      state.removeMdSymbol(msg.symbol);
+      state.removeBookSymbol(msg.symbol);
+      break;
+    case "md.book.snapshot":   state.applyMdBookSnapshot(msg); break;
+    case "md.book.cleared":    state.applyMdBookCleared(msg); break;
+    case "md.level.snapshot":  state.applyMdLevelSnapshot(msg); break;
+    case "md.level.update":    state.applyMdLevelUpdate(msg); break;
+    case "md.level.deleted":   state.applyMdLevelDeleted(msg); break;
+    case "md.candle.snapshot": /* T3 */ break;
+    case "md.candle.update":   /* T3 */ break;
     case "md.error":    console.warn("[md]", msg); break;
   }
 }
@@ -421,6 +453,7 @@ function logout() {
     mdWorker.terminate();
     mdWorker = null;
   }
+  mbpEnabled = false;
   session = null;
   mdConfig = null;
   clearSession();

--- a/frontend/js/mdWorker.js
+++ b/frontend/js/mdWorker.js
@@ -25,7 +25,7 @@
 //   { type: "md.candle.snapshot",   symbol, resolution, candles, isFirst, isLast }
 //   { type: "md.candle.update",     symbol, resolution, candle }
 //   { type: "md.subError", symbol, errorName }
-//   { type: "md.clear" }                        // dropped; main thread should reset cache
+//   { type: "md.clear" }                        // posted on (re)connect; reset all derived caches
 //   { type: "md.error",    message }
 
 import { buildSubscribe, buildUnsubscribe, parseFrames, FLAGS } from './mdProtocol.js';
@@ -274,14 +274,16 @@ function resetSubscriptionsForFlagsChange() {
   // new flags. The server resolves a fresh securityId per (symbol, flags)
   // session, so we drop the reverse index and let SubscribeOk repopulate.
   // Frames in flight under the previous flags are intentionally lost
-  // during the gap; post `md.clear` so panels (DOB, chart, tape) reset
-  // their per-symbol caches instead of mixing stale state with new.
+  // during the gap. We do NOT post `md.clear` here — that semantic is
+  // reserved for the full reconnect path so the trade-tape / lastPrice
+  // cache survives a flag flip (e.g. enabling MBP for a DOB panel).
+  // Per-side book/level caches reset naturally as the server resends
+  // snapshots after the new SubscribeOk.
   for (const [, id] of subscriptions) {
     if (id !== null) safeSend(buildUnsubscribe(id));
   }
   for (const sym of subscriptions.keys()) subscriptions.set(sym, null);
   securityIdToSymbol.clear();
-  post({ type: 'md.clear' });
   if (serverReady) flushSubscribes();
 }
 

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -14,6 +14,14 @@ const state = {
   marketData: new Map(),   // Symbol -> { lastPrice, lastQty, lastTradeId, updatedAt, info }
   marketDataStatus: "disconnected", // disconnected | connecting | connected | not_ready
   watchlist: [],           // [string] symbols (UPPERCASE)
+  // Depth-of-Book slice (T2). One book entry per symbol; sides are
+  // Map<priceKey, { qty, count }>. `ready` flips false on book.snapshot
+  // marker and true on the following level.snapshot — incremental
+  // updates that arrive before a snapshot are dropped to avoid
+  // displaying a partial book. Sorting (top-N for render) happens
+  // render-side, not in state.
+  book: new Map(),         // Symbol -> { bids: Map, asks: Map, ready: bool, updatedAt: number }
+  dobSymbol: null,         // currently selected DOB symbol or null
   // UX-only slices added in the operability pass.
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
@@ -138,9 +146,125 @@ export function clearMarketData() {
   notify("marketData");
 }
 
+// ── Depth-of-Book slice (T2) ───────────────────────────────────────
+
+// Side encoding from mdWorker (mdProtocol.SIDE): 0=Bid, 1=Ask.
+const SIDE_BID = 0;
+const SIDE_ASK = 1;
+
+// Decoder produces JS numbers post-PRICE_DIVISOR division. The wire
+// price exponent is -4, so toFixed(4) is the canonical bucket key —
+// resilient to any future float-rounding drift.
+function priceKey(price) { return Number(price).toFixed(4); }
+
+function ensureBook(symbol) {
+  let entry = state.book.get(symbol);
+  if (!entry) {
+    entry = { bids: new Map(), asks: new Map(), ready: false, updatedAt: 0 };
+    state.book.set(symbol, entry);
+  }
+  return entry;
+}
+
+function sideMap(entry, side) {
+  if (side === SIDE_BID) return entry.bids;
+  if (side === SIDE_ASK) return entry.asks;
+  return null;
+}
+
+export function applyMdBookSnapshot({ symbol }) {
+  // Marker that a fresh full snapshot is incoming — the level.snapshot
+  // that follows carries the data. Mark not-ready and clear so the UI
+  // doesn't render a half-built book during the gap.
+  const entry = ensureBook(symbol);
+  entry.bids.clear();
+  entry.asks.clear();
+  entry.ready = false;
+  entry.updatedAt = Date.now();
+  notify("book");
+}
+
+export function applyMdLevelSnapshot({ symbol, bids, asks }) {
+  const entry = ensureBook(symbol);
+  entry.bids.clear();
+  entry.asks.clear();
+  for (const lv of bids ?? []) entry.bids.set(priceKey(lv.price), { qty: lv.qty, count: lv.count });
+  for (const lv of asks ?? []) entry.asks.set(priceKey(lv.price), { qty: lv.qty, count: lv.count });
+  entry.ready = true;
+  entry.updatedAt = Date.now();
+  notify("book");
+}
+
+export function applyMdLevelUpdate({ symbol, side, price, qty, count }) {
+  const entry = ensureBook(symbol);
+  // Drop incremental updates before the first level.snapshot — they
+  // would build a partial / misleading book.
+  if (!entry.ready) return;
+  const target = sideMap(entry, side);
+  if (target === null) return; // defensive: ignore malformed/future sides
+  target.set(priceKey(price), { qty, count });
+  entry.updatedAt = Date.now();
+  notify("book");
+}
+
+export function applyMdLevelDeleted({ symbol, side, price }) {
+  const entry = state.book.get(symbol);
+  if (!entry?.ready) return;
+  const target = sideMap(entry, side);
+  if (target === null) return;
+  if (target.delete(priceKey(price))) {
+    entry.updatedAt = Date.now();
+    notify("book");
+  }
+}
+
+export function applyMdBookCleared({ symbol, side }) {
+  const entry = state.book.get(symbol);
+  if (!entry) return;
+  if (side === null || side === undefined) {
+    entry.bids.clear();
+    entry.asks.clear();
+  } else {
+    const target = sideMap(entry, side);
+    if (target === null) return;
+    target.clear();
+  }
+  entry.updatedAt = Date.now();
+  notify("book");
+}
+
+export function removeBookSymbol(symbol) {
+  if (state.book.delete(symbol)) notify("book");
+}
+
+export function clearAllBooks() {
+  if (state.book.size === 0) return;
+  state.book.clear();
+  notify("book");
+}
+
+export function setDobSymbol(symbol) {
+  const next = symbol ?? null;
+  if (state.dobSymbol === next) return;
+  state.dobSymbol = next;
+  notify("dobSymbol");
+}
+
 export function setWatchlist(symbols) {
-  state.watchlist = symbols.slice();
+  const next = symbols.slice();
+  state.watchlist = next;
+  // Drop book caches for symbols no longer watched.
+  const wanted = new Set(next);
+  for (const sym of [...state.book.keys()]) {
+    if (!wanted.has(sym)) state.book.delete(sym);
+  }
+  // Reset DOB selection if the chosen symbol just left the watchlist.
+  if (state.dobSymbol && !wanted.has(state.dobSymbol)) {
+    state.dobSymbol = null;
+    notify("dobSymbol");
+  }
   notify("watchlist");
+  notify("book");
 }
 
 export function isTerminalOrderStatus(status) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -15,6 +15,7 @@ let onSwitchView  = () => {};
 let onBlotterFilter  = () => {};
 let onSelectOrder    = () => {};
 let onKeyboardCancel = () => {};
+let onSelectDobSymbol = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
@@ -25,6 +26,7 @@ export function setHandlers(handlers) {
   onBlotterFilter  = handlers.onBlotterFilter  ?? onBlotterFilter;
   onSelectOrder    = handlers.onSelectOrder    ?? onSelectOrder;
   onKeyboardCancel = handlers.onKeyboardCancel ?? onKeyboardCancel;
+  onSelectDobSymbol = handlers.onSelectDobSymbol ?? onSelectDobSymbol;
 }
 
 export function showLogin() {
@@ -161,6 +163,14 @@ export function bindUi() {
       .filter(Boolean);
     onApplyMd({ url, symbols });
   });
+
+  // DOB symbol selector — empty value clears the selection.
+  const dobSelect = $("dob-symbol");
+  if (dobSelect) {
+    dobSelect.addEventListener("change", (e) => {
+      onSelectDobSymbol(e.target.value || null);
+    });
+  }
 
   // View toggle (trader / admin) — only wired here, visibility is
   // gated in app.js based on the JWT role claim.
@@ -360,6 +370,7 @@ function renderForSlice(slice) {
   if (slice === "wsReconnect") renderReconnect();
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
   if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
+  if (slice === "watchlist" || slice === "dobSymbol" || slice === "book" || slice === "all") renderDob();
 }
 
 function renderAll() {
@@ -369,6 +380,7 @@ function renderAll() {
   setStatusPill(getState().status);
   setUserLabel(getState().user);
   renderMarketData();
+  renderDob();
   setMdStatusPill(getState().marketDataStatus);
   renderInflight();
   renderReconnect();
@@ -409,6 +421,75 @@ function renderMarketData() {
       <td class="num">${e.lastTradeId ?? "—"}</td>
       <td>${ts}</td>
     </tr>`;
+  }).join("");
+}
+
+const DOB_TOP_N = 10;
+
+function renderDob() {
+  const select = $("dob-symbol");
+  const bidsBody = document.querySelector("#dob-bids tbody");
+  const asksBody = document.querySelector("#dob-asks tbody");
+  const feedback = $("dob-feedback");
+  if (!select || !bidsBody || !asksBody) return;
+
+  const st = getState();
+  const watch = st.watchlist;
+  const current = st.dobSymbol;
+
+  // Sync the symbol dropdown with the current watchlist.
+  const desired = ["", ...watch];
+  const existing = [...select.options].map(o => o.value);
+  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
+    select.innerHTML = `<option value="">— select symbol —</option>` +
+      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
+  }
+  if (select.value !== (current ?? "")) {
+    select.value = current ?? "";
+  }
+
+  if (!current) {
+    bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">select a symbol</td></tr>`;
+    asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">select a symbol</td></tr>`;
+    if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+    return;
+  }
+
+  const entry = st.book.get(current);
+  if (!entry || !entry.ready) {
+    bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">awaiting book snapshot…</td></tr>`;
+    asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">awaiting book snapshot…</td></tr>`;
+    if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+    return;
+  }
+
+  const bids = [...entry.bids.entries()]
+    .map(([k, v]) => ({ price: Number(k), qty: v.qty, count: v.count }))
+    .sort((a, b) => b.price - a.price)
+    .slice(0, DOB_TOP_N);
+  const asks = [...entry.asks.entries()]
+    .map(([k, v]) => ({ price: Number(k), qty: v.qty, count: v.count }))
+    .sort((a, b) => a.price - b.price)
+    .slice(0, DOB_TOP_N);
+
+  bidsBody.innerHTML = renderDobSide(bids, "bid");
+  asksBody.innerHTML = renderDobSide(asks, "ask");
+  if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+}
+
+function renderDobSide(levels, side) {
+  if (levels.length === 0) {
+    return `<tr><td colspan="3" class="muted-cell">empty</td></tr>`;
+  }
+  let cum = 0;
+  return levels.map(lv => {
+    cum += Number(lv.qty) || 0;
+    const price = lv.price.toFixed(2);
+    const qty = lv.qty;
+    if (side === "bid") {
+      return `<tr><td class="num">${cum}</td><td class="num">${qty}</td><td class="num">${price}</td></tr>`;
+    }
+    return `<tr><td class="num">${price}</td><td class="num">${qty}</td><td class="num">${cum}</td></tr>`;
   }).join("");
 }
 

--- a/frontend/test/state-book.test.mjs
+++ b/frontend/test/state-book.test.mjs
@@ -1,0 +1,169 @@
+// DOB (Depth-of-Book) state reducer tests for frontend/js/state.js.
+// Runs with `node --test frontend/test/state-book.test.mjs`.
+//
+// Coverage: snapshot/level/cleared semantics, ready-gate (incremental
+// drops before snapshot), watchlist trimming book + dobSymbol, and
+// clearAllBooks. Each test resets the module by re-importing via a
+// cache-busting query string; state.js holds module-scope mutable
+// state so isolation matters.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust=${n}`);
+}
+
+test('book.snapshot marker resets entry to not-ready', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({
+    symbol: 'PETR4',
+    bids: [{ price: 32.50, qty: 100, count: 1 }],
+    asks: [{ price: 32.55, qty: 200, count: 2 }],
+  });
+  assert.equal(s.getState().book.get('PETR4').ready, true);
+
+  s.applyMdBookSnapshot({ symbol: 'PETR4' });
+  const entry = s.getState().book.get('PETR4');
+  assert.equal(entry.ready, false);
+  assert.equal(entry.bids.size, 0);
+  assert.equal(entry.asks.size, 0);
+});
+
+test('level.snapshot replaces both sides and flips ready=true', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({
+    symbol: 'VALE3',
+    bids: [
+      { price: 65.00, qty: 100, count: 1 },
+      { price: 64.99, qty: 200, count: 2 },
+    ],
+    asks: [{ price: 65.05, qty: 300, count: 3 }],
+  });
+  const e = s.getState().book.get('VALE3');
+  assert.equal(e.ready, true);
+  assert.equal(e.bids.size, 2);
+  assert.equal(e.asks.size, 1);
+  assert.deepEqual(e.bids.get('65.0000'), { qty: 100, count: 1 });
+  assert.deepEqual(e.asks.get('65.0500'), { qty: 300, count: 3 });
+});
+
+test('level.update before snapshot is dropped (ready=false)', async () => {
+  const s = await freshState();
+  s.applyMdBookSnapshot({ symbol: 'ITUB4' });
+  s.applyMdLevelUpdate({ symbol: 'ITUB4', side: 0, price: 30.00, qty: 500, count: 1 });
+  const e = s.getState().book.get('ITUB4');
+  assert.equal(e.ready, false);
+  assert.equal(e.bids.size, 0);
+});
+
+test('level.update with valid side after snapshot updates the bucket', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({ symbol: 'PETR4', bids: [], asks: [] });
+  s.applyMdLevelUpdate({ symbol: 'PETR4', side: 0, price: 32.50, qty: 1000, count: 4 });
+  s.applyMdLevelUpdate({ symbol: 'PETR4', side: 1, price: 32.55, qty: 2000, count: 5 });
+  const e = s.getState().book.get('PETR4');
+  assert.deepEqual(e.bids.get('32.5000'), { qty: 1000, count: 4 });
+  assert.deepEqual(e.asks.get('32.5500'), { qty: 2000, count: 5 });
+});
+
+test('level.update with invalid side is silently ignored', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({ symbol: 'PETR4', bids: [], asks: [] });
+  s.applyMdLevelUpdate({ symbol: 'PETR4', side: 99, price: 32.50, qty: 1, count: 1 });
+  const e = s.getState().book.get('PETR4');
+  assert.equal(e.bids.size, 0);
+  assert.equal(e.asks.size, 0);
+});
+
+test('level.deleted removes only the targeted side', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({
+    symbol: 'PETR4',
+    bids: [{ price: 32.50, qty: 100, count: 1 }],
+    asks: [{ price: 32.55, qty: 200, count: 2 }],
+  });
+  s.applyMdLevelDeleted({ symbol: 'PETR4', side: 0, price: 32.50 });
+  const e = s.getState().book.get('PETR4');
+  assert.equal(e.bids.size, 0);
+  assert.equal(e.asks.size, 1);
+});
+
+test('book.cleared with null clears both sides', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({
+    symbol: 'PETR4',
+    bids: [{ price: 32.50, qty: 100, count: 1 }],
+    asks: [{ price: 32.55, qty: 200, count: 2 }],
+  });
+  s.applyMdBookCleared({ symbol: 'PETR4', side: null });
+  const e = s.getState().book.get('PETR4');
+  assert.equal(e.bids.size, 0);
+  assert.equal(e.asks.size, 0);
+});
+
+test('book.cleared with side=BID clears only the bid side', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({
+    symbol: 'PETR4',
+    bids: [{ price: 32.50, qty: 100, count: 1 }],
+    asks: [{ price: 32.55, qty: 200, count: 2 }],
+  });
+  s.applyMdBookCleared({ symbol: 'PETR4', side: 0 });
+  const e = s.getState().book.get('PETR4');
+  assert.equal(e.bids.size, 0);
+  assert.equal(e.asks.size, 1);
+});
+
+test('setWatchlist drops books for symbols no longer watched', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.applyMdLevelSnapshot({ symbol: 'PETR4', bids: [{ price: 1, qty: 1, count: 1 }], asks: [] });
+  s.applyMdLevelSnapshot({ symbol: 'VALE3', bids: [{ price: 2, qty: 2, count: 2 }], asks: [] });
+  s.setWatchlist(['PETR4']);
+  assert.equal(s.getState().book.has('PETR4'), true);
+  assert.equal(s.getState().book.has('VALE3'), false);
+});
+
+test('setWatchlist clears dobSymbol if it was removed', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.setDobSymbol('VALE3');
+  assert.equal(s.getState().dobSymbol, 'VALE3');
+  s.setWatchlist(['PETR4']);
+  assert.equal(s.getState().dobSymbol, null);
+});
+
+test('setWatchlist preserves dobSymbol if still in list', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.setDobSymbol('PETR4');
+  s.setWatchlist(['PETR4', 'ITUB4']);
+  assert.equal(s.getState().dobSymbol, 'PETR4');
+});
+
+test('clearAllBooks empties the book Map', async () => {
+  const s = await freshState();
+  s.applyMdLevelSnapshot({ symbol: 'PETR4', bids: [{ price: 1, qty: 1, count: 1 }], asks: [] });
+  s.applyMdLevelSnapshot({ symbol: 'VALE3', bids: [{ price: 2, qty: 2, count: 2 }], asks: [] });
+  s.clearAllBooks();
+  assert.equal(s.getState().book.size, 0);
+});
+
+test('setDobSymbol notifies "dobSymbol" slice', async () => {
+  const s = await freshState();
+  const seen = [];
+  s.subscribe((slice) => seen.push(slice));
+  s.setDobSymbol('PETR4');
+  assert.ok(seen.includes('dobSymbol'));
+});
+
+test('book reducers notify "book" slice', async () => {
+  const s = await freshState();
+  const seen = [];
+  s.subscribe((slice) => seen.push(slice));
+  s.applyMdLevelSnapshot({ symbol: 'PETR4', bids: [], asks: [] });
+  assert.ok(seen.includes('book'));
+});


### PR DESCRIPTION
## What

Trader UI slice **T2 — Depth-of-book panel**. Adds a per-symbol DOB
view (bids left, asks right, top-10 levels) consuming the
`md.book.*` / `md.level.*` messages already plumbed in T1 (#74).

## How

- **state.js** — new `book` slice (Map<symbol, {bids, asks, ready,
  updatedAt}>) plus `dobSymbol`. Reducers cover snapshot, level
  upsert/delete, BookCleared (full or per-side), watchlist trim, and
  `clearAllBooks`. `priceKey` (`Number(p).toFixed(4)`) is the canonical
  bucket key — matches SBE Price exponent -4.
- **Ready-gate**: `md.book.snapshot` flips `ready=false` (clears both
  sides); incoming `md.level.update`/`deleted` are dropped until
  `md.level.snapshot` arrives and flips `ready=true`. The UI never
  shows a half-built book.
- **mdWorker.js** — removed the destructive `md.clear` post inside the
  `setFlags` re-subscribe path. It wiped the trade-tape `lastPrice`
  cache for no benefit (server resends fresh snapshots after the new
  SubscribeOk).
- **app.js** — routes the 5 new worker messages; new
  `onSelectDobSymbol` enables `MBP` once per session (sticky) so
  re-toggling doesn't blip every existing securityId. `md.subError` /
  `md.removed` now also drop the symbol's book entry.
- **ui.js + index.html + css** — new `<section class="panel dob">`
  with side-by-side tables + cumulative-qty column, dropdown synced
  with the watchlist, render-time top-N sort.
- **Tests** — 14 new state reducer tests (`state-book.test.mjs`).
  Total frontend suite: **46 / 46 pass**, `node --check` clean,
  `dotnet format --verify-no-changes` clean.

## Design decisions (rubber-ducked)

- **Sticky MBP** — once a trader picks a DOB symbol, MBP stays on for
  the session. Cheaper than re-allocating securityIds on every
  open/close.
- **Top-N at render time** — ~2800 cmp/sec at 10Hz with 50 levels;
  no memoization needed.
- **Per-symbol readiness** — required so updates arriving before the
  level.snapshot don't paint a partial book.
- **No `md.clear` on flag flip** — semantic stays "full reconnect".
  Trade-tape continuity wins; book repopulates naturally.

## Open follow-ups (non-blocking)

- Top-N=10 default; can tweak after feedback.
- Per-symbol flag refactor (today flags are global to the worker)
  if watchlists grow large — punted; not on the critical path.

## Tests

```
$ node --test frontend/test/*.test.mjs
# tests 46 / pass 46 / fail 0
$ dotnet format --verify-no-changes      # clean
```

Closes #68
