### PR TITLE
feat(trader-ui): T3 — server-fed candlestick chart

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -77,12 +77,13 @@ body {
   flex: 1;
   display: grid;
   grid-template-columns: 280px 1fr 240px;
-  grid-template-rows: auto 1fr auto auto;
+  grid-template-rows: auto 1fr auto auto auto;
   grid-template-areas:
     "ticket  blotter   positions"
     "ticket  blotter   positions"
     "md      execs     positions"
-    "dob     dob       positions";
+    "dob     dob       positions"
+    "chart   chart     positions";
   gap: 8px; padding: 8px; min-height: 0;
 }
 .panel {
@@ -120,6 +121,27 @@ body {
 .dob-bid td:last-child { color: #1f9d55; font-weight: 600; } /* bid price */
 .dob-ask td:first-child { color: #c53030; font-weight: 600; } /* ask price */
 .dob-grid .muted-cell { color: var(--muted); text-align: center; padding: .8rem; }
+
+/* ---------- Chart panel (T3) ---------- */
+.chart { grid-area: chart; min-height: 220px; }
+.chart h2 { display: flex; align-items: center; gap: .55rem; }
+.chart .chart-controls { display: inline-flex; gap: .35rem; }
+.chart h2 select {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: .15rem .3rem; font: inherit; font-size: .8rem;
+}
+.chart-canvas { position: relative; flex: 1; min-height: 180px; }
+.chart-canvas svg { width: 100%; height: 100%; display: block; background: var(--bg); border-radius: 4px; }
+.chart-empty {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--muted); margin: 0; pointer-events: none;
+}
+.chart-empty[hidden] { display: none; }
+.candle-up   { stroke: #1f9d55; fill: #1f9d55; }
+.candle-down { stroke: #c53030; fill: #c53030; }
+.candle-wick { stroke-width: 1; }
 
 /* ---------- Order ticket ---------- */
 .ticket-form { display: flex; flex-direction: column; gap: .55rem; }
@@ -180,7 +202,9 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
     grid-template-areas:
       "ticket    positions"
       "blotter   blotter"
-      "execs     md";
+      "execs     md"
+      "dob       dob"
+      "chart     chart";
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -205,6 +205,27 @@
           </table>
         </div>
       </section>
+
+      <!-- CHART ------------------------------------------------------ -->
+      <section class="panel chart">
+        <h2>
+          Chart
+          <span class="chart-controls">
+            <select id="chart-symbol" aria-label="Chart symbol">
+              <option value="">— select symbol —</option>
+            </select>
+            <select id="chart-resolution" aria-label="Chart resolution">
+              <option value="60">1m</option>
+              <option value="300">5m</option>
+              <option value="900">15m</option>
+            </select>
+          </span>
+        </h2>
+        <div class="chart-canvas">
+          <svg id="chart-svg" viewBox="0 0 300 100" preserveAspectRatio="none" aria-label="Candlestick chart"></svg>
+          <p id="chart-empty" class="chart-empty muted-cell">select a symbol</p>
+        </div>
+      </section>
     </main>
   </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -57,6 +57,8 @@ function init() {
     onSelectOrder: handleSelectOrder,
     onKeyboardCancel: handleKeyboardCancel,
     onSelectDobSymbol: handleSelectDobSymbol,
+    onSelectChartSymbol: state.setChartSymbol,
+    onSelectChartResolution: state.setChartResolution,
   });
   adminUi.setAdminHandlers({
     onToggleFirm:      handleToggleFirm,
@@ -271,6 +273,7 @@ function handleApplyMd({ url, symbols }) {
     }
     state.clearMarketData();
     state.clearAllBooks();
+    state.clearAllCandles();
     mbpEnabled = false;
     startMdWorker();
   } else {
@@ -304,6 +307,7 @@ function onMdWorkerMessage(msg) {
     case "md.clear":
       state.clearMarketData();
       state.clearAllBooks();
+      state.clearAllCandles();
       break;
     case "md.trade":    state.applyMdTrade(msg); break;
     case "md.info":     state.applyMdInfo(msg); break;
@@ -316,18 +320,20 @@ function onMdWorkerMessage(msg) {
       ui.setMdFeedback(`subscribe ${msg.symbol}: ${msg.errorName}`, "error");
       state.removeMdSymbol(msg.symbol);
       state.removeBookSymbol(msg.symbol);
+      state.removeCandlesSymbol(msg.symbol);
       break;
     case "md.removed":
       state.removeMdSymbol(msg.symbol);
       state.removeBookSymbol(msg.symbol);
+      state.removeCandlesSymbol(msg.symbol);
       break;
     case "md.book.snapshot":   state.applyMdBookSnapshot(msg); break;
     case "md.book.cleared":    state.applyMdBookCleared(msg); break;
     case "md.level.snapshot":  state.applyMdLevelSnapshot(msg); break;
     case "md.level.update":    state.applyMdLevelUpdate(msg); break;
     case "md.level.deleted":   state.applyMdLevelDeleted(msg); break;
-    case "md.candle.snapshot": /* T3 */ break;
-    case "md.candle.update":   /* T3 */ break;
+    case "md.candle.snapshot": state.applyMdCandleSnapshot(msg); break;
+    case "md.candle.update":   state.applyMdCandleUpdate(msg); break;
     case "md.error":    console.warn("[md]", msg); break;
   }
 }

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -22,6 +22,16 @@ const state = {
   // render-side, not in state.
   book: new Map(),         // Symbol -> { bids: Map, asks: Map, ready: bool, updatedAt: number }
   dobSymbol: null,         // currently selected DOB symbol or null
+  // Candle slice (T3). Server may multiplex multiple resolutions for
+  // the same symbol on a single subscription, so we cache them all
+  // (Map<symbol, Map<resolutionSec, {bars, ready, updatedAt}>>) and
+  // let the UI filter at render time. `ready` flips true only when
+  // a snapshot's CANDLE_FLAGS.LAST frame arrives — partial history
+  // with no FIRST stays not-ready to avoid presenting a truncated
+  // chart as complete.
+  candles: new Map(),      // Symbol -> Map<resolutionSec, { bars: [...], ready: bool, updatedAt: number }>
+  chartSymbol: null,       // currently selected chart symbol or null
+  chartResolution: 60,     // seconds (60=1m, 300=5m, 900=15m)
   // UX-only slices added in the operability pass.
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
@@ -250,21 +260,129 @@ export function setDobSymbol(symbol) {
   notify("dobSymbol");
 }
 
+// ── Candle slice (T3) ──────────────────────────────────────────────
+
+// Bars-per-resolution memory cap. Long histories (e.g. day-long 1m
+// chart at 8h session ≈ 480 bars) fit comfortably; beyond that we
+// drop the oldest. Snapshot replace and live update both honour this.
+const MAX_BARS = 600;
+
+// Supported resolutions in seconds. Frames carrying any other
+// resolution are accepted into state (the server may multiplex them)
+// but the chart selector exposes only these three.
+export const CHART_RESOLUTIONS = [60, 300, 900];
+
+function ensureCandleEntry(symbol, resolution) {
+  let perRes = state.candles.get(symbol);
+  if (!perRes) {
+    perRes = new Map();
+    state.candles.set(symbol, perRes);
+  }
+  let entry = perRes.get(resolution);
+  if (!entry) {
+    entry = { bars: [], ready: false, updatedAt: 0 };
+    perRes.set(resolution, entry);
+  }
+  return entry;
+}
+
+function trimBars(entry) {
+  const overflow = entry.bars.length - MAX_BARS;
+  if (overflow > 0) entry.bars.splice(0, overflow);
+}
+
+export function applyMdCandleSnapshot({ symbol, resolution, candles, isFirst, isLast }) {
+  const entry = ensureCandleEntry(symbol, resolution);
+  if (isFirst) {
+    // Fresh history sequence — restart accumulation.
+    entry.bars = candles.slice();
+    entry.ready = false;
+    entry._startedFromFirst = true;
+  } else {
+    // Mid/tail frame. If we never saw FIRST (mid-stream join, or the
+    // first frame was lost), accumulate but stay not-ready — we'd
+    // rather show "awaiting…" than present a truncated history as
+    // complete.
+    entry.bars.push(...candles);
+  }
+  trimBars(entry);
+  if (isLast && entry._startedFromFirst) {
+    entry.ready = true;
+    entry._startedFromFirst = false;
+  }
+  entry.updatedAt = Date.now();
+  notify("candles");
+}
+
+export function applyMdCandleUpdate({ symbol, resolution, candle }) {
+  const perRes = state.candles.get(symbol);
+  const entry = perRes?.get(resolution);
+  if (!entry?.ready) return; // drop until snapshot completes
+  const last = entry.bars[entry.bars.length - 1];
+  if (last && last.time === candle.time) {
+    entry.bars[entry.bars.length - 1] = candle;
+  } else {
+    entry.bars.push(candle);
+    trimBars(entry);
+  }
+  entry.updatedAt = Date.now();
+  notify("candles");
+}
+
+export function removeCandlesSymbol(symbol) {
+  if (state.candles.delete(symbol)) notify("candles");
+}
+
+export function clearAllCandles() {
+  if (state.candles.size === 0) return;
+  state.candles.clear();
+  notify("candles");
+}
+
+export function setChartSymbol(symbol) {
+  const next = symbol ?? null;
+  if (state.chartSymbol === next) return;
+  state.chartSymbol = next;
+  notify("chartSymbol");
+}
+
+export function setChartResolution(seconds) {
+  const next = Number(seconds);
+  if (!CHART_RESOLUTIONS.includes(next)) return;
+  if (state.chartResolution === next) return;
+  state.chartResolution = next;
+  notify("chartResolution");
+}
+
 export function setWatchlist(symbols) {
   const next = symbols.slice();
   state.watchlist = next;
-  // Drop book caches for symbols no longer watched.
+  // Drop book + candle caches for symbols no longer watched.
   const wanted = new Set(next);
   for (const sym of [...state.book.keys()]) {
     if (!wanted.has(sym)) state.book.delete(sym);
   }
-  // Reset DOB selection if the chosen symbol just left the watchlist.
+  for (const sym of [...state.candles.keys()]) {
+    if (!wanted.has(sym)) state.candles.delete(sym);
+  }
+  // Reset DOB / chart selection if the chosen symbol just left the
+  // watchlist. Auto-pick a sensible default for chart so the panel
+  // doesn't sit empty when the trader has symbols available.
   if (state.dobSymbol && !wanted.has(state.dobSymbol)) {
     state.dobSymbol = null;
     notify("dobSymbol");
   }
+  if (state.chartSymbol && !wanted.has(state.chartSymbol)) {
+    state.chartSymbol = null;
+    notify("chartSymbol");
+  }
+  if (state.chartSymbol === null && next.length > 0) {
+    state.chartSymbol = next[0];
+    notify("chartSymbol");
+  }
   notify("watchlist");
   notify("book");
+  notify("candles");
 }
 
 export function isTerminalOrderStatus(status) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -16,6 +16,8 @@ let onBlotterFilter  = () => {};
 let onSelectOrder    = () => {};
 let onKeyboardCancel = () => {};
 let onSelectDobSymbol = () => {};
+let onSelectChartSymbol = () => {};
+let onSelectChartResolution = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
@@ -27,6 +29,8 @@ export function setHandlers(handlers) {
   onSelectOrder    = handlers.onSelectOrder    ?? onSelectOrder;
   onKeyboardCancel = handlers.onKeyboardCancel ?? onKeyboardCancel;
   onSelectDobSymbol = handlers.onSelectDobSymbol ?? onSelectDobSymbol;
+  onSelectChartSymbol     = handlers.onSelectChartSymbol     ?? onSelectChartSymbol;
+  onSelectChartResolution = handlers.onSelectChartResolution ?? onSelectChartResolution;
 }
 
 export function showLogin() {
@@ -169,6 +173,20 @@ export function bindUi() {
   if (dobSelect) {
     dobSelect.addEventListener("change", (e) => {
       onSelectDobSymbol(e.target.value || null);
+    });
+  }
+
+  // Chart selectors (T3).
+  const chartSym = $("chart-symbol");
+  if (chartSym) {
+    chartSym.addEventListener("change", (e) => {
+      onSelectChartSymbol(e.target.value || null);
+    });
+  }
+  const chartRes = $("chart-resolution");
+  if (chartRes) {
+    chartRes.addEventListener("change", (e) => {
+      onSelectChartResolution(Number(e.target.value));
     });
   }
 
@@ -371,6 +389,7 @@ function renderForSlice(slice) {
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
   if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
   if (slice === "watchlist" || slice === "dobSymbol" || slice === "book" || slice === "all") renderDob();
+  if (slice === "watchlist" || slice === "chartSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
 }
 
 function renderAll() {
@@ -381,6 +400,7 @@ function renderAll() {
   setUserLabel(getState().user);
   renderMarketData();
   renderDob();
+  scheduleChartRender();
   setMdStatusPill(getState().marketDataStatus);
   renderInflight();
   renderReconnect();
@@ -491,6 +511,98 @@ function renderDobSide(levels, side) {
     }
     return `<tr><td class="num">${price}</td><td class="num">${qty}</td><td class="num">${cum}</td></tr>`;
   }).join("");
+}
+
+// ── Chart panel (T3) ──────────────────────────────────────────────
+
+const CHART_VISIBLE_BARS = 150;
+const CHART_VIEW_W = 300;
+const CHART_VIEW_H = 100;
+const CHART_PADDING = 4;
+
+let chartRafHandle = null;
+
+function scheduleChartRender() {
+  if (chartRafHandle != null) return;
+  // requestAnimationFrame may be unavailable in the test runtime; fall
+  // back to a microtask to keep the contract identical (one repaint
+  // per batch of state notifies).
+  const raf = typeof requestAnimationFrame === "function"
+    ? requestAnimationFrame
+    : (cb) => setTimeout(cb, 16);
+  chartRafHandle = raf(() => {
+    chartRafHandle = null;
+    renderChart();
+  });
+}
+
+function renderChart() {
+  const svg   = $("chart-svg");
+  const empty = $("chart-empty");
+  const symSel = $("chart-symbol");
+  const resSel = $("chart-resolution");
+  if (!svg || !symSel || !resSel) return;
+
+  const st = getState();
+  const watch = st.watchlist;
+
+  // Sync symbol dropdown with the watchlist.
+  const desired = ["", ...watch];
+  const existing = [...symSel.options].map(o => o.value);
+  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
+    symSel.innerHTML = `<option value="">— select symbol —</option>` +
+      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
+  }
+  if (symSel.value !== (st.chartSymbol ?? "")) symSel.value = st.chartSymbol ?? "";
+  const resStr = String(st.chartResolution);
+  if (resSel.value !== resStr) resSel.value = resStr;
+
+  const showEmpty = (msg) => {
+    svg.innerHTML = "";
+    if (empty) { empty.hidden = false; empty.textContent = msg; }
+  };
+
+  if (!st.chartSymbol) { showEmpty("select a symbol"); return; }
+
+  const perRes = st.candles.get(st.chartSymbol);
+  const entry = perRes?.get(st.chartResolution);
+  if (!entry || !entry.ready || entry.bars.length === 0) {
+    showEmpty("awaiting candle snapshot…");
+    return;
+  }
+
+  if (empty) empty.hidden = true;
+
+  const bars = entry.bars.slice(-CHART_VISIBLE_BARS);
+  const lows = bars.map(b => Number(b.low));
+  const highs = bars.map(b => Number(b.high));
+  const lo = Math.min(...lows);
+  const hi = Math.max(...highs);
+  const range = hi - lo || Math.abs(hi) * 1e-4 || 1; // avoid div-zero on flat books
+
+  const innerW = CHART_VIEW_W - CHART_PADDING * 2;
+  const innerH = CHART_VIEW_H - CHART_PADDING * 2;
+  const slotW = innerW / bars.length;
+  const bodyW = Math.max(0.4, slotW * 0.7);
+
+  const yFor = (price) => CHART_PADDING + (1 - (Number(price) - lo) / range) * innerH;
+
+  let parts = "";
+  for (let i = 0; i < bars.length; i++) {
+    const b = bars[i];
+    const cx = CHART_PADDING + slotW * (i + 0.5);
+    const yHigh = yFor(b.high);
+    const yLow  = yFor(b.low);
+    const yOpen  = yFor(b.open);
+    const yClose = yFor(b.close);
+    const up = Number(b.close) >= Number(b.open);
+    const cls = up ? "candle-up" : "candle-down";
+    const yTop = Math.min(yOpen, yClose);
+    const bodyH = Math.max(0.4, Math.abs(yClose - yOpen));
+    parts += `<line class="candle-wick ${cls}" x1="${cx.toFixed(2)}" x2="${cx.toFixed(2)}" y1="${yHigh.toFixed(2)}" y2="${yLow.toFixed(2)}"/>`;
+    parts += `<rect class="${cls}" x="${(cx - bodyW / 2).toFixed(2)}" y="${yTop.toFixed(2)}" width="${bodyW.toFixed(2)}" height="${bodyH.toFixed(2)}"/>`;
+  }
+  svg.innerHTML = parts;
 }
 
 function renderBlotter() {

--- a/frontend/test/state-candle.test.mjs
+++ b/frontend/test/state-candle.test.mjs
@@ -1,0 +1,266 @@
+// Candle (T3) state reducer tests for frontend/js/state.js.
+// Runs with `node --test frontend/test/state-candle.test.mjs`.
+//
+// Coverage: multi-frame snapshot ready-gate, FIRST/LAST flag handling,
+// mid-stream join (no FIRST) stays not-ready, update replace-vs-append,
+// MAX_BARS cap, watchlist trim + chartSymbol auto-pick, resolution
+// validation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust=${n}`);
+}
+
+const RES = 60;
+
+function bar(time, o, h, l, c, vol = 100) {
+  return { time, open: o, high: h, low: l, close: c, volume: vol, avg: (h + l) / 2 };
+}
+
+test('single-frame snapshot (FIRST|LAST) flips ready immediately', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 32.0, 32.5, 31.9, 32.4)],
+    isFirst: true, isLast: true,
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.ready, true);
+  assert.equal(e.bars.length, 1);
+});
+
+test('multi-frame snapshot stays not-ready until LAST', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 32, 33, 31, 32.5)],
+    isFirst: true, isLast: false,
+  });
+  let e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.ready, false);
+  assert.equal(e.bars.length, 1);
+
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1060, 32.5, 33.5, 32, 33)],
+    isFirst: false, isLast: false,
+  });
+  e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.ready, false);
+  assert.equal(e.bars.length, 2);
+
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1120, 33, 34, 33, 33.8)],
+    isFirst: false, isLast: true,
+  });
+  e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.ready, true);
+  assert.equal(e.bars.length, 3);
+});
+
+test('mid-stream join (no FIRST seen) stays not-ready even on LAST', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 32, 33, 31, 32.5)],
+    isFirst: false, isLast: true,
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.ready, false);
+  assert.equal(e.bars.length, 1);
+});
+
+test('FIRST after partial sequence resets accumulation', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 1, 1, 1, 1), bar(1060, 2, 2, 2, 2)],
+    isFirst: true, isLast: false,
+  });
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(2000, 9, 9, 9, 9)],
+    isFirst: true, isLast: true,
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.bars.length, 1);
+  assert.equal(e.bars[0].time, 2000);
+  assert.equal(e.ready, true);
+});
+
+test('candle.update before ready is dropped', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 1, 1, 1, 1)],
+    isFirst: true, isLast: false,
+  });
+  s.applyMdCandleUpdate({
+    symbol: 'PETR4', resolution: RES,
+    candle: bar(1060, 2, 2, 2, 2),
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.bars.length, 1); // update ignored
+});
+
+test('candle.update with same time replaces last bar', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 32, 32.5, 31.9, 32.2)],
+    isFirst: true, isLast: true,
+  });
+  s.applyMdCandleUpdate({
+    symbol: 'PETR4', resolution: RES,
+    candle: bar(1000, 32, 32.8, 31.9, 32.7, 250),
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.bars.length, 1);
+  assert.equal(e.bars[0].close, 32.7);
+  assert.equal(e.bars[0].volume, 250);
+});
+
+test('candle.update with new time appends a new bar', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES,
+    candles: [bar(1000, 32, 32.5, 31.9, 32.2)],
+    isFirst: true, isLast: true,
+  });
+  s.applyMdCandleUpdate({
+    symbol: 'PETR4', resolution: RES,
+    candle: bar(1060, 32.2, 32.6, 32.1, 32.5),
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.bars.length, 2);
+  assert.equal(e.bars[1].time, 1060);
+});
+
+test('multi-resolution caching for same symbol', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: 60,
+    candles: [bar(1000, 1, 1, 1, 1)],
+    isFirst: true, isLast: true,
+  });
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: 300,
+    candles: [bar(1000, 5, 5, 5, 5)],
+    isFirst: true, isLast: true,
+  });
+  const perRes = s.getState().candles.get('PETR4');
+  assert.equal(perRes.size, 2);
+  assert.equal(perRes.get(60).bars[0].close, 1);
+  assert.equal(perRes.get(300).bars[0].close, 5);
+});
+
+test('setWatchlist drops candles for removed symbols', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: [bar(1, 1, 1, 1, 1)],
+    isFirst: true, isLast: true,
+  });
+  s.applyMdCandleSnapshot({
+    symbol: 'VALE3', resolution: RES, candles: [bar(1, 2, 2, 2, 2)],
+    isFirst: true, isLast: true,
+  });
+  s.setWatchlist(['PETR4']);
+  assert.equal(s.getState().candles.has('PETR4'), true);
+  assert.equal(s.getState().candles.has('VALE3'), false);
+});
+
+test('setWatchlist auto-picks first symbol as chartSymbol when empty', async () => {
+  const s = await freshState();
+  assert.equal(s.getState().chartSymbol, null);
+  s.setWatchlist(['PETR4', 'VALE3']);
+  assert.equal(s.getState().chartSymbol, 'PETR4');
+});
+
+test('setWatchlist clears chartSymbol if it was removed', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.setChartSymbol('VALE3');
+  s.setWatchlist(['PETR4']);
+  // chartSymbol cleared because VALE3 left, then auto-picked first.
+  assert.equal(s.getState().chartSymbol, 'PETR4');
+});
+
+test('setChartResolution rejects unsupported values', async () => {
+  const s = await freshState();
+  s.setChartResolution(60);
+  assert.equal(s.getState().chartResolution, 60);
+  s.setChartResolution(45); // not in CHART_RESOLUTIONS
+  assert.equal(s.getState().chartResolution, 60);
+  s.setChartResolution(900);
+  assert.equal(s.getState().chartResolution, 900);
+});
+
+test('clearAllCandles wipes all symbols/resolutions', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: [bar(1, 1, 1, 1, 1)],
+    isFirst: true, isLast: true,
+  });
+  s.clearAllCandles();
+  assert.equal(s.getState().candles.size, 0);
+});
+
+test('removeCandlesSymbol drops only that symbol', async () => {
+  const s = await freshState();
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: [bar(1, 1, 1, 1, 1)],
+    isFirst: true, isLast: true,
+  });
+  s.applyMdCandleSnapshot({
+    symbol: 'VALE3', resolution: RES, candles: [bar(1, 2, 2, 2, 2)],
+    isFirst: true, isLast: true,
+  });
+  s.removeCandlesSymbol('PETR4');
+  assert.equal(s.getState().candles.has('PETR4'), false);
+  assert.equal(s.getState().candles.has('VALE3'), true);
+});
+
+test('snapshot append also honours MAX_BARS cap', async () => {
+  const s = await freshState();
+  // First batch with 400 bars.
+  const first = Array.from({ length: 400 }, (_, i) => bar(i, 1, 1, 1, 1));
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: first,
+    isFirst: true, isLast: false,
+  });
+  // Second batch pushes total over 600 (MAX_BARS).
+  const second = Array.from({ length: 400 }, (_, i) => bar(400 + i, 2, 2, 2, 2));
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: second,
+    isFirst: false, isLast: true,
+  });
+  const e = s.getState().candles.get('PETR4').get(RES);
+  assert.equal(e.bars.length, 600);
+  // Newest bars retained.
+  assert.equal(e.bars[e.bars.length - 1].time, 799);
+});
+
+test('candles reducers notify "candles" slice', async () => {
+  const s = await freshState();
+  const seen = [];
+  s.subscribe((slice) => seen.push(slice));
+  s.applyMdCandleSnapshot({
+    symbol: 'PETR4', resolution: RES, candles: [bar(1, 1, 1, 1, 1)],
+    isFirst: true, isLast: true,
+  });
+  assert.ok(seen.includes('candles'));
+});
+
+test('setChartSymbol notifies "chartSymbol" slice', async () => {
+  const s = await freshState();
+  const seen = [];
+  s.subscribe((slice) => seen.push(slice));
+  s.setChartSymbol('PETR4');
+  assert.ok(seen.includes('chartSymbol'));
+});


### PR DESCRIPTION
## What

Trader UI slice **T3 — Candlestick chart**. Inline SVG, vanilla JS, no
external charting library. Consumes the `md.candle.snapshot` /
`md.candle.update` messages decoded by T1.

## How

- **state.js** — new `candles` slice
  (`Map<symbol, Map<resolutionSec, {bars, ready, updatedAt}>>`) plus
  `chartSymbol` / `chartResolution` (default 60s). Server may
  multiplex multiple resolutions per subscription, so we cache them
  all and let the UI filter at render time.
- **Multi-frame snapshot ready-gate** — `isFirst` resets the
  accumulator and starts the run; subsequent frames append; `isLast`
  flips `ready=true` only if the run started from `FIRST`. A
  mid-stream join (no `FIRST` ever seen) accumulates but stays
  `ready=false`, so a truncated history never displays as complete
  — per rubber-duck.
- **Live updates** — drop while `!ready`; replace last bar when
  the update carries the same `time`, otherwise append. Capped at
  `MAX_BARS=600` per `(symbol, resolution)`; snapshot append also
  honours the cap.
- **Watchlist hygiene** — `setWatchlist` now drops candle entries
  for removed symbols, clears `chartSymbol` if removed, and
  auto-picks the first watchlist symbol so the panel doesn't sit
  empty after the trader applies the form.
- **app.js** — routes `md.candle.*` (was a no-op); resets candle
  state on `md.subError` / `md.removed` / `md.clear` /
  `handleApplyMd` URL change.
- **ui.js + index.html + css** — `<section class="panel chart">`
  with symbol selector + 1m/5m/15m resolution selector. Inline
  SVG (300×100 viewBox, `preserveAspectRatio="none"`) renders the
  last 150 bars with auto Y-scale (min low → max high). Render is
  **RAF-throttled** — a single `requestAnimationFrame` coalesces
  bursts of `candle.update` notifies into one repaint.
- **CSS grid + responsive** — both layouts updated so `dob` and
  `chart` rows are visible on wide and narrow viewports.

## Tests

```
$ node --test frontend/test/*.test.mjs
# tests 63 / pass 63 / fail 0
$ dotnet format --verify-no-changes      # clean
```

17 new tests in `frontend/test/state-candle.test.mjs`:
single + multi-frame snapshots, mid-stream join, FIRST mid-sequence
reset, update replace/append, multi-resolution cache, watchlist
trim + chartSymbol auto-pick, MAX_BARS cap, resolution validation,
slice notification.

## Open follow-ups (non-blocking)

- **Empirical flag verification**: today the worker subscribes with
  `TRADES | INFO` (and `MBP` once a DOB symbol is picked). We're
  trusting that candles flow on this set — there is no `CANDLE`
  bit in the wire. If the upstream MD service requires a new flag,
  add it and resubscribe. Doesn't affect the panel's correctness;
  just whether data appears.
- **Crosshair tooltip** (in the issue UX section) — punted to keep
  this slice focused; the auto-scale + RAF foundation makes adding
  it later cheap.
- **Symbol selection sharing across DOB / chart / tape** — issue
  notes "símbolo ativo sincronizado". Deferred to a small
  `selectedSymbol` refactor once T4 (tape) is in, so we can collapse
  three independent dropdowns at once.

Closes #69
