### PR TITLE
ci(infra): retry apt-get in trading-host Dockerfile

### DIFF
--- a/backend/src/B3.Trading.Host/Dockerfile
+++ b/backend/src/B3.Trading.Host/Dockerfile
@@ -28,9 +28,19 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
 # curl is used by the HEALTHCHECK below. Kept tiny: install + cleanup in one
 # layer, no recommends.
-RUN apt-get update \
- && apt-get install --no-install-recommends -y curl \
- && rm -rf /var/lib/apt/lists/*
+#
+# Network resilience: CI repeatedly hits transient connection failures
+# pulling from security.ubuntu.com / archive.ubuntu.com (Connection
+# failed [IP: …]:80). Combine apt's built-in retry with an outer loop
+# and a per-request timeout so a single dropped TCP handshake doesn't
+# kill the whole build. Net cost on a healthy run: zero.
+RUN set -eux; \
+    APT_OPTS="-o Acquire::Retries=5 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"; \
+    for attempt in 1 2 3 4 5; do \
+      apt-get $APT_OPTS update && break || { echo "apt-get update failed (attempt $attempt), sleeping…" >&2; sleep $((attempt * 5)); }; \
+    done; \
+    apt-get $APT_OPTS install --no-install-recommends -y curl; \
+    rm -rf /var/lib/apt/lists/*
 
 # Persistence root (event store WAL + snapshots). Created and chowned BEFORE
 # we drop to non-root, otherwise the running user can't write to it.


### PR DESCRIPTION
## Why

CI keeps falling over with the same transient on the
`Run conformance suite against real stack` job:

```
#12 802.2 E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/Packages
            Connection failed [IP: 185.125.190.81 80]
```

It's hit #75, #76, #78 (and others before this slice). The fetch
happens at the start of the trading-host runtime stage, so a single
dropped TCP handshake fails the whole 14-minute matrix job and we
end up manually rerunning.

## Fix

Three layers of defence, all cheap when the mirror is healthy:

- `Acquire::Retries=5` — apt's built-in per-package download retry.
- `Acquire::http(s)::Timeout=20` — fail fast (default is 120 s) so
  a black-holed mirror IP isn't held for two minutes per attempt.
- Outer 5-attempt bash loop with linear backoff (5/10/15/20/25 s)
  around `apt-get update`, since the index refresh is the step that
  actually flakes; once the mirrors respond, the install itself
  consistently succeeds.

No change to the installed package set (still just `curl` for the
HEALTHCHECK, no recommends, apt lists cleaned up).

## Validation

Pure Dockerfile change; CI is the test bed. Will become observable
across the next few PRs by the absence of "Connection failed" in
the conformance docker-build step.
