### PR TITLE
feat(trader-ui): T4 — trade tape

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -77,13 +77,14 @@ body {
   flex: 1;
   display: grid;
   grid-template-columns: 280px 1fr 240px;
-  grid-template-rows: auto 1fr auto auto auto;
+  grid-template-rows: auto 1fr auto auto auto auto;
   grid-template-areas:
     "ticket  blotter   positions"
     "ticket  blotter   positions"
     "md      execs     positions"
     "dob     dob       positions"
-    "chart   chart     positions";
+    "chart   chart     positions"
+    "tape    tape      positions";
   gap: 8px; padding: 8px; min-height: 0;
 }
 .panel {
@@ -142,6 +143,37 @@ body {
 .candle-up   { stroke: #1f9d55; fill: #1f9d55; }
 .candle-down { stroke: #c53030; fill: #c53030; }
 .candle-wick { stroke-width: 1; }
+
+/* ---------- Trade tape (T4) ---------- */
+.tape { grid-area: tape; min-height: 200px; }
+.tape h2 { display: flex; align-items: center; gap: .55rem; }
+.tape h2 select {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: .15rem .3rem; font: inherit; font-size: .8rem;
+}
+.tape-paused {
+  font-size: .65rem; color: var(--warn);
+  background: rgba(250, 192, 64, .12); border: 1px solid var(--warn);
+  border-radius: 999px; padding: 0 .45rem;
+}
+.tape-list {
+  list-style: none; margin: 0; padding: 0;
+  flex: 1; min-height: 0; overflow-y: auto;
+  font-size: .78rem; font-variant-numeric: tabular-nums;
+}
+.tape-list li {
+  display: grid; grid-template-columns: 64px 1fr 1fr 1fr 56px;
+  gap: .35rem; padding: .12rem .35rem;
+  border-bottom: 1px solid var(--border);
+}
+.tape-list li:last-child { border-bottom: 0; }
+.tape-list .tape-num { text-align: right; }
+.tape-list .tape-up   { color: #1f9d55; }
+.tape-list .tape-down { color: #c53030; }
+.tape-list .tape-flat { color: var(--muted); }
+.tape-list .tape-busted { text-decoration: line-through; opacity: .55; }
+.tape-list .tape-empty { color: var(--muted); text-align: center; padding: .8rem; display: block; }
 
 /* ---------- Order ticket ---------- */
 .ticket-form { display: flex; flex-direction: column; gap: .55rem; }
@@ -204,7 +236,8 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
       "blotter   blotter"
       "execs     md"
       "dob       dob"
-      "chart     chart";
+      "chart     chart"
+      "tape      tape";
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -226,6 +226,18 @@
           <p id="chart-empty" class="chart-empty muted-cell">select a symbol</p>
         </div>
       </section>
+
+      <!-- TAPE ------------------------------------------------------- -->
+      <section class="panel tape">
+        <h2>
+          Tape
+          <select id="tape-symbol" aria-label="Tape symbol filter">
+            <option value="">All</option>
+          </select>
+          <span id="tape-paused" class="tape-paused" hidden>paused</span>
+        </h2>
+        <ol id="tape-list" class="tape-list" aria-live="off"></ol>
+      </section>
     </main>
   </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -59,6 +59,7 @@ function init() {
     onSelectDobSymbol: handleSelectDobSymbol,
     onSelectChartSymbol: state.setChartSymbol,
     onSelectChartResolution: state.setChartResolution,
+    onSelectTapeSymbol: state.setTapeSymbol,
   });
   adminUi.setAdminHandlers({
     onToggleFirm:      handleToggleFirm,
@@ -274,6 +275,7 @@ function handleApplyMd({ url, symbols }) {
     state.clearMarketData();
     state.clearAllBooks();
     state.clearAllCandles();
+    state.clearAllTape();
     mbpEnabled = false;
     startMdWorker();
   } else {
@@ -308,14 +310,11 @@ function onMdWorkerMessage(msg) {
       state.clearMarketData();
       state.clearAllBooks();
       state.clearAllCandles();
+      state.clearAllTape();
       break;
     case "md.trade":    state.applyMdTrade(msg); break;
     case "md.info":     state.applyMdInfo(msg); break;
-    case "md.bust":
-      // Risk consumers ignore busts (the next live trade overwrites);
-      // surface in the executions log so the trader sees it happened.
-      console.warn("[md] trade bust", msg);
-      break;
+    case "md.bust":     state.applyMdTradeBust(msg); break;
     case "md.subError":
       ui.setMdFeedback(`subscribe ${msg.symbol}: ${msg.errorName}`, "error");
       state.removeMdSymbol(msg.symbol);

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -32,6 +32,13 @@ const state = {
   candles: new Map(),      // Symbol -> Map<resolutionSec, { bars: [...], ready: bool, updatedAt: number }>
   chartSymbol: null,       // currently selected chart symbol or null
   chartResolution: 60,     // seconds (60=1m, 300=5m, 900=15m)
+  // Trade tape slice (T4). Per-symbol ring buffer of recent trades
+  // with side inferred from the previous trade's price (uptick=buy,
+  // downtick=sell, flat=unknown — TRADE wire frame doesn't carry an
+  // aggressor). `tapeSymbol === null` means "all" — render flattens
+  // and re-sorts by receivedAt for the cross-symbol view.
+  tape: new Map(),         // Symbol -> [{tradeId, price, qty, side, receivedAt, busted}]
+  tapeSymbol: null,        // null => "all", else specific symbol
   // UX-only slices added in the operability pass.
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
@@ -119,6 +126,7 @@ export function setMarketDataStatus(status) {
 
 export function applyMdTrade({ symbol, price, qty, tradeId }) {
   const prev = state.marketData.get(symbol) || {};
+  const prevPrice = prev.lastPrice;
   state.marketData.set(symbol, {
     ...prev,
     lastPrice: price,
@@ -127,6 +135,19 @@ export function applyMdTrade({ symbol, price, qty, tradeId }) {
     updatedAt: Date.now(),
   });
   notify("marketData");
+  // Tape: append to the per-symbol ring; infer side from the previous
+  // trade's price (TRADE frame has no aggressor field). 'flat' = first
+  // trade or unchanged price.
+  pushTapeEntry(symbol, {
+    tradeId,
+    price,
+    qty,
+    side: prevPrice == null ? "flat"
+        : price > prevPrice ? "up"
+        : price < prevPrice ? "down" : "flat",
+    receivedAt: Date.now(),
+    busted: false,
+  });
 }
 
 export function applyMdInfo({ symbol, fields }) {
@@ -147,7 +168,9 @@ export function applyMdInfo({ symbol, fields }) {
 }
 
 export function removeMdSymbol(symbol) {
-  if (state.marketData.delete(symbol)) notify("marketData");
+  let touched = state.marketData.delete(symbol);
+  if (touched) notify("marketData");
+  if (state.tape.delete(symbol)) notify("tape");
 }
 
 export function clearMarketData() {
@@ -354,10 +377,59 @@ export function setChartResolution(seconds) {
   notify("chartResolution");
 }
 
+// ── Trade tape slice (T4) ──────────────────────────────────────────
+
+// Per-symbol cap on the tape ring buffer. 200 keeps the cross-symbol
+// "all" view bounded as well: even with N watched symbols, total
+// memory is N * 200, and the render path slices a top-200 window.
+const TAPE_MAX = 200;
+
+function pushTapeEntry(symbol, entry) {
+  let arr = state.tape.get(symbol);
+  if (!arr) { arr = []; state.tape.set(symbol, arr); }
+  arr.push(entry);
+  const overflow = arr.length - TAPE_MAX;
+  if (overflow > 0) arr.splice(0, overflow);
+  notify("tape");
+}
+
+export function applyMdTradeBust({ symbol, tradeId }) {
+  const arr = state.tape.get(symbol);
+  if (!arr) return;
+  // Search from the end — busts overwhelmingly target very recent
+  // prints, so the linear walk almost always hits in O(1) trips.
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i].tradeId === tradeId) {
+      if (arr[i].busted) return; // already marked
+      arr[i] = { ...arr[i], busted: true };
+      notify("tape");
+      return;
+    }
+  }
+}
+
+export function removeTapeSymbol(symbol) {
+  if (state.tape.delete(symbol)) notify("tape");
+}
+
+export function clearAllTape() {
+  if (state.tape.size === 0) return;
+  state.tape.clear();
+  notify("tape");
+}
+
+export function setTapeSymbol(symbol) {
+  // null === "all"; an empty string from the dropdown maps to null.
+  const next = symbol == null || symbol === "" ? null : symbol;
+  if (state.tapeSymbol === next) return;
+  state.tapeSymbol = next;
+  notify("tapeSymbol");
+}
+
 export function setWatchlist(symbols) {
   const next = symbols.slice();
   state.watchlist = next;
-  // Drop book + candle caches for symbols no longer watched.
+  // Drop book + candle + tape caches for symbols no longer watched.
   const wanted = new Set(next);
   for (const sym of [...state.book.keys()]) {
     if (!wanted.has(sym)) state.book.delete(sym);
@@ -365,9 +437,13 @@ export function setWatchlist(symbols) {
   for (const sym of [...state.candles.keys()]) {
     if (!wanted.has(sym)) state.candles.delete(sym);
   }
-  // Reset DOB / chart selection if the chosen symbol just left the
-  // watchlist. Auto-pick a sensible default for chart so the panel
-  // doesn't sit empty when the trader has symbols available.
+  for (const sym of [...state.tape.keys()]) {
+    if (!wanted.has(sym)) state.tape.delete(sym);
+  }
+  // Reset DOB / chart / tape selection if the chosen symbol just left
+  // the watchlist. Auto-pick a sensible default for chart so the
+  // panel doesn't sit empty when the trader has symbols available.
+  // tapeSymbol stays at "all" by default — no auto-pick needed.
   if (state.dobSymbol && !wanted.has(state.dobSymbol)) {
     state.dobSymbol = null;
     notify("dobSymbol");
@@ -380,9 +456,14 @@ export function setWatchlist(symbols) {
     state.chartSymbol = next[0];
     notify("chartSymbol");
   }
+  if (state.tapeSymbol && !wanted.has(state.tapeSymbol)) {
+    state.tapeSymbol = null; // back to "all"
+    notify("tapeSymbol");
+  }
   notify("watchlist");
   notify("book");
   notify("candles");
+  notify("tape");
 }
 
 export function isTerminalOrderStatus(status) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -18,6 +18,7 @@ let onKeyboardCancel = () => {};
 let onSelectDobSymbol = () => {};
 let onSelectChartSymbol = () => {};
 let onSelectChartResolution = () => {};
+let onSelectTapeSymbol = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
@@ -31,6 +32,7 @@ export function setHandlers(handlers) {
   onSelectDobSymbol = handlers.onSelectDobSymbol ?? onSelectDobSymbol;
   onSelectChartSymbol     = handlers.onSelectChartSymbol     ?? onSelectChartSymbol;
   onSelectChartResolution = handlers.onSelectChartResolution ?? onSelectChartResolution;
+  onSelectTapeSymbol      = handlers.onSelectTapeSymbol      ?? onSelectTapeSymbol;
 }
 
 export function showLogin() {
@@ -187,6 +189,29 @@ export function bindUi() {
   if (chartRes) {
     chartRes.addEventListener("change", (e) => {
       onSelectChartResolution(Number(e.target.value));
+    });
+  }
+
+  // Tape (T4): symbol filter + pause-on-hover.
+  const tapeSel = $("tape-symbol");
+  if (tapeSel) {
+    tapeSel.addEventListener("change", (e) => {
+      onSelectTapeSymbol(e.target.value || null);
+    });
+  }
+  const tapeList = $("tape-list");
+  if (tapeList) {
+    tapeList.addEventListener("mouseenter", () => {
+      tapePaused = true;
+      const badge = $("tape-paused");
+      if (badge) badge.hidden = false;
+    });
+    tapeList.addEventListener("mouseleave", () => {
+      tapePaused = false;
+      const badge = $("tape-paused");
+      if (badge) badge.hidden = true;
+      // Flush any updates that arrived while hovered.
+      if (tapeDirty) scheduleTapeRender();
     });
   }
 
@@ -390,6 +415,7 @@ function renderForSlice(slice) {
   if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
   if (slice === "watchlist" || slice === "dobSymbol" || slice === "book" || slice === "all") renderDob();
   if (slice === "watchlist" || slice === "chartSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
+  if (slice === "watchlist" || slice === "tapeSymbol" || slice === "tape" || slice === "all") scheduleTapeRender();
 }
 
 function renderAll() {
@@ -401,6 +427,7 @@ function renderAll() {
   renderMarketData();
   renderDob();
   scheduleChartRender();
+  scheduleTapeRender();
   setMdStatusPill(getState().marketDataStatus);
   renderInflight();
   renderReconnect();
@@ -603,6 +630,86 @@ function renderChart() {
     parts += `<rect class="${cls}" x="${(cx - bodyW / 2).toFixed(2)}" y="${yTop.toFixed(2)}" width="${bodyW.toFixed(2)}" height="${bodyH.toFixed(2)}"/>`;
   }
   svg.innerHTML = parts;
+}
+
+// ── Trade tape (T4) ───────────────────────────────────────────────
+
+const TAPE_VISIBLE = 200;
+
+let tapeRafHandle = null;
+let tapePaused = false;
+let tapeDirty = false;
+
+function scheduleTapeRender() {
+  // Pause-on-hover: while the user is reading the tape, freeze DOM
+  // updates so rows don't shift under the cursor. Latest state still
+  // gets painted on mouseleave (we just remember a repaint is owed).
+  tapeDirty = true;
+  if (tapePaused) return;
+  if (tapeRafHandle != null) return;
+  const raf = typeof requestAnimationFrame === "function"
+    ? requestAnimationFrame
+    : (cb) => setTimeout(cb, 16);
+  tapeRafHandle = raf(() => {
+    tapeRafHandle = null;
+    tapeDirty = false;
+    renderTape();
+  });
+}
+
+function renderTape() {
+  const list = $("tape-list");
+  const sel = $("tape-symbol");
+  if (!list || !sel) return;
+
+  const st = getState();
+  const watch = st.watchlist;
+
+  // Sync filter dropdown with the watchlist; "" === all.
+  const desired = ["", ...watch];
+  const existing = [...sel.options].map(o => o.value);
+  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
+    sel.innerHTML = `<option value="">All</option>` +
+      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
+  }
+  if (sel.value !== (st.tapeSymbol ?? "")) sel.value = st.tapeSymbol ?? "";
+
+  // Collect rows. Single-symbol view is just the per-symbol ring; the
+  // "all" view flattens every cached symbol and re-sorts by receivedAt
+  // descending. Both paths slice to TAPE_VISIBLE before rendering.
+  let rows;
+  if (st.tapeSymbol) {
+    const arr = st.tape.get(st.tapeSymbol);
+    rows = arr ? arr.slice().reverse() : [];
+    rows = rows.slice(0, TAPE_VISIBLE).map(e => ({ ...e, symbol: st.tapeSymbol }));
+  } else {
+    rows = [];
+    for (const [sym, arr] of st.tape) {
+      for (const e of arr) rows.push({ ...e, symbol: sym });
+    }
+    rows.sort((a, b) => b.receivedAt - a.receivedAt);
+    rows = rows.slice(0, TAPE_VISIBLE);
+  }
+
+  if (rows.length === 0) {
+    list.innerHTML = `<li class="tape-empty">no trades yet</li>`;
+    return;
+  }
+
+  list.innerHTML = rows.map(tapeRow).join("");
+}
+
+function tapeRow(e) {
+  const cls = `tape-${e.side}` + (e.busted ? " tape-busted" : "");
+  const ts = new Date(e.receivedAt).toISOString().slice(11, 19);
+  const arrow = e.side === "up" ? "▲" : e.side === "down" ? "▼" : "·";
+  return `<li class="${cls}">`
+    + `<span>${ts}</span>`
+    + `<span>${escapeHtml(e.symbol)}</span>`
+    + `<span class="tape-num">${arrow} ${Number(e.price).toFixed(2)}</span>`
+    + `<span class="tape-num">${e.qty}</span>`
+    + `<span class="tape-num">#${e.tradeId}</span>`
+    + `</li>`;
 }
 
 function renderBlotter() {

--- a/frontend/test/state-tape.test.mjs
+++ b/frontend/test/state-tape.test.mjs
@@ -1,0 +1,139 @@
+// Trade tape (T4) state reducer tests for frontend/js/state.js.
+// Runs with `node --test frontend/test/state-tape.test.mjs`.
+//
+// Coverage: side inference (up/down/flat), ring buffer cap (TAPE_MAX),
+// applyMdTradeBust marks the entry, missing tradeId is a no-op,
+// removeMdSymbol drops tape entries, clearAllTape, setTapeSymbol
+// normalises empty string to null, setWatchlist drops stale symbols
+// + resets tapeSymbol, slice notifications fire.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust=${n}`);
+}
+
+test('first trade for a symbol has side=flat', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  const arr = s.getState().tape.get('PETR4');
+  assert.equal(arr.length, 1);
+  assert.equal(arr[0].side, 'flat');
+  assert.equal(arr[0].busted, false);
+  assert.equal(arr[0].tradeId, 1);
+});
+
+test('side is inferred from the previous trade price', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.15, qty: 100, tradeId: 2 });
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.05, qty: 100, tradeId: 3 });
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.05, qty: 100, tradeId: 4 });
+  const arr = s.getState().tape.get('PETR4');
+  assert.deepEqual(arr.map(e => e.side), ['flat', 'up', 'down', 'flat']);
+});
+
+test('side inference is per-symbol (independent histories)', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'VALE3', price: 65.00, qty: 100, tradeId: 2 });
+  const vale = s.getState().tape.get('VALE3');
+  assert.equal(vale[0].side, 'flat');
+});
+
+test('tape per-symbol ring is capped at TAPE_MAX', async () => {
+  const s = await freshState();
+  for (let i = 0; i < 250; i++) {
+    s.applyMdTrade({ symbol: 'PETR4', price: 32.0 + (i % 5) * 0.01, qty: 100, tradeId: i });
+  }
+  const arr = s.getState().tape.get('PETR4');
+  assert.equal(arr.length, 200);
+  // Newest (highest tradeId) must still be the last element.
+  assert.equal(arr[arr.length - 1].tradeId, 249);
+  // Oldest retained = 250 - 200 = 50.
+  assert.equal(arr[0].tradeId, 50);
+});
+
+test('applyMdTradeBust marks the matching entry busted', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.20, qty: 100, tradeId: 2 });
+  s.applyMdTradeBust({ symbol: 'PETR4', tradeId: 2 });
+  const arr = s.getState().tape.get('PETR4');
+  assert.equal(arr.find(e => e.tradeId === 2).busted, true);
+  assert.equal(arr.find(e => e.tradeId === 1).busted, false);
+});
+
+test('applyMdTradeBust is a no-op when tradeId is unknown', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTradeBust({ symbol: 'PETR4', tradeId: 999 });
+  const arr = s.getState().tape.get('PETR4');
+  assert.equal(arr[0].busted, false);
+});
+
+test('applyMdTradeBust on unknown symbol is a no-op', async () => {
+  const s = await freshState();
+  s.applyMdTradeBust({ symbol: 'NOPE', tradeId: 1 });
+  assert.equal(s.getState().tape.size, 0);
+});
+
+test('removeMdSymbol drops tape entries for that symbol', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'VALE3', price: 65.00, qty: 100, tradeId: 2 });
+  s.removeMdSymbol('PETR4');
+  assert.equal(s.getState().tape.has('PETR4'), false);
+  assert.equal(s.getState().tape.has('VALE3'), true);
+});
+
+test('clearAllTape empties every per-symbol ring', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'VALE3', price: 65.00, qty: 100, tradeId: 2 });
+  s.clearAllTape();
+  assert.equal(s.getState().tape.size, 0);
+});
+
+test('setTapeSymbol("") normalises to null (all)', async () => {
+  const s = await freshState();
+  s.setTapeSymbol('PETR4');
+  assert.equal(s.getState().tapeSymbol, 'PETR4');
+  s.setTapeSymbol('');
+  assert.equal(s.getState().tapeSymbol, null);
+});
+
+test('setWatchlist drops tape for removed symbols and resets tapeSymbol', async () => {
+  const s = await freshState();
+  s.setWatchlist(['PETR4', 'VALE3']);
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  s.applyMdTrade({ symbol: 'VALE3', price: 65.00, qty: 100, tradeId: 2 });
+  s.setTapeSymbol('PETR4');
+  s.setWatchlist(['VALE3']); // PETR4 leaves the watchlist
+  assert.equal(s.getState().tape.has('PETR4'), false);
+  assert.equal(s.getState().tape.has('VALE3'), true);
+  assert.equal(s.getState().tapeSymbol, null);
+});
+
+test('applyMdTrade emits a tape notification', async () => {
+  const s = await freshState();
+  let count = 0;
+  const off = s.subscribe(slice => { if (slice === 'tape') count += 1; });
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  off();
+  assert.equal(count, 1);
+});
+
+test('applyMdTradeBust emits a tape notification on a hit', async () => {
+  const s = await freshState();
+  s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
+  let count = 0;
+  const off = s.subscribe(slice => { if (slice === 'tape') count += 1; });
+  s.applyMdTradeBust({ symbol: 'PETR4', tradeId: 1 });
+  s.applyMdTradeBust({ symbol: 'PETR4', tradeId: 999 }); // miss → no notify
+  off();
+  assert.equal(count, 1);
+});


### PR DESCRIPTION
Closes #70.

Adds a per-symbol trade tape panel to the trader UI with filter
dropdown, color-coded uptick/downtick rows, busted prints rendered
as strikethrough, and pause-on-hover so rows don't shift under the
cursor while the user is reading.

## State (`frontend/js/state.js`)

- `tape: Map<symbol, Array>` ring (TAPE_MAX=200/symbol) +
  `tapeSymbol` filter (`null` = "all").
- `applyMdTrade` now also pushes to the tape; side inferred from
  previous trade price (TRADE frame has no aggressor field):
  `flat` (first trade or unchanged) | `up` | `down`.
- `applyMdTradeBust` reverse-searches the symbol's ring and flips
  `busted: true`. Unknown tradeId / unknown symbol = no-op (no
  notification fired).
- `removeMdSymbol` drops the tape ring; `setWatchlist` cleans
  rings for symbols that left the watchlist and resets
  `tapeSymbol → null` if the active filter was removed.
- New helpers: `clearAllTape`, `removeTapeSymbol`,
  `setTapeSymbol` (empty string normalises to null).

## UI (`frontend/js/ui.js` + `index.html` + `styles.css`)

- New `<section class="panel tape">` between Chart and the end of
  the grid; grid template extended (default + responsive) to host
  the new row spanning the two left columns.
- Symbol dropdown synced to the watchlist; option `""` = All.
- 'All' view flattens every cached symbol and re-sorts by
  receivedAt desc; both views slice to TAPE_VISIBLE before
  painting.
- Pause-on-hover: mouseenter sets a paused flag + shows a
  "paused" badge; subsequent updates only mark dirty; mouseleave
  hides the badge and flushes any pending repaint. RAF-throttled
  paint mirrors the chart pattern.
- Color classes `.tape-up` / `.tape-down` / `.tape-flat`
  (with arrow glyphs ▲/▼/·) plus `.tape-busted` (strikethrough +
  dimmed).

## Wiring (`frontend/js/app.js`)

- `md.bust` now routes to `state.applyMdTradeBust` (was a
  console.warn).
- `md.clear` and the MD-URL-change reset path also call
  `state.clearAllTape()`.
- New `onSelectTapeSymbol` handler bound to
  `state.setTapeSymbol`.

## Tests

- New `frontend/test/state-tape.test.mjs` with 13 tests covering:
  side inference (up/down/flat + per-symbol independence),
  TAPE_MAX cap (250 → 200, oldest dropped), bust hit/miss,
  unknown-symbol bust no-op, removeMdSymbol drop, clearAllTape,
  setTapeSymbol("") normalisation, watchlist hygiene
  (drop + reset filter), slice notifications.
- Suite total: **76/76 pass** (was 63).
- `node --check` clean on `state.js`/`ui.js`/`app.js`.
- `dotnet format --verify-no-changes` clean.

## Manual smoke (planned)

`docker compose -f docker/docker-compose.yml -f docker-compose.demo.yml up`
→ login alice → tape panel populates with bot trades; filter to
PETR4 narrows the view; hovering pauses; `md.bust` injection via
admin endpoint flips a row to strikethrough.