### PR TITLE
refactor(trader-ui): unify DOB/chart/tape under selectedSymbol

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -68,6 +68,31 @@ body {
 .status-disconnected { background: rgba(239,83,80,.18);  color: var(--red); }
 .status-not_ready    { background: rgba(245,166,35,.18); color: var(--warn); }
 .user-label { color: var(--muted); }
+.symbol-select {
+  display: inline-flex; align-items: center; gap: .35rem;
+  font-size: .72rem; color: var(--muted); text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.symbol-select select {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: .15rem .35rem; font-size: .85rem; text-transform: none; letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+.symbol-tag {
+  display: inline-block; margin-left: .35rem;
+  padding: 0 .35rem; border-radius: 4px;
+  background: var(--panel-2); color: var(--text);
+  font-size: .75rem; font-weight: 500; font-variant-numeric: tabular-nums;
+  border: 1px solid var(--border);
+}
+.symbol-tag--muted { color: var(--muted); }
+.tape-all-toggle {
+  display: inline-flex; align-items: center; gap: .25rem;
+  font-size: .7rem; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.tape-all-toggle input { margin: 0; }
 .link-button {
   background: transparent; border: 0; color: var(--accent); cursor: pointer; font: inherit;
 }
@@ -107,11 +132,6 @@ body {
 .market-data{ grid-area: md; }
 .market-data .empty { color: var(--muted); font-size: .8rem; }
 .dob { grid-area: dob; }
-.dob h2 select {
-  background: var(--panel-2); color: var(--text);
-  border: 1px solid var(--border); border-radius: 4px;
-  padding: .15rem .3rem; font: inherit; font-size: .8rem;
-}
 .dob-grid {
   display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; min-height: 0;
 }
@@ -147,11 +167,6 @@ body {
 /* ---------- Trade tape (T4) ---------- */
 .tape { grid-area: tape; min-height: 200px; }
 .tape h2 { display: flex; align-items: center; gap: .55rem; }
-.tape h2 select {
-  background: var(--panel-2); color: var(--text);
-  border: 1px solid var(--border); border-radius: 4px;
-  padding: .15rem .3rem; font: inherit; font-size: .8rem;
-}
 .tape-paused {
   font-size: .65rem; color: var(--warn);
   background: rgba(250, 192, 64, .12); border: 1px solid var(--warn);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,12 @@
           <button type="button" data-view="trader" class="active" role="tab" aria-selected="true">Trader</button>
           <button type="button" data-view="admin" role="tab" aria-selected="false">Admin</button>
         </span>
+        <label class="symbol-select" for="selected-symbol">
+          Symbol
+          <select id="selected-symbol" aria-label="Selected symbol (DOB / chart / tape)">
+            <option value="">— select —</option>
+          </select>
+        </label>
         <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
         <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
         <span id="ws-reconnect" class="reconnect-countdown" role="status" aria-live="polite" hidden></span>
@@ -177,9 +183,7 @@
       <section class="panel dob">
         <h2>
           Depth of book
-          <select id="dob-symbol" aria-label="DOB symbol">
-            <option value="">— select symbol —</option>
-          </select>
+          <span id="dob-symbol-tag" class="symbol-tag" aria-live="polite"></span>
         </h2>
         <p id="dob-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
         <div class="dob-grid">
@@ -210,10 +214,8 @@
       <section class="panel chart">
         <h2>
           Chart
+          <span id="chart-symbol-tag" class="symbol-tag" aria-live="polite"></span>
           <span class="chart-controls">
-            <select id="chart-symbol" aria-label="Chart symbol">
-              <option value="">— select symbol —</option>
-            </select>
             <select id="chart-resolution" aria-label="Chart resolution">
               <option value="60">1m</option>
               <option value="300">5m</option>
@@ -231,9 +233,11 @@
       <section class="panel tape">
         <h2>
           Tape
-          <select id="tape-symbol" aria-label="Tape symbol filter">
-            <option value="">All</option>
-          </select>
+          <span id="tape-symbol-tag" class="symbol-tag" aria-live="polite"></span>
+          <label class="tape-all-toggle">
+            <input id="tape-show-all" type="checkbox" />
+            All symbols
+          </label>
           <span id="tape-paused" class="tape-paused" hidden>paused</span>
         </h2>
         <ol id="tape-list" class="tape-list" aria-live="off"></ol>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -56,10 +56,9 @@ function init() {
     onBlotterFilter: handleBlotterFilter,
     onSelectOrder: handleSelectOrder,
     onKeyboardCancel: handleKeyboardCancel,
-    onSelectDobSymbol: handleSelectDobSymbol,
-    onSelectChartSymbol: state.setChartSymbol,
     onSelectChartResolution: state.setChartResolution,
-    onSelectTapeSymbol: state.setTapeSymbol,
+    onSelectSymbol: handleSelectSymbol,
+    onToggleTapeShowAll: state.setTapeShowAll,
   });
   adminUi.setAdminHandlers({
     onToggleFirm:      handleToggleFirm,
@@ -295,8 +294,11 @@ function handleApplyMd({ url, symbols }) {
 // briefly blank market-data and trade-tape — not worth it.
 let mbpEnabled = false;
 
-function handleSelectDobSymbol(symbol) {
-  state.setDobSymbol(symbol || null);
+function handleSelectSymbol(symbol) {
+  // Single global selector drives DOB, chart and tape. As soon as the
+  // user picks anything we promote the MD subscription to MBP so the
+  // book panel can render depth (the default is TRADES|INFO only).
+  state.setSelectedSymbol(symbol || null);
   if (!symbol || !mdWorker || mbpEnabled) return;
   const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
   mdWorker.postMessage({ type: "setFlags", flags });

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -21,7 +21,6 @@ const state = {
   // displaying a partial book. Sorting (top-N for render) happens
   // render-side, not in state.
   book: new Map(),         // Symbol -> { bids: Map, asks: Map, ready: bool, updatedAt: number }
-  dobSymbol: null,         // currently selected DOB symbol or null
   // Candle slice (T3). Server may multiplex multiple resolutions for
   // the same symbol on a single subscription, so we cache them all
   // (Map<symbol, Map<resolutionSec, {bars, ready, updatedAt}>>) and
@@ -30,15 +29,20 @@ const state = {
   // with no FIRST stays not-ready to avoid presenting a truncated
   // chart as complete.
   candles: new Map(),      // Symbol -> Map<resolutionSec, { bars: [...], ready: bool, updatedAt: number }>
-  chartSymbol: null,       // currently selected chart symbol or null
   chartResolution: 60,     // seconds (60=1m, 300=5m, 900=15m)
   // Trade tape slice (T4). Per-symbol ring buffer of recent trades
   // with side inferred from the previous trade's price (uptick=buy,
   // downtick=sell, flat=unknown — TRADE wire frame doesn't carry an
-  // aggressor). `tapeSymbol === null` means "all" — render flattens
-  // and re-sorts by receivedAt for the cross-symbol view.
+  // aggressor). When `tapeShowAll` is true the render path flattens
+  // every symbol and re-sorts by receivedAt; otherwise it scopes to
+  // `selectedSymbol`.
   tape: new Map(),         // Symbol -> [{tradeId, price, qty, side, receivedAt, busted}]
-  tapeSymbol: null,        // null => "all", else specific symbol
+  tapeShowAll: true,
+  // Single symbol selection shared by DOB / chart / tape (the three
+  // panels used to carry their own *Symbol slice; that drift made
+  // it easy to look at the wrong instrument across panels). Auto-
+  // picks watchlist[0] when null and a watchlist exists.
+  selectedSymbol: null,
   // UX-only slices added in the operability pass.
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
@@ -277,10 +281,15 @@ export function clearAllBooks() {
 }
 
 export function setDobSymbol(symbol) {
-  const next = symbol ?? null;
-  if (state.dobSymbol === next) return;
-  state.dobSymbol = next;
-  notify("dobSymbol");
+  // Back-compat shim: DOB selector is now driven by selectedSymbol.
+  setSelectedSymbol(symbol);
+}
+
+export function setSelectedSymbol(symbol) {
+  const next = symbol == null || symbol === "" ? null : symbol;
+  if (state.selectedSymbol === next) return;
+  state.selectedSymbol = next;
+  notify("selectedSymbol");
 }
 
 // ── Candle slice (T3) ──────────────────────────────────────────────
@@ -363,10 +372,8 @@ export function clearAllCandles() {
 }
 
 export function setChartSymbol(symbol) {
-  const next = symbol ?? null;
-  if (state.chartSymbol === next) return;
-  state.chartSymbol = next;
-  notify("chartSymbol");
+  // Back-compat shim: chart selector is now driven by selectedSymbol.
+  setSelectedSymbol(symbol);
 }
 
 export function setChartResolution(seconds) {
@@ -419,11 +426,21 @@ export function clearAllTape() {
 }
 
 export function setTapeSymbol(symbol) {
-  // null === "all"; an empty string from the dropdown maps to null.
-  const next = symbol == null || symbol === "" ? null : symbol;
-  if (state.tapeSymbol === next) return;
-  state.tapeSymbol = next;
-  notify("tapeSymbol");
+  // Back-compat shim — empty/null means "all", anything else
+  // becomes the global selectedSymbol with showAll cleared.
+  if (symbol == null || symbol === "") {
+    setTapeShowAll(true);
+  } else {
+    setTapeShowAll(false);
+    setSelectedSymbol(symbol);
+  }
+}
+
+export function setTapeShowAll(showAll) {
+  const next = !!showAll;
+  if (state.tapeShowAll === next) return;
+  state.tapeShowAll = next;
+  notify("tapeShowAll");
 }
 
 export function setWatchlist(symbols) {
@@ -440,25 +457,16 @@ export function setWatchlist(symbols) {
   for (const sym of [...state.tape.keys()]) {
     if (!wanted.has(sym)) state.tape.delete(sym);
   }
-  // Reset DOB / chart / tape selection if the chosen symbol just left
-  // the watchlist. Auto-pick a sensible default for chart so the
-  // panel doesn't sit empty when the trader has symbols available.
-  // tapeSymbol stays at "all" by default — no auto-pick needed.
-  if (state.dobSymbol && !wanted.has(state.dobSymbol)) {
-    state.dobSymbol = null;
-    notify("dobSymbol");
+  // Reset shared selectedSymbol if the chosen symbol just left the
+  // watchlist; auto-pick the first available so DOB/chart/tape don't
+  // sit empty when symbols exist. tapeShowAll is preserved.
+  if (state.selectedSymbol && !wanted.has(state.selectedSymbol)) {
+    state.selectedSymbol = null;
+    notify("selectedSymbol");
   }
-  if (state.chartSymbol && !wanted.has(state.chartSymbol)) {
-    state.chartSymbol = null;
-    notify("chartSymbol");
-  }
-  if (state.chartSymbol === null && next.length > 0) {
-    state.chartSymbol = next[0];
-    notify("chartSymbol");
-  }
-  if (state.tapeSymbol && !wanted.has(state.tapeSymbol)) {
-    state.tapeSymbol = null; // back to "all"
-    notify("tapeSymbol");
+  if (state.selectedSymbol === null && next.length > 0) {
+    state.selectedSymbol = next[0];
+    notify("selectedSymbol");
   }
   notify("watchlist");
   notify("book");

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -15,10 +15,9 @@ let onSwitchView  = () => {};
 let onBlotterFilter  = () => {};
 let onSelectOrder    = () => {};
 let onKeyboardCancel = () => {};
-let onSelectDobSymbol = () => {};
-let onSelectChartSymbol = () => {};
 let onSelectChartResolution = () => {};
-let onSelectTapeSymbol = () => {};
+let onSelectSymbol = () => {};
+let onToggleTapeShowAll = () => {};
 
 export function setHandlers(handlers) {
   onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
@@ -29,10 +28,9 @@ export function setHandlers(handlers) {
   onBlotterFilter  = handlers.onBlotterFilter  ?? onBlotterFilter;
   onSelectOrder    = handlers.onSelectOrder    ?? onSelectOrder;
   onKeyboardCancel = handlers.onKeyboardCancel ?? onKeyboardCancel;
-  onSelectDobSymbol = handlers.onSelectDobSymbol ?? onSelectDobSymbol;
-  onSelectChartSymbol     = handlers.onSelectChartSymbol     ?? onSelectChartSymbol;
   onSelectChartResolution = handlers.onSelectChartResolution ?? onSelectChartResolution;
-  onSelectTapeSymbol      = handlers.onSelectTapeSymbol      ?? onSelectTapeSymbol;
+  onSelectSymbol      = handlers.onSelectSymbol      ?? onSelectSymbol;
+  onToggleTapeShowAll = handlers.onToggleTapeShowAll ?? onToggleTapeShowAll;
 }
 
 export function showLogin() {
@@ -170,21 +168,15 @@ export function bindUi() {
     onApplyMd({ url, symbols });
   });
 
-  // DOB symbol selector — empty value clears the selection.
-  const dobSelect = $("dob-symbol");
-  if (dobSelect) {
-    dobSelect.addEventListener("change", (e) => {
-      onSelectDobSymbol(e.target.value || null);
+  // Global symbol selector (drives DOB / chart / tape).
+  const symSelect = $("selected-symbol");
+  if (symSelect) {
+    symSelect.addEventListener("change", (e) => {
+      onSelectSymbol(e.target.value || null);
     });
   }
 
-  // Chart selectors (T3).
-  const chartSym = $("chart-symbol");
-  if (chartSym) {
-    chartSym.addEventListener("change", (e) => {
-      onSelectChartSymbol(e.target.value || null);
-    });
-  }
+  // Chart resolution selector (T3).
   const chartRes = $("chart-resolution");
   if (chartRes) {
     chartRes.addEventListener("change", (e) => {
@@ -192,11 +184,11 @@ export function bindUi() {
     });
   }
 
-  // Tape (T4): symbol filter + pause-on-hover.
-  const tapeSel = $("tape-symbol");
-  if (tapeSel) {
-    tapeSel.addEventListener("change", (e) => {
-      onSelectTapeSymbol(e.target.value || null);
+  // Tape (T4): "All symbols" toggle + pause-on-hover.
+  const tapeAll = $("tape-show-all");
+  if (tapeAll) {
+    tapeAll.addEventListener("change", (e) => {
+      onToggleTapeShowAll(e.target.checked);
     });
   }
   const tapeList = $("tape-list");
@@ -413,9 +405,10 @@ function renderForSlice(slice) {
   if (slice === "wsReconnect") renderReconnect();
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
   if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
-  if (slice === "watchlist" || slice === "dobSymbol" || slice === "book" || slice === "all") renderDob();
-  if (slice === "watchlist" || slice === "chartSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
-  if (slice === "watchlist" || slice === "tapeSymbol" || slice === "tape" || slice === "all") scheduleTapeRender();
+  if (slice === "watchlist" || slice === "selectedSymbol" || slice === "all") renderSelectedSymbol();
+  if (slice === "watchlist" || slice === "selectedSymbol" || slice === "book" || slice === "all") renderDob();
+  if (slice === "watchlist" || slice === "selectedSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
+  if (slice === "watchlist" || slice === "selectedSymbol" || slice === "tapeShowAll" || slice === "tape" || slice === "all") scheduleTapeRender();
 }
 
 function renderAll() {
@@ -425,6 +418,7 @@ function renderAll() {
   setStatusPill(getState().status);
   setUserLabel(getState().user);
   renderMarketData();
+  renderSelectedSymbol();
   renderDob();
   scheduleChartRender();
   scheduleTapeRender();
@@ -473,27 +467,47 @@ function renderMarketData() {
 
 const DOB_TOP_N = 10;
 
+function renderSelectedSymbol() {
+  const sel = $("selected-symbol");
+  if (!sel) return;
+  const st = getState();
+  const watch = st.watchlist;
+  const desired = ["", ...watch];
+  const existing = [...sel.options].map(o => o.value);
+  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
+    sel.innerHTML = `<option value="">— select —</option>` +
+      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
+  }
+  if (sel.value !== (st.selectedSymbol ?? "")) sel.value = st.selectedSymbol ?? "";
+
+  // Mirror the active symbol on each panel header tag.
+  for (const id of ["dob-symbol-tag", "chart-symbol-tag", "tape-symbol-tag"]) {
+    const tag = $(id);
+    if (!tag) continue;
+    if (id === "tape-symbol-tag" && st.tapeShowAll) {
+      tag.textContent = "all";
+      tag.classList.add("symbol-tag--muted");
+    } else {
+      tag.textContent = st.selectedSymbol ?? "—";
+      tag.classList.toggle("symbol-tag--muted", !st.selectedSymbol);
+    }
+  }
+
+  // Keep the tape "All symbols" checkbox in sync with state.
+  const tapeAll = $("tape-show-all");
+  if (tapeAll && tapeAll.checked !== !!st.tapeShowAll) {
+    tapeAll.checked = !!st.tapeShowAll;
+  }
+}
+
 function renderDob() {
-  const select = $("dob-symbol");
   const bidsBody = document.querySelector("#dob-bids tbody");
   const asksBody = document.querySelector("#dob-asks tbody");
   const feedback = $("dob-feedback");
-  if (!select || !bidsBody || !asksBody) return;
+  if (!bidsBody || !asksBody) return;
 
   const st = getState();
-  const watch = st.watchlist;
-  const current = st.dobSymbol;
-
-  // Sync the symbol dropdown with the current watchlist.
-  const desired = ["", ...watch];
-  const existing = [...select.options].map(o => o.value);
-  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
-    select.innerHTML = `<option value="">— select symbol —</option>` +
-      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
-  }
-  if (select.value !== (current ?? "")) {
-    select.value = current ?? "";
-  }
+  const current = st.selectedSymbol;
 
   if (!current) {
     bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">select a symbol</td></tr>`;
@@ -566,21 +580,11 @@ function scheduleChartRender() {
 function renderChart() {
   const svg   = $("chart-svg");
   const empty = $("chart-empty");
-  const symSel = $("chart-symbol");
   const resSel = $("chart-resolution");
-  if (!svg || !symSel || !resSel) return;
+  if (!svg || !resSel) return;
 
   const st = getState();
-  const watch = st.watchlist;
 
-  // Sync symbol dropdown with the watchlist.
-  const desired = ["", ...watch];
-  const existing = [...symSel.options].map(o => o.value);
-  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
-    symSel.innerHTML = `<option value="">— select symbol —</option>` +
-      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
-  }
-  if (symSel.value !== (st.chartSymbol ?? "")) symSel.value = st.chartSymbol ?? "";
   const resStr = String(st.chartResolution);
   if (resSel.value !== resStr) resSel.value = resStr;
 
@@ -589,9 +593,9 @@ function renderChart() {
     if (empty) { empty.hidden = false; empty.textContent = msg; }
   };
 
-  if (!st.chartSymbol) { showEmpty("select a symbol"); return; }
+  if (!st.selectedSymbol) { showEmpty("select a symbol"); return; }
 
-  const perRes = st.candles.get(st.chartSymbol);
+  const perRes = st.candles.get(st.selectedSymbol);
   const entry = perRes?.get(st.chartResolution);
   if (!entry || !entry.ready || entry.bars.length === 0) {
     showEmpty("awaiting candle snapshot…");
@@ -659,40 +663,34 @@ function scheduleTapeRender() {
 
 function renderTape() {
   const list = $("tape-list");
-  const sel = $("tape-symbol");
-  if (!list || !sel) return;
+  if (!list) return;
 
   const st = getState();
-  const watch = st.watchlist;
 
-  // Sync filter dropdown with the watchlist; "" === all.
-  const desired = ["", ...watch];
-  const existing = [...sel.options].map(o => o.value);
-  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
-    sel.innerHTML = `<option value="">All</option>` +
-      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
-  }
-  if (sel.value !== (st.tapeSymbol ?? "")) sel.value = st.tapeSymbol ?? "";
-
-  // Collect rows. Single-symbol view is just the per-symbol ring; the
-  // "all" view flattens every cached symbol and re-sorts by receivedAt
-  // descending. Both paths slice to TAPE_VISIBLE before rendering.
+  // Source of rows: when tapeShowAll is true, flatten every cached
+  // symbol and re-sort by receivedAt desc. Otherwise scope to the
+  // shared selectedSymbol — if no symbol is picked, render empty.
   let rows;
-  if (st.tapeSymbol) {
-    const arr = st.tape.get(st.tapeSymbol);
-    rows = arr ? arr.slice().reverse() : [];
-    rows = rows.slice(0, TAPE_VISIBLE).map(e => ({ ...e, symbol: st.tapeSymbol }));
-  } else {
+  if (st.tapeShowAll) {
     rows = [];
     for (const [sym, arr] of st.tape) {
       for (const e of arr) rows.push({ ...e, symbol: sym });
     }
     rows.sort((a, b) => b.receivedAt - a.receivedAt);
     rows = rows.slice(0, TAPE_VISIBLE);
+  } else if (st.selectedSymbol) {
+    const arr = st.tape.get(st.selectedSymbol);
+    rows = arr ? arr.slice().reverse() : [];
+    rows = rows.slice(0, TAPE_VISIBLE).map(e => ({ ...e, symbol: st.selectedSymbol }));
+  } else {
+    rows = [];
   }
 
   if (rows.length === 0) {
-    list.innerHTML = `<li class="tape-empty">no trades yet</li>`;
+    const msg = st.tapeShowAll
+      ? "no trades yet"
+      : (st.selectedSymbol ? "no trades yet" : "select a symbol");
+    list.innerHTML = `<li class="tape-empty">${msg}</li>`;
     return;
   }
 

--- a/frontend/test/state-book.test.mjs
+++ b/frontend/test/state-book.test.mjs
@@ -127,21 +127,23 @@ test('setWatchlist drops books for symbols no longer watched', async () => {
   assert.equal(s.getState().book.has('VALE3'), false);
 });
 
-test('setWatchlist clears dobSymbol if it was removed', async () => {
+test('setWatchlist clears selectedSymbol if it was removed', async () => {
   const s = await freshState();
   s.setWatchlist(['PETR4', 'VALE3']);
-  s.setDobSymbol('VALE3');
-  assert.equal(s.getState().dobSymbol, 'VALE3');
+  s.setSelectedSymbol('VALE3');
+  assert.equal(s.getState().selectedSymbol, 'VALE3');
   s.setWatchlist(['PETR4']);
-  assert.equal(s.getState().dobSymbol, null);
+  // Auto-pick promotes the only remaining symbol; the removed one
+  // never lingers as the selection.
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
 });
 
-test('setWatchlist preserves dobSymbol if still in list', async () => {
+test('setWatchlist preserves selectedSymbol if still in list', async () => {
   const s = await freshState();
   s.setWatchlist(['PETR4', 'VALE3']);
-  s.setDobSymbol('PETR4');
+  s.setSelectedSymbol('PETR4');
   s.setWatchlist(['PETR4', 'ITUB4']);
-  assert.equal(s.getState().dobSymbol, 'PETR4');
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
 });
 
 test('clearAllBooks empties the book Map', async () => {
@@ -152,12 +154,18 @@ test('clearAllBooks empties the book Map', async () => {
   assert.equal(s.getState().book.size, 0);
 });
 
-test('setDobSymbol notifies "dobSymbol" slice', async () => {
+test('setSelectedSymbol notifies "selectedSymbol" slice', async () => {
   const s = await freshState();
   const seen = [];
   s.subscribe((slice) => seen.push(slice));
+  s.setSelectedSymbol('PETR4');
+  assert.ok(seen.includes('selectedSymbol'));
+});
+
+test('setDobSymbol back-compat shim writes selectedSymbol', async () => {
+  const s = await freshState();
   s.setDobSymbol('PETR4');
-  assert.ok(seen.includes('dobSymbol'));
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
 });
 
 test('book reducers notify "book" slice', async () => {

--- a/frontend/test/state-candle.test.mjs
+++ b/frontend/test/state-candle.test.mjs
@@ -175,20 +175,20 @@ test('setWatchlist drops candles for removed symbols', async () => {
   assert.equal(s.getState().candles.has('VALE3'), false);
 });
 
-test('setWatchlist auto-picks first symbol as chartSymbol when empty', async () => {
+test('setWatchlist auto-picks first symbol as selectedSymbol when empty', async () => {
   const s = await freshState();
-  assert.equal(s.getState().chartSymbol, null);
+  assert.equal(s.getState().selectedSymbol, null);
   s.setWatchlist(['PETR4', 'VALE3']);
-  assert.equal(s.getState().chartSymbol, 'PETR4');
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
 });
 
-test('setWatchlist clears chartSymbol if it was removed', async () => {
+test('setWatchlist clears selectedSymbol if it was removed', async () => {
   const s = await freshState();
   s.setWatchlist(['PETR4', 'VALE3']);
-  s.setChartSymbol('VALE3');
+  s.setSelectedSymbol('VALE3');
   s.setWatchlist(['PETR4']);
-  // chartSymbol cleared because VALE3 left, then auto-picked first.
-  assert.equal(s.getState().chartSymbol, 'PETR4');
+  // selectedSymbol cleared because VALE3 left, then auto-picked first.
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
 });
 
 test('setChartResolution rejects unsupported values', async () => {
@@ -257,10 +257,11 @@ test('candles reducers notify "candles" slice', async () => {
   assert.ok(seen.includes('candles'));
 });
 
-test('setChartSymbol notifies "chartSymbol" slice', async () => {
+test('setChartSymbol back-compat shim writes selectedSymbol', async () => {
   const s = await freshState();
   const seen = [];
   s.subscribe((slice) => seen.push(slice));
   s.setChartSymbol('PETR4');
-  assert.ok(seen.includes('chartSymbol'));
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
+  assert.ok(seen.includes('selectedSymbol'));
 });

--- a/frontend/test/state-tape.test.mjs
+++ b/frontend/test/state-tape.test.mjs
@@ -98,24 +98,35 @@ test('clearAllTape empties every per-symbol ring', async () => {
   assert.equal(s.getState().tape.size, 0);
 });
 
-test('setTapeSymbol("") normalises to null (all)', async () => {
+test('setTapeShowAll toggles the tape "all" mode', async () => {
   const s = await freshState();
-  s.setTapeSymbol('PETR4');
-  assert.equal(s.getState().tapeSymbol, 'PETR4');
-  s.setTapeSymbol('');
-  assert.equal(s.getState().tapeSymbol, null);
+  assert.equal(s.getState().tapeShowAll, true); // default
+  s.setTapeShowAll(false);
+  assert.equal(s.getState().tapeShowAll, false);
+  s.setTapeShowAll(true);
+  assert.equal(s.getState().tapeShowAll, true);
 });
 
-test('setWatchlist drops tape for removed symbols and resets tapeSymbol', async () => {
+test('setTapeSymbol back-compat: empty enables show-all, non-empty disables', async () => {
+  const s = await freshState();
+  s.setTapeSymbol('PETR4');
+  assert.equal(s.getState().selectedSymbol, 'PETR4');
+  assert.equal(s.getState().tapeShowAll, false);
+  s.setTapeSymbol('');
+  assert.equal(s.getState().tapeShowAll, true);
+});
+
+test('setWatchlist drops tape for removed symbols and resets selectedSymbol', async () => {
   const s = await freshState();
   s.setWatchlist(['PETR4', 'VALE3']);
   s.applyMdTrade({ symbol: 'PETR4', price: 32.10, qty: 100, tradeId: 1 });
   s.applyMdTrade({ symbol: 'VALE3', price: 65.00, qty: 100, tradeId: 2 });
-  s.setTapeSymbol('PETR4');
+  s.setSelectedSymbol('PETR4');
   s.setWatchlist(['VALE3']); // PETR4 leaves the watchlist
   assert.equal(s.getState().tape.has('PETR4'), false);
   assert.equal(s.getState().tape.has('VALE3'), true);
-  assert.equal(s.getState().tapeSymbol, null);
+  // PETR4 left → auto-pick the only remaining symbol.
+  assert.equal(s.getState().selectedSymbol, 'VALE3');
 });
 
 test('applyMdTrade emits a tape notification', async () => {


### PR DESCRIPTION
Refactor the trader UI so DOB, chart and tape share a single
`selectedSymbol` slice driven by one global selector in the topbar,
instead of three independent dropdowns that invited cross-panel drift.

## Why

Looking at PETR4 in DOB while the chart is on VALE3 is almost never
what a trader wants. The per-panel selectors that landed in T2/T3/T4
made it easy to end up in that state. A single source of truth keeps
all three panels in sync by construction.

## State (`frontend/js/state.js`)

- New `selectedSymbol: string|null` + `setSelectedSymbol`.
- New `tapeShowAll: boolean` (default true) + `setTapeShowAll` —
  the only orthogonal axis the tape needed beyond the selection.
- Removed `dobSymbol` / `chartSymbol` / `tapeSymbol` fields and
  the per-slice notifications.
- `setDobSymbol` / `setChartSymbol` / `setTapeSymbol` kept as
  back-compat shims that route through `setSelectedSymbol` (and
  `setTapeShowAll` for the tape's empty-string "all" semantics).
- `setWatchlist` resets `selectedSymbol` only when the active
  symbol leaves the list and auto-picks `watchlist[0]` so panels
  don't sit empty.

## UI (`frontend/js/ui.js` + `index.html` + `styles.css`)

- Single `<select id="selected-symbol">` in the topbar drives
  every panel.
- DOB / chart / tape lose their dropdowns; each header now shows
  the active symbol via a `<span class="symbol-tag">`.
- Tape replaces the "All" option with an "All symbols"
  checkbox bound to `tapeShowAll`. Off → scopes to
  `selectedSymbol`; On → cross-symbol flatten + sort (existing
  behaviour).
- `renderForSlice` dispatches on `selectedSymbol` /
  `tapeShowAll` instead of the old per-panel slices.

## Wiring (`frontend/js/app.js`)

- `onSelectSymbol` routes through `handleSelectSymbol`, which
  still promotes the MD subscription to MBP on first non-null
  pick (logic moved verbatim from the old `handleSelectDobSymbol`).
- New `onToggleTapeShowAll` handler bound to
  `state.setTapeShowAll`.

## Tests

- Updated `state-book` / `state-candle` / `state-tape` suites
  for the new slice name; coverage of the back-compat shims and
  watchlist auto-pick behaviour added.
- New tests for `setTapeShowAll` and the
  "empty string → show-all" semantics of `setTapeSymbol`.
- **Suite total: 78/78 pass** (was 76).
- `dotnet format --verify-no-changes` clean.

## Manual smoke (next)

After merge, plan is to run `docker-compose.demo.yml` and verify
the topbar selector simultaneously updates DOB / chart / tape.