### PR TITLE
chore(deps): bump B3.EntryPoint.Client 0.8.0 → 0.14.1 (closes #83)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -211,7 +211,10 @@ jobs:
         # service consuming matching's UMDF unicast — so trading-host's
         # IReferencePrice is wired through MarketDataReferencePrice end-to-end
         # instead of falling back to the static map. Conformance overlay still
-        # piles on the carol admin seed. --wait blocks until matching's
+        # piles on the carol admin seed. real-conformance.yml opts the run
+        # into RequiresSandboxMatching specs (separate file so non-conformance
+        # combos like real+demo don't trip a "service has no image" validation
+        # on a partial conformance fragment). --wait blocks until matching's
         # healthcheck passes AND trading-host reports healthy (FIXP Negotiate
         # succeeded against matching).
         run: |
@@ -219,6 +222,7 @@ jobs:
               -f docker/docker-compose.yml \
               -f docker/docker-compose.real.yml \
               -f docker/docker-compose.conformance.yml \
+              -f docker/docker-compose.real-conformance.yml \
               up -d --build --wait trading-host
 
       - name: Run conformance
@@ -236,6 +240,7 @@ jobs:
               -f docker/docker-compose.yml \
               -f docker/docker-compose.real.yml \
               -f docker/docker-compose.conformance.yml \
+              -f docker/docker-compose.real-conformance.yml \
               run --rm --no-deps conformance
 
       - name: Logs (always)
@@ -247,6 +252,7 @@ jobs:
                 -f docker/docker-compose.yml \
                 -f docker/docker-compose.real.yml \
                 -f docker/docker-compose.conformance.yml \
+                -f docker/docker-compose.real-conformance.yml \
                 logs --no-color --timestamps "$svc" || true
             echo "::endgroup::"
           done
@@ -258,4 +264,5 @@ jobs:
               -f docker/docker-compose.yml \
               -f docker/docker-compose.real.yml \
               -f docker/docker-compose.conformance.yml \
+              -f docker/docker-compose.real-conformance.yml \
               down -v

--- a/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
+++ b/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="B3.EntryPoint.Client" Version="0.8.0" />
+    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.1" />
     <PackageReference Include="System.IO.Hashing" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -33,7 +33,10 @@ services:
       Trading__Auth__Users__1__Salt: ${DEMO_BOT_A_SALT:-MKxchosZRRVTRQZe4u4Ykw==}
       Trading__Auth__Users__1__Iterations: "600000"
       Trading__Auth__Users__1__Role: user
-      Trading__Auth__Users__1__Firm: default
+      # FIRM01 so the bots route correctly when this overlay is combined
+      # with docker-compose.real.yml (real-stack registers FIRM01 only).
+      # In standalone Simulator mode the firm name is irrelevant.
+      Trading__Auth__Users__1__Firm: FIRM01
 
       # User-bot 2 (default seed; submits orders).
       Trading__Auth__Users__2__Username: ${DEMO_BOT_B_USER:-bot-clientB}
@@ -41,7 +44,7 @@ services:
       Trading__Auth__Users__2__Salt: ${DEMO_BOT_B_SALT:-Bj20VGNiURA5SHsRHKWsUw==}
       Trading__Auth__Users__2__Iterations: "600000"
       Trading__Auth__Users__2__Role: user
-      Trading__Auth__Users__2__Firm: default
+      Trading__Auth__Users__2__Firm: FIRM01
 
       # Admin used exclusively by the demo-driver injector. Kept distinct
       # from carol (conformance overlay) so the two overlays can coexist
@@ -51,7 +54,7 @@ services:
       Trading__Auth__Users__3__Salt: ${DEMO_ADMIN_SALT:-wtrNdBpmiH7nWtMwM6v9cA==}
       Trading__Auth__Users__3__Iterations: "600000"
       Trading__Auth__Users__3__Role: admin
-      Trading__Auth__Users__3__Firm: default
+      Trading__Auth__Users__3__Firm: FIRM01
 
       # Static reference prices the bots quote around. Mirrors the defaults
       # the demo-driver bakes in via DEMO_SYMBOLS so the price collar (10%

--- a/docker/docker-compose.real-conformance.yml
+++ b/docker/docker-compose.real-conformance.yml
@@ -1,0 +1,22 @@
+# Tiny merge overlay for the (real-stack + conformance) combination.
+#
+# The conformance service is defined in docker-compose.conformance.yml.
+# When stacked on top of docker-compose.real.yml, set the env flag that
+# opts the run into RequiresSandboxMatching specs (e.g. ReferencePriceLiveSpec).
+# Any non-real conformance run keeps skipping them at discovery time.
+#
+# Usage:
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.real.yml \
+#       -f docker/docker-compose.conformance.yml \
+#       -f docker/docker-compose.real-conformance.yml \
+#       run --rm conformance
+#
+# Kept as a separate file so docker-compose.real.yml can be combined with
+# overlays that don't define a `conformance` service (e.g. demo) without
+# tripping compose's "service has neither image nor build" validation.
+services:
+  conformance:
+    environment:
+      B3T_REAL_STACK_CONFORMANCE: "true"

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -175,13 +175,3 @@ services:
       Trading__MarketData__Symbols__0: PETR4
       Trading__MarketData__Symbols__1: VALE3
       Trading__MarketData__Symbols__2: ITUB4
-
-  # When the conformance overlay is also stacked on top, opt this run into
-  # the destructive real-stack scenarios. RequiresSandboxMatching specs
-  # (e.g. ReferencePriceLiveSpec) will only execute when this flag is set;
-  # any non-real conformance run keeps skipping them at discovery time.
-  # The conformance service is defined in docker-compose.conformance.yml;
-  # we just merge an env var into it from this overlay.
-  conformance:
-    environment:
-      B3T_REAL_STACK_CONFORMANCE: "true"

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -366,6 +366,7 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
   position: fixed; inset: 0; background: rgba(8,11,16,.65);
   display: grid; place-items: center; z-index: 1000;
 }
+.modal-backdrop[hidden] { display: none; }
 .modal-card {
   background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
   padding: 1.25rem 1.5rem; width: min(360px, 90vw);

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -14,6 +14,11 @@
 }
 
 * { box-sizing: border-box; }
+/* The `hidden` HTML attribute must always win, even on elements that
+   declare a custom `display` (grid/flex/etc) further down. Without
+   this, .login-view / .trader-view / .modal-backdrop with hidden=true
+   would still render. */
+[hidden] { display: none !important; }
 html, body { height: 100%; margin: 0; }
 body {
   background: var(--bg);
@@ -366,7 +371,6 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
   position: fixed; inset: 0; background: rgba(8,11,16,.65);
   display: grid; place-items: center; z-index: 1000;
 }
-.modal-backdrop[hidden] { display: none; }
 .modal-card {
   background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
   padding: 1.25rem 1.5rem; width: min(360px, 90vw);

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -53,7 +53,7 @@ body {
 .error { color: var(--red); font-size: .85rem; margin: 0; }
 
 /* ---------- Trader shell ---------- */
-.trader-view { display: flex; flex-direction: column; height: 100vh; }
+.trader-view { display: flex; flex-direction: column; min-height: 100vh; }
 .topbar {
   display: flex; justify-content: space-between; align-items: center;
   padding: .6rem 1rem; background: var(--panel); border-bottom: 1px solid var(--border);
@@ -107,7 +107,6 @@ body {
   flex: 1;
   display: grid;
   grid-template-columns: 280px 1fr 240px;
-  grid-template-rows: auto 1fr auto auto auto auto;
   grid-template-areas:
     "ticket  blotter   positions"
     "ticket  blotter   positions"
@@ -256,7 +255,6 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 @media (max-width: 1280px) {
   .grid {
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: repeat(6, auto);
     grid-template-areas:
       "ticket    positions"
       "blotter   blotter"
@@ -269,7 +267,6 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 @media (max-width: 720px) {
   .grid {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(8, auto);
     grid-template-areas:
       "ticket"
       "positions"

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -119,7 +119,12 @@ body {
 }
 .panel {
   background: var(--panel); border: 1px solid var(--border); border-radius: 6px;
-  padding: .8rem; display: flex; flex-direction: column; min-height: 0;
+  padding: .8rem; display: flex; flex-direction: column;
+  min-height: 0; min-width: 0;
+}
+.panel > table,
+.panel .table-scroll {
+  display: block; overflow-x: auto; max-width: 100%;
 }
 .panel h2 {
   margin: 0 0 .6rem 0; font-size: .85rem; font-weight: 600; color: var(--muted);
@@ -248,7 +253,7 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 .executions-log .meta { color: var(--muted); }
 
 /* ---------- Responsive ---------- */
-@media (max-width: 1100px) {
+@media (max-width: 1280px) {
   .grid {
     grid-template-columns: 1fr 1fr;
     grid-template-areas:
@@ -258,6 +263,20 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
       "dob       dob"
       "chart     chart"
       "tape      tape";
+  }
+}
+@media (max-width: 720px) {
+  .grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "ticket"
+      "positions"
+      "blotter"
+      "execs"
+      "md"
+      "dob"
+      "chart"
+      "tape";
   }
 }
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -256,6 +256,7 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 @media (max-width: 1280px) {
   .grid {
     grid-template-columns: 1fr 1fr;
+    grid-template-rows: repeat(6, auto);
     grid-template-areas:
       "ticket    positions"
       "blotter   blotter"
@@ -268,6 +269,7 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 @media (max-width: 720px) {
   .grid {
     grid-template-columns: 1fr;
+    grid-template-rows: repeat(8, auto);
     grid-template-areas:
       "ticket"
       "positions"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -295,7 +295,7 @@
   <div id="session-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="session-modal-title">
     <form id="session-modal-form" class="modal-card">
       <h2 id="session-modal-title">Session expiring</h2>
-      <p id="session-modal-msg" class="muted-line">Re-enter your password to extend the session.</p>
+      <p id="session-modal-msg" class="muted-line">Re-enter your password to extend the session, or click outside to log out.</p>
       <label>
         <span>Password</span>
         <input id="session-modal-password" type="password" autocomplete="current-password" required />

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,6 @@
 // App entry point: wires login → worker → state → UI together.
 
-import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms,
+import { defaultBackend, defaultMarketDataUrl, login, submitOrder, cancelOrder, getAdminFirms,
          validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          runEod } from "./protocol.js";
@@ -238,12 +238,11 @@ function restartWorker() {
 }
 
 function defaultMdUrl() {
-  // The B3MarketDataPlatform WS is an OPTIONAL external feed (separate
-  // from the trading-host WS). Don't guess a URL — leave empty so the
-  // worker stays idle until an operator enters one in the Market Data
-  // panel. Auto-defaulting to localhost:8081 caused noisy connection
-  // errors in setups (like the demo) that don't run that service.
-  return "";
+  // Optional external B3MarketDataPlatform WS. Defaults to the dev port
+  // 8081 on localhost so the docker-compose stack works out of the box;
+  // returns empty for non-localhost deployments where the operator must
+  // configure an explicit endpoint via the Market Data panel.
+  return defaultMarketDataUrl();
 }
 
 function readMdConfig() {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -238,15 +238,12 @@ function restartWorker() {
 }
 
 function defaultMdUrl() {
-  // Heuristic: same host as the trading-host backend with port 8081 and
-  // ws:// scheme. Operators on a different topology can override.
-  try {
-    const u = new URL(session.backend);
-    u.protocol = u.protocol === "https:" ? "wss:" : "ws:";
-    u.port = "8081";
-    u.pathname = "/ws";
-    return u.toString();
-  } catch { return ""; }
+  // The B3MarketDataPlatform WS is an OPTIONAL external feed (separate
+  // from the trading-host WS). Don't guess a URL — leave empty so the
+  // worker stays idle until an operator enters one in the Market Data
+  // panel. Auto-defaulting to localhost:8081 caused noisy connection
+  // errors in setups (like the demo) that don't run that service.
+  return "";
 }
 
 function readMdConfig() {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,7 @@
 // App entry point: wires login → worker → state → UI together.
 
 import { defaultBackend, login, submitOrder, cancelOrder, getAdminFirms,
+         validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          runEod } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
@@ -69,8 +70,26 @@ function init() {
   });
 
   const stored = readSession();
-  if (stored) startSession(stored);
-  else ui.showLogin();
+  if (stored) {
+    // Probe before we commit: a token that survived a host signing-key
+    // rotation will look fresh client-side (expiresAt in the future)
+    // but be rejected by the backend on the very first WS upgrade.
+    // Showing the "session expiring" modal in that case is confusing
+    // because the user never logged in this run. Drop silently and
+    // fall back to login if the probe fails.
+    validateSession(stored.backend, stored.token)
+      .then((ok) => {
+        if (ok) startSession(stored);
+        else { clearSession(); ui.showLogin(); }
+      })
+      .catch(() => {
+        // Network error — give the optimistic path a chance; if the
+        // token is genuinely bad, /orders / WS will surface it later.
+        startSession(stored);
+      });
+  } else {
+    ui.showLogin();
+  }
 }
 
 async function onLogin(e) {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -71,22 +71,33 @@ function init() {
 
   const stored = readSession();
   if (stored) {
+    // Boot guard: if the stored session is already inside the warning
+    // window (or past its expiry), don't even attempt to adopt it.
+    // Showing the "session expiring" modal as the very first thing the
+    // user sees on page load is confusing — they have no context. Treat
+    // it as expired and require a fresh login.
+    const expiresAtMs = Date.parse(stored.expiresAt || "");
+    const remaining = Number.isFinite(expiresAtMs) ? expiresAtMs - Date.now() : -1;
+    if (remaining <= SESSION_WARNING_LEAD_MS) {
+      clearSession();
+      ui.showLogin();
+      return;
+    }
     // Probe before we commit: a token that survived a host signing-key
     // rotation will look fresh client-side (expiresAt in the future)
     // but be rejected by the backend on the very first WS upgrade.
     // Showing the "session expiring" modal in that case is confusing
     // because the user never logged in this run. Drop silently and
-    // fall back to login if the probe fails.
+    // fall back to login if the probe fails. On network error we ALSO
+    // drop — the optimistic path used to fall through here, but if the
+    // stored backend URL is stale/wrong the user lands in a half-open
+    // UI with no way out. Re-login is cheap; bias toward correctness.
     validateSession(stored.backend, stored.token)
       .then((ok) => {
         if (ok) startSession(stored);
         else { clearSession(); ui.showLogin(); }
       })
-      .catch(() => {
-        // Network error — give the optimistic path a chance; if the
-        // token is genuinely bad, /orders / WS will surface it later.
-        startSession(stored);
-      });
+      .catch(() => { clearSession(); ui.showLogin(); });
   } else {
     ui.showLogin();
   }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -270,10 +270,18 @@ function startMdWorker() {
 
   mdWorker = new Worker(new URL("./mdWorker.js", import.meta.url), { type: "module" });
   mdWorker.onmessage = (ev) => onMdWorkerMessage(ev.data);
+  // Subscribe with MBP from the start. DOB is always rendered, so the
+  // book channel needs to populate without waiting for the user to
+  // explicitly pick a symbol from the topbar selector. Keeping MBP off
+  // by default would leave the DOB stuck on "awaiting book snapshot…"
+  // for users who accept the default-selected symbol.
+  const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
+  mbpEnabled = true;
   mdWorker.postMessage({
     type: "start",
     url: mdConfig.url,
     symbols: mdConfig.symbols,
+    flags,
   });
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -2,9 +2,14 @@
 // this module is HTTP-only.
 
 export function defaultBackend() {
-  return location.hostname === "localhost" || location.hostname === "127.0.0.1"
-    ? "http://localhost:5000"
-    : location.origin;
+  // Prefer the page origin so requests go through the nginx reverse-proxy
+  // (same-origin, no CORS). The legacy "localhost:5000" shortcut only kicks
+  // in for non-http schemes (e.g. file://) where there is no real origin to
+  // talk to. The login form lets the user override either way.
+  if (location.protocol === "http:" || location.protocol === "https:") {
+    return location.origin;
+  }
+  return "http://localhost:5000";
 }
 
 async function jsonOrThrow(resp) {

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -30,6 +30,18 @@ export async function login(backend, username, password) {
   return jsonOrThrow(resp);
 }
 
+// Cheap, side-effect-free probe used at boot to detect stored tokens
+// that no longer authenticate (e.g. after the host's signing key was
+// rotated). Returns true on 2xx, false on 401/403, throws on network
+// errors so the caller can fall back to the optimistic path.
+export async function validateSession(backend, token) {
+  const resp = await fetch(`${backend}/positions`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (resp.status === 401 || resp.status === 403) return false;
+  return resp.ok;
+}
+
 export async function submitOrder(backend, token, payload) {
   const resp = await fetch(`${backend}/orders`, {
     method: "POST",

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -12,6 +12,18 @@ export function defaultBackend() {
   return "http://localhost:5000";
 }
 
+// Default WebSocket endpoint for the OPTIONAL B3MarketDataPlatform feed
+// (DOB / candles / trade prints). Distinct origin from the trader WS, so
+// it can't go through the nginx reverse-proxy. Convention: same host as
+// the page, port 8081, /ws path. Returns "" off-localhost so non-dev
+// deployments don't auto-attempt a guess that's likely wrong.
+export function defaultMarketDataUrl() {
+  if (location.protocol !== "http:" && location.protocol !== "https:") return "";
+  if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") return "";
+  const wsScheme = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${wsScheme}//${location.hostname}:8081/ws`;
+}
+
 async function jsonOrThrow(resp) {
   const text = await resp.text();
   let body;

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -65,6 +65,7 @@ export function setLoginError(message) {
 // ── Session-expiry modal ───────────────────────────────────────────
 let sessionModalSubmit = null;
 let sessionModalLogout = null;
+let sessionModalBackdrop = null;
 
 export function openSessionModal({ onRenew, onLogout }) {
   const modal = $("session-modal");
@@ -78,6 +79,7 @@ export function openSessionModal({ onRenew, onLogout }) {
   // Replace handlers (idempotent across multiple opens).
   if (sessionModalSubmit) form.removeEventListener("submit", sessionModalSubmit);
   if (sessionModalLogout) logoutBtn?.removeEventListener("click", sessionModalLogout);
+  if (sessionModalBackdrop) modal.removeEventListener("click", sessionModalBackdrop);
   sessionModalSubmit = (e) => {
     e.preventDefault();
     const value = pwd.value;
@@ -85,8 +87,16 @@ export function openSessionModal({ onRenew, onLogout }) {
     onRenew?.(value);
   };
   sessionModalLogout = () => onLogout?.();
+  // Click on the backdrop (anywhere outside the modal-card) = logout.
+  // Defensive escape hatch so a user staring at the modal after a key
+  // rotation or stale-token boot doesn't get trapped if the inner
+  // Logout button somehow fails (or they're confused by it).
+  sessionModalBackdrop = (e) => {
+    if (e.target === modal) onLogout?.();
+  };
   form.addEventListener("submit", sessionModalSubmit);
   logoutBtn?.addEventListener("click", sessionModalLogout);
+  modal.addEventListener("click", sessionModalBackdrop);
   // Defer focus to the next frame so backdrop transitions don't steal it.
   requestAnimationFrame(() => pwd.focus());
 }


### PR DESCRIPTION
Closes #83. Stacked on top of #82 (fix/stale-session-probe).

## Summary

Bumps `B3.EntryPoint.Client` from `0.8.0` to `0.14.1` to resolve the two interop bugs reported in [B3MatchingPlatform#259](https://github.com/pedrosakuma/B3MatchingPlatform/issues/259).

## What was wrong (per matching #259 diagnosis)

1. **gap=2 sustained**: `KeepAliveScheduler` in 0.8.0 calls `NextOutboundSeqNum()` (which `Interlocked.Increment`s) instead of a peek, so each keepalive consumes one business seqnum without sending a business message → next `NewOrderSingle` lands at `seq=N+2` → matching answers `NotApplied(gap=2)` → orders never execute.
2. **`ArgumentOutOfRangeException` in `InboundDecoder.DecodeNew`**: 0.8.0 does `MemoryMarshal.AsRef<ExecutionReport_NewData>(payload)` blindly; struct V6 needs 176 bytes but matching pre-#254 emitted V3 ER with BlockLength=172 → AsRef OOR → inbound loop terminates → firm gateway becomes unavailable.

## Fix

- 0.14.x `KeepAliveScheduler` uses `PeekNextOutboundSeqNum()` (peek, no bump) → kills the gap=2 cause.
- Image refresh (`docker pull ghcr.io/pedrosakuma/b3-matching:latest` → sha256:2c895cb…) brings in the V6 ER encoder from matching #254 → kills the OOR cause.

## Smoke run

After the bump + image refresh, against the combined demo + real-stack overlay:

- ✅ no more `Inbound loop terminated by unhandled exception`
- ✅ no more `ArgumentOutOfRangeException` in `InboundDecoder.DecodeNew`
- ✅ `gap=2` sustained → resolved
- ✅ orders submit and produce ExecutionReport_New / Fill events (marketdata sees `trades emit>0`, `orders add/upd/del>0`)
- ✅ build clean, no public API breaks between 0.8 and 0.14.1
- ✅ existing test suite passes (one pre-existing test isolation flake on `ReferencePriceMetricsTests` Meter state, passes when run alone — unrelated to bump)

## Remaining anomalies (separate follow-up)

Two intermittent warnings remain after the bump; both produce no fatal failure and orders still fill, so they're tracked as separate issues, not blockers for #83:

- `gap=1` appears intermittently (different signature than the sustained gap=2). Could be a race or another residual seqnum accounting mismatch.
- `ExecutionReportProcessor`: `Fill delta mismatch for X: ER lastQty=N, computed delta=M`. Could be ER ordering, duplicate delivery, or a V6 field offset/encoding interpretation difference for `LastQty`.

Both deserve their own investigation tickets — happy to file them after this lands.

## Notes

- Branch is based on `fix/stale-session-probe` (PR #82) for the conformance compose split + frontend MBP subscribe fix needed to bring the combined stack up; merge #82 first for a clean diff against `main`.