### PR TITLE
feat(risk): block naked short on cash equities (NoNakedShortCheck) — closes #85

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
@@ -1,0 +1,79 @@
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Pre-trade gate that blocks naked short sales — Sells that, in the
+/// pessimistic projection, would drive the end-client's position
+/// negative for the symbol.
+///
+/// Background: B3 cash equities (mercado à vista) does not allow
+/// short-selling without prior stock borrow (BTC). The platform
+/// today does not integrate with a borrow registry, so the safe
+/// default is to refuse any Sell that exceeds the seller's long
+/// inventory — whether or not the matching engine would accept it.
+/// Toggleable per firm / per end-client via
+/// <see cref="RiskLimits.AllowShortSell"/> (default: blocked).
+///
+/// Pessimism rules (intentional):
+///   * Subtract every <em>open Sell</em>'s remaining leaves from the
+///     current net long, even if the new Sell could in theory share
+///     inventory with one that's about to fill against a Buy.
+///   * Do <strong>not</strong> credit open Buys' leaves: those may
+///     be cancelled and would never become inventory.
+///   * The order being evaluated is already in the working order
+///     book by the time the pipeline runs (see
+///     <see cref="WorkingOrderBook.SumOpenSellLeavesForSymbol"/>
+///     remarks), so the sum already includes it. The reject
+///     condition is therefore <c>sellable &lt; 0</c>, not
+///     <c>incoming &gt; sellable</c>.
+/// </summary>
+public sealed class NoNakedShortCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly PositionKeeper _positions;
+    private readonly WorkingOrderBook _orders;
+
+    public NoNakedShortCheck(
+        IOptionsMonitor<RiskOptions> options,
+        PositionKeeper positions,
+        WorkingOrderBook orders)
+    {
+        _options = options;
+        _positions = positions;
+        _orders = orders;
+    }
+
+    // Sits between the throttle band (150/160/170) and PositionLimit
+    // (200): naked-short is a hard inventory invariant, more
+    // fundamental than the absolute |net| cap.
+    public int Order => 180;
+
+    public string Name => "no_naked_short";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.Side != OrderSide.Sell) return RiskDecision.Approve;
+
+        var opts = _options.CurrentValue;
+        var allow = RiskLimitsResolver.Resolve(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.AllowShortSell);
+        if (allow == true) return RiskDecision.Approve;
+
+        var currentLong = _positions.GetOrCreate(ctx.Owner, ctx.Symbol).NetQuantity;
+        var openSellLeaves = _orders.SumOpenSellLeavesForSymbol(ctx.Owner, ctx.Symbol);
+        // The incoming Sell is already counted in openSellLeaves
+        // because OrderSubmissionService.TryAdd runs before risk
+        // evaluation. So `sellable` is the projected net assuming
+        // every open Sell fills and no open Buy does.
+        var sellable = currentLong - openSellLeaves;
+        if (sellable < 0)
+        {
+            return RiskDecision.Reject(
+                $"naked short blocked: current long={currentLong}, open sell leaves={openSellLeaves} " +
+                $"(set AllowShortSell=true to opt out)");
+        }
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -127,6 +127,20 @@ public sealed class RiskLimits
     /// trade-off as <see cref="PositionLimit"/>).
     /// </summary>
     public int? MaxOpenOrders { get; set; }
+
+    /// <summary>
+    /// Whether the seller is allowed to take a Sell that would
+    /// drive their projected net position negative. B3 cash equities
+    /// (mercado à vista) does not allow naked shorts — a Sell must
+    /// be covered by long inventory (or, in a future iteration, by
+    /// borrowed stock from a BTC registry). Default semantics when
+    /// unset everywhere in the precedence chain are conservative:
+    /// naked short is **blocked** (see
+    /// <see cref="Risk.Checks.NoNakedShortCheck"/>). Set to <c>true</c>
+    /// per-firm or per-end-client to opt out (e.g. authorised
+    /// market makers, or test accounts).
+    /// </summary>
+    public bool? AllowShortSell { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -173,5 +187,6 @@ public static class RiskLimitsResolver
             PriceCollarAbsolute = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarAbsolute),
             PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),
             MaxOpenOrders = Resolve(opts, endClient, firmId, symbol, l => l.MaxOpenOrders),
+            AllowShortSell = Resolve(opts, endClient, firmId, symbol, l => l.AllowShortSell),
         };
 }

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -75,6 +75,40 @@ public sealed class WorkingOrderBook
     }
 
     /// <summary>
+    /// Sums <see cref="Order.LeavesQuantity"/> across the end-client's
+    /// non-terminal Sell orders for a single symbol. Used by the
+    /// pre-trade naked-short gate to compute available sellable
+    /// inventory pessimistically (assume every open Sell still
+    /// executes; do not net against open Buys, which may be
+    /// cancelled). Index-driven via <see cref="_byOwner"/> so cost
+    /// is O(orders for owner), not O(total orders) — same shape as
+    /// <see cref="CountOpenForOwner"/>.
+    /// </summary>
+    /// <remarks>
+    /// As with <see cref="CountOpenForOwner"/>, the order being
+    /// submitted is **already** in the book by the time the risk
+    /// pipeline runs (the persistence dispatcher adds it before
+    /// evaluation). Callers must subtract their own incoming
+    /// quantity from the returned sum to avoid double-counting it
+    /// against itself.
+    /// </remarks>
+    public long SumOpenSellLeavesForSymbol(EndClientId owner, string symbol)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
+        long total = 0;
+        foreach (var clOrdId in set.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (order.Side != OrderSide.Sell) continue;
+            if (!string.Equals(order.Symbol, symbol, StringComparison.Ordinal)) continue;
+            if (IsTerminal(order.Status)) continue;
+            total += order.LeavesQuantity;
+        }
+        return total;
+    }
+
+    /// <summary>
     /// Snapshots the orders associated with <paramref name="firmId"/>. By default
     /// only non-terminal orders are returned (PendingNew / Working / PartiallyFilled),
     /// which matches the FIXP "outstanding orders" semantics used to reconcile

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -128,6 +128,7 @@ builder.Services.AddSingleton<IRiskCheck, PositionLimitCheck>();
 builder.Services.AddSingleton<IRiskCheck, RollingNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, OrderRateLimitCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
+builder.Services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
 builder.Services.AddSingleton<IRiskCheck, PriceCollarCheck>();
 builder.Services.AddSingleton<RiskPipeline>();
 

--- a/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
@@ -22,6 +22,11 @@ public class MarginCheckIntegrationTests
             // Push other limits high so margin is the only gate that matters.
             ["Trading:Risk:Default:MaxQuantity"] = "1000000",
             ["Trading:Risk:Default:MaxNotional"] = "999999999",
+            // These tests are about the margin provider; opt out of
+            // the naked-short gate (added later) which would otherwise
+            // pre-empt margin evaluation on the Sell-with-zero-inventory
+            // case in SellsAndUnknownOwnersBypassMargin.
+            ["Trading:Risk:Default:AllowShortSell"] = "true",
         };
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
@@ -1,0 +1,215 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+public class NoNakedShortCheckTests
+{
+    private const string DefaultFirm = "FIRM01";
+    private const string DefaultOwner = "alice";
+    private const string DefaultSymbol = "PETR4";
+
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) =>
+        new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskOptions DefaultBlockedOpts() => new();
+
+    private static RiskContext SellCtx(long qty, string owner = DefaultOwner,
+                                       string firm = DefaultFirm, string symbol = DefaultSymbol) =>
+        new(new EndClientId(owner), firm, symbol,
+            OrderSide.Sell, OrderType.Limit, qty, 30m);
+
+    private static RiskContext BuyCtx(long qty) =>
+        new(new EndClientId(DefaultOwner), DefaultFirm, DefaultSymbol,
+            OrderSide.Buy, OrderType.Limit, qty, 30m);
+
+    private static Order MakeSell(ulong clOrdId, long qty,
+                                  string owner = DefaultOwner, string symbol = DefaultSymbol) =>
+        new(clOrdId, new EndClientId(owner), symbol, 4321UL,
+            OrderSide.Sell, OrderType.Limit, qty, 30m, DefaultFirm);
+
+    private static Order MakeBuy(ulong clOrdId, long qty) =>
+        new(clOrdId, new EndClientId(DefaultOwner), DefaultSymbol, 4321UL,
+            OrderSide.Buy, OrderType.Limit, qty, 30m, DefaultFirm);
+
+    private static (NoNakedShortCheck, PositionKeeper, WorkingOrderBook) Build(RiskOptions? opts = null)
+    {
+        var positions = new PositionKeeper();
+        var orders = new WorkingOrderBook();
+        var check = new NoNakedShortCheck(Wrap(opts ?? DefaultBlockedOpts()), positions, orders);
+        return (check, positions, orders);
+    }
+
+    // Mirrors what OrderSubmissionService does just before the risk
+    // pipeline runs: the incoming order is already in the book.
+    private static void SubmitInto(WorkingOrderBook book, Order order) =>
+        Assert.True(book.TryAdd(order));
+
+    [Fact]
+    public void Buy_AlwaysApproved_RegardlessOfPosition()
+    {
+        var (check, _, _) = Build();
+        Assert.True(check.Check(BuyCtx(1_000_000)).Approved);
+    }
+
+    [Fact]
+    public void Sell_NoPosition_NoOpenSells_Rejected()
+    {
+        var (check, _, orders) = Build();
+        SubmitInto(orders, MakeSell(1UL, 100));
+        var d = check.Check(SellCtx(100));
+        Assert.False(d.Approved);
+        Assert.Contains("naked short blocked", d.Reason);
+    }
+
+    [Fact]
+    public void Sell_LongCoversFully_Approved()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        SubmitInto(orders, MakeSell(1UL, 500));
+        Assert.True(check.Check(SellCtx(500)).Approved);
+    }
+
+    [Fact]
+    public void Sell_LongInsufficientByOne_Rejected()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        SubmitInto(orders, MakeSell(1UL, 501));
+        Assert.False(check.Check(SellCtx(501)).Approved);
+    }
+
+    [Fact]
+    public void Sell_OpenSellsConsumeAvailableInventory()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        // 300 already working as Sell; this incoming Sell of 200 just
+        // fills the remaining sellable inventory exactly.
+        SubmitInto(orders, MakeSell(1UL, 300));
+        SubmitInto(orders, MakeSell(2UL, 200));
+        Assert.True(check.Check(SellCtx(200)).Approved);
+    }
+
+    [Fact]
+    public void Sell_OpenSellsExceedAvailableInventory_Rejected()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        SubmitInto(orders, MakeSell(1UL, 300));
+        SubmitInto(orders, MakeSell(2UL, 201));
+        Assert.False(check.Check(SellCtx(201)).Approved);
+    }
+
+    [Fact]
+    public void Sell_OpenBuysDoNotCount_PessimisticProjection()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 100, 30m);
+        // A pending Buy of 1000 would, if it filled, give plenty of
+        // inventory. The check must not credit it — open Buys can be
+        // cancelled.
+        SubmitInto(orders, MakeBuy(99UL, 1000));
+        SubmitInto(orders, MakeSell(1UL, 200));
+        Assert.False(check.Check(SellCtx(200)).Approved);
+    }
+
+    [Fact]
+    public void Sell_TerminalSellsDoNotConsumeInventory()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        var oldSell = MakeSell(99UL, 500);
+        SubmitInto(orders, oldSell);
+        oldSell.MarkCancelled();
+        SubmitInto(orders, MakeSell(1UL, 500));
+        Assert.True(check.Check(SellCtx(500)).Approved);
+    }
+
+    [Fact]
+    public void Sell_PartiallyFilled_OnlyLeavesConsumeInventory()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        var partial = MakeSell(99UL, 400);
+        SubmitInto(orders, partial);
+        partial.ApplyFill(300); // 100 leaves
+        // PositionKeeper would have been updated by the fill, but the
+        // check reads the current net at evaluation time. Mirror that
+        // here: net long is now 200, leaves on the partial sell are 100.
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Sell, 300, 30m);
+        SubmitInto(orders, MakeSell(1UL, 100));
+        Assert.True(check.Check(SellCtx(100)).Approved);
+    }
+
+    [Fact]
+    public void Sell_OtherSymbolLeaves_DoNotConsumeThisSymbolInventory()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        SubmitInto(orders, MakeSell(99UL, 500, symbol: "VALE3"));
+        SubmitInto(orders, MakeSell(1UL, 500));
+        Assert.True(check.Check(SellCtx(500)).Approved);
+    }
+
+    [Fact]
+    public void Sell_OtherOwnerInventory_DoesNotCoverThisOwner()
+    {
+        var (check, positions, orders) = Build();
+        positions.ApplyFill(new EndClientId("bob"), DefaultSymbol, OrderSide.Buy, 1000, 30m);
+        SubmitInto(orders, MakeSell(1UL, 100, owner: DefaultOwner));
+        Assert.False(check.Check(SellCtx(100, owner: DefaultOwner)).Approved);
+    }
+
+    [Fact]
+    public void Sell_AllowShortSellPerEndClient_BypassesGate()
+    {
+        var opts = new RiskOptions
+        {
+            PerEndClient = { [DefaultOwner] = new RiskLimits { AllowShortSell = true } },
+        };
+        var (check, _, orders) = Build(opts);
+        SubmitInto(orders, MakeSell(1UL, 1000));
+        Assert.True(check.Check(SellCtx(1000)).Approved);
+    }
+
+    [Fact]
+    public void Sell_AllowShortSellPerFirm_BypassesGate()
+    {
+        var opts = new RiskOptions
+        {
+            PerFirm = { [DefaultFirm] = new RiskLimits { AllowShortSell = true } },
+        };
+        var (check, _, orders) = Build(opts);
+        SubmitInto(orders, MakeSell(1UL, 1000));
+        Assert.True(check.Check(SellCtx(1000)).Approved);
+    }
+
+    [Fact]
+    public void Sell_AllowShortSellExplicitlyFalse_Blocks()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowShortSell = false },
+        };
+        var (check, _, orders) = Build(opts);
+        SubmitInto(orders, MakeSell(1UL, 100));
+        Assert.False(check.Check(SellCtx(100)).Approved);
+    }
+
+    [Fact]
+    public void Order_SitsBetweenThrottleAndPositionLimit()
+    {
+        // Naked-short is more fundamental than the |net| cap, so it
+        // must run before PositionLimitCheck (Order=200) but after
+        // the throttle band (150..170) — sanity-check the constant
+        // here so future reorders trigger this test.
+        var (check, _, _) = Build();
+        Assert.True(check.Order > 170);
+        Assert.True(check.Order < 200);
+    }
+}

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -63,6 +63,17 @@ services:
       Trading__Risk__ReferencePrices__VALE3: "65.00"
       Trading__Risk__ReferencePrices__ITUB4: "30.00"
 
+      # The demo bots produce Buys and Sells uniformly to populate
+      # both sides of the book. With the naked-short gate enabled
+      # (the safe default for cash equities), Sells from accounts
+      # that haven't yet accumulated long inventory would be blocked
+      # and the demo would degenerate into Buy-only flow. Opt the
+      # demo bots out via per-end-client AllowShortSell so the demo
+      # keeps showing two-sided activity. Real participant accounts
+      # would not set this in production.
+      Trading__Risk__PerEndClient__bot-clientA__AllowShortSell: "true"
+      Trading__Risk__PerEndClient__bot-clientB__AllowShortSell: "true"
+
       # SecurityId mapping so POST /orders can resolve symbol → SecurityId
       # (the demo-driver leaves SecurityId=0 in the request payload — the
       # ResolveOwner path looks the symbol up in this directory). Same IDs

--- a/docker/docker-compose.real-conformance.yml
+++ b/docker/docker-compose.real-conformance.yml
@@ -20,3 +20,16 @@ services:
   conformance:
     environment:
       B3T_REAL_STACK_CONFORMANCE: "true"
+
+  # The ReferencePriceLiveSpec scenario crosses Buy+Sell from a single
+  # authenticated end-client (alice) so matching can print a trade and
+  # the live ref-price cache can be observed displacing the static
+  # fallback. With the NoNakedShortCheck gate enabled by default in
+  # the real overlay (protects ad-hoc dogfooding), alice's Sell would
+  # otherwise be risk-rejected before reaching matching ("current
+  # long=0, open sell leaves=100"). Opt alice out here, scoped to the
+  # conformance run only — the gate stays armed for every other user
+  # in this stack.
+  trading-host:
+    environment:
+      Trading__Risk__PerEndClient__alice__AllowShortSell: "true"


### PR DESCRIPTION
Closes #85.

## Why

B3 cash equities (mercado à vista) does not allow short-selling without a prior stock borrow. The platform had no gate enforcing this — the manual demo run produced `ITUB4 net=-900` from bots with no inventory. Existing pre-trade checks don't cover it: `PositionLimitCheck` only enforces `|net| ≤ limit` (sign-blind), and `ReserveOnSubmitMarginProvider` explicitly notes "short-sale collateral (future RFC)" as a TODO.

## What

A new `IRiskCheck` registered with `Order = 180` (between throttle band and `PositionLimitCheck`). Default behavior is **blocked** — opt out per firm / per-end-client via `RiskLimits.AllowShortSell`.

### Logic

For every Sell:

```
current_long  = PositionKeeper.Get(owner, symbol).NetQuantity
open_sell_lvs = WorkingOrderBook.SumOpenSellLeavesForSymbol(owner, symbol)
sellable      = current_long - open_sell_lvs
reject if sellable < 0
```

**Pessimism (intentional):**
- Open Buys are **not** credited (they may be cancelled).
- Incoming order is already in the book by the time risk runs (`OrderSubmissionService.TryAdd` → `Risk.Evaluate` ordering, see `OrderSubmissionService.cs:115` vs `:134`), so it's already counted in `open_sell_lvs`. The reject condition is therefore `sellable < 0`, not `incoming > sellable`.

### Wiring

- `WorkingOrderBook.SumOpenSellLeavesForSymbol(owner, symbol)` — new public method, index-driven via the existing `_byOwner` secondary index (O(orders for owner)).
- `RiskOptions.AllowShortSell` (`bool?`) + `RiskLimitsResolver.ResolveAll` entry. Standard precedence: `PerEndClient → PerFirm → PerSymbol → Default`.
- Registered in `Program.cs` alongside the other `IRiskCheck`s.

## Tests

15 new unit tests in `NoNakedShortCheckTests` covering:
- Buy always approved
- Long covers fully / off-by-one / cumulative open Sells consume inventory
- Pessimism: open Buys do **not** count
- Terminal (Cancelled / Filled / Rejected) Sells don't consume
- Partial fills: only `LeavesQuantity` consumes
- Cross-symbol isolation
- Cross-owner isolation
- Per-end-client / per-firm `AllowShortSell=true` opt-out
- Explicit `AllowShortSell=false` blocks
- Order-position guard (sits between throttle band and PositionLimit)

`MarginCheckIntegrationTests.SellsAndUnknownOwnersBypassMargin` was the only existing test affected — it intentionally Sells with zero inventory to verify the margin path. Updated its config to set `Trading:Risk:Default:AllowShortSell=true` since that test is scoped to margin behavior, not naked-short.

Full suite: 401/401 passing locally.

## Demo

`docker-compose.demo.yml` opts in `bot-clientA` and `bot-clientB` via:

```yaml
Trading__Risk__PerEndClient__bot-clientA__AllowShortSell: "true"
Trading__Risk__PerEndClient__bot-clientB__AllowShortSell: "true"
```

so the demo keeps generating two-sided book activity. Real participant accounts would **not** set this in production. Manual orders from `alice` (the default UI login) **will** now be blocked when she tries to Sell without inventory — that's the intended behavior.

## Out of scope (separate issues)

- Margin / collateral on covered shorts (with active borrow)
- Real BTC registry integration / `IInventoryProvider` plug-in point
- Margin call / liquidation
