### PR TITLE
feat(frontend): trader-ui ergonomics — DOB next to ticket, MD config in popover

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -106,14 +106,13 @@ body {
 .grid {
   flex: 1;
   display: grid;
-  grid-template-columns: 280px 1fr 240px;
+  grid-template-columns: 1fr 280px 280px;
+  grid-template-rows: minmax(260px, 1.4fr) minmax(180px, 1fr) auto minmax(140px, .8fr);
   grid-template-areas:
-    "ticket  blotter   positions"
-    "ticket  blotter   positions"
-    "md      execs     positions"
-    "dob     dob       positions"
-    "chart   chart     positions"
-    "tape    tape      positions";
+    "chart    dob      ticket"
+    "tape     dob      positions"
+    "blotter  blotter  blotter"
+    "execs    execs    md";
   gap: 8px; padding: 8px; min-height: 0;
 }
 .panel {
@@ -254,43 +253,49 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 /* ---------- Responsive ---------- */
 @media (max-width: 1280px) {
   .grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 280px;
+    grid-template-rows: minmax(240px, 1fr) minmax(180px, 1fr) auto auto minmax(140px, .8fr);
     grid-template-areas:
+      "chart     dob"
+      "tape      dob"
       "ticket    positions"
       "blotter   blotter"
-      "execs     md"
-      "dob       dob"
-      "chart     chart"
-      "tape      tape";
+      "execs     md";
   }
 }
 @media (max-width: 720px) {
   .grid {
     grid-template-columns: 1fr;
+    grid-template-rows: none;
     grid-template-areas:
       "ticket"
+      "dob"
+      "chart"
+      "tape"
       "positions"
       "blotter"
       "execs"
-      "md"
-      "dob"
-      "chart"
-      "tape";
+      "md";
   }
 }
 
 /* ---------- Market data panel ---------- */
-.md-form { display: flex; flex-direction: column; gap: .5rem; margin-bottom: .8rem; }
-.md-form label { display: grid; gap: .2rem; font-size: .75rem; color: var(--muted); }
-.md-form input {
+.market-data h2 {
+  display: flex; align-items: center; justify-content: space-between; gap: .55rem;
+}
+.market-data h2 .md-title { display: inline-flex; align-items: center; gap: .55rem; }
+.icon-button {
+  background: transparent; border: 1px solid var(--border); color: var(--muted);
+  border-radius: 4px; padding: .05rem .4rem; cursor: pointer; font: inherit;
+  font-size: .9rem; line-height: 1;
+}
+.icon-button:hover { color: var(--text); border-color: var(--accent); }
+.md-settings-card { width: min(420px, 90vw); gap: .8rem; }
+.md-settings-card label { display: grid; gap: .2rem; font-size: .75rem; color: var(--muted); }
+.md-settings-card input {
   background: var(--bg); color: var(--text); border: 1px solid var(--border);
-  border-radius: 4px; padding: .35rem .5rem; font: inherit;
+  border-radius: 4px; padding: .4rem .55rem; font: inherit;
 }
-.md-form button {
-  background: var(--accent); color: #fff; border: 0; border-radius: 4px;
-  padding: .35rem .8rem; font-weight: 600; cursor: pointer; align-self: flex-start;
-}
-.market-data h2 { display: flex; align-items: center; gap: .55rem; }
 
 /* ---------- Operability badges (added in frontend hardening pass) ---------- */
 .reconnect-countdown {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -153,21 +153,12 @@
       <!-- MARKET DATA ----------------------------------------------- -->
       <section class="panel market-data">
         <h2>
-          Market data
-          <span id="md-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Market data: disconnected" title="MarketData WebSocket connection">disconnected</span>
+          <span class="md-title">
+            Market data
+            <span id="md-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Market data: disconnected" title="MarketData WebSocket connection">disconnected</span>
+          </span>
+          <button type="button" id="md-settings-open" class="icon-button" aria-label="Market data settings" title="Market data settings">⚙</button>
         </h2>
-        <form id="md-form" class="md-form">
-          <label>
-            <span>WS URL</span>
-            <input id="md-url" type="url" placeholder="ws://localhost:8081/ws" />
-          </label>
-          <label>
-            <span>Watchlist (comma-separated)</span>
-            <input id="md-symbols" type="text" placeholder="PETR4,VALE3" />
-          </label>
-          <button type="submit" id="md-apply">Apply</button>
-          <p id="md-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
-        </form>
         <div class="table-scroll">
           <table id="md-table">
             <thead>
@@ -295,6 +286,26 @@
       <pre id="admin-eod-output" class="admin-eod-output" hidden></pre>
     </section>
   </section>
+
+  <!-- MARKET DATA SETTINGS POPOVER ------------------------------------ -->
+  <div id="md-settings-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="md-settings-title">
+    <form id="md-form" class="modal-card md-settings-card">
+      <h2 id="md-settings-title">Market data settings</h2>
+      <label>
+        <span>WS URL</span>
+        <input id="md-url" type="url" placeholder="ws://localhost:8081/ws" />
+      </label>
+      <label>
+        <span>Watchlist (comma-separated)</span>
+        <input id="md-symbols" type="text" placeholder="PETR4,VALE3" />
+      </label>
+      <p id="md-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
+      <div class="modal-actions">
+        <button type="button" id="md-settings-close" class="link-button">Close</button>
+        <button type="submit" id="md-apply">Apply</button>
+      </div>
+    </form>
+  </div>
 
   <!-- SESSION-EXPIRY MODAL -------------------------------------------- -->
   <div id="session-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="session-modal-title">

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -188,6 +188,26 @@ export function bindUi() {
     onApplyMd({ url, symbols });
   });
 
+  // Market data settings popover (⚙ button in MD panel header).
+  const mdModal = $("md-settings-modal");
+  const mdOpen = $("md-settings-open");
+  const mdClose = $("md-settings-close");
+  if (mdOpen && mdModal) {
+    mdOpen.addEventListener("click", () => {
+      mdModal.hidden = false;
+      const urlInput = $("md-url");
+      if (urlInput) urlInput.focus();
+    });
+  }
+  if (mdClose && mdModal) {
+    mdClose.addEventListener("click", () => { mdModal.hidden = true; });
+  }
+  if (mdModal) {
+    mdModal.addEventListener("click", (e) => {
+      if (e.target === mdModal) mdModal.hidden = true;
+    });
+  }
+
   // Global symbol selector (drives DOB / chart / tape).
   const symSelect = $("selected-symbol");
   if (symSelect) {


### PR DESCRIPTION
## Summary

Trader-UI ergonomics pass focused on **box placement** + the **MD config panel necessity**.

### Old layout
```
ticket   blotter    positions
ticket   blotter    positions
md       execs      positions   ← MD form occupies prime real estate
dob      dob        positions   ← DOB / chart / tape below the fold
chart    chart      positions
tape     tape       positions
```

### New layout (≥1280px)
```
chart    dob   ticket
tape     dob   positions
blotter  blotter  blotter
execs    execs    md
```

- **DOB grudado no ticket** (right column) — quem mira preço pelo book agora lê e age na mesma região visual.
- **Chart + tape à esquerda** dão contexto de preço sem competir.
- **Positions** sai da coluna full-height (era desproporcional pra 3-5 linhas).
- **Blotter** ocupa largura total — fica scaneável como blotter de fato.
- **Execs + MD-table** descem pro rodapé (informação histórica, importância secundária).

### MD config form
Saiu do painel central e virou popover (`modal-backdrop`) acionado por um **⚙** ao lado do status pill de Market data. Razão: `defaultMarketDataUrl()` já preenche em demo/real-stack — o form era tocado uma vez por sessão e ocupava célula nobre permanentemente.

- Click fora do popover ou no botão **Close** = dismiss (não destrutivo).
- IDs do form (`md-form`, `md-url`, `md-symbols`, `md-apply`, `md-feedback`) preservados — controller intocado.

### Out of scope (PRs futuros)
- **Click-to-prefill** do nível do DOB no ticket (acordado no chat: PR próprio).
- Outras melhorias do report de ergonomics (cancel-confirm, fat-finger debounce, top-bar symbol → ticket prefill, stale-data marking on WS disconnect, modal backdrop click logout review, ⚡ quick wins).

### Tests
- `node --check` em todos os JS — clean.
- 78/78 frontend node tests passam (decoder + state-book + state-tape + state-candle).
- Nenhum seletor de teste mudou.

Closes none (informal request, sem issue).
