### PR TITLE
feat(frontend): trader UI quick wins (PR A)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -50,6 +50,11 @@ body {
   font-weight: 600; cursor: pointer; font: inherit;
 }
 .login-card button:hover { filter: brightness(1.1); }
+.login-card button[disabled] { opacity: .6; cursor: not-allowed; filter: none; }
+.login-advanced { font-size: .75rem; color: var(--muted); }
+.login-advanced summary { cursor: pointer; padding: .15rem 0; user-select: none; }
+.login-advanced summary:hover { color: var(--text); }
+.login-advanced > .row { margin-top: .5rem; }
 .error { color: var(--red); font-size: .85rem; margin: 0; }
 
 /* ---------- Trader shell ---------- */
@@ -229,6 +234,8 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
   padding: .15rem .5rem; border-radius: 3px; cursor: pointer; font: inherit; font-size: .75rem;
 }
 .cancel-btn:disabled { opacity: .35; cursor: not-allowed; }
+.cancel-btn.cancelling { opacity: .55; cursor: progress; }
+.md-cell-stale { color: var(--warn); }
 .status-cell-Working   { color: var(--green); }
 .status-cell-PendingNew { color: var(--warn); }
 .status-cell-Cancelled { color: var(--gray); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,16 +20,19 @@
         <span>Password</span>
         <input id="login-password" type="password" autocomplete="current-password" required />
       </label>
-      <label class="row">
-        <span>Backend</span>
-        <input id="login-backend" type="url" placeholder="http://localhost:5000" />
-      </label>
       <label class="row remember">
         <input id="login-remember" type="checkbox" />
         <span>Remember me on this device</span>
       </label>
+      <details class="login-advanced">
+        <summary>Advanced</summary>
+        <label class="row">
+          <span>Backend</span>
+          <input id="login-backend" type="url" placeholder="http://localhost:5000" />
+        </label>
+      </details>
       <button type="submit" id="login-submit">Sign in</button>
-      <p id="login-error" class="error" hidden></p>
+      <p id="login-error" class="error" role="alert" hidden></p>
     </form>
   </section>
 
@@ -50,7 +53,7 @@
         </label>
         <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
         <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
-        <span id="ws-reconnect" class="reconnect-countdown" role="status" aria-live="polite" hidden></span>
+        <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
         <span id="user-label" class="user-label"></span>
         <span id="user-role" class="role-badge" hidden></span>
         <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
@@ -64,7 +67,8 @@
         <form id="ticket-form" class="ticket-form">
           <label>
             <span>Symbol</span>
-            <input id="ticket-symbol" type="text" required maxlength="12" />
+            <input id="ticket-symbol" type="text" required maxlength="12" list="watchlist-symbols" title="Focus (F2)" />
+            <datalist id="watchlist-symbols"></datalist>
           </label>
           <div class="row-two">
             <label>
@@ -85,7 +89,7 @@
           <div class="row-two">
             <label>
               <span>Quantity</span>
-              <input id="ticket-qty" type="number" min="1" step="1" required />
+              <input id="ticket-qty" type="number" min="100" step="100" required />
             </label>
             <label>
               <span>Price</span>
@@ -93,7 +97,7 @@
             </label>
           </div>
           <button type="submit" id="ticket-submit">Submit</button>
-          <p id="ticket-inflight" class="inflight" role="status" aria-live="polite" hidden></p>
+          <p id="ticket-inflight" class="inflight" hidden></p>
           <p id="ticket-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
         </form>
       </section>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -111,6 +111,7 @@ async function onLogin(e) {
   const username = document.getElementById("login-username").value.trim();
   const password = document.getElementById("login-password").value;
   const remember = !!document.getElementById("login-remember")?.checked;
+  ui.setLoginSubmitting(true);
   try {
     const resp = await login(backend, username, password);
     const claims = claimsFromToken(resp.token);
@@ -128,6 +129,8 @@ async function onLogin(e) {
     startSession(next);
   } catch (err) {
     ui.setLoginError(err.message || "Login failed");
+  } finally {
+    ui.setLoginSubmitting(false);
   }
 }
 
@@ -328,12 +331,28 @@ function handleApplyMd({ url, symbols }) {
 // symbol (server allocates fresh securityIds per flag set), which would
 // briefly blank market-data and trade-tape — not worth it.
 let mbpEnabled = false;
+let lastAutoFilledTicketSymbol = null;
+let _successToastTimer = null;
 
 function handleSelectSymbol(symbol) {
   // Single global selector drives DOB, chart and tape. As soon as the
   // user picks anything we promote the MD subscription to MBP so the
   // book panel can render depth (the default is TRADES|INFO only).
   state.setSelectedSymbol(symbol || null);
+  // Auto-fill the ticket-symbol input when it's empty or still tracking
+  // a previously auto-filled symbol. We never clobber a value the trader
+  // is actively editing for a different name — wrong-symbol orders are
+  // the worst class of mistake we can prevent here.
+  if (symbol) {
+    const sym = document.getElementById("ticket-symbol");
+    if (sym) {
+      const cur = (sym.value || "").trim().toUpperCase();
+      if (!cur || cur === lastAutoFilledTicketSymbol) {
+        sym.value = symbol;
+        lastAutoFilledTicketSymbol = symbol;
+      }
+    }
+  }
   if (!symbol || !mdWorker || mbpEnabled) return;
   const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
   mdWorker.postMessage({ type: "setFlags", flags });
@@ -404,15 +423,23 @@ async function handleSubmitOrder(payload) {
   // Fat-finger guard: first attempt with a >threshold deviation from
   // the last observed trade is rejected with a warning; the same exact
   // payload submitted again within the pending window goes through.
+  // We TTL the pending guard at 15s so a trader who walks away and
+  // returns later doesn't have an old "armed" override silently apply
+  // to a fresh ticket.
+  const FAT_FINGER_TTL_MS = 15_000;
   const lastPrice = state.getState().marketData.get(payload.symbol)?.lastPrice;
   const ff = fatFingerCheck(payload, lastPrice);
   const key = payloadKey(payload);
-  const pending = state.getState().pendingFatFinger;
+  let pending = state.getState().pendingFatFinger;
+  if (pending && pending.setAt && (Date.now() - pending.setAt) > FAT_FINGER_TTL_MS) {
+    state.setPendingFatFinger(null);
+    pending = null;
+  }
   if (ff && (!pending || pending.key !== key)) {
     state.setPendingFatFinger(payload, key);
     const pct = (ff.deviation * 100).toFixed(1);
     ui.setTicketFeedback(
-      `fat-finger guard: price deviates ${pct}% from last trade ${ff.lastPrice}. Click Submit again to override.`,
+      `fat-finger guard: price deviates ${pct}% from last trade ${ui.fmtPx(ff.lastPrice)}. Click Submit again to override.`,
       "warn",
     );
     return;
@@ -425,8 +452,16 @@ async function handleSubmitOrder(payload) {
   state.setSubmitInflight({ startedAt: Date.now() });
   try {
     const resp = await submitOrder(session.backend, session.token, payload);
-    ui.setTicketFeedback(`accepted: ${resp.clOrdId}${resp.status ? ` (${resp.status})` : ""}`, "ok");
+    const msg = `accepted: ${resp.clOrdId}${resp.status ? ` (${resp.status})` : ""}`;
+    ui.setTicketFeedback(msg, "ok");
     ui.clearTicket();
+    // Auto-dismiss the success toast after 5s, but only if the message
+    // hasn't been replaced (e.g. by a later submit's warning/error).
+    if (_successToastTimer) clearTimeout(_successToastTimer);
+    _successToastTimer = setTimeout(() => {
+      _successToastTimer = null;
+      ui.setTicketFeedbackIfMatches(msg, null);
+    }, 5000);
   } catch (err) {
     if (err.status === 401) { logout(); return; }
     ui.setTicketFeedback(err.message || "submit failed", "error");
@@ -438,11 +473,24 @@ async function handleSubmitOrder(payload) {
 
 async function handleCancelOrder(clOrdId) {
   if (!session) return;
+  const st = state.getState();
+  // Don't prompt twice / send duplicate DELETEs while one is in flight,
+  // and skip orders that already finished or have a cancel acked.
+  if (st.inflightCancels && st.inflightCancels.has(clOrdId)) return;
+  const order = st.orders.get(clOrdId);
+  if (order && ["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(order.status)) return;
+  // Both the mouse (blotter Cancel button) and the keyboard (Del)
+  // routes funnel through here; confirmation is centralised so the two
+  // paths can't drift in safety.
+  if (!window.confirm(`Cancel order ${clOrdId}?`)) return;
+  state.markCancelInflight(clOrdId, true);
   try {
     await cancelOrder(session.backend, session.token, clOrdId);
   } catch (err) {
     if (err.status === 401) { logout(); return; }
     ui.setTicketFeedback(`cancel failed: ${err.message}`, "error");
+  } finally {
+    state.markCancelInflight(clOrdId, false);
   }
 }
 
@@ -470,7 +518,8 @@ function handleKeyboardCancel() {
   if (!id) return;
   const order = state.getState().orders.get(id);
   if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) return;
-  if (!window.confirm(`Cancel order ${id}?`)) return;
+  // Confirmation lives inside handleCancelOrder so mouse and keyboard
+  // routes share the same safety prompt.
   handleCancelOrder(id);
 }
 

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -64,7 +64,16 @@ const state = {
   blotterPage: 1,
   ordersHighlight: new Map(),              // ClOrdID -> Date.now() of last delta
   selectedClOrdId: null,                   // currently selected blotter row (for keyboard cancel)
-  pendingFatFinger: null,                  // { payload, key } — set when a submit needs override
+  pendingFatFinger: null,                  // { payload, key, setAt } — set when a submit needs override
+  // Per-ClOrdID set of cancels currently in flight (DELETE issued, no
+  // server ack yet). Used to disable the row's Cancel button so the
+  // trader gets immediate visual feedback and can't fire repeat DELETEs.
+  inflightCancels: new Set(),
+  // Wall-clock when the active selectedSymbol was set. The DOB renderer
+  // uses this to decide when to upgrade the "awaiting book snapshot…"
+  // placeholder to a louder "no book — check MD settings ⚙" warning
+  // (after ~10s without a snapshot).
+  selectedSymbolSetAt: 0,
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -145,6 +154,7 @@ export function clearAll() {
   state.blotterPage = 1;
   state.selectedClOrdId = null;
   state.pendingFatFinger = null;
+  state.inflightCancels.clear();
   notify("all");
 }
 
@@ -316,6 +326,7 @@ export function setSelectedSymbol(symbol) {
   const next = symbol == null || symbol === "" ? null : symbol;
   if (state.selectedSymbol === next) return;
   state.selectedSymbol = next;
+  state.selectedSymbolSetAt = next ? Date.now() : 0;
   notify("selectedSymbol");
 }
 
@@ -489,10 +500,12 @@ export function setWatchlist(symbols) {
   // sit empty when symbols exist. tapeShowAll is preserved.
   if (state.selectedSymbol && !wanted.has(state.selectedSymbol)) {
     state.selectedSymbol = null;
+    state.selectedSymbolSetAt = 0;
     notify("selectedSymbol");
   }
   if (state.selectedSymbol === null && next.length > 0) {
     state.selectedSymbol = next[0];
+    state.selectedSymbolSetAt = Date.now();
     notify("selectedSymbol");
   }
   notify("watchlist");
@@ -564,6 +577,18 @@ export function setSelectedOrder(clOrdId) {
 }
 
 export function setPendingFatFinger(payload, key) {
-  state.pendingFatFinger = payload ? { payload, key } : null;
+  state.pendingFatFinger = payload ? { payload, key, setAt: Date.now() } : null;
   notify("pendingFatFinger");
+}
+
+// In-flight cancel tracking. The blotter Cancel button calls
+// markCancelInflight(clOrdId, true) immediately on click so the row
+// renders disabled; once the server ER lands (or the cancel errors)
+// the caller toggles it back. Re-entrant safe — Set semantics.
+export function markCancelInflight(clOrdId, inflight) {
+  if (!clOrdId) return;
+  const before = state.inflightCancels.has(clOrdId);
+  if (inflight) state.inflightCancels.add(clOrdId);
+  else state.inflightCancels.delete(clOrdId);
+  if (before !== inflight) notify("orders");
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -7,6 +7,23 @@ import {
 
 const $ = (id) => document.getElementById(id);
 
+// ── Number formatting (pt-BR) ──────────────────────────────────────
+// B3 traders expect Brazilian locale (`100.000,00`) for quantities,
+// prices and notionals. Centralised here so every panel stays in sync
+// and we have a single place to flip the locale if the product call
+// changes later.
+const _qtyFmt = new Intl.NumberFormat("pt-BR", { maximumFractionDigits: 0 });
+const _pxFmt  = new Intl.NumberFormat("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+function fmtQty(n) {
+  if (n == null || n === "" || Number.isNaN(Number(n))) return "—";
+  return _qtyFmt.format(Number(n));
+}
+function fmtPx(n) {
+  if (n == null || n === "" || Number.isNaN(Number(n))) return "—";
+  return _pxFmt.format(Number(n));
+}
+export { fmtQty, fmtPx };
+
 let onSubmitOrder = () => {};
 let onCancelOrder = () => {};
 let onLogout      = () => {};
@@ -64,10 +81,18 @@ export function setLoginError(message) {
   el.hidden = false; el.textContent = message;
 }
 
+export function setLoginSubmitting(submitting) {
+  const btn = $("login-submit");
+  if (!btn) return;
+  btn.disabled = !!submitting;
+  btn.textContent = submitting ? "Signing in…" : "Sign in";
+}
+
 // ── Session-expiry modal ───────────────────────────────────────────
 let sessionModalSubmit = null;
 let sessionModalLogout = null;
 let sessionModalBackdrop = null;
+let sessionModalKey = null;
 
 export function openSessionModal({ onRenew, onLogout }) {
   const modal = $("session-modal");
@@ -82,6 +107,7 @@ export function openSessionModal({ onRenew, onLogout }) {
   if (sessionModalSubmit) form.removeEventListener("submit", sessionModalSubmit);
   if (sessionModalLogout) logoutBtn?.removeEventListener("click", sessionModalLogout);
   if (sessionModalBackdrop) modal.removeEventListener("click", sessionModalBackdrop);
+  if (sessionModalKey) document.removeEventListener("keydown", sessionModalKey);
   sessionModalSubmit = (e) => {
     e.preventDefault();
     const value = pwd.value;
@@ -96,9 +122,17 @@ export function openSessionModal({ onRenew, onLogout }) {
   sessionModalBackdrop = (e) => {
     if (e.target === modal) onLogout?.();
   };
+  // Esc on the session modal = logout (consistent with backdrop click).
+  sessionModalKey = (e) => {
+    if (e.key === "Escape" && !modal.hidden) {
+      e.preventDefault();
+      onLogout?.();
+    }
+  };
   form.addEventListener("submit", sessionModalSubmit);
   logoutBtn?.addEventListener("click", sessionModalLogout);
   modal.addEventListener("click", sessionModalBackdrop);
+  document.addEventListener("keydown", sessionModalKey);
   // Defer focus to the next frame so backdrop transitions don't steal it.
   requestAnimationFrame(() => pwd.focus());
 }
@@ -110,6 +144,10 @@ export function closeSessionModal() {
   setSessionModalError(null);
   const pwd = $("session-modal-password");
   if (pwd) pwd.value = "";
+  if (sessionModalKey) {
+    document.removeEventListener("keydown", sessionModalKey);
+    sessionModalKey = null;
+  }
 }
 
 export function setSessionModalError(message) {
@@ -143,6 +181,26 @@ export function bindUi() {
     };
     onSubmitOrder(payload);
   });
+
+  // Auto-uppercase the symbol field as the trader types so the visual
+  // matches what we actually submit (we already toUpperCase on submit).
+  const symEl = $("ticket-symbol");
+  if (symEl) {
+    symEl.addEventListener("input", (e) => {
+      // Don't fight IME composition; uppercase on compositionend instead.
+      if (e.isComposing) return;
+      const pos = e.target.selectionStart;
+      const upper = e.target.value.toUpperCase();
+      if (e.target.value !== upper) {
+        e.target.value = upper;
+        try { e.target.setSelectionRange(pos, pos); } catch {}
+      }
+    });
+    symEl.addEventListener("compositionend", (e) => {
+      const upper = e.target.value.toUpperCase();
+      if (e.target.value !== upper) e.target.value = upper;
+    });
+  }
 
   $("logout").addEventListener("click", () => onLogout());
 
@@ -206,6 +264,13 @@ export function bindUi() {
     mdModal.addEventListener("click", (e) => {
       if (e.target === mdModal) mdModal.hidden = true;
     });
+    // Esc closes the popover (non-destructive — no logout).
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !mdModal.hidden) {
+        e.preventDefault();
+        mdModal.hidden = true;
+      }
+    });
   }
 
   // Global symbol selector (drives DOB / chart / tape).
@@ -263,7 +328,8 @@ export function bindUi() {
   //   Esc → clear the ticket form (when focus is inside it)
   //   Del → cancel the currently-selected blotter row
   // We deliberately ignore key events when the user is typing into a
-  // text input to avoid stealing keystrokes.
+  // text input to avoid stealing keystrokes. Backspace is intentionally
+  // NOT a cancel shortcut — too easy to fire accidentally.
   document.addEventListener("keydown", onGlobalKeydown);
 
   subscribe(renderForSlice);
@@ -293,7 +359,7 @@ function onGlobalKeydown(e) {
     }
     return;
   }
-  if ((e.key === "Delete" || e.key === "Backspace") && !inEditable) {
+  if (e.key === "Delete" && !inEditable) {
     if (!getState().selectedClOrdId) return;
     e.preventDefault();
     onKeyboardCancel();
@@ -322,6 +388,16 @@ export function setTicketFeedback(message, kind) {
   el.className = `feedback ${cls}`;
 }
 
+// Clear the ticket feedback only if it still shows `expected`. Used by
+// the success-toast auto-dismiss so a later warning/error message that
+// landed before the timer fires isn't accidentally erased.
+export function setTicketFeedbackIfMatches(expected, replacement) {
+  const el = $("ticket-feedback");
+  if (!el || el.hidden) return;
+  if (el.textContent !== expected) return;
+  setTicketFeedback(replacement, null);
+}
+
 export function setTicketSubmitting(submitting) {
   $("ticket-submit").disabled = !!submitting;
   $("ticket-submit").textContent = submitting ? "Submitting…" : "Submit";
@@ -341,7 +417,14 @@ export function setStatusPill(status) {
 }
 
 export function setUserLabel(user) {
-  $("user-label").textContent = user ? `${user.username}` : "";
+  const el = $("user-label");
+  if (el) {
+    if (user?.username) {
+      el.textContent = user.firm ? `${user.username} @ ${user.firm}` : user.username;
+    } else {
+      el.textContent = "";
+    }
+  }
   const roleEl = $("user-role");
   if (roleEl) {
     if (user?.role && user.role !== "user") {
@@ -372,14 +455,26 @@ function applyCurrentView(view) {
 }
 
 // Periodic UI tick for time-based elements (in-flight elapsed, reconnect
-// countdown). Started lazily on first render so SSR / non-browser hosts
-// stay quiet.
+// countdown, market-data staleness, DOB "no book" promotion). Started
+// lazily on first render so SSR / non-browser hosts stay quiet.
 let tickTimer = null;
+let lastSlowTick = 0;
 function ensureTicker() {
   if (tickTimer) return;
   tickTimer = setInterval(() => {
     renderInflight();
     renderReconnect();
+    // Slow tick (1s) for time-driven re-renders that don't need 4 Hz.
+    const now = Date.now();
+    if (now - lastSlowTick >= 1000) {
+      lastSlowTick = now;
+      renderMarketData();
+      // Only re-render the DOB while we're still waiting for a snapshot
+      // — the live render path is already wired to the book slice.
+      const st = getState();
+      const entry = st.selectedSymbol ? st.book.get(st.selectedSymbol) : null;
+      if (st.selectedSymbol && (!entry || !entry.ready)) renderDob();
+    }
   }, 250);
 }
 
@@ -477,6 +572,8 @@ function setMdStatusPill(status) {
   el.setAttribute("aria-label", `Market data: ${status}`);
 }
 
+const MD_STALE_MS = 5_000;
+
 function renderMarketData() {
   const body = $("md-body");
   if (!body) return;
@@ -489,56 +586,27 @@ function renderMarketData() {
     body.innerHTML = `<tr><td colspan="5" class="muted">No subscriptions</td></tr>`;
     return;
   }
+  const now = Date.now();
   body.innerHTML = rows.map(symbol => {
     const e = md.get(symbol);
     if (!e || e.lastPrice == null) {
       return `<tr><td>${escapeHtml(symbol)}</td><td colspan="4" class="muted-cell">awaiting data…</td></tr>`;
     }
     const ts = e.updatedAt ? new Date(e.updatedAt).toISOString().slice(11, 19) : "—";
+    const stale = e.updatedAt && (now - e.updatedAt) > MD_STALE_MS;
+    const tsCls = stale ? ' class="md-cell-stale"' : "";
     return `<tr>
       <td>${escapeHtml(symbol)}</td>
-      <td class="num">${Number(e.lastPrice).toFixed(2)}</td>
-      <td class="num">${e.lastQty ?? "—"}</td>
+      <td class="num">${fmtPx(e.lastPrice)}</td>
+      <td class="num">${fmtQty(e.lastQty)}</td>
       <td class="num">${e.lastTradeId ?? "—"}</td>
-      <td>${ts}</td>
+      <td${tsCls}>${ts}</td>
     </tr>`;
   }).join("");
 }
 
 const DOB_TOP_N = 10;
-
-function renderSelectedSymbol() {
-  const sel = $("selected-symbol");
-  if (!sel) return;
-  const st = getState();
-  const watch = st.watchlist;
-  const desired = ["", ...watch];
-  const existing = [...sel.options].map(o => o.value);
-  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
-    sel.innerHTML = `<option value="">— select —</option>` +
-      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
-  }
-  if (sel.value !== (st.selectedSymbol ?? "")) sel.value = st.selectedSymbol ?? "";
-
-  // Mirror the active symbol on each panel header tag.
-  for (const id of ["dob-symbol-tag", "chart-symbol-tag", "tape-symbol-tag"]) {
-    const tag = $(id);
-    if (!tag) continue;
-    if (id === "tape-symbol-tag" && st.tapeShowAll) {
-      tag.textContent = "all";
-      tag.classList.add("symbol-tag--muted");
-    } else {
-      tag.textContent = st.selectedSymbol ?? "—";
-      tag.classList.toggle("symbol-tag--muted", !st.selectedSymbol);
-    }
-  }
-
-  // Keep the tape "All symbols" checkbox in sync with state.
-  const tapeAll = $("tape-show-all");
-  if (tapeAll && tapeAll.checked !== !!st.tapeShowAll) {
-    tapeAll.checked = !!st.tapeShowAll;
-  }
-}
+const DOB_NO_BOOK_AFTER_MS = 10_000;
 
 function renderDob() {
   const bidsBody = document.querySelector("#dob-bids tbody");
@@ -558,8 +626,15 @@ function renderDob() {
 
   const entry = st.book.get(current);
   if (!entry || !entry.ready) {
-    bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">awaiting book snapshot…</td></tr>`;
-    asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">awaiting book snapshot…</td></tr>`;
+    // After ~10s without a snapshot, swap the soft "awaiting…" copy for
+    // a louder hint that something is wrong with the MD subscription
+    // (most commonly: MBP not enabled or the URL is mistyped).
+    const waited = st.selectedSymbolSetAt ? Date.now() - st.selectedSymbolSetAt : 0;
+    const msg = waited > DOB_NO_BOOK_AFTER_MS
+      ? "no book — check MD settings ⚙"
+      : "awaiting book snapshot…";
+    bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">${msg}</td></tr>`;
+    asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">${msg}</td></tr>`;
     if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
     return;
   }
@@ -585,13 +660,55 @@ function renderDobSide(levels, side) {
   let cum = 0;
   return levels.map(lv => {
     cum += Number(lv.qty) || 0;
-    const price = lv.price.toFixed(2);
-    const qty = lv.qty;
+    const price = fmtPx(lv.price);
+    const qty = fmtQty(lv.qty);
+    const cumS = fmtQty(cum);
     if (side === "bid") {
-      return `<tr><td class="num">${cum}</td><td class="num">${qty}</td><td class="num">${price}</td></tr>`;
+      return `<tr><td class="num">${cumS}</td><td class="num">${qty}</td><td class="num">${price}</td></tr>`;
     }
-    return `<tr><td class="num">${price}</td><td class="num">${qty}</td><td class="num">${cum}</td></tr>`;
+    return `<tr><td class="num">${price}</td><td class="num">${qty}</td><td class="num">${cumS}</td></tr>`;
   }).join("");
+}
+
+function renderSelectedSymbol() {
+  const sel = $("selected-symbol");
+  if (!sel) return;
+  const st = getState();
+  const watch = st.watchlist;
+  const desired = ["", ...watch];
+  const existing = [...sel.options].map(o => o.value);
+  if (desired.length !== existing.length || desired.some((v, i) => v !== existing[i])) {
+    sel.innerHTML = `<option value="">— select —</option>` +
+      watch.map(s => `<option value="${escapeHtml(s)}">${escapeHtml(s)}</option>`).join("");
+  }
+  if (sel.value !== (st.selectedSymbol ?? "")) sel.value = st.selectedSymbol ?? "";
+
+  // Sync the ticket-symbol <datalist> from the watchlist so the trader
+  // gets autocomplete for tickers they're already subscribed to.
+  const dl = $("watchlist-symbols");
+  if (dl) {
+    const want = watch.map(s => `<option value="${escapeHtml(s)}"></option>`).join("");
+    if (dl.innerHTML !== want) dl.innerHTML = want;
+  }
+
+  // Mirror the active symbol on each panel header tag.
+  for (const id of ["dob-symbol-tag", "chart-symbol-tag", "tape-symbol-tag"]) {
+    const tag = $(id);
+    if (!tag) continue;
+    if (id === "tape-symbol-tag" && st.tapeShowAll) {
+      tag.textContent = "all";
+      tag.classList.add("symbol-tag--muted");
+    } else {
+      tag.textContent = st.selectedSymbol ?? "—";
+      tag.classList.toggle("symbol-tag--muted", !st.selectedSymbol);
+    }
+  }
+
+  // Keep the tape "All symbols" checkbox in sync with state.
+  const tapeAll = $("tape-show-all");
+  if (tapeAll && tapeAll.checked !== !!st.tapeShowAll) {
+    tapeAll.checked = !!st.tapeShowAll;
+  }
 }
 
 // ── Chart panel (T3) ──────────────────────────────────────────────
@@ -739,13 +856,15 @@ function renderTape() {
 
 function tapeRow(e) {
   const cls = `tape-${e.side}` + (e.busted ? " tape-busted" : "");
-  const ts = new Date(e.receivedAt).toISOString().slice(11, 19);
+  // Include milliseconds (slice 11..23) so two prints in the same
+  // second can still be ordered visually.
+  const ts = new Date(e.receivedAt).toISOString().slice(11, 23);
   const arrow = e.side === "up" ? "▲" : e.side === "down" ? "▼" : "·";
   return `<li class="${cls}">`
     + `<span>${ts}</span>`
     + `<span>${escapeHtml(e.symbol)}</span>`
-    + `<span class="tape-num">${arrow} ${Number(e.price).toFixed(2)}</span>`
-    + `<span class="tape-num">${e.qty}</span>`
+    + `<span class="tape-num">${arrow} ${fmtPx(e.price)}</span>`
+    + `<span class="tape-num">${fmtQty(e.qty)}</span>`
     + `<span class="tape-num">#${e.tradeId}</span>`
     + `</li>`;
 }
@@ -800,22 +919,26 @@ const HIGHLIGHT_MS = 2000;
 
 function orderRow(o, st) {
   const terminal = isTerminalOrderStatus(o.status);
-  const price = o.price == null ? "—" : Number(o.price).toFixed(2);
+  const cancelInflight = st.inflightCancels?.has(o.clOrdId);
+  const price = o.price == null ? "—" : fmtPx(o.price);
   const highlightAt = st.ordersHighlight?.get(o.clOrdId);
   const fresh = highlightAt && (Date.now() - highlightAt) < HIGHLIGHT_MS;
   const selected = st.selectedClOrdId === o.clOrdId;
   const cls = [fresh ? "row-fresh" : "", selected ? "row-selected" : ""].filter(Boolean).join(" ");
+  const cancelDisabled = terminal || cancelInflight;
+  const cancelLabel = cancelInflight ? "Cancelling…" : "Cancel";
+  const cancelCls = "cancel-btn" + (cancelInflight ? " cancelling" : "");
   return `<tr data-clordid="${escapeHtml(o.clOrdId)}"${cls ? ` class="${cls}"` : ""}>
     <td><code>${escapeHtml(o.clOrdId)}</code></td>
     <td>${escapeHtml(o.symbol)}</td>
     <td>${escapeHtml(o.side)}</td>
     <td>${escapeHtml(o.type)}</td>
-    <td class="num">${o.quantity}</td>
-    <td class="num">${o.leavesQuantity}</td>
-    <td class="num">${o.cumulativeQuantity}</td>
+    <td class="num">${fmtQty(o.quantity)}</td>
+    <td class="num">${fmtQty(o.leavesQuantity)}</td>
+    <td class="num">${fmtQty(o.cumulativeQuantity)}</td>
     <td class="num">${price}</td>
     <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}</td>
-    <td><button class="cancel-btn" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" ${terminal ? "disabled" : ""}>Cancel</button></td>
+    <td><button class="${cancelCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" title="Cancel (Del)" ${cancelDisabled ? "disabled" : ""}>${cancelLabel}</button></td>
   </tr>`;
 }
 
@@ -835,8 +958,8 @@ function renderPositions() {
     ? `<tr><td colspan="3" class="muted">No positions</td></tr>`
     : positions.map(p => `<tr>
         <td>${escapeHtml(p.symbol)}</td>
-        <td class="num">${p.netQuantity}</td>
-        <td class="num">${Number(p.averageEntryPrice).toFixed(2)}</td>
+        <td class="num">${fmtQty(p.netQuantity)}</td>
+        <td class="num">${fmtPx(p.averageEntryPrice)}</td>
       </tr>`).join("");
 }
 
@@ -850,11 +973,12 @@ function renderExecutions() {
 function execRow(e) {
   const ts = new Date(e.timestampUtc).toISOString().slice(11, 23);
   const reason = e.rejectReason ? ` — ${escapeHtml(e.rejectReason)}` : "";
-  const lastPx = e.lastQuantity > 0 ? ` @ ${Number(e.lastPrice).toFixed(2)}` : "";
+  const lastPx = e.lastQuantity > 0 ? ` @ ${fmtPx(e.lastPrice)}` : "";
+  const lastQty = e.lastQuantity > 0 ? fmtQty(e.lastQuantity) : "";
   return `<li>
     <span class="ts">${ts}</span>
     <span class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</span>
-    <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${e.lastQuantity || ""}${lastPx}${reason}</span>
+    <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${lastQty}${lastPx}${reason}</span>
   </li>`;
 }
 


### PR DESCRIPTION
First of three PRs splitting the post-#88 ergonomics work
(`files/trader-ui-ergonomics-review.md`).

**Scope (PR A — this PR):** 15 quick wins + 4 small Top-5 items + pt-BR locale formatter.
**PR B (next):** T2 panel-wide stale overlay (50% opacity + header).
**PR C (after):** T3 Cancel-all with type-CANCEL modal.

## Decisões fechadas com o usuário

| Item | Decisão |
|---|---|
| T1 | Confirmação em **ambos** os caminhos (mouse + Del). |
| T4 | `min=100 step=100` (B3 lot size). |
| T5 | Login submit disabled + \"Signing in…\". |
| Topbar→ticket | Auto-fill **não-destrutivo** (não sobrescreve ticket em edição). |
| Locale | pt-BR (`100.000,00`). |

## Quick wins entregues

- **Cancel safety**: `state.inflightCancels` Set; `handleCancelOrder` confirma uma vez, bloqueia duplicate / terminal / PendingCancel; mouse + Del compartilham o mesmo guard.
- **Fat-finger TTL** de 15s — override armado expira sozinho.
- **Login submitting** — botão + label.
- **Toast de sucesso auto-dismiss** após 5s, mas só apaga se não foi substituído.
- **DOB \"no book\" hint** após 10s sem snapshot (driven por slow tick 1Hz).
- **MD stale class** após 5s sem tick.
- **Symbol auto-uppercase** (respeita IME composition).
- **Symbol datalist** povoado da watchlist.
- **Esc** no modal de sessão expirada → logout; Esc no MD popover → fecha.
- **Backspace shortcut removido** (apenas Del cancela).
- **Login Backend field** sob `<details>`.
- **`role=\"alert\"` no #login-error**, removido aria-live noise de #ws-reconnect / #ticket-inflight.
- **User label** mostra `username @ firm`.
- **Tape timestamp** inclui ms.
- **pt-BR Intl.NumberFormat** em positions, blotter, MD, DOB, tape, executions, fat-finger feedback.

## Topbar → ticket (correção de wrong-symbol risk)

Auto-fill apenas se o campo está **vazio** OU ainda contém o último símbolo auto-preenchido. Se o trader está digitando ticket pra `VALE3` e clica em `PETR4` no seletor pra olhar DOB/chart/tape, o ticket **não é tocado**.

## Tests

`frontend/test/*.mjs`: 78/78 (decoder 32, state-book 15, state-candle 17, state-tape 14). Sem regressão.

## Riscos / não-escopo

- T2 (panel-wide stale overlay) e T3 (cancel-all modal) ficam para os PRs B e C respectivamente.
- Nenhuma mudança de protocolo, backend ou DOM acessível por testes Node.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>