### PR TITLE
chore(deps): bump B3.EntryPoint.Client 0.14.1 → 0.14.2 — fixes #92

### DIFF
--- a/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
+++ b/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.1" />
+    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.2" />
     <PackageReference Include="System.IO.Hashing" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />


### PR DESCRIPTION
Bumps B3.EntryPoint.Client to **0.14.2**, which includes the upstream fix for [pedrosakuma/B3EntryPointClient#152](https://github.com/pedrosakuma/B3EntryPointClient/issues/152) (`SaveAsync` now fires at session lifecycle boundaries, not only every 1024 deltas).

## Closes
- #92 — FIXP `SessionVerId` not durable across restarts. Root cause was upstream; downstream wiring (`Program.cs` → `SessionVerIdResolver.Resolve(configured, persisted)`) was already correct, it just always saw `persisted=null`.

## Likely also resolves
- #93 — Orders return 202 but never get ER. The reproduction always involved the matching-restart workaround for #92, which destabilised the FIXP session. Worth retesting on this branch before closing.

## Validation
- `dotnet restore` resolves 0.14.2 cleanly.
- Full build: 0 errors / 0 warnings.
- Unit + API + Domain tests: 401/401 passing.
- Conformance suite skipped at unit-test level (gated on docker stack), will run in CI.