### PR TITLE
chore(compose): seed bob alongside alice by default

### DIFF
--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -19,15 +19,16 @@ services:
   # Add an admin-role seed user so the conformance suite can hit /admin/*.
   # Reuses alice's hash/salt (PBKDF2 is deterministic on plaintext+salt)
   # under a different username + role=admin, so no extra secret-management
-  # is required.
+  # is required. Slot Users__4 to avoid colliding with base (alice=0,
+  # bob=3) and demo (bot-clientA=1, bot-clientB=2).
   trading-host:
     environment:
-      Trading__Auth__Users__1__Username: ${TRADING_ADMIN_USER:-carol}
-      Trading__Auth__Users__1__PasswordHash: ${TRADING_SEED_PASSWORD_HASH:?Set TRADING_SEED_PASSWORD_HASH in .env (PBKDF2 base64)}
-      Trading__Auth__Users__1__Salt: ${TRADING_SEED_PASSWORD_SALT:?Set TRADING_SEED_PASSWORD_SALT in .env (base64)}
-      Trading__Auth__Users__1__Iterations: "600000"
-      Trading__Auth__Users__1__Role: admin
-      Trading__Auth__Users__1__Firm: default
+      Trading__Auth__Users__4__Username: ${TRADING_ADMIN_USER:-carol}
+      Trading__Auth__Users__4__PasswordHash: ${TRADING_SEED_PASSWORD_HASH:?Set TRADING_SEED_PASSWORD_HASH in .env (PBKDF2 base64)}
+      Trading__Auth__Users__4__Salt: ${TRADING_SEED_PASSWORD_SALT:?Set TRADING_SEED_PASSWORD_SALT in .env (base64)}
+      Trading__Auth__Users__4__Iterations: "600000"
+      Trading__Auth__Users__4__Role: admin
+      Trading__Auth__Users__4__Firm: default
 
   conformance:
     build:

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -149,6 +149,9 @@ services:
       # the seeded user actually reaches matching instead of bouncing as
       # a gateway-routing miss.
       Trading__Auth__Users__0__Firm: FIRM01
+      # Same firm override for bob (seeded by base compose at slot 5) so
+      # both default users route through the FIRM01 gateway in Real mode.
+      Trading__Auth__Users__5__Firm: FIRM01
       # Map the conformance-driven symbols onto the SecurityIds matching
       # advertises in instruments-eqt.json. v1 used placeholder ids that
       # would have been silently rejected by matching had any order ever

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,23 @@ services:
       Trading__Auth__Users__0__Iterations: "600000"
       Trading__Auth__Users__0__Role: user
       Trading__Auth__Users__0__Firm: default
+      # Second user (bob) seeded by default so dogfooding scenarios that
+      # need both sides of a trade — crosses, fill-against, position-flip
+      # exercises — work out of the box. PBKDF2 is deterministic on
+      # plaintext+salt, so reusing TRADING_SEED_PASSWORD_HASH/SALT under
+      # a different username produces a valid login for the same password.
+      # Same firm as alice on purpose; a future overlay can move bob to
+      # a separate firm when cross-firm scenarios become a thing.
+      # Slot Users__5 (not 1) so demo-overlay seed users — bot-clientA (1),
+      # bot-clientB (2), demo-admin (3), and the conformance overlay's
+      # carol (4) — don't collide with bob when overlays stack on top.
+      # Sparse indexes are fine for .NET's configuration array binder.
+      Trading__Auth__Users__5__Username: ${TRADING_SEED_USER_2:-bob}
+      Trading__Auth__Users__5__PasswordHash: ${TRADING_SEED_PASSWORD_HASH}
+      Trading__Auth__Users__5__Salt: ${TRADING_SEED_PASSWORD_SALT}
+      Trading__Auth__Users__5__Iterations: "600000"
+      Trading__Auth__Users__5__Role: user
+      Trading__Auth__Users__5__Firm: default
       # CORS list from origin of nginx frontend. Same-origin via nginx proxy
       # means this is mostly redundant, but cheap insurance for direct curls.
       Trading__Cors__AllowedOrigins__0: http://localhost:${FRONTEND_PORT:-8080}


### PR DESCRIPTION
Closes the gap that two-sided dogfooding requires either the demo overlay (which also boots bot-clientA/B + demo-driver) or hand-crafted env overrides.

## Slot map (sparse, .NET binder handles gaps)
| Slot | User          | Source                |
|------|---------------|-----------------------|
| 0    | alice         | base                  |
| 1    | bot-clientA   | demo overlay          |
| 2    | bot-clientB   | demo overlay          |
| 3    | demo-admin    | demo overlay          |
| 4    | carol         | conformance overlay   |
| 5    | **bob**       | **base (this PR)**    |

## Notes
- Bob reuses alice's PBKDF2 hash+salt (deterministic on plaintext+salt under a different username).
- Same firm as alice (`default` → `FIRM01` in real overlay) so orders from both sides hit the same gateway and can match.
- NoNakedShortCheck stays armed — bob has to buy before he sells, which is the intended UX.

## Validation
- `docker compose ... config` for real-only + real+demo+conformance: no slot collisions.
- `POST /auth/login` for bob returns a JWT with `firm=FIRM01`.