### PR TITLE
feat(positions): config-driven opening position seeds — alice + bob start with 2000 PETR4 + 2000 VALE3

### DIFF
--- a/backend/src/B3.Trading.Application/PositionKeeper.cs
+++ b/backend/src/B3.Trading.Application/PositionKeeper.cs
@@ -14,6 +14,19 @@ public sealed class PositionKeeper
     public Position GetOrCreate(EndClientId owner, string symbol) =>
         _positions.GetOrAdd((owner, symbol), key => new Position(key.Owner, key.Symbol));
 
+    /// <summary>
+    /// Insert a starting position iff one is not already tracked for
+    /// <paramref name="owner"/>/<paramref name="symbol"/>. Returns
+    /// <c>true</c> when the seed was applied; <c>false</c> when an
+    /// existing position (from snapshot/WAL replay or a prior fill)
+    /// already occupies the slot. Idempotent and thread-safe.
+    /// </summary>
+    public bool SeedIfAbsent(EndClientId owner, string symbol, long netQuantity, decimal averageEntryPrice)
+    {
+        var seeded = Position.Hydrate(owner, symbol, netQuantity, averageEntryPrice);
+        return _positions.TryAdd((owner, symbol), seeded);
+    }
+
     public void ApplyFill(EndClientId owner, string symbol, OrderSide side, long quantity, decimal price)
     {
         var position = GetOrCreate(owner, symbol);

--- a/backend/src/B3.Trading.Application/PositionSeedOptions.cs
+++ b/backend/src/B3.Trading.Application/PositionSeedOptions.cs
@@ -1,0 +1,47 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Optional starting positions applied to <see cref="PositionKeeper"/>
+/// at process startup. Intended for dogfood / dev environments where
+/// the naked-short gate would otherwise block any first Sell — seeding
+/// an end-client with N units of a symbol lets them sell up to that
+/// quantity before having to buy.
+///
+/// <para>
+/// Seeds are applied <b>only when the position is absent</b> (after
+/// snapshot/WAL recovery), so a warm restart preserves the actual
+/// trading state and never overwrites real fills with the seed.
+/// </para>
+/// </summary>
+public sealed class PositionSeedOptions
+{
+    public const string SectionName = "Trading:Positions";
+
+    /// <summary>
+    /// Per-end-client / per-symbol opening positions. The list shape
+    /// (rather than a nested dict) keeps env-var binding ergonomic:
+    /// <c>Trading__Positions__Seeds__0__EndClientId=alice</c>.
+    /// </summary>
+    public List<PositionSeed> Seeds { get; set; } = new();
+}
+
+public sealed class PositionSeed
+{
+    public string EndClientId { get; set; } = string.Empty;
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Net quantity. Positive = long (the only useful seed today, since
+    /// the naked-short gate cares about the long side); negative values
+    /// are accepted by <see cref="PositionKeeper"/> but no current risk
+    /// check rewards seeding a short.
+    /// </summary>
+    public long Quantity { get; set; }
+
+    /// <summary>
+    /// Average entry price stamped on the seeded position. Reported on
+    /// <c>positions.me</c> and used by P&amp;L diagnostics; zero is fine
+    /// when the dogfood scenario doesn't care about avg-cost accuracy.
+    /// </summary>
+    public decimal AverageEntryPrice { get; set; }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -11,6 +11,7 @@ using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
 using B3.Trading.Host.Observability;
 using B3.Trading.Host.MarketData;
 using B3.Trading.Infrastructure;
@@ -35,6 +36,8 @@ builder.Services.AddSingleton(sp =>
     new SymbolDirectory(sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value));
 builder.Services.Configure<PersistenceOptions>(
     builder.Configuration.GetSection(PersistenceOptions.SectionName));
+builder.Services.Configure<PositionSeedOptions>(
+    builder.Configuration.GetSection(PositionSeedOptions.SectionName));
 
 // CORS: opt-in allowlist for the dev/prod frontend origins. Empty list
 // disables CORS entirely (server-only deploys, integration tests).
@@ -394,6 +397,45 @@ var app = builder.Build();
     {
         var recovery = scope.ServiceProvider.GetRequiredService<PersistenceRecovery>();
         await recovery.RunAsync();
+    }
+
+    // Apply optional opening-position seeds AFTER recovery, so warm
+    // restarts always preserve the actual fills and the seed is only
+    // ever applied to slots that recovery left empty. Intended for
+    // dogfood / dev environments where the naked-short gate would
+    // otherwise block any first Sell from a fresh account.
+    var seedOpts = scope.ServiceProvider.GetRequiredService<IOptions<PositionSeedOptions>>().Value;
+    if (seedOpts.Seeds.Count > 0)
+    {
+        var keeper = scope.ServiceProvider.GetRequiredService<PositionKeeper>();
+        var seedLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("PositionSeeder");
+        var applied = 0;
+        var skipped = 0;
+        foreach (var seed in seedOpts.Seeds)
+        {
+            if (string.IsNullOrWhiteSpace(seed.EndClientId) || string.IsNullOrWhiteSpace(seed.Symbol))
+            {
+                seedLogger.LogWarning("Skipping malformed PositionSeed (EndClientId='{Owner}', Symbol='{Symbol}').",
+                    seed.EndClientId, seed.Symbol);
+                continue;
+            }
+            var owner = new EndClientId(seed.EndClientId);
+            if (keeper.SeedIfAbsent(owner, seed.Symbol, seed.Quantity, seed.AverageEntryPrice))
+            {
+                applied++;
+                seedLogger.LogInformation(
+                    "Seeded opening position {Owner}/{Symbol} = {Qty} @ {AvgPx}.",
+                    seed.EndClientId, seed.Symbol, seed.Quantity, seed.AverageEntryPrice);
+            }
+            else
+            {
+                skipped++;
+                seedLogger.LogInformation(
+                    "Skipped seed for {Owner}/{Symbol}: position already present from recovery.",
+                    seed.EndClientId, seed.Symbol);
+            }
+        }
+        seedLogger.LogInformation("PositionSeeder finished: {Applied} applied, {Skipped} skipped.", applied, skipped);
     }
 }
 

--- a/backend/tests/B3.Trading.Application.Tests/PositionKeeperSeedTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PositionKeeperSeedTests.cs
@@ -1,0 +1,55 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+public class PositionKeeperSeedTests
+{
+    [Fact]
+    public void SeedIfAbsent_AppliesWhenSlotEmpty()
+    {
+        var keeper = new PositionKeeper();
+        var owner = new EndClientId("alice");
+
+        var applied = keeper.SeedIfAbsent(owner, "PETR4", 2000, 32.50m);
+
+        Assert.True(applied);
+        var pos = keeper.GetOrCreate(owner, "PETR4");
+        Assert.Equal(2000, pos.NetQuantity);
+        Assert.Equal(32.50m, pos.AverageEntryPrice);
+    }
+
+    [Fact]
+    public void SeedIfAbsent_NoOpWhenPositionAlreadyPresent()
+    {
+        // Simulates the warm-restart path: PersistenceRecovery has
+        // already restored a real fill, so the seed must NOT clobber it.
+        var keeper = new PositionKeeper();
+        var owner = new EndClientId("alice");
+        keeper.ApplyFill(owner, "PETR4", OrderSide.Buy, 100, 30m);
+
+        var applied = keeper.SeedIfAbsent(owner, "PETR4", 2000, 32.50m);
+
+        Assert.False(applied);
+        var pos = keeper.GetOrCreate(owner, "PETR4");
+        Assert.Equal(100, pos.NetQuantity);
+        Assert.Equal(30m, pos.AverageEntryPrice);
+    }
+
+    [Fact]
+    public void SeedIfAbsent_ScopedPerOwnerAndSymbol()
+    {
+        var keeper = new PositionKeeper();
+        var alice = new EndClientId("alice");
+        var bob = new EndClientId("bob");
+
+        Assert.True(keeper.SeedIfAbsent(alice, "PETR4", 2000, 32.50m));
+        Assert.True(keeper.SeedIfAbsent(alice, "VALE3", 2000, 65.00m));
+        Assert.True(keeper.SeedIfAbsent(bob, "PETR4", 2000, 32.50m));
+
+        Assert.Equal(2000, keeper.GetOrCreate(alice, "PETR4").NetQuantity);
+        Assert.Equal(2000, keeper.GetOrCreate(alice, "VALE3").NetQuantity);
+        Assert.Equal(2000, keeper.GetOrCreate(bob, "PETR4").NetQuantity);
+        Assert.Equal(0, keeper.GetOrCreate(bob, "VALE3").NetQuantity);
+    }
+}

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -166,6 +166,28 @@ services:
       Trading__Risk__ReferencePrices__PETR4: "32.50"
       Trading__Risk__ReferencePrices__VALE3: "65.00"
       Trading__Risk__ReferencePrices__ITUB4: "30.00"
+      # Opening positions seeded for the default dogfood accounts so
+      # both alice and bob can sell out of the box without being blocked
+      # by the NoNakedShortCheck gate. Quantities are expressed in
+      # board-lot units (matching's lotSize=100, so 2000 = 20 lots).
+      # Seeds apply only when PersistenceRecovery leaves the slot empty,
+      # so a warm restart never overwrites real fills.
+      Trading__Positions__Seeds__0__EndClientId: ${TRADING_SEED_USER:-alice}
+      Trading__Positions__Seeds__0__Symbol: PETR4
+      Trading__Positions__Seeds__0__Quantity: "2000"
+      Trading__Positions__Seeds__0__AverageEntryPrice: "32.50"
+      Trading__Positions__Seeds__1__EndClientId: ${TRADING_SEED_USER:-alice}
+      Trading__Positions__Seeds__1__Symbol: VALE3
+      Trading__Positions__Seeds__1__Quantity: "2000"
+      Trading__Positions__Seeds__1__AverageEntryPrice: "65.00"
+      Trading__Positions__Seeds__2__EndClientId: ${TRADING_SEED_USER_2:-bob}
+      Trading__Positions__Seeds__2__Symbol: PETR4
+      Trading__Positions__Seeds__2__Quantity: "2000"
+      Trading__Positions__Seeds__2__AverageEntryPrice: "32.50"
+      Trading__Positions__Seeds__3__EndClientId: ${TRADING_SEED_USER_2:-bob}
+      Trading__Positions__Seeds__3__Symbol: VALE3
+      Trading__Positions__Seeds__3__Quantity: "2000"
+      Trading__Positions__Seeds__3__AverageEntryPrice: "65.00"
       # Live reference price via the marketdata WS leg (RFC §4.5 D3).
       # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
       # cache misses fall back to Trading:Risk:ReferencePrices map. The


### PR DESCRIPTION
Stacks naturally on top of #95 (bob seeded by default).

## Why
NoNakedShortCheck is now armed in the real overlay (#87). A fresh dogfood account hits `current long=0, open sell leaves=N` on its first Sell. Pre-seeding alice + bob with 2000 PETR4 + 2000 VALE3 each lets dogfood scenarios — crosses, fill-against, position flip — work immediately without a buy-then-sell bootstrap.

## What
- `Trading:Positions:Seeds[]` config (list of `{EndClientId, Symbol, Quantity, AverageEntryPrice}`).
- `PositionKeeper.SeedIfAbsent(...)` — idempotent, thread-safe, never overwrites.
- Applied in `Program.cs` AFTER `PersistenceRecovery`, so warm restarts preserve real fills.
- `docker/docker-compose.real.yml` pre-populates 4 seeds (alice/bob × PETR4/VALE3 × 2000).

## Safety
- Seeds touch only empty slots — recovery wins on every collision.
- No effect when `Seeds[]` is empty or unset (zero-cost no-op).
- New unit tests cover the empty-slot, occupied-slot, and per-owner/symbol scoping invariants.

## Validation
- Build: 0/0.
- Tests: 404/404 (3 new in `PositionKeeperSeedTests`).