### PR TITLE
feat(auth): self-service signup (FIRM01, in-memory v0)

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -1,28 +1,45 @@
 using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Api.Auth;
 
 public static class AuthEndpoints
 {
+    // v0 self-service signup is hardcoded to FIRM01 ("inicialmente users
+    // dentro firm01"). Multi-firm signup is a tracked follow-up.
+    private const string SignupFirm = "FIRM01";
+    private const string SignupRole = "user";
+
+    // Default opening positions for fresh signups, mirroring the alice/bob
+    // seed in docker-compose.real.yml. Lets a brand-new user immediately
+    // submit a Sell without tripping NoNakedShortCheck during dogfood.
+    // Quantities deliberately match the operator-seeded defaults so
+    // anyone signing up gets the same baseline as the demo accounts.
+    private static readonly (string Symbol, long Quantity)[] SignupSeedPositions =
+    {
+        ("PETR4", 2000),
+        ("VALE3", 2000),
+    };
+
     public static IEndpointRouteBuilder MapAuth(this IEndpointRouteBuilder app)
     {
         app.MapPost("/auth/login", (
             LoginRequest req,
-            IOptions<AuthOptions> opts,
+            IUserStore users,
             JwtIssuer issuer,
             EndClientRegistry registry) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrWhiteSpace(req.Password))
                 return Results.BadRequest(new { error = "username and password required" });
 
-            var user = opts.Value.Users.FirstOrDefault(u =>
-                string.Equals(u.Username, req.Username, StringComparison.OrdinalIgnoreCase));
-
-            if (user is null || !PasswordHasher.Verify(req.Password, user.PasswordHash, user.Salt, user.Iterations))
+            if (!users.TryGet(req.Username, out var user) || user is null
+                || !PasswordHasher.Verify(req.Password, user.PasswordHash, user.Salt, user.Iterations))
                 return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
 
             // Pre-register so subsequent ER routing / WS subscribe work
@@ -33,9 +50,69 @@ public static class AuthEndpoints
             return Results.Ok(new LoginResponse(token, expires));
         });
 
+        app.MapPost("/auth/signup", (
+            SignupRequest req,
+            IUserStore users,
+            IOptions<AuthOptions> opts,
+            JwtIssuer issuer,
+            EndClientRegistry registry,
+            PositionKeeper positions,
+            IReferencePrice refPrice,
+            ILoggerFactory loggerFactory) =>
+        {
+            if (req is null
+                || string.IsNullOrWhiteSpace(req.Username)
+                || string.IsNullOrWhiteSpace(req.Password))
+                return Results.BadRequest(new { error = "username and password required" });
+
+            // Minimal hygiene only — full policy (length/complexity/captcha
+            // /rate-limit) is a tracked hardening follow-up. Reject strings
+            // we know will break downstream consumers (claim parsing,
+            // ClOrdID emission, WS topic routing).
+            var username = req.Username.Trim();
+            if (username.Length > 64 || username.Any(c => char.IsWhiteSpace(c) || c == ':' || c == '"' || c == '\\'))
+                return Results.BadRequest(new { error = "username contains invalid characters" });
+
+            var iterations = opts.Value.Pbkdf2Iterations > 0 ? opts.Value.Pbkdf2Iterations : 600_000;
+            var (hash, salt) = PasswordHasher.Hash(req.Password, iterations);
+            var newUser = new UserConfig
+            {
+                Username = username,
+                PasswordHash = hash,
+                Salt = salt,
+                Iterations = iterations,
+                Role = SignupRole,
+                Firm = SignupFirm,
+            };
+
+            if (!users.TryAdd(newUser))
+                return Results.Conflict(new { error = "username already taken" });
+
+            var endClientId = registry.Register(newUser.Username);
+
+            // Seed default opening positions. Avg cost = current ref price
+            // when known (so P&L doesn't show a fake gain/loss); zero is
+            // a fine fallback (matches the dogfood overlay's choice for
+            // symbols without a configured ref price).
+            foreach (var (symbol, qty) in SignupSeedPositions)
+            {
+                refPrice.TryGet(symbol, out var avgPx);
+                positions.SeedIfAbsent(endClientId, symbol, qty, avgPx);
+            }
+
+            var log = loggerFactory.CreateLogger("AuthEndpoints");
+            log.LogInformation(
+                "Self-service signup: user={Username} firm={Firm} role={Role} (positions seeded).",
+                newUser.Username, newUser.Firm, newUser.Role);
+
+            var (token, expires) = issuer.Issue(newUser.Username, newUser.Role, newUser.Firm);
+            return Results.Created($"/auth/users/{newUser.Username}", new LoginResponse(token, expires));
+        });
+
         return app;
     }
 }
 
 public sealed record LoginRequest(string Username, string Password);
 public sealed record LoginResponse(string Token, DateTimeOffset ExpiresAt);
+public sealed record SignupRequest(string Username, string Password);

--- a/backend/src/B3.Trading.Api/Auth/IUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/IUserStore.cs
@@ -1,0 +1,25 @@
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// User directory used by login + signup. Hides the split between
+/// env-seeded users (immutable, from <see cref="AuthOptions.Users"/>)
+/// and runtime users created via self-service signup.
+///
+/// <para>
+/// v1 is in-memory only; runtime entries are lost on restart by design
+/// (see plan: persistence is a tracked follow-up). Env-seeded users
+/// always survive because they're rebuilt from configuration at boot.
+/// </para>
+/// </summary>
+public interface IUserStore
+{
+    /// <summary>Lookup by username (case-insensitive).</summary>
+    bool TryGet(string username, out UserConfig? user);
+
+    /// <summary>
+    /// Insert a runtime user. Returns <c>false</c> when the username
+    /// already exists in either the env slot or the runtime slot.
+    /// Thread-safe.
+    /// </summary>
+    bool TryAdd(UserConfig user);
+}

--- a/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// In-memory <see cref="IUserStore"/>. Env-seeded users are snapshotted
+/// from <see cref="AuthOptions"/> at construction into an immutable
+/// dictionary so signup can never accidentally shadow them; runtime
+/// users live in a separate <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+/// Both are case-insensitive (matches <see cref="AuthEndpoints"/> login
+/// behaviour pre-refactor).
+/// </summary>
+public sealed class InMemoryUserStore : IUserStore
+{
+    private readonly Dictionary<string, UserConfig> _seeded;
+    private readonly ConcurrentDictionary<string, UserConfig> _runtime =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public InMemoryUserStore(IOptions<AuthOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _seeded = new Dictionary<string, UserConfig>(StringComparer.OrdinalIgnoreCase);
+        foreach (var u in options.Value.Users)
+        {
+            if (string.IsNullOrWhiteSpace(u.Username)) continue;
+            // Last-write-wins for duplicate env entries — mirrors how
+            // FirstOrDefault used to behave (first wins) only by accident
+            // of enumeration order. We pick last-wins so an operator
+            // overriding a username in a later config layer actually takes
+            // effect; collisions in a single config file are an operator
+            // bug regardless.
+            _seeded[u.Username] = u;
+        }
+    }
+
+    public bool TryGet(string username, out UserConfig? user)
+    {
+        if (string.IsNullOrWhiteSpace(username)) { user = null; return false; }
+        if (_seeded.TryGetValue(username, out var s)) { user = s; return true; }
+        if (_runtime.TryGetValue(username, out var r)) { user = r; return true; }
+        user = null;
+        return false;
+    }
+
+    public bool TryAdd(UserConfig user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        if (string.IsNullOrWhiteSpace(user.Username)) return false;
+        // Block runtime collisions with env-seeded users: an operator
+        // shouldn't have a self-service signup silently shadowed and a
+        // self-service signer-up shouldn't be able to "claim" alice.
+        if (_seeded.ContainsKey(user.Username)) return false;
+        return _runtime.TryAdd(user.Username, user);
+    }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -53,6 +53,7 @@ if (corsOrigins.Length > 0)
 }
 
 // Application-layer singletons: registries, books, processor, sink.
+builder.Services.AddSingleton<IUserStore, InMemoryUserStore>();
 builder.Services.AddSingleton<EndClientRegistry>();
 builder.Services.AddSingleton<ClOrdIdPrefixRegistry>();
 builder.Services.AddSingleton<OrderOwnershipMap>();

--- a/backend/tests/B3.Trading.Api.Tests/InMemoryUserStoreTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/InMemoryUserStoreTests.cs
@@ -1,0 +1,77 @@
+using B3.Trading.Api.Auth;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Tests;
+
+public class InMemoryUserStoreTests
+{
+    private static InMemoryUserStore Build(params UserConfig[] seeded)
+    {
+        var opts = Options.Create(new AuthOptions { Users = seeded.ToList() });
+        return new InMemoryUserStore(opts);
+    }
+
+    private static UserConfig User(string username, string role = "user", string firm = "FIRM01") =>
+        new()
+        {
+            Username = username,
+            PasswordHash = "h",
+            Salt = "s",
+            Iterations = 1,
+            Role = role,
+            Firm = firm,
+        };
+
+    [Fact]
+    public void Hydrates_seeded_users_from_options()
+    {
+        var store = Build(User("alice"), User("bob"));
+        Assert.True(store.TryGet("alice", out var a));
+        Assert.Equal("alice", a!.Username);
+        Assert.True(store.TryGet("BOB", out var b));
+        Assert.Equal("bob", b!.Username);
+    }
+
+    [Fact]
+    public void TryAdd_runtime_user_succeeds_and_is_visible()
+    {
+        var store = Build();
+        Assert.True(store.TryAdd(User("carol")));
+        Assert.True(store.TryGet("carol", out var c));
+        Assert.Equal("carol", c!.Username);
+    }
+
+    [Fact]
+    public void TryAdd_runtime_collision_returns_false()
+    {
+        var store = Build();
+        Assert.True(store.TryAdd(User("dave")));
+        Assert.False(store.TryAdd(User("DAVE")));
+    }
+
+    [Fact]
+    public void TryAdd_envseeded_collision_returns_false_and_does_not_shadow()
+    {
+        var store = Build(User("alice", role: "user", firm: "ORIG"));
+        Assert.False(store.TryAdd(User("ALICE", role: "admin", firm: "FAKE")));
+        Assert.True(store.TryGet("alice", out var u));
+        Assert.Equal("ORIG", u!.Firm);
+        Assert.Equal("user", u.Role);
+    }
+
+    [Fact]
+    public void TryGet_missing_returns_false()
+    {
+        var store = Build(User("alice"));
+        Assert.False(store.TryGet("nobody", out var u));
+        Assert.Null(u);
+    }
+
+    [Fact]
+    public void TryGet_with_blank_returns_false()
+    {
+        var store = Build(User("alice"));
+        Assert.False(store.TryGet("", out _));
+        Assert.False(store.TryGet("  ", out _));
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/SignupEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SignupEndpointTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+public class SignupEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+
+    public SignupEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    private static string FreshUsername() => "u" + Guid.NewGuid().ToString("N")[..10];
+
+    [Fact]
+    public async Task Signup_HappyPath_Returns201_WithToken()
+    {
+        using var client = _factory.CreateClient();
+        var username = FreshUsername();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "wonderland-1"));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<LoginResponse>();
+        Assert.False(string.IsNullOrWhiteSpace(body!.Token));
+        Assert.True(body.ExpiresAt > DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task Signup_ThenLogin_Succeeds()
+    {
+        using var client = _factory.CreateClient();
+        var username = FreshUsername();
+        var signup = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "secret-pass-9"));
+        signup.EnsureSuccessStatusCode();
+
+        var login = await client.PostAsJsonAsync("/auth/login",
+            new LoginRequest(username, "secret-pass-9"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_DuplicateUsername_Returns409()
+    {
+        using var client = _factory.CreateClient();
+        var username = FreshUsername();
+        var first = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "pw1"));
+        first.EnsureSuccessStatusCode();
+
+        var second = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "pw2"));
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_CollidesWithEnvSeeded_Returns409()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("alice", "anything"));
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_BlankCredentials_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("", "pw"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_InvalidUsernameChars_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("bad name", "pw"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Signup_SeedsDefaultPositions_ForNewUser()
+    {
+        using var client = _factory.CreateClient();
+        var username = FreshUsername();
+        var signup = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "pw"));
+        signup.EnsureSuccessStatusCode();
+
+        var keeper = _factory.Services.GetRequiredService<PositionKeeper>();
+        var owner = new EndClientId(username);
+        var positions = keeper.ForEndClient(owner);
+        var bySymbol = positions.ToDictionary(p => p.Symbol, p => p);
+        Assert.True(bySymbol.ContainsKey("PETR4"), "PETR4 not seeded");
+        Assert.True(bySymbol.ContainsKey("VALE3"), "VALE3 not seeded");
+        Assert.Equal(2000, bySymbol["PETR4"].NetQuantity);
+        Assert.Equal(2000, bySymbol["VALE3"].NetQuantity);
+    }
+}

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -56,6 +56,14 @@ body {
 .login-advanced summary:hover { color: var(--text); }
 .login-advanced > .row { margin-top: .5rem; }
 .error { color: var(--red); font-size: .85rem; margin: 0; }
+.login-switch {
+  font-size: .8rem; color: var(--muted); margin: .2rem 0 0; text-align: center;
+}
+.login-switch .link-button {
+  background: none; color: var(--accent); border: 0; padding: 0; cursor: pointer;
+  font: inherit; text-decoration: underline;
+}
+.login-switch .link-button:hover { filter: brightness(1.2); }
 
 /* ---------- Trader shell ---------- */
 .trader-view { display: flex; flex-direction: column; height: 100vh; min-height: 0; overflow: hidden; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,40 @@
       </details>
       <button type="submit" id="login-submit">Sign in</button>
       <p id="login-error" class="error" role="alert" hidden></p>
+      <p class="login-switch">
+        Sem conta?
+        <button type="button" id="login-go-signup" class="link-button">Criar conta</button>
+      </p>
+    </form>
+
+    <form id="signup-form" class="login-card" hidden>
+      <h1>Criar conta</h1>
+      <p class="subtitle">Self-service · FIRM01</p>
+      <label>
+        <span>Username</span>
+        <input id="signup-username" type="text" autocomplete="username" required maxlength="64" />
+      </label>
+      <label>
+        <span>Password</span>
+        <input id="signup-password" type="password" autocomplete="new-password" required minlength="6" />
+      </label>
+      <label>
+        <span>Confirmar password</span>
+        <input id="signup-password-confirm" type="password" autocomplete="new-password" required minlength="6" />
+      </label>
+      <details class="login-advanced">
+        <summary>Advanced</summary>
+        <label class="row">
+          <span>Backend</span>
+          <input id="signup-backend" type="url" placeholder="http://localhost:5000" />
+        </label>
+      </details>
+      <button type="submit" id="signup-submit">Criar e entrar</button>
+      <p id="signup-error" class="error" role="alert" hidden></p>
+      <p class="login-switch">
+        Já tem conta?
+        <button type="button" id="signup-go-login" class="link-button">Voltar para login</button>
+      </p>
     </form>
   </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,6 @@
 // App entry point: wires login → worker → state → UI together.
 
-import { defaultBackend, defaultMarketDataUrl, login, submitOrder, cancelOrder, getAdminFirms,
+import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cancelOrder, getAdminFirms,
          validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          runEod } from "./protocol.js";
@@ -46,6 +46,12 @@ let firmsPollTimer = null;
 function init() {
   document.getElementById("login-backend").placeholder = defaultBackend();
   document.getElementById("login-form").addEventListener("submit", onLogin);
+  const signupBackendInput = document.getElementById("signup-backend");
+  if (signupBackendInput) signupBackendInput.placeholder = defaultBackend();
+  const signupForm = document.getElementById("signup-form");
+  if (signupForm) signupForm.addEventListener("submit", onSignup);
+  document.getElementById("login-go-signup")?.addEventListener("click", () => showSignupCard(true));
+  document.getElementById("signup-go-login")?.addEventListener("click", () => showSignupCard(false));
   ui.bindUi();
   adminUi.bindAdminUi();
   ui.setHandlers({
@@ -131,6 +137,58 @@ async function onLogin(e) {
     ui.setLoginError(err.message || "Login failed");
   } finally {
     ui.setLoginSubmitting(false);
+  }
+}
+
+function showSignupCard(show) {
+  const loginCard = document.getElementById("login-form");
+  const signupCard = document.getElementById("signup-form");
+  if (!signupCard || !loginCard) return;
+  loginCard.hidden = !!show;
+  signupCard.hidden = !show;
+  setSignupError(null);
+  if (show) document.getElementById("signup-username")?.focus();
+  else document.getElementById("login-username")?.focus();
+}
+
+function setSignupError(msg) {
+  const el = document.getElementById("signup-error");
+  if (!el) return;
+  if (!msg) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false;
+  el.textContent = msg;
+}
+
+async function onSignup(e) {
+  e.preventDefault();
+  setSignupError(null);
+  const backend = (document.getElementById("signup-backend").value || defaultBackend()).replace(/\/+$/, "");
+  const username = document.getElementById("signup-username").value.trim();
+  const password = document.getElementById("signup-password").value;
+  const confirm = document.getElementById("signup-password-confirm").value;
+  if (!username || !password) { setSignupError("Preencha username e password."); return; }
+  if (password !== confirm) { setSignupError("As senhas não coincidem."); return; }
+  const submitBtn = document.getElementById("signup-submit");
+  if (submitBtn) submitBtn.disabled = true;
+  try {
+    const resp = await signup(backend, username, password);
+    const claims = claimsFromToken(resp.token);
+    const next = {
+      token: resp.token,
+      expiresAt: resp.expiresAt,
+      username,
+      backend,
+      role: claims.role,
+      firm: claims.firm,
+      remember: false,
+    };
+    sessionStore = sessionStorage;
+    writeSession(next);
+    startSession(next);
+  } catch (err) {
+    setSignupError(err.message || "Signup falhou");
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
   }
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -47,6 +47,19 @@ export async function login(backend, username, password) {
   return jsonOrThrow(resp);
 }
 
+// Self-service signup. Returns the same shape as /auth/login (token +
+// expiresAt) so the caller can drop the new user straight into the
+// trader view without a follow-up login round-trip. v0 is FIRM01-only,
+// role=user — see backend AuthEndpoints for the policy.
+export async function signup(backend, username, password) {
+  const resp = await fetch(`${backend}/auth/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  return jsonOrThrow(resp);
+}
+
 // Cheap, side-effect-free probe used at boot to detect stored tokens
 // that no longer authenticate (e.g. after the host's signing key was
 // rotated). Returns true on 2xx, false on 401/403, throws on network

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -56,6 +56,13 @@ export function showLogin() {
   $("login-view").hidden = false;
   $("trader-view").hidden = true;
   $("admin-view").hidden = true;
+  // Default to the login card; a user that previously toggled to the
+  // signup card and was bumped back to login (e.g. logout, expiry)
+  // shouldn't land staring at the signup form.
+  const loginCard = document.getElementById("login-form");
+  const signupCard = document.getElementById("signup-form");
+  if (loginCard) loginCard.hidden = false;
+  if (signupCard) signupCard.hidden = true;
   setViewToggleVisible(false, "trader");
 }
 


### PR DESCRIPTION
Self-service signup (FIRM01) — v0 in-memory.

Adds `POST /auth/signup` (anonymous, public) com `IUserStore` cobrindo env-seeded + runtime. Novo usuário entra como `role=user` na `FIRM01`, recebe seed de 2000 PETR4 + 2000 VALE3 (igual alice/bob), e o endpoint devolve JWT direto pra cair no trader UI.

**Backend:** `IUserStore` + `InMemoryUserStore` (env-seeded imutável, runtime ConcurrentDictionary, case-insensitive), `AuthEndpoints` refatorado para usar o store, novo endpoint `/auth/signup` com validação mínima + PBKDF2 + seed de posições.

**Frontend:** segunda card no login view com toggle "Criar conta" / "Voltar para login", form com confirm-password client-side, sucesso loga direto.

**Tests:** 13 novos (6 store + 7 endpoint). Suite total verde (32 + 244 + 141 + 12 conformance skip).

**Não-objetivos (#97):** persistência, rate limit, password policy, captcha, lockout, admin user mgmt, multi-firm signup, reserved usernames.

Closes na prática a demanda "viabilizar auto-serviço de usuários dentro da firm01" — itens hardening seguem em #97.