### PR TITLE
fix(er): resolve cancel acks when upstream omits OrigClOrdID — closes #99

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -83,6 +83,7 @@ public static class OrdersEndpoints
             EndClientRegistry registry,
             ClOrdIdPrefixRegistry clOrdIds,
             WorkingOrderBook book,
+            OrderOwnershipMap ownership,
             IExchangeGateway gateway,
             CancellationToken ct) =>
         {
@@ -97,6 +98,10 @@ public static class OrdersEndpoints
                 return Results.NotFound();
 
             var cancelClOrdId = clOrdIds.Generate(owner);
+            // Record the cancel-side → original mapping BEFORE sending so
+            // the cancel-ack ER can resolve back to the right order even
+            // when upstream omits OrigClOrdID on the wire.
+            ownership.RegisterCancelLink(cancelClOrdId, order.ClOrdId);
             await gateway.CancelAsync(order, cancelClOrdId, ct);
             MetricsRegistry.OrdersCancelRequested.Add(1);
             // Status transition to Cancelled happens when the exchange ER

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -75,6 +75,7 @@ public sealed class AlgoEngine : BackgroundService
     private readonly EventDispatcher _dispatcher;
     private readonly TimeProvider _clock;
     private readonly ILogger<AlgoEngine> _logger;
+    private readonly OrderOwnershipMap _ownership;
 
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
@@ -92,7 +93,8 @@ public sealed class AlgoEngine : BackgroundService
         IAlgoEventSink algoSink,
         EventDispatcher dispatcher,
         TimeProvider clock,
-        ILogger<AlgoEngine> logger)
+        ILogger<AlgoEngine> logger,
+        OrderOwnershipMap ownership)
     {
         _queue = queue;
         _algos = algos;
@@ -104,6 +106,7 @@ public sealed class AlgoEngine : BackgroundService
         _dispatcher = dispatcher;
         _clock = clock;
         _logger = logger;
+        _ownership = ownership;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -448,6 +451,10 @@ public sealed class AlgoEngine : BackgroundService
         var newClOrdId = _clOrdIds.Generate(child.Owner);
         try
         {
+            // Pre-register the cancel-side → original mapping so the
+            // cancel-ack ER can resolve back to the child order even if
+            // upstream omits OrigClOrdID on the wire.
+            _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
             await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
             // Don't mark terminal here — wait for the cancel-ack ER to land
             // via OnChildErAsync. That's what makes the engine consistent

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -63,8 +63,18 @@ public sealed class ExecutionReportProcessor
     {
         // For cancel/replace acks, the meaningful identity is the original
         // ClOrdID; the cancel-side ClOrdID was never registered as an order.
-        var lookupId = (kind is ExecKind.Canceled or ExecKind.Replaced) && origClOrdId != 0
-            ? origClOrdId
+        // Some upstream gateways (and certain SDK versions) drop OrigClOrdID
+        // on cancel acks — fall back to the cancel-link map populated when
+        // we sent the request so the ER still resolves to the right order.
+        var resolvedOrig = origClOrdId;
+        if ((kind is ExecKind.Canceled or ExecKind.Replaced) && resolvedOrig == 0
+            && _ownership.TryResolveOrig(clOrdId, out var linked))
+        {
+            resolvedOrig = linked;
+        }
+
+        var lookupId = (kind is ExecKind.Canceled or ExecKind.Replaced) && resolvedOrig != 0
+            ? resolvedOrig
             : clOrdId;
 
         if (!_ownership.TryResolve(lookupId, out var owner) || owner is null)

--- a/backend/src/B3.Trading.Application/OrderOwnershipMap.cs
+++ b/backend/src/B3.Trading.Application/OrderOwnershipMap.cs
@@ -15,6 +15,7 @@ namespace B3.Trading.Application;
 public sealed class OrderOwnershipMap
 {
     private readonly ConcurrentDictionary<ulong, EndClientId> _byClOrdId = new();
+    private readonly ConcurrentDictionary<ulong, ulong> _cancelToOrig = new();
 
     public void Register(ulong clOrdId, EndClientId owner)
     {
@@ -38,6 +39,34 @@ public sealed class OrderOwnershipMap
             throw new InvalidOperationException($"Unknown original ClOrdID '{originalClOrdId}'.");
         _byClOrdId[newClOrdId] = owner;
     }
+
+    /// <summary>
+    /// Records the cancel/replace-side <paramref name="newClOrdId"/> as a
+    /// pointer back to <paramref name="originalClOrdId"/>. Lets
+    /// <see cref="ExecutionReportProcessor"/> resolve cancel/replace
+    /// acknowledgements when the upstream gateway omits the
+    /// <c>OrigClOrdID</c> on the ER (defensive against
+    /// <see href="https://github.com/pedrosakuma/B3EntryPointClient/issues/154">SDK</see>
+    /// not echoing it back). Also registers the new ClOrdID against the
+    /// same owner so per-end-client ER fan-out continues to work.
+    /// </summary>
+    public void RegisterCancelLink(ulong newClOrdId, ulong originalClOrdId)
+    {
+        if (newClOrdId == 0)
+            throw new ArgumentOutOfRangeException(nameof(newClOrdId));
+        if (originalClOrdId == 0)
+            throw new ArgumentOutOfRangeException(nameof(originalClOrdId));
+        _cancelToOrig[newClOrdId] = originalClOrdId;
+        if (_byClOrdId.TryGetValue(originalClOrdId, out var owner))
+            _byClOrdId[newClOrdId] = owner;
+    }
+
+    /// <summary>
+    /// Looks up the original ClOrdID a cancel/replace request was issued
+    /// against. Returns <c>false</c> when no such link was registered.
+    /// </summary>
+    public bool TryResolveOrig(ulong newClOrdId, out ulong originalClOrdId) =>
+        _cancelToOrig.TryGetValue(newClOrdId, out originalClOrdId);
 
     public IEnumerable<Persistence.OwnershipMappingSnapshot> Snapshot()
     {

--- a/backend/tests/B3.Trading.Application.Tests/ClOrdIdAndOwnershipTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ClOrdIdAndOwnershipTests.cs
@@ -68,4 +68,33 @@ public class OrderOwnershipMapTests
         Assert.True(map.TryResolve(101UL, out var got));
         Assert.Equal(owner, got);
     }
+
+    [Fact]
+    public void CancelLink_InheritsOwner_AndIsResolvableBackToOriginal()
+    {
+        var map = new OrderOwnershipMap();
+        var owner = new EndClientId("alice");
+        map.Register(100UL, owner);
+        map.RegisterCancelLink(101UL, 100UL);
+
+        Assert.True(map.TryResolve(101UL, out var got));
+        Assert.Equal(owner, got);
+
+        Assert.True(map.TryResolveOrig(101UL, out var orig));
+        Assert.Equal(100UL, orig);
+    }
+
+    [Fact]
+    public void CancelLink_OnUnknownOriginal_DoesNotThrow_AndDoesNotInventOwner()
+    {
+        // Register the cancel-side ID even when the original isn't (yet)
+        // tracked locally — covers cold-start race after a snapshot
+        // restored the order but the ownership entry is still hydrating.
+        var map = new OrderOwnershipMap();
+        map.RegisterCancelLink(201UL, 200UL);
+
+        Assert.False(map.TryResolve(201UL, out _));
+        Assert.True(map.TryResolveOrig(201UL, out var orig));
+        Assert.Equal(200UL, orig);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -177,6 +177,49 @@ public class ExecutionReportProcessorTests
     }
 
     [Fact]
+    public void Cancel_WithMissingOrigClOrdId_ResolvesViaCancelLink()
+    {
+        // Upstream gateway sometimes drops OrigClOrdID on cancel acks
+        // (issue #99). When it does, the processor must still resolve
+        // back to the original order via the cancel-side → original
+        // link recorded at cancel-request time.
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+
+        const ulong cancelClOrdId = 2UL;
+        ownership.RegisterCancelLink(cancelClOrdId, order.ClOrdId);
+
+        // Wire ER comes back addressing the cancel-side ID with no OrigClOrdID.
+        proc.Apply(cancelClOrdId, ExecKind.Canceled, leaves: 0, cumQty: 0,
+                   lastQty: 0, lastPx: 0m, rejectReason: null, origClOrdId: 0);
+
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+    }
+
+    [Fact]
+    public void Cancel_PrefersExplicitOrigClOrdIdOverFallback()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+
+        const ulong cancelClOrdId = 2UL;
+        ownership.RegisterCancelLink(cancelClOrdId, order.ClOrdId);
+
+        proc.Apply(cancelClOrdId, ExecKind.Canceled, leaves: 0, cumQty: 0,
+                   lastQty: 0, lastPx: 0m, rejectReason: null, origClOrdId: 1UL);
+
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+    }
+
+    [Fact]
     public void Overfill_DoesNotThrow_AndCapsLeavesAtZero()
     {
         // Overfill (cumQty > order.Quantity) is a wire-side bug, but Apply must


### PR DESCRIPTION
Closes #99 (defensive in-process fix). Upstream SDK bug filed in pedrosakuma/B3EntryPointClient#155.

**Sintoma.** Cancelamento sai do book mas o ER nunca chega na trader UI. Log: `ER for unknown ClOrdID 2 (orig=0); dropping.`

**Causa.** SDK upstream entrega `OrderCancelled.OrigClOrdID = null` no real stack. Nosso processor caía no fallback (lookup pelo cancel-side ClOrdID), não achava ordem, dropava.

**Fix.**
- `OrderOwnershipMap.RegisterCancelLink(cancelClOrdId, origClOrdId)` recorda mapeamento + herda owner.
- `TryResolveOrig` lookup helper.
- `ExecutionReportProcessor.Apply` consulta o cancel-link como fallback quando o ER chega com `origClOrdId=0`.
- Callsites: `OrdersEndpoints.MapDelete` e `AlgoEngine.OnCancelRequestedAsync` registram o link antes de enviar.

**Tests.** 5 novos (3 OwnershipMap + 2 Processor). Suite verde 248 + 141.