### PR TITLE
fix(risk): self-trade prevention (newest-rejects) — closes #102

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
@@ -1,0 +1,118 @@
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Pre-trade gate that blocks an end-client from trading against
+/// themselves (self-cross / wash trade).
+///
+/// <para>
+/// Background: the downstream B3.EntryPoint matching engine knows the
+/// FIRM session but not the end-client identity our platform layers on
+/// top. Two orders submitted by the same end-client within the same
+/// firm are seen as independent and are matched normally if their
+/// prices cross. Issue #102 documents the dogfood incident where
+/// <c>bob</c>'s Buy 200 @ 32.50 self-crossed with their own Sell 100
+/// @ 32.40 and reported a Filled trade with the position unchanged.
+/// </para>
+///
+/// <para>
+/// Policy: when an incoming order would cross any of the end-client's
+/// own opposite-side working orders for the same symbol, reject the
+/// incoming (newest-rejects). This is the most conservative STP mode
+/// and matches what most exchanges call "STP-N" / "Cancel newest".
+/// Toggleable per firm / per end-client via
+/// <see cref="RiskLimits.AllowSelfTrade"/> (default: blocked).
+/// </para>
+///
+/// <para>
+/// Limitations (intentional, tracked in #103):
+/// <list type="bullet">
+///   <item>TOCTOU: there is a small window between this check and
+///   the gateway dispatch in which a contra order could be added by
+///   another concurrent submission. The pipeline runs synchronously
+///   under the same submission flow, so the only race is across
+///   different end-clients — and those legitimately match. The same
+///   end-client can only submit serially through the API.</item>
+///   <item>Does not block crossing against orders of <em>other</em>
+///   end-clients in the same firm — that is legitimate inter-trader
+///   activity at the firm level.</item>
+///   <item>Does not look at orders mid-cancellation: a working order
+///   for which the user already sent a Cancel still counts as
+///   "working" until the cancel-ack ER arrives.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class SelfTradePreventionCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly WorkingOrderBook _orders;
+
+    public SelfTradePreventionCheck(IOptionsMonitor<RiskOptions> options, WorkingOrderBook orders)
+    {
+        _options = options;
+        _orders = orders;
+    }
+
+    // Ordered just after no_naked_short (180) and before position
+    // limits (200). STP is a counterparty-identity invariant and
+    // independent of inventory; cheap to evaluate (per-owner index
+    // scoped to the symbol).
+    public int Order => 190;
+
+    public string Name => "self_trade_prevention";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var opts = _options.CurrentValue;
+        var allow = RiskLimitsResolver.Resolve(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.AllowSelfTrade);
+        if (allow == true) return RiskDecision.Approve;
+
+        var oppositeSide = ctx.Side == OrderSide.Buy ? OrderSide.Sell : OrderSide.Buy;
+        foreach (var existing in _orders.ForEndClient(ctx.Owner))
+        {
+            if (existing.Side != oppositeSide) continue;
+            if (!string.Equals(existing.Symbol, ctx.Symbol, StringComparison.Ordinal)) continue;
+            if (!IsStillRestable(existing)) continue;
+            if (!WouldCross(ctx, existing)) continue;
+
+            return RiskDecision.Reject(
+                $"self_trade_prevention: would cross own working " +
+                $"{existing.Side} {existing.LeavesQuantity}@" +
+                $"{(existing.Price.HasValue ? existing.Price.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "MKT")} " +
+                $"(clOrdId={existing.ClOrdId}); set AllowSelfTrade=true to opt out");
+        }
+
+        return RiskDecision.Approve;
+    }
+
+    // "Still restable" = order is on the book and has unfilled quantity.
+    // We exclude terminal states (Filled/Cancelled/Rejected) defensively
+    // even though a fully-cancelled or filled order should also have
+    // LeavesQuantity == 0.
+    private static bool IsStillRestable(Order o) =>
+        o.LeavesQuantity > 0
+        && o.Status is not OrderStatus.Filled
+                       and not OrderStatus.Cancelled
+                       and not OrderStatus.Rejected;
+
+    // Crossing rules:
+    //   * If either side is Market, the new order will sweep — always cross.
+    //   * Buy@P crosses Sell@Q when P >= Q.
+    //   * Sell@P crosses Buy@Q when P <= Q.
+    private static bool WouldCross(RiskContext incoming, Order existing)
+    {
+        if (incoming.Type == OrderType.Market || existing.Type == OrderType.Market)
+            return true;
+
+        // Limit-vs-Limit requires both prices set; defensive nulls treat as no-cross.
+        if (!incoming.Price.HasValue || !existing.Price.HasValue)
+            return false;
+
+        return incoming.Side == OrderSide.Buy
+            ? incoming.Price.Value >= existing.Price.Value
+            : incoming.Price.Value <= existing.Price.Value;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -141,6 +141,18 @@ public sealed class RiskLimits
     /// market makers, or test accounts).
     /// </summary>
     public bool? AllowShortSell { get; set; }
+
+    /// <summary>
+    /// Whether the end-client may self-cross — i.e. submit an order
+    /// that would match against one of their own opposite-side working
+    /// orders on the same symbol. Default semantics when unset
+    /// everywhere in the precedence chain are conservative: self-trade
+    /// is **blocked** with newest-rejects (see
+    /// <see cref="Risk.Checks.SelfTradePreventionCheck"/>). Set to
+    /// <c>true</c> per-firm or per-end-client to opt out (e.g.
+    /// market-maker accounts or test scenarios).
+    /// </summary>
+    public bool? AllowSelfTrade { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -188,5 +200,6 @@ public static class RiskLimitsResolver
             PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),
             MaxOpenOrders = Resolve(opts, endClient, firmId, symbol, l => l.MaxOpenOrders),
             AllowShortSell = Resolve(opts, endClient, firmId, symbol, l => l.AllowShortSell),
+            AllowSelfTrade = Resolve(opts, endClient, firmId, symbol, l => l.AllowSelfTrade),
         };
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -133,6 +133,7 @@ builder.Services.AddSingleton<IRiskCheck, RollingNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, OrderRateLimitCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
 builder.Services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
+builder.Services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
 builder.Services.AddSingleton<IRiskCheck, PriceCollarCheck>();
 builder.Services.AddSingleton<RiskPipeline>();
 

--- a/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
@@ -64,7 +64,10 @@ public class MarginCheckIntegrationTests
         Assert.NotEqual("Rejected", sellBody!.Status);
 
         // Buy with 0 balance must be rejected with the margin reason.
-        var buy = await PostOrder(http, token, qty: 1, price: 30m, side: "Buy");
+        // Use a price below the resting Sell so the self-trade-prevention
+        // check (which would also fire and reject first) is not triggered;
+        // this test specifically exercises the margin path.
+        var buy = await PostOrder(http, token, qty: 1, price: 29m, side: "Buy");
         var buyBody = await buy.Content.ReadFromJsonAsync<OrderAck>();
         Assert.Equal("Rejected", buyBody!.Status);
         Assert.Contains("margin", buyBody.Reason!, StringComparison.OrdinalIgnoreCase);

--- a/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
@@ -1,0 +1,151 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+public class SelfTradePreventionCheckTests
+{
+    private const string Firm = "FIRM01";
+    private const string Owner = "alice";
+    private const string Symbol = "PETR4";
+    private static readonly EndClientId OwnerId = new(Owner);
+
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) =>
+        new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static (SelfTradePreventionCheck check, WorkingOrderBook book) Build(RiskOptions? opts = null)
+    {
+        var book = new WorkingOrderBook();
+        var check = new SelfTradePreventionCheck(Wrap(opts ?? new RiskOptions()), book);
+        return (check, book);
+    }
+
+    private static Order Make(ulong clOrdId, OrderSide side, decimal? price, OrderType type = OrderType.Limit,
+                              long qty = 100, string owner = Owner, string symbol = Symbol) =>
+        new(clOrdId, new EndClientId(owner), symbol, 4321UL, side, type, qty, price, Firm);
+
+    private static RiskContext Ctx(OrderSide side, decimal? price, OrderType type = OrderType.Limit,
+                                   long qty = 100, string owner = Owner, string symbol = Symbol) =>
+        new(new EndClientId(owner), Firm, symbol, side, type, qty, price);
+
+    [Fact]
+    public void NoOpenOrders_Approves()
+    {
+        var (check, _) = Build();
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 30m)).Approved);
+    }
+
+    [Fact]
+    public void Buy_CrossesOwnSell_Rejected()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.40m)));
+        var decision = check.Check(Ctx(OrderSide.Buy, 32.50m));
+        Assert.False(decision.Approved);
+        Assert.Contains("self_trade_prevention", decision.Reason);
+        Assert.Contains("clOrdId=1", decision.Reason);
+    }
+
+    [Fact]
+    public void Sell_CrossesOwnBuy_Rejected()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(7, OrderSide.Buy, 32.50m)));
+        var decision = check.Check(Ctx(OrderSide.Sell, 32.40m));
+        Assert.False(decision.Approved);
+        Assert.Contains("clOrdId=7", decision.Reason);
+    }
+
+    [Fact]
+    public void Buy_BelowOwnSellPrice_Approves()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.50m)));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.40m)).Approved);
+    }
+
+    [Fact]
+    public void Sell_AboveOwnBuyPrice_Approves()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Buy, 32.40m)));
+        Assert.True(check.Check(Ctx(OrderSide.Sell, 32.50m)).Approved);
+    }
+
+    [Fact]
+    public void EqualPrice_Crosses()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.50m)));
+        Assert.False(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
+    }
+
+    [Fact]
+    public void IncomingMarket_AnyContraWorking_Rejected()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 99.99m)));
+        Assert.False(check.Check(Ctx(OrderSide.Buy, price: null, type: OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void RestingMarket_NewLimit_Rejected()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, price: null, type: OrderType.Market)));
+        Assert.False(check.Check(Ctx(OrderSide.Buy, 0.01m)).Approved);
+    }
+
+    [Fact]
+    public void ContraOrder_DifferentOwner_Approves()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.40m, owner: "bob")));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m, owner: Owner)).Approved);
+    }
+
+    [Fact]
+    public void ContraOrder_DifferentSymbol_Approves()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.40m, symbol: "VALE3")));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m, symbol: Symbol)).Approved);
+    }
+
+    [Fact]
+    public void TerminalContra_Ignored_Approves()
+    {
+        var (check, book) = Build();
+        var sell = Make(1, OrderSide.Sell, 32.40m);
+        Assert.True(book.TryAdd(sell));
+        // Drive to Cancelled — leaves should hit 0 too, but we test the
+        // status branch defensively.
+        sell.MarkCancelled();
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
+    }
+
+    [Fact]
+    public void AllowSelfTrade_OptIn_Approves()
+    {
+        var opts = new RiskOptions
+        {
+            PerEndClient =
+            {
+                [Owner] = new RiskLimits { AllowSelfTrade = true },
+            },
+        };
+        var (check, book) = Build(opts);
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.40m)));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
+    }
+
+    [Fact]
+    public void SameSide_Ignored_Approves()
+    {
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(1, OrderSide.Buy, 32.40m)));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
+    }
+}

--- a/docker/docker-compose.real-conformance.yml
+++ b/docker/docker-compose.real-conformance.yml
@@ -33,3 +33,11 @@ services:
   trading-host:
     environment:
       Trading__Risk__PerEndClient__alice__AllowShortSell: "true"
+      # Same rationale for self-trade prevention (#102): the spec
+      # crosses Buy+Sell from the SAME end-client (alice) to print a
+      # trade and observe the live ref-price displace the fallback.
+      # The default-on STP gate would risk-reject the second leg
+      # ("would cross own working Buy ..."). Opt alice out, scoped
+      # to the conformance run only — the gate stays armed for
+      # every other end-client in this stack.
+      Trading__Risk__PerEndClient__alice__AllowSelfTrade: "true"


### PR DESCRIPTION
## Sumário

Adiciona `SelfTradePreventionCheck` ao risk pipeline. Bloqueia um end-client de submeter uma ordem que cruzaria com qualquer ordem oposta dele mesmo no mesmo símbolo.

Repro do dogfood (issue #102): `bob` Buy 200 @ 32.50 cruzou com Sell 100 @ 32.40 do próprio bob → Filled, posição inalterada (self-trade).

## Política

- **STP-N (Newest Rejects)**: ordem entrante é rejeitada se cruzaria com working contrária do mesmo owner. Working contrária permanece intacta.
- **Toggle**: `RiskLimits.AllowSelfTrade` (precedence padrão: per-end-client → per-firm → per-symbol → default). Default: bloqueado.
- **Order=190**, depois de `no_naked_short` (180), antes de `position_limit` (200).

## Cobertura de cruzamento

- Buy@P × Sell@Q working → cruza se P ≥ Q
- Sell@P × Buy@Q working → cruza se P ≤ Q
- Market entrante × qualquer working contrária → cruza
- Qualquer entrante × Market resting → cruza
- Side igual → ignorado
- Owner ou symbol diferente → ignorado
- Status terminal (Filled/Cancelled/Rejected) ou LeavesQuantity=0 → ignorado

## Limitações documentadas

- TOCTOU pequeno (mitigado por submissão serial por end-client via API).
- Não bloqueia cross entre end-clients diferentes da mesma firma (legítimo).
- Não cobre orders mid-cancel até o cancel-ack ER chegar.
- STP nativa do servidor B3.EntryPoint é a solução de produção — investigação tracked em #103.

## Testes

13 unit tests novos (`SelfTradePreventionCheckTests`) + 1 ajuste em integração (`MarginCheckIntegrationTests.SellsAndUnknownOwnersBypassMargin`: muda preço pra 29 abaixo da Sell @ 30 pra não disparar STP — preserva intenção do teste de exercitar margin path).

Suite total: **32 + 261 + 141 verde**.

## Issues relacionadas

- Closes #102
- Tracked: #103 (STP nativa)