### PR TITLE
fix(frontend): isolate per-tab session + show ticket Submit

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -120,7 +120,13 @@ body {
   flex: 1;
   display: grid;
   grid-template-columns: 1fr 280px 280px;
-  grid-template-rows: minmax(300px, 1.2fr) minmax(160px, .9fr) minmax(220px, 1.4fr) minmax(140px, .8fr);
+  /* Row 1 min-height bumped from 300px → 360px so the Order Ticket
+     Submit button stays visible without scrolling at viewport ≥1024×600
+     (issue #105). 300px was within ~5px of the ticket form's natural
+     height, leaving the button clipped by `.ticket { overflow-y: auto }`
+     under default font-size. 360px gives ~50px of headroom for future
+     fields (TIF, Stop, etc.) without forcing the chart smaller. */
+  grid-template-rows: minmax(360px, 1.2fr) minmax(160px, .9fr) minmax(220px, 1.4fr) minmax(140px, .8fr);
   grid-template-areas:
     "chart    dob      ticket"
     "tape     dob      positions"

--- a/frontend/e2e/smoke.spec.js
+++ b/frontend/e2e/smoke.spec.js
@@ -80,6 +80,11 @@ test.describe("trader workspace smoke", () => {
     await page.selectOption("#ticket-type", "Limit");
     await page.fill("#ticket-qty", "100");
     await page.fill("#ticket-price", "25.00");
+    // Issue #105: Submit must be visible in the ticket panel viewport
+    // without scrolling. Playwright's click() auto-scrolls into view,
+    // so the click itself wouldn't catch a clipped button — assert
+    // explicit in-viewport visibility before exercising it.
+    await expect(page.locator("#ticket-submit")).toBeInViewport();
     await page.click("#ticket-submit");
 
     // The accepted ClOrdId is shown in the ticket-feedback line and

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -727,32 +727,55 @@ async function handleRunEod() {
   }
 }
 
-function readSession() {
-  // Read both stores; pick the freshest non-expired one. If "remember
-  // me" was used, it lives in localStorage. Otherwise, sessionStorage.
-  const candidates = [];
-  for (const store of [localStorage, sessionStorage]) {
-    try {
-      const raw = store.getItem(SESSION_KEY);
-      if (!raw) continue;
-      const parsed = JSON.parse(raw);
-      if (!parsed.token || !parsed.expiresAt) continue;
-      if (new Date(parsed.expiresAt).getTime() <= Date.now()) continue;
-      candidates.push({ store, parsed });
-    } catch { /* fall through */ }
+function readStoredSession(store) {
+  try {
+    const raw = store.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed.token || !parsed.expiresAt) return null;
+    if (new Date(parsed.expiresAt).getTime() <= Date.now()) return null;
+    return parsed;
+  } catch {
+    return null;
   }
-  if (!candidates.length) return null;
-  candidates.sort((a, b) =>
-    new Date(b.parsed.expiresAt).getTime() - new Date(a.parsed.expiresAt).getTime());
-  const winner = candidates[0];
-  sessionStore = winner.store;
-  return winner.parsed;
+}
+
+function readSession() {
+  // sessionStorage is the per-tab anchor: once a tab has its own
+  // session pinned there, no other tab can hijack it via localStorage.
+  // localStorage is consulted only as a "boot seed" for fresh tabs
+  // that don't yet have their own pinned session — that's how
+  // "Remember me" survives a full browser close. Issue #104:
+  // previously we picked the freshest of either store, which let a
+  // remember-me login in tab B silently take over tab A on reload.
+  const fromTab = readStoredSession(sessionStorage);
+  if (fromTab) {
+    sessionStore = sessionStorage;
+    return fromTab;
+  }
+  const fromBoot = readStoredSession(localStorage);
+  if (fromBoot) {
+    // Pin the boot seed into this tab so subsequent reloads/writes
+    // stay isolated from other tabs.
+    try { sessionStorage.setItem(SESSION_KEY, JSON.stringify(fromBoot)); } catch { /* swallow */ }
+    sessionStore = fromBoot.remember ? localStorage : sessionStorage;
+    return fromBoot;
+  }
+  return null;
 }
 function writeSession(s) {
-  sessionStore.setItem(SESSION_KEY, JSON.stringify(s));
-  // Make sure the other store doesn't shadow our write.
-  const other = sessionStore === localStorage ? sessionStorage : localStorage;
-  try { other.removeItem(SESSION_KEY); } catch { /* swallow */ }
+  // Always pin in sessionStorage so the tab owns its identity going
+  // forward. Mirror to localStorage only when remember-me is on, so
+  // a fresh browser launch can recover the session via the boot seed
+  // path in readSession(). We deliberately do NOT clear the "other"
+  // store here: another tab may legitimately have a remember-me
+  // session in localStorage that this tab's write must not erase
+  // (issue #104).
+  try { sessionStorage.setItem(SESSION_KEY, JSON.stringify(s)); } catch { /* swallow */ }
+  if (s.remember) {
+    try { localStorage.setItem(SESSION_KEY, JSON.stringify(s)); } catch { /* swallow */ }
+  }
+  sessionStore = s.remember ? localStorage : sessionStorage;
 }
 function clearSession() {
   try { localStorage.removeItem(SESSION_KEY); } catch { /* swallow */ }


### PR DESCRIPTION
Closes #104 (cross-tab session leak via Remember me).
Closes #105 (Order Ticket Submit button hidden by tight grid row).

## #104 — Cross-tab session leak

`readSession()` previously picked the freshest token across both `sessionStorage` and `localStorage`. Combined with a 'Remember me' login in another tab, this let tab A silently adopt tab B's identity on reload — confirmed via WAL during dogfooding (alice tab submitted orders as bob).

Refactor: `sessionStorage` is now the per-tab anchor. `localStorage` is consulted only as a 'boot seed' for fresh tabs (so Remember me still survives a full browser close). On boot from a seed, the session is immediately pinned into `sessionStorage` so that tab is isolated from other tabs' subsequent writes. `writeSession()` no longer wipes the other store — another tab's legitimate remember-me session in `localStorage` is preserved. Logout still clears both stores (explicit user intent).

Acceptance covered by issue body:
- Tab A login alice + Tab B login bob with remember → reload Tab A continues as alice ✅
- Fresh tab opened after remember-me login adopts the seed ✅
- Logout clears both stores ✅

## #105 — Submit button hidden

Bumped `.grid` row 1 minmax from 300px → 360px so the ticket-form Submit button renders inside the panel viewport without scrolling at ≥1024×600. Added `toBeInViewport()` assertion to the e2e smoke spec (Playwright's `click()` auto-scrolls into view, which would mask a clipped button otherwise).

## Test
- `node --test frontend/test/decoder.test.mjs` — green (32/32)
- E2E smoke runs in CI.