### PR TITLE
feat(risk): add MinNotional anti-dust pre-trade check

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -98,6 +98,7 @@ public static class AdminEndpoints
                 {
                     maxQuantity = resolved.MaxQuantity,
                     maxNotional = resolved.MaxNotional,
+                    minNotional = resolved.MinNotional,
                     priceCollarPercent = resolved.PriceCollarPercent,
                     priceCollarAbsolute = resolved.PriceCollarAbsolute,
                     positionLimit = resolved.PositionLimit,

--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
@@ -40,3 +40,44 @@ public sealed class MaxNotionalCheck : IRiskCheck
         return RiskDecision.Approve;
     }
 }
+
+/// <summary>
+/// Anti-dust pre-trade gate. Rejects Limit orders whose notional
+/// (price × quantity) sits below a per-symbol/firm/end-client floor.
+/// Market orders skip the check (no price to evaluate; the venue and
+/// the lot-size / max-quantity gates already bound the worst case).
+///
+/// Rationale: B3 cash equities have an implicit "lote padrão" floor
+/// that the lot-size gate already enforces in shares, but a notional
+/// floor is the operationally meaningful one for risk and surveillance
+/// (avoids fragmented executions used to mark prices, dust positions
+/// nobody can clear, and trivially-small orders that consume gateway
+/// throughput for no economic purpose). Also serves as a cheap guard
+/// against typo-fat-finger in the price field (e.g. 0.01 instead of
+/// 30.00 on PETR4 still passes max-quantity but trips min-notional).
+///
+/// Default semantics when unset everywhere in the precedence chain
+/// are permissive: no floor enforced (Approve). Configure via
+/// <c>Trading:Risk:Default:MinNotional</c> or any of the per-X
+/// overrides.
+/// </summary>
+public sealed class MinNotionalCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    public MinNotionalCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
+
+    public int Order => 110; // after max-quantity / max-notional, before throttles
+    public string Name => "min_notional";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var opts = _options.CurrentValue;
+        var min = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MinNotional);
+        if (!min.HasValue || !ctx.Price.HasValue)
+            return RiskDecision.Approve; // no floor configured, or market order
+        var notional = ctx.Price.Value * ctx.Quantity;
+        if (notional < min.Value)
+            return RiskDecision.Reject($"notional {notional} below min {min.Value}");
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -105,6 +105,18 @@ public sealed class RiskLimits
 {
     public long? MaxQuantity { get; set; }
     public decimal? MaxNotional { get; set; }
+
+    /// <summary>
+    /// Optional notional floor (price × quantity) for Limit orders.
+    /// Rejects sub-floor submissions as anti-dust / typo-guard
+    /// (e.g. fat-finger 0.01 on PETR4 still passes max-quantity but
+    /// trips min-notional). Market orders skip the check — there's
+    /// no price to evaluate and the venue + max-quantity gates
+    /// already bound the worst case. Default semantics when unset
+    /// everywhere in the precedence chain are permissive: no floor
+    /// (see <see cref="Risk.Checks.MinNotionalCheck"/>).
+    /// </summary>
+    public decimal? MinNotional { get; set; }
     public decimal? PriceCollarPercent { get; set; }
     /// <summary>
     /// Optional absolute price band (in price units) around the
@@ -195,6 +207,7 @@ public static class RiskLimitsResolver
         {
             MaxQuantity = Resolve(opts, endClient, firmId, symbol, l => l.MaxQuantity),
             MaxNotional = Resolve(opts, endClient, firmId, symbol, l => l.MaxNotional),
+            MinNotional = Resolve(opts, endClient, firmId, symbol, l => l.MinNotional),
             PriceCollarPercent = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarPercent),
             PriceCollarAbsolute = Resolve(opts, endClient, firmId, symbol, l => l.PriceCollarAbsolute),
             PositionLimit = Resolve(opts, endClient, firmId, symbol, l => l.PositionLimit),

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -128,6 +128,7 @@ builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxNotionalCheck>();
+builder.Services.AddSingleton<IRiskCheck, MinNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, PositionLimitCheck>();
 builder.Services.AddSingleton<IRiskCheck, RollingNotionalCheck>();
 builder.Services.AddSingleton<IRiskCheck, OrderRateLimitCheck>();

--- a/backend/tests/B3.Trading.Api.Tests/AdminRiskEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminRiskEndpointsTests.cs
@@ -30,6 +30,8 @@ public class AdminRiskEndpointsTests : IClassFixture<TestAppFactory>
         var limits = body.GetProperty("limits");
         Assert.Equal(1000, limits.GetProperty("maxQuantity").GetInt64());
         Assert.Equal(1000000m, limits.GetProperty("maxNotional").GetDecimal());
+        // MinNotional defaults to null (permissive) — surfaced as JSON null.
+        Assert.Equal(JsonValueKind.Null, limits.GetProperty("minNotional").ValueKind);
         Assert.Equal(10m, limits.GetProperty("priceCollarPercent").GetDecimal());
         Assert.Equal(5000, limits.GetProperty("positionLimit").GetInt64());
     }

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -207,6 +207,48 @@ public class RiskPipelineTests
     }
 
     [Fact]
+    public void MinNotional_RejectsBelowFloor_ApprovesAtAndAbove()
+    {
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MinNotional = 1000m } });
+        var check = new MinNotionalCheck(opts);
+        Assert.True(check.Check(Ctx(qty: 100, price: 30m)).Approved);    // 3000 ≥ 1000
+        Assert.True(check.Check(Ctx(qty: 100, price: 10m)).Approved);    // 1000 == floor
+        var d = check.Check(Ctx(qty: 10, price: 10m));                   // 100 < 1000
+        Assert.False(d.Approved);
+        Assert.Contains("min", d.Reason);
+    }
+
+    [Fact]
+    public void MinNotional_NullPriceIsApproved()
+    {
+        // Market orders don't carry a price; min-notional cannot fire.
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MinNotional = 999_999m } });
+        Assert.True(new MinNotionalCheck(opts).Check(Ctx(price: null, type: OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void MinNotional_NoFloorConfigured_IsApproved()
+    {
+        // Default semantics: permissive when unset everywhere.
+        var opts = Wrap(new RiskOptions());
+        Assert.True(new MinNotionalCheck(opts).Check(Ctx(qty: 1, price: 0.01m)).Approved);
+    }
+
+    [Fact]
+    public void MinNotional_PerEndClient_OverridesDefault()
+    {
+        var opts = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { MinNotional = 100m },
+            PerEndClient = { ["alice"] = new RiskLimits { MinNotional = 5000m } },
+        });
+        var check = new MinNotionalCheck(opts);
+        // Notional 1000 passes default but trips alice's tighter floor.
+        Assert.False(check.Check(Ctx(owner: "alice", qty: 100, price: 10m)).Approved);
+        Assert.True(check.Check(Ctx(owner: "bob", qty: 100, price: 10m)).Approved);
+    }
+
+    [Fact]
     public void PriceCollar_RejectsOutsideBand()
     {
         var refPx = new StubRef(("PETR4", 30m));


### PR DESCRIPTION
First slice of #108 (umbrella tracking for novos pre-trade checks).

## What

`MinNotionalCheck` rejects Limit orders whose notional (`price × quantity`) sits below a configurable floor. Market orders skip the check (no price to evaluate; venue + max-quantity gates already bound the worst case).

## Why

Two cheap, complementary protections in one check:

1. **Anti-dust / surveillance hygiene** — fragmented sub-floor executions are operationally noisy and can be used to mark prices.
2. **Typo-fat-finger guard on the price field** — e.g. typing `0.01` instead of `30.00` on PETR4 still passes max-quantity but trips min-notional. The existing collar catches some of this, but not when a price entry is *below* the band asymmetrically (rare, but possible with a wide collar).

## Defaults

Permissive (no floor) when unset everywhere in the precedence chain, so existing deployments aren't affected until they opt in via:

```json
"Trading": { "Risk": { "Default": { "MinNotional": 100.0 } } }
```

Per-firm / per-end-client / per-symbol overrides follow the existing `RiskLimitsResolver` precedence.

## Surface

- `RiskLimits.MinNotional` (decimal?) — same shape as MaxNotional.
- `MinNotionalCheck` — pipeline order=110 (after max-notional, before throttles).
- `GET /admin/risk/limits` — new `minNotional` field in the resolved payload.
- DI wiring in `Program.cs`.

## Tests

- 4 new unit tests in `RiskPipelineTests`: rejects below floor, approves at floor, approves above, null-price (Market) skip, no-floor permissive default, per-end-client override beats Default.
- `AdminRiskEndpointsTests` extended to assert the new `minNotional` field is present in the resolved payload (defaults to JSON null).
- Full suite green locally: 32 + 265 + 141.
- `dotnet format --verify-no-changes` green.

Refs #108. The umbrella tracking issue stays open with the remaining candidate checks (SymbolHalted next per user priority).