### PR TITLE
feat(risk): per-symbol trading halt with WAL persistence

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -39,6 +39,20 @@ public static class AdminEndpoints
         group.MapDelete("/kill/firm/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher) =>
             ToggleKill(dispatcher, "firm", id, killed: false, ctx, () => svc.ReviveFirm(id)));
 
+        // ── Symbol trading halts ─────────────────────────────────
+        // Per-symbol pre-trade gate (#108 slice 2). Halts are
+        // event-sourced via SymbolHaltToggledEvent so they survive
+        // restart — losing a halt on crash would be the worst
+        // possible default for a safety control.
+        group.MapGet("/halts", (SymbolHaltService svc) =>
+            Results.Ok(new { Symbols = svc.ListHalted() }));
+
+        group.MapPost("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
+            ToggleHalt(dispatcher, symbol, halted: true, ctx, () => svc.Halt(symbol)));
+
+        group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
+            ToggleHalt(dispatcher, symbol, halted: false, ctx, () => svc.Resume(symbol)));
+
         group.MapPost("/eod", (EodMaterialiser eod, IOptions<PersistenceOptions> opts) =>
         {
             // EOD materialisation runs against persisted segments, so it
@@ -256,6 +270,38 @@ public static class AdminEndpoints
         {
             MetricsRegistry.WalBackpressure.Add(1,
                 new KeyValuePair<string, object?>("call_site", "admin.kill"));
+            return Results.Json(
+                new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    private static IResult ToggleHalt(
+        EventDispatcher dispatcher,
+        string symbol,
+        bool halted,
+        HttpContext ctx,
+        Action mutate)
+    {
+        var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+        try
+        {
+            dispatcher.Dispatch(
+                new SymbolHaltToggledEvent
+                {
+                    Symbol = symbol,
+                    Halted = halted,
+                    ActorUserId = actor,
+                },
+                mutate);
+            MetricsRegistry.SymbolHaltToggled.Add(1,
+                new KeyValuePair<string, object?>("halted", halted));
+            return Results.NoContent();
+        }
+        catch (WalBackpressureException ex)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "admin.halts"));
             return Results.Json(
                 new { error = "system busy (WAL backpressure)", detail = ex.Message },
                 statusCode: StatusCodes.Status503ServiceUnavailable);

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -52,6 +52,9 @@ public static class MetricsRegistry
     public static readonly Counter<long> KillSwitchToggled =
         Meter.CreateCounter<long>("trading.kill_switch.toggled");
 
+    public static readonly Counter<long> SymbolHaltToggled =
+        Meter.CreateCounter<long>("trading.symbol_halt.toggled");
+
     // WAL
     public static readonly Counter<long> WalAppended =
         Meter.CreateCounter<long>("trading.wal.appended");

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -14,6 +14,13 @@ public sealed class PlatformSnapshot
     public List<PositionSnapshot> Positions { get; init; } = new();
     public List<string> KilledEndClients { get; init; } = new();
     public List<string> KilledFirms { get; init; } = new();
+    /// <summary>
+    /// Symbols currently trading-halted via <c>SymbolHaltService</c>.
+    /// Added in the symbol-halt slice; older snapshots that pre-date
+    /// the field deserialise with an empty list, which matches the
+    /// "no halts" semantics they actually carried.
+    /// </summary>
+    public List<string> HaltedSymbols { get; init; } = new();
     public ClOrdIdRegistrySnapshot ClOrdIds { get; init; } = new();
     public List<OwnershipMappingSnapshot> Ownership { get; init; } = new();
     public List<AlgoSnapshot> Algos { get; init; } = new();

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -19,6 +19,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(OrderSubmittedEvent), "order.submitted")]
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
+[JsonDerivedType(typeof(SymbolHaltToggledEvent), "symbol-halt.toggled")]
 [JsonDerivedType(typeof(AlgoCreatedEvent), "algo.created")]
 [JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
@@ -92,6 +93,19 @@ public sealed record KillSwitchToggledEvent : WalEvent
     public required string Scope { get; init; }   // "end-client" | "firm"
     public required string Target { get; init; }
     public required bool Killed { get; init; }    // true=kill, false=revive
+    public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Per-symbol trading halt toggle. Audit trail for "who halted what,
+/// when, and why" — and the only way recovery reconstructs the halt
+/// set, since halts are an out-of-band admin decision rather than a
+/// side-effect of an exchange ER.
+/// </summary>
+public sealed record SymbolHaltToggledEvent : WalEvent
+{
+    public required string Symbol { get; init; }
+    public required bool Halted { get; init; }    // true=halt, false=resume
     public string? ActorUserId { get; init; }
 }
 

--- a/backend/src/B3.Trading.Application/Risk/Checks/SymbolHaltedCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SymbolHaltedCheck.cs
@@ -1,0 +1,28 @@
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Pre-trade gate that rejects any submission for a symbol marked
+/// halted via <see cref="SymbolHaltService"/>. Pipeline order=10
+/// (right after the kill-switch) so a halted-symbol submission fails
+/// before any of the per-instrument or per-end-client work runs —
+/// the cheapest possible reject for a control that's binary.
+///
+/// <para>Defaults are conservative: the halted set is empty on a
+/// fresh process; halts survive process restart via WAL +
+/// snapshot. Resume requires an explicit admin call.</para>
+/// </summary>
+public sealed class SymbolHaltedCheck : IRiskCheck
+{
+    private readonly SymbolHaltService _halts;
+    public SymbolHaltedCheck(SymbolHaltService halts) => _halts = halts;
+
+    public int Order => 10;
+    public string Name => "symbol_halted";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (_halts.IsHalted(ctx.Symbol))
+            return RiskDecision.Reject($"symbol '{ctx.Symbol}' trading halted");
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/SymbolHaltService.cs
+++ b/backend/src/B3.Trading.Application/Risk/SymbolHaltService.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// In-memory per-symbol trading halt state. Toggles take effect on the
+/// very next risk evaluation — used by <see cref="Checks.SymbolHaltedCheck"/>.
+///
+/// <para>
+/// Modelled per-symbol (no firm/end-client split) because in B3 cash
+/// equities a halt is an instrument-level decision: when ITUB4 is in
+/// circuit-breaker, no participant should be sending orders for it,
+/// regardless of who they are. If a per-firm or per-symbol+firm slot
+/// is ever needed (e.g. a single firm's gateway is degraded for one
+/// ticker), it can be layered on top without changing this surface.
+/// </para>
+///
+/// <para>
+/// Symbol comparisons are case-insensitive (PETR4 == petr4) to match
+/// the rest of the platform's symbol handling. The halted set is
+/// captured by the snapshotter and replayed from
+/// <c>SymbolHaltToggledEvent</c> records on recovery, so a halt
+/// survives a process restart — losing it on crash would be the
+/// worst possible default for a safety control.
+/// </para>
+/// </summary>
+public sealed class SymbolHaltService
+{
+    private readonly ConcurrentDictionary<string, byte> _haltedSymbols =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public bool IsHalted(string symbol) => _haltedSymbols.ContainsKey(symbol);
+
+    public void Halt(string symbol) => _haltedSymbols[symbol] = 1;
+    public bool Resume(string symbol) => _haltedSymbols.TryRemove(symbol, out _);
+
+    public IReadOnlyCollection<string> ListHalted() => _haltedSymbols.Keys.ToArray();
+
+    public void Restore(IEnumerable<string> haltedSymbols)
+    {
+        ArgumentNullException.ThrowIfNull(haltedSymbols);
+        _haltedSymbols.Clear();
+        foreach (var s in haltedSymbols) _haltedSymbols[s] = 1;
+    }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -113,6 +113,7 @@ builder.Services.AddSingleton<EventDispatcher>();
 // margin provider. Each IRiskCheck registration is auto-discovered by
 // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.
 builder.Services.AddSingleton<KillSwitchService>();
+builder.Services.AddSingleton<SymbolHaltService>();
 builder.Services.AddTradingMarketData(builder.Configuration);
 builder.Services.AddSingleton<IMarginProvider>(sp =>
 {
@@ -124,6 +125,7 @@ builder.Services.AddSingleton<IMarginProvider>(sp =>
         : new NoOpMarginProvider();
 });
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
+builder.Services.AddSingleton<IRiskCheck, SymbolHaltedCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -70,6 +70,7 @@ public sealed class EodMaterialiser
                             report.RejectedCount++;
                         break;
                     case KillSwitchToggledEvent: report.KillSwitchToggleCount++; break;
+                    case SymbolHaltToggledEvent: report.SymbolHaltToggleCount++; break;
                 }
             }
         }
@@ -99,6 +100,7 @@ public sealed class EodReport
     public long CanceledCount { get; set; }
     public long RejectedCount { get; set; }
     public long KillSwitchToggleCount { get; set; }
+    public long SymbolHaltToggleCount { get; set; }
     public string Sha256 { get; set; } = "";
     public string Path { get; set; } = "";
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -17,6 +17,7 @@ public sealed class StateSnapshotter
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
     private readonly KillSwitchService _killSwitch;
+    private readonly SymbolHaltService _symbolHalts;
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly OrderOwnershipMap _ownership;
     private readonly AlgoBook _algos;
@@ -26,6 +27,7 @@ public sealed class StateSnapshotter
         WorkingOrderBook orders,
         PositionKeeper positions,
         KillSwitchService killSwitch,
+        SymbolHaltService symbolHalts,
         ClOrdIdPrefixRegistry clOrdIds,
         OrderOwnershipMap ownership,
         AlgoBook algos,
@@ -34,6 +36,7 @@ public sealed class StateSnapshotter
         _orders = orders;
         _positions = positions;
         _killSwitch = killSwitch;
+        _symbolHalts = symbolHalts;
         _clOrdIds = clOrdIds;
         _ownership = ownership;
         _algos = algos;
@@ -48,6 +51,7 @@ public sealed class StateSnapshotter
         Positions = _positions.Snapshot().ToList(),
         KilledEndClients = _killSwitch.ListKilledEndClients().ToList(),
         KilledFirms = _killSwitch.ListKilledFirms().ToList(),
+        HaltedSymbols = _symbolHalts.ListHalted().ToList(),
         ClOrdIds = _clOrdIds.Snapshot(),
         Ownership = _ownership.Snapshot().ToList(),
         Algos = _algos.Snapshot().ToList(),
@@ -60,6 +64,7 @@ public sealed class StateSnapshotter
         _orders.Restore(snap.WorkingOrders);
         _positions.Restore(snap.Positions);
         _killSwitch.Restore(snap.KilledEndClients, snap.KilledFirms);
+        _symbolHalts.Restore(snap.HaltedSymbols);
         _clOrdIds.Restore(snap.ClOrdIds);
         _ownership.Restore(snap.Ownership);
         _algos.Restore(snap.Algos);
@@ -79,6 +84,7 @@ public sealed class EventReplayer
     private readonly WorkingOrderBook _orders;
     private readonly OrderOwnershipMap _ownership;
     private readonly KillSwitchService _killSwitch;
+    private readonly SymbolHaltService _symbolHalts;
     private readonly ExecutionReportProcessor _processor;
     private readonly AlgoBook _algos;
 
@@ -86,12 +92,14 @@ public sealed class EventReplayer
         WorkingOrderBook orders,
         OrderOwnershipMap ownership,
         KillSwitchService killSwitch,
+        SymbolHaltService symbolHalts,
         ExecutionReportProcessor processor,
         AlgoBook algos)
     {
         _orders = orders;
         _ownership = ownership;
         _killSwitch = killSwitch;
+        _symbolHalts = symbolHalts;
         _processor = processor;
         _algos = algos;
     }
@@ -130,6 +138,10 @@ public sealed class EventReplayer
                     if (k.Killed) _killSwitch.KillFirm(k.Target);
                     else _killSwitch.ReviveFirm(k.Target);
                 }
+                break;
+            case SymbolHaltToggledEvent sh:
+                if (sh.Halted) _symbolHalts.Halt(sh.Symbol);
+                else _symbolHalts.Resume(sh.Symbol);
                 break;
             case AlgoCreatedEvent ac:
                 ApplyAlgoCreated(ac);

--- a/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
@@ -43,6 +43,55 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
     }
 
     [Fact]
+    public async Task AdminHaltsEndpoints_RequireAdminRole()
+    {
+        using var userClient = await _factory.CreateAuthedClientAsync(); // alice (user role)
+        var post = await userClient.PostAsync("/admin/halts/PETR4", content: null);
+        Assert.Equal(HttpStatusCode.Forbidden, post.StatusCode);
+        var get = await userClient.GetAsync("/admin/halts");
+        Assert.Equal(HttpStatusCode.Forbidden, get.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminGetHalts_ReturnsCurrentSymbols()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        // Clean any state from a previous test in the shared factory.
+        await admin.DeleteAsync("/admin/halts/ABEV3");
+
+        await admin.PostAsync("/admin/halts/ABEV3", content: null);
+        var state = await admin.GetFromJsonAsync<HaltStateDto>("/admin/halts");
+        Assert.Contains("ABEV3", state!.Symbols);
+        await admin.DeleteAsync("/admin/halts/ABEV3");
+    }
+
+    [Fact]
+    public async Task SymbolHaltToggle_RejectsNextOrder_ThenResumes()
+    {
+        using var http = _factory.CreateClient();
+        var token = await _factory.LoginAsync(http, "bob");
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+
+        var ws = await OpenSubscribedAsync(token, Channels.ExecutionsMe);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await admin.PostAsync("/admin/halts/PETR4", content: null);
+        try
+        {
+            var blocked = await PostAsync(http, token, "/orders",
+                new { Symbol = "PETR4", SecurityId = 4321UL, Side = "Buy", Type = "Limit", Quantity = 1, Price = 30m });
+            Assert.Equal(HttpStatusCode.Accepted, blocked.StatusCode);
+            var delta = await ReadJsonAsync(ws, cts.Token);
+            Assert.Equal("Rejected", delta.GetProperty("data").GetProperty("kind").GetString());
+            Assert.Contains("halted", delta.GetProperty("data").GetProperty("rejectReason").GetString());
+        }
+        finally
+        {
+            await admin.DeleteAsync("/admin/halts/PETR4");
+        }
+    }
+
+    [Fact]
     public async Task SubmitOrder_OverMaxQuantity_ProducesSyntheticRejectionOnExecutionsMe()
     {
         using var http = _factory.CreateClient();
@@ -131,4 +180,5 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
     }
 
     private sealed record KillStateDto(string[] EndClients, string[] Firms);
+    private sealed record HaltStateDto(string[] Symbols);
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -117,8 +117,8 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, processor, algos, _) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
-            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -151,7 +151,7 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, _, algos, dispatcher) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
 
             dispatcher.Dispatch(
                 new AlgoCreatedEvent

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -66,7 +66,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, positions, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
             var recovery = new PersistenceRecovery(store,
                 snapshotter,
                 replayer,
@@ -120,7 +120,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, processor, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -166,7 +166,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
             new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
-        var snapshotter = new StateSnapshotter(book, positions, killSwitch, clOrdIds, ownership, algos, new AlgoIdRegistry());
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(), clOrdIds, ownership, algos, new AlgoIdRegistry());
         var dispatcher = new EventDispatcher(store);
         return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
     }

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -59,6 +59,41 @@ public class RiskPipelineTests
     }
 
     [Fact]
+    public void SymbolHalted_BlocksThenResumes()
+    {
+        var halts = new SymbolHaltService();
+        var check = new SymbolHaltedCheck(halts);
+        Assert.True(check.Check(Ctx(symbol: "PETR4")).Approved);
+        halts.Halt("PETR4");
+        var d = check.Check(Ctx(symbol: "PETR4"));
+        Assert.False(d.Approved);
+        Assert.Contains("halted", d.Reason);
+        Assert.True(check.Check(Ctx(symbol: "VALE3")).Approved); // unrelated symbol unaffected
+        halts.Resume("PETR4");
+        Assert.True(check.Check(Ctx(symbol: "PETR4")).Approved);
+    }
+
+    [Fact]
+    public void SymbolHalted_IsCaseInsensitive()
+    {
+        var halts = new SymbolHaltService();
+        halts.Halt("petr4");
+        Assert.True(halts.IsHalted("PETR4"));
+        Assert.False(new SymbolHaltedCheck(halts).Check(Ctx(symbol: "PETR4")).Approved);
+    }
+
+    [Fact]
+    public void SymbolHaltService_RestoreReplacesPreviousState()
+    {
+        var halts = new SymbolHaltService();
+        halts.Halt("PETR4");
+        halts.Restore(new[] { "VALE3", "ITUB4" });
+        Assert.False(halts.IsHalted("PETR4")); // gone
+        Assert.True(halts.IsHalted("VALE3"));
+        Assert.True(halts.IsHalted("ITUB4"));
+    }
+
+    [Fact]
     public void KillSwitch_PerFirm_Blocks()
     {
         var ks = new KillSwitchService();


### PR DESCRIPTION
Second slice of #108.

## What

`SymbolHaltService` is an in-memory per-symbol halted set; `SymbolHaltedCheck` (pipeline order=10, right after the kill-switch) rejects any submission for a halted symbol with the cheapest possible early-out for a binary safety control.

Modelled per-symbol (no firm/end-client split) because in B3 cash equities a halt is an instrument-level decision: when ITUB4 is in circuit-breaker, no participant should be sending orders for it. Per-firm or per-symbol+firm slots can be layered on top later without changing this surface.

## Persistence

Halts are event-sourced via a new `SymbolHaltToggledEvent` and captured in `PlatformSnapshot.HaltedSymbols`, so they survive a process restart — losing a halt on crash would be the worst possible default for a safety control. Snapshot field is backward-compatible: older snapshots deserialise with an empty list, matching the 'no halts' semantics they actually carried.

## Admin surface (mirrors `/admin/kill`)

| Method | Path | Effect |
|--------|------|--------|
| GET | `/admin/halts` | `{ symbols: [...] }` |
| POST | `/admin/halts/{symbol}` | 204 NoContent (halt) |
| DELETE | `/admin/halts/{symbol}` | 204 NoContent (resume) |

All admin role-gated; both POST/DELETE go through `EventDispatcher` so the toggle is durably written before the in-memory mutation takes effect, and increment a new `trading.symbol_halt.toggled` meter. `EodReport` extended with `SymbolHaltToggleCount`.

## Tests

- 4 unit tests for the check + service (block/resume, case-insensitive symbol match, Restore replaces previous state, unrelated symbol unaffected).
- 3 admin-endpoint e2e tests (role gate, GET shape, halt → next order rejected with 'halted' reason via the WS `executions.me` channel).
- Existing snapshot/replayer tests adjusted for the new constructor parameter.
- Suite green locally: 32 + 268 + 144. Format check green.

Refs #108. Umbrella stays open with the remaining candidate checks.