### PR TITLE
feat(frontend): admin UI for symbol halts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -319,6 +319,20 @@
     </section>
 
     <section class="panel admin-panel">
+      <h3>Symbols (halted)</h3>
+      <form id="admin-add-halt-form" class="admin-inline-form">
+        <input id="admin-add-halt-symbol" type="text" placeholder="symbol (e.g. PETR4)" maxlength="16" />
+        <button type="submit" class="danger-btn engage">Halt symbol</button>
+      </form>
+      <div class="table-scroll">
+        <table>
+          <thead><tr><th>Symbol</th><th></th></tr></thead>
+          <tbody id="admin-halts-body"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="panel admin-panel">
       <h3>EOD materialisation</h3>
       <button id="admin-eod-btn" type="button">Run EOD now</button>
       <pre id="admin-eod-output" class="admin-eod-output" hidden></pre>

--- a/frontend/js/adminUi.js
+++ b/frontend/js/adminUi.js
@@ -10,6 +10,8 @@ const $ = (id) => document.getElementById(id);
 let onToggleFirm = () => {};
 let onToggleEndClient = () => {};
 let onAddEndClient = () => {};
+let onToggleHalt = () => {};
+let onAddHalt = () => {};
 let onRunEod = () => {};
 let onRefresh = () => {};
 
@@ -17,6 +19,8 @@ export function setAdminHandlers(handlers) {
   onToggleFirm      = handlers.onToggleFirm      ?? onToggleFirm;
   onToggleEndClient = handlers.onToggleEndClient ?? onToggleEndClient;
   onAddEndClient    = handlers.onAddEndClient    ?? onAddEndClient;
+  onToggleHalt      = handlers.onToggleHalt      ?? onToggleHalt;
+  onAddHalt         = handlers.onAddHalt         ?? onAddHalt;
   onRunEod          = handlers.onRunEod          ?? onRunEod;
   onRefresh         = handlers.onRefresh         ?? onRefresh;
 }
@@ -59,6 +63,29 @@ export function bindAdminUi() {
     $("admin-add-ec-id").value = "";
   });
 
+  $("admin-halts-body").addEventListener("click", (e) => {
+    const btn = e.target.closest(".halt-resume");
+    if (!btn) return;
+    const symbol = btn.dataset.symbol;
+    if (!confirmTwice(
+      `Resume trading for ${symbol}?`,
+      `Confirm: resume ${symbol}. Orders for this symbol will be accepted again.`,
+    )) return;
+    onToggleHalt({ symbol, halt: false });
+  });
+
+  $("admin-add-halt-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const symbol = $("admin-add-halt-symbol").value.trim().toUpperCase();
+    if (!symbol) return;
+    if (!confirmTwice(
+      `HALT trading for symbol ${symbol}?`,
+      `Confirm: halt ${symbol}. ALL participants will be blocked from sending orders for this symbol until resumed.`,
+    )) return;
+    onAddHalt({ symbol });
+    $("admin-add-halt-symbol").value = "";
+  });
+
   $("admin-eod-btn").addEventListener("click", () => {
     if (!confirmTwice(
       "Run EOD materialisation now?",
@@ -77,6 +104,7 @@ function confirmTwice(first, second) {
 function renderForSlice(slice) {
   if (slice === "firmsHealth" || slice === "killStatus" || slice === "all") renderFirms();
   if (slice === "killStatus"  || slice === "all") renderEndClients();
+  if (slice === "haltStatus"  || slice === "all") renderHalts();
   if (slice === "eodReport"   || slice === "all") renderEod();
   if (slice === "currentView") onViewChanged();
 }
@@ -88,6 +116,7 @@ function onViewChanged() {
   if (getState().currentView === "admin") {
     renderFirms();
     renderEndClients();
+    renderHalts();
     renderEod();
   }
 }
@@ -95,6 +124,7 @@ function onViewChanged() {
 export function renderAdminAll() {
   renderFirms();
   renderEndClients();
+  renderHalts();
   renderEod();
 }
 
@@ -150,6 +180,25 @@ function renderEndClients() {
   body.innerHTML = list.map(id => `<tr>
     <td><code>${escapeHtml(id)}</code></td>
     <td><button type="button" class="ec-revive danger-btn revive" data-ec="${escapeHtml(id)}">Revive</button></td>
+  </tr>`).join("");
+}
+
+function renderHalts() {
+  const body = $("admin-halts-body");
+  if (!body) return;
+  const hs = getState().haltStatus;
+  if (!hs) {
+    body.innerHTML = `<tr><td colspan="2" class="muted">awaiting /admin/halts…</td></tr>`;
+    return;
+  }
+  const list = hs.symbols ?? [];
+  if (list.length === 0) {
+    body.innerHTML = `<tr><td colspan="2" class="muted">no halted symbols</td></tr>`;
+    return;
+  }
+  body.innerHTML = list.map(sym => `<tr>
+    <td><code>${escapeHtml(sym)}</code></td>
+    <td><button type="button" class="halt-resume danger-btn revive" data-symbol="${escapeHtml(sym)}">Resume</button></td>
   </tr>`).join("");
 }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -3,6 +3,7 @@
 import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cancelOrder, getAdminFirms,
          validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
+         getHaltStatus, haltSymbol, resumeSymbol,
          runEod } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
 import { validateOrder, fatFingerCheck, payloadKey } from "./validation.js";
@@ -72,6 +73,8 @@ function init() {
     onToggleFirm:      handleToggleFirm,
     onToggleEndClient: handleToggleEndClient,
     onAddEndClient:    handleAddEndClient,
+    onToggleHalt:      handleToggleHalt,
+    onAddHalt:         handleAddHalt,
     onRunEod:          handleRunEod,
     onRefresh:         refreshAdminData,
   });
@@ -212,6 +215,7 @@ function startSession(next) {
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
   state.setKillStatus(null);
+  state.setHaltStatus(null);
   state.setEodReport(null);
   state.setCurrentView("trader");
   ui.showTrader();
@@ -622,6 +626,7 @@ function logout() {
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
   state.setKillStatus(null);
+  state.setHaltStatus(null);
   state.setEodReport(null);
   state.setCurrentView("trader");
   state.setBlotterFilter(readBlotterFilter());
@@ -652,14 +657,19 @@ function stopFirmsPoll() {
 async function pollFirmsOnce() {
   if (!session) return;
   try {
-    const [firms, kill] = await Promise.all([
+    const [firms, kill, halts] = await Promise.all([
       getAdminFirms(session.backend, session.token),
       getKillStatus(session.backend, session.token),
+      getHaltStatus(session.backend, session.token),
     ]);
     state.setFirmsHealth({ ...firms, fetchedAt: Date.now() });
     state.setKillStatus({
       firms: kill?.Firms ?? [],
       endClients: kill?.EndClients ?? [],
+      fetchedAt: Date.now(),
+    });
+    state.setHaltStatus({
+      symbols: halts?.Symbols ?? [],
       fetchedAt: Date.now(),
     });
   } catch (err) {
@@ -713,6 +723,17 @@ function handleToggleEndClient({ id, engage }) {
 
 function handleAddEndClient({ id }) {
   handleToggleEndClient({ id, engage: true });
+}
+
+function handleToggleHalt({ symbol, halt }) {
+  withAdminCall(
+    () => (halt ? haltSymbol : resumeSymbol)(session.backend, session.token, symbol),
+    `symbol ${symbol}: ${halt ? "halted" : "resumed"}`,
+  );
+}
+
+function handleAddHalt({ symbol }) {
+  handleToggleHalt({ symbol, halt: true });
 }
 
 async function handleRunEod() {

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -127,6 +127,31 @@ export const reviveFirm      = (b, t, id) => toggleKill(b, t, "firm",       id, 
 export const killEndClient   = (b, t, id) => toggleKill(b, t, "end-client", id, true);
 export const reviveEndClient = (b, t, id) => toggleKill(b, t, "end-client", id, false);
 
+// Admin-only: current per-symbol trading halt set.
+// Backend: GET /admin/halts -> { Symbols: [...] }.
+export async function getHaltStatus(backend, token) {
+  const resp = await fetch(`${backend}/admin/halts`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}
+
+// Admin-only: toggle a symbol halt. POST = halt, DELETE = resume.
+// Returns 204 on success, 503 on WAL backpressure.
+async function toggleHalt(backend, token, symbol, halt) {
+  const resp = await fetch(
+    `${backend}/admin/halts/${encodeURIComponent(symbol)}`,
+    {
+      method: halt ? "POST" : "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  if (resp.status === 204) return null;
+  return jsonOrThrow(resp);
+}
+
+export const haltSymbol   = (b, t, sym) => toggleHalt(b, t, sym, true);
+export const resumeSymbol = (b, t, sym) => toggleHalt(b, t, sym, false);
+
 // Admin-only: trigger EOD materialisation. Returns the report or 409
 // when persistence is disabled.
 export async function runEod(backend, token) {

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -48,6 +48,7 @@ const state = {
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
   firmsHealth: null,       // { mode, firms, fetchedAt } | null — admin-only poll of /admin/firms
   killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
+  haltStatus: null,        // { symbols: [], fetchedAt } | null — admin-only
   eodReport: null,         // { ranAt, report } | null — last EOD response in this session
   currentView: "trader",   // "trader" | "admin" — which view is mounted
   // Blotter UX (section 3 of #30).
@@ -538,6 +539,11 @@ export function setFirmsHealth(value) {
 export function setKillStatus(value) {
   state.killStatus = value;
   notify("killStatus");
+}
+
+export function setHaltStatus(value) {
+  state.haltStatus = value;
+  notify("haltStatus");
 }
 
 export function setEodReport(value) {


### PR DESCRIPTION
Frontend counterpart to #111 (per-symbol halt backend). Refs #108.

## What

New panel in the admin console between **End-clients** and **EOD materialisation**:

- Lists currently halted symbols, one per row, each with a **Resume** button.
- Inline form to halt a new symbol by ticker.
- Both actions go through `confirmTwice()` — a mistaken click can't wedge trading for everyone on a ticker.

## Wiring

| File | Change |
|------|--------|
| `protocol.js` | `getHaltStatus` (GET /admin/halts) + `haltSymbol` / `resumeSymbol` (POST/DELETE /admin/halts/{symbol}). |
| `state.js` | New `haltStatus` slice + `setHaltStatus`. |
| `app.js` | `pollFirmsOnce` now also fetches /admin/halts; logout/init clear both. New `handleToggleHalt` + `handleAddHalt` handlers. |
| `adminUi.js` | Bind new form/button + `renderHalts` on `haltStatus` / `currentView` slice changes. |
| `index.html` | New admin panel (input + table) mirroring End-clients. |

Symbols are upper-cased on submit to match the backend's case-insensitive match. The poll runs every 5s for admins, so manual halts placed via curl/CLI also surface in the UI within that window.

## Test
- `node --check` clean on all 4 modified JS files.
- `node --test frontend/test/decoder.test.mjs` — green (32/32).
- E2E smoke is alice-only (user role) so it can't exercise admin UI directly; manual verification path is the docker stack.