### PR TITLE
feat(cash): per-end-client CashBalance ledger (slice 1 of #107)

### DIFF
--- a/backend/src/B3.Trading.Api/BalanceEndpoints.cs
+++ b/backend/src/B3.Trading.Api/BalanceEndpoints.cs
@@ -1,0 +1,25 @@
+using System.Security.Claims;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+public static class BalanceEndpoints
+{
+    public static IEndpointRouteBuilder MapBalance(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/balance", [Authorize] (HttpContext ctx, EndClientRegistry registry, CashLedger cash) =>
+        {
+            var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                      ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
+            var owner = registry.Register(sub);
+            return Results.Ok(new BalanceDto(cash.GetAvailable(owner)));
+        });
+
+        return app;
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -40,6 +40,13 @@ public sealed record PositionDto(
     long NetQuantity,
     decimal AverageEntryPrice);
 
+/// <summary>
+/// Wire shape for <c>GET /balance</c>. Slice 1 of #107 exposes only
+/// <see cref="Available"/>; reserved/total are placeholders for slice 2
+/// when the margin provider plugs into the same ledger.
+/// </summary>
+public sealed record BalanceDto(decimal Available);
+
 public sealed record ExecutionDto(
     string ClOrdId,
     string Symbol,

--- a/backend/src/B3.Trading.Application/CashLedger.cs
+++ b/backend/src/B3.Trading.Application/CashLedger.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Cumulative cash ledger, derived from <c>ExecutionReport</c> fills via
+/// <see cref="ExecutionReportProcessor"/>. Per-end-client; ephemeral in
+/// v1 but reconstructed from snapshot + ER replay on cold start, so the
+/// final number after recovery is byte-identical to the live state.
+///
+/// <para>
+/// Slice 1 of issue #107 — exposes the balance via a read-only API and a
+/// startup seed. Margin integration (slice 2) plugs into
+/// <see cref="GetAvailable(EndClientId)"/> through a separate provider.
+/// </para>
+/// </summary>
+public sealed class CashLedger
+{
+    private readonly ConcurrentDictionary<EndClientId, CashBalance> _balances = new();
+
+    /// <summary>
+    /// Returns the existing balance or creates a fresh one at zero. Used
+    /// by ER processor to fold fills lazily — accounts that never fill
+    /// stay out of memory.
+    /// </summary>
+    public CashBalance GetOrCreate(EndClientId owner) =>
+        _balances.GetOrAdd(owner, key => new CashBalance(key));
+
+    /// <summary>
+    /// Insert an opening balance iff one is not already tracked. Returns
+    /// <c>true</c> when the seed was applied; <c>false</c> when an
+    /// existing balance (from snapshot/WAL replay or a prior fill)
+    /// already occupies the slot. Idempotent and thread-safe.
+    /// </summary>
+    public bool SeedIfAbsent(EndClientId owner, decimal initialAvailable)
+    {
+        var seeded = CashBalance.Hydrate(owner, initialAvailable);
+        return _balances.TryAdd(owner, seeded);
+    }
+
+    public void ApplyFill(EndClientId owner, OrderSide side, long quantity, decimal price)
+    {
+        var balance = GetOrCreate(owner);
+        lock (balance)
+        {
+            balance.ApplyFill(side, quantity, price);
+        }
+    }
+
+    /// <summary>
+    /// Read-only convenience for risk / API callers. Returns <c>0</c> for
+    /// an unknown owner without materialising an entry, so probing the
+    /// balance can't pollute the dictionary.
+    /// </summary>
+    public decimal GetAvailable(EndClientId owner) =>
+        _balances.TryGetValue(owner, out var b) ? b.Available : 0m;
+
+    public bool TryGet(EndClientId owner, out CashBalance? balance)
+    {
+        if (_balances.TryGetValue(owner, out var b))
+        {
+            balance = b;
+            return true;
+        }
+        balance = null;
+        return false;
+    }
+
+    public IEnumerable<Persistence.CashBalanceSnapshot> Snapshot()
+    {
+        foreach (var kv in _balances)
+        {
+            // Skip exact-zero rows — they re-materialise the moment a
+            // fill arrives, and persisting them would bloat the snapshot
+            // for no behavioural difference. Negative balances ARE
+            // captured (debt is real state).
+            if (kv.Value.Available == 0m) continue;
+            yield return new Persistence.CashBalanceSnapshot(kv.Key.Value, kv.Value.Available);
+        }
+    }
+
+    public void Restore(IEnumerable<Persistence.CashBalanceSnapshot> snaps)
+    {
+        ArgumentNullException.ThrowIfNull(snaps);
+        _balances.Clear();
+        foreach (var s in snaps)
+        {
+            var owner = new EndClientId(s.EndClientId);
+            _balances[owner] = CashBalance.Hydrate(owner, s.Available);
+        }
+    }
+}

--- a/backend/src/B3.Trading.Application/CashSeedOptions.cs
+++ b/backend/src/B3.Trading.Application/CashSeedOptions.cs
@@ -1,0 +1,48 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Optional opening cash balances applied to <see cref="CashLedger"/>
+/// at process startup. Mirrors <see cref="PositionSeedOptions"/> in
+/// shape and lifecycle: applied <b>after</b> snapshot/WAL recovery,
+/// so a warm restart preserves real settled cash and never overwrites
+/// fills with the seed.
+///
+/// <para>
+/// Slice 1 of issue #107 — the dogfood path. Without this seed a
+/// fresh end-client created via <c>POST /auth/signup</c> would have
+/// zero cash; signup integration in slice 3 will pre-fund new accounts
+/// from this same option.
+/// </para>
+/// </summary>
+public sealed class CashSeedOptions
+{
+    public const string SectionName = "Trading:Cash";
+
+    /// <summary>
+    /// Per-end-client opening balance. List shape (rather than nested
+    /// dict) keeps env-var binding ergonomic:
+    /// <c>Trading__Cash__Seeds__0__EndClientId=alice</c>.
+    /// </summary>
+    public List<CashSeed> Seeds { get; set; } = new();
+
+    /// <summary>
+    /// Default opening balance applied to any end-client that signs up
+    /// via <c>POST /auth/signup</c> in slice 3. Currently informational
+    /// for slice 1 (signup wiring lands in slice 3); kept here so the
+    /// config surface is settled before consumers depend on it.
+    /// </summary>
+    public decimal SignupInitialBalance { get; set; }
+}
+
+public sealed class CashSeed
+{
+    public string EndClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Opening cash. Negative values are accepted by
+    /// <see cref="CashLedger"/> (the ledger doesn't enforce solvency
+    /// — that's the margin provider's job in slice 2), but seeding a
+    /// negative balance is almost certainly a config typo.
+    /// </summary>
+    public decimal InitialAvailable { get; set; }
+}

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -34,6 +34,7 @@ public sealed class ExecutionReportProcessor
     private readonly Risk.IMarginProvider _margin;
     private readonly ILogger<ExecutionReportProcessor> _logger;
     private readonly IAlgoSignalQueue? _algoSignals;
+    private readonly CashLedger? _cash;
 
     public ExecutionReportProcessor(
         OrderOwnershipMap ownership,
@@ -42,7 +43,8 @@ public sealed class ExecutionReportProcessor
         IExecutionEventSink sink,
         Risk.IMarginProvider margin,
         ILogger<ExecutionReportProcessor> logger,
-        IAlgoSignalQueue? algoSignals = null)
+        IAlgoSignalQueue? algoSignals = null,
+        CashLedger? cash = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -51,6 +53,7 @@ public sealed class ExecutionReportProcessor
         _margin = margin;
         _logger = logger;
         _algoSignals = algoSignals;
+        _cash = cash;
     }
 
     /// <summary>
@@ -141,6 +144,11 @@ public sealed class ExecutionReportProcessor
                             lookupId, lastQty, delta);
                     }
                     _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
+                    // Book the cash leg of the fill on the same delta as
+                    // the position. Buys debit, Sells credit; T+0 settle.
+                    // Null when the host hasn't wired CashLedger yet
+                    // (test contexts only — production DI always injects).
+                    _cash?.ApplyFill(owner, order.Side, delta, lastPx);
                     // Release reserved margin against the actual booked
                     // delta — not the wire lastQty — so a lost
                     // intermediate ER can't leave the ledger under-released.

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -25,6 +25,15 @@ public sealed class PlatformSnapshot
     public List<OwnershipMappingSnapshot> Ownership { get; init; } = new();
     public List<AlgoSnapshot> Algos { get; init; } = new();
     public AlgoIdRegistrySnapshot AlgoIds { get; init; } = new();
+    /// <summary>
+    /// Per-end-client cash balances captured by <c>CashLedger</c>.
+    /// Added in the cash-balance slice (#107 slice 1); older
+    /// snapshots that pre-date the field deserialise with an empty
+    /// list, which matches the "no balance recorded" semantics they
+    /// actually carried (callers see zero until the seed re-applies
+    /// or a fill arrives).
+    /// </summary>
+    public List<CashBalanceSnapshot> CashBalances { get; init; } = new();
 }
 
 public sealed record OrderSnapshot(
@@ -76,6 +85,10 @@ public sealed record PositionSnapshot(
     string Symbol,
     long NetQuantity,
     decimal AverageEntryPrice);
+
+public sealed record CashBalanceSnapshot(
+    string EndClientId,
+    decimal Available);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Domain/CashBalance.cs
+++ b/backend/src/B3.Trading.Domain/CashBalance.cs
@@ -1,0 +1,51 @@
+namespace B3.Trading.Domain;
+
+/// <summary>
+/// Per-end-client cash balance, derived from the ER fill stream. T+0
+/// settlement: every Buy fill debits <c>fillQty · fillPrice</c> from
+/// <see cref="Available"/>; every Sell fill credits the same amount.
+/// Negative balances are allowed at the domain level (the gating is the
+/// margin provider's job, not this aggregate's).
+///
+/// <para>
+/// Currency is implicit single-currency (BRL) for v1 — multi-currency
+/// is explicitly out of scope (see issue #107).
+/// </para>
+/// </summary>
+public sealed class CashBalance
+{
+    public CashBalance(EndClientId owner)
+    {
+        Owner = owner;
+    }
+
+    public EndClientId Owner { get; }
+
+    /// <summary>
+    /// Free cash that can settle new Buys. Reserve-on-submit accounting
+    /// (slice 2) will overlay a "reserved" notion on top, but this
+    /// aggregate stays a pure ledger of settled cash.
+    /// </summary>
+    public decimal Available { get; private set; }
+
+    public void ApplyFill(OrderSide side, long quantity, decimal price)
+    {
+        if (quantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        if (price < 0m)
+            throw new ArgumentOutOfRangeException(nameof(price));
+
+        var notional = price * (decimal)quantity;
+        Available += side == OrderSide.Buy ? -notional : notional;
+    }
+
+    /// <summary>
+    /// Recovery / seed-only constructor used by snapshot replay and
+    /// startup seeding. Skips the ApplyFill arithmetic so a snapshot
+    /// loaded with a negative or zero balance round-trips exactly.
+    /// </summary>
+    internal static CashBalance Hydrate(EndClientId owner, decimal available)
+    {
+        return new CashBalance(owner) { Available = available };
+    }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -38,6 +38,8 @@ builder.Services.Configure<PersistenceOptions>(
     builder.Configuration.GetSection(PersistenceOptions.SectionName));
 builder.Services.Configure<PositionSeedOptions>(
     builder.Configuration.GetSection(PositionSeedOptions.SectionName));
+builder.Services.Configure<CashSeedOptions>(
+    builder.Configuration.GetSection(CashSeedOptions.SectionName));
 
 // CORS: opt-in allowlist for the dev/prod frontend origins. Empty list
 // disables CORS entirely (server-only deploys, integration tests).
@@ -61,6 +63,7 @@ builder.Services.AddSingleton<WorkingOrderBook>();
 builder.Services.AddSingleton<AlgoBook>();
 builder.Services.AddSingleton<AlgoIdRegistry>();
 builder.Services.AddSingleton<PositionKeeper>();
+builder.Services.AddSingleton<CashLedger>();
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
@@ -442,6 +445,51 @@ var app = builder.Build();
         }
         seedLogger.LogInformation("PositionSeeder finished: {Applied} applied, {Skipped} skipped.", applied, skipped);
     }
+
+    // Cash balance seeds (#107 slice 1) — same lifecycle as position
+    // seeds: applied AFTER recovery so warm restarts preserve the
+    // settled-cash ledger and the seed only fills slots recovery left
+    // empty. Negative balances are accepted by the ledger but logged
+    // here as a warning so a config typo doesn't silently put a fresh
+    // dogfood account in the red.
+    var cashOpts = scope.ServiceProvider.GetRequiredService<IOptions<CashSeedOptions>>().Value;
+    if (cashOpts.Seeds.Count > 0)
+    {
+        var ledger = scope.ServiceProvider.GetRequiredService<CashLedger>();
+        var cashLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("CashSeeder");
+        var applied = 0;
+        var skipped = 0;
+        foreach (var seed in cashOpts.Seeds)
+        {
+            if (string.IsNullOrWhiteSpace(seed.EndClientId))
+            {
+                cashLogger.LogWarning("Skipping malformed CashSeed (empty EndClientId).");
+                continue;
+            }
+            if (seed.InitialAvailable < 0m)
+            {
+                cashLogger.LogWarning(
+                    "CashSeed for {Owner} has negative InitialAvailable={Balance} — applying anyway, but this is almost certainly a typo.",
+                    seed.EndClientId, seed.InitialAvailable);
+            }
+            var owner = new EndClientId(seed.EndClientId);
+            if (ledger.SeedIfAbsent(owner, seed.InitialAvailable))
+            {
+                applied++;
+                cashLogger.LogInformation(
+                    "Seeded opening cash {Owner} = {Balance}.",
+                    seed.EndClientId, seed.InitialAvailable);
+            }
+            else
+            {
+                skipped++;
+                cashLogger.LogInformation(
+                    "Skipped cash seed for {Owner}: balance already present from recovery.",
+                    seed.EndClientId);
+            }
+        }
+        cashLogger.LogInformation("CashSeeder finished: {Applied} applied, {Skipped} skipped.", applied, skipped);
+    }
 }
 
 if (corsOrigins.Length > 0)
@@ -458,6 +506,7 @@ app.MapAuth();
 app.MapOrders();
 app.MapAlgo();
 app.MapPositions();
+app.MapBalance();
 app.MapAdmin();
 app.MapWebSocketHub();
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -22,6 +22,7 @@ public sealed class StateSnapshotter
     private readonly OrderOwnershipMap _ownership;
     private readonly AlgoBook _algos;
     private readonly AlgoIdRegistry _algoIds;
+    private readonly CashLedger _cash;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -31,7 +32,8 @@ public sealed class StateSnapshotter
         ClOrdIdPrefixRegistry clOrdIds,
         OrderOwnershipMap ownership,
         AlgoBook algos,
-        AlgoIdRegistry algoIds)
+        AlgoIdRegistry algoIds,
+        CashLedger cash)
     {
         _orders = orders;
         _positions = positions;
@@ -41,6 +43,7 @@ public sealed class StateSnapshotter
         _ownership = ownership;
         _algos = algos;
         _algoIds = algoIds;
+        _cash = cash;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -56,6 +59,7 @@ public sealed class StateSnapshotter
         Ownership = _ownership.Snapshot().ToList(),
         Algos = _algos.Snapshot().ToList(),
         AlgoIds = _algoIds.Snapshot(),
+        CashBalances = _cash.Snapshot().ToList(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -69,6 +73,7 @@ public sealed class StateSnapshotter
         _ownership.Restore(snap.Ownership);
         _algos.Restore(snap.Algos);
         _algoIds.Restore(snap.AlgoIds);
+        _cash.Restore(snap.CashBalances);
     }
 }
 

--- a/backend/tests/B3.Trading.Api.Tests/BalanceEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BalanceEndpointTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+public class BalanceEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+
+    public BalanceEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task UnauthenticatedGet_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/balance");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task FreshAccount_ReturnsZero()
+    {
+        // alice (test user) has not transacted in this isolated factory
+        // and isn't seeded in the test config — balance starts at zero.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.GetAsync("/balance");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<BalanceDto>();
+
+        Assert.NotNull(body);
+        Assert.Equal(0m, body!.Available);
+    }
+
+    [Fact]
+    public async Task AfterFill_ReflectsLedger()
+    {
+        // Drive the ledger directly via the singleton CashLedger and
+        // confirm GET /balance reads the same source of truth.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var ledger = factory.Services.GetRequiredService<CashLedger>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+        ledger.ApplyFill(owner, OrderSide.Sell, 100, 50m); // +5000
+
+        var body = await client.GetFromJsonAsync<BalanceDto>("/balance");
+        Assert.Equal(5000m, body!.Available);
+    }
+
+    [Fact]
+    public async Task SeededOpening_AppliedAtBoot()
+    {
+        var overrides = new Dictionary<string, string?>
+        {
+            ["Trading:Cash:Seeds:0:EndClientId"] = TestAppFactory.TestUser,
+            ["Trading:Cash:Seeds:0:InitialAvailable"] = "12345.67",
+        };
+        await using var factory = TestAppFactory.WithOverrides(overrides);
+        var client = await factory.CreateAuthedClientAsync();
+
+        var body = await client.GetFromJsonAsync<BalanceDto>("/balance");
+        Assert.Equal(12345.67m, body!.Available);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
@@ -1,0 +1,106 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+public class CashLedgerTests
+{
+    [Fact]
+    public void GetAvailable_UnknownOwner_ReturnsZero_DoesNotMaterialise()
+    {
+        var ledger = new CashLedger();
+
+        Assert.Equal(0m, ledger.GetAvailable(new EndClientId("ghost")));
+        // Snapshot is empty: probing didn't pollute the dictionary.
+        Assert.Empty(ledger.Snapshot());
+    }
+
+    [Fact]
+    public void ApplyFill_TracksRunningBalance()
+    {
+        var ledger = new CashLedger();
+        var alice = new EndClientId("alice");
+
+        ledger.ApplyFill(alice, OrderSide.Buy, 100, 30m);   // -3000
+        ledger.ApplyFill(alice, OrderSide.Sell, 50, 32m);   // +1600
+
+        Assert.Equal(-1400m, ledger.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void SeedIfAbsent_AppliesOnce_RespectsExisting()
+    {
+        var ledger = new CashLedger();
+        var alice = new EndClientId("alice");
+
+        Assert.True(ledger.SeedIfAbsent(alice, 100_000m));
+        Assert.Equal(100_000m, ledger.GetAvailable(alice));
+
+        // Second seed is a no-op.
+        Assert.False(ledger.SeedIfAbsent(alice, 1m));
+        Assert.Equal(100_000m, ledger.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void SeedIfAbsent_AfterFill_DoesNotOverwrite()
+    {
+        // Mirrors the production lifecycle: WAL replay/fill happens
+        // BEFORE the seed loop runs. Seed must never clobber real cash.
+        var ledger = new CashLedger();
+        var alice = new EndClientId("alice");
+
+        ledger.ApplyFill(alice, OrderSide.Sell, 10, 50m);   // +500
+        Assert.False(ledger.SeedIfAbsent(alice, 100_000m));
+        Assert.Equal(500m, ledger.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void Snapshot_SkipsZeroBalances_KeepsNegatives()
+    {
+        var ledger = new CashLedger();
+        var alice = new EndClientId("alice");
+        var bob = new EndClientId("bob");
+        var carol = new EndClientId("carol");
+
+        ledger.SeedIfAbsent(alice, 1_000m);
+        ledger.SeedIfAbsent(bob, 0m);              // skipped
+        ledger.SeedIfAbsent(carol, -250m);         // kept (debt is real)
+
+        var snap = ledger.Snapshot().ToDictionary(s => s.EndClientId, s => s.Available);
+
+        Assert.Equal(2, snap.Count);
+        Assert.Equal(1_000m, snap["alice"]);
+        Assert.Equal(-250m, snap["carol"]);
+        Assert.False(snap.ContainsKey("bob"));
+    }
+
+    [Fact]
+    public void Restore_ReplacesState()
+    {
+        var ledger = new CashLedger();
+        ledger.ApplyFill(new EndClientId("alice"), OrderSide.Buy, 1, 10m);
+
+        ledger.Restore(new[]
+        {
+            new CashBalanceSnapshot("bob", 42_000m),
+        });
+
+        Assert.Equal(0m, ledger.GetAvailable(new EndClientId("alice")));
+        Assert.Equal(42_000m, ledger.GetAvailable(new EndClientId("bob")));
+    }
+
+    [Fact]
+    public void Restore_RoundTripsViaSnapshot()
+    {
+        var src = new CashLedger();
+        src.ApplyFill(new EndClientId("alice"), OrderSide.Buy, 100, 30m);
+        src.ApplyFill(new EndClientId("bob"), OrderSide.Sell, 50, 100m);
+
+        var dst = new CashLedger();
+        dst.Restore(src.Snapshot());
+
+        Assert.Equal(src.GetAvailable(new EndClientId("alice")), dst.GetAvailable(new EndClientId("alice")));
+        Assert.Equal(src.GetAvailable(new EndClientId("bob")), dst.GetAvailable(new EndClientId("bob")));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorCashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorCashLedgerTests.cs
@@ -1,0 +1,109 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+public class ExecutionReportProcessorCashLedgerTests
+{
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+
+    private static (ExecutionReportProcessor Proc, OrderOwnershipMap Own, WorkingOrderBook Book, PositionKeeper Pos, CashLedger Cash) Build()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var cash = new CashLedger();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, new NullSink(), new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: cash);
+        return (proc, ownership, book, positions, cash);
+    }
+
+    [Fact]
+    public void BuyFill_DebitsCash()
+    {
+        var (proc, ownership, book, _, cash) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(-3000m, cash.GetAvailable(owner));
+    }
+
+    [Fact]
+    public void SellFill_CreditsCash()
+    {
+        var (proc, ownership, book, _, cash) = Build();
+        var owner = new EndClientId("bob");
+        var order = new Order(2UL, owner, "VALE3", 2UL, OrderSide.Sell, OrderType.Limit, 50, 65m);
+        book.TryAdd(order);
+        ownership.Register(2UL, owner);
+
+        proc.Apply(2UL, ExecKind.Fill, leaves: 0, cumQty: 50, lastQty: 50, lastPx: 65m, rejectReason: null);
+
+        Assert.Equal(3250m, cash.GetAvailable(owner));
+    }
+
+    [Fact]
+    public void PartialFill_BooksOnDelta()
+    {
+        var (proc, ownership, book, _, cash) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(3UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(3UL, owner);
+
+        proc.Apply(3UL, ExecKind.PartialFill, leaves: 60, cumQty: 40, lastQty: 40, lastPx: 30m, rejectReason: null);
+        proc.Apply(3UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 60, lastPx: 31m, rejectReason: null);
+
+        // 40@30 + 60@31 = 1200 + 1860 = 3060 debit
+        Assert.Equal(-3060m, cash.GetAvailable(owner));
+    }
+
+    [Fact]
+    public void DuplicateFill_IsIdempotent()
+    {
+        // ER processor dedups by cumulative quantity — replaying the
+        // same Fill twice must not double-debit cash.
+        var (proc, ownership, book, _, cash) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(4UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(4UL, owner);
+
+        proc.Apply(4UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+        proc.Apply(4UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        Assert.Equal(-3000m, cash.GetAvailable(owner));
+    }
+
+    [Fact]
+    public void NullCashLedger_DoesNotThrow()
+    {
+        // Test contexts that omit the CashLedger should still process
+        // fills exactly as before — production DI always injects it.
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, new NullSink(), new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance);
+        var owner = new EndClientId("alice");
+        var order = new Order(5UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 10, 1m);
+        book.TryAdd(order);
+        ownership.Register(5UL, owner);
+
+        proc.Apply(5UL, ExecKind.Fill, leaves: 0, cumQty: 10, lastQty: 10, lastPx: 1m, rejectReason: null);
+
+        Assert.Equal(10, positions.GetOrCreate(owner, "PETR4").NetQuantity);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -117,7 +117,7 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, processor, algos, _) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
             var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
@@ -151,7 +151,7 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, _, algos, dispatcher) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
 
             dispatcher.Dispatch(
                 new AlgoCreatedEvent

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -166,7 +166,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
             new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
-        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(), clOrdIds, ownership, algos, new AlgoIdRegistry());
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(), clOrdIds, ownership, algos, new AlgoIdRegistry(), new CashLedger());
         var dispatcher = new EventDispatcher(store);
         return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
     }

--- a/backend/tests/B3.Trading.Domain.Tests/CashBalanceTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/CashBalanceTests.cs
@@ -1,0 +1,55 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+public class CashBalanceTests
+{
+    [Fact]
+    public void Buy_DebitsAvailable()
+    {
+        var b = new CashBalance(new EndClientId("alice"));
+
+        b.ApplyFill(OrderSide.Buy, 100, 30m);
+
+        Assert.Equal(-3000m, b.Available);
+    }
+
+    [Fact]
+    public void Sell_CreditsAvailable()
+    {
+        var b = new CashBalance(new EndClientId("alice"));
+
+        b.ApplyFill(OrderSide.Sell, 100, 30m);
+
+        Assert.Equal(3000m, b.Available);
+    }
+
+    [Fact]
+    public void BuyThenSell_Nets()
+    {
+        var b = new CashBalance(new EndClientId("alice"));
+
+        b.ApplyFill(OrderSide.Buy, 100, 30m);   // -3000
+        b.ApplyFill(OrderSide.Sell, 50, 31m);   // +1550
+        b.ApplyFill(OrderSide.Sell, 50, 32m);   // +1600
+
+        Assert.Equal(150m, b.Available);
+    }
+
+    [Fact]
+    public void NegativeOrZeroQuantity_Throws()
+    {
+        var b = new CashBalance(new EndClientId("alice"));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => b.ApplyFill(OrderSide.Buy, 0, 10m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => b.ApplyFill(OrderSide.Sell, -5, 10m));
+    }
+
+    [Fact]
+    public void NegativePrice_Throws()
+    {
+        var b = new CashBalance(new EndClientId("alice"));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => b.ApplyFill(OrderSide.Buy, 1, -0.01m));
+    }
+}


### PR DESCRIPTION
Slice 1 of **#107** (introduzir noção de saldo). Lands the domain model, the ledger, snapshot/replay, the startup seed, and a read-only `GET /balance`. Margin / signup / deprecation slices follow.

## Behaviour

T+0 settlement, per end-client, single-currency (BRL):

| Fill side | Effect on `Available`            |
|-----------|-----------------------------------|
| Buy       | debit  `qty · price`            |
| Sell      | credit `qty · price`            |

Idempotent: ER processor books on the **cumulative-quantity delta**, so a replayed Fill (FIXP retransmit or WAL replay) cannot double-debit. Inherits the same dedup logic that already protects `PositionKeeper`.

## Surface

- `Domain/CashBalance.cs` — aggregate with `ApplyFill(side, qty, price)` + `Hydrate` for snapshot/seed paths.
- `Application/CashLedger.cs` — concurrent-dict keeper, exact mirror of `PositionKeeper`. `GetAvailable` on an unknown owner returns 0 without materialising the slot (probing is side-effect-free).
- `Application/CashSeedOptions.cs` — `Trading:Cash:Seeds[]` opening balances + `SignupInitialBalance` (parked here so the config surface is settled before slice 3 consumes it).
- `Application/Persistence/Snapshots.cs` — additive `PlatformSnapshot.CashBalances` + `CashBalanceSnapshot`. Older snapshots replay with empty list (matches "no balance recorded" semantics → caller sees zero).
- `Application/ExecutionReportProcessor.cs` — optional `CashLedger` ctor param (last, defaulted null) booked at the same site as `PositionKeeper.ApplyFill` and against the same delta.
- `Infrastructure/Persistence/StateSnapshotter.cs` — capture/restore cash alongside positions.
- `Api/BalanceEndpoints.cs` — `GET /balance` → `{ available }`. `[Authorize]`.
- `Api/WebSockets/Dtos.cs` — `BalanceDto`.
- `Host/Program.cs` — DI singleton + options binding + post-recovery seed loop. Lifecycle mirrors position seeds: applied only if snapshot/WAL didn't already populate the slot, so warm restarts never overwrite settled cash.

## What's NOT in this PR (next slices, per #107)

- **Slice 2** — margin provider reads `CashLedger.GetAvailable` (with fallback to `RiskOptions.Margin.Initial` during transition).
- **Slice 3** — `POST /auth/signup` pre-funds new accounts via `SignupInitialBalance`.
- **Slice 4** — deprecate `RiskOptions.Margin.Initial`.
- WS channel `balance.me` — polling `GET /balance` is enough for slice 1; broadcasting deltas is meaningfully coupled to the slice-2 reservation events.

## Tests

- Domain: **5** (debit/credit/mix/invariants).
- Application: **7** ledger (seed-respects-existing, snapshot skips zero / keeps negatives, restore round-trip) + **5** ER-processor integration (Buy debits, Sell credits, partial-fill booking, replay idempotency, null-cash safety).
- Api: **4** endpoint (401 unauth, fresh=0, post-fill reflects, seed applied at boot).

Suite: **37 + 280 + 148** green (+ 12 conformance skip). `dotnet format` clean.