### PR TITLE
feat(margin): reserve against CashLedger w/ config fallback (slice 2 of #107)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -38,11 +38,22 @@ namespace B3.Trading.Application.Risk;
 /// (no orphaned holds because the reservation lives only as long as
 /// the working order).
 /// </para>
+///
+/// <para>
+/// <b>Cash source (slice 2 of #107):</b> when a <see cref="CashLedger"/>
+/// is wired in, the per-owner base capacity is read from the ledger's
+/// settled-cash balance — this is the post-fill number, so a Buy that
+/// just executed correctly reduces the available figure for the next
+/// reservation. When the ledger has no entry for the owner, the
+/// provider falls back to <c>RiskOptions.Margin.Initial</c> so legacy
+/// dogfood configs keep working until slice 4 retires the option.
+/// </para>
 /// </summary>
 public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly ILogger<ReserveOnSubmitMarginProvider> _logger;
+    private readonly CashLedger? _cash;
 
     private readonly ConcurrentDictionary<ulong, ReservationEntry> _reservations = new();
     private readonly ConcurrentDictionary<string, decimal> _reserved =
@@ -51,10 +62,12 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
 
     public ReserveOnSubmitMarginProvider(
         IOptionsMonitor<RiskOptions> options,
-        ILogger<ReserveOnSubmitMarginProvider> logger)
+        ILogger<ReserveOnSubmitMarginProvider> logger,
+        CashLedger? cash = null)
     {
         _options = options;
         _logger = logger;
+        _cash = cash;
     }
 
     public Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct)
@@ -76,7 +89,7 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
             return Task.FromResult(RiskDecision.Approve);
 
         var owner = ctx.Owner.Value;
-        var initial = ResolveInitial(owner);
+        var baseAvailable = ResolveBaseAvailable(owner);
 
         // Atomic check+reserve: take the gate, snapshot reserved,
         // verify capacity, mutate. The provider is a singleton so the
@@ -84,7 +97,7 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
         lock (_gate)
         {
             var reserved = _reserved.GetValueOrDefault(owner, 0m);
-            var available = initial - reserved;
+            var available = baseAvailable - reserved;
             if (notional > available)
             {
                 return Task.FromResult(RiskDecision.Reject(
@@ -170,15 +183,36 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
         _reserved[owner] = next;
     }
 
-    private decimal ResolveInitial(string owner) =>
-        _options.CurrentValue.Margin.Initial.GetValueOrDefault(owner, 0m);
+    /// <summary>
+    /// Resolves the per-owner base capacity that the reservation ledger
+    /// debits against. Slice 2 of #107 introduces a CashLedger fallback:
+    /// when the ledger has an entry for the owner (seeded or built up
+    /// from fills) it is the authoritative settled-cash figure; the
+    /// owner-pinned <c>RiskOptions.Margin.Initial</c> is consulted as a
+    /// fallback so existing dogfood configs keep working until slice 4
+    /// retires the option.
+    ///
+    /// <para>
+    /// The ledger answer is preferred even when it's lower than the
+    /// config — a trader who's already debited cash via Buy fills must
+    /// see the post-settlement number, not the original allowance.
+    /// </para>
+    /// </summary>
+    private decimal ResolveBaseAvailable(string owner)
+    {
+        if (_cash is not null && _cash.TryGet(new EndClientId(owner), out var balance) && balance is not null)
+        {
+            return balance.Available;
+        }
+        return _options.CurrentValue.Margin.Initial.GetValueOrDefault(owner, 0m);
+    }
 
     /// <summary>Test/observability helper: returns the currently reserved amount for an owner.</summary>
     internal decimal ReservedForTesting(string owner) => _reserved.GetValueOrDefault(owner, 0m);
 
     /// <summary>Test/observability helper: returns the currently available amount for an owner.</summary>
     internal decimal AvailableForTesting(string owner) =>
-        ResolveInitial(owner) - ReservedForTesting(owner);
+        ResolveBaseAvailable(owner) - ReservedForTesting(owner);
 
     private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional);
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -124,7 +124,8 @@ builder.Services.AddSingleton<IMarginProvider>(sp =>
     return opts.Margin.Enabled
         ? new ReserveOnSubmitMarginProvider(
             sp.GetRequiredService<IOptionsMonitor<RiskOptions>>(),
-            sp.GetRequiredService<ILogger<ReserveOnSubmitMarginProvider>>())
+            sp.GetRequiredService<ILogger<ReserveOnSubmitMarginProvider>>(),
+            sp.GetRequiredService<CashLedger>())
         : new NoOpMarginProvider();
 });
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderCashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderCashLedgerTests.cs
@@ -1,0 +1,109 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Slice 2 of #107: when a CashLedger is wired in, it overrides the
+/// per-owner allowance from <c>RiskOptions.Margin.Initial</c> and the
+/// reservation ledger debits against settled cash instead of a static
+/// config number.
+/// </summary>
+public class ReserveOnSubmitMarginProviderCashLedgerTests
+{
+    private static (ReserveOnSubmitMarginProvider provider, CashLedger ledger) Build(
+        decimal? configInitial = null, string owner = "alice")
+    {
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        if (configInitial.HasValue)
+            opts.Margin.Initial[owner] = configInitial.Value;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var ledger = new CashLedger();
+        var provider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance, ledger);
+        return (provider, ledger);
+    }
+
+    private static RiskContext Buy(string owner, decimal price, long qty) =>
+        new(new EndClientId(owner), "FIRM", "PETR4", OrderSide.Buy, OrderType.Limit, qty, price);
+
+    [Fact]
+    public async Task LedgerSeed_TakesPrecedenceOverConfig()
+    {
+        // Config says 1M but ledger seeded at 500: ledger wins.
+        var (p, ledger) = Build(configInitial: 1_000_000m);
+        ledger.SeedIfAbsent(new EndClientId("alice"), 500m);
+
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 50), default)).Approved);
+        var rejected = await p.TryReserveAsync(2, Buy("alice", 10m, 1), default);
+        Assert.False(rejected.Approved);
+    }
+
+    [Fact]
+    public async Task LedgerAbsent_FallsBackToConfig()
+    {
+        // No ledger entry for alice → config Margin.Initial wins.
+        var (p, _) = Build(configInitial: 100m);
+
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 10), default)).Approved);
+        Assert.False((await p.TryReserveAsync(2, Buy("alice", 10m, 1), default)).Approved);
+    }
+
+    [Fact]
+    public async Task LedgerNoEntryAndNoConfig_RejectsAtFirstBuy()
+    {
+        var (p, _) = Build();
+
+        var rejected = await p.TryReserveAsync(1, Buy("ghost", 1m, 1), default);
+        Assert.False(rejected.Approved);
+    }
+
+    [Fact]
+    public async Task LedgerDebitedByFill_ReducesAvailableForNextOrder()
+    {
+        // The whole point of slice 2: a Buy that just filled must
+        // reduce the ledger, so the NEXT Buy sees less capacity.
+        var (p, ledger) = Build();
+        var alice = new EndClientId("alice");
+        ledger.SeedIfAbsent(alice, 1_000m);
+
+        // First Buy reserved, then filled — production wires
+        // CashLedger.ApplyFill via ER processor; we simulate it here.
+        Assert.True((await p.TryReserveAsync(10, Buy("alice", 10m, 100), default)).Approved);
+        ledger.ApplyFill(alice, OrderSide.Buy, 100, 10m);   // -1000 → balance 0
+        p.OnExecution(10, ExecKind.Fill, lastQty: 100);     // releases the reservation
+
+        // Next Buy must see zero available, even though the original
+        // 1000 seed remains in config-land.
+        var next = await p.TryReserveAsync(11, Buy("alice", 10m, 1), default);
+        Assert.False(next.Approved);
+    }
+
+    [Fact]
+    public async Task SellFill_CreditsLedger_GrowsAvailable()
+    {
+        var (p, ledger) = Build();
+        var alice = new EndClientId("alice");
+        ledger.SeedIfAbsent(alice, 0m);
+
+        // Selling inventory we already own credits cash, lifting the
+        // ceiling for subsequent Buys.
+        ledger.ApplyFill(alice, OrderSide.Sell, 10, 50m);   // +500
+
+        Assert.True((await p.TryReserveAsync(20, Buy("alice", 10m, 50), default)).Approved);
+        Assert.False((await p.TryReserveAsync(21, Buy("alice", 10m, 1), default)).Approved);
+    }
+
+    [Fact]
+    public async Task NegativeLedgerBalance_BlocksAllBuys()
+    {
+        // Defensive: if cash settled negative (margin call edge case),
+        // every Buy must reject — we don't want the config fallback to
+        // mask a real overdraft.
+        var (p, ledger) = Build(configInitial: 1_000_000m);
+        ledger.SeedIfAbsent(new EndClientId("alice"), -10m);
+
+        Assert.False((await p.TryReserveAsync(1, Buy("alice", 1m, 1), default)).Approved);
+    }
+}


### PR DESCRIPTION
Slice 2 of **#107** — margin reads cash from the ledger.

## What

`ReserveOnSubmitMarginProvider` now resolves the per-owner base capacity from `CashLedger` when an entry exists, falling back to `RiskOptions.Margin.Initial[owner]` when it doesn't. The reservation ledger continues to overlay short-lived holds on top:

```
available_for_new_buy = ledger.Available - reserved_in_flight
```

## Bug fix

Pre-slice-2 behaviour: a Buy that filled released the reservation but the static `Initial` config was unaffected, so the trader could chain Buys *past their actual cash*:

| Step | Pre-slice-2 `available` | Post-slice-2 `available` |
|------|--------------------------|----------------------------|
| Seed: 1000                          | 1000 | 1000 |
| Buy 100@10 reserved                 |    0 |    0 |
| Buy fills (ledger debits, reservation releases) | **1000 ❌** | **0 ✅** |

The trader now correctly sees zero available after spending the lot.

## Fallback contract

- Owner has CashLedger entry → ledger is authoritative (even when LOWER than the config — settled cash wins).
- Owner has no ledger entry → `Margin.Initial[owner]`.
- Neither → 0 (every Buy rejects). Matches prior behaviour for unknown owners.

This keeps every existing dogfood config working until **slice 4** retires `Margin.Initial` entirely.

## Tests

6 new under `ReserveOnSubmitMarginProviderCashLedgerTests`:

- `LedgerSeed_TakesPrecedenceOverConfig`
- `LedgerAbsent_FallsBackToConfig`
- `LedgerNoEntryAndNoConfig_RejectsAtFirstBuy`
- **`LedgerDebitedByFill_ReducesAvailableForNextOrder`** ← the bug fix
- `SellFill_CreditsLedger_GrowsAvailable`
- `NegativeLedgerBalance_BlocksAllBuys` (defensive: overdraft blocks Buys, fallback can't mask)

Existing 24 margin provider tests cover the fallback path unchanged (CashLedger ctor arg defaults to `null`). Suite: **37 + 286 + 148** green. Format clean.

## What's NOT in this PR

- **Slice 3** — `POST /auth/signup` pre-funds new users via `SignupInitialBalance`.
- **Slice 4** — deprecate `RiskOptions.Margin.Initial` once dogfood configs migrate.