### PR TITLE
feat(cash): slice 4 — deprecate Margin.Initial in favor of CashLedger

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -204,7 +204,13 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
         {
             return balance.Available;
         }
+        // Transition fallback: Margin.Initial is deprecated under #107
+        // slice 4 but kept here so legacy dogfood configs keep working
+        // until a follow-up removes the property. The startup warning
+        // in Program.cs nudges operators to migrate.
+#pragma warning disable CS0618 // Type or member is obsolete
         return _options.CurrentValue.Margin.Initial.GetValueOrDefault(owner, 0m);
+#pragma warning restore CS0618
     }
 
     /// <summary>Test/observability helper: returns the currently reserved amount for an owner.</summary>

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -86,6 +86,17 @@ public sealed class OrderRateLimit
 /// <see cref="NoOpMarginProvider"/> stays in place until an operator
 /// opts in. See <c>docs/rfcs/pre-trade-risk-v2.md</c> §3.1 for the
 /// model assumed by v2 (crypto-spot ledger; not T+N, not derivatives).
+///
+/// <para>
+/// <b>Migration note (#107 slice 4):</b> the per-end-client opening
+/// balance has moved from <see cref="Initial"/> to the
+/// <see cref="B3.Trading.Application.CashSeedOptions"/> ledger seeds
+/// (<c>Trading:Cash:Seeds[]</c>) and to
+/// <c>Trading:Cash:SignupInitialBalance</c> for self-service signup.
+/// Operators populating <see cref="Initial"/> will get a one-time
+/// startup warning with migration guidance; the fallback path stays
+/// in place until a follow-up retires the property entirely.
+/// </para>
 /// </summary>
 public sealed class MarginOptions
 {
@@ -96,7 +107,19 @@ public sealed class MarginOptions
     /// currency v2 assumes). Missing entries are treated as zero, so
     /// unrecognized end-clients cannot place buy orders when margin
     /// is enabled — fail-closed by default.
+    ///
+    /// <para>
+    /// <b>Deprecated (#107 slice 4):</b> use
+    /// <c>Trading:Cash:Seeds[]</c> for static opening balances and
+    /// <c>Trading:Cash:SignupInitialBalance</c> for the self-service
+    /// signup default. The <see cref="B3.Trading.Application.CashLedger"/>
+    /// overlay introduced in slice 1 is the source of truth; this
+    /// property is consulted only as a transition fallback for owners
+    /// that have no ledger entry, and a follow-up will remove it
+    /// entirely once dogfood configs migrate.
+    /// </para>
     /// </summary>
+    [Obsolete("Use Trading:Cash:Seeds[] for static opening balances or Trading:Cash:SignupInitialBalance for self-service signup defaults. Margin.Initial is the transition fallback only and will be removed in a follow-up to #107.")]
     public Dictionary<string, decimal> Initial { get; set; } =
         new(StringComparer.OrdinalIgnoreCase);
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -491,6 +491,27 @@ var app = builder.Build();
         }
         cashLogger.LogInformation("CashSeeder finished: {Applied} applied, {Skipped} skipped.", applied, skipped);
     }
+
+    // Deprecation warning (#107 slice 4): Margin.Initial is the
+    // legacy per-end-client opening-balance config. It still works as
+    // a transition fallback inside ReserveOnSubmitMarginProvider, but
+    // every populated key here means the operator is on the legacy
+    // path and should migrate to Trading:Cash:Seeds[].
+    var riskOpts = scope.ServiceProvider.GetRequiredService<IOptions<RiskOptions>>().Value;
+#pragma warning disable CS0618 // Type or member is obsolete
+    if (riskOpts.Margin.Initial.Count > 0)
+    {
+        var deprecationLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MarginInitialDeprecation");
+        deprecationLogger.LogWarning(
+            "Trading:Risk:Margin:Initial is DEPRECATED (#107 slice 4) and will be removed in a follow-up. "
+            + "{Count} owner entry(ies) populated: [{Owners}]. "
+            + "Migrate to Trading:Cash:Seeds[] for static opening balances and "
+            + "Trading:Cash:SignupInitialBalance for self-service signup defaults.",
+            riskOpts.Margin.Initial.Count,
+            string.Join(", ", riskOpts.Margin.Initial.Keys));
+    }
+#pragma warning restore CS0618
 }
 
 if (corsOrigins.Length > 0)

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderCashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderCashLedgerTests.cs
@@ -2,6 +2,13 @@ using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 
+// Slice 4 of #107 deprecates Margin.Initial; the configInitial branch
+// here exercises the legacy fallback on purpose to prove ledger
+// presence wins over config and that fallback still works when no
+// ledger entry exists. Suppress at file scope; will be migrated when
+// Margin.Initial is removed.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace B3.Trading.Application.Tests;
 
 /// <summary>

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
@@ -2,6 +2,12 @@ using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 
+// These tests cover the legacy Margin.Initial fallback path on
+// purpose (#107 slice 4 deprecated but did not remove it). Suppress
+// the obsolete warning at file scope; when the property is removed
+// in a follow-up, this file will be migrated or deleted.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace B3.Trading.Application.Tests;
 
 public class ReserveOnSubmitMarginProviderTests


### PR DESCRIPTION
Closes the last in-flight slice of #107. Soft deprecation, no behavior change.

## What

- `MarginOptions.Initial` marked `[Obsolete]` with migration guidance
  pointing to:
  - `Trading:Cash:Seeds[]` for static per-owner opening balances
    (slice 1).
  - `Trading:Cash:SignupInitialBalance` for self-service signup
    defaults (slice 3).
- `Program.cs` emits a one-time WARN at startup when `Margin.Initial`
  is populated, listing the affected owners + the migration target.
- `ReserveOnSubmitMarginProvider.ResolveBaseAvailable` keeps the
  `Margin.Initial` fallback for owners with no ledger entry — that's
  the transition contract; a follow-up will retire it.
- Test files exercising the legacy fallback on purpose
  (`ReserveOnSubmitMarginProviderTests`,
  `ReserveOnSubmitMarginProviderCashLedgerTests`) get file-scope
  `#pragma warning disable CS0618` with a comment explaining intent.

## What's NOT in this PR

- Hard removal of `MarginOptions.Initial` — that's a follow-up after
  any operator running on the legacy path migrates. The startup
  warning is the nudge.
- Test migration to `Trading:Cash:Seeds[]` — same reason: keeping
  the legacy coverage until removal.

## Migration audit

`grep -r Margin.Initial docker/ backend/src/B3.Trading.Host/appsettings* docs/`
returns empty. Only the test suite references it; production configs
were never on this path.

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: **475 / 475** green
  (37 domain + 286 application + 152 api).
- `dotnet format --verify-no-changes`: clean.

Refs #107.