### PR TITLE
feat(stp): switch to presence-based self-trade prevention

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
@@ -18,16 +18,35 @@ namespace B3.Trading.Application.Risk.Checks;
 /// </para>
 ///
 /// <para>
-/// Policy: when an incoming order would cross any of the end-client's
-/// own opposite-side working orders for the same symbol, reject the
-/// incoming (newest-rejects). This is the most conservative STP mode
-/// and matches what most exchanges call "STP-N" / "Cancel newest".
-/// Toggleable per firm / per end-client via
-/// <see cref="RiskLimits.AllowSelfTrade"/> (default: blocked).
+/// <b>Policy (presence-based STP):</b> reject any incoming order if
+/// the end-client already has at least one opposite-side working
+/// order for the same symbol — <em>regardless of price</em>. This is
+/// stricter than the price-crossing check it replaces, and is the
+/// only correct policy given that the submit pipeline does not have
+/// strict execution guarantees: a non-crossing pair today (e.g. Buy
+/// 32.40 + Sell 32.50) can become crossing after a Modify, a partial
+/// fill, or a market move, with no atomic check↔dispatch step we
+/// could synchronise against. The price-crossing variant left the
+/// burden of "is this pair safe right now AND going forward?" on
+/// every state transition, which is impossible to guarantee from
+/// pre-trade. By collapsing the rule to "no opposite-side
+/// coexistence", we make the gate decidable from the snapshot the
+/// check sees and fail closed by construction. Mode is
+/// "newest-rejects" (a.k.a. STP-N / Cancel newest). Toggleable per
+/// firm / per end-client via
+/// <see cref="RiskLimits.AllowSelfTrade"/> (default: blocked) — set
+/// to <c>true</c> for accounts that legitimately need both sides
+/// resting (market makers, hedgers).
 /// </para>
 ///
 /// <para>
-/// Limitations (intentional, tracked in #103):
+/// Native server STP (the second viable layer, see #103) is
+/// stateful too and lives at the matching engine; #117 tracks
+/// surfacing its restatement reasons in the UI when active.
+/// </para>
+///
+/// <para>
+/// Limitations (intentional):
 /// <list type="bullet">
 ///   <item>TOCTOU: there is a small window between this check and
 ///   the gateway dispatch in which a contra order could be added by
@@ -76,13 +95,15 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
             if (existing.Side != oppositeSide) continue;
             if (!string.Equals(existing.Symbol, ctx.Symbol, StringComparison.Ordinal)) continue;
             if (!IsStillRestable(existing)) continue;
-            if (!WouldCross(ctx, existing)) continue;
 
+            // Presence-based: do NOT consult prices. Any opposite-side
+            // working order in the same symbol is enough to reject.
             return RiskDecision.Reject(
-                $"self_trade_prevention: would cross own working " +
-                $"{existing.Side} {existing.LeavesQuantity}@" +
+                $"self_trade_prevention: own opposite-side {existing.Side} order " +
+                $"{existing.LeavesQuantity}@" +
                 $"{(existing.Price.HasValue ? existing.Price.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "MKT")} " +
-                $"(clOrdId={existing.ClOrdId}); set AllowSelfTrade=true to opt out");
+                $"is working on {ctx.Symbol} (clOrdId={existing.ClOrdId}); " +
+                $"set AllowSelfTrade=true to opt out");
         }
 
         return RiskDecision.Approve;
@@ -97,22 +118,4 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
         && o.Status is not OrderStatus.Filled
                        and not OrderStatus.Cancelled
                        and not OrderStatus.Rejected;
-
-    // Crossing rules:
-    //   * If either side is Market, the new order will sweep — always cross.
-    //   * Buy@P crosses Sell@Q when P >= Q.
-    //   * Sell@P crosses Buy@Q when P <= Q.
-    private static bool WouldCross(RiskContext incoming, Order existing)
-    {
-        if (incoming.Type == OrderType.Market || existing.Type == OrderType.Market)
-            return true;
-
-        // Limit-vs-Limit requires both prices set; defensive nulls treat as no-cross.
-        if (!incoming.Price.HasValue || !existing.Price.HasValue)
-            return false;
-
-        return incoming.Side == OrderSide.Buy
-            ? incoming.Price.Value >= existing.Price.Value
-            : incoming.Price.Value <= existing.Price.Value;
-    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MarginCheckIntegrationTests.cs
@@ -27,6 +27,12 @@ public class MarginCheckIntegrationTests
             // pre-empt margin evaluation on the Sell-with-zero-inventory
             // case in SellsAndUnknownOwnersBypassMargin.
             ["Trading:Risk:Default:AllowShortSell"] = "true",
+            // Same rationale for self-trade prevention: the
+            // presence-based STP would reject SellsAndUnknownOwnersBypassMargin's
+            // Buy because a Sell from the same owner is already
+            // resting (regardless of price). Opt out so the assertion
+            // exercises the margin path.
+            ["Trading:Risk:Default:AllowSelfTrade"] = "true",
         };
 
     [Fact]
@@ -64,9 +70,9 @@ public class MarginCheckIntegrationTests
         Assert.NotEqual("Rejected", sellBody!.Status);
 
         // Buy with 0 balance must be rejected with the margin reason.
-        // Use a price below the resting Sell so the self-trade-prevention
-        // check (which would also fire and reject first) is not triggered;
-        // this test specifically exercises the margin path.
+        // STP is opted out at the EnabledFor() level so this Buy is
+        // not pre-empted by the presence-based STP gate even though
+        // an opposite-side Sell from the same owner is resting.
         var buy = await PostOrder(http, token, qty: 1, price: 29m, side: "Buy");
         var buyBody = await buy.Content.ReadFromJsonAsync<OrderAck>();
         Assert.Equal("Rejected", buyBody!.Status);

--- a/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
@@ -58,20 +58,30 @@ public class SelfTradePreventionCheckTests
         Assert.Contains("clOrdId=7", decision.Reason);
     }
 
+    // Presence-based STP (no price-cross filter): a non-crossing pair
+    // is also rejected, because Modify/partial-fill/market-move can
+    // turn it crossing later and we have no atomic check↔dispatch
+    // step to re-validate. Opt out via AllowSelfTrade=true.
     [Fact]
-    public void Buy_BelowOwnSellPrice_Approves()
+    public void Buy_BelowOwnSellPrice_Rejected_PresenceBased()
     {
         var (check, book) = Build();
         Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.50m)));
-        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.40m)).Approved);
+        var decision = check.Check(Ctx(OrderSide.Buy, 32.40m));
+        Assert.False(decision.Approved);
+        Assert.Contains("self_trade_prevention", decision.Reason);
+        Assert.Contains("clOrdId=1", decision.Reason);
     }
 
     [Fact]
-    public void Sell_AboveOwnBuyPrice_Approves()
+    public void Sell_AboveOwnBuyPrice_Rejected_PresenceBased()
     {
         var (check, book) = Build();
         Assert.True(book.TryAdd(Make(1, OrderSide.Buy, 32.40m)));
-        Assert.True(check.Check(Ctx(OrderSide.Sell, 32.50m)).Approved);
+        var decision = check.Check(Ctx(OrderSide.Sell, 32.50m));
+        Assert.False(decision.Approved);
+        Assert.Contains("self_trade_prevention", decision.Reason);
+        Assert.Contains("clOrdId=1", decision.Reason);
     }
 
     [Fact]
@@ -139,6 +149,22 @@ public class SelfTradePreventionCheckTests
         var (check, book) = Build(opts);
         Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.40m)));
         Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
+    }
+
+    // Opt-in covers BOTH crossing and non-crossing pairs.
+    [Fact]
+    public void AllowSelfTrade_OptIn_NonCrossing_Approves()
+    {
+        var opts = new RiskOptions
+        {
+            PerEndClient =
+            {
+                [Owner] = new RiskLimits { AllowSelfTrade = true },
+            },
+        };
+        var (check, book) = Build(opts);
+        Assert.True(book.TryAdd(Make(1, OrderSide.Sell, 32.50m)));
+        Assert.True(check.Check(Ctx(OrderSide.Buy, 32.40m)).Approved);
     }
 
     [Fact]


### PR DESCRIPTION
Stricter, simpler, correct given that the submit pipeline does **not** have strict execution guarantees.

## Motivation

The previous price-crossing STP would let through a non-crossing pair (e.g. Buy 32.40 + Sell 32.50 from the same owner). That pair can turn crossing later via Modify, partial fill, or market move — and there is no atomic check↔dispatch step we could synchronise against to re-validate. The check is decidable on the snapshot it sees but the invariant it tries to defend extends past that snapshot, which is the bug.

User-led design call:

> stp teria que validar se ja existe uma compra pendente para mesma mercadoria caso esteja tentando vender e vice versa. independente de preço.

## What changes

`SelfTradePreventionCheck` (`backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs`):

- Drop `WouldCross` entirely. Any opposite-side working order for the same `(owner, symbol)` is enough to reject — regardless of price.
- Reject reason text reflects the presence-based rationale.
- Mode unchanged (STP-N / newest rejects).
- Opt-out unchanged: `RiskLimits.AllowSelfTrade = true` (per-firm / per-end-client) for market makers + hedgers + anyone who knowingly wants two sides resting.
- Docstring rewritten to explain the design constraint (no atomic check↔dispatch, fail-closed by construction).

## Test impact

- `SelfTradePreventionCheckTests`: two "non-crossing approves" tests flipped to assert reject under the new policy; new test added confirming opt-in approves a non-crossing pair too.
- `MarginCheckIntegrationTests.SellsAndUnknownOwnersBypassMargin` used the price-below-resting-Sell trick to dodge STP; switched to `Trading:Risk:Default:AllowSelfTrade=true` in its overlay (test intent is margin, not STP) and the dated comment is updated.
- Conformance `ReferencePriceLiveSpecTests` already had `AllowSelfTrade=true` for alice in `docker/docker-compose.real-conformance.yml` — no change needed.

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: **476 / 476** green (37 domain + 287 application + 152 api).
- `dotnet format --verify-no-changes`: clean.

## Related

- #102 original STP incident.
- #103 spike (closed) — confirms there is no client-side native STP toggle in `B3.EntryPoint.Client` 0.14.3, so this layer remains source-of-truth.
- #117 follow-up — surface server-side STP restatement reasons in the UI when the B3 server has its own STP active for the account.

