### PR TITLE
feat(stp): surface server-side STP cancels distinctly (#117)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -58,7 +58,8 @@ public sealed record ExecutionDto(
     long LastQuantity,
     decimal LastPrice,
     string? RejectReason,
-    DateTimeOffset TimestampUtc);
+    DateTimeOffset TimestampUtc,
+    bool IsNativeStp = false);
 
 /// <summary>
 /// Wire shape for an algo parent. Per-type parameters live in the
@@ -103,7 +104,8 @@ public static class DtoMappings
 
     public static ExecutionDto ToDto(this ExecutionEvent ev) => new(
         ev.ClOrdId.ToString(), ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),
-        ev.LeavesQuantity, ev.CumulativeQuantity, ev.LastQuantity, ev.LastPrice, ev.RejectReason, ev.TimestampUtc);
+        ev.LeavesQuantity, ev.CumulativeQuantity, ev.LastQuantity, ev.LastPrice, ev.RejectReason, ev.TimestampUtc,
+        ev.IsNativeStp);
 
     public static AlgoDto ToDto(this Algo a)
     {

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -183,6 +183,22 @@ public sealed class ExecutionReportProcessor
                 break;
         }
 
+        // Server-side STP detection (#117): if the matching engine
+        // emitted a cancel with a SelfTradePrevention restatement
+        // reason, mark the outbound event so the UI/logs can surface
+        // it differently from generic cancels. Native STP is the
+        // ONLY layer that can catch a self-cross within the gateway
+        // dispatch race window; this surfacing is what makes the
+        // event actionable for diagnostics.
+        var isNativeStp = kind == ExecKind.Canceled
+            && NativeStpDetector.IsNativeStpReason(rejectReason);
+        if (isNativeStp)
+        {
+            _logger.LogInformation(
+                "event=stp.native.cancel clOrdId={ClOrdId} owner={Owner} symbol={Symbol} side={Side} reason={Reason}",
+                lookupId, owner.Value, order.Symbol, order.Side, rejectReason);
+        }
+
         _sink.Publish(new ExecutionEvent(
             owner,
             lookupId,
@@ -195,7 +211,8 @@ public sealed class ExecutionReportProcessor
             lastQty,
             lastPx,
             rejectReason,
-            DateTimeOffset.UtcNow));
+            DateTimeOffset.UtcNow,
+            isNativeStp));
 
         // Algo engine hook: signal AFTER fan-out so the engine reactor
         // sees the same world the WS subscribers see, and so the dispatch

--- a/backend/src/B3.Trading.Application/IExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Application/IExecutionEventSink.cs
@@ -30,7 +30,8 @@ public sealed record ExecutionEvent(
     long LastQuantity,
     decimal LastPrice,
     string? RejectReason,
-    DateTimeOffset TimestampUtc);
+    DateTimeOffset TimestampUtc,
+    bool IsNativeStp = false);
 
 public sealed class NoOpExecutionEventSink : IExecutionEventSink
 {

--- a/backend/src/B3.Trading.Application/NativeStpDetector.cs
+++ b/backend/src/B3.Trading.Application/NativeStpDetector.cs
@@ -1,0 +1,46 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Detects whether an ExecutionReport's <c>RejectReason</c> string
+/// corresponds to a server-side Self-Trade Prevention restatement
+/// emitted by the B3 EntryPoint matching engine.
+///
+/// <para>
+/// Background: <c>B3.EntryPoint.Client.Models.ExecRestatementReason</c>
+/// 0.14.3 defines two STP-related codes — <c>SelfTradingPrevention =
+/// 103</c> and <c>CancelRestingOrderOnSelfTrade = 107</c>. The gateway
+/// (<c>B3EntryPointClientGateway</c>) forwards the enum's
+/// <c>ToString()</c> as the <c>RejectReason</c> on cancel envelopes.
+/// We text-match here instead of taking a hard SDK type dependency to
+/// keep the Application layer free of the wire SDK; if the SDK renames
+/// the enum the gateway will drift first and a focused failure here
+/// makes the regression obvious.
+/// </para>
+///
+/// <para>
+/// Spike + design rationale in #103 / #117: the client SDK does not
+/// expose any per-order STP toggle, so the only way to act on
+/// server-driven STP is to recognise these reasons after the fact and
+/// surface them differently from generic cancels (UI badge,
+/// structured logs).
+/// </para>
+/// </summary>
+public static class NativeStpDetector
+{
+    // String literals match B3.EntryPoint.Client.Models.ExecRestatementReason
+    // member names. Comparison is ordinal case-insensitive — defensive
+    // against any caller that might Title-Case the reason on its way
+    // through the pipeline. Whitespace is trimmed to absorb log/format
+    // noise (the gateway emits the raw enum name today, no spaces, but
+    // future envelopes that wrap it shouldn't break detection).
+    private const string SelfTradingPrevention = "SelfTradingPrevention";
+    private const string CancelRestingOrderOnSelfTrade = "CancelRestingOrderOnSelfTrade";
+
+    public static bool IsNativeStpReason(string? rejectReason)
+    {
+        if (string.IsNullOrWhiteSpace(rejectReason)) return false;
+        var trimmed = rejectReason.Trim();
+        return string.Equals(trimmed, SelfTradingPrevention, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(trimmed, CancelRestingOrderOnSelfTrade, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -239,6 +239,60 @@ public class ExecutionReportProcessorTests
         Assert.Equal(150, positions.GetOrCreate(owner, "PETR4").NetQuantity);
     }
 
+    [Fact]
+    public void Cancel_WithNativeStpReason_MarksEventAsNativeStp()
+    {
+        var (proc, ownership, book, _, sink) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+
+        proc.Apply(1UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m,
+                   rejectReason: "CancelRestingOrderOnSelfTrade");
+
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+        var ev = Assert.Single(sink.Events);
+        Assert.True(ev.IsNativeStp);
+        Assert.Equal("CancelRestingOrderOnSelfTrade", ev.RejectReason);
+    }
+
+    [Fact]
+    public void Cancel_WithGenericReason_DoesNotMarkAsNativeStp()
+    {
+        var (proc, ownership, book, _, sink) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(2UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(2UL, owner);
+        order.MarkWorking();
+
+        proc.Apply(2UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m,
+                   rejectReason: "RiskManagementCancellation");
+
+        var ev = Assert.Single(sink.Events);
+        Assert.False(ev.IsNativeStp);
+    }
+
+    [Fact]
+    public void Fill_WithStpLikeReason_DoesNotMarkAsNativeStp()
+    {
+        // Defensive: native-STP marker is gated on Kind == Canceled.
+        // A Fill ER with a freaky reason text must not be miscategorised.
+        var (proc, ownership, book, _, sink) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(3UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(3UL, owner);
+
+        proc.Apply(3UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m,
+                   rejectReason: "SelfTradingPrevention");
+
+        var ev = Assert.Single(sink.Events);
+        Assert.False(ev.IsNativeStp);
+    }
+
     private sealed class RecordingSink : IExecutionEventSink
     {
         public readonly List<ExecutionEvent> Events = new();

--- a/backend/tests/B3.Trading.Application.Tests/NativeStpDetectorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NativeStpDetectorTests.cs
@@ -1,0 +1,39 @@
+using B3.Trading.Application;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Coverage for #117: detection of server-side Self-Trade Prevention
+/// reasons emitted by the B3 EntryPoint matching engine.
+/// </summary>
+public class NativeStpDetectorTests
+{
+    [Theory]
+    [InlineData("SelfTradingPrevention")]
+    [InlineData("CancelRestingOrderOnSelfTrade")]
+    public void Recognises_KnownStpReasons(string reason)
+    {
+        Assert.True(NativeStpDetector.IsNativeStpReason(reason));
+    }
+
+    [Theory]
+    [InlineData("selftradingprevention")]
+    [InlineData("CANCELRESTINGORDERONSELFTRADE")]
+    [InlineData("  SelfTradingPrevention  ")]
+    public void Recognises_KnownStpReasons_CaseAndWhitespaceInsensitive(string reason)
+    {
+        Assert.True(NativeStpDetector.IsNativeStpReason(reason));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("RiskManagementCancellation")]
+    [InlineData("CancelOnDisconnect")]
+    [InlineData("self_trade_prevention: would cross own working Sell 100@30")]
+    public void Rejects_OtherReasons(string? reason)
+    {
+        Assert.False(NativeStpDetector.IsNativeStpReason(reason));
+    }
+}

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -270,6 +270,17 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 .executions-log .Canceled    { color: var(--gray); }
 .executions-log .New         { color: var(--accent); }
 .executions-log .meta { color: var(--muted); }
+.executions-log .badge {
+  display: inline-block;
+  padding: 0 .35em;
+  margin-left: .25em;
+  border-radius: .25em;
+  font-size: .7rem;
+  font-weight: 600;
+  vertical-align: baseline;
+}
+.executions-log .badge.stp-native { background: #5a3a14; color: #ffd28a; }
+.executions-log .badge.stp-local  { background: #2a3a5a; color: #b8d2ff; }
 
 /* ---------- Responsive ---------- */
 @media (max-width: 1280px) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -982,11 +982,28 @@ function execRow(e) {
   const reason = e.rejectReason ? ` — ${escapeHtml(e.rejectReason)}` : "";
   const lastPx = e.lastQuantity > 0 ? ` @ ${fmtPx(e.lastPrice)}` : "";
   const lastQty = e.lastQuantity > 0 ? fmtQty(e.lastQuantity) : "";
+  // Categorize STP cancels for the trader: server-driven STP from
+  // the matching engine (#117) is distinct from the local pre-trade
+  // reject. Both categories surface as small badges so a glance at
+  // the executions log tells the trader which layer fired.
+  const stpBadge = stpBadgeFor(e);
   return `<li>
     <span class="ts">${ts}</span>
     <span class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</span>
-    <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${lastQty}${lastPx}${reason}</span>
+    <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${lastQty}${lastPx}${stpBadge}${reason}</span>
   </li>`;
+}
+
+function stpBadgeFor(e) {
+  if (e.isNativeStp) {
+    return ` <span class="badge stp-native" title="Cancelado pelo motor de matching da B3 por Self-Trade Prevention">STP servidor B3</span>`;
+  }
+  if (e.kind === "Rejected"
+      && typeof e.rejectReason === "string"
+      && e.rejectReason.startsWith("self_trade_prevention")) {
+    return ` <span class="badge stp-local" title="Rejeitado pela camada local de Self-Trade Prevention antes de chegar ao gateway">STP local</span>`;
+  }
+  return "";
 }
 
 function escapeHtml(s) {


### PR DESCRIPTION
Closes #117. Makes server-driven Self-Trade Prevention cancels actionable in the trader UI and operator logs, instead of arriving as anonymous "Canceled" events.

## Why

- #103 spike confirmed the client SDK 0.14.3 has no per-order STP toggle.
- #118 made local STP presence-based (correct given no atomic check↔dispatch), but local STP can never close the gateway-dispatch race window — only the matching engine can.
- When the engine fires its native STP, today the cancel ER reaches the trader as a generic "Canceled". That is the layer this PR makes visible.

## Backend

- `NativeStpDetector.IsNativeStpReason(string?)` (`backend/src/B3.Trading.Application/NativeStpDetector.cs`): text-based matcher for `SelfTradingPrevention` / `CancelRestingOrderOnSelfTrade`, case- and whitespace-insensitive. Text-based on purpose so the Application layer stays free of a hard SDK dependency; if the SDK ever renames the enum, the gateway drifts first and the failure is focused.
- `ExecutionEvent` (`IExecutionEventSink.cs`) and `ExecutionDto` (`Dtos.cs`) gain `bool IsNativeStp = false` (additive — existing clients keep working).
- `ExecutionReportProcessor.Apply` sets the flag only when `Kind == Canceled` AND the detector matches; emits a structured log line `event=stp.native.cancel clOrdId={...} owner={...} symbol={...} side={...} reason={...}` for operator dashboards.

## Frontend

- New badges on the executions log:
  - `STP servidor B3` (warm/orange) — native server STP cancel.
  - `STP local` (cool/blue) — pre-trade `self_trade_prevention` reject.
- Detection in `execRow`: server side reads `isNativeStp` from the DTO; local side detects by `rejectReason` prefix (no behavior change to local-STP rejects, just a visual badge).
- CSS additions in `frontend/css/styles.css` (`.executions-log .badge.stp-native|.stp-local`). No new files.

## Tests

- `NativeStpDetectorTests` (11 cases):
  - Positives: both enum names exact + case-mixed + whitespace-padded.
  - Negatives: null, empty, whitespace, other reasons, local-STP prefix string.
- `ExecutionReportProcessorTests` (+3):
  - `Cancel_WithNativeStpReason_MarksEventAsNativeStp`.
  - `Cancel_WithGenericReason_DoesNotMarkAsNativeStp`.
  - `Fill_WithStpLikeReason_DoesNotMarkAsNativeStp` — gate on Kind == Canceled.

## Verification

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: **490 / 490** green (37 + 301 + 152).
- `dotnet format --verify-no-changes`: clean.

## Out of scope

- Conformance test exercising the matching engine STP path — would require server-side B3 config we do not control. Spike #103 noted this. Manual smoke recommended once any operator opts in to server STP for a dogfood account.
- New metric `trading.stp.native.cancels.total` — easy to add later if operators want a dashboard tile; the structured log is enough for v1.

Refs #117 #103 #102 #118.