### PR TITLE
feat(auth): signup hardening slice 1 — password policy + reserved usernames

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -67,13 +67,9 @@ public static class AuthEndpoints
                 || string.IsNullOrWhiteSpace(req.Password))
                 return Results.BadRequest(new { error = "username and password required" });
 
-            // Minimal hygiene only — full policy (length/complexity/captcha
-            // /rate-limit) is a tracked hardening follow-up. Reject strings
-            // we know will break downstream consumers (claim parsing,
-            // ClOrdID emission, WS topic routing).
-            var username = req.Username.Trim();
-            if (username.Length > 64 || username.Any(c => char.IsWhiteSpace(c) || c == ':' || c == '"' || c == '\\'))
-                return Results.BadRequest(new { error = "username contains invalid characters" });
+            var validation = ValidateSignupRequest(req, opts.Value, out var username);
+            if (validation is not null)
+                return validation;
 
             var iterations = opts.Value.Pbkdf2Iterations > 0 ? opts.Value.Pbkdf2Iterations : 600_000;
             var (hash, salt) = PasswordHasher.Hash(req.Password, iterations);
@@ -129,6 +125,66 @@ public static class AuthEndpoints
         });
 
         return app;
+    }
+
+    /// <summary>
+    /// Slice 1 of #97 hardening: shape + reserved-name + password-policy
+    /// validation for signup. Returns <c>null</c> on success and emits the
+    /// normalized (trimmed) <paramref name="username"/> so the caller does
+    /// not re-trim and risk drift between validate/store.
+    /// </summary>
+    private static IResult? ValidateSignupRequest(SignupRequest req, AuthOptions opts, out string username)
+    {
+        username = req.Username.Trim();
+
+        // Existing minimal hygiene — reject strings we know will break
+        // downstream consumers (claim parsing, ClOrdID emission, WS topic
+        // routing).
+        if (username.Length > 64 || username.Any(c => char.IsWhiteSpace(c) || c == ':' || c == '"' || c == '\\'))
+            return Results.BadRequest(new { error = "username contains invalid characters" });
+
+        // Reserved usernames + prefixes (case-insensitive). 409 mirrors
+        // the duplicate-username UX; the body string distinguishes the
+        // two cases for client-side messaging.
+        if (IsReserved(username, opts))
+            return Results.Conflict(new { error = "username is reserved" });
+
+        var policyError = ValidatePassword(req.Password, opts.PasswordPolicy);
+        if (policyError is not null)
+            return Results.BadRequest(new { error = policyError });
+
+        return null;
+    }
+
+    private static bool IsReserved(string username, AuthOptions opts)
+    {
+        foreach (var name in opts.ReservedUsernames ?? new())
+        {
+            if (string.IsNullOrWhiteSpace(name)) continue;
+            if (string.Equals(username, name.Trim(), StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        foreach (var prefix in opts.ReservedUsernamePrefixes ?? new())
+        {
+            if (string.IsNullOrWhiteSpace(prefix)) continue;
+            if (username.StartsWith(prefix.Trim(), StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string? ValidatePassword(string password, PasswordPolicyOptions policy)
+    {
+        var minLength = policy.EffectiveMinLength;
+        if (password.Length < minLength)
+            return $"password does not meet policy: minimum length is {minLength}";
+        if (policy.RequireDigit && !password.Any(char.IsDigit))
+            return "password does not meet policy: must contain a digit";
+        if (policy.RequireLetter && !password.Any(char.IsLetter))
+            return "password does not meet policy: must contain a letter";
+        return null;
     }
 }
 

--- a/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
@@ -16,6 +16,47 @@ public sealed class AuthOptions
     public int TokenLifetimeMinutes { get; set; } = 60;
     public int Pbkdf2Iterations { get; set; } = 600_000;
     public List<UserConfig> Users { get; set; } = new();
+
+    /// <summary>
+    /// Password policy applied at signup only. Login intentionally does not
+    /// re-check the policy so env-seeded operator accounts are not retroactively
+    /// locked out when defaults tighten. See issue #97 (slice 1).
+    /// </summary>
+    public PasswordPolicyOptions PasswordPolicy { get; set; } = new();
+
+    /// <summary>
+    /// Exact-match (case-insensitive) reserved usernames blocked at signup.
+    /// Defaults cover well-known admin handles. Operators may override via
+    /// <c>Trading:Auth:ReservedUsernames</c>; the configured list replaces
+    /// defaults (standard .NET options array semantics).
+    /// </summary>
+    public List<string> ReservedUsernames { get; set; } = new()
+    {
+        "admin", "administrator", "root", "system",
+    };
+
+    /// <summary>
+    /// Prefix-match (case-insensitive) reserved username patterns. Same
+    /// override semantics as <see cref="ReservedUsernames"/>. Defaults
+    /// reserve the demo/bot namespaces used by docker-compose.demo.yml so a
+    /// drive-by signup cannot impersonate a bot identity.
+    /// </summary>
+    public List<string> ReservedUsernamePrefixes { get; set; } = new()
+    {
+        "bot-", "bot_", "demo-", "demo_",
+    };
+}
+
+public sealed class PasswordPolicyOptions
+{
+    /// <summary>Minimum length. Values &lt;= 0 are clamped to <see cref="DefaultMinLength"/>.</summary>
+    public int MinLength { get; set; } = DefaultMinLength;
+    public bool RequireDigit { get; set; } = true;
+    public bool RequireLetter { get; set; } = true;
+
+    public const int DefaultMinLength = 8;
+
+    public int EffectiveMinLength => MinLength <= 0 ? DefaultMinLength : MinLength;
 }
 
 public sealed class UserConfig

--- a/backend/tests/B3.Trading.Api.Tests/SignupEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SignupEndpointTests.cs
@@ -49,11 +49,11 @@ public class SignupEndpointTests : IClassFixture<TestAppFactory>
         using var client = _factory.CreateClient();
         var username = FreshUsername();
         var first = await client.PostAsJsonAsync("/auth/signup",
-            new SignupRequest(username, "pw1"));
+            new SignupRequest(username, "wonderland-1"));
         first.EnsureSuccessStatusCode();
 
         var second = await client.PostAsJsonAsync("/auth/signup",
-            new SignupRequest(username, "pw2"));
+            new SignupRequest(username, "wonderland-2"));
         Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
     }
 
@@ -62,7 +62,7 @@ public class SignupEndpointTests : IClassFixture<TestAppFactory>
     {
         using var client = _factory.CreateClient();
         var resp = await client.PostAsJsonAsync("/auth/signup",
-            new SignupRequest("alice", "anything"));
+            new SignupRequest("alice", "wonderland-1"));
         Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
     }
 
@@ -80,7 +80,7 @@ public class SignupEndpointTests : IClassFixture<TestAppFactory>
     {
         using var client = _factory.CreateClient();
         var resp = await client.PostAsJsonAsync("/auth/signup",
-            new SignupRequest("bad name", "pw"));
+            new SignupRequest("bad name", "wonderland-1"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
@@ -90,7 +90,7 @@ public class SignupEndpointTests : IClassFixture<TestAppFactory>
         using var client = _factory.CreateClient();
         var username = FreshUsername();
         var signup = await client.PostAsJsonAsync("/auth/signup",
-            new SignupRequest(username, "pw"));
+            new SignupRequest(username, "wonderland-1"));
         signup.EnsureSuccessStatusCode();
 
         var keeper = _factory.Services.GetRequiredService<PositionKeeper>();
@@ -101,5 +101,103 @@ public class SignupEndpointTests : IClassFixture<TestAppFactory>
         Assert.True(bySymbol.ContainsKey("VALE3"), "VALE3 not seeded");
         Assert.Equal(2000, bySymbol["PETR4"].NetQuantity);
         Assert.Equal(2000, bySymbol["VALE3"].NetQuantity);
+    }
+
+    private static async Task<string?> ReadErrorAsync(HttpResponseMessage resp)
+    {
+        var doc = await resp.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        return doc.TryGetProperty("error", out var err) ? err.GetString() : null;
+    }
+
+    [Fact]
+    public async Task Signup_ShortPassword_Returns400_WithPolicyError()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(FreshUsername(), "abc1"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.NotNull(err);
+        Assert.Contains("policy", err!);
+        Assert.Contains("length", err);
+    }
+
+    [Fact]
+    public async Task Signup_NoDigit_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(FreshUsername(), "wonderland"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.Contains("digit", err!);
+    }
+
+    [Fact]
+    public async Task Signup_NoLetter_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(FreshUsername(), "12345678"));
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.Contains("letter", err!);
+    }
+
+    [Fact]
+    public async Task Signup_ReservedExactName_Root_Returns409()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("root", "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.Equal("username is reserved", err);
+    }
+
+    [Fact]
+    public async Task Signup_ReservedExactName_CaseInsensitive_Returns409()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("SyStEm", "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.Equal("username is reserved", err);
+    }
+
+    [Fact]
+    public async Task Signup_ReservedPrefix_BotDash_Returns409()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("bot-rogueX", "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var err = await ReadErrorAsync(resp);
+        Assert.Equal("username is reserved", err);
+    }
+
+    [Fact]
+    public async Task Signup_NonPrefixSubstring_IsAllowed()
+    {
+        using var client = _factory.CreateClient();
+        // "fooadmin" contains "admin" but is not an exact match nor a prefix
+        // hit; should pass policy/reserved and create a fresh account.
+        var resp = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("fooadmin" + Guid.NewGuid().ToString("N")[..6], "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_AfterPolicyTightened_StillWorks_ForEnvSeededUser()
+    {
+        // Slice 1 design: policy is signup-only. Env-seeded "alice/wonderland"
+        // would fail RequireDigit if policy were re-checked at login. This
+        // test pins the decision so a future refactor sharing validation
+        // between login/signup trips immediately.
+        using var client = _factory.CreateClient();
+        var login = await client.PostAsJsonAsync("/auth/login",
+            new LoginRequest("alice", "wonderland"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
     }
 }


### PR DESCRIPTION
Slice 1 of #97 (signup hardening backlog). Pure validation in the
signup handler — no new infra.

## What ships

- **Password policy** (signup-only) via `Trading:Auth:PasswordPolicy`:
  - `MinLength` (default 8; clamps <=0 to 8)
  - `RequireDigit` (default true)
  - `RequireLetter` (default true)
  Returns `400` with `error: "password does not meet policy: ..."`.
  Login does **not** re-check the policy: env-seeded operator accounts
  like `alice/wonderland` would fail `RequireDigit`, and a signup-time
  policy must not retroactively lock out existing users. A regression
  test pins that decision.
- **Reserved usernames** via `Trading:Auth:ReservedUsernames` (default:
  `admin`, `administrator`, `root`, `system`) and
  `Trading:Auth:ReservedUsernamePrefixes` (default: `bot-`, `bot_`,
  `demo-`, `demo_` — so a drive-by signup cannot impersonate the
  docker-compose.demo.yml bot identities). All comparisons are
  `OrdinalIgnoreCase`. Returns `409` with body
  `error: "username is reserved"` (status mirrors duplicate-username
  UX; the body distinguishes the two cases for the client).

## What does NOT ship (still in #97)

- Rate limit on `/auth/signup` — slice 2.
- Persistence of runtime users — slice 3.
- Login lockout after N failed attempts — slice 4.
- Captcha, admin user mgmt, multi-firm signup.
- Common-password breach list — only useful with a rate limit, so it
  rides with slice 2.

## Tests

- 8 new `SignupEndpointTests`: short password, missing digit, missing
  letter (each asserts the policy fragment in the body), reserved
  exact match (`root`), reserved case-insensitive (`SyStEm`), reserved
  prefix (`bot-rogueX`), non-prefix substring (`fooadmin*`) is allowed,
  and a login-after-policy regression for env-seeded `alice`.
- Bumped existing `pw` / `pw1` / `anything` test passwords to
  `wonderland-1` so the duplicate-username and env-collision paths are
  exercised without tripping the new policy.
- Suite: 37 + 301 + 160 = 498 unit tests green; 12 conformance skipped.
- `dotnet format` clean.

## Frontend

Already surfaces server-side `error` body via `jsonOrThrow` →
`setSignupError(err.message)`, so policy/reserved messages render
verbatim without code changes.

Refs #97.