### PR TITLE
fix(ui): order ticket horizontal scrollbar + restore page scroll

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -152,7 +152,7 @@ body {
   background: var(--panel-2); color: var(--text); border-radius: 999px;
   padding: 0 .5rem; font-size: .7rem;
 }
-.ticket     { grid-area: ticket; overflow-y: auto; }
+.ticket     { grid-area: ticket; overflow-y: auto; overflow-x: hidden; min-width: 0; }
 .blotter    { grid-area: blotter; min-height: 0; }
 .positions  { grid-area: positions; }
 .executions { grid-area: execs; min-height: 0; }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -66,7 +66,14 @@ body {
 .login-switch .link-button:hover { filter: brightness(1.2); }
 
 /* ---------- Trader shell ---------- */
-.trader-view { display: flex; flex-direction: column; height: 100vh; min-height: 0; overflow: hidden; }
+/* `min-height: 100vh` + no overflow trap: at viewports tall enough to
+   fit all four grid rows the layout still feels "fit-to-viewport", but
+   when the minimum row sizes exceed the viewport (small laptops,
+   browser zoom, dense fonts) the page scrolls vertically instead of
+   trapping content under the topbar. The previous `height: 100vh;
+   overflow: hidden` swallowed the bottom row (Executions Log + Market
+   Data) and let the Tape panel paint over the Blotter. */
+.trader-view { display: flex; flex-direction: column; min-height: 100vh; }
 .topbar {
   display: flex; justify-content: space-between; align-items: center;
   padding: .6rem 1rem; background: var(--panel); border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Bugs

1. Stray horizontal scrollbar appearing inside the **Order Ticket** panel between Submit and Positions.
2. **Page scroll lost** in the trader view: at viewports where the sum of grid row mins (~970px including topbar/gaps/paddings) exceeds the available height, the bottom row (Executions Log + Market Data) was inaccessible and the **Tape** panel (min-height: 200px) painted over the Blotter row.

## Fix 1 — order ticket horizontal scrollbar

Per CSS spec, when one overflow axis is non-visible the OTHER axis computes to `auto` (not `visible`), so any child reaching the container width forced a horizontal track to appear. Pinned `overflow-x: hidden` and added `min-width: 0` so inputs can shrink inside the grid column.

## Fix 2 — restore page scroll fallback

`.trader-view { height: 100vh; overflow: hidden }` trapped overflow under the topbar. Switched to `min-height: 100vh` (and dropped `overflow: hidden`). Tall monitors keep the fit-to-viewport feel; smaller viewports get a proper body scroll instead of clipped panels. Inner panel scrollers (.ticket overflow-y, .panel table overflow-x) are unchanged.

Pure cosmetic; no JS, no behavior changes.