### PR TITLE
feat(auth): signup hardening slice 2 — anti-abuse rate limits

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/AuthRateLimitOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthRateLimitOptions.cs
@@ -1,0 +1,64 @@
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Slice 2 of #97 hardening: anti-abuse rate limits for the public auth
+/// endpoints. Bound from <c>Trading:Auth:RateLimit</c> in
+/// <c>appsettings.json</c>. Each policy is independently toggleable so
+/// operators can ship behind a proxy that already throttles, or test
+/// suites can run hot loops without tripping limits.
+/// </summary>
+/// <remarks>
+/// All three policies are wired into a single chained
+/// <see cref="System.Threading.RateLimiting.PartitionedRateLimiter"/>
+/// installed as <c>GlobalLimiter</c>. The chain order is intentional:
+/// per-IP runs first so a single abusive source cannot burn the global
+/// signup fuse before being rejected at the IP layer.
+/// </remarks>
+public sealed class AuthRateLimitOptions
+{
+    public const string SectionName = "Trading:Auth:RateLimit";
+
+    /// <summary>Per-IP throttle for <c>POST /auth/signup</c>.</summary>
+    public RateLimitPolicyOptions SignupPerIp { get; set; } = new()
+    {
+        Enabled = true,
+        PermitLimit = 5,
+        WindowSeconds = 3600,
+    };
+
+    /// <summary>Global fuse for <c>POST /auth/signup</c>; second link of the chain.</summary>
+    public RateLimitPolicyOptions SignupGlobal { get; set; } = new()
+    {
+        Enabled = true,
+        PermitLimit = 100,
+        WindowSeconds = 3600,
+    };
+
+    /// <summary>
+    /// Per-IP throttle for <c>POST /auth/login</c>. Defense-in-depth
+    /// against credential stuffing while slice 4 (per-username failed-
+    /// login lockout) is not in place. Counts ALL login attempts (incl.
+    /// successful) since this is endpoint-level — not a substitute for
+    /// proper failed-login tracking.
+    /// </summary>
+    public RateLimitPolicyOptions LoginPerIp { get; set; } = new()
+    {
+        Enabled = true,
+        PermitLimit = 20,
+        WindowSeconds = 300,
+    };
+}
+
+public sealed class RateLimitPolicyOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Requests allowed per window. Values &lt;= 0 disable the policy.</summary>
+    public int PermitLimit { get; set; } = 5;
+
+    /// <summary>Window length in seconds. Values &lt;= 0 disable the policy.</summary>
+    public int WindowSeconds { get; set; } = 60;
+
+    public bool IsActive => Enabled && PermitLimit > 0 && WindowSeconds > 0;
+    public TimeSpan Window => TimeSpan.FromSeconds(WindowSeconds);
+}

--- a/backend/src/B3.Trading.Api/Auth/AuthRateLimiterSetup.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthRateLimiterSetup.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Slice 2 of #97 hardening: anti-abuse rate limiting for the public
+/// auth endpoints (<c>/auth/signup</c>, <c>/auth/login</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// All limiters are installed as a single chained
+/// <see cref="PartitionedRateLimiter{TResource}"/> on
+/// <see cref="RateLimiterOptions.GlobalLimiter"/>. The chain order is
+/// per-IP signup → per-IP login → global signup fuse so a single
+/// abusive source is rejected before it can advance the global counter.
+/// </para>
+/// <para>
+/// Each partitioner resolves <see cref="IOptionsMonitor{T}"/> from
+/// <see cref="HttpContext.RequestServices"/> on every request. This is
+/// what makes <c>WebApplicationFactory</c> overrides actually take
+/// effect (eager startup capture would freeze defaults).
+/// </para>
+/// <para>
+/// Trust of <c>X-Forwarded-For</c> is intentionally NOT enabled here.
+/// Behind a reverse proxy the IP partition collapses to the proxy's IP,
+/// effectively converting per-IP into global; operators must opt-in to
+/// forwarded headers (with trusted-proxy config) before the per-IP
+/// partition becomes meaningful in that topology.
+/// </para>
+/// </remarks>
+internal static class AuthRateLimiterSetup
+{
+    private const string SignupPath = "/auth/signup";
+    private const string LoginPath = "/auth/login";
+
+    public static void AddAuthRateLimiter(this IServiceCollection services)
+    {
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                var http = context.HttpContext;
+                var loggerFactory = http.RequestServices.GetService<ILoggerFactory>();
+                var logger = loggerFactory?.CreateLogger("AuthRateLimiter");
+
+                int retryAfterSeconds = 60;
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                {
+                    retryAfterSeconds = Math.Max(1, (int)Math.Ceiling(retryAfter.TotalSeconds));
+                }
+
+                http.Response.Headers.RetryAfter =
+                    retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+                http.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                http.Response.ContentType = "application/json";
+
+                logger?.LogWarning(
+                    "auth.ratelimit.rejected path={Path} retryAfterSeconds={RetryAfter}",
+                    http.Request.Path.Value,
+                    retryAfterSeconds);
+
+                await http.Response.WriteAsync(
+                    $"{{\"error\":\"too many requests\",\"retryAfterSeconds\":{retryAfterSeconds.ToString(CultureInfo.InvariantCulture)}}}",
+                    cancellationToken);
+            };
+
+            options.GlobalLimiter = PartitionedRateLimiter.CreateChained(
+                BuildPathPolicy(SignupPath, opts => opts.SignupPerIp, partitionByIp: true),
+                BuildPathPolicy(LoginPath, opts => opts.LoginPerIp, partitionByIp: true),
+                BuildPathPolicy(SignupPath, opts => opts.SignupGlobal, partitionByIp: false));
+        });
+    }
+
+    private static PartitionedRateLimiter<HttpContext> BuildPathPolicy(
+        string path,
+        Func<AuthRateLimitOptions, RateLimitPolicyOptions> select,
+        bool partitionByIp)
+    {
+        return PartitionedRateLimiter.Create<HttpContext, string>(http =>
+        {
+            // Path gate: anything outside the auth endpoint is a no-op
+            // partition, so the chained global limiter does not affect
+            // the rest of the API surface.
+            if (!http.Request.Path.StartsWithSegments(path, StringComparison.OrdinalIgnoreCase))
+                return RateLimitPartition.GetNoLimiter("none");
+
+            var monitor = http.RequestServices.GetRequiredService<IOptionsMonitor<AuthRateLimitOptions>>();
+            var policy = select(monitor.CurrentValue);
+
+            if (!policy.IsActive)
+                return RateLimitPartition.GetNoLimiter("disabled");
+
+            var key = partitionByIp ? ClientIpKey(http) : "global";
+
+            return RateLimitPartition.GetFixedWindowLimiter(
+                $"{path}:{(partitionByIp ? "ip" : "global")}:{key}",
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = policy.PermitLimit,
+                    Window = policy.Window,
+                    QueueLimit = 0,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    AutoReplenishment = true,
+                });
+        });
+    }
+
+    private static string ClientIpKey(HttpContext http)
+    {
+        // Intentionally NOT consulting X-Forwarded-For here — see class
+        // remarks for rationale. ConnectionInfo.RemoteIpAddress is the
+        // socket peer; behind a proxy that becomes the proxy IP and the
+        // per-IP bucket collapses, but that is a configuration concern
+        // (UseForwardedHeaders) the operator must opt into.
+        var ip = http.Connection.RemoteIpAddress;
+        return ip is null ? "unknown" : ip.ToString();
+    }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -28,6 +28,9 @@ builder.Services.AddOptions<ExchangeOptions>()
 builder.Services.AddSingleton<IValidateOptions<ExchangeOptions>, ExchangeOptionsValidator>();
 builder.Services.Configure<AuthOptions>(
     builder.Configuration.GetSection(AuthOptions.SectionName));
+builder.Services.Configure<AuthRateLimitOptions>(
+    builder.Configuration.GetSection(AuthRateLimitOptions.SectionName));
+builder.Services.AddAuthRateLimiter();
 builder.Services.Configure<RiskOptions>(
     builder.Configuration.GetSection(RiskOptions.SectionName));
 builder.Services.Configure<SymbolDirectoryOptions>(
@@ -516,6 +519,11 @@ var app = builder.Build();
 
 if (corsOrigins.Length > 0)
     app.UseCors(CorsPolicy);
+
+// Rate limiter must run after CORS (so preflight OPTIONS still gets the
+// CORS headers before potential 429s) and before auth so abusive
+// callers cannot tie up the password hashing pipeline with floods.
+app.UseRateLimiter();
 
 app.UseWebSockets();
 app.UseAuthentication();

--- a/backend/tests/B3.Trading.Api.Tests/AuthRateLimitTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AuthRateLimitTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Slice 2 of #97 — anti-abuse rate limit on /auth/signup and /auth/login.
+/// Defaults disable the limiter inside <see cref="TestAppFactory"/>; each
+/// test here opts into a specific policy via <c>WithOverrides</c> so the
+/// rest of the suite is unaffected.
+/// </summary>
+public class AuthRateLimitTests
+{
+    private static string FreshUsername() => "u" + Guid.NewGuid().ToString("N")[..10];
+
+    private static async Task<int?> RetryAfterFromBodyAsync(HttpResponseMessage resp)
+    {
+        var doc = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return doc.TryGetProperty("retryAfterSeconds", out var v) ? v.GetInt32() : null;
+    }
+
+    [Fact]
+    public async Task Signup_PerIp_LimitTrips_Returns429_WithRetryAfter()
+    {
+        using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:RateLimit:SignupPerIp:Enabled"] = "true",
+            ["Trading:Auth:RateLimit:SignupPerIp:PermitLimit"] = "3",
+            ["Trading:Auth:RateLimit:SignupPerIp:WindowSeconds"] = "60",
+        });
+        using var client = factory.CreateClient();
+
+        // First 3 succeed (PermitLimit=3, fresh per-IP window, all from
+        // localhost so they share the partition).
+        for (var i = 0; i < 3; i++)
+        {
+            var ok = await client.PostAsJsonAsync("/auth/signup",
+                new SignupRequest(FreshUsername(), "wonderland-1"));
+            Assert.Equal(HttpStatusCode.Created, ok.StatusCode);
+        }
+
+        // 4th must be rejected before hitting the handler. We use a fresh
+        // username to ensure the conflict path could not steal the
+        // assertion if the limiter were silently disabled.
+        var rejected = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(FreshUsername(), "wonderland-1"));
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+        Assert.True(rejected.Headers.Contains("Retry-After"),
+            "Retry-After header missing on 429 — required for slice 2 contract.");
+        var retryAfter = await RetryAfterFromBodyAsync(rejected);
+        Assert.NotNull(retryAfter);
+        Assert.True(retryAfter > 0);
+    }
+
+    [Fact]
+    public async Task Signup_Global_FuseTrips_Returns429()
+    {
+        // Per-IP at 100 (effectively disabled for this test) so we
+        // exclusively exercise the global fuse at PermitLimit=2.
+        using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:RateLimit:SignupPerIp:Enabled"] = "true",
+            ["Trading:Auth:RateLimit:SignupPerIp:PermitLimit"] = "100",
+            ["Trading:Auth:RateLimit:SignupPerIp:WindowSeconds"] = "60",
+            ["Trading:Auth:RateLimit:SignupGlobal:Enabled"] = "true",
+            ["Trading:Auth:RateLimit:SignupGlobal:PermitLimit"] = "2",
+            ["Trading:Auth:RateLimit:SignupGlobal:WindowSeconds"] = "60",
+        });
+        using var client = factory.CreateClient();
+
+        for (var i = 0; i < 2; i++)
+        {
+            var ok = await client.PostAsJsonAsync("/auth/signup",
+                new SignupRequest(FreshUsername(), "wonderland-1"));
+            Assert.Equal(HttpStatusCode.Created, ok.StatusCode);
+        }
+        var rejected = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(FreshUsername(), "wonderland-1"));
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_PerIp_LimitTrips_Returns429()
+    {
+        using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:RateLimit:LoginPerIp:Enabled"] = "true",
+            ["Trading:Auth:RateLimit:LoginPerIp:PermitLimit"] = "3",
+            ["Trading:Auth:RateLimit:LoginPerIp:WindowSeconds"] = "60",
+        });
+        using var client = factory.CreateClient();
+
+        // 3 valid logins succeed (env-seeded alice). The 4th — even with
+        // valid credentials — must be rejected at the limiter, proving
+        // the gate runs BEFORE password verification (defense against
+        // tying up PBKDF2 hashing under flood).
+        for (var i = 0; i < 3; i++)
+        {
+            var ok = await client.PostAsJsonAsync("/auth/login",
+                new LoginRequest("alice", "wonderland"));
+            Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+        }
+        var rejected = await client.PostAsJsonAsync("/auth/login",
+            new LoginRequest("alice", "wonderland"));
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+    }
+
+    [Fact]
+    public async Task Limiter_DoesNotAffect_OtherEndpoints()
+    {
+        // Aggressive signup limit of 1 — must NOT bleed into other paths.
+        // /positions is auth-protected so we go through login first
+        // (login limit untouched here, default disabled).
+        using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:RateLimit:SignupPerIp:Enabled"] = "true",
+            ["Trading:Auth:RateLimit:SignupPerIp:PermitLimit"] = "1",
+            ["Trading:Auth:RateLimit:SignupPerIp:WindowSeconds"] = "60",
+        });
+        using var http = factory.CreateClient();
+
+        var token = await factory.LoginAsync(http);
+        http.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        // Many calls to /positions: zero rate-limit interference.
+        for (var i = 0; i < 20; i++)
+        {
+            var resp = await http.GetAsync("/positions");
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Limiter_Disabled_NoThrottling()
+    {
+        // Default TestAppFactory disables all three policies. Verify the
+        // baseline so a future regression that flips defaults doesn't
+        // silently break the rest of the suite.
+        using var factory = new TestAppFactory();
+        using var client = factory.CreateClient();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var resp = await client.PostAsJsonAsync("/auth/signup",
+                new SignupRequest(FreshUsername(), "wonderland-1"));
+            Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -88,6 +88,14 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 ["Trading:Risk:Default:PositionLimit"] = "5000",
                 ["Trading:Risk:ReferencePrices:PETR4"] = "30.0",
                 ["Trading:Persistence:Enabled"] = "false",
+                // Slice 2 of #97 ships rate limits enabled by default.
+                // The default suite hits /auth/login and /auth/signup
+                // hundreds of times per run; disable here so individual
+                // tests opt-in via WithOverrides when they want to
+                // exercise the limiter behavior.
+                ["Trading:Auth:RateLimit:SignupPerIp:Enabled"] = "false",
+                ["Trading:Auth:RateLimit:SignupGlobal:Enabled"] = "false",
+                ["Trading:Auth:RateLimit:LoginPerIp:Enabled"] = "false",
             });
 
             if (_configOverrides is not null)


### PR DESCRIPTION
Slice 2 of #97. Per-IP and global rate limits on `/auth/signup` and
`/auth/login` using built-in `Microsoft.AspNetCore.RateLimiting`. No
new dependencies.

## Policies (default)

| Policy           | Default       | Path           | Partition |
|------------------|---------------|----------------|-----------|
| `SignupPerIp`    | 5 / 1h        | /auth/signup   | per-IP    |
| `SignupGlobal`   | 100 / 1h      | /auth/signup   | global    |
| `LoginPerIp`     | 20 / 5min     | /auth/login    | per-IP    |

Each policy is independently toggleable via
`Trading:Auth:RateLimit:{policy}:Enabled`.

## Architecture (rubber-duck driven)

- Single composed `PartitionedRateLimiter.CreateChained(...)` installed
  as `RateLimiterOptions.GlobalLimiter`. Chain order is **per-IP first,
  global last**, so an abusive IP is rejected before the global signup
  fuse counter advances.
- Path gating via `StartsWithSegments` keeps every non-auth request on
  a no-op partition; rest of the API is unaffected.
- Each partitioner resolves `IOptionsMonitor<AuthRateLimitOptions>`
  from `HttpContext.RequestServices` per request — NOT eager capture
  in Program.cs — so `WebApplicationFactory` overrides actually take
  effect inside tests.
- 429 sets `Retry-After` from `MetadataName.RetryAfter` lease metadata
  with a 60s floor fallback, plus JSON body
  `{\"error\":\"too many requests\",\"retryAfterSeconds\":N}`.
  `OnRejected` logs `auth.ratelimit.rejected path={Path} retryAfterSeconds={N}`.
- `QueueLimit=0` everywhere — anti-abuse means immediate rejection.
- Middleware: `app.UseRateLimiter()` AFTER CORS, BEFORE Authentication
  (so preflight OPTIONS still gets CORS headers and floods cannot tie
  up PBKDF2).

## Trust-of-proxy

`X-Forwarded-For` is intentionally **not** honored. Behind a reverse
proxy the per-IP partition collapses to the proxy IP. Operators must
opt-in via `UseForwardedHeaders` + trusted-network config before the
per-IP partition is meaningful — documented in the class remarks.

## Tests

5 new `AuthRateLimitTests`:
- `Signup_PerIp_LimitTrips_Returns429_WithRetryAfter` — asserts the
  header AND body carry the retry-after seconds.
- `Signup_Global_FuseTrips_Returns429` — uses a high per-IP limit so
  only the global fuse can fire.
- `Login_PerIp_LimitTrips_Returns429` — proves the gate runs BEFORE
  password verification (4th valid login is rejected).
- `Limiter_DoesNotAffect_OtherEndpoints` — 20 calls to `/positions`
  under aggressive signup limit, none rate-limited.
- `Limiter_Disabled_NoThrottling` — pins the default-disabled behavior
  in TestAppFactory.

`TestAppFactory` now disables all three policies by default; individual
tests opt-in via `WithOverrides`.

Suite: 37 + 301 + 165 = **503 unit tests green**; 12 conformance skipped.
`dotnet format` clean.

## Out of scope (still in #97)

- Persistence of runtime users — slice 3.
- Per-username failed-login lockout — slice 4.
- Common-password breach list — depends on persistence/rate-limit infra.
- Captcha, admin user mgmt, multi-firm signup.

Refs #97.