### PR TITLE
feat(auth): signup hardening slice 3 — runtime user persistence

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
@@ -1,0 +1,202 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Slice 3 of #97 hardening: file-backed <see cref="IUserStore"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Env-seeded users (from <see cref="AuthOptions.Users"/>) live in an
+/// immutable in-memory dictionary and are NEVER written to disk —
+/// configuration is authoritative and the file is only the runtime
+/// signup tail. Runtime users are loaded on construction (boot) and
+/// written through on every successful <see cref="TryAdd"/>.
+/// </para>
+/// <para>
+/// On-disk format is JSON with a top-level envelope so future schema
+/// evolutions can migrate without breaking startup:
+/// <code>
+/// { "version": 1, "users": [ { "Username": "...", "PasswordHash": "...",
+///                              "Salt": "...", "Iterations": 600000,
+///                              "Role": "user", "Firm": "FIRM01" }, ... ] }
+/// </code>
+/// </para>
+/// <para>
+/// Writes are atomic (write to <c>users.json.tmp</c> + fsync + rename)
+/// and serialized via a single <c>lock</c> so concurrent signups can't
+/// corrupt the file. A corrupt file is logged at WARN level and treated
+/// as empty so a poisoned file does not brick boot — operators inspect
+/// the warning and either restore from backup or delete the file.
+/// </para>
+/// </remarks>
+public sealed class FileBackedUserStore : IUserStore
+{
+    private readonly Dictionary<string, UserConfig> _seeded;
+    private readonly ConcurrentDictionary<string, UserConfig> _runtime =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _filePath;
+    private readonly object _writeGate = new();
+    private readonly ILogger<FileBackedUserStore> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public FileBackedUserStore(
+        IOptions<AuthOptions> authOptions,
+        IOptions<UserStoreOptions> storeOptions,
+        ILogger<FileBackedUserStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(authOptions);
+        ArgumentNullException.ThrowIfNull(storeOptions);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var path = storeOptions.Value.FilePath;
+        if (string.IsNullOrWhiteSpace(path))
+            throw new InvalidOperationException(
+                "FileBackedUserStore requires Trading:Auth:UserStore:FilePath. " +
+                "Either set it explicitly or rely on the host's default derivation " +
+                "from Trading:Persistence:DataDirectory.");
+        _filePath = path;
+
+        _seeded = new Dictionary<string, UserConfig>(StringComparer.OrdinalIgnoreCase);
+        foreach (var u in authOptions.Value.Users)
+        {
+            if (string.IsNullOrWhiteSpace(u.Username)) continue;
+            _seeded[u.Username] = u;
+        }
+
+        LoadRuntimeUsers();
+    }
+
+    public bool TryGet(string username, out UserConfig? user)
+    {
+        if (string.IsNullOrWhiteSpace(username)) { user = null; return false; }
+        if (_seeded.TryGetValue(username, out var s)) { user = s; return true; }
+        if (_runtime.TryGetValue(username, out var r)) { user = r; return true; }
+        user = null;
+        return false;
+    }
+
+    public bool TryAdd(UserConfig user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        if (string.IsNullOrWhiteSpace(user.Username)) return false;
+
+        // Block runtime collisions with env-seeded users — same invariant
+        // as InMemoryUserStore.
+        if (_seeded.ContainsKey(user.Username)) return false;
+
+        // Serialize TryAdd through the write gate so the in-memory state
+        // and the on-disk snapshot can never disagree under concurrent
+        // signups. The signup endpoint is rate-limited and rare; this is
+        // not a hot path.
+        lock (_writeGate)
+        {
+            if (!_runtime.TryAdd(user.Username, user))
+                return false;
+
+            try
+            {
+                PersistRuntimeUsersLocked();
+            }
+            catch (Exception ex)
+            {
+                // Roll back the in-memory insert so the next signup with
+                // the same username sees a 409 (or succeeds and retries
+                // the write) rather than a silent disk-vs-memory drift.
+                _runtime.TryRemove(user.Username, out _);
+                _logger.LogError(ex,
+                    "FileBackedUserStore: failed to persist runtime user {Username} to {Path}; " +
+                    "in-memory insert rolled back.",
+                    user.Username, _filePath);
+                throw;
+            }
+
+            return true;
+        }
+    }
+
+    private void LoadRuntimeUsers()
+    {
+        if (!File.Exists(_filePath))
+        {
+            _logger.LogInformation(
+                "FileBackedUserStore: no runtime user file at {Path}; starting with empty runtime set.",
+                _filePath);
+            return;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(_filePath);
+            var envelope = JsonSerializer.Deserialize<UserStoreFileEnvelope>(stream, JsonOpts);
+            if (envelope?.Users is null)
+            {
+                _logger.LogWarning(
+                    "FileBackedUserStore: {Path} parsed but contained no users; starting empty.",
+                    _filePath);
+                return;
+            }
+
+            foreach (var u in envelope.Users)
+            {
+                if (string.IsNullOrWhiteSpace(u.Username)) continue;
+                if (_seeded.ContainsKey(u.Username)) continue; // env wins
+                _runtime[u.Username] = u;
+            }
+            _logger.LogInformation(
+                "FileBackedUserStore: loaded {Count} runtime users from {Path}.",
+                _runtime.Count, _filePath);
+        }
+        catch (Exception ex)
+        {
+            // Don't brick boot — log loud and start empty. Operators
+            // inspect the warning to decide between restore from backup
+            // or accepting that runtime users are gone.
+            _logger.LogWarning(ex,
+                "FileBackedUserStore: failed to read {Path}; starting with empty runtime set. " +
+                "Existing runtime signups (if any) are NOT loaded — operator action required.",
+                _filePath);
+        }
+    }
+
+    private void PersistRuntimeUsersLocked()
+    {
+        var dir = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var envelope = new UserStoreFileEnvelope
+        {
+            Version = 1,
+            Users = _runtime.Values
+                .OrderBy(u => u.Username, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+        };
+
+        // Atomic write: tmp + fsync + rename. Crash between fsync and
+        // rename leaves the previous good file intact; crash after
+        // rename is fine because the new file is on disk.
+        var tmp = _filePath + ".tmp";
+        using (var stream = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            JsonSerializer.Serialize(stream, envelope, JsonOpts);
+            stream.Flush(true);
+        }
+        File.Move(tmp, _filePath, overwrite: true);
+    }
+
+    private sealed class UserStoreFileEnvelope
+    {
+        public int Version { get; set; }
+        public List<UserConfig> Users { get; set; } = new();
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/UserStoreOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/UserStoreOptions.cs
@@ -1,0 +1,29 @@
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Slice 3 of #97 hardening: configuration for runtime user persistence.
+/// Bound from <c>Trading:Auth:UserStore</c>.
+/// </summary>
+/// <remarks>
+/// When <see cref="Enabled"/> is <c>false</c>, the host wires the legacy
+/// <see cref="InMemoryUserStore"/> and runtime signups evaporate on
+/// restart (matches the v0 behavior). Used by integration tests and
+/// ephemeral demos that don't want a writable user file. Env-seeded
+/// users are NEVER written to disk regardless — they live in
+/// configuration and remain authoritative across restarts.
+/// </remarks>
+public sealed class UserStoreOptions
+{
+    public const string SectionName = "Trading:Auth:UserStore";
+
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Absolute or relative path to the runtime users JSON file. When
+    /// empty (the production default), the host derives
+    /// <c>{Trading:Persistence:DataDirectory}/users.json</c> so the
+    /// runtime store shares the same lifecycle/durability as the WAL
+    /// volume. Operators using a custom data layout can override.
+    /// </summary>
+    public string FilePath { get; set; } = string.Empty;
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -30,6 +30,8 @@ builder.Services.Configure<AuthOptions>(
     builder.Configuration.GetSection(AuthOptions.SectionName));
 builder.Services.Configure<AuthRateLimitOptions>(
     builder.Configuration.GetSection(AuthRateLimitOptions.SectionName));
+builder.Services.Configure<UserStoreOptions>(
+    builder.Configuration.GetSection(UserStoreOptions.SectionName));
 builder.Services.AddAuthRateLimiter();
 builder.Services.Configure<RiskOptions>(
     builder.Configuration.GetSection(RiskOptions.SectionName));
@@ -58,7 +60,32 @@ if (corsOrigins.Length > 0)
 }
 
 // Application-layer singletons: registries, books, processor, sink.
-builder.Services.AddSingleton<IUserStore, InMemoryUserStore>();
+//
+// Slice 3 of #97: when Trading:Auth:UserStore:Enabled is true (the
+// production default), runtime self-service signups persist to disk so
+// they survive restarts. Tests and ephemeral demos can opt out via
+// Enabled=false to keep the legacy in-memory behavior.
+//
+// FilePath is resolved via PostConfigure so tests can override it
+// before construction; the IUserStore registration is a factory
+// function so Enabled is read AFTER all configuration sources
+// (including WebApplicationFactory overrides) have been merged.
+builder.Services.PostConfigure<UserStoreOptions>(opts =>
+{
+    if (!opts.Enabled) return;
+    if (!string.IsNullOrWhiteSpace(opts.FilePath)) return;
+    var persistDir = builder.Configuration
+        .GetSection(PersistenceOptions.SectionName).Get<PersistenceOptions>()?.DataDirectory
+        ?? "data";
+    opts.FilePath = Path.Combine(persistDir, "users.json");
+});
+builder.Services.AddSingleton<IUserStore>(sp =>
+{
+    var opts = sp.GetRequiredService<IOptions<UserStoreOptions>>().Value;
+    return opts.Enabled
+        ? ActivatorUtilities.CreateInstance<FileBackedUserStore>(sp)
+        : ActivatorUtilities.CreateInstance<InMemoryUserStore>(sp);
+});
 builder.Services.AddSingleton<EndClientRegistry>();
 builder.Services.AddSingleton<ClOrdIdPrefixRegistry>();
 builder.Services.AddSingleton<OrderOwnershipMap>();

--- a/backend/tests/B3.Trading.Api.Tests/FileBackedUserStoreTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/FileBackedUserStoreTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Slice 3 of #97 — runtime users persist to <c>users.json</c> across
+/// host restarts. Tests stand up TWO factories sharing the same temp
+/// file path and verify the second can authenticate users created
+/// against the first. Env-seeded users are NEVER serialized to disk —
+/// configuration is the only source of truth for them.
+/// </summary>
+public class FileBackedUserStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+
+    public FileBackedUserStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(),
+            "b3-userstore-tests-" + Guid.NewGuid().ToString("N")[..10]);
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "users.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private TestAppFactory MakeFactory()
+        => TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:UserStore:Enabled"] = "true",
+            ["Trading:Auth:UserStore:FilePath"] = _filePath,
+        });
+
+    private static string FreshUsername() => "u" + Guid.NewGuid().ToString("N")[..10];
+
+    [Fact]
+    public async Task Signup_PersistsToFile_AndLoginSurvivesRestart()
+    {
+        var username = FreshUsername();
+
+        // First boot: signup the runtime user.
+        using (var factory = MakeFactory())
+        using (var client = factory.CreateClient())
+        {
+            var resp = await client.PostAsJsonAsync("/auth/signup",
+                new SignupRequest(username, "wonderland-1"));
+            Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        }
+
+        // File must exist with the user serialized.
+        Assert.True(File.Exists(_filePath));
+        var json = JsonDocument.Parse(File.ReadAllText(_filePath)).RootElement;
+        Assert.Equal(1, json.GetProperty("Version").GetInt32());
+        var users = json.GetProperty("Users").EnumerateArray().ToList();
+        Assert.Single(users);
+        Assert.Equal(username, users[0].GetProperty("Username").GetString());
+
+        // Second boot reads the same file. Login must succeed without
+        // re-signup — proves the persisted hash/salt round-tripped.
+        using (var factory = MakeFactory())
+        using (var client = factory.CreateClient())
+        {
+            var login = await client.PostAsJsonAsync("/auth/login",
+                new LoginRequest(username, "wonderland-1"));
+            Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task EnvSeededUser_IsNeverWrittenToFile()
+    {
+        // alice/bob/admin are env-seeded by TestAppFactory. Run a single
+        // signup to force a flush, then assert the file contains ONLY
+        // the runtime user — env-seeded must not leak to disk.
+        var runtimeUser = FreshUsername();
+        using (var factory = MakeFactory())
+        using (var client = factory.CreateClient())
+        {
+            var resp = await client.PostAsJsonAsync("/auth/signup",
+                new SignupRequest(runtimeUser, "wonderland-1"));
+            Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        }
+
+        var json = JsonDocument.Parse(File.ReadAllText(_filePath)).RootElement;
+        var usernames = json.GetProperty("Users").EnumerateArray()
+            .Select(u => u.GetProperty("Username").GetString())
+            .ToList();
+        Assert.Equal(new[] { runtimeUser }, usernames);
+    }
+
+    [Fact]
+    public async Task CorruptFile_DoesNotBrickBoot_StartsWithEmptyRuntimeSet()
+    {
+        // Pre-poison the file with garbage. The store should log a warning
+        // and treat the runtime set as empty — env-seeded users still work.
+        await File.WriteAllTextAsync(_filePath, "not valid json {[}");
+
+        using var factory = MakeFactory();
+        using var client = factory.CreateClient();
+
+        // Env-seeded login still works.
+        var aliceLogin = await client.PostAsJsonAsync("/auth/login",
+            new LoginRequest("alice", "wonderland"));
+        Assert.Equal(HttpStatusCode.OK, aliceLogin.StatusCode);
+
+        // Signup still works (and the corrupt file gets overwritten).
+        var fresh = FreshUsername();
+        var signup = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(fresh, "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Created, signup.StatusCode);
+
+        // File is now valid JSON with exactly one user.
+        var json = JsonDocument.Parse(File.ReadAllText(_filePath)).RootElement;
+        Assert.Single(json.GetProperty("Users").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task RuntimeUser_CannotShadowEnvSeeded_AfterFileTampering()
+    {
+        // Hand-craft a file that pretends to override "alice" with a
+        // different password hash. Env-seeded must win on read AND we
+        // must reject any future signup attempt for "alice" with 409.
+        var poisoned = """
+            {
+              "Version": 1,
+              "Users": [
+                { "Username": "alice", "PasswordHash": "ZmFrZQ==", "Salt": "ZmFrZQ==",
+                  "Iterations": 1, "Role": "user", "Firm": "FIRM01" }
+              ]
+            }
+            """;
+        await File.WriteAllTextAsync(_filePath, poisoned);
+
+        using var factory = MakeFactory();
+        using var client = factory.CreateClient();
+
+        // Real alice still authenticates with the env-seeded password.
+        var login = await client.PostAsJsonAsync("/auth/login",
+            new LoginRequest("alice", "wonderland"));
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+
+        // Attempt to signup as alice → 409 (env collision check).
+        var signup = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest("alice", "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Conflict, signup.StatusCode);
+    }
+
+    [Fact]
+    public async Task DuplicateRuntimeSignup_Returns409_AndDoesNotDoubleWrite()
+    {
+        var username = FreshUsername();
+        using var factory = MakeFactory();
+        using var client = factory.CreateClient();
+
+        var first = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "wonderland-1"));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await client.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(username, "wonderland-2"));
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+
+        var json = JsonDocument.Parse(File.ReadAllText(_filePath)).RootElement;
+        var matching = json.GetProperty("Users").EnumerateArray()
+            .Where(u => u.GetProperty("Username").GetString() == username)
+            .ToList();
+        Assert.Single(matching);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -96,6 +96,10 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 ["Trading:Auth:RateLimit:SignupPerIp:Enabled"] = "false",
                 ["Trading:Auth:RateLimit:SignupGlobal:Enabled"] = "false",
                 ["Trading:Auth:RateLimit:LoginPerIp:Enabled"] = "false",
+                // Slice 3 of #97: keep tests on the in-memory user store
+                // so they don't write a users.json into the repo. Tests
+                // exercising the file-backed store opt in via WithOverrides.
+                ["Trading:Auth:UserStore:Enabled"] = "false",
             });
 
             if (_configOverrides is not null)


### PR DESCRIPTION
Slice 3 of #97. Self-service signups now survive host restarts via a
file-backed `IUserStore` that loads on boot and write-throughs on
`TryAdd`. No new dependencies — pure `System.Text.Json` + atomic
file ops.

## What ships

- `UserStoreOptions` bound to `Trading:Auth:UserStore`:
  - `Enabled` (default `true`)
  - `FilePath` (default empty → derived as
    `{Trading:Persistence:DataDirectory}/users.json` so the runtime
    store shares the same volume lifecycle as the WAL).
- `FileBackedUserStore : IUserStore` — env-seeded users live in the
  same immutable in-memory dict as `InMemoryUserStore` (NEVER written
  to disk; configuration remains authoritative); runtime users live
  in a `ConcurrentDictionary` plus a JSON file.
- DI: `IUserStore` registered via factory function so `Enabled` is
  read AFTER all configuration sources merge (matters under
  `WebApplicationFactory` which adds overrides via the IHostBuilder
  pipeline; eager `Configuration.Get<T>()` in Program.cs would freeze
  the production default and 500 every test that touches `/auth/login`).
- `PostConfigure` derives `FilePath` from `PersistenceOptions` when
  not explicitly set, so `FileBackedUserStore` stays decoupled from
  `PersistenceOptions`.

## On-disk format

```json
{ "Version": 1, "Users": [ { "Username": "...", "PasswordHash": "...", "Salt": "...", "Iterations": 600000, "Role": "user", "Firm": "FIRM01" } ] }
```

Top-level envelope so a future schema change can branch on `Version`
without breaking startup.

## Atomicity & crash safety

- Writes go to `users.json.tmp`, fsync (`FileStream.Flush(true)`),
  then `File.Move(overwrite: true)`. Crash before move leaves the
  previous good file intact; crash after move is fine because the
  new file is durable.
- A single `lock` around snapshot+write serializes concurrent
  signups so the in-memory dict and on-disk file cannot diverge.
  If the persist throws, the in-memory insert is rolled back and
  the exception bubbles — better a 500 than silent disk-vs-memory drift.
- Corrupt file at boot is logged at WARN and the runtime set starts
  empty. Boot does NOT brick — operators inspect the warning,
  decide restore-from-backup vs accepting that runtime users are
  gone. Env-seeded users are unaffected.

## Tests

5 new `FileBackedUserStoreTests` using per-test temp directories:
- `Signup_PersistsToFile_AndLoginSurvivesRestart` — two factories
  sharing the same FilePath; second authenticates. Asserts envelope
  shape.
- `EnvSeededUser_IsNeverWrittenToFile` — alice/bob/admin don't leak
  to disk when a runtime signup forces a flush.
- `CorruptFile_DoesNotBrickBoot_StartsWithEmptyRuntimeSet` — pre-
  poisons with garbage; env-seeded login still works, signup works
  and overwrites the corrupt file.
- `RuntimeUser_CannotShadowEnvSeeded_AfterFileTampering` — hand-
  crafts a file that pretends to override alice; real alice still
  authenticates with env password.
- `DuplicateRuntimeSignup_Returns409_AndDoesNotDoubleWrite` —
  second signup gets 409 and the file still contains one entry.

`TestAppFactory` disables `UserStore` by default (`Enabled=false`) so
the rest of the suite uses `InMemoryUserStore` and doesn't write a
`users.json` into the repo. Tests opt in via `WithOverrides`.

Suite: 37 + 301 + 170 = **508 unit tests green**; 12 conformance skipped.
`dotnet format` clean.

## Out of scope (still in #97)

- Per-username failed-login lockout — slice 4.
- Common-password breach list, captcha, admin user mgmt, multi-firm
  signup.

Refs #97.