### PR TITLE
feat(auth): signup hardening slice 4 — per-username login lockout

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -33,14 +33,34 @@ public static class AuthEndpoints
             LoginRequest req,
             IUserStore users,
             JwtIssuer issuer,
-            EndClientRegistry registry) =>
+            EndClientRegistry registry,
+            ILoginAttemptTracker lockout) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrWhiteSpace(req.Password))
                 return Results.BadRequest(new { error = "username and password required" });
 
-            if (!users.TryGet(req.Username, out var user) || user is null
-                || !PasswordHasher.Verify(req.Password, user.PasswordHash, user.Salt, user.Iterations))
+            // Lockout check uses the trimmed username so "alice " and
+            // "alice" share the same bucket. Response is intentionally
+            // identical to the wrong-password 401 — exposing a distinct
+            // "locked" state would let an attacker enumerate which
+            // usernames exist.
+            var loginUsername = req.Username.Trim();
+            if (lockout.IsLocked(loginUsername))
                 return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            if (!users.TryGet(loginUsername, out var user) || user is null
+                || !PasswordHasher.Verify(req.Password, user.PasswordHash, user.Salt, user.Iterations))
+            {
+                // Record failure under the username the client sent
+                // (normalized). Recording even for unknown usernames is
+                // intentional — otherwise an attacker can probe which
+                // usernames exist by observing whether lockouts engage.
+                lockout.RecordFailure(loginUsername);
+                return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            // Successful auth wipes the failure counter for this user.
+            lockout.RecordSuccess(user.Username);
 
             // Pre-register so subsequent ER routing / WS subscribe work
             // immediately even before the first business call.

--- a/backend/src/B3.Trading.Api/Auth/LoginAttemptTracker.cs
+++ b/backend/src/B3.Trading.Api/Auth/LoginAttemptTracker.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Tracks consecutive failed login attempts per username and decides
+/// when an account is locked. The interface is deliberately silent:
+/// callers translate <see cref="IsLocked"/> into the same 401 used for
+/// wrong-password to avoid leaking which usernames exist or are locked.
+/// </summary>
+public interface ILoginAttemptTracker
+{
+    /// <summary>Returns <c>true</c> if <paramref name="username"/> is currently locked.</summary>
+    bool IsLocked(string username);
+
+    /// <summary>Record a failed attempt; may engage lockout.</summary>
+    void RecordFailure(string username);
+
+    /// <summary>Reset failure count after a successful authentication.</summary>
+    void RecordSuccess(string username);
+}
+
+/// <summary>
+/// Process-local in-memory implementation. State is intentionally not
+/// persisted — restart clears lockouts, which is acceptable for v1
+/// (restarts are rare and operators may need an emergency unlock by
+/// design). Multi-host coordination is out of scope until the auth
+/// stack is centralized.
+/// </summary>
+internal sealed class InMemoryLoginAttemptTracker : ILoginAttemptTracker
+{
+    // Soft cap on tracked usernames. We grow lazily but prune aggressively
+    // when we cross the cap so a flood of distinct usernames cannot drive
+    // the host OOM. 50k is generous: at ~80 bytes per entry that's ~4 MB.
+    private const int MaxTrackedUsernames = 50_000;
+
+    private readonly IOptionsMonitor<LoginLockoutOptions> _options;
+    private readonly ILogger<InMemoryLoginAttemptTracker> _logger;
+    private readonly TimeProvider _clock;
+    private readonly ConcurrentDictionary<string, AttemptState> _state =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public InMemoryLoginAttemptTracker(
+        IOptionsMonitor<LoginLockoutOptions> options,
+        ILogger<InMemoryLoginAttemptTracker> logger,
+        TimeProvider clock)
+    {
+        _options = options;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public bool IsLocked(string username)
+    {
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled || string.IsNullOrEmpty(username)) return false;
+        if (!_state.TryGetValue(username, out var st)) return false;
+        lock (st)
+        {
+            return st.LockedUntil is { } until && until > _clock.GetUtcNow();
+        }
+    }
+
+    public void RecordFailure(string username)
+    {
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled || string.IsNullOrEmpty(username)) return;
+
+        var now = _clock.GetUtcNow();
+        var state = _state.GetOrAdd(username, _ => new AttemptState());
+
+        bool engagedLockout = false;
+        DateTimeOffset lockedUntilForLog = default;
+
+        lock (state)
+        {
+            // Clear an expired lockout before counting fresh failures so
+            // the user gets a full new window after their cooldown.
+            if (state.LockedUntil is { } existing && existing <= now)
+            {
+                state.LockedUntil = null;
+                state.FirstFailure = default;
+                state.FailureCount = 0;
+            }
+
+            // Already locked: we don't extend the lockout based on
+            // additional misses while inside the cooldown.
+            if (state.LockedUntil is not null) return;
+
+            // Sliding window: drop old failures.
+            if (state.FailureCount == 0 || now - state.FirstFailure > opts.Window)
+            {
+                state.FirstFailure = now;
+                state.FailureCount = 0;
+            }
+
+            state.FailureCount++;
+            if (state.FailureCount >= opts.MaxFailedAttempts)
+            {
+                state.LockedUntil = now + opts.LockoutDuration;
+                engagedLockout = true;
+                lockedUntilForLog = state.LockedUntil.Value;
+            }
+        }
+
+        if (engagedLockout)
+        {
+            // INFO is high enough for ops dashboards but doesn't include
+            // the password attempt itself. Username is sensitive but is
+            // already logged on signup; we mirror that level.
+            _logger.LogInformation(
+                "Login lockout engaged for username={Username} until {Until:o}.",
+                username, lockedUntilForLog);
+        }
+
+        MaybePrune(now, opts);
+    }
+
+    public void RecordSuccess(string username)
+    {
+        if (string.IsNullOrEmpty(username)) return;
+        _state.TryRemove(username, out _);
+    }
+
+    private void MaybePrune(DateTimeOffset now, LoginLockoutOptions opts)
+    {
+        if (_state.Count <= MaxTrackedUsernames) return;
+
+        // Evict entries whose lockout has expired AND whose window has
+        // also elapsed. Bounded scan; runs only past the cap so the
+        // common path stays O(1).
+        foreach (var kvp in _state)
+        {
+            var st = kvp.Value;
+            bool evict;
+            lock (st)
+            {
+                bool lockoutClear = st.LockedUntil is null || st.LockedUntil <= now;
+                bool windowStale = st.FailureCount == 0 || now - st.FirstFailure > opts.Window;
+                evict = lockoutClear && windowStale;
+            }
+            if (evict)
+            {
+                _state.TryRemove(kvp.Key, out _);
+                if (_state.Count <= MaxTrackedUsernames * 9 / 10) break;
+            }
+        }
+    }
+
+    private sealed class AttemptState
+    {
+        public DateTimeOffset FirstFailure;
+        public int FailureCount;
+        public DateTimeOffset? LockedUntil;
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/LoginLockoutOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/LoginLockoutOptions.cs
@@ -1,0 +1,28 @@
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Per-username login lockout. Slice 4 of issue #97. Complements
+/// <see cref="AuthRateLimitOptions"/> (per-IP / global rate limit) by
+/// throttling guesses against a single account from any IP. Bound from
+/// <c>Trading:Auth:LoginLockout</c>.
+/// </summary>
+public sealed class LoginLockoutOptions
+{
+    public const string SectionName = "Trading:Auth:LoginLockout";
+
+    /// <summary>Disable for tests (default in <c>TestAppFactory</c>).</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Failed attempts that flip a username into lockout. Counted only
+    /// inside the rolling <see cref="Window"/>; once <see cref="LockoutDuration"/>
+    /// elapses, the slate is wiped and the next failure starts a fresh window.
+    /// </summary>
+    public int MaxFailedAttempts { get; set; } = 5;
+
+    /// <summary>Rolling window across which failures accumulate.</summary>
+    public TimeSpan Window { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>How long a locked username stays locked.</summary>
+    public TimeSpan LockoutDuration { get; set; } = TimeSpan.FromMinutes(15);
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -32,6 +32,9 @@ builder.Services.Configure<AuthRateLimitOptions>(
     builder.Configuration.GetSection(AuthRateLimitOptions.SectionName));
 builder.Services.Configure<UserStoreOptions>(
     builder.Configuration.GetSection(UserStoreOptions.SectionName));
+builder.Services.Configure<LoginLockoutOptions>(
+    builder.Configuration.GetSection(LoginLockoutOptions.SectionName));
+builder.Services.AddSingleton<ILoginAttemptTracker, InMemoryLoginAttemptTracker>();
 builder.Services.AddAuthRateLimiter();
 builder.Services.Configure<RiskOptions>(
     builder.Configuration.GetSection(RiskOptions.SectionName));

--- a/backend/tests/B3.Trading.Api.Tests/LoginLockoutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/LoginLockoutTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Api.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Slice 4 of #97: per-username login lockout. Unit tests pin the
+/// state machine against a stub clock; integration tests verify the
+/// HTTP endpoint wires the tracker correctly and that the lockout
+/// response is indistinguishable from wrong-password.
+/// </summary>
+public class LoginLockoutTests
+{
+    private static InMemoryLoginAttemptTracker MakeTracker(LoginLockoutOptions opts, StubClock clock)
+    {
+        var monitor = new StaticOptionsMonitor<LoginLockoutOptions>(opts);
+        return new InMemoryLoginAttemptTracker(monitor, NullLogger<InMemoryLoginAttemptTracker>.Instance, clock);
+    }
+
+    [Fact]
+    public void IsLocked_FlipsTrueAfterMaxFailures_AndClearsAfterDuration()
+    {
+        var clock = new StubClock();
+        var opts = new LoginLockoutOptions { MaxFailedAttempts = 3, Window = TimeSpan.FromMinutes(15), LockoutDuration = TimeSpan.FromMinutes(10) };
+        var t = MakeTracker(opts, clock);
+
+        Assert.False(t.IsLocked("alice"));
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        Assert.False(t.IsLocked("alice"));
+        t.RecordFailure("alice");
+        Assert.True(t.IsLocked("alice"));
+
+        // Still locked just before the cooldown elapses.
+        clock.Now += TimeSpan.FromMinutes(9);
+        Assert.True(t.IsLocked("alice"));
+
+        // Cooldown elapsed: locked flips false even before any new
+        // failure resets the slate.
+        clock.Now += TimeSpan.FromMinutes(2);
+        Assert.False(t.IsLocked("alice"));
+    }
+
+    [Fact]
+    public void RecordSuccess_WipesFailureCount()
+    {
+        var clock = new StubClock();
+        var opts = new LoginLockoutOptions { MaxFailedAttempts = 3, Window = TimeSpan.FromMinutes(15), LockoutDuration = TimeSpan.FromMinutes(10) };
+        var t = MakeTracker(opts, clock);
+
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        t.RecordSuccess("alice");
+        // Two more failures should not be enough to lock — the prior
+        // two were wiped by the success.
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        Assert.False(t.IsLocked("alice"));
+    }
+
+    [Fact]
+    public void Window_RollsForward_WhenStaleFailuresExpire()
+    {
+        var clock = new StubClock();
+        var opts = new LoginLockoutOptions { MaxFailedAttempts = 3, Window = TimeSpan.FromMinutes(15), LockoutDuration = TimeSpan.FromMinutes(10) };
+        var t = MakeTracker(opts, clock);
+
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        // Window elapses; the prior two failures must not count.
+        clock.Now += TimeSpan.FromMinutes(20);
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        Assert.False(t.IsLocked("alice"));
+        // Third attempt inside the new window does lock.
+        t.RecordFailure("alice");
+        Assert.True(t.IsLocked("alice"));
+    }
+
+    [Fact]
+    public void Username_IsCaseInsensitive()
+    {
+        var clock = new StubClock();
+        var opts = new LoginLockoutOptions { MaxFailedAttempts = 2, Window = TimeSpan.FromMinutes(15), LockoutDuration = TimeSpan.FromMinutes(10) };
+        var t = MakeTracker(opts, clock);
+
+        t.RecordFailure("Alice");
+        t.RecordFailure("ALICE");
+        Assert.True(t.IsLocked("alice"));
+    }
+
+    [Fact]
+    public void Disabled_NeverLocks()
+    {
+        var clock = new StubClock();
+        var opts = new LoginLockoutOptions { Enabled = false, MaxFailedAttempts = 1 };
+        var t = MakeTracker(opts, clock);
+
+        t.RecordFailure("alice");
+        t.RecordFailure("alice");
+        Assert.False(t.IsLocked("alice"));
+    }
+
+    [Fact]
+    public async Task Login_LocksOutAfterMaxFailedAttempts_ReturnsSame401AsWrongPassword()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:LoginLockout:Enabled"] = "true",
+            ["Trading:Auth:LoginLockout:MaxFailedAttempts"] = "3",
+            ["Trading:Auth:LoginLockout:Window"] = "00:15:00",
+            ["Trading:Auth:LoginLockout:LockoutDuration"] = "00:15:00",
+        });
+        var http = factory.CreateClient();
+
+        // Three wrong-password attempts: each returns 401 invalid.
+        for (var i = 0; i < 3; i++)
+        {
+            var r = await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "nope" });
+            Assert.Equal(HttpStatusCode.Unauthorized, r.StatusCode);
+        }
+
+        // Fourth attempt — even with the CORRECT password — must be
+        // refused with the same 401 response shape because lockout
+        // engaged on the third miss. Anti-enumeration: locked vs
+        // wrong-password indistinguishable from the client's POV.
+        var blocked = await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wonderland" });
+        Assert.Equal(HttpStatusCode.Unauthorized, blocked.StatusCode);
+        var body = await blocked.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        Assert.Equal("invalid credentials", body?["error"]);
+    }
+
+    [Fact]
+    public async Task Login_SuccessClearsCounter_ForNextSession()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:LoginLockout:Enabled"] = "true",
+            ["Trading:Auth:LoginLockout:MaxFailedAttempts"] = "3",
+            ["Trading:Auth:LoginLockout:Window"] = "00:15:00",
+            ["Trading:Auth:LoginLockout:LockoutDuration"] = "00:15:00",
+        });
+        var http = factory.CreateClient();
+
+        // Two misses then a success: the slate must be wiped, so the
+        // user can miss two MORE times without locking out.
+        await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "nope" });
+        await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "nope" });
+        var ok = await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wonderland" });
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+
+        await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "nope" });
+        await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "nope" });
+        var stillOk = await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wonderland" });
+        Assert.Equal(HttpStatusCode.OK, stillOk.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_RecordsFailureForUnknownUsername_PreventingEnumeration()
+    {
+        // Probing rationale: if we did NOT count failures for unknown
+        // usernames, an attacker could enumerate which usernames exist
+        // by observing whether lockouts engage. This test pins the
+        // anti-enumeration behavior.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:LoginLockout:Enabled"] = "true",
+            ["Trading:Auth:LoginLockout:MaxFailedAttempts"] = "2",
+            ["Trading:Auth:LoginLockout:Window"] = "00:15:00",
+            ["Trading:Auth:LoginLockout:LockoutDuration"] = "00:15:00",
+        });
+        var http = factory.CreateClient();
+
+        await http.PostAsJsonAsync("/auth/login", new { username = "ghost-user", password = "x" });
+        await http.PostAsJsonAsync("/auth/login", new { username = "ghost-user", password = "x" });
+        var third = await http.PostAsJsonAsync("/auth/login", new { username = "ghost-user", password = "x" });
+
+        // All three look identical — 401 invalid credentials. We can't
+        // observe the lock externally from a single response (by design),
+        // but the tracker's behavior is exercised end-to-end and the
+        // unit tests pin the lockout state.
+        Assert.Equal(HttpStatusCode.Unauthorized, third.StatusCode);
+    }
+
+    private sealed class StubClock : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = new(2026, 5, 6, 12, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -100,6 +100,10 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 // so they don't write a users.json into the repo. Tests
                 // exercising the file-backed store opt in via WithOverrides.
                 ["Trading:Auth:UserStore:Enabled"] = "false",
+                // Slice 4 of #97: lockout disabled by default so tests
+                // hammering /auth/login with bad creds don't trip the
+                // gate. Lockout-specific tests opt in via WithOverrides.
+                ["Trading:Auth:LoginLockout:Enabled"] = "false",
             });
 
             if (_configOverrides is not null)


### PR DESCRIPTION
Slice 4 of #97. Complements slice 2 (per-IP/global rate limit) by
throttling guesses against a single account from any IP. The classic
anti-credential-stuffing pair: slice 2 caps one IP, slice 4 caps one
USERNAME regardless of source.

## What ships

- `LoginLockoutOptions` (`Trading:Auth:LoginLockout`):
  - `Enabled` (default `true`)
  - `MaxFailedAttempts` (default `5`)
  - `Window` (default 15min, rolling)
  - `LockoutDuration` (default 15min)
- `ILoginAttemptTracker` + `InMemoryLoginAttemptTracker`:
  - In-memory only (process-local). State NOT persisted; restart
    clears lockouts. Acceptable for v1 — restarts are rare; multi-
    host coordination is out of scope until auth is centralized.
  - `ConcurrentDictionary` keyed case-insensitively, per-key lock
    around the small state struct.
  - Sliding window: stale failures don't accumulate forever.
  - Lockout does NOT extend on additional misses while inside the
    cooldown — duration is fixed.
  - Soft cap of 50k tracked usernames with prune-on-write of stale
    entries; prevents distinct-username flood from driving OOM.
- Wire-up in `/auth/login`:
  - Username trimmed once, used for both lockout key and user lookup
    (`'alice '` and `'alice'` share the bucket).
  - `IsLocked` checked **before** `PasswordHasher.Verify` so a
    locked user pays no PBKDF2 cost on attempt N+1.
  - **Lockout response = same 401 + `'invalid credentials'` body as
    wrong-password.** Anti-enumeration: a distinct `'locked'` state
    would let an attacker probe which usernames exist and which are
    mid-attack.
  - `RecordFailure` is called even for unknown usernames. Otherwise
    differential behavior would let attackers enumerate which
    usernames exist.
  - `RecordSuccess` clears the counter for the user.
- INFO log on every lockout transition (`username` + `UntilUtc`).

## Tests

8 new tests in `LoginLockoutTests` (5 unit + 3 integration):

- State machine: lock-after-N, cooldown expiry against stub
  `TimeProvider`.
- Sliding window rolls forward when stale.
- Case-insensitive (`Alice` / `ALICE` / `alice`).
- `Enabled=false` never locks.
- Success wipes counter.
- **Pinning anti-enumeration**: even with the correct password the
  locked user gets the same 401 `'invalid credentials'` as a wrong-
  password attempt.
- End-to-end success clears counter for next session.
- Anti-probing: failures are recorded for unknown usernames.

`TestAppFactory` disables `LoginLockout` by default so the rest of
the suite can hammer `/auth/login` with bad creds without tripping
the gate.

## DoS surface considered

- **Username squatting**: per-IP rate limit from slice 2 caps a
  single IP at 20/5min = ~12 victims locked per IP per 15-min
  window. Acceptable for v1; would need distributed attempts to
  escalate.
- **Memory growth**: prune-on-write past the 50k soft cap.

Suite: 37 + 301 + 178 = **516 unit tests green**; 12 conformance
skipped. `dotnet format` clean.

## #97 status

- Slice 1 (password policy + reserved usernames) ✅ #120
- Slice 2 (per-IP/global rate limit) ✅ #123
- Slice 3 (file-backed persistence) ✅ #124
- Slice 4 (per-username lockout) ✅ **this PR**
- Deferred: captcha, admin user mgmt, multi-firm signup, common-
  password breach list. Closing #97 once this lands.

Closes #97.