### PR TITLE
feat(orders): order modify slice 1 — domain prep for cancel-replace

### DIFF
--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -647,7 +647,7 @@ public sealed class AlgoEngine : BackgroundService
     }
 
     private static bool IsChildTerminal(Order o) =>
-        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
+        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced;
 
     private static string SignalKind(AlgoSignal s) => s switch
     {

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -202,7 +202,7 @@ public sealed class AlgoScheduler : BackgroundService
     }
 
     private static bool IsChildTerminal(Order o) =>
-        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
+        o.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced;
 
     /// <summary>
     /// Cheap stopwatch-equivalent that avoids allocating a Stopwatch per

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -110,7 +110,7 @@ public sealed class ExecutionReportProcessor
             case ExecKind.PartialFill:
             case ExecKind.Fill:
                 {
-                    var wasTerminal = order.Status is OrderStatus.Cancelled or OrderStatus.Rejected;
+                    var wasTerminal = order.Status is OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced;
                     var delta = order.ApplyCumulativeFill(cumQty);
                     if (delta == 0)
                     {
@@ -156,7 +156,7 @@ public sealed class ExecutionReportProcessor
                     break;
                 }
             case ExecKind.Canceled:
-                if (order.Status is OrderStatus.Cancelled or OrderStatus.Filled or OrderStatus.Rejected)
+                if (order.Status is OrderStatus.Cancelled or OrderStatus.Filled or OrderStatus.Rejected or OrderStatus.Replaced)
                 {
                     MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
                     _logger.LogDebug("Dropping Cancelled ER for {ClOrdId}; order already {Status}.", lookupId, order.Status);
@@ -166,7 +166,7 @@ public sealed class ExecutionReportProcessor
                 _margin.OnExecution(lookupId, kind, 0);
                 break;
             case ExecKind.Rejected:
-                if (order.Status is OrderStatus.Rejected or OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Cancelled)
+                if (order.Status is OrderStatus.Rejected or OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Cancelled or OrderStatus.Replaced)
                 {
                     MetricsRegistry.ExecutionReportsReplayDeduped.Add(1, KindTag(kind));
                     _logger.LogDebug("Dropping Rejected ER for {ClOrdId}; order already {Status}.", lookupId, order.Status);

--- a/backend/src/B3.Trading.Application/OrderOwnershipMap.cs
+++ b/backend/src/B3.Trading.Application/OrderOwnershipMap.cs
@@ -62,6 +62,34 @@ public sealed class OrderOwnershipMap
     }
 
     /// <summary>
+    /// Slice 1 of #122. Records a cancel-replace request: registers the
+    /// owner of <paramref name="newClOrdId"/> (same as original) AND the
+    /// reverse <paramref name="newClOrdId"/> → <paramref name="originalClOrdId"/>
+    /// fallback link used by <see cref="ExecutionReportProcessor"/> when
+    /// the venue omits <c>OrigClOrdID</c> on the Replaced ER.
+    ///
+    /// <para>
+    /// Functionally equivalent to calling <see cref="RegisterCancelLink"/>
+    /// today, but exposed under a replace-specific name so callers can
+    /// signal intent and so future divergence (e.g. in-flight tracking
+    /// keyed by original) has an obvious extension point. Throws when
+    /// the original is unknown — a replace request against an
+    /// unregistered ClOrdID is always a programmer error.
+    /// </para>
+    /// </summary>
+    public void RegisterReplaceLink(ulong originalClOrdId, ulong newClOrdId)
+    {
+        if (originalClOrdId == 0)
+            throw new ArgumentOutOfRangeException(nameof(originalClOrdId));
+        if (newClOrdId == 0)
+            throw new ArgumentOutOfRangeException(nameof(newClOrdId));
+        if (!_byClOrdId.TryGetValue(originalClOrdId, out var owner))
+            throw new InvalidOperationException($"Unknown original ClOrdID '{originalClOrdId}'.");
+        _byClOrdId[newClOrdId] = owner;
+        _cancelToOrig[newClOrdId] = originalClOrdId;
+    }
+
+    /// <summary>
     /// Looks up the original ClOrdID a cancel/replace request was issued
     /// against. Returns <c>false</c> when no such link was registered.
     /// </summary>

--- a/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
@@ -110,12 +110,13 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
     }
 
     // "Still restable" = order is on the book and has unfilled quantity.
-    // We exclude terminal states (Filled/Cancelled/Rejected) defensively
-    // even though a fully-cancelled or filled order should also have
+    // We exclude terminal states (Filled/Cancelled/Rejected/Replaced)
+    // defensively even though terminal orders should also have
     // LeavesQuantity == 0.
     private static bool IsStillRestable(Order o) =>
         o.LeavesQuantity > 0
         && o.Status is not OrderStatus.Filled
                        and not OrderStatus.Cancelled
-                       and not OrderStatus.Rejected;
+                       and not OrderStatus.Rejected
+                       and not OrderStatus.Replaced;
 }

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -141,7 +141,7 @@ public sealed class WorkingOrderBook
     }
 
     private static bool IsTerminal(OrderStatus s) =>
-        s is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected;
+        s is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced;
 
     /// <summary>
     /// Returns every order whose <see cref="Order.ParentAlgoId"/> matches

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -20,6 +20,16 @@ public enum OrderStatus
     Filled,
     Cancelled,
     Rejected,
+
+    /// <summary>
+    /// Terminal state assigned to the original order after a successful
+    /// cancel-replace (FIX 35=G amend). The replacement order lives under
+    /// a different ClOrdID; the original is non-restable from this point
+    /// on and is filtered out of all open-order projections (margin,
+    /// risk, blotter, snapshots). Slice 1 of #122 introduces the value;
+    /// slice 2 wires the transition.
+    /// </summary>
+    Replaced,
 }
 
 /// <summary>
@@ -137,7 +147,10 @@ public sealed class Order
         LeavesQuantity = Math.Max(0, Quantity - newCumulativeQty);
 
         // Status only advances; never regresses out of a terminal state.
-        if (Status is not (OrderStatus.Cancelled or OrderStatus.Rejected))
+        // Replaced is also terminal-for-restability — an original order in
+        // Replaced status is not a restable surface for late fills (those
+        // arrive against the replacement ClOrdID).
+        if (Status is not (OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced))
             Status = LeavesQuantity == 0 ? OrderStatus.Filled : OrderStatus.PartiallyFilled;
 
         return delta;
@@ -155,9 +168,11 @@ public sealed class Order
 
     public void MarkCancelled()
     {
-        // Once filled, the order can't be cancelled — a stale Cancelled ER
-        // delivered after the final fill would otherwise regress status.
-        if (Status is OrderStatus.Filled or OrderStatus.Rejected or OrderStatus.Cancelled)
+        // Once filled / replaced, the order can't be cancelled — a stale
+        // Cancelled ER delivered after the final fill (or after a
+        // successful replace re-targeted under a new ClOrdID) would
+        // otherwise regress status.
+        if (Status is OrderStatus.Filled or OrderStatus.Rejected or OrderStatus.Cancelled or OrderStatus.Replaced)
             return;
         Status = OrderStatus.Cancelled;
     }
@@ -165,10 +180,25 @@ public sealed class Order
     public void MarkRejected()
     {
         // Rejection is only valid before any fill. A stale Reject after a
-        // partial/full fill must be ignored.
-        if (Status is OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Rejected or OrderStatus.Cancelled)
+        // partial/full fill (or after the order was replaced) must be
+        // ignored.
+        if (Status is OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Rejected or OrderStatus.Cancelled or OrderStatus.Replaced)
             return;
         Status = OrderStatus.Rejected;
+    }
+
+    /// <summary>
+    /// Marks the original order as terminally replaced. Slice 1 of #122
+    /// only exposes the transition; slice 2 will fire it from
+    /// <see cref="ExecutionReportProcessor"/> on a successful Replaced
+    /// ER. Idempotent and refuses to regress out of Filled/Rejected
+    /// (a late Replaced ER must not erase a final fill).
+    /// </summary>
+    public void MarkReplaced()
+    {
+        if (Status is OrderStatus.Filled or OrderStatus.Rejected or OrderStatus.Cancelled or OrderStatus.Replaced)
+            return;
+        Status = OrderStatus.Replaced;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -343,6 +343,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             LastQuantity: 0,
             LastPrice: 0m,
             RejectReason: null,
+            // OrigClOrdID is a non-nullable ClOrdID struct in the SDK,
+            // but a venue that sends 0 on the wire would surface as
+            // Value == 0 here. The processor treats OrigClOrdId == 0
+            // as "missing" and falls back to OrderOwnershipMap's
+            // new→orig link populated by RegisterReplaceLink (slice 1
+            // of #122).
             OrigClOrdId: m.OrigClOrdID.Value),
 
         UpModels.OrderRejected r => new ExecutionReportEnvelope(

--- a/backend/tests/B3.Trading.Application.Tests/ApplicationTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ApplicationTests.cs
@@ -31,6 +31,32 @@ public class WorkingOrderBookTests
         Assert.True(book.TryAdd(order));
         Assert.False(book.TryAdd(order));
     }
+
+    [Fact]
+    public void ReplacedStatus_IsTreatedAsTerminal_ByOpenOrderProjections()
+    {
+        // Slice 1 of #122 invariant: an order in Replaced status is
+        // filtered out of every "open" projection (counts, sums,
+        // enumerations) so risk/margin/UI cannot double-count the
+        // original alongside the replacement.
+        var book = new WorkingOrderBook();
+        var alice = new EndClientId("alice");
+        var sell = new Order(1UL, alice, "PETR4", 4321UL, OrderSide.Sell, OrderType.Limit, 100, 30m, "FIRM01");
+        sell.MarkWorking();
+        Assert.True(book.TryAdd(sell));
+
+        Assert.Equal(1, book.CountOpenForOwner(alice));
+        Assert.Equal(100, book.SumOpenSellLeavesForSymbol(alice, "PETR4"));
+
+        sell.MarkReplaced();
+
+        Assert.Equal(0, book.CountOpenForOwner(alice));
+        Assert.Equal(0, book.SumOpenSellLeavesForSymbol(alice, "PETR4"));
+        // Lookup still works — the original Order object is retained for
+        // ER bookkeeping (late fills can still arrive) but it is no
+        // longer surfaced as live.
+        Assert.True(book.TryGet(1UL, out _));
+    }
 }
 
 public class EndClientRegistryTests

--- a/backend/tests/B3.Trading.Application.Tests/ClOrdIdAndOwnershipTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ClOrdIdAndOwnershipTests.cs
@@ -97,4 +97,34 @@ public class OrderOwnershipMapTests
         Assert.True(map.TryResolveOrig(201UL, out var orig));
         Assert.Equal(200UL, orig);
     }
+
+    [Fact]
+    public void RegisterReplaceLink_PopulatesOwner_AndOrigFallback()
+    {
+        // Slice 1 of #122: cancel-replace must register both the owner of
+        // the new ClOrdID AND the new→orig fallback link so the
+        // processor can resolve a Replaced ER even when the venue omits
+        // OrigClOrdID. Mirrors the cancel-link guarantees so the same
+        // dropout-recovery story applies to modify.
+        var map = new OrderOwnershipMap();
+        var owner = new EndClientId("alice");
+        map.Register(300UL, owner);
+
+        map.RegisterReplaceLink(originalClOrdId: 300UL, newClOrdId: 301UL);
+
+        Assert.True(map.TryResolve(301UL, out var got));
+        Assert.Equal(owner, got);
+        Assert.True(map.TryResolveOrig(301UL, out var orig));
+        Assert.Equal(300UL, orig);
+    }
+
+    [Fact]
+    public void RegisterReplaceLink_OnUnknownOriginal_Throws()
+    {
+        // Replace against an unregistered original is always a programmer
+        // error — there's no plausible code path that fires Modify
+        // without first having submitted the original.
+        var map = new OrderOwnershipMap();
+        Assert.Throws<InvalidOperationException>(() => map.RegisterReplaceLink(originalClOrdId: 999UL, newClOrdId: 1000UL));
+    }
 }

--- a/backend/tests/B3.Trading.Domain.Tests/OrderTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderTests.cs
@@ -107,4 +107,75 @@ public class OrderTests
         order.MarkWorking(); // replayed New ER
         Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
     }
+
+    // -------- MarkReplaced (Slice 1 of #122) --------
+
+    [Fact]
+    public void MarkReplaced_FromWorking_TerminalisesOriginal()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.MarkWorking();
+        order.MarkReplaced();
+        Assert.Equal(OrderStatus.Replaced, order.Status);
+    }
+
+    [Fact]
+    public void MarkReplaced_FromPartiallyFilled_TerminalisesOriginal()
+    {
+        // Cumulative fills survive on the original (the replacement order
+        // takes them as its baseline); the original's status moves to
+        // Replaced and is filtered out of restable surfaces.
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyFill(40);
+        order.MarkReplaced();
+        Assert.Equal(OrderStatus.Replaced, order.Status);
+        Assert.Equal(40, order.CumulativeQuantity);
+    }
+
+    [Fact]
+    public void MarkReplaced_AfterFilled_NoOp()
+    {
+        // Late Replaced ER must NOT erase a final fill — terminal status
+        // wins, exchange truth is the position state.
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyFill(100);
+        order.MarkReplaced();
+        Assert.Equal(OrderStatus.Filled, order.Status);
+    }
+
+    [Fact]
+    public void MarkReplaced_IsIdempotent()
+    {
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.MarkReplaced();
+        order.MarkReplaced();
+        Assert.Equal(OrderStatus.Replaced, order.Status);
+    }
+
+    [Fact]
+    public void MarkCancelled_AfterReplaced_NoOp()
+    {
+        // A Cancelled ER drifting in for an already-replaced original
+        // must not regress the status (the new ClOrdID owns the live
+        // surface now).
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.MarkReplaced();
+        order.MarkCancelled();
+        Assert.Equal(OrderStatus.Replaced, order.Status);
+    }
+
+    [Fact]
+    public void ApplyCumulativeFill_AfterReplaced_PreservesReplacedStatus()
+    {
+        // Slice 1 invariant: a late fill ER against an already-Replaced
+        // original still books position truth (cumQty advances) but
+        // status stays Replaced — the live order is the replacement.
+        var order = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        order.ApplyFill(40);
+        order.MarkReplaced();
+        var delta = order.ApplyCumulativeFill(50);
+        Assert.Equal(10, delta);
+        Assert.Equal(50, order.CumulativeQuantity);
+        Assert.Equal(OrderStatus.Replaced, order.Status);
+    }
 }


### PR DESCRIPTION
Slice 1 of #122. Foundation for exposing order modify (cancel-replace).
**No new behavior** — the new `OrderStatus.Replaced` value is reachable
only through `Order.MarkReplaced()`, which slice 2 will fire from
`ExecutionReportProcessor` on a successful Replaced ER. Wiring the
status transition without first having the building blocks in place
would corrupt margin/risk projections (the original would double-count
in STP / NoNakedShort / open-order projections alongside the
replacement).

## What ships

- **Domain**: new `OrderStatus.Replaced` enum value + `Order.MarkReplaced()`.
  Idempotent, refuses to regress out of Filled/Rejected/Cancelled (a
  late Replaced ER cannot erase a final fill); `MarkCancelled` refuses
  to overwrite Replaced for the symmetric reason.
  `ApplyCumulativeFill` preserves Replaced on a late fill so exchange-
  truth position keeping still works while keeping the original off
  restable surfaces.
- **Open-order projections**: `WorkingOrderBook.IsTerminal`,
  `AlgoScheduler.IsChildTerminal`, `AlgoEngine.IsChildTerminal`, and
  `SelfTradePreventionCheck.IsStillRestable` now treat Replaced as
  terminal. A Replaced original is filtered out of `CountOpenForOwner`,
  `SumOpenSellLeavesForSymbol`, the algo child bookkeeping, and STP's
  opposite-side scan — so margin/risk/UI cannot double-count the
  original alongside the replacement when slice 2 lands.
- **ER processor terminal guards**: short-circuit Cancelled / Rejected
  ERs when the order is already Replaced (mirror of the existing
  terminal short-circuits — protects under FIXP retransmits).
- **`OrderOwnershipMap.RegisterReplaceLink(orig, new)`**: replace-
  specific helper that registers the new ClOrdID against the same
  owner AND populates the new→orig fallback link consumed by
  `ExecutionReportProcessor` when the venue omits `OrigClOrdID`.
  Throws on unknown original (programmer error). Functionally a
  renamed `RegisterCancelLink` today, but exposed under a replace-
  specific name so slice 4's endpoint can signal intent and so future
  divergence (in-flight tracking keyed by original) has an obvious
  extension point. Legacy `RegisterReplacement` / `RegisterCancelLink`
  remain.
- **B3EntryPointClientGateway**: documented the OrderModified→Replaced
  translation `OrigClOrdID == 0` sentinel semantics. No behavior
  change — the SDK exposes `OrigClOrdID` as a non-nullable struct
  so the existing `.Value` access is correct.

## Tests

- 6 new `OrderTests` covering `MarkReplaced` from Working /
  PartiallyFilled, idempotency, no-op after Filled, `MarkCancelled`
  no-op after Replaced, and the late-fill-preserves-Replaced
  invariant.
- New `WorkingOrderBookTests` case pinning that
  `CountOpenForOwner` / `SumOpenSellLeavesForSymbol` drop a sell as
  soon as it transitions to Replaced.
- 2 new `OrderOwnershipMap` tests covering `RegisterReplaceLink`
  (populates owner + orig fallback) and the throw-on-unknown-original
  guard.

Suite: 43 + 304 + 178 = **525 unit tests green**; 12 conformance
skipped. `dotnet format` clean.

## Roadmap (remaining slices of #122)

- **Slice 2**: `IReplaceMarginCoordinator` (Prepare/Commit/Abort) +
  ER processor Replaced branch that terminalises the original,
  hydrates the new Order with cum/leaves baseline, and commits the
  margin transfer; replace-reject branch.
- **Slice 3**: risk replacement projection (`NoNakedShortCheck`) via
  `RiskContext.ReplaceOriginalClOrdId` + `EffectiveLeavesQuantity`.
- **Slice 4**: `PUT /orders/{clOrdId}` endpoint, `OrderReplaceRequestedEvent`
  in WAL, in-flight registry keyed by original, synthetic reject on
  gateway failure.
- **Slice 5**: frontend Modify button + modal + `protocol.modifyOrder()`.

Refs #122.