### PR TITLE
feat(orders): margin coordinator + ER processor state machine for cancel-replace

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -35,6 +35,8 @@ public sealed class ExecutionReportProcessor
     private readonly ILogger<ExecutionReportProcessor> _logger;
     private readonly IAlgoSignalQueue? _algoSignals;
     private readonly CashLedger? _cash;
+    private readonly PendingReplacementRegistry? _replacements;
+    private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
 
     public ExecutionReportProcessor(
         OrderOwnershipMap ownership,
@@ -44,7 +46,9 @@ public sealed class ExecutionReportProcessor
         Risk.IMarginProvider margin,
         ILogger<ExecutionReportProcessor> logger,
         IAlgoSignalQueue? algoSignals = null,
-        CashLedger? cash = null)
+        CashLedger? cash = null,
+        PendingReplacementRegistry? replacements = null,
+        Risk.IReplaceMarginCoordinator? replaceMargin = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -54,6 +58,8 @@ public sealed class ExecutionReportProcessor
         _logger = logger;
         _algoSignals = algoSignals;
         _cash = cash;
+        _replacements = replacements;
+        _replaceMargin = replaceMargin;
     }
 
     /// <summary>
@@ -64,6 +70,28 @@ public sealed class ExecutionReportProcessor
     /// </summary>
     public void Apply(ulong clOrdId, ExecKind kind, long leaves, long cumQty, long lastQty, decimal lastPx, string? rejectReason, ulong origClOrdId = 0)
     {
+        // Slice 2 of #122: replace lifecycle early intercepts. Both
+        // branches are gated on the registry having an intent recorded
+        // for this ClOrdID — outside of that, the original switch
+        // semantics apply unchanged.
+        if (_replacements is not null)
+        {
+            if (kind == ExecKind.Rejected
+                && _replacements.TryConsume(clOrdId, out var rejectedIntent)
+                && rejectedIntent is not null)
+            {
+                ApplyReplaceRejected(clOrdId, rejectedIntent, rejectReason);
+                return;
+            }
+            if (kind == ExecKind.Replaced
+                && _replacements.TryConsume(clOrdId, out var replaceIntent)
+                && replaceIntent is not null)
+            {
+                ApplyReplaceAccepted(clOrdId, leaves, cumQty, lastPx, origClOrdId, replaceIntent);
+                return;
+            }
+        }
+
         // For cancel/replace acks, the meaningful identity is the original
         // ClOrdID; the cancel-side ClOrdID was never registered as an order.
         // Some upstream gateways (and certain SDK versions) drop OrigClOrdID
@@ -176,10 +204,12 @@ public sealed class ExecutionReportProcessor
                 _margin.OnExecution(lookupId, kind, 0);
                 break;
             case ExecKind.Replaced:
-                // Re-issuance: the gateway is responsible for calling
-                // OrderOwnershipMap.RegisterReplacement first; here we
-                // just leave the original order alone — the new ClOrdID
-                // already has its own Order.
+                // Slice 2 of #122 handles replace acks via the early
+                // intercept above (consumes a PendingReplacementRegistry
+                // intent). Falling through here means no intent was
+                // tracked — either we're in a test context with no
+                // registry wired, or we received an unsolicited Replaced
+                // ER. Original behavior: leave the original alone.
                 break;
         }
 
@@ -242,6 +272,139 @@ public sealed class ExecutionReportProcessor
 
     private static KeyValuePair<string, object?> KindTag(ExecKind kind) =>
         new("kind", kind.ToString());
+
+    private void ApplyReplaceRejected(ulong newClOrdId, OrderReplacementIntent intent, string? rejectReason)
+    {
+        // Replace-reject: original order is untouched (continues
+        // Working / PartiallyFilled), pending margin delta is released.
+        _replaceMargin?.AbortReplace(newClOrdId);
+        _logger.LogInformation(
+            "event=order.replace.rejected newClOrdId={NewClOrdId} origClOrdId={OrigClOrdId} owner={Owner} symbol={Symbol} reason={Reason}",
+            newClOrdId, intent.OriginalClOrdId, intent.Owner.Value, intent.Symbol, rejectReason ?? "(none)");
+    }
+
+    private void ApplyReplaceAccepted(
+        ulong newClOrdId,
+        long erLeaves,
+        long erCum,
+        decimal erLastPx,
+        ulong erOrigClOrdId,
+        OrderReplacementIntent intent)
+    {
+        var origId = erOrigClOrdId != 0 ? erOrigClOrdId : intent.OriginalClOrdId;
+
+        if (!_orders.TryGet(origId, out var origOrder) || origOrder is null)
+        {
+            _logger.LogWarning(
+                "Replaced ER for new ClOrdID {NewClOrdId} but original {OrigClOrdId} not found in book; aborting margin transfer.",
+                newClOrdId, origId);
+            _replaceMargin?.AbortReplace(newClOrdId);
+            return;
+        }
+
+        // 1) Terminalize the original. MarkReplaced is idempotent and
+        //    refuses to regress true terminal states (Filled / Rejected
+        //    / Cancelled), so a Replaced ack racing a final fill keeps
+        //    the original at its real terminal status.
+        var originalAlreadyTerminal = origOrder.Status is OrderStatus.Filled
+            or OrderStatus.Rejected
+            or OrderStatus.Cancelled
+            or OrderStatus.Replaced;
+        origOrder.MarkReplaced();
+
+        _sink.Publish(new ExecutionEvent(
+            intent.Owner,
+            origId,
+            origOrder.Symbol,
+            origOrder.Side,
+            origOrder.Status,
+            ExecKind.Replaced,
+            origOrder.LeavesQuantity,
+            origOrder.CumulativeQuantity,
+            0,
+            0m,
+            null,
+            DateTimeOffset.UtcNow,
+            false));
+
+        // 2) Hydrate the replacement with intent metadata + venue's
+        //    cum/leaves baseline. Existing fills booked under the
+        //    original are NOT re-booked — PositionKeeper already saw
+        //    them. The cum/leaves on the new Order exists so subsequent
+        //    fill ERs (now arriving under newClOrdID) advance from the
+        //    correct baseline.
+        Order newOrder;
+        try
+        {
+            newOrder = Order.HydrateReplacement(
+                origOrder, newClOrdId, intent.NewQuantity, intent.NewPrice, erLeaves, erCum);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to hydrate replacement for new ClOrdID {NewClOrdId}; aborting margin.", newClOrdId);
+            _replaceMargin?.AbortReplace(newClOrdId);
+            return;
+        }
+
+        if (!_orders.TryAdd(newOrder))
+        {
+            _logger.LogWarning(
+                "Replacement order {NewClOrdId} already in book; aborting (duplicate Replaced ER?).", newClOrdId);
+            _replaceMargin?.AbortReplace(newClOrdId);
+            return;
+        }
+
+        // 3) Margin commit: rebalance to venue-confirmed remaining.
+        //    For Buy + Limit + cash, that's intent.NewPrice * leaves;
+        //    everything else is zero (the coordinator no-ops on 0).
+        var confirmedRemaining = (intent.Side == OrderSide.Buy
+                                  && intent.Type == OrderType.Limit
+                                  && intent.NewPrice is { } px
+                                  && erLeaves > 0)
+            ? px * erLeaves
+            : 0m;
+        _replaceMargin?.CommitReplace(intent.OriginalClOrdId, newClOrdId, confirmedRemaining);
+
+        // 4) Publish event for the new order — same shape as a New ack
+        //    so WS subscribers see the order appear in the blotter.
+        _sink.Publish(new ExecutionEvent(
+            intent.Owner,
+            newClOrdId,
+            newOrder.Symbol,
+            newOrder.Side,
+            newOrder.Status,
+            ExecKind.Replaced,
+            newOrder.LeavesQuantity,
+            newOrder.CumulativeQuantity,
+            0,
+            erLastPx,
+            null,
+            DateTimeOffset.UtcNow,
+            false));
+
+        // 5) Algo-engine signal: replacement is, for the engine's
+        //    purposes, an execution observation on the parent. Mirrors
+        //    the bottom-of-method logic for normal ERs.
+        if (_algoSignals is not null
+            && intent.ParentAlgoId is { } parentAlgoId
+            && !string.IsNullOrEmpty(intent.FirmId))
+        {
+            var enqueued = _algoSignals.TryEnqueue(new ChildExecutionObservedSignal
+            {
+                FirmId = intent.FirmId,
+                AlgoId = parentAlgoId,
+                ChildClOrdId = newClOrdId,
+            });
+            if (!enqueued)
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "child_er"));
+            }
+        }
+
+        _ = originalAlreadyTerminal; // currently observational; future metric hook.
+    }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Slice 2 of #122. In-process tracking of in-flight cancel-replace
+/// requests, keyed by the new ClOrdID. The endpoint (slice 4) records
+/// an intent here BEFORE dispatching to the gateway; the
+/// <see cref="ExecutionReportProcessor"/> consumes it on the matching
+/// Replaced ER (success path) or Rejected ER (replace-reject path).
+///
+/// <para>
+/// Slice 2 is in-memory only. Slice 4 will append a matching
+/// <c>OrderReplaceRequestedEvent</c> to the WAL so the registry can be
+/// rebuilt on cold start without losing in-flight modifies.
+/// </para>
+///
+/// <para>
+/// Concurrency: <see cref="ConcurrentDictionary{TKey,TValue}"/> backs
+/// the storage; <see cref="TryAdd"/> / <see cref="TryConsume"/> are
+/// thread-safe atomic operations. Slice 4 will additionally enforce
+/// "one in-flight modify per original ClOrdID" by indexing on
+/// <see cref="OrderReplacementIntent.OriginalClOrdId"/>.
+/// </para>
+/// </summary>
+public sealed class PendingReplacementRegistry
+{
+    private readonly ConcurrentDictionary<ulong, OrderReplacementIntent> _byNewClOrdId = new();
+
+    /// <summary>
+    /// Records an in-flight modify. Returns <c>false</c> when an intent
+    /// for the same <paramref name="intent"/>.<see cref="OrderReplacementIntent.NewClOrdId"/>
+    /// is already tracked — should be impossible because new ClOrdIDs
+    /// come from <see cref="ClOrdIdPrefixRegistry"/> and are unique by
+    /// construction, but the guard is cheap and fails loud.
+    /// </summary>
+    public bool TryAdd(OrderReplacementIntent intent)
+    {
+        ArgumentNullException.ThrowIfNull(intent);
+        return _byNewClOrdId.TryAdd(intent.NewClOrdId, intent);
+    }
+
+    /// <summary>
+    /// Removes and returns the intent for <paramref name="newClOrdId"/>
+    /// if present. Used by the ER processor on a successful Replaced
+    /// ack or a replace-reject — both terminate the in-flight state.
+    /// </summary>
+    public bool TryConsume(ulong newClOrdId, out OrderReplacementIntent? intent)
+    {
+        if (_byNewClOrdId.TryRemove(newClOrdId, out var found))
+        {
+            intent = found;
+            return true;
+        }
+        intent = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Peeks at the intent without removing it — used by callers that
+    /// need to distinguish a normal Rejected ER from a replace-reject
+    /// before deciding to consume.
+    /// </summary>
+    public bool TryGet(ulong newClOrdId, out OrderReplacementIntent? intent)
+    {
+        if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
+        {
+            intent = found;
+            return true;
+        }
+        intent = null;
+        return false;
+    }
+
+    /// <summary>Test/observability helper.</summary>
+    internal int CountForTesting => _byNewClOrdId.Count;
+}
+
+/// <summary>
+/// Captures everything the <see cref="ExecutionReportProcessor"/>
+/// needs to hydrate a replacement <see cref="Order"/> when the
+/// matching Replaced ER arrives. All fields except cum/leaves come
+/// from the modify request; cum/leaves are filled in from the ER.
+/// </summary>
+public sealed record OrderReplacementIntent(
+    ulong OriginalClOrdId,
+    ulong NewClOrdId,
+    EndClientId Owner,
+    string Symbol,
+    ulong SecurityId,
+    OrderSide Side,
+    OrderType Type,
+    long NewQuantity,
+    decimal? NewPrice,
+    string FirmId,
+    ulong? ParentAlgoId,
+    int? AlgoSliceSeq);

--- a/backend/src/B3.Trading.Application/Risk/IReplaceMarginCoordinator.cs
+++ b/backend/src/B3.Trading.Application/Risk/IReplaceMarginCoordinator.cs
@@ -1,0 +1,69 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Slice 2 of #122. Margin coordination for cancel-replace.
+///
+/// <para>
+/// Modify is delta-aware. The naive "release the original reservation
+/// then re-reserve under the new ClOrdID" creates a window in which
+/// the trader must hold capacity for both legs of the replace
+/// simultaneously — a downsize from R1 to R2 (R2 &lt; R1) would
+/// momentarily require <c>R1 + R2</c> of cash and could spuriously
+/// reject. The coordinator instead reserves only the upsize delta at
+/// <see cref="PrepareReplaceAsync"/> time and rebalances at
+/// <see cref="CommitReplace"/> time using the venue-confirmed
+/// leaves quantity.
+/// </para>
+///
+/// <para>
+/// Implementations are expected to be the same singleton as
+/// <see cref="IMarginProvider"/> so the underlying reservation ledger
+/// is shared.
+/// </para>
+/// </summary>
+public interface IReplaceMarginCoordinator
+{
+    /// <summary>
+    /// Atomically check that the upsize delta (if any) fits in the
+    /// owner's available cash and reserve it under
+    /// <paramref name="newClOrdId"/>. Returns
+    /// <see cref="RiskDecision.Approve"/> when no extra cash is needed
+    /// (downsize / same / non-cash side) or when the delta fits;
+    /// otherwise <see cref="RiskDecision.Reject"/>.
+    /// </summary>
+    /// <remarks>
+    /// The original reservation under <paramref name="originalClOrdId"/>
+    /// is left intact so that, if the venue rejects the replace, the
+    /// trader's original order continues to hold its capacity.
+    /// </remarks>
+    Task<RiskDecision> PrepareReplaceAsync(
+        ulong originalClOrdId,
+        ulong newClOrdId,
+        EndClientId owner,
+        decimal newRemainingNotional,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Called from the ER processor on a successful Replaced ack.
+    /// Atomically releases the original reservation and finalizes the
+    /// replacement reservation at <paramref name="confirmedRemainingNotional"/>
+    /// (computed from <c>intent.NewPrice * ER.LeavesQty</c> by the
+    /// caller — using the venue's view of leaves means partial fills
+    /// that landed during the Prepare→Commit window self-correct).
+    /// </summary>
+    void CommitReplace(
+        ulong originalClOrdId,
+        ulong newClOrdId,
+        decimal confirmedRemainingNotional);
+
+    /// <summary>
+    /// Called from the ER processor on a replace-reject (Rejected ER
+    /// for a ClOrdID present in <see cref="PendingReplacementRegistry"/>)
+    /// or from the endpoint when the gateway dispatch throws after
+    /// Prepare succeeded. Releases the upsize delta reserved at
+    /// Prepare; the original reservation is untouched.
+    /// </summary>
+    void AbortReplace(ulong newClOrdId);
+}

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -49,7 +49,7 @@ namespace B3.Trading.Application.Risk;
 /// dogfood configs keep working until slice 4 retires the option.
 /// </para>
 /// </summary>
-public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
+public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMarginCoordinator
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly ILogger<ReserveOnSubmitMarginProvider> _logger;
@@ -219,6 +219,132 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider
     /// <summary>Test/observability helper: returns the currently available amount for an owner.</summary>
     internal decimal AvailableForTesting(string owner) =>
         ResolveBaseAvailable(owner) - ReservedForTesting(owner);
+
+    // ----- IReplaceMarginCoordinator (slice 2 of #122) -----
+
+    /// <inheritdoc />
+    public Task<RiskDecision> PrepareReplaceAsync(
+        ulong originalClOrdId,
+        ulong newClOrdId,
+        EndClientId owner,
+        decimal newRemainingNotional,
+        CancellationToken ct)
+    {
+        // Sells / markets / non-positive notionals never touched the
+        // reservation ledger on submit; they don't here either.
+        if (newRemainingNotional <= 0m)
+            return Task.FromResult(RiskDecision.Approve);
+
+        var ownerKey = owner.Value;
+        lock (_gate)
+        {
+            var oldRemaining = _reservations.TryGetValue(originalClOrdId, out var origEntry)
+                ? origEntry.RemainingNotional
+                : 0m;
+
+            // Delta semantics: we only need to reserve *additional*
+            // capacity when scaling up. Downsize / same / sell-side
+            // replace requires no extra reserve at Prepare time;
+            // Commit will rebalance to the venue-confirmed figure.
+            var delta = newRemainingNotional - oldRemaining;
+            if (delta <= 0m)
+            {
+                // Track the in-flight intent with a zero-notional entry
+                // so AbortReplace has something to remove and Commit
+                // knows the Prepare ran. No effect on _reserved.
+                _reservations[newClOrdId] = new ReservationEntry(ownerKey, 0m, 0L, 0m);
+                return Task.FromResult(RiskDecision.Approve);
+            }
+
+            var reserved = _reserved.GetValueOrDefault(ownerKey, 0m);
+            var available = ResolveBaseAvailable(ownerKey) - reserved;
+            if (delta > available)
+            {
+                return Task.FromResult(RiskDecision.Reject(
+                    $"insufficient margin for replace upsize: delta {delta} exceeds available {available} for end-client '{ownerKey}'"));
+            }
+
+            _reserved[ownerKey] = reserved + delta;
+            // The transient reservation under newClOrdId carries only
+            // the delta — Commit will top it up to confirmedRemainingNotional.
+            _reservations[newClOrdId] = new ReservationEntry(ownerKey, 0m, 0L, delta);
+            return Task.FromResult(RiskDecision.Approve);
+        }
+    }
+
+    /// <inheritdoc />
+    public void CommitReplace(
+        ulong originalClOrdId,
+        ulong newClOrdId,
+        decimal confirmedRemainingNotional)
+    {
+        lock (_gate)
+        {
+            // Remove the transient entry (set up by Prepare) — its
+            // RemainingNotional is the upsize delta we already reserved
+            // (or zero for downsize/same).
+            decimal transientDelta = 0m;
+            string? owner = null;
+            if (_reservations.TryRemove(newClOrdId, out var transient))
+            {
+                transientDelta = transient.RemainingNotional;
+                owner = transient.Owner;
+            }
+
+            // Release the original entry entirely (returns oldRemaining).
+            decimal oldRemaining = 0m;
+            if (_reservations.TryRemove(originalClOrdId, out var origEntry))
+            {
+                oldRemaining = origEntry.RemainingNotional;
+                owner ??= origEntry.Owner;
+            }
+
+            if (owner is null)
+            {
+                // No reservation existed on either side (sell or
+                // never-reserved). Nothing to track going forward.
+                if (confirmedRemainingNotional > 0m)
+                {
+                    _logger.LogWarning(
+                        "CommitReplace asked to track {Notional} for new ClOrdID {NewClOrdId} but neither original nor pending reservation has an owner; dropping.",
+                        confirmedRemainingNotional, newClOrdId);
+                }
+                return;
+            }
+
+            // Net change to _reserved[owner]:
+            //   release oldRemaining (-)
+            //   release transientDelta (- because we'll re-add via newReserved)
+            //   add confirmedRemainingNotional (+)
+            // Combined: confirmedRemainingNotional - oldRemaining - transientDelta
+            // (which equals zero for the upsize/same Prepare-then-Commit sequence
+            // when the venue confirms the qty we asked for).
+            var reserved = _reserved.GetValueOrDefault(owner, 0m);
+            var adjustment = confirmedRemainingNotional - oldRemaining - transientDelta;
+            var next = reserved + adjustment;
+            if (next < 0m)
+            {
+                _logger.LogWarning(
+                    "CommitReplace adjustment for owner {Owner} would push reserved below zero ({Reserved} + {Adjustment}); clamping to zero.",
+                    owner, reserved, adjustment);
+                next = 0m;
+            }
+            _reserved[owner] = next;
+
+            if (confirmedRemainingNotional > 0m)
+            {
+                _reservations[newClOrdId] =
+                    new ReservationEntry(owner, 0m, 0L, confirmedRemainingNotional);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void AbortReplace(ulong newClOrdId)
+    {
+        // Releases the upsize delta only; original reservation untouched.
+        ReleaseRemaining(newClOrdId);
+    }
 
     private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional);
 }

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -217,4 +217,71 @@ public sealed class Order
         o.Status = status;
         return o;
     }
+
+    /// <summary>
+    /// Slice 2 of #122. Builds the replacement Order that the venue
+    /// just acknowledged via a Replaced ER. Symbol/side/type/owner/
+    /// firm/parent-algo are inherited from the original; quantity and
+    /// price are the values requested by the modify; cumQty and leaves
+    /// come from the ER (the venue's view of how much was already
+    /// filled under the original at the moment the replace took effect).
+    ///
+    /// <para>
+    /// Status is derived from the cum/leaves baseline:
+    /// <c>cum &gt;= quantity</c> → <see cref="OrderStatus.Filled"/> (the
+    /// modify was over-filled before it took effect — degenerate but
+    /// possible if a fill races the replace; status reflects venue truth);
+    /// <c>cum &gt; 0</c> → <see cref="OrderStatus.PartiallyFilled"/>;
+    /// otherwise → <see cref="OrderStatus.Working"/> (no
+    /// <see cref="OrderStatus.PendingNew"/> because the venue has
+    /// already accepted the replacement — slice 2 invariant).
+    /// </para>
+    ///
+    /// <para>
+    /// Existing fills booked under the original ClOrdID are NOT
+    /// re-booked here — <see cref="PositionKeeper"/> already saw them
+    /// when their fill ERs flowed under the original. The cum/leaves
+    /// values exist on the replacement only so subsequent fill ERs
+    /// (which arrive under the new ClOrdID) can advance via
+    /// <see cref="ApplyCumulativeFill"/> from the correct baseline.
+    /// </para>
+    /// </summary>
+    public static Order HydrateReplacement(
+        Order original,
+        ulong newClOrdId,
+        long newQuantity,
+        decimal? newPrice,
+        long erLeaves,
+        long erCumulative)
+    {
+        ArgumentNullException.ThrowIfNull(original);
+        if (newClOrdId == 0)
+            throw new ArgumentOutOfRangeException(nameof(newClOrdId), "ClOrdID cannot be zero.");
+        if (newQuantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(newQuantity), "Replacement quantity must be positive.");
+        if (erCumulative < 0)
+            throw new ArgumentOutOfRangeException(nameof(erCumulative));
+        if (erLeaves < 0)
+            throw new ArgumentOutOfRangeException(nameof(erLeaves));
+
+        var status = erCumulative >= newQuantity
+            ? OrderStatus.Filled
+            : (erCumulative > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Working);
+
+        return Hydrate(
+            clOrdId: newClOrdId,
+            owner: original.Owner,
+            symbol: original.Symbol,
+            securityId: original.SecurityId,
+            side: original.Side,
+            type: original.Type,
+            quantity: newQuantity,
+            price: newPrice,
+            leaves: erLeaves,
+            cumQty: erCumulative,
+            status: status,
+            firmId: original.FirmId,
+            parentAlgoId: original.ParentAlgoId,
+            algoSliceSeq: original.AlgoSliceSeq);
+    }
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -151,16 +151,26 @@ builder.Services.AddSingleton<EventDispatcher>();
 builder.Services.AddSingleton<KillSwitchService>();
 builder.Services.AddSingleton<SymbolHaltService>();
 builder.Services.AddTradingMarketData(builder.Configuration);
+builder.Services.AddSingleton<ReserveOnSubmitMarginProvider>(sp =>
+    new ReserveOnSubmitMarginProvider(
+        sp.GetRequiredService<IOptionsMonitor<RiskOptions>>(),
+        sp.GetRequiredService<ILogger<ReserveOnSubmitMarginProvider>>(),
+        sp.GetRequiredService<CashLedger>()));
 builder.Services.AddSingleton<IMarginProvider>(sp =>
 {
     var opts = sp.GetRequiredService<IOptionsMonitor<RiskOptions>>().CurrentValue;
     return opts.Margin.Enabled
-        ? new ReserveOnSubmitMarginProvider(
-            sp.GetRequiredService<IOptionsMonitor<RiskOptions>>(),
-            sp.GetRequiredService<ILogger<ReserveOnSubmitMarginProvider>>(),
-            sp.GetRequiredService<CashLedger>())
+        ? sp.GetRequiredService<ReserveOnSubmitMarginProvider>()
         : new NoOpMarginProvider();
 });
+// Slice 2 of #122: the replace coordinator shares the reservation
+// ledger with IMarginProvider, so it always points at the concrete
+// ReserveOnSubmitMarginProvider singleton — even when margin is
+// disabled the coordinator's Commit/Abort are harmless no-ops on an
+// empty ledger.
+builder.Services.AddSingleton<PendingReplacementRegistry>();
+builder.Services.AddSingleton<IReplaceMarginCoordinator>(sp =>
+    sp.GetRequiredService<ReserveOnSubmitMarginProvider>());
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
 builder.Services.AddSingleton<IRiskCheck, SymbolHaltedCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1,0 +1,310 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+#pragma warning disable CS0618 // legacy Margin.Initial used to seed capacity in tests
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Slice 2 of #122 — order modify lifecycle wiring:
+/// <see cref="OrderReplacementIntent"/> + <see cref="PendingReplacementRegistry"/>,
+/// <see cref="IReplaceMarginCoordinator"/> on
+/// <see cref="ReserveOnSubmitMarginProvider"/>, and the
+/// <see cref="ExecutionReportProcessor"/> Replaced / replace-reject
+/// branches.
+/// </summary>
+public class OrderModifyMarginAndProcessorTests
+{
+    private static OrderReplacementIntent BuyLimitIntent(
+        ulong origId, ulong newId, string owner, long newQty, decimal newPrice) =>
+        new(
+            OriginalClOrdId: origId,
+            NewClOrdId: newId,
+            Owner: new EndClientId(owner),
+            Symbol: "PETR4",
+            SecurityId: 4321UL,
+            Side: OrderSide.Buy,
+            Type: OrderType.Limit,
+            NewQuantity: newQty,
+            NewPrice: newPrice,
+            FirmId: "FIRM",
+            ParentAlgoId: null,
+            AlgoSliceSeq: null);
+
+    // ---------------- PendingReplacementRegistry ----------------
+
+    [Fact]
+    public void Registry_TryAdd_thenTryConsume_returnsIntentOnce()
+    {
+        var reg = new PendingReplacementRegistry();
+        var intent = BuyLimitIntent(1UL, 2UL, "alice", 100, 30m);
+        Assert.True(reg.TryAdd(intent));
+        Assert.True(reg.TryConsume(2UL, out var first));
+        Assert.NotNull(first);
+        Assert.Equal(1UL, first!.OriginalClOrdId);
+        Assert.False(reg.TryConsume(2UL, out _));
+    }
+
+    [Fact]
+    public void Registry_TryAdd_rejectsDuplicateNewClOrdId()
+    {
+        var reg = new PendingReplacementRegistry();
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30m)));
+        Assert.False(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 200, 31m)));
+    }
+
+    [Fact]
+    public void Registry_TryGet_doesNotRemove()
+    {
+        var reg = new PendingReplacementRegistry();
+        reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30m));
+        Assert.True(reg.TryGet(2UL, out var peek));
+        Assert.NotNull(peek);
+        Assert.True(reg.TryConsume(2UL, out _));
+    }
+
+    // ---------------- HydrateReplacement ----------------
+
+    [Fact]
+    public void HydrateReplacement_workingWhenNoCum()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var newOrder = Order.HydrateReplacement(orig, 2UL, 200, 31m, erLeaves: 200, erCumulative: 0);
+        Assert.Equal(OrderStatus.Working, newOrder.Status);
+        Assert.Equal(200, newOrder.LeavesQuantity);
+        Assert.Equal(0, newOrder.CumulativeQuantity);
+        Assert.Equal(31m, newOrder.Price);
+        Assert.Equal("PETR4", newOrder.Symbol);
+        Assert.Equal(owner, newOrder.Owner);
+        Assert.Equal("FIRM", newOrder.FirmId);
+    }
+
+    [Fact]
+    public void HydrateReplacement_partiallyFilledWhenCumPositive()
+    {
+        var orig = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var newOrder = Order.HydrateReplacement(orig, 2UL, 200, 31m, erLeaves: 150, erCumulative: 50);
+        Assert.Equal(OrderStatus.PartiallyFilled, newOrder.Status);
+        Assert.Equal(50, newOrder.CumulativeQuantity);
+    }
+
+    [Fact]
+    public void HydrateReplacement_filledWhenCumGreaterEqualNewQty()
+    {
+        var orig = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var newOrder = Order.HydrateReplacement(orig, 2UL, 60, 31m, erLeaves: 0, erCumulative: 60);
+        Assert.Equal(OrderStatus.Filled, newOrder.Status);
+    }
+
+    [Fact]
+    public void HydrateReplacement_rejectsZeroClOrdId()
+    {
+        var orig = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Order.HydrateReplacement(orig, 0UL, 200, 31m, 200, 0));
+    }
+
+    // ---------------- IReplaceMarginCoordinator ----------------
+
+    private static (ReserveOnSubmitMarginProvider provider, StaticOptionsMonitor<RiskOptions> monitor) BuildProvider(
+        decimal initial = 100_000m, string owner = "alice")
+    {
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial[owner] = initial;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var provider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        return (provider, monitor);
+    }
+
+    private static RiskContext BuyCtx(string owner, decimal price, long qty) =>
+        new(new EndClientId(owner), "FIRM", "PETR4", OrderSide.Buy, OrderType.Limit, qty, price);
+
+    [Fact]
+    public async Task Coordinator_upsize_reservesDelta_thenCommitTransfersOwnership()
+    {
+        var (p, _) = BuildProvider(initial: 10_000m);
+        Assert.True((await p.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        // reserved = 1000, available = 9000
+
+        // Upsize from 100@10 → 200@10. Delta = 1000.
+        var prep = await ((IReplaceMarginCoordinator)p).PrepareReplaceAsync(
+            1UL, 2UL, new EndClientId("alice"), newRemainingNotional: 2000m, default);
+        Assert.True(prep.Approved);
+        Assert.Equal(2000m, p.ReservedForTesting("alice"));
+
+        // Commit: confirmed remaining = 2000.
+        ((IReplaceMarginCoordinator)p).CommitReplace(1UL, 2UL, 2000m);
+        Assert.Equal(2000m, p.ReservedForTesting("alice"));
+
+        // Now releasing the new order should fully restore the ledger.
+        p.ReleaseReservation(2UL);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Coordinator_downsize_doesNotReserveAtPrepare_releasesAtCommit()
+    {
+        var (p, _) = BuildProvider(initial: 10_000m);
+        Assert.True((await p.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        Assert.Equal(1000m, p.ReservedForTesting("alice"));
+
+        // Downsize 100@10 → 50@10. Delta = -500. No extra reserve.
+        var prep = await ((IReplaceMarginCoordinator)p).PrepareReplaceAsync(
+            1UL, 2UL, new EndClientId("alice"), newRemainingNotional: 500m, default);
+        Assert.True(prep.Approved);
+        Assert.Equal(1000m, p.ReservedForTesting("alice"));
+
+        ((IReplaceMarginCoordinator)p).CommitReplace(1UL, 2UL, 500m);
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Coordinator_upsizeRejected_whenDeltaExceedsAvailable()
+    {
+        var (p, _) = BuildProvider(initial: 1_500m);
+        Assert.True((await p.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        // available = 500. Try upsize that needs +1000 delta.
+        var prep = await ((IReplaceMarginCoordinator)p).PrepareReplaceAsync(
+            1UL, 2UL, new EndClientId("alice"), newRemainingNotional: 2000m, default);
+        Assert.False(prep.Approved);
+        Assert.Contains("insufficient margin", prep.Reason);
+        // Original reservation still intact.
+        Assert.Equal(1000m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Coordinator_abort_releasesUpsizeDeltaOnly_originalIntact()
+    {
+        var (p, _) = BuildProvider(initial: 10_000m);
+        Assert.True((await p.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        await ((IReplaceMarginCoordinator)p).PrepareReplaceAsync(
+            1UL, 2UL, new EndClientId("alice"), 2000m, default);
+        Assert.Equal(2000m, p.ReservedForTesting("alice"));
+
+        ((IReplaceMarginCoordinator)p).AbortReplace(2UL);
+        Assert.Equal(1000m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Coordinator_sellOrZeroNotional_isApproveNoOp()
+    {
+        var (p, _) = BuildProvider(initial: 1_000m);
+        var prep = await ((IReplaceMarginCoordinator)p).PrepareReplaceAsync(
+            999UL, 1000UL, new EndClientId("alice"), newRemainingNotional: 0m, default);
+        Assert.True(prep.Approved);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    // ---------------- ExecutionReportProcessor wiring ----------------
+
+    private sealed class CaptureSink : IExecutionEventSink
+    {
+        public List<ExecutionEvent> Events { get; } = new();
+        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    private static (ExecutionReportProcessor proc, OrderOwnershipMap own, WorkingOrderBook book,
+                    PendingReplacementRegistry reg, ReserveOnSubmitMarginProvider margin, CaptureSink sink) BuildProcessor(
+        decimal initial = 10_000m)
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new CaptureSink();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["alice"] = initial;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        var reg = new PendingReplacementRegistry();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink, margin,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: null,
+            replacements: reg,
+            replaceMargin: margin);
+        return (proc, ownership, book, reg, margin, sink);
+    }
+
+    [Fact]
+    public async Task Processor_Replaced_terminalizesOriginalAndHydratesNew_andTransfersMargin()
+    {
+        var (proc, ownership, book, reg, margin, sink) = BuildProcessor();
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 10m, "FIRM");
+        book.TryAdd(orig);
+        ownership.Register(1UL, owner);
+        Assert.True((await margin.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        // upsize 100@10 → 200@10
+        reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 200, 10m));
+        await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(
+            1UL, 2UL, owner, 2000m, default);
+
+        proc.Apply(2UL, ExecKind.Replaced, leaves: 200, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null, origClOrdId: 1UL);
+
+        Assert.Equal(OrderStatus.Replaced, orig.Status);
+        Assert.True(book.TryGet(2UL, out var newOrder));
+        Assert.Equal(OrderStatus.Working, newOrder!.Status);
+        Assert.Equal(200, newOrder.LeavesQuantity);
+        Assert.Equal(2000m, margin.ReservedForTesting("alice"));
+        Assert.Equal(2, sink.Events.Count); // one for orig, one for new
+        Assert.False(reg.TryGet(2UL, out _));
+    }
+
+    [Fact]
+    public void Processor_Rejected_forIntentInRegistry_treatsAsReplaceReject_originalUntouched()
+    {
+        var (proc, ownership, book, reg, _, sink) = BuildProcessor();
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 10m, "FIRM");
+        book.TryAdd(orig);
+        ownership.Register(1UL, owner);
+        reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 200, 10m));
+
+        proc.Apply(2UL, ExecKind.Rejected, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: "tick-out-of-range");
+
+        Assert.Equal(OrderStatus.PendingNew, orig.Status); // unchanged
+        Assert.False(book.TryGet(2UL, out _));
+        Assert.False(reg.TryGet(2UL, out _));
+        Assert.Empty(sink.Events); // replace-reject does not publish (no new order to surface)
+    }
+
+    [Fact]
+    public async Task Processor_Replaced_aborts_whenOriginalMissing()
+    {
+        var (proc, _, _, reg, margin, sink) = BuildProcessor();
+        // Reserve under origId but never add to book — simulate desync.
+        Assert.True((await margin.TryReserveAsync(1UL, BuyCtx("alice", 10m, 100), default)).Approved);
+        reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 200, 10m));
+        await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(
+            1UL, 2UL, new EndClientId("alice"), 2000m, default);
+
+        proc.Apply(2UL, ExecKind.Replaced, leaves: 200, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null, origClOrdId: 1UL);
+
+        // upsize delta released; original reservation still alive.
+        Assert.Equal(1000m, margin.ReservedForTesting("alice"));
+        Assert.Empty(sink.Events);
+        Assert.False(reg.TryGet(2UL, out _)); // intent consumed
+    }
+
+    [Fact]
+    public void Processor_Rejected_normalRejectionStillFlowsThroughOriginalPath_whenNoIntent()
+    {
+        // Sanity: a Rejected ER for a ClOrdID NOT in the registry must
+        // continue to follow the normal terminate-the-order branch.
+        var (proc, ownership, book, _, _, sink) = BuildProcessor();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 10m, "FIRM");
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+
+        proc.Apply(1UL, ExecKind.Rejected, 0, 0, 0, 0m, "venue-down");
+
+        Assert.Equal(OrderStatus.Rejected, order.Status);
+        Assert.Single(sink.Events);
+    }
+}


### PR DESCRIPTION
Slice 2 of #122. Adds the wiring that lets a Replaced ER from the venue terminalize the original order, hydrate the new order with the venue-confirmed cum/leaves baseline, and atomically transfer the margin reservation — without ever requiring the trader to hold capacity for both legs of the modify simultaneously.

## Components

- **`PendingReplacementRegistry`** — in-process map keyed by newClOrdId, consumed by the ER processor on the matching Replaced or Rejected ER. Slice 4 will append a WAL event so cold start rebuilds in-flight modifies.
- **`IReplaceMarginCoordinator`** — Prepare/Commit/Abort. Implemented on `ReserveOnSubmitMarginProvider` so the reservation ledger is shared.
  - **Prepare** reserves only the upsize delta. Downsize and same-size paths approve without touching capacity, eliminating the false-reject window where the trader would briefly need `R_old + R_new` of capacity.
  - **Commit** rebalances to `intent.NewPrice * ER.LeavesQty` — partial fills landing in the Prepare→Commit window self-correct.
  - **Abort** releases just the upsize delta; original reservation untouched.
- **`Order.HydrateReplacement`** — domain factory that derives the replacement Order from intent metadata + ER cum/leaves. Status is Working / PartiallyFilled / Filled depending on cum vs new qty. Existing fills booked under the original ClOrdID are NOT re-booked — PositionKeeper already saw them.
- **`ExecutionReportProcessor`** — early intercept BEFORE the existing lookup logic:
  - `Rejected` ER for a ClOrdID present in the registry → **replace-reject** path (original untouched, margin delta released).
  - `Replaced` ER with intent → MarkReplaced original + publish, hydrate new + add to book, CommitReplace, publish, algo signal. The vestigial Replaced switch case is now a no-op fallback for test contexts without a registry wired.

## DI

`ReserveOnSubmitMarginProvider` registered as a concrete singleton and forwarded to both `IMarginProvider` and `IReplaceMarginCoordinator` so they share state. `PendingReplacementRegistry` is a singleton. `ExecutionReportProcessor` picks both up via constructor injection.

## Tests

16 new tests cover:
- Registry: TryAdd/TryConsume/TryGet semantics + duplicate rejection.
- HydrateReplacement: status derivation (Working/PartiallyFilled/Filled), inheritance of metadata, zero-clOrdId rejection.
- Coordinator: upsize delta + commit transfer, downsize no-op + commit release, upsize-rejected when delta > available, abort releases delta only, sell/zero-notional no-op.
- Processor: Replaced success (terminalizes original + hydrates new + transfers margin + publishes 2 events), replace-reject (original untouched), Replaced with missing original (aborts margin gracefully), normal Rejected sanity (unchanged behavior when no intent).

Suite **541/541** verde (was 525). Format clean.

Refs #122

---

**Next slices:**
- Slice 3 — risk replacement projection (`RiskContext.ReplaceOriginalClOrdId` + `EffectiveLeavesQuantity`; NakedShort projects).
- Slice 4 — endpoint + WAL + in-flight guard.
- Slice 5 — frontend.