### PR TITLE
feat(orders): slice 4 of #122 — PUT /orders/{clOrdId} modify endpoint

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -77,6 +77,51 @@ public static class OrdersEndpoints
             };
         });
 
+        group.MapPut("/{clOrdId}", async (
+            string clOrdId,
+            ModifyOrderRequest req,
+            HttpContext ctx,
+            EndClientRegistry registry,
+            OrderModifyService modifier,
+            CancellationToken ct) =>
+        {
+            if (!ulong.TryParse(clOrdId, out var clOrdIdU))
+                return Results.NotFound();
+
+            var owner = ResolveOwner(ctx, registry);
+            var result = await modifier.ModifyAsync(
+                new OrderModifyRequest(owner, clOrdIdU, req.Quantity, req.Price), ct);
+
+            return result.Kind switch
+            {
+                OrderModifyResultKind.Accepted =>
+                    Results.Accepted(
+                        $"/orders/{result.NewClOrdId}",
+                        new { ClOrdId = result.NewClOrdId.ToString(), OriginalClOrdId = clOrdIdU.ToString() }),
+                OrderModifyResultKind.NotFound =>
+                    Results.NotFound(),
+                OrderModifyResultKind.Conflict =>
+                    Results.Conflict(new { error = result.Reason }),
+                OrderModifyResultKind.BadRequest =>
+                    Results.BadRequest(new { error = result.Reason }),
+                OrderModifyResultKind.RiskRejected =>
+                    Results.UnprocessableEntity(new { error = result.Reason }),
+                OrderModifyResultKind.GatewayFailed =>
+                    Results.Json(
+                        new { error = "gateway unavailable", clOrdId = result.NewClOrdId.ToString() },
+                        statusCode: StatusCodes.Status502BadGateway),
+                OrderModifyResultKind.WalBackpressure =>
+                    Results.Json(
+                        new { error = "system busy (WAL backpressure)", detail = result.Reason },
+                        statusCode: StatusCodes.Status503ServiceUnavailable),
+                OrderModifyResultKind.Drained =>
+                    Results.Json(
+                        new { error = "service draining" },
+                        statusCode: StatusCodes.Status503ServiceUnavailable),
+                _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+            };
+        });
+
         group.MapDelete("/{clOrdId}", async (
             string clOrdId,
             HttpContext ctx,
@@ -128,6 +173,10 @@ public sealed record SubmitOrderRequest(
     ulong SecurityId,
     string Side,
     string Type,
+    long Quantity,
+    decimal? Price);
+
+public sealed record ModifyOrderRequest(
     long Quantity,
     decimal? Price);
 

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -25,6 +25,8 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.orders.gateway_failed");
     public static readonly Counter<long> OrdersCancelRequested =
         Meter.CreateCounter<long>("trading.orders.cancel_requested");
+    public static readonly Counter<long> OrdersModifyRequested =
+        Meter.CreateCounter<long>("trading.orders.modify_requested");
 
     // Execution reports inbound
     public static readonly Counter<long> ExecutionReportsReceived =

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -1,0 +1,306 @@
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Slice 4 of #122. The "modify (cancel-replace) an order" pipeline,
+/// counterpart to <see cref="OrderSubmissionService"/>. Both manual
+/// modifies (PUT /orders/{clOrdId}) and any future engine-driven
+/// replace flows funnel through here so risk evaluation, margin
+/// coordination, in-flight tracking, WAL durability, and gateway
+/// dispatch live in exactly one place.
+///
+/// <para>
+/// The service is stateless apart from its injected collaborators.
+/// All per-call mutable state lives on the returned
+/// <see cref="OrderModifyResult"/> or in the underlying books and
+/// registries. Callers translate the result into their transport
+/// (HTTP status + JSON body for endpoints).
+/// </para>
+/// </summary>
+public sealed class OrderModifyService
+{
+    private readonly ClOrdIdPrefixRegistry _clOrdIds;
+    private readonly OrderOwnershipMap _ownership;
+    private readonly WorkingOrderBook _book;
+    private readonly IExchangeGateway _gateway;
+    private readonly IExecutionEventSink _sink;
+    private readonly RiskPipeline _risk;
+    private readonly IReplaceMarginCoordinator _replaceMargin;
+    private readonly PendingReplacementRegistry _replacements;
+    private readonly EventDispatcher _dispatcher;
+    private readonly Lifecycle.IDrainGate _drain;
+    private readonly ILogger<OrderModifyService> _logger;
+
+    public OrderModifyService(
+        ClOrdIdPrefixRegistry clOrdIds,
+        OrderOwnershipMap ownership,
+        WorkingOrderBook book,
+        IExchangeGateway gateway,
+        IExecutionEventSink sink,
+        RiskPipeline risk,
+        IReplaceMarginCoordinator replaceMargin,
+        PendingReplacementRegistry replacements,
+        EventDispatcher dispatcher,
+        Lifecycle.IDrainGate drain,
+        ILogger<OrderModifyService> logger)
+    {
+        _clOrdIds = clOrdIds;
+        _ownership = ownership;
+        _book = book;
+        _gateway = gateway;
+        _sink = sink;
+        _risk = risk;
+        _replaceMargin = replaceMargin;
+        _replacements = replacements;
+        _dispatcher = dispatcher;
+        _drain = drain;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Runs the full modify pipeline for one order. Side-effect order
+    /// is intentional and matches the rationale in the slice-2
+    /// rubber-duck pass:
+    /// <list type="number">
+    ///   <item>Validate ownership + non-terminal status.</item>
+    ///   <item>Reject if a modify for the same orig is already in
+    ///     flight (prevents two pending replaces from racing the
+    ///     venue, which the FIXP spec doesn't disambiguate).</item>
+    ///   <item>Allocate a new ClOrdID up-front so risk + margin can
+    ///     bind to it.</item>
+    ///   <item>Run the pre-trade risk pipeline with
+    ///     <see cref="RiskContext.ReplaceOriginalClOrdId"/> set so
+    ///     <c>NoNakedShortCheck</c> projects the swap.</item>
+    ///   <item>Prepare margin (delta-only reservation; downsize is
+    ///     a no-op).</item>
+    ///   <item>Persist the WAL event AND mutate the registry +
+    ///     ownership map in a single dispatch — both happen or
+    ///     neither does.</item>
+    ///   <item>Dispatch to the gateway. On exception, abort margin +
+    ///     remove the in-flight intent and synthesize a rejection so
+    ///     the trader sees the failure in the blotter; the WAL
+    ///     event stays (replay tolerates "intent without resolution"
+    ///     the same way a synthetic-rejected ER terminates the orig
+    ///     today).</item>
+    /// </list>
+    /// </summary>
+    public async Task<OrderModifyResult> ModifyAsync(OrderModifyRequest req, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(req);
+
+        if (_drain.IsDraining)
+        {
+            MetricsRegistry.DrainRejections.Add(1,
+                new KeyValuePair<string, object?>("route", "PUT /orders"));
+            return OrderModifyResult.Drained;
+        }
+
+        if (req.NewQuantity <= 0)
+            return OrderModifyResult.BadRequest("quantity must be positive");
+
+        if (!_book.TryGet(req.OriginalClOrdId, out var orig) || orig is null)
+            return OrderModifyResult.NotFound;
+
+        if (orig.Owner != req.Owner)
+            return OrderModifyResult.NotFound; // do not leak existence cross-owner
+
+        if (orig.Status is OrderStatus.Filled or OrderStatus.Cancelled
+            or OrderStatus.Rejected or OrderStatus.Replaced)
+        {
+            return OrderModifyResult.Conflict("order is terminal");
+        }
+
+        if (req.NewQuantity <= orig.CumulativeQuantity)
+        {
+            // Modifying the total qty to or below already-filled cum
+            // means there is nothing left to leave on the venue —
+            // semantically a cancel, not a modify, and the venue
+            // will reject anyway.
+            return OrderModifyResult.BadRequest(
+                $"new quantity ({req.NewQuantity}) must exceed already-filled quantity ({orig.CumulativeQuantity})");
+        }
+
+        if (_replacements.IsOriginalInFlight(req.OriginalClOrdId))
+        {
+            return OrderModifyResult.Conflict("a modify for this order is already in flight");
+        }
+
+        var newClOrdId = _clOrdIds.Generate(req.Owner);
+        var effectiveLeaves = req.NewQuantity - orig.CumulativeQuantity;
+        var riskCtx = new RiskContext(
+            req.Owner, orig.FirmId, orig.Symbol, orig.Side, orig.Type,
+            req.NewQuantity, req.NewPrice,
+            ReplaceOriginalClOrdId: req.OriginalClOrdId,
+            EffectiveLeavesQuantity: effectiveLeaves);
+
+        var decision = _risk.Evaluate(riskCtx);
+        if (!decision.Approved)
+        {
+            MetricsRegistry.OrdersRejectedByRisk.Add(1,
+                new KeyValuePair<string, object?>("reason", decision.Reason ?? "risk_rejected"),
+                new KeyValuePair<string, object?>("path", "modify"));
+            return OrderModifyResult.RiskRejected(decision.Reason ?? "risk_rejected");
+        }
+
+        // Margin Prepare: reserve only the upsize delta. The
+        // coordinator no-ops on sells / markets / non-positive notionals.
+        var newRemainingNotional = (orig.Side == OrderSide.Buy
+                                    && orig.Type == OrderType.Limit
+                                    && req.NewPrice is { } px)
+            ? px * effectiveLeaves
+            : 0m;
+        var marginDecision = await _replaceMargin.PrepareReplaceAsync(
+            req.OriginalClOrdId, newClOrdId, req.Owner, newRemainingNotional, ct);
+        if (!marginDecision.Approved)
+        {
+            MetricsRegistry.OrdersRejectedByRisk.Add(1,
+                new KeyValuePair<string, object?>("reason", marginDecision.Reason ?? "margin_rejected"),
+                new KeyValuePair<string, object?>("path", "modify"));
+            return OrderModifyResult.RiskRejected(marginDecision.Reason ?? "margin_rejected");
+        }
+
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: req.OriginalClOrdId,
+            NewClOrdId: newClOrdId,
+            Owner: req.Owner,
+            Symbol: orig.Symbol,
+            SecurityId: orig.SecurityId,
+            Side: orig.Side,
+            Type: orig.Type,
+            NewQuantity: req.NewQuantity,
+            NewPrice: req.NewPrice,
+            FirmId: orig.FirmId,
+            ParentAlgoId: orig.ParentAlgoId,
+            AlgoSliceSeq: orig.AlgoSliceSeq);
+
+        try
+        {
+            _dispatcher.Dispatch(
+                new OrderReplaceRequestedEvent
+                {
+                    OriginalClOrdId = req.OriginalClOrdId,
+                    NewClOrdId = newClOrdId,
+                    EndClientId = req.Owner.Value,
+                    FirmId = orig.FirmId,
+                    Symbol = orig.Symbol,
+                    SecurityId = orig.SecurityId,
+                    Side = orig.Side.ToString(),
+                    Type = orig.Type.ToString(),
+                    NewQuantity = req.NewQuantity,
+                    NewPrice = req.NewPrice,
+                    ParentAlgoId = orig.ParentAlgoId,
+                    AlgoSliceSeq = orig.AlgoSliceSeq,
+                },
+                () =>
+                {
+                    _replacements.TryAdd(intent);
+                    _ownership.RegisterReplaceLink(req.OriginalClOrdId, newClOrdId);
+                });
+        }
+        catch (WalBackpressureException ex)
+        {
+            // Roll back the margin Prepare since neither the registry
+            // nor the ownership link was populated.
+            _replaceMargin.AbortReplace(newClOrdId);
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "orders.modify"));
+            return OrderModifyResult.WalBackpressure(ex.Message);
+        }
+
+        try
+        {
+            await _gateway.CancelReplaceAsync(orig, newClOrdId, req.NewQuantity, req.NewPrice, ct);
+        }
+        catch (Exception ex)
+        {
+            MetricsRegistry.OrdersGatewayFailed.Add(1,
+                new KeyValuePair<string, object?>("path", "modify"));
+            _logger.LogError(ex,
+                "Gateway CancelReplaceAsync failed for orig {OrigClOrdId} new {NewClOrdId}; rolling back.",
+                req.OriginalClOrdId, newClOrdId);
+            // Roll back: drop intent, abort margin delta. Original
+            // order keeps its pre-modify state (Working /
+            // PartiallyFilled). Surface a synthetic Rejected ER under
+            // the new ClOrdID so the trader's blotter shows the
+            // failure rather than a phantom "modify pending forever".
+            _replacements.TryConsume(newClOrdId, out _);
+            _replaceMargin.AbortReplace(newClOrdId);
+            _sink.Publish(new ExecutionEvent(
+                req.Owner, newClOrdId, orig.Symbol, orig.Side,
+                OrderStatus.Rejected, ExecKind.Rejected,
+                LeavesQuantity: 0, CumulativeQuantity: 0,
+                LastQuantity: 0, LastPrice: 0m,
+                RejectReason: "gateway_unavailable",
+                TimestampUtc: DateTimeOffset.UtcNow));
+            return OrderModifyResult.GatewayFailed(newClOrdId, ex);
+        }
+
+        MetricsRegistry.OrdersModifyRequested.Add(1,
+            new KeyValuePair<string, object?>("symbol", orig.Symbol),
+            new KeyValuePair<string, object?>("side", orig.Side.ToString()));
+
+        return OrderModifyResult.Accepted(newClOrdId);
+    }
+}
+
+public sealed record OrderModifyRequest(
+    EndClientId Owner,
+    ulong OriginalClOrdId,
+    long NewQuantity,
+    decimal? NewPrice);
+
+/// <summary>
+/// Outcome of <see cref="OrderModifyService.ModifyAsync"/>. The
+/// discriminator is the <see cref="Kind"/> property; callers branch
+/// on it to map to their transport.
+/// </summary>
+public sealed class OrderModifyResult
+{
+    public OrderModifyResultKind Kind { get; }
+    public ulong NewClOrdId { get; }
+    public string? Reason { get; }
+    public Exception? GatewayException { get; }
+
+    private OrderModifyResult(OrderModifyResultKind kind, ulong newClOrdId, string? reason, Exception? ex)
+    {
+        Kind = kind;
+        NewClOrdId = newClOrdId;
+        Reason = reason;
+        GatewayException = ex;
+    }
+
+    public static OrderModifyResult Accepted(ulong newClOrdId) =>
+        new(OrderModifyResultKind.Accepted, newClOrdId, null, null);
+    public static OrderModifyResult RiskRejected(string reason) =>
+        new(OrderModifyResultKind.RiskRejected, 0, reason, null);
+    public static OrderModifyResult GatewayFailed(ulong newClOrdId, Exception ex) =>
+        new(OrderModifyResultKind.GatewayFailed, newClOrdId, "gateway_unavailable", ex);
+    public static OrderModifyResult WalBackpressure(string detail) =>
+        new(OrderModifyResultKind.WalBackpressure, 0, detail, null);
+    public static OrderModifyResult BadRequest(string reason) =>
+        new(OrderModifyResultKind.BadRequest, 0, reason, null);
+    public static OrderModifyResult Conflict(string reason) =>
+        new(OrderModifyResultKind.Conflict, 0, reason, null);
+    public static OrderModifyResult NotFound { get; } =
+        new(OrderModifyResultKind.NotFound, 0, null, null);
+    public static OrderModifyResult Drained { get; } =
+        new(OrderModifyResultKind.Drained, 0, "service draining", null);
+}
+
+public enum OrderModifyResultKind
+{
+    Accepted,
+    NotFound,
+    Conflict,
+    BadRequest,
+    RiskRejected,
+    GatewayFailed,
+    WalBackpressure,
+    Drained,
+}

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -27,18 +27,33 @@ namespace B3.Trading.Application;
 public sealed class PendingReplacementRegistry
 {
     private readonly ConcurrentDictionary<ulong, OrderReplacementIntent> _byNewClOrdId = new();
+    // Secondary index: original ClOrdID → new ClOrdID. Enforces the
+    // "one in-flight modify per original" guard (slice 4).
+    private readonly ConcurrentDictionary<ulong, ulong> _byOriginalClOrdId = new();
 
     /// <summary>
     /// Records an in-flight modify. Returns <c>false</c> when an intent
     /// for the same <paramref name="intent"/>.<see cref="OrderReplacementIntent.NewClOrdId"/>
-    /// is already tracked — should be impossible because new ClOrdIDs
-    /// come from <see cref="ClOrdIdPrefixRegistry"/> and are unique by
-    /// construction, but the guard is cheap and fails loud.
+    /// is already tracked OR when there's already an in-flight modify
+    /// for the same <see cref="OrderReplacementIntent.OriginalClOrdId"/>
+    /// (the slice-4 guard) — exactly one pending modify per original
+    /// order at any time.
     /// </summary>
     public bool TryAdd(OrderReplacementIntent intent)
     {
         ArgumentNullException.ThrowIfNull(intent);
-        return _byNewClOrdId.TryAdd(intent.NewClOrdId, intent);
+        // Reserve the orig slot first; if successful, claim the new
+        // slot. If new slot is unexpectedly taken (collision on the
+        // ClOrdID counter — should never happen in practice), roll
+        // back the orig reservation.
+        if (!_byOriginalClOrdId.TryAdd(intent.OriginalClOrdId, intent.NewClOrdId))
+            return false;
+        if (!_byNewClOrdId.TryAdd(intent.NewClOrdId, intent))
+        {
+            _byOriginalClOrdId.TryRemove(intent.OriginalClOrdId, out _);
+            return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -50,6 +65,7 @@ public sealed class PendingReplacementRegistry
     {
         if (_byNewClOrdId.TryRemove(newClOrdId, out var found))
         {
+            _byOriginalClOrdId.TryRemove(found.OriginalClOrdId, out _);
             intent = found;
             return true;
         }
@@ -72,6 +88,16 @@ public sealed class PendingReplacementRegistry
         intent = null;
         return false;
     }
+
+    /// <summary>
+    /// Slice 4 of #122: in-flight guard for the modify endpoint.
+    /// Returns <c>true</c> when there's already a pending modify for
+    /// <paramref name="originalClOrdId"/> — the endpoint rejects with
+    /// 409 in that case so the caller cannot stack two modify requests
+    /// on the same order and race the venue.
+    /// </summary>
+    public bool IsOriginalInFlight(ulong originalClOrdId) =>
+        _byOriginalClOrdId.ContainsKey(originalClOrdId);
 
     /// <summary>Test/observability helper.</summary>
     internal int CountForTesting => _byNewClOrdId.Count;

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -17,6 +17,7 @@ namespace B3.Trading.Application.Persistence;
 /// </summary>
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
 [JsonDerivedType(typeof(OrderSubmittedEvent), "order.submitted")]
+[JsonDerivedType(typeof(OrderReplaceRequestedEvent), "order.replace-requested")]
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
 [JsonDerivedType(typeof(SymbolHaltToggledEvent), "symbol-halt.toggled")]
@@ -54,6 +55,38 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// with <c>null</c> on both, which matches the manual-order semantics
     /// they actually carried.
     /// </summary>
+    public ulong? ParentAlgoId { get; init; }
+    public int? AlgoSliceSeq { get; init; }
+}
+
+/// <summary>
+/// Slice 4 of #122. Recorded the moment <c>PUT /orders/{clOrdId}</c>
+/// reaches the modify pipeline (post-validation, post-risk, after
+/// margin Prepare succeeded but before the gateway dispatch).
+///
+/// <para>
+/// Replay re-registers the in-flight intent in
+/// <see cref="PendingReplacementRegistry"/> and the new→orig link in
+/// <see cref="OrderOwnershipMap"/> so that, if the host restarts
+/// between the WAL append and the venue's Replaced/Rejected ER, the
+/// rebuilt state can still resolve the eventual ack. Margin
+/// reservations are NOT replayed (matches
+/// <see cref="OrderSubmittedEvent"/> semantics — reservations are
+/// not durable across restarts in slice 2 of #107).
+/// </para>
+/// </summary>
+public sealed record OrderReplaceRequestedEvent : WalEvent
+{
+    public required ulong OriginalClOrdId { get; init; }
+    public required ulong NewClOrdId { get; init; }
+    public required string EndClientId { get; init; }
+    public required string FirmId { get; init; }
+    public required string Symbol { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required string Side { get; init; }
+    public required string Type { get; init; }
+    public required long NewQuantity { get; init; }
+    public decimal? NewPrice { get; init; }
     public ulong? ParentAlgoId { get; init; }
     public int? AlgoSliceSeq { get; init; }
 }

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -230,6 +230,15 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         decimal newRemainingNotional,
         CancellationToken ct)
     {
+        // Margin globally disabled: the DI container points
+        // IMarginProvider at the NoOp variant and never reserves on
+        // submit. The replace coordinator, however, is always wired
+        // to the concrete provider (so Commit/Abort can clean up if
+        // margin gets toggled mid-session); short-circuit Prepare here
+        // so it doesn't reject upsizes against an empty ledger.
+        if (!_options.CurrentValue.Margin.Enabled)
+            return Task.FromResult(RiskDecision.Approve);
+
         // Sells / markets / non-positive notionals never touched the
         // reservation ledger on submit; they don't here either.
         if (newRemainingNotional <= 0m)

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -102,6 +102,7 @@ builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>(
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
 builder.Services.AddSingleton<ExecutionReportProcessor>();
 builder.Services.AddSingleton<OrderSubmissionService>();
+builder.Services.AddSingleton<OrderModifyService>();
 
 // Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).
 // In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -92,6 +92,7 @@ public sealed class EventReplayer
     private readonly SymbolHaltService _symbolHalts;
     private readonly ExecutionReportProcessor _processor;
     private readonly AlgoBook _algos;
+    private readonly PendingReplacementRegistry? _replacements;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -99,7 +100,8 @@ public sealed class EventReplayer
         KillSwitchService killSwitch,
         SymbolHaltService symbolHalts,
         ExecutionReportProcessor processor,
-        AlgoBook algos)
+        AlgoBook algos,
+        PendingReplacementRegistry? replacements = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -107,6 +109,7 @@ public sealed class EventReplayer
         _symbolHalts = symbolHalts;
         _processor = processor;
         _algos = algos;
+        _replacements = replacements;
     }
 
     public void Apply(WalEvent evt)
@@ -124,6 +127,36 @@ public sealed class EventReplayer
                 // engine-side (slice 5/6); replay only re-creates the order
                 // — the parent's Working/Filled state is reconstructed from
                 // the child ER stream through the processor below.
+                break;
+            case OrderReplaceRequestedEvent rr:
+                // Slice 4 of #122. Re-register the in-flight intent and
+                // the new→orig link so a subsequent Replaced/Rejected ER
+                // on the new ClOrdID still resolves correctly. If the
+                // orig is already gone (e.g. terminal ER replayed after
+                // this event), the intent will never be consumed and the
+                // entry stays as a benign artifact — same posture as a
+                // re-created order whose ER stream was lost.
+                if (_replacements is not null
+                    && _ownership.TryResolve(rr.OriginalClOrdId, out _))
+                {
+                    var rrSide = Enum.Parse<OrderSide>(rr.Side, ignoreCase: true);
+                    var rrType = Enum.Parse<OrderType>(rr.Type, ignoreCase: true);
+                    var intent = new OrderReplacementIntent(
+                        OriginalClOrdId: rr.OriginalClOrdId,
+                        NewClOrdId: rr.NewClOrdId,
+                        Owner: new EndClientId(rr.EndClientId),
+                        Symbol: rr.Symbol,
+                        SecurityId: rr.SecurityId,
+                        Side: rrSide,
+                        Type: rrType,
+                        NewQuantity: rr.NewQuantity,
+                        NewPrice: rr.NewPrice,
+                        FirmId: rr.FirmId,
+                        ParentAlgoId: rr.ParentAlgoId,
+                        AlgoSliceSeq: rr.AlgoSliceSeq);
+                    _replacements.TryAdd(intent);
+                    _ownership.RegisterReplaceLink(rr.OriginalClOrdId, rr.NewClOrdId);
+                }
                 break;
             case ExecutionReportReceivedEvent er:
                 if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))

--- a/backend/tests/B3.Trading.Api.Tests/OrdersModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersModifyEndpointTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Slice 4 of #122 — HTTP integration coverage for
+/// <c>PUT /orders/{clOrdId}</c>. Asserts the mapping from
+/// <see cref="B3.Trading.Application.OrderModifyResultKind"/> values
+/// to status codes and the side-effect contract (in-flight guard,
+/// owner-isolation, cum-quantity floor).
+/// </summary>
+public class OrdersModifyEndpointTests
+{
+    [Fact]
+    public async Task PUT_orders_HappyPath_Returns202WithNewClOrdId()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, posted.StatusCode);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        var put = await PutModify(http, token, origAck!.ClOrdId, qty: 200, price: 30m);
+        var bodyText = await put.Content.ReadAsStringAsync();
+        Assert.True(put.StatusCode == HttpStatusCode.Accepted, $"Expected 202, got {put.StatusCode}: {bodyText}");
+        var ack = System.Text.Json.JsonSerializer.Deserialize<ModifyAck>(bodyText,
+            new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+        Assert.NotNull(ack);
+        Assert.Equal(origAck.ClOrdId, ack!.OriginalClOrdId);
+        Assert.NotEqual(origAck.ClOrdId, ack.ClOrdId);
+        Assert.False(string.IsNullOrEmpty(ack.ClOrdId));
+    }
+
+    [Fact]
+    public async Task PUT_orders_InvalidClOrdIdFormat_Returns404()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var put = await PutModify(http, token, "not-a-number", qty: 200, price: 30m);
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_orders_UnknownClOrdId_Returns404()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // The ClOrdID space is per-end-client and starts non-zero; a
+        // very large number will never have been generated.
+        var put = await PutModify(http, token, "99999999999999999", qty: 200, price: 30m);
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_orders_OwnerMismatch_Returns404_NoCrossOwnerLeak()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var aliceToken = await f.LoginAsync(http);
+        var posted = await PostOrder(http, aliceToken, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        // bob is a separately-seeded user (env-seeded alongside alice).
+        var bobToken = await f.LoginAsync(http, user: "bob", password: "wonderland");
+        var put = await PutModify(http, bobToken, origAck!.ClOrdId, qty: 200, price: 30m);
+        // Same status as a non-existent order — do not leak existence
+        // across owners.
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_orders_ZeroQuantity_Returns400()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        var put = await PutModify(http, token, origAck!.ClOrdId, qty: 0, price: 30m);
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_orders_SecondModifyForSameOrig_Returns409()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        var first = await PutModify(http, token, origAck!.ClOrdId, qty: 200, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+
+        // Mock gateway just queues the cancel-replace request; no ER
+        // arrives, so the in-flight intent stays pending.
+        var second = await PutModify(http, token, origAck.ClOrdId, qty: 250, price: 30m);
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    private static async Task<HttpResponseMessage> PostOrder(
+        HttpClient http, string token, int qty, decimal price, string side = "Buy")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = side,
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+            })
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PutModify(
+        HttpClient http, string token, string clOrdId, int qty, decimal? price)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{clOrdId}")
+        {
+            Content = JsonContent.Create(new { Quantity = qty, Price = price })
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason);
+    private sealed record ModifyAck(string ClOrdId, string OriginalClOrdId);
+}

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -64,6 +64,32 @@ public class OrderModifyMarginAndProcessorTests
         Assert.True(reg.TryConsume(2UL, out _));
     }
 
+    [Fact]
+    public void Registry_IsOriginalInFlight_reflectsAddAndConsume()
+    {
+        var reg = new PendingReplacementRegistry();
+        Assert.False(reg.IsOriginalInFlight(1UL));
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30m)));
+        Assert.True(reg.IsOriginalInFlight(1UL));
+        Assert.True(reg.TryConsume(2UL, out _));
+        Assert.False(reg.IsOriginalInFlight(1UL));
+    }
+
+    [Fact]
+    public void Registry_TryAdd_rejectsSecondModifyForSameOriginal()
+    {
+        // Slice-4 guard: only one in-flight modify per original ClOrdID.
+        // Second TryAdd with same OriginalClOrdId but a fresh new
+        // ClOrdID must fail (prevents stacked modifies racing the venue).
+        var reg = new PendingReplacementRegistry();
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30m)));
+        Assert.False(reg.TryAdd(BuyLimitIntent(1UL, 3UL, "alice", 200, 31m)));
+        // After consuming the first, a second modify for the same orig
+        // is now allowed.
+        Assert.True(reg.TryConsume(2UL, out _));
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 3UL, "alice", 200, 31m)));
+    }
+
     // ---------------- HydrateReplacement ----------------
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -146,6 +146,95 @@ public class RecoveryAndSnapshotTests : IDisposable
         Assert.Empty(snap!.Positions);
     }
 
+    [Fact]
+    public async Task Recovery_OrderReplaceRequested_RestoresIntentAndOwnershipLink()
+    {
+        // Phase 1: submit an order, then dispatch a replace-requested event.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, _, dispatcher, _, _, _) = BuildState(store);
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "PETR4", OrderSide.Buy, 100, 30m);
+            dispatcher.Dispatch(
+                new OrderReplaceRequestedEvent
+                {
+                    OriginalClOrdId = 1UL,
+                    NewClOrdId = 2UL,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Limit",
+                    NewQuantity = 200,
+                    NewPrice = 31m,
+                },
+                () => { /* live wiring done by OrderModifyService; replay re-applies it */ });
+            await store.FlushAsync();
+        }
+
+        // Phase 2: cold boot — replayer with PendingReplacementRegistry must
+        // re-register the intent AND the new→orig ownership link so a
+        // subsequent Replaced/Rejected ER under newClOrdId resolves.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
+            var replacements = new PendingReplacementRegistry();
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos, replacements);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.True(replacements.IsOriginalInFlight(1UL));
+            Assert.True(replacements.TryGet(2UL, out var intent));
+            Assert.NotNull(intent);
+            Assert.Equal(1UL, intent!.OriginalClOrdId);
+            Assert.Equal(200, intent.NewQuantity);
+            Assert.Equal(31m, intent.NewPrice);
+            // Owner of newClOrdId resolves through the replace link.
+            Assert.True(ownership.TryResolve(2UL, out var newOwner));
+            Assert.Equal(new EndClientId("alice"), newOwner);
+        }
+    }
+
+    [Fact]
+    public async Task Recovery_OrderReplaceRequested_NoReplacementsRegistry_IsNoOp()
+    {
+        // Backward-compat: existing constructors without the optional
+        // PendingReplacementRegistry must still tolerate the new event.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, _, dispatcher, _, _, _) = BuildState(store);
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "PETR4", OrderSide.Buy, 100, 30m);
+            dispatcher.Dispatch(
+                new OrderReplaceRequestedEvent
+                {
+                    OriginalClOrdId = 1UL,
+                    NewClOrdId = 2UL,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Limit",
+                    NewQuantity = 200,
+                    NewPrice = 31m,
+                },
+                () => { });
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out _));
+        }
+    }
+
     private static (
         WorkingOrderBook,
         PositionKeeper,


### PR DESCRIPTION
Slice 4 of #122 — wires the cancel-replace pipeline end-to-end and exposes it as `PUT /orders/{clOrdId}`.

## What ships

- **`OrderModifyService`** (Application): full pipeline mirroring `OrderSubmissionService` — drain gate, owner-isolation, in-flight guard, qty>cum check, risk evaluation with `ReplaceOriginalClOrdId` context (slice 3), margin Prepare (delta-only), atomic WAL dispatch + intent registration + ownership replace-link, gateway dispatch, rollback with synthetic Rejected ER on gateway failure.
- **`PUT /orders/{clOrdId}`** endpoint mapping `OrderModifyResultKind` → HTTP statuses (202 / 404 / 409 / 400 / 422 / 502 / 503).
- **`PendingReplacementRegistry.IsOriginalInFlight`** + secondary index by `OriginalClOrdId`. `TryAdd` is now atomic across both indices (rolls back orig slot if new slot collides). Enforces one in-flight modify per original.
- **`OrderReplaceRequestedEvent`** WAL record (discriminator `order.replace-requested`). `EventReplayer` ctor takes optional `PendingReplacementRegistry`; on replay, re-registers the intent + replace-link iff the orig is still resolvable.
- **Metric** `trading.orders.modify_requested` (tags symbol + side); risk/gateway counters tagged with `path=modify`.
- **Bug fix uncovered by the new HTTP tests:** `ReserveOnSubmitMarginProvider.PrepareReplaceAsync` now honors `Margin.Enabled`. When margin is globally disabled, the always-wired coordinator was rejecting modify-upsizes against an empty ledger; short-circuits to Approve when disabled.
- **DI:** `OrderModifyService` singleton registered.

## Tests (+10)

- `OrdersModifyEndpointTests` (Api, 6): happy path, 404 unknown / bad format, cross-owner isolation (no leak), qty=0 → 400, in-flight guard → 409.
- Registry tests (Application, 2): `IsOriginalInFlight` reflects add/consume; second `TryAdd` for same orig rejected.
- `RecoveryAndSnapshotTests` (Application, 2): replay restores intent + ownership link; backward-compat with EventReplayer ctor that doesn't take the registry.

Suite **557 verde** (43 + 330 + 184 + 12 skip). Format clean.

Refs #122.