### PR TITLE
feat(frontend): slice 5 of #122 — Modify button + modal in the blotter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,6 @@ jobs:
 
       - name: Run mdProtocol decoder tests (no deps, node:test)
         run: node --test frontend/test/decoder.test.mjs
+
+      - name: Run state reducer tests (no deps, node:test)
+        run: node --test frontend/test/state-modify.test.mjs

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -156,7 +156,7 @@
               <tr>
                 <th>ClOrdID</th><th>Symbol</th><th>Side</th><th>Type</th>
                 <th class="num">Qty</th><th class="num">Leaves</th><th class="num">Cum</th>
-                <th class="num">Price</th><th>Status</th><th></th>
+                <th class="num">Price</th><th>Status</th><th></th><th></th>
               </tr>
             </thead>
             <tbody id="blotter-body"></tbody>
@@ -372,6 +372,30 @@
       <div class="modal-actions">
         <button type="button" id="session-modal-logout" class="link-button">Logout</button>
         <button type="submit" id="session-modal-submit">Renew session</button>
+      </div>
+    </form>
+  </div>
+
+  <!-- ORDER MODIFY MODAL --------------------------------------------- -->
+  <!-- Slice 5 of #122. Triggered by the Modify button in the blotter
+       row (or programmatically by app.js); pre-fills with the order's
+       current quantity/price and routes through PUT /orders/{clOrdId}. -->
+  <div id="modify-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="modify-modal-title">
+    <form id="modify-modal-form" class="modal-card">
+      <h2 id="modify-modal-title">Modify order</h2>
+      <p id="modify-modal-summary" class="muted-line"></p>
+      <label>
+        <span>New quantity</span>
+        <input id="modify-modal-qty" type="number" min="1" step="1" required inputmode="numeric" />
+      </label>
+      <label>
+        <span>New price</span>
+        <input id="modify-modal-price" type="number" min="0" step="any" inputmode="decimal" />
+      </label>
+      <p id="modify-modal-error" class="error" hidden></p>
+      <div class="modal-actions">
+        <button type="button" id="modify-modal-cancel" class="link-button">Cancel</button>
+        <button type="submit" id="modify-modal-submit">Send modify</button>
       </div>
     </form>
   </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,6 @@
 // App entry point: wires login → worker → state → UI together.
 
-import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cancelOrder, getAdminFirms,
+import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cancelOrder, modifyOrder, getAdminFirms,
          validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          getHaltStatus, haltSymbol, resumeSymbol,
@@ -58,6 +58,7 @@ function init() {
   ui.setHandlers({
     onSubmitOrder: handleSubmitOrder,
     onCancelOrder: handleCancelOrder,
+    onModifyOrder: handleModifyOrder,
     onLogout: logout,
     onApplyMd: handleApplyMd,
     onSwitchView: handleSwitchView,
@@ -553,6 +554,41 @@ async function handleCancelOrder(clOrdId) {
     ui.setTicketFeedback(`cancel failed: ${err.message}`, "error");
   } finally {
     state.markCancelInflight(clOrdId, false);
+  }
+}
+
+// Slice 5 of #122. Routes the blotter "Modify" intent through
+// PUT /orders/{clOrdId}. The modal already validated qty/price and
+// is responsible for showing the inline error; here we only translate
+// transport failures into modal errors and toggle inflight state.
+async function handleModifyOrder(clOrdId, payload) {
+  if (!session) return;
+  const st = state.getState();
+  if (st.inflightModifies && st.inflightModifies.has(clOrdId)) return;
+  const order = st.orders.get(clOrdId);
+  if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) {
+    ui.setModifyModalError("Order is no longer modifiable.");
+    return;
+  }
+  state.markModifyInflight(clOrdId, true);
+  ui.setModifyModalSubmitting(true);
+  try {
+    await modifyOrder(session.backend, session.token, clOrdId, payload);
+    // Close the modal on accept; the new ClOrdID will arrive via the
+    // orders.me stream and surface in the blotter — no need for a
+    // toast since the trader can see the row appear.
+    ui.closeModifyModal();
+  } catch (err) {
+    if (err.status === 401) { logout(); return; }
+    // Backend error bodies vary across status codes (Conflict /
+    // BadRequest / UnprocessableEntity / BadGateway / etc). The
+    // shared shape is `{ error: "..." }` for the structured cases —
+    // fall back to err.message for transport errors.
+    const reason = (err.body && err.body.error) || err.message || "modify failed";
+    ui.setModifyModalError(reason);
+  } finally {
+    state.markModifyInflight(clOrdId, false);
+    ui.setModifyModalSubmitting(false);
   }
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -90,6 +90,20 @@ export async function cancelOrder(backend, token, clOrdId) {
   return jsonOrThrow(resp);
 }
 
+// Slice 5 of #122. Cancel-replace ("modify") the working order.
+// Backend returns 202 + { ClOrdId, OriginalClOrdId } on accept, with
+// the new ClOrdID being the venue-bound replacement. Other status
+// codes (404 / 409 / 400 / 422 / 502 / 503) bubble up via jsonOrThrow
+// so the caller can surface a user-readable reason.
+export async function modifyOrder(backend, token, clOrdId, payload) {
+  const resp = await fetch(`${backend}/orders/${encodeURIComponent(clOrdId)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(payload),
+  });
+  return jsonOrThrow(resp);
+}
+
 // Admin-only: per-firm operator visibility. Returns 403 for non-admin
 // callers — the UI must gate the call by inspecting the JWT role
 // before invoking this. Schema mirrors AdminEndpoints.MapAdmin /firms.

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -70,6 +70,11 @@ const state = {
   // server ack yet). Used to disable the row's Cancel button so the
   // trader gets immediate visual feedback and can't fire repeat DELETEs.
   inflightCancels: new Set(),
+  // Slice 5 of #122. Per-ClOrdID set of modifies currently in flight
+  // (PUT /orders issued, no server ack yet). Drives the "Modifying…"
+  // state on the row's Modify button so a slow server can't yield two
+  // PUTs racing the venue.
+  inflightModifies: new Set(),
   // Wall-clock when the active selectedSymbol was set. The DOB renderer
   // uses this to decide when to upgrade the "awaiting book snapshot…"
   // placeholder to a louder "no book — check MD settings ⚙" warning
@@ -156,6 +161,7 @@ export function clearAll() {
   state.selectedClOrdId = null;
   state.pendingFatFinger = null;
   state.inflightCancels.clear();
+  state.inflightModifies.clear();
   notify("all");
 }
 
@@ -596,5 +602,16 @@ export function markCancelInflight(clOrdId, inflight) {
   const before = state.inflightCancels.has(clOrdId);
   if (inflight) state.inflightCancels.add(clOrdId);
   else state.inflightCancels.delete(clOrdId);
+  if (before !== inflight) notify("orders");
+}
+
+// Slice 5 of #122. Modify counterpart of markCancelInflight — flips
+// the per-ClOrdID flag the renderer reads to decide whether the row's
+// Modify button shows "Modifying…" + disabled.
+export function markModifyInflight(clOrdId, inflight) {
+  if (!clOrdId) return;
+  const before = state.inflightModifies.has(clOrdId);
+  if (inflight) state.inflightModifies.add(clOrdId);
+  else state.inflightModifies.delete(clOrdId);
   if (before !== inflight) notify("orders");
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -26,6 +26,7 @@ export { fmtQty, fmtPx };
 
 let onSubmitOrder = () => {};
 let onCancelOrder = () => {};
+let onModifyOrder = () => {};
 let onLogout      = () => {};
 let onApplyMd     = () => {};
 let onSwitchView  = () => {};
@@ -40,6 +41,7 @@ let onToggleTapeShowAll = () => {};
 export function setHandlers(handlers) {
   onSubmitOrder    = handlers.onSubmitOrder    ?? onSubmitOrder;
   onCancelOrder    = handlers.onCancelOrder    ?? onCancelOrder;
+  onModifyOrder    = handlers.onModifyOrder    ?? onModifyOrder;
   onLogout         = handlers.onLogout         ?? onLogout;
   onApplyMd        = handlers.onApplyMd        ?? onApplyMd;
   onSwitchView     = handlers.onSwitchView     ?? onSwitchView;
@@ -164,6 +166,107 @@ export function setSessionModalError(message) {
   el.hidden = false; el.textContent = message;
 }
 
+// ── Modify-order modal (slice 5 of #122) ───────────────────────────
+
+// The modal stores its "current target" on the form element via
+// dataset so the submit handler doesn't depend on UI state churn
+// while the modal is open (e.g. background ER updates the row but
+// the trader's intent is still keyed to the originally-clicked
+// ClOrdID).
+function openModifyModal(clOrdId) {
+  const st = getState();
+  const order = st.orders?.get(clOrdId);
+  if (!order) return;
+  if (isTerminalOrderStatus(order.status)) return;
+  if (st.inflightModifies?.has(clOrdId)) return;
+  if (st.inflightCancels?.has(clOrdId)) return;
+
+  const modal = $("modify-modal");
+  const form  = $("modify-modal-form");
+  const qty   = $("modify-modal-qty");
+  const price = $("modify-modal-price");
+  const summary = $("modify-modal-summary");
+  const error = $("modify-modal-error");
+  if (!modal || !form || !qty) return;
+
+  form.dataset.clordid = clOrdId;
+  qty.value = order.quantity ?? "";
+  if (price) {
+    if (order.price == null) {
+      price.value = "";
+      price.disabled = (order.type === "Market");
+    } else {
+      price.value = order.price;
+      price.disabled = false;
+    }
+  }
+  if (summary) {
+    const px = order.price == null ? "MKT" : order.price;
+    summary.textContent =
+      `Order ${order.clOrdId} — ${order.symbol} ${order.side} ${order.type} ` +
+      `(qty ${order.quantity}, leaves ${order.leavesQuantity}, cum ${order.cumulativeQuantity}, px ${px})`;
+  }
+  if (error) { error.hidden = true; error.textContent = ""; }
+  modal.hidden = false;
+  // Focus the qty field so keyboard-only operators don't need a
+  // round-trip through the mouse to change the size.
+  setTimeout(() => qty.focus(), 0);
+}
+
+export function closeModifyModal() {
+  const modal = $("modify-modal");
+  const form  = $("modify-modal-form");
+  if (!modal) return;
+  modal.hidden = true;
+  if (form) delete form.dataset.clordid;
+  setModifyModalError(null);
+  setModifyModalSubmitting(false);
+}
+
+export function setModifyModalError(message) {
+  const el = $("modify-modal-error");
+  if (!el) return;
+  if (!message) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false; el.textContent = message;
+}
+
+export function setModifyModalSubmitting(busy) {
+  const submit = $("modify-modal-submit");
+  if (!submit) return;
+  submit.disabled = !!busy;
+  submit.textContent = busy ? "Sending…" : "Send modify";
+}
+
+function submitModifyForm() {
+  const form  = $("modify-modal-form");
+  const qtyEl = $("modify-modal-qty");
+  const pxEl  = $("modify-modal-price");
+  if (!form || !qtyEl) return;
+  const clOrdId = form.dataset.clordid;
+  if (!clOrdId) return;
+
+  const qtyRaw = qtyEl.value.trim();
+  const qty = Number(qtyRaw);
+  if (!Number.isFinite(qty) || qty <= 0 || !Number.isInteger(qty)) {
+    setModifyModalError("Quantity must be a positive integer.");
+    return;
+  }
+  let price = null;
+  if (pxEl && !pxEl.disabled) {
+    const pxRaw = pxEl.value.trim();
+    if (pxRaw !== "") {
+      const px = Number(pxRaw);
+      if (!Number.isFinite(px) || px <= 0) {
+        setModifyModalError("Price must be a positive number.");
+        return;
+      }
+      price = px;
+    }
+  }
+  setModifyModalError(null);
+  onModifyOrder(clOrdId, { quantity: qty, price });
+}
+
 export function bindUi() {
   // Order ticket: enable/disable price field by type.
   const typeEl = $("ticket-type");
@@ -211,18 +314,47 @@ export function bindUi() {
 
   $("logout").addEventListener("click", () => onLogout());
 
-  // Event delegation for per-row Cancel buttons in the blotter,
-  // plus row selection (clicking anywhere outside the cancel button).
+  // Event delegation for per-row Cancel + Modify buttons in the
+  // blotter, plus row selection (clicking anywhere outside the
+  // action buttons).
   $("blotter-body").addEventListener("click", (e) => {
-    const btn = e.target.closest(".cancel-btn");
-    if (btn) {
-      const clOrdId = btn.dataset.clordid;
+    const cancelBtn = e.target.closest(".cancel-btn");
+    if (cancelBtn) {
+      const clOrdId = cancelBtn.dataset.clordid;
       if (clOrdId) onCancelOrder(clOrdId);
+      return;
+    }
+    const modifyBtn = e.target.closest(".modify-btn");
+    if (modifyBtn) {
+      const clOrdId = modifyBtn.dataset.clordid;
+      if (clOrdId) openModifyModal(clOrdId);
       return;
     }
     const row = e.target.closest("tr[data-clordid]");
     if (row) onSelectOrder(row.dataset.clordid);
   });
+
+  // Modify modal wiring (slice 5 of #122).
+  const modifyForm = $("modify-modal-form");
+  const modifyCancelBtn = $("modify-modal-cancel");
+  if (modifyForm) {
+    modifyForm.addEventListener("submit", (e) => {
+      e.preventDefault();
+      submitModifyForm();
+    });
+  }
+  if (modifyCancelBtn) {
+    modifyCancelBtn.addEventListener("click", () => closeModifyModal());
+  }
+  const modifyModal = $("modify-modal");
+  if (modifyModal) {
+    // Backdrop click closes the modal — same UX precedent as the
+    // session-expiry modal but with closeModifyModal() (no logout
+    // side-effect). Esc handled in the global keydown below.
+    modifyModal.addEventListener("click", (e) => {
+      if (e.target === modifyModal) closeModifyModal();
+    });
+  }
 
   // Blotter filter: text + status select. Persisted via app.js.
   const filterText = $("blotter-filter-text");
@@ -358,7 +490,14 @@ function onGlobalKeydown(e) {
     return;
   }
   if (e.key === "Escape") {
-    // Esc inside the ticket form clears it; outside, clear blotter selection.
+    // Esc closes the modify modal first if open (highest-priority
+    // dismiss); inside the ticket form clears it; outside, clear
+    // blotter selection.
+    const modifyModal = $("modify-modal");
+    if (modifyModal && !modifyModal.hidden) {
+      closeModifyModal();
+      return;
+    }
     if (target?.closest && target.closest("#ticket-form")) {
       clearTicket();
     } else {
@@ -927,14 +1066,24 @@ const HIGHLIGHT_MS = 2000;
 function orderRow(o, st) {
   const terminal = isTerminalOrderStatus(o.status);
   const cancelInflight = st.inflightCancels?.has(o.clOrdId);
+  const modifyInflight = st.inflightModifies?.has(o.clOrdId);
   const price = o.price == null ? "—" : fmtPx(o.price);
   const highlightAt = st.ordersHighlight?.get(o.clOrdId);
   const fresh = highlightAt && (Date.now() - highlightAt) < HIGHLIGHT_MS;
   const selected = st.selectedClOrdId === o.clOrdId;
   const cls = [fresh ? "row-fresh" : "", selected ? "row-selected" : ""].filter(Boolean).join(" ");
-  const cancelDisabled = terminal || cancelInflight;
+  const cancelDisabled = terminal || cancelInflight || modifyInflight;
   const cancelLabel = cancelInflight ? "Cancelling…" : "Cancel";
   const cancelCls = "cancel-btn" + (cancelInflight ? " cancelling" : "");
+  // Slice 5 of #122. Modify button shares row-selection delegation
+  // (data-clordid on the button so the click handler can map it back
+  // to the order without walking the row). Disabled while terminal
+  // or while either a cancel or another modify is in flight — the
+  // backend's in-flight guard would 409 a second modify anyway, but
+  // gating client-side avoids the round-trip and keeps the UX honest.
+  const modifyDisabled = terminal || modifyInflight || cancelInflight;
+  const modifyLabel = modifyInflight ? "Modifying…" : "Modify";
+  const modifyCls = "modify-btn" + (modifyInflight ? " modifying" : "");
   return `<tr data-clordid="${escapeHtml(o.clOrdId)}"${cls ? ` class="${cls}"` : ""}>
     <td><code>${escapeHtml(o.clOrdId)}</code></td>
     <td>${escapeHtml(o.symbol)}</td>
@@ -945,6 +1094,7 @@ function orderRow(o, st) {
     <td class="num">${fmtQty(o.cumulativeQuantity)}</td>
     <td class="num">${price}</td>
     <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}</td>
+    <td><button class="${modifyCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Modify order ${escapeHtml(o.clOrdId)}" title="Modify" ${modifyDisabled ? "disabled" : ""}>${modifyLabel}</button></td>
     <td><button class="${cancelCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" title="Cancel (Del)" ${cancelDisabled ? "disabled" : ""}>${cancelLabel}</button></td>
   </tr>`;
 }

--- a/frontend/test/state-modify.test.mjs
+++ b/frontend/test/state-modify.test.mjs
@@ -1,0 +1,59 @@
+// Slice 5 of #122 — markModifyInflight reducer tests for state.js.
+// Runs with `node --test frontend/test/state-modify.test.mjs`.
+//
+// Coverage: idempotency, set/clear flips notify("orders"), clearAll
+// resets the set, and inflightModifies starts empty.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust=${n}`);
+}
+
+test('inflightModifies starts empty', async () => {
+  const s = await freshState();
+  const st = s.getState();
+  assert.ok(st.inflightModifies instanceof Set);
+  assert.equal(st.inflightModifies.size, 0);
+});
+
+test('markModifyInflight(true) adds to the set, false removes', async () => {
+  const s = await freshState();
+  s.markModifyInflight('123', true);
+  assert.ok(s.getState().inflightModifies.has('123'));
+  s.markModifyInflight('123', false);
+  assert.ok(!s.getState().inflightModifies.has('123'));
+});
+
+test('markModifyInflight is idempotent and no-ops on falsy ClOrdID', async () => {
+  const s = await freshState();
+  s.markModifyInflight('A', true);
+  s.markModifyInflight('A', true);
+  assert.equal(s.getState().inflightModifies.size, 1);
+  s.markModifyInflight('', true);
+  s.markModifyInflight(null, true);
+  s.markModifyInflight(undefined, true);
+  assert.equal(s.getState().inflightModifies.size, 1);
+});
+
+test('markModifyInflight notifies the "orders" slice on flip only', async () => {
+  const s = await freshState();
+  let calls = 0;
+  s.subscribe((slice) => { if (slice === 'orders') calls += 1; });
+  s.markModifyInflight('A', true);   // flip
+  s.markModifyInflight('A', true);   // no-op
+  s.markModifyInflight('A', false);  // flip
+  s.markModifyInflight('A', false);  // no-op
+  assert.equal(calls, 2);
+});
+
+test('clearAll() empties inflightModifies', async () => {
+  const s = await freshState();
+  s.markModifyInflight('A', true);
+  s.markModifyInflight('B', true);
+  s.clearAll();
+  assert.equal(s.getState().inflightModifies.size, 0);
+});


### PR DESCRIPTION
Closes the trader-side leg of #122. Slices 1-4 already shipped the cancel-replace state machine, WAL durability, risk projection, and the `PUT /orders/{clOrdId}` endpoint. This slice exposes it in the trader UI.

## What ships

- **Blotter row** gains a **Modify** button next to Cancel. Disabled while the order is terminal or while a cancel/modify is already in flight (mirrors the backend's in-flight guard so the trader avoids the round-trip 409).
- **Modify modal** pre-filled with the order's current quantity / price. Inputs validated client-side (positive integer qty, optional positive price) before issuing the PUT. Esc / backdrop / Cancel button all dismiss it; Esc takes priority over the ticket-form Esc handler so an open modal always closes first.
- **Inflight tracking** (`inflightModifies` Set in state.js) drives the Modifying… label and disables the row's Modify button until the request resolves. The new ClOrdID materialises in the blotter through the existing orders.me stream — no toast / refresh needed.
- **Structured error mapping**: 404/409/400/422/502/503 surface their backend `{ error }` text inline in the modal; 401 falls through to the global logout path.

## Tests (+5)

- `frontend/test/state-modify.test.mjs` — `markModifyInflight` reducer (idempotency, falsy guard, slice notification on flip only, `clearAll` resets the set). Wired into CI alongside the existing decoder tests.

Backend untouched; suite still **557 verde**, format clean.

Refs #122.