### PR TITLE
feat(real-stack): mount matching-platform persistence volume

### DIFF
--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -55,6 +55,7 @@ services:
     volumes:
       - ./real/exchange-simulator.bridge.json:/app/config/exchange-simulator.bridge.json:ro
       - ./real/instruments-eqt.json:/app/config/instruments-eqt.json:ro
+      - matching-data:/var/lib/b3matching
     command: ["/app/config/exchange-simulator.bridge.json"]
     depends_on:
       # The UnicastUdpPacketSink resolves the "marketdata" hostname at
@@ -200,3 +201,11 @@ services:
       Trading__MarketData__Symbols__0: PETR4
       Trading__MarketData__Symbols__1: VALE3
       Trading__MarketData__Symbols__2: ITUB4
+
+volumes:
+  # Persists matching-platform's per-channel snapshots + WAL across
+  # restarts. Closes the desync loop documented in #132 (working orders
+  # going phantom on venue restart) by making upstream
+  # pedrosakuma/B3MatchingPlatform#260 phase work observable here.
+  matching-data:
+    name: b3-matching-data

--- a/docker/real/exchange-simulator.bridge.json
+++ b/docker/real/exchange-simulator.bridge.json
@@ -68,6 +68,19 @@
         "group": "marketdata",
         "port": 31084,
         "cadenceMs": 5000
+      },
+      // Persistence (upstream PRs #261/#269/#262/#274 etc, closes part of
+      // pedrosakuma/B3MatchingPlatform#260). dataDir is mounted from the
+      // named volume `b3-matching-data` in docker-compose.real.yml so
+      // restarts preserve order book + FIXP session counters / SessionVerId.
+      // WAL closes the RPO gap between snapshots; fsyncPerWrite trades
+      // throughput for at-most-one-cmd loss on unclean shutdown.
+      "persistence": {
+        "dataDir": "/var/lib/b3matching",
+        "wal": {
+          "enabled": true,
+          "fsyncPerWrite": true
+        }
       }
     }
   ]

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -256,6 +256,12 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 }
 .cancel-btn:disabled { opacity: .35; cursor: not-allowed; }
 .cancel-btn.cancelling { opacity: .55; cursor: progress; }
+.modify-btn {
+  background: transparent; border: 1px solid var(--accent); color: var(--accent);
+  padding: .15rem .5rem; border-radius: 3px; cursor: pointer; font: inherit; font-size: .75rem;
+}
+.modify-btn:disabled { opacity: .35; cursor: not-allowed; }
+.modify-btn.modifying { opacity: .55; cursor: progress; }
 .md-cell-stale { color: var(--warn); }
 .status-cell-Working   { color: var(--green); }
 .status-cell-PendingNew { color: var(--warn); }


### PR DESCRIPTION
Wires upstream B3MatchingPlatform persistence epic (pedrosakuma/B3MatchingPlatform#260) into our real-stack overlay.

## Upstream context

Overnight upstream shipped the entire persistence epic: PRs #261 (snapshots), #262 (FIXP counters), #269 (WAL between snapshots), #274 (stop orders), #275 (metrics), #276 (throttling), #277 (async writer), #278 (rotation), #279 (WAL hookup), #280 (admin endpoints), #281 (orphan check), #282 (schema evolution), #283 (binary format). Closes our blocker for #132.

## Changes

- `docker/real/exchange-simulator.bridge.json`: per-channel `persistence` block (dataDir=/var/lib/b3matching, wal.enabled=true, wal.fsyncPerWrite=true).
- `docker/docker-compose.real.yml`: named volume `b3-matching-data` mounted at `/var/lib/b3matching`, mirroring `b3-trading-data`.
- `frontend/css/styles.css`: ship dangling `.modify-btn` styles from #122 slice 5 (working tree leftover).

## Validation

```
# clean boot
docker volume rm b3-matching-data b3-trading-data
docker compose -f docker/docker-compose.yml -f docker/docker-compose.real.yml up -d

# submit order
curl -X POST .../auth/login {alice/wonderland}
curl -X POST .../orders {PETR4 Sell Limit 100 @ 32.55}

# verify snapshot grew
docker exec b3-matching-platform ls /var/lib/b3matching
# channel-84.snapshot.0 (437B initial), channel-84.snapshot.1 (749B post-order), channel-84.wal

# restart and verify restore
docker compose restart matching-platform
docker logs b3-matching-platform | grep -i restore
# loaded snapshot from /var/lib/b3matching/channel-84.snapshot.1 (seq=1/1, owners=1)
# RestoreState complete: nextOrderId=2 nextTradeId=1 rptSeq=1 restingOrders=1
# restored snapshot — seq=1/1 owners=1 orphansDropped=1
```

Pre-fix: `docker compose restart matching-platform` zerava o book mas trading-host mantinha ordens "Working" no blotter (fantasmas). Pós-fix: book sobrevive; só o owner FIXP é dropado (esperado pelo PR #270 cross-channel consistency check, porque a sessão remota mudou).

## Out of scope

`#132` continua aberta para a outra metade (consumer-side reconciliation: marcar como Stale ordens cuja sessão owner foi dropada na venue, surfacing no UI/risk).