### PR TITLE
feat(docker): default compose stack is now Mode=Real

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,12 +119,13 @@ jobs:
           TRADING_SEED_PASSWORD_SALT: rXA+be7/gEYYZQrQDsUr2g==
         run: |
           docker compose -f docker/docker-compose.yml config --quiet
+          docker compose -f docker/docker-compose.yml -f docker/docker-compose.unavailable.yml config --quiet
           docker compose -f docker/docker-compose.yml -f docker/docker-compose.observability.yml config --quiet
           docker compose -f docker/docker-compose.yml -f docker/docker-compose.conformance.yml config --quiet
           docker compose -f docker/docker-compose.yml -f docker/docker-compose.demo.yml config --quiet
 
   conformance:
-    name: Run conformance suite against compose stack
+    name: Run conformance suite against unavailable-mode stack
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: trading-host
@@ -139,6 +140,12 @@ jobs:
           # alice/wonderland — the committed hash/salt match this plaintext.
           # Signing key is a CI-only placeholder; conformance only checks
           # the round-trip works, not that the key is unique.
+          # The unavailable.yml overlay flips trading-host back to
+          # Mode=Unavailable (the pre-default-Real posture) so this job
+          # exercises the no-broker fail-closed contract — admin/firms
+          # CRUD, auth, risk-rejection-shape — without spinning up
+          # matching-platform. The real-stack-conformance job below
+          # covers the Mode=Real wire end-to-end.
           TRADING_AUTH_SIGNING_KEY: ci-conformance-placeholder-key-min-32-bytes-long-aaaaa
           TRADING_SEED_USER: alice
           TRADING_SEED_PASSWORD: wonderland
@@ -147,6 +154,7 @@ jobs:
         run: |
           docker compose \
               -f docker/docker-compose.yml \
+              -f docker/docker-compose.unavailable.yml \
               -f docker/docker-compose.conformance.yml \
               up -d --build --wait trading-host
 
@@ -160,6 +168,7 @@ jobs:
         run: |
           docker compose \
               -f docker/docker-compose.yml \
+              -f docker/docker-compose.unavailable.yml \
               -f docker/docker-compose.conformance.yml \
               run --rm --no-deps conformance
 
@@ -172,6 +181,7 @@ jobs:
         run: |
           docker compose \
               -f docker/docker-compose.yml \
+              -f docker/docker-compose.unavailable.yml \
               -f docker/docker-compose.conformance.yml \
               logs trading-host || true
 
@@ -184,6 +194,7 @@ jobs:
         run: |
           docker compose \
               -f docker/docker-compose.yml \
+              -f docker/docker-compose.unavailable.yml \
               -f docker/docker-compose.conformance.yml \
               down -v
 
@@ -246,7 +257,7 @@ jobs:
       - name: Logs (always)
         if: always()
         run: |
-          for svc in trading-host matching-platform marketdata-live; do
+          for svc in trading-host matching-platform marketdata; do
             echo "::group::$svc"
             docker compose \
                 -f docker/docker-compose.yml \

--- a/docker/docker-compose.real.yml
+++ b/docker/docker-compose.real.yml
@@ -1,211 +1,26 @@
-# Real-stack overlay: matching-platform + marketdata + trading-host(Mode=Real).
+# DEPRECATED — historical no-op shim.
 #
-# Brings up the only services in the family that can drive the real
-# B3 EntryPoint wire (matching) and the live UMDF reference-price WS
-# (marketdata) against a trading-host running in Mode=Real. The overlay
-# is opt-in — `docker compose up` (no -f overlay) keeps the honest
-# Mode=Unavailable default.
+# Until 2026-05-07 this overlay added matching-platform + marketdata
+# (and flipped trading-host to Mode=Real) on top of a Mode=Unavailable
+# default. Since the family compose was restructured to make Real the
+# default, all that wiring now lives directly in
+# `docker/docker-compose.yml` and there is nothing for this overlay to
+# add.
 #
-# Topology (all on b3-net):
+# It is preserved as an empty file so:
+#   - Pre-existing CI command-lines (`-f docker/docker-compose.real.yml`)
+#     keep parsing without error.
+#   - External tutorials / runbooks that still reference the old layout
+#     don't break overnight.
 #
-#   matching-platform ──FIXP TCP 9876──> trading-host ──> frontend
-#         │
-#         └──UMDF unicast UDP──> marketdata ──WS 8080──> trading-host
-#                                                       (IReferencePrice)
+# New tooling SHOULD NOT pass `-f docker/docker-compose.real.yml`. To
+# get the real stack, just `docker compose -f docker/docker-compose.yml
+# up`. To opt OUT of the real stack (no-broker fail-closed posture),
+# stack `-f docker/docker-compose.unavailable.yml`.
 #
-# Usage:
-#   docker compose \
-#       -f docker/docker-compose.yml \
-#       -f docker/docker-compose.real.yml \
-#       up
-#
-# Compose with the conformance overlay to drive the existing 11-spec
-# suite against the real FIXP wire (auth + admin/firms + risk run
-# end-to-end; simulator + algo specs auto-skip because their RequiresSimulator
-# guard does not see Mode=Simulator):
-#
-#   docker compose \
-#       -f docker/docker-compose.yml \
-#       -f docker/docker-compose.real.yml \
-#       -f docker/docker-compose.conformance.yml \
-#       up -d --wait trading-host
-#   docker compose \
-#       -f docker/docker-compose.yml \
-#       -f docker/docker-compose.real.yml \
-#       -f docker/docker-compose.conformance.yml \
-#       run --rm conformance
-#
-# v1 (this file) reinstates the marketdata leg after upstream
-# B3MarketDataPlatform#10 (PR #11) shipped the unicast bridge transport.
-# The marketdata service in docker-compose.yml is profile-gated under the
-# PCAP-replay configuration; here we redefine it to consume matching's
-# UMDF over the bridge and clear the profile so it boots with the overlay.
-# See RFC docs/rfcs/integration-real-stack-v0.md § v1 amendment.
+# Removal target: when no first-party doc or workflow references this
+# file (tracked via the simulator-as-bot follow-up; see plan.md).
 
-services:
-  matching-platform:
-    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching:latest}
-    container_name: b3-matching-platform
-    restart: unless-stopped
-    networks:
-      - b3-net
-    expose:
-      - "9876"   # FIXP TCP listener consumed by trading-host
-      - "8080"   # /metrics + /sessions HTTP surface
-    volumes:
-      - ./real/exchange-simulator.bridge.json:/app/config/exchange-simulator.bridge.json:ro
-      - ./real/instruments-eqt.json:/app/config/instruments-eqt.json:ro
-      - matching-data:/var/lib/b3matching
-    command: ["/app/config/exchange-simulator.bridge.json"]
-    depends_on:
-      # The UnicastUdpPacketSink resolves the "marketdata" hostname at
-      # startup via DNS (B3.Exchange.Core.UnicastUdpPacketSink:36). If
-      # marketdata-live is not up, matching aborts with "Name or service
-      # not known". service_started is enough — we don't need the WS to
-      # be ready before matching opens its UDP sockets.
-      marketdata-live:
-        condition: service_started
-    healthcheck:
-      # Matching ships /metrics + /sessions on its HTTP port (no /health).
-      # /metrics returning 200 is a sufficient readiness signal: the HTTP
-      # server only binds after the channel dispatcher and the FIXP
-      # listener are up (see B3.Exchange.Host.ExchangeHost startup order).
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/metrics > /dev/null"]
-      interval: 5s
-      timeout: 2s
-      retries: 12
-      start_period: 5s
+name: b3trading
 
-  marketdata-live:
-    # Live UMDF unicast variant for the real-stack overlay. Defined as a
-    # separate service from the profile-gated PCAP-replay `marketdata` in
-    # the base compose so the two never conflict (volumes are
-    # additively-merged in compose, which would force a phantom PCAP bind
-    # here). Resolves to the hostname `marketdata` on b3-net via the
-    # network alias below — that name is hard-coded into
-    # docker/real/exchange-simulator.bridge.json (matching's UMDF sink)
-    # and into trading-host's Trading__MarketData__WsUrl below.
-    image: ghcr.io/pedrosakuma/b3-marketdata:${MARKETDATA_TAG:-latest}
-    container_name: b3-marketdata
-    restart: unless-stopped
-    environment:
-      UMDF_WS_PORT: "8080"
-      UMDF_MULTICAST_CONFIG: /app/config/transport.json
-    volumes:
-      - ./real/marketdata-transport.json:/app/config/transport.json:ro
-    networks:
-      b3-net:
-        aliases:
-          - marketdata
-    expose:
-      - "8080"     # WebSocket fanout consumed by trading-host
-      - "30084/udp"  # IncrementalA  (matching → marketdata)
-      - "30085/udp"  # IncrementalB  (silent in v1; matching only emits A)
-      - "30184/udp"  # SnapshotRecovery
-      - "31084/udp"  # InstrumentDefinition
-    ports:
-      # Host port for direct WS smoke (browser / debug). Not required
-      # for the in-bridge trading-host → marketdata WS hop.
-      - "${MARKETDATA_PORT:-8081}:8080"
-    healthcheck:
-      # The image is distroless-ish (no curl/wget). Use dotnet --info as
-      # a liveness probe — proves the runtime is alive and the container
-      # hasn't crashed silently. The trading-host's WS subscriber retries
-      # on its own if the WS server isn't yet accepting.
-      test: ["CMD", "/usr/bin/dotnet", "--info"]
-      interval: 10s
-      timeout: 3s
-      retries: 6
-      start_period: 5s
-
-  trading-host:
-    depends_on:
-      matching-platform:
-        condition: service_healthy
-      marketdata-live:
-        condition: service_started
-    environment:
-      Trading__Exchange__Mode: Real
-      # Single firm wired to matching's pre-#42 default session, matching
-      # docker/real/exchange-simulator.bridge.json verbatim so the FIXP
-      # Negotiate succeeds. Bridge auth.devMode=true ignores AccessKey,
-      # but we still set it so the field is non-empty (validator gate).
-      Trading__Exchange__Firms__0__FirmId: FIRM01
-      Trading__Exchange__Firms__0__Endpoint: matching-platform:9876
-      Trading__Exchange__Firms__0__SessionId: "10101"
-      Trading__Exchange__Firms__0__SessionVerId: "1"
-      Trading__Exchange__Firms__0__EnteringFirm: "100"
-      # Matching's FixpSession parses Credentials as JSON expecting
-      # { auth_type, username, access_key }. devMode disables enforcement
-      # but the parse still requires the schema. Pre-this-fix, the raw
-      # "dev-key-1" string was rejected with "'d' is an invalid start of
-      # a value", and a too-thin {"accessKey":...} was rejected with
-      # "missing required field (auth_type/username/access_key)".
-      Trading__Exchange__Firms__0__AccessKey: '{"auth_type":"basic","username":"10101","access_key":"dev-key-1"}'
-      Trading__Exchange__Firms__0__SenderLocation: SP
-      Trading__Exchange__Firms__0__EnteringTrader: ALICE
-      # alice's firm is `default` in the base compose for back-compat with
-      # Mock/Simulator mode, but in Real mode every order routed by JWT
-      # firm claim has to find a registered FirmGateway. Override here so
-      # the seeded user actually reaches matching instead of bouncing as
-      # a gateway-routing miss.
-      Trading__Auth__Users__0__Firm: FIRM01
-      # Same firm override for bob (seeded by base compose at slot 5) so
-      # both default users route through the FIRM01 gateway in Real mode.
-      Trading__Auth__Users__5__Firm: FIRM01
-      # Map the conformance-driven symbols onto the SecurityIds matching
-      # advertises in instruments-eqt.json. v1 used placeholder ids that
-      # would have been silently rejected by matching had any order ever
-      # reached the gateway; v2 corrects them so /orders submissions for
-      # PETR4/VALE3/ITUB4 hit a real instrument and can print trades.
-      Trading__SymbolDirectory__SecurityIds__PETR4: "900000000001"
-      Trading__SymbolDirectory__SecurityIds__VALE3: "900000000002"
-      Trading__SymbolDirectory__SecurityIds__ITUB4: "900000000003"
-      # Static fallback prices for the price-collar check. Required so the
-      # collar accepts the v2 cross prices below the live cache warms up,
-      # AND so the v2 conformance spec can deterministically prove that a
-      # live trade observation displaces this static value (ITUB4 baseline
-      # = 30.00; cross prints at a different price; live block updatedUtc
-      # has to advance past baseline).
-      Trading__Risk__ReferencePrices__PETR4: "32.50"
-      Trading__Risk__ReferencePrices__VALE3: "65.00"
-      Trading__Risk__ReferencePrices__ITUB4: "30.00"
-      # Opening positions seeded for the default dogfood accounts so
-      # both alice and bob can sell out of the box without being blocked
-      # by the NoNakedShortCheck gate. Quantities are expressed in
-      # board-lot units (matching's lotSize=100, so 2000 = 20 lots).
-      # Seeds apply only when PersistenceRecovery leaves the slot empty,
-      # so a warm restart never overwrites real fills.
-      Trading__Positions__Seeds__0__EndClientId: ${TRADING_SEED_USER:-alice}
-      Trading__Positions__Seeds__0__Symbol: PETR4
-      Trading__Positions__Seeds__0__Quantity: "2000"
-      Trading__Positions__Seeds__0__AverageEntryPrice: "32.50"
-      Trading__Positions__Seeds__1__EndClientId: ${TRADING_SEED_USER:-alice}
-      Trading__Positions__Seeds__1__Symbol: VALE3
-      Trading__Positions__Seeds__1__Quantity: "2000"
-      Trading__Positions__Seeds__1__AverageEntryPrice: "65.00"
-      Trading__Positions__Seeds__2__EndClientId: ${TRADING_SEED_USER_2:-bob}
-      Trading__Positions__Seeds__2__Symbol: PETR4
-      Trading__Positions__Seeds__2__Quantity: "2000"
-      Trading__Positions__Seeds__2__AverageEntryPrice: "32.50"
-      Trading__Positions__Seeds__3__EndClientId: ${TRADING_SEED_USER_2:-bob}
-      Trading__Positions__Seeds__3__Symbol: VALE3
-      Trading__Positions__Seeds__3__Quantity: "2000"
-      Trading__Positions__Seeds__3__AverageEntryPrice: "65.00"
-      # Live reference price via the marketdata WS leg (RFC §4.5 D3).
-      # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
-      # cache misses fall back to Trading:Risk:ReferencePrices map. The
-      # subscription is best-effort: marketdata being slow to come up
-      # doesn't block trading-host startup.
-      Trading__MarketData__WsUrl: ws://marketdata:8080/ws
-      Trading__MarketData__Symbols__0: PETR4
-      Trading__MarketData__Symbols__1: VALE3
-      Trading__MarketData__Symbols__2: ITUB4
-
-volumes:
-  # Persists matching-platform's per-channel snapshots + WAL across
-  # restarts. Closes the desync loop documented in #132 (working orders
-  # going phantom on venue restart) by making upstream
-  # pedrosakuma/B3MatchingPlatform#260 phase work observable here.
-  matching-data:
-    name: b3-matching-data
+services: {}

--- a/docker/docker-compose.unavailable.yml
+++ b/docker/docker-compose.unavailable.yml
@@ -1,0 +1,67 @@
+# Honest "no-broker" overlay. Flips trading-host back to Mode=Unavailable
+# (the pre-default-Real posture) and suppresses matching-platform +
+# marketdata so a `docker compose up` with this overlay brings up only
+# trading-host + frontend.
+#
+# Use cases:
+#   - Validating the fail-closed surface (POST /orders → 502 BadGateway,
+#     /health readyForOrders=false, blotter empty, ticket disabled).
+#   - Auth/admin-only flows (login, /admin/firms CRUD) without spinning
+#     up the matching engine.
+#   - CI conformance jobs that exercise the Unavailable contract
+#     (admin/firms tests, risk-rejection-shape).
+#
+# Usage:
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.unavailable.yml \
+#       up
+#
+# Why a profile-based suppression: setting `profiles: ["never-on"]` on
+# matching-platform/marketdata in this overlay hides them from the
+# default `up` (no `--profile never-on` ever passed). depends_on on
+# trading-host is also cleared so compose doesn't wait on services it
+# was just told to ignore.
+
+services:
+  trading-host:
+    # Override depends_on entirely. `!reset` is the compose v2 directive
+    # for clearing a parent value (compose merges by default; an empty
+    # mapping `{}` would no-op-merge instead of replacing). Without this
+    # the validator complains "trading-host depends on undefined service
+    # marketdata" because the suppressed services below are still
+    # referenced by the inherited depends_on.
+    depends_on: !reset null
+    environment:
+      # Honest no-broker posture. EntryPointModeValidator accepts
+      # Unavailable without any Firms[] config — no FIXP wire is opened.
+      Trading__Exchange__Mode: Unavailable
+      # Clear the FIRM01 wiring so the Firms[] array is empty and no
+      # gateway is registered. Empty strings make .NET's array binder
+      # treat the slot as missing on bind (config sources prefer to
+      # signal absence via empty string for env-var transports).
+      Trading__Exchange__Firms__0__FirmId: ""
+      Trading__Exchange__Firms__0__Endpoint: ""
+      Trading__Exchange__Firms__0__SessionId: ""
+      Trading__Exchange__Firms__0__SessionVerId: ""
+      Trading__Exchange__Firms__0__EnteringFirm: ""
+      Trading__Exchange__Firms__0__AccessKey: ""
+      Trading__Exchange__Firms__0__SenderLocation: ""
+      Trading__Exchange__Firms__0__EnteringTrader: ""
+      # Revert alice + bob to "default" firm. With no FirmGateway
+      # registered (Mode=Unavailable), the JWT firm claim is informational
+      # and order submissions short-circuit at the EntryPointMode gate
+      # before any gateway routing.
+      Trading__Auth__Users__0__Firm: default
+      Trading__Auth__Users__5__Firm: default
+      # Live ref-prices are unreachable without marketdata; kill the
+      # subscriber so it doesn't churn reconnect attempts in logs.
+      # Static fallback Trading:Risk:ReferencePrices map (still set by
+      # base) keeps the price-collar happy if any code path consults it.
+      Trading__MarketData__WsUrl: ""
+
+  matching-platform:
+    profiles: ["never-on"]
+
+  marketdata:
+    profiles: ["never-on"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,25 +1,134 @@
 # Family docker-compose for B3TradingPlatform.
 #
-# Default `docker compose up` brings the trading-host up in honest no-broker
-# mode (Mode=Unavailable: /health shows readyForOrders=false, POST /orders
-# returns 502 BadGateway). The frontend is served by an nginx that
-# reverse-proxies REST + WebSocket back to the trading-host over the
-# internal `b3-net` bridge so the browser sees a single origin and CORS is
-# a non-issue.
+# Default `docker compose -f docker/docker-compose.yml up` brings the FULL
+# real stack online: matching-platform (FIXP TCP 9876) + marketdata (UMDF
+# unicast → WS 8080) + trading-host (Mode=Real, FIRM01 wired) + frontend
+# (nginx reverse-proxy on host port 8080). The trading-host actually
+# routes /orders submissions through matching, prints trades on the book
+# in marketdata, and surfaces live ref-prices back to the risk layer —
+# no synthetic ER injection, no stub gateway, no "honest no-broker"
+# fallback.
 #
-# The `marketdata` service is gated behind the `marketdata` profile because
-# it requires a PCAP volume that's not in this repo:
+# Persistence:
+#   - trading-data volume → trading-host's WAL + snapshots.
+#   - matching-data volume → matching-platform's per-channel snapshots +
+#     WAL (upstream pedrosakuma/B3MatchingPlatform#260 phase work). A
+#     `docker compose restart matching-platform` no longer drops the
+#     working order book on the floor.
 #
-#   docker compose --profile marketdata up
+# Topology (all on b3-net):
 #
-# The real-stack overlay `docker-compose.real.yml` adds `matching-platform`
-# (ghcr.io/pedrosakuma/b3-matching) wired to the trading-host over the
-# `b3-net` bridge with `Mode=Real`. See docs/DOCKER.md § Real-stack overlay
-# and `docs/rfcs/integration-real-stack-v0.md`.
+#   matching-platform ──FIXP TCP 9876──► trading-host ──REST/WS──► frontend
+#         │
+#         └──UMDF unicast UDP──► marketdata ──WS 8080──► trading-host
+#                                                       (IReferencePrice)
+#
+# Opt-in overlays:
+#
+#   - docker-compose.unavailable.yml  → flip trading-host to
+#       Mode=Unavailable + suppress matching/marketdata via profiles.
+#       Useful for testing the no-broker fail-closed path
+#       (POST /orders → 502 BadGateway, /health readyForOrders=false).
+#   - docker-compose.observability.yml → Prometheus + Grafana sidecars.
+#   - docker-compose.conformance.yml  → one-shot conformance suite runner
+#       (carol admin seed). Combine with real-conformance.yml when running
+#       on top of the real stack to opt into RequiresSandboxMatching specs.
+#   - docker-compose.real-conformance.yml → see above; sets
+#       B3T_REAL_STACK_CONFORMANCE=true and exempts alice from short/STP.
+#   - docker-compose.demo.yml         → flip to Mode=Simulator + demo bots
+#       (synthetic ER injection inside trading-host; not for production).
+#       Implicitly disables matching/marketdata (still come up by default
+#       but Simulator path doesn't talk to them).
+#   - docker-compose.e2e.yml          → flip to Mode=Stub for the frontend
+#       smoke E2E (StubExchangeGateway echoes ERs in-process; matching/
+#       marketdata suppressed via profiles).
+#
+# The PCAP-replay marketdata variant is gated under the `marketdata-pcap`
+# profile (separate service from the live unicast `marketdata` because
+# the two consume from different transports and configs):
+#
+#   PCAP_DIR=/path/to/pcaps docker compose --profile marketdata-pcap up
+#
+# Historical: the previous default was Mode=Unavailable (an "honest
+# no-broker" posture), and the real stack was an opt-in overlay
+# `docker-compose.real.yml`. That overlay is kept as a no-op shim so
+# pre-existing tutorials and CI command-lines that still pass
+# `-f docker-compose.real.yml` keep working.
 
 name: b3trading
 
 services:
+  matching-platform:
+    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching:latest}
+    container_name: b3-matching-platform
+    restart: unless-stopped
+    networks:
+      - b3-net
+    expose:
+      - "9876"   # FIXP TCP listener consumed by trading-host
+      - "8080"   # /metrics + /sessions HTTP surface + /admin/channels/*
+    volumes:
+      - ./real/exchange-simulator.bridge.json:/app/config/exchange-simulator.bridge.json:ro
+      - ./real/instruments-eqt.json:/app/config/instruments-eqt.json:ro
+      - matching-data:/var/lib/b3matching
+    command: ["/app/config/exchange-simulator.bridge.json"]
+    depends_on:
+      # The UnicastUdpPacketSink resolves the "marketdata" hostname at
+      # startup via DNS (B3.Exchange.Core.UnicastUdpPacketSink:36). If
+      # marketdata is not up, matching aborts with "Name or service
+      # not known". service_started is enough — we don't need the WS to
+      # be ready before matching opens its UDP sockets.
+      marketdata:
+        condition: service_started
+    healthcheck:
+      # Matching ships /metrics + /sessions on its HTTP port (no /health).
+      # /metrics returning 200 is a sufficient readiness signal: the HTTP
+      # server only binds after the channel dispatcher and the FIXP
+      # listener are up (see B3.Exchange.Host.ExchangeHost startup order).
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/metrics > /dev/null"]
+      interval: 5s
+      timeout: 2s
+      retries: 12
+      start_period: 5s
+
+  marketdata:
+    # Live UMDF unicast variant — reads UDP from matching-platform and
+    # fans out over WebSocket to trading-host (and any other consumer).
+    # Resolves to the hostname `marketdata` on b3-net (no alias needed)
+    # — that name is hard-coded into docker/real/exchange-simulator.bridge.json
+    # (matching's UMDF sink) and into trading-host's
+    # Trading__MarketData__WsUrl below.
+    image: ghcr.io/pedrosakuma/b3-marketdata:${MARKETDATA_TAG:-latest}
+    container_name: b3-marketdata
+    restart: unless-stopped
+    environment:
+      UMDF_WS_PORT: "8080"
+      UMDF_MULTICAST_CONFIG: /app/config/transport.json
+    volumes:
+      - ./real/marketdata-transport.json:/app/config/transport.json:ro
+    networks:
+      - b3-net
+    expose:
+      - "8080"     # WebSocket fanout consumed by trading-host
+      - "30084/udp"  # IncrementalA  (matching → marketdata)
+      - "30085/udp"  # IncrementalB  (silent in v1; matching only emits A)
+      - "30184/udp"  # SnapshotRecovery
+      - "31084/udp"  # InstrumentDefinition
+    ports:
+      # Host port for direct WS smoke (browser / debug). Not required
+      # for the in-bridge trading-host → marketdata WS hop.
+      - "${MARKETDATA_PORT:-8081}:8080"
+    healthcheck:
+      # The image is distroless-ish (no curl/wget). Use dotnet --info as
+      # a liveness probe — proves the runtime is alive and the container
+      # hasn't crashed silently. The trading-host's WS subscriber retries
+      # on its own if the WS server isn't yet accepting.
+      test: ["CMD", "/usr/bin/dotnet", "--info"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+
   trading-host:
     build:
       context: ..
@@ -27,6 +136,11 @@ services:
     image: ${TRADING_IMAGE:-ghcr.io/pedrosakuma/b3-trading-host:latest}
     container_name: b3-trading-host
     restart: unless-stopped
+    depends_on:
+      matching-platform:
+        condition: service_healthy
+      marketdata:
+        condition: service_started
     environment:
       ASPNETCORE_ENVIRONMENT: Docker
       ASPNETCORE_URLS: http://+:5000
@@ -41,35 +155,94 @@ services:
       Trading__Auth__Users__0__Salt: ${TRADING_SEED_PASSWORD_SALT:?Set TRADING_SEED_PASSWORD_SALT in .env (base64)}
       Trading__Auth__Users__0__Iterations: "600000"
       Trading__Auth__Users__0__Role: user
-      Trading__Auth__Users__0__Firm: default
+      # alice routes through FIRM01 in Real mode (every order needs a
+      # registered FirmGateway by JWT firm claim). The Mode=Unavailable
+      # overlay flips this back to "default".
+      Trading__Auth__Users__0__Firm: FIRM01
       # Second user (bob) seeded by default so dogfooding scenarios that
       # need both sides of a trade — crosses, fill-against, position-flip
       # exercises — work out of the box. PBKDF2 is deterministic on
       # plaintext+salt, so reusing TRADING_SEED_PASSWORD_HASH/SALT under
       # a different username produces a valid login for the same password.
-      # Same firm as alice on purpose; a future overlay can move bob to
-      # a separate firm when cross-firm scenarios become a thing.
       # Slot Users__5 (not 1) so demo-overlay seed users — bot-clientA (1),
       # bot-clientB (2), demo-admin (3), and the conformance overlay's
       # carol (4) — don't collide with bob when overlays stack on top.
-      # Sparse indexes are fine for .NET's configuration array binder.
       Trading__Auth__Users__5__Username: ${TRADING_SEED_USER_2:-bob}
       Trading__Auth__Users__5__PasswordHash: ${TRADING_SEED_PASSWORD_HASH}
       Trading__Auth__Users__5__Salt: ${TRADING_SEED_PASSWORD_SALT}
       Trading__Auth__Users__5__Iterations: "600000"
       Trading__Auth__Users__5__Role: user
-      Trading__Auth__Users__5__Firm: default
+      Trading__Auth__Users__5__Firm: FIRM01
       # CORS list from origin of nginx frontend. Same-origin via nginx proxy
       # means this is mostly redundant, but cheap insurance for direct curls.
       Trading__Cors__AllowedOrigins__0: http://localhost:${FRONTEND_PORT:-8080}
-      # Live reference price via B3MarketDataPlatform. When unset the host
-      # falls back to the static Trading:Risk:ReferencePrices map (zero
-      # background work, no SDK pull). Set when running --profile marketdata
-      # or pointing at an external MD WebSocket endpoint.
-      Trading__MarketData__WsUrl: ${TRADING_MARKETDATA_WS_URL:-}
-      # Symbols to subscribe to (array binding). Add Trading__MarketData__Symbols__1, _2, …
-      # for additional tickers. Ignored when WsUrl is empty.
-      Trading__MarketData__Symbols__0: ${TRADING_MARKETDATA_SYMBOL_0:-PETR4}
+
+      # ── Real-mode wire (matching-platform / FIXP) ──────────────────────
+      # The Mode=Unavailable overlay clears Mode + Firms__0__* + reverts
+      # Auth__Users__{0,5}__Firm to "default".
+      Trading__Exchange__Mode: Real
+      # Single firm wired to matching's pre-#42 default session, matching
+      # docker/real/exchange-simulator.bridge.json verbatim so the FIXP
+      # Negotiate succeeds. Bridge auth.devMode=true ignores AccessKey,
+      # but we still set it so the field is non-empty (validator gate).
+      Trading__Exchange__Firms__0__FirmId: FIRM01
+      Trading__Exchange__Firms__0__Endpoint: matching-platform:9876
+      Trading__Exchange__Firms__0__SessionId: "10101"
+      Trading__Exchange__Firms__0__SessionVerId: "1"
+      Trading__Exchange__Firms__0__EnteringFirm: "100"
+      # Matching's FixpSession parses Credentials as JSON expecting
+      # { auth_type, username, access_key }. devMode disables enforcement
+      # but the parse still requires the schema. Pre-this-fix, the raw
+      # "dev-key-1" string was rejected with "'d' is an invalid start of
+      # a value", and a too-thin {"accessKey":...} was rejected with
+      # "missing required field (auth_type/username/access_key)".
+      Trading__Exchange__Firms__0__AccessKey: '{"auth_type":"basic","username":"10101","access_key":"dev-key-1"}'
+      Trading__Exchange__Firms__0__SenderLocation: SP
+      Trading__Exchange__Firms__0__EnteringTrader: ALICE
+      # Map the conformance-driven symbols onto the SecurityIds matching
+      # advertises in instruments-eqt.json so /orders submissions for
+      # PETR4/VALE3/ITUB4 hit a real instrument and can print trades.
+      Trading__SymbolDirectory__SecurityIds__PETR4: "900000000001"
+      Trading__SymbolDirectory__SecurityIds__VALE3: "900000000002"
+      Trading__SymbolDirectory__SecurityIds__ITUB4: "900000000003"
+      # Static fallback prices for the price-collar check. Required so the
+      # collar accepts cross prices below the live cache warms up. Live
+      # ref-prices via the marketdata WS leg below displace these.
+      Trading__Risk__ReferencePrices__PETR4: "32.50"
+      Trading__Risk__ReferencePrices__VALE3: "65.00"
+      Trading__Risk__ReferencePrices__ITUB4: "30.00"
+      # Opening positions seeded for the default dogfood accounts so
+      # both alice and bob can sell out of the box without being blocked
+      # by the NoNakedShortCheck gate. Quantities are expressed in
+      # board-lot units (matching's lotSize=100, so 2000 = 20 lots).
+      # Seeds apply only when PersistenceRecovery leaves the slot empty,
+      # so a warm restart never overwrites real fills.
+      Trading__Positions__Seeds__0__EndClientId: ${TRADING_SEED_USER:-alice}
+      Trading__Positions__Seeds__0__Symbol: PETR4
+      Trading__Positions__Seeds__0__Quantity: "2000"
+      Trading__Positions__Seeds__0__AverageEntryPrice: "32.50"
+      Trading__Positions__Seeds__1__EndClientId: ${TRADING_SEED_USER:-alice}
+      Trading__Positions__Seeds__1__Symbol: VALE3
+      Trading__Positions__Seeds__1__Quantity: "2000"
+      Trading__Positions__Seeds__1__AverageEntryPrice: "65.00"
+      Trading__Positions__Seeds__2__EndClientId: ${TRADING_SEED_USER_2:-bob}
+      Trading__Positions__Seeds__2__Symbol: PETR4
+      Trading__Positions__Seeds__2__Quantity: "2000"
+      Trading__Positions__Seeds__2__AverageEntryPrice: "32.50"
+      Trading__Positions__Seeds__3__EndClientId: ${TRADING_SEED_USER_2:-bob}
+      Trading__Positions__Seeds__3__Symbol: VALE3
+      Trading__Positions__Seeds__3__Quantity: "2000"
+      Trading__Positions__Seeds__3__AverageEntryPrice: "65.00"
+      # Live reference price via the marketdata WS leg (RFC §4.5 D3).
+      # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
+      # cache misses fall back to Trading:Risk:ReferencePrices map. The
+      # subscription is best-effort: marketdata being slow to come up
+      # doesn't block trading-host startup. The Mode=Unavailable overlay
+      # clears WsUrl so the subscriber stays idle.
+      Trading__MarketData__WsUrl: ws://marketdata:8080/ws
+      Trading__MarketData__Symbols__0: PETR4
+      Trading__MarketData__Symbols__1: VALE3
+      Trading__MarketData__Symbols__2: ITUB4
     volumes:
       - trading-data:/var/lib/b3trading
     networks:
@@ -95,16 +268,17 @@ services:
     ports:
       - "${FRONTEND_PORT:-8080}:80"
 
-  # Opt-in. Pull the published image from GHCR. Requires the package
-  # to be public — see B3MarketDataPlatform#2 closing comment.
+  # PCAP-replay marketdata variant. Opt-in via `--profile marketdata-pcap`.
+  # Replays a captured B3 UMDF session for offline regression. Conflicts
+  # with the live `marketdata` service above on the same hostname/ports —
+  # do not enable both at once.
   #
-  # Bring up with PCAPs mounted:
-  #   PCAP_DIR=/path/to/pcaps docker compose --profile marketdata up
-  marketdata:
+  #   PCAP_DIR=/path/to/pcaps docker compose --profile marketdata-pcap up
+  marketdata-pcap:
     image: ghcr.io/pedrosakuma/b3-marketdata:${MARKETDATA_TAG:-latest}
-    container_name: b3-marketdata
+    container_name: b3-marketdata-pcap
     restart: unless-stopped
-    profiles: ["marketdata"]
+    profiles: ["marketdata-pcap"]
     environment:
       WS_PORT: "8080"
       PCAP_DIR: /app/pcap
@@ -115,7 +289,7 @@ services:
     networks:
       - b3-net
     ports:
-      - "${MARKETDATA_PORT:-8081}:8080"
+      - "${MARKETDATA_PCAP_PORT:-8082}:8080"
     deploy:
       resources:
         limits:
@@ -125,6 +299,11 @@ services:
 volumes:
   trading-data:
     name: b3-trading-data
+  # Persists matching-platform's per-channel snapshots + WAL across
+  # restarts (upstream pedrosakuma/B3MatchingPlatform#260). Closes the
+  # venue half of the desync described in #132 — see #133.
+  matching-data:
+    name: b3-matching-data
 
 networks:
   b3-net:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -13,61 +13,84 @@ docker compose -f docker/docker-compose.yml up --build
 # open http://localhost:8080
 ```
 
-You'll see the trader UI; logging in works; submitting an order returns
-**502 BadGateway with `reason: gateway unavailable`**. That's the honest
-default — see [Honest no-broker mode](#honest-no-broker-mode) below.
+You'll see the trader UI, log in as `alice / wonderland` (the seeded
+default), and submit a PETR4 order — it routes through the real
+matching engine, prints on the book, and the live tape lights up.
+That's the **default Real stack** — see
+[What runs by default](#what-runs-by-default) below.
+
+To validate the no-broker fail-closed surface instead (POST /orders →
+502, /health `readyForOrders=false`), stack the unavailable overlay:
+
+```bash
+docker compose \
+    -f docker/docker-compose.yml \
+    -f docker/docker-compose.unavailable.yml \
+    up
+```
 
 ## What runs by default
 
 | Service | Image | Port (host) | Purpose |
 |---|---|---|---|
-| `trading-host` | `ghcr.io/pedrosakuma/b3-trading-host:latest` | `5000` | REST + WebSocket; `Mode=Unavailable` |
+| `matching-platform` | `ghcr.io/pedrosakuma/b3-matching:latest` | (internal `:9876`, `:8080`) | FIXP TCP listener + UMDF unicast publisher + `/admin/channels/*` snapshot ops |
+| `marketdata` | `ghcr.io/pedrosakuma/b3-marketdata:latest` | `8081` | UMDF unicast consumer (`30084/30184/31084 udp`) + WebSocket fanout (`:8080`) |
+| `trading-host` | `ghcr.io/pedrosakuma/b3-trading-host:latest` | `5000` | REST + WebSocket; `Mode=Real`, FIRM01 session against matching, live `IReferencePrice` wired through marketdata WS |
 | `frontend` | `ghcr.io/pedrosakuma/b3-trading-frontend:latest` | `8080` | nginx serving the static UI + reverse-proxy to trading-host |
 
-The `marketdata` service is defined but **gated behind the `marketdata`
-profile** because it needs PCAP files this repo doesn't ship. Bring it up
-explicitly:
+Persistence:
+
+- **`b3-trading-data`** named volume → trading-host WAL + snapshots.
+- **`b3-matching-data`** named volume → matching-platform per-channel
+  snapshots + WAL (upstream
+  [B3MatchingPlatform#260](https://github.com/pedrosakuma/B3MatchingPlatform/issues/260)
+  phase work). `docker compose restart matching-platform` no longer
+  drops the working order book on the floor.
+
+The PCAP-replay marketdata variant is now a separate service
+(`marketdata-pcap`) gated behind the `marketdata-pcap` profile so it
+doesn't conflict with the live `marketdata`:
 
 ```bash
-PCAP_DIR=/path/to/your/pcaps docker compose -f docker/docker-compose.yml --profile marketdata up
+PCAP_DIR=/path/to/pcaps docker compose -f docker/docker-compose.yml --profile marketdata-pcap up
 ```
 
-A future PR will refresh this section once
-[B3MarketDataPlatform#2](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/2)
-follow-ups land a unicast-bind mode (see RFC integration-real-stack-v0
-§4.4 R1.b). Today, marketdata only knows how to consume multicast
-UMDF, which is not routable across the docker bridge.
+> **Heads up — venue-restart caveat.** Working orders submitted before
+> a `docker compose restart matching-platform` survive on the venue
+> (snapshot + WAL), but the FIXP owner session is dropped on restore
+> (matching's cross-channel consistency check). Trading-host still sees
+> them as Working in the blotter — see
+> [#132](https://github.com/pedrosakuma/B3TradingPlatform/issues/132)
+> for the consumer-side reconciliation work.
 
-## Real-stack overlay (opt-in)
+## Honest no-broker overlay (opt-in)
 
 ```bash
 docker compose \
     -f docker/docker-compose.yml \
-    -f docker/docker-compose.real.yml \
+    -f docker/docker-compose.unavailable.yml \
     up
 ```
 
-Brings up the real-wire trio against the trading-host:
+Flips trading-host back to `Mode=Unavailable` and suppresses
+`matching-platform` + `marketdata` so only `trading-host + frontend`
+come up. Useful for:
 
-| Service | Image | What it does |
-|---|---|---|
-| `matching-platform` | `ghcr.io/pedrosakuma/b3-matching:latest` | FIXP TCP listener (`:9876`) + UMDF unicast publisher |
-| `marketdata-live` | `ghcr.io/pedrosakuma/b3-marketdata:latest` | UMDF consumer (binds `30084/30184/31084 udp`) + WebSocket fanout (`:8080`, hostname `marketdata` on `b3-net`) |
-| `trading-host` | (this repo) | `Mode=Real`, FIRM01 session against matching, `IReferencePrice` wired through `marketdata-live` WS |
+- Validating the fail-closed surface (POST /orders → 502 BadGateway,
+  /health `readyForOrders=false`, ticket disabled).
+- Auth/admin-only flows (login, /admin/firms CRUD) without paying the
+  matching+marketdata startup cost.
+- CI conformance jobs that exercise the Unavailable contract
+  (admin/firms tests, risk-rejection-shape).
 
-The overlay is opt-in — `docker compose up` (no `-f`) keeps the honest
-`Mode=Unavailable` default.
+## Historical: `docker-compose.real.yml`
 
-Use this overlay when you need to see the real `B3.EntryPoint.Client`
-path drive end-to-end (gap detection, latency probes, multi-firm
-registry) and the live reference-price WS pipeline (versus the in-process
-mock + static-map fallback).
-
-The base compose's profile-gated `marketdata` (PCAP-replay) is unrelated
-and stays dormant under this overlay; the live variant is a separate
-service named `marketdata-live` with a network alias `marketdata` so the
-hostnames in `docker/real/exchange-simulator.bridge.json` and the
-trading-host `Trading__MarketData__WsUrl` resolve.
+Until the family compose was restructured to make Real the default
+(2026-05-07), the real stack was an opt-in overlay
+`docker-compose.real.yml`. That file is preserved as an empty no-op
+shim so pre-existing CI command-lines and external tutorials still
+parse. New tooling should use `docker-compose.yml` directly (or
+combine with `docker-compose.unavailable.yml` for the inverse).
 
 ## Demo overlay (opt-in, laptop-only)
 


### PR DESCRIPTION
Promotes the previously-opt-in real overlay to the family default. `docker compose -f docker/docker-compose.yml up` now brings up the full real stack (matching-platform + marketdata + trading-host(Mode=Real) + frontend) with persistence on both sides.

## Why now

Upstream B3MatchingPlatform shipped persistence (pedrosakuma/B3MatchingPlatform#260) so `docker compose restart matching-platform` no longer drops the working order book on the floor (#133 wired the volume on our side). With persistence in place, Real is the most useful default for dogfood; the honest no-broker posture moves to an opt-in overlay.

## Changes

- `docker/docker-compose.yml`: full Real stack as default. Renamed `marketdata-live` → `marketdata` (canonical service name now, no alias trick needed). PCAP variant moved to new service `marketdata-pcap` gated by its own profile. Persistence volumes for both trading-host (`b3-trading-data`) and matching (`b3-matching-data`).
- `docker/docker-compose.real.yml`: gutted to a no-op shim with deprecation header so pre-existing CI command-lines and tutorials passing `-f docker-compose.real.yml` keep parsing.
- `.github/workflows/docker.yml`:
  - validate step adds unavailable overlay
  - existing 'conformance' job renamed to 'against unavailable-mode stack' and now stacks unavailable.yml to preserve its no-broker semantics
  - logs loop `marketdata-live` → `marketdata`
- `docs/DOCKER.md`: TL;DR + topology rewritten for new default. New section 'Honest no-broker overlay' + 'Historical: docker-compose.real.yml'.

## Validation

```
# default = Real
docker compose -f docker/docker-compose.yml up -d
curl localhost:8080/health
# {"exchange":{"mode":"Real","readyForOrders":true,"firmCount":1}}
curl -X POST .../auth/login {alice/wonderland}
curl -X POST .../orders {PETR4 Sell Limit 100 @ 32.55}
# {"clOrdId":"1"}
docker logs b3-trading-host | grep 'EntryPoint session connected'
# EntryPoint session connected for firm FIRM01.

# unavailable opt-in
docker compose ... -f unavailable.yml up -d
docker compose ps  # only trading-host + frontend
curl localhost:8080/health
# {"exchange":{"mode":"Unavailable","readyForOrders":false,"firmCount":0}}
curl -X POST .../orders ...
# HTTP 502
```

All 8 compose-validate combos pass `docker compose config --quiet` locally.

## Follow-up

Filed #134 for the next architectural step: refactor 'simulator' from an in-process trading-host mode (`Mode=Simulator` + `SimulatorBootGuard` + `/admin/simulator/er`) into an external bot client connected via FIXP. With Real as the default and matching-platform persistent, removing the in-process simulator is the next cleanup.

Roadmap entry added to #29.