### PR TITLE
fix(frontend): ticket inputs overflow ticket panel on narrow grid

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -230,6 +230,14 @@ body {
 .ticket-form input, .ticket-form select {
   background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
   border-radius: 4px; padding: .4rem .5rem; font: inherit;
+  /* Inputs inherit a default intrinsic width from the user-agent
+     (≈200px from `size=20`). Inside the row-two grid, a 1fr column on
+     the 280px ticket panel ends up ~130px wide — narrower than the
+     intrinsic min, so the input overflows the box on the right side
+     (visible in the ticket panel). `width:100%` + `min-width:0` lets
+     the input shrink with the grid track instead of clipping out. */
+  width: 100%;
+  min-width: 0;
 }
 .ticket-form .row-two { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; }
 .ticket-form button {


### PR DESCRIPTION
Visible regression in the order ticket: the Price input extended beyond the right edge of the ticket panel (visual report 2026-05-07).

Root cause: `.ticket-form input` did not set `width` or `min-width`. Inputs default to an intrinsic width derived from `size=20` (~200px). Inside the `.row-two` grid (`1fr 1fr`) on the 280px ticket panel, each track is ~130px — narrower than the intrinsic min — so the input overflows.

Fix: `width: 100%; min-width: 0;` on `.ticket-form input, .ticket-form select`. Both rules are needed: `width:100%` constrains to the grid track when there's room, and `min-width:0` overrides the auto-min that would otherwise keep the box at its content min and force overflow.

Verified locally on rebuilt frontend image (default Real stack).