### PR TITLE
fix(health): /health reflects live FIXP session state per firm

### DIFF
--- a/backend/src/B3.Trading.Api/Lifecycle/HealthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Lifecycle/HealthEndpoints.cs
@@ -40,6 +40,11 @@ public static class HealthEndpoints
             // perspective so legacy test hosts that skip the wire-side
             // setup still serve /health.
             var exchange = ctx.RequestServices.GetService<ExchangeStatus>();
+            // Live FIXP session state per firm. Only registered in Real
+            // mode (FirmGatewayRegistry); Mock/Stub/Unavailable hosts get
+            // null here and the response collapses to the legacy shape
+            // (no firms[] array; readyForOrders driven by mode alone).
+            var sessions = ctx.RequestServices.GetService<IFirmSessionStatusProvider>();
             return Results.Json(new
             {
                 status = drain.IsDraining ? "draining" : "ready",
@@ -52,15 +57,50 @@ public static class HealthEndpoints
                     dataDirectory = p.DataDirectory,
                     snapshotInterval = p.SnapshotInterval,
                 },
-                exchange = exchange is null ? null : (object)new
-                {
-                    mode = exchange.Mode.ToString(),
-                    readyForOrders = exchange.ReadyForOrders,
-                    firmCount = exchange.FirmCount,
-                },
+                exchange = exchange is null ? null : BuildExchangeBlock(exchange, sessions),
             });
         });
 
         return app;
+    }
+
+    /// <summary>
+    /// Compose the <c>exchange</c> block of <c>/health</c>. When live session
+    /// state is available (Real mode), <c>readyForOrders</c> is the AND of
+    /// the configuration-level <see cref="ExchangeStatus.ReadyForOrders"/>
+    /// and "every firm in <c>established</c>". A configured-but-disconnected
+    /// gateway therefore reports <c>readyForOrders=false</c>, fixing the
+    /// long-standing surfacing bug where the badge stayed green while
+    /// submits were silently rejected by the SDK guard. Without a session
+    /// provider we keep the legacy shape (no <c>firms[]</c>, ready by mode
+    /// alone) so Mock/Stub/Unavailable smoke tests don't have to be retaught.
+    /// </summary>
+    private static object BuildExchangeBlock(ExchangeStatus exchange, IFirmSessionStatusProvider? sessions)
+    {
+        if (sessions is null)
+        {
+            return new
+            {
+                mode = exchange.Mode.ToString(),
+                readyForOrders = exchange.ReadyForOrders,
+                firmCount = exchange.FirmCount,
+            };
+        }
+
+        var firms = sessions.Snapshot();
+        var allEstablished = firms.Count == 0 || firms.All(f => f.IsEstablished);
+        return new
+        {
+            mode = exchange.Mode.ToString(),
+            readyForOrders = exchange.ReadyForOrders && allEstablished,
+            firmCount = exchange.FirmCount,
+            firms = firms.Select(f => new
+            {
+                firmId = f.FirmId,
+                state = f.SessionState,
+                reconnecting = f.IsReconnecting,
+                sessionVerId = f.SessionVerId,
+            }).ToArray(),
+        };
     }
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -331,6 +331,7 @@ if (earlyIsReal)
         return new FirmGatewayRegistry(gateways);
     });
     builder.Services.AddSingleton<IEntryPointClient>(sp => sp.GetRequiredService<FirmGatewayRegistry>());
+    builder.Services.AddSingleton<IFirmSessionStatusProvider>(sp => sp.GetRequiredService<FirmGatewayRegistry>());
     builder.Services.AddSingleton<MultiFirmExchangeGateway>(sp =>
         new MultiFirmExchangeGateway(sp.GetRequiredService<FirmGatewayRegistry>()));
     builder.Services.AddSingleton<EntryPointExecutionReportRouter>();

--- a/backend/src/B3.Trading.Infrastructure/ExchangeStatus.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeStatus.cs
@@ -5,11 +5,13 @@ namespace B3.Trading.Infrastructure;
 /// as a singleton at host startup so <c>/health</c> can surface
 /// <c>exchange.{mode, readyForOrders, firmCount}</c> without poking DI.
 /// <para>
-/// <c>ReadyForOrders</c> reflects configuration, not live session state —
-/// a <see cref="ExchangeMode.Real"/> gateway with a disconnected FIXP
-/// session is still <c>true</c> here. Live connection state surfaces
-/// separately via <c>trading.entrypoint.connected</c> metrics and (Phase 8)
-/// per-firm readiness.
+/// <c>ReadyForOrders</c> here reflects configuration only — a
+/// <see cref="ExchangeMode.Real"/> gateway with a disconnected FIXP
+/// session is still <c>true</c> at this layer. The lifecycle endpoint
+/// AND-s this against per-firm live session state from
+/// <see cref="IFirmSessionStatusProvider"/> when one is registered, so the
+/// JSON-facing <c>readyForOrders</c> only flips green when every
+/// configured firm is actually <c>established</c>.
 /// </para>
 /// </summary>
 public sealed class ExchangeStatus

--- a/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
+++ b/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
@@ -15,7 +15,7 @@ namespace B3.Trading.Infrastructure;
 ///         consume all firms transparently.</item>
 /// </list>
 /// </summary>
-public sealed class FirmGatewayRegistry : IEntryPointClient, IAsyncDisposable
+public sealed class FirmGatewayRegistry : IEntryPointClient, IFirmSessionStatusProvider, IAsyncDisposable
 {
     private readonly Dictionary<string, B3EntryPointClientGateway> _gateways;
     private readonly Action<ExecutionReportEnvelope> _bridge;
@@ -46,6 +46,26 @@ public sealed class FirmGatewayRegistry : IEntryPointClient, IAsyncDisposable
 
     public Task ConnectAllAsync(CancellationToken ct) =>
         Task.WhenAll(_gateways.Values.Select(g => g.ConnectAsync(ct)));
+
+    /// <inheritdoc />
+    public IReadOnlyList<FirmSessionStatus> Snapshot()
+    {
+        var result = new FirmSessionStatus[_gateways.Count];
+        var i = 0;
+        foreach (var g in _gateways.Values)
+        {
+            // SessionStateTag and IsReconnecting both read volatile snapshots
+            // off the gateway. SessionStateTag projects the SDK's live
+            // FixpClientState, so a Suspended/Terminated session is
+            // immediately visible to /health on the next request.
+            result[i++] = new FirmSessionStatus(
+                g.FirmId,
+                g.SessionStateTag,
+                g.IsReconnecting,
+                g.CurrentSessionVerId);
+        }
+        return result;
+    }
 
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
 

--- a/backend/src/B3.Trading.Infrastructure/IFirmSessionStatusProvider.cs
+++ b/backend/src/B3.Trading.Infrastructure/IFirmSessionStatusProvider.cs
@@ -1,0 +1,48 @@
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Per-firm live FIXP session snapshot. Surfaced via <c>/health</c> so the
+/// frontend, dashboards, and ops can answer "is firm X actually able to send
+/// orders right now?" without scraping metrics. Independent of
+/// <see cref="ExchangeStatus"/>, which only reflects configuration.
+/// </summary>
+/// <param name="FirmId">Firm identifier (matches <c>FirmConfig.FirmId</c>).</param>
+/// <param name="SessionState">Lower-snake-case tag of the live SDK
+/// <c>FixpClientState</c> — e.g. <c>established</c>, <c>suspended</c>,
+/// <c>terminated</c>. Mirrors the <c>trading.entrypoint.session_state</c>
+/// metric tag.</param>
+/// <param name="IsReconnecting">True when the gateway's auto-reconnect loop
+/// is currently running for this firm.</param>
+/// <param name="SessionVerId">Last <c>SessionVerId</c> the gateway has tried
+/// to use. Bumps on every reconnect attempt.</param>
+public sealed record FirmSessionStatus(
+    string FirmId,
+    string SessionState,
+    bool IsReconnecting,
+    uint SessionVerId)
+{
+    /// <summary>Tag value emitted by <see cref="FixpStateGaugeProjector"/>
+    /// for the SDK's healthy steady state.</summary>
+    public const string EstablishedState = "established";
+
+    /// <summary>True when this firm is in the only state where new orders can
+    /// reach the venue. Anything else (suspended, reconnecting, disconnected)
+    /// means a submit will throw <c>InvalidOperationException</c> at the SDK
+    /// boundary, regardless of <see cref="ExchangeStatus.ReadyForOrders"/>.</summary>
+    public bool IsEstablished => string.Equals(SessionState, EstablishedState, StringComparison.Ordinal);
+}
+
+/// <summary>
+/// DI seam for surfacing live FIXP session state into <c>/health</c> and
+/// the frontend gateway badge. Implemented by <see cref="FirmGatewayRegistry"/>
+/// in Real mode; absent in Mock/Stub/Unavailable modes (the lifecycle endpoint
+/// treats the missing service as "no live wire to report on" and falls back
+/// to <see cref="ExchangeStatus.ReadyForOrders"/> alone).
+/// </summary>
+public interface IFirmSessionStatusProvider
+{
+    /// <summary>Cheap snapshot of every firm's current session state.
+    /// Safe to call on the request hot path; reads volatile fields and
+    /// allocates a small array.</summary>
+    IReadOnlyList<FirmSessionStatus> Snapshot();
+}

--- a/backend/tests/B3.Trading.Api.Tests/Lifecycle/HealthSessionStatusTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/Lifecycle/HealthSessionStatusTests.cs
@@ -1,0 +1,119 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests.Lifecycle;
+
+/// <summary>
+/// /health surfaces live FIXP session state when an
+/// <see cref="IFirmSessionStatusProvider"/> is registered (Real mode wires
+/// it via FirmGatewayRegistry). Without a provider (Mock/Stub) the response
+/// keeps the legacy shape — no firms[] array, readyForOrders driven by
+/// <see cref="ExchangeStatus.ReadyForOrders"/> alone — so existing smoke
+/// tests / dashboards keep working.
+/// </summary>
+public class HealthSessionStatusTests
+{
+    private sealed class FakeProvider : IFirmSessionStatusProvider
+    {
+        private readonly IReadOnlyList<FirmSessionStatus> _snapshot;
+        public FakeProvider(params FirmSessionStatus[] snapshot) => _snapshot = snapshot;
+        public IReadOnlyList<FirmSessionStatus> Snapshot() => _snapshot;
+    }
+
+    private static WebApplicationFactory<Program> WithProvider(IFirmSessionStatusProvider? provider) =>
+        new TestAppFactory().WithWebHostBuilder(b => b.ConfigureTestServices(s =>
+        {
+            // Mock-mode default doesn't register the provider; tests that
+            // need one inject a fake here so we don't have to spin up a
+            // real EntryPointClient just to assert /health JSON shape.
+            if (provider is not null)
+                s.AddSingleton(provider);
+        }));
+
+    [Fact]
+    public async Task NoProvider_LegacyShape_NoFirmsArray()
+    {
+        using var factory = WithProvider(provider: null);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+
+        var exchange = doc.RootElement.GetProperty("exchange");
+        Assert.True(exchange.GetProperty("readyForOrders").GetBoolean(),
+            "Mock-mode test host should remain ready when no live session info is available.");
+        Assert.False(exchange.TryGetProperty("firms", out _),
+            "Legacy /health consumers must not see a firms[] field when no provider is wired.");
+    }
+
+    [Fact]
+    public async Task AllFirmsEstablished_ReadyTrue_FirmsArrayPresent()
+    {
+        var fake = new FakeProvider(
+            new FirmSessionStatus("FIRM01", "established", IsReconnecting: false, SessionVerId: 7),
+            new FirmSessionStatus("FIRM02", "established", IsReconnecting: false, SessionVerId: 3));
+        using var factory = WithProvider(fake);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+
+        var exchange = doc.RootElement.GetProperty("exchange");
+        Assert.True(exchange.GetProperty("readyForOrders").GetBoolean());
+
+        var firms = exchange.GetProperty("firms");
+        Assert.Equal(2, firms.GetArrayLength());
+        Assert.Equal("FIRM01", firms[0].GetProperty("firmId").GetString());
+        Assert.Equal("established", firms[0].GetProperty("state").GetString());
+        Assert.False(firms[0].GetProperty("reconnecting").GetBoolean());
+        Assert.Equal(7u, firms[0].GetProperty("sessionVerId").GetUInt32());
+    }
+
+    [Fact]
+    public async Task AnyFirmNotEstablished_ReadyFalse()
+    {
+        // Reproduces the dogfood bug from issue #137: a Real-mode firm with
+        // a suspended session was still surfacing readyForOrders=true,
+        // leaving the UI badge green while submits were rejected by the
+        // SDK guard ("Client is not in Established state").
+        var fake = new FakeProvider(
+            new FirmSessionStatus("FIRM01", "established", IsReconnecting: false, SessionVerId: 1),
+            new FirmSessionStatus("FIRM02", "suspended",   IsReconnecting: true,  SessionVerId: 4));
+        using var factory = WithProvider(fake);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var exchange = doc.RootElement.GetProperty("exchange");
+
+        Assert.False(exchange.GetProperty("readyForOrders").GetBoolean(),
+            "readyForOrders must be false while any configured firm is not established.");
+        var firms = exchange.GetProperty("firms");
+        Assert.Equal("suspended", firms[1].GetProperty("state").GetString());
+        Assert.True(firms[1].GetProperty("reconnecting").GetBoolean());
+    }
+
+    [Fact]
+    public async Task EmptyFirmList_ReadyTrue_DoesNotBlockOnVacuouslyTrueAnd()
+    {
+        // Defensive: a registered provider that happens to return zero
+        // firms (transient registration race or a future per-firm
+        // reload) should not flip readyForOrders to false. The AND over
+        // an empty set is vacuously true, matching the no-provider path.
+        using var factory = WithProvider(new FakeProvider());
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var exchange = doc.RootElement.GetProperty("exchange");
+
+        Assert.True(exchange.GetProperty("readyForOrders").GetBoolean());
+        Assert.Equal(0, exchange.GetProperty("firms").GetArrayLength());
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/Lifecycle/HealthSessionStatusTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/Lifecycle/HealthSessionStatusTests.cs
@@ -84,7 +84,7 @@ public class HealthSessionStatusTests
         // SDK guard ("Client is not in Established state").
         var fake = new FakeProvider(
             new FirmSessionStatus("FIRM01", "established", IsReconnecting: false, SessionVerId: 1),
-            new FirmSessionStatus("FIRM02", "suspended",   IsReconnecting: true,  SessionVerId: 4));
+            new FirmSessionStatus("FIRM02", "suspended", IsReconnecting: true, SessionVerId: 4));
         using var factory = WithProvider(fake);
         using var client = factory.CreateClient();
 


### PR DESCRIPTION
Addresses **Bug B** from #137 (the `/health` surfacing half). Bug A (auto-reconnect resilience after `DUPLICATE_SESSION_CONNECTION`) stays open in #137 for a follow-up — fixing it requires SDK-state-machine verification that's out of scope here.

## Problem

In dogfood, a Real-mode trading-host with a suspended FIXP session was still surfacing:

```json
"exchange": { "mode": "Real", "readyForOrders": true, "firmCount": 1 }
```

…while every `POST /orders` was rejected at the SDK boundary with `Client is not in Established state`. The endpoint reflected the *configuration* slot (Mode + FirmCount), never the live wire.

The dogfood narrative on #137 has the full timeline. Short version: a momentary `recv-eof` between trading-host and matching put the FIXP session into `suspended`; the matching reaper holds suspended sessions for 5 minutes; submits during that window get a synthesized 502; the UI badge reads `/health` and stayed green the entire time.

## Change

1. **`IFirmSessionStatusProvider`** (new, Infrastructure) — DI seam returning `{firmId, sessionState, isReconnecting, sessionVerId}` per firm.
2. **`FirmGatewayRegistry`** implements it. Every datum was already exposed on `B3EntryPointClientGateway` (`SessionStateTag`, `IsReconnecting`, `CurrentSessionVerId`); the provider just snapshots them.
3. **`Program.cs`** registers the provider only in Real mode (alongside the existing `FirmGatewayRegistry` registration). Mock/Stub/Unavailable hosts don't get one — see below.
4. **`/health`** consults the provider when present:
    - Adds `exchange.firms[]` array (one entry per firm).
    - Recomputes `exchange.readyForOrders` = `ExchangeStatus.ReadyForOrders` **AND** every firm in `established`.

When no provider is registered (Mock/Stub/Unavailable, plus legacy test hosts that bypass the wire setup), the response keeps the legacy three-field shape — no `firms[]`, `readyForOrders` driven by mode alone. Backwards compatible.

## Example new shape (Real mode)

```json
"exchange": {
  "mode": "Real",
  "readyForOrders": false,
  "firmCount": 1,
  "firms": [
    { "firmId": "FIRM01", "state": "suspended", "reconnecting": true, "sessionVerId": 4 }
  ]
}
```

## Tests

- **`HealthSessionStatusTests`** (new): no-provider keeps legacy shape; all-established → ready=true with firms[]; one suspended → ready=false; empty list → vacuously true (defensive).
- Existing `UnavailableModeTests` + `ExchangeStatusTests` unchanged and still pass — new logic only kicks in when a provider is wired.
- Full suite: 561 passed / 0 failed.

## Out of scope

- **Auto-reconnect resilience** (Bug A on #137) — `B3EntryPointClientGateway` already has `ReconnectLoopAsync` with backoff; in dogfood, the loop fired once after `recv-eof` then the SDK appeared to stop emitting `Terminated`. Needs SDK-side investigation + likely a watchdog kicker, both better as a separate PR.
- **Frontend gateway badge.** Header still uses the orders-WS pill, which honestly reports its own state. A second indicator wired off `/health` `exchange.firms[*].state` is the natural follow-up.

Closes part of #137.