### PR TITLE
feat(frontend): header gateway badge fed by /health.exchange.firms

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,6 +86,7 @@
           </select>
         </label>
         <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
+        <span id="gateway-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Exchange gateway: unknown" title="Exchange gateway session state (FIXP)" hidden>gateway</span>
         <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
         <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
         <span id="user-label" class="user-label"></span>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -17,6 +17,10 @@ const MD_KEY = "b3tp.md";
 const BLOTTER_FILTER_KEY = "b3tp.blotter.filter";
 const DEFAULT_WATCHLIST = ["PETR4", "VALE3"];
 const FIRMS_POLL_INTERVAL_MS = 5_000;
+// /health is unauthenticated and cheap, so a tighter cadence than the
+// admin-only /admin/firms poll is fine. Drives the gateway badge that
+// every logged-in user sees in the header.
+const GATEWAY_POLL_INTERVAL_MS = 5_000;
 
 // ─────────────────────────────────────────────────────────────────
 // Session storage strategy:
@@ -43,6 +47,7 @@ let mdConfig = null;         // { url, symbols }
 let expiryTimer = null;
 let warningTimer = null;
 let firmsPollTimer = null;
+let gatewayPollTimer = null;
 
 function init() {
   document.getElementById("login-backend").placeholder = defaultBackend();
@@ -215,6 +220,7 @@ function startSession(next) {
   state.setSubmitInflight(null);
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
+  state.setGatewayHealth(null);
   state.setKillStatus(null);
   state.setHaltStatus(null);
   state.setEodReport(null);
@@ -224,6 +230,7 @@ function startSession(next) {
   startWorker();
   startMdWorker();
   startFirmsPoll();
+  startGatewayPoll();
   scheduleExpiry();
 }
 
@@ -640,6 +647,7 @@ function logout() {
   warningShown = false;
   ui.closeSessionModal();
   stopFirmsPoll();
+  stopGatewayPoll();
   if (worker) {
     try { worker.postMessage({ type: "stop" }); } catch { /* swallow */ }
     worker.terminate();
@@ -661,6 +669,7 @@ function logout() {
   state.setSubmitInflight(null);
   state.setWsReconnect(null);
   state.setFirmsHealth(null);
+  state.setGatewayHealth(null);
   state.setKillStatus(null);
   state.setHaltStatus(null);
   state.setEodReport(null);
@@ -714,6 +723,60 @@ async function pollFirmsOnce() {
     // hammer the endpoint with rejected calls.
     if (err.status === 403) { stopFirmsPoll(); return; }
     console.warn("[admin/poll]", err);
+  }
+}
+
+// ── Gateway health poll ────────────────────────────────────────────
+// Polls /health (unauthenticated, cheap) so every logged-in user sees
+// an honest exchange-gateway badge in the header. /health.exchange.firms
+// is populated only when the host wires IFirmSessionStatusProvider
+// (Real mode); in Mock/Stub/Unavailable hosts the badge stays hidden
+// rather than guessing at a state we don't have. Failure to fetch is
+// treated as "unknown" — we deliberately don't logout on 401 here
+// (the endpoint requires no auth, so anything other than network/5xx
+// is unexpected and shouldn't kick the user out of the session).
+
+function startGatewayPoll() {
+  stopGatewayPoll();
+  if (!session) return;
+  pollGatewayOnce();
+  gatewayPollTimer = setInterval(pollGatewayOnce, GATEWAY_POLL_INTERVAL_MS);
+}
+
+function stopGatewayPoll() {
+  if (gatewayPollTimer) { clearInterval(gatewayPollTimer); gatewayPollTimer = null; }
+}
+
+async function pollGatewayOnce() {
+  if (!session) return;
+  try {
+    const resp = await fetch(`${session.backend}/health`, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!resp.ok) {
+      // Only flag as fetch-error on a non-2xx — leaves the existing badge
+      // alone for transient blips (304 isn't possible with no-store) so
+      // a single bad response doesn't paint the badge red while the
+      // session is otherwise fine.
+      state.setGatewayHealth({ error: `http_${resp.status}`, fetchedAt: Date.now() });
+      return;
+    }
+    const body = await resp.json();
+    const ex = body?.exchange ?? null;
+    if (!ex) {
+      state.setGatewayHealth(null);
+      return;
+    }
+    state.setGatewayHealth({
+      mode: ex.mode,
+      readyForOrders: !!ex.readyForOrders,
+      firmCount: ex.firmCount ?? 0,
+      firms: Array.isArray(ex.firms) ? ex.firms : null,
+      fetchedAt: Date.now(),
+    });
+  } catch (err) {
+    state.setGatewayHealth({ error: err?.message || "fetch_failed", fetchedAt: Date.now() });
   }
 }
 

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -47,6 +47,13 @@ const state = {
   submitInflight: null,    // { startedAt: ms } | null — true while POST /orders is awaiting response
   wsReconnect: null,       // { nextAt: ms } | null — when worker has scheduled the next attempt
   firmsHealth: null,       // { mode, firms, fetchedAt } | null — admin-only poll of /admin/firms
+  // Public, unauthenticated mirror of /health.exchange. Polled for every
+  // logged-in user (not just admin) so the gateway badge can stop lying
+  // when the FIXP session goes Suspended/Disconnected mid-trading.
+  // Shape: { mode, readyForOrders, firmCount, firms?: [{firmId,state,reconnecting,sessionVerId}], fetchedAt } | null
+  // firms[] is absent in Mock/Stub/Unavailable hosts; the badge then
+  // hides itself rather than guessing.
+  gatewayHealth: null,
   killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
   haltStatus: null,        // { symbols: [], fetchedAt } | null — admin-only
   eodReport: null,         // { ranAt, report } | null — last EOD response in this session
@@ -540,6 +547,11 @@ export function setWsReconnect(value) {
 export function setFirmsHealth(value) {
   state.firmsHealth = value;
   notify("firmsHealth");
+}
+
+export function setGatewayHealth(value) {
+  state.gatewayHealth = value;
+  notify("gatewayHealth");
 }
 
 export function setKillStatus(value) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -671,6 +671,63 @@ function renderFirmsHealth() {
   el.title = ranked.map(r => `${r.firmId}: ${r.state}${r.reconnecting ? " (reconnecting)" : ""}`).join("\n");
 }
 
+// Header gateway pill, fed by the public /health poll. Visible to every
+// logged-in user (admins also see the richer #firms-health badge from
+// /admin/firms). Hidden when the host is in a no-session mode (Mock/
+// Stub/Unavailable — /health.exchange.firms is absent), so it never
+// guesses at a state we can't observe.
+function renderGatewayPill() {
+  const el = $("gateway-status");
+  if (!el) return;
+  const gh = getState().gatewayHealth;
+  // No data yet, or host doesn't expose firm-level state → keep hidden.
+  if (!gh || !Array.isArray(gh.firms)) {
+    el.hidden = true;
+    return;
+  }
+  el.hidden = false;
+  let toneClass, label, ariaLabel, tooltip;
+  if (gh.error) {
+    toneClass = "status-disconnected";
+    label = "gateway: unreachable";
+    ariaLabel = `Exchange gateway: unreachable (${gh.error})`;
+    tooltip = `/health fetch failed: ${gh.error}`;
+  } else if (gh.firms.length === 0) {
+    // Real mode wired but no firms registered — defensive; mirrors the
+    // /health "no firms" branch where readyForOrders is vacuously true.
+    toneClass = "status-not_ready";
+    label = "gateway: no firms";
+    ariaLabel = "Exchange gateway: no firms configured";
+    tooltip = `${gh.mode}: no firms`;
+  } else {
+    const allEstablished = gh.firms.every(f => f.state === "established");
+    const anyReconnecting = gh.firms.some(f => !!f.reconnecting);
+    if (allEstablished && gh.readyForOrders) {
+      toneClass = "status-connected";
+      label = "gateway";
+      ariaLabel = "Exchange gateway: established";
+    } else if (anyReconnecting) {
+      toneClass = "status-connecting";
+      label = "gateway: reconnecting";
+      ariaLabel = "Exchange gateway: reconnecting";
+    } else {
+      toneClass = "status-disconnected";
+      // Pick the most useful single-word state to surface in the pill
+      // when the firms differ; tooltip carries the per-firm breakdown.
+      const worst = gh.firms.find(f => f.state !== "established") ?? gh.firms[0];
+      label = `gateway: ${worst.state}`;
+      ariaLabel = `Exchange gateway: ${worst.state}`;
+    }
+    tooltip = gh.firms.map(f =>
+      `${f.firmId}: ${f.state}${f.reconnecting ? " (reconnecting)" : ""} v${f.sessionVerId}`
+    ).join("\n");
+  }
+  el.className = `status-pill ${toneClass}`;
+  el.textContent = label;
+  el.setAttribute("aria-label", ariaLabel);
+  el.title = tooltip;
+}
+
 function renderForSlice(slice) {
   if (slice === "orders" || slice === "all" || slice === "blotterFilter" || slice === "blotterPage" || slice === "selectedOrder") renderBlotter();
   if (slice === "positions" || slice === "all") renderPositions();
@@ -685,6 +742,7 @@ function renderForSlice(slice) {
   if (slice === "submitInflight") renderInflight();
   if (slice === "wsReconnect") renderReconnect();
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
+  if (slice === "gatewayHealth" || slice === "all") renderGatewayPill();
   if (slice === "currentView" || slice === "all") applyCurrentView(getState().currentView);
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "all") renderSelectedSymbol();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "book" || slice === "all") renderDob();


### PR DESCRIPTION
Follow-up to #138 (which made `/health` honest). Wires a header **gateway** pill that every logged-in user sees, fed by polling the now-honest `/health` endpoint.

## Why

The header has had a single `#ws-status` pill that says CONNECTED based on the orders WebSocket transport. That's accurate about the WS, but says nothing about whether the upstream FIXP session can actually accept orders. In #137 dogfood, the WS pill stayed green while the gateway was `disconnected` and every submit was returning a synthesized 502.

This PR adds a separate `#gateway-status` pill that surfaces the *exchange* state, distinct from transport.

## Behaviour

Polls `GET /health` (unauthenticated, 5s cadence — matches the admin firms poll) and renders:

| state | label | tone |
| --- | --- | --- |
| every firm `established` AND `readyForOrders=true` | `gateway` | green |
| any `firm.reconnecting=true` | `gateway: reconnecting` | yellow |
| any firm not established (suspended/disconnected/terminated) | `gateway: <worst-state>` | red |
| `/health` fetch failed | `gateway: unreachable` | red |
| Mock/Stub/Unavailable host (no `firms[]` in response) | hidden | — |

Tooltip carries the per-firm breakdown with `sessionVerId` so an operator can see which firm is degraded without opening Admin.

## Validation (live, just now)

Rebuilt the Real-mode stack. Trading-host hit the very Bug A from #137 — initial `Negotiate rejected by peer` because matching still considered the previous trading-host session valid:

```
GET /health → exchange.firms[0]: { firmId: "FIRM01", state: "disconnected", reconnecting: false, sessionVerId: 5 }
```

The new pill correctly says `gateway: disconnected` (red) instead of the old false-green CONNECTED. Once Bug A is fixed (separate work), the same pill will transition through `reconnecting` → `gateway` automatically.

## Out of scope

- **Bug A** (auto-reconnect after `DUPLICATE_SESSION_CONNECTION` / Negotiate-reject) still open in #137. This PR doesn't fix the gateway resilience itself; it only ensures the user is no longer lied to about its state.
- Admin-only `#firms-health` badge (fed by `/admin/firms`) stays unchanged — complementary, richer view.