### PR TITLE
fix(gateway): retry cold-start FIXP connect with exponential backoff

### DIFF
--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -599,17 +599,28 @@ internal sealed class EntryPointRouterStarter : Microsoft.Extensions.Hosting.IHo
 
 /// <summary>
 /// Connects every per-firm <see cref="B3EntryPointClientGateway"/> at
-/// startup and tears them down on shutdown. Connection errors are logged
-/// but do not abort host start — failed firms surface via the
-/// <c>trading.entrypoint.connected</c> gauge and via gateway-unavailable
-/// rejections at submit time. Subsequent peer-initiated terminations
-/// drive the gateway's own auto-reconnect loop (Phase 3/1b); this hosted
-/// service only owns the cold-start connect.
+/// startup and tears them down on shutdown. A failed cold-start connect
+/// (e.g. <c>FixpRejectedException: Negotiate rejected</c> when matching
+/// still considers a previous trading-host session valid) does NOT abort
+/// host start — it falls back to a background retry loop with exponential
+/// backoff so the firm recovers automatically once the peer reaps the
+/// stale session (Bug A from #137). Subsequent peer-initiated terminations
+/// are handled by the gateway's own hot-path reconnect loop, which fires
+/// from the SDK's <c>Terminated</c> event.
 /// </summary>
 internal sealed class FirmGatewayConnector : Microsoft.Extensions.Hosting.IHostedService
 {
+    // Same shape as the gateway's hot-path reconnect: 1s base, ×2 to a
+    // 30s cap, ±25% jitter, capped at 16 doublings so we don't overflow
+    // for a long-degraded firm.
+    private static readonly TimeSpan InitialReconnectDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(30);
+
     private readonly FirmGatewayRegistry _registry;
     private readonly ILogger<FirmGatewayConnector> _logger;
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly List<Task> _backgroundLoops = new();
+
     public FirmGatewayConnector(FirmGatewayRegistry registry, ILogger<FirmGatewayConnector> logger)
     {
         _registry = registry;
@@ -618,6 +629,11 @@ internal sealed class FirmGatewayConnector : Microsoft.Extensions.Hosting.IHoste
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // StartAsync's CT is the host's start-budget token, not the
+        // shutdown lifetime. Each firm gets a single attempt up front;
+        // on failure we hand off to a background retry that lives until
+        // StopAsync. This keeps boot non-blocking while still recovering
+        // from a transient peer-side reject without a manual restart.
         foreach (var (firmId, gw) in _registry.Gateways)
         {
             try
@@ -627,12 +643,69 @@ internal sealed class FirmGatewayConnector : Microsoft.Extensions.Hosting.IHoste
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "EntryPoint connect failed for firm {Firm}; submits will surface as gateway-unavailable until recovered.", firmId);
+                _logger.LogError(ex, "EntryPoint connect failed for firm {Firm}; scheduling background retry with backoff.", firmId);
+                _backgroundLoops.Add(Task.Run(() => RetryConnectAsync(firmId, gw, _shutdownCts.Token)));
             }
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => _registry.DisposeAsync().AsTask();
+    /// <summary>
+    /// Background retry of <see cref="B3EntryPointClientGateway.ConnectAsync"/>
+    /// with exponential backoff + jitter. Singleflight-safe per firm
+    /// because the gateway's own <c>_reconnectLock</c> prevents the
+    /// hot-path Terminated-driven loop from racing with us if the SDK
+    /// happens to fire Terminated mid-attempt.
+    /// </summary>
+    private async Task RetryConnectAsync(string firmId, B3EntryPointClientGateway gw, CancellationToken ct)
+    {
+        var attempt = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            attempt++;
+            var delay = ComputeBackoff(attempt);
+            try { await Task.Delay(delay, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+
+            try
+            {
+                await gw.ConnectAsync(ct).ConfigureAwait(false);
+                _logger.LogInformation(
+                    "EntryPoint session connected for firm {Firm} on cold-start retry attempt {N}.",
+                    firmId, attempt);
+                return;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "EntryPoint cold-start connect retry failed for firm {Firm} (attempt {N}); will retry after backoff.",
+                    firmId, attempt);
+            }
+        }
+    }
+
+    private static TimeSpan ComputeBackoff(int attempt)
+    {
+        var basisMs = Math.Min(MaxReconnectDelay.TotalMilliseconds,
+            InitialReconnectDelay.TotalMilliseconds * Math.Pow(2, Math.Min(attempt - 1, 16)));
+        var jitterMs = Random.Shared.NextDouble() * 0.25 * basisMs;
+        return TimeSpan.FromMilliseconds(basisMs + jitterMs);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try { _shutdownCts.Cancel(); } catch { /* swallow */ }
+        if (_backgroundLoops.Count > 0)
+        {
+            try { await Task.WhenAll(_backgroundLoops).ConfigureAwait(false); }
+            catch { /* loops swallow individually; defensive WhenAll */ }
+        }
+        _shutdownCts.Dispose();
+        await _registry.DisposeAsync().ConfigureAwait(false);
+    }
 }
 
 internal static class FirmConfigValidation


### PR DESCRIPTION
Closes the remaining half of #137 (**Bug A**: gateway resilience). Bug B (`/health` surfacing) shipped in #138 and the header badge in #139 made the degradation visible.

## Problem

`B3EntryPointClientGateway` already has a hot-path reconnect loop (`ReconnectLoopAsync` with backoff + jitter), but it only fires from the SDK's `Terminated` event. **Cold-start** failures from `FirmGatewayConnector.StartAsync` were just logged and dropped:

```csharp
catch (Exception ex)
{
    _logger.LogError(ex, "EntryPoint connect failed for firm {Firm}; submits will surface as gateway-unavailable until recovered.", firmId);
}
```

Practical effect: any `FixpRejectedException: Negotiate rejected` at boot (typical when matching still has a previously-suspended trading-host session in its 5-minute reaper window) left the firm permanently degraded. Submits returned synthesized 502s until manual `docker compose restart trading-host` — and even that hit the same race if attempted inside the reaper window.

## Fix

`FirmGatewayConnector` now schedules a per-firm background retry loop on cold-start failure:

- Same backoff shape as the hot-path reconnect: 1s base, ×2 to 30s cap, ±25% jitter, capped at 16 doublings.
- Uses a connector-owned `CancellationTokenSource` (not `StartAsync`'s start-budget CT) so retries survive past host start.
- `StopAsync` cancels the CTS and awaits the background loops before disposing the registry.
- Singleflight-safe with the gateway's hot-path reconnect: `B3EntryPointClientGateway` keeps its `_reconnectLock`, so a `Terminated` event firing mid-retry can't double-pump.

`StartAsync` itself is unchanged on the happy path — first attempt is synchronous, success logs as before. Only on failure do we hand off to the background loop.

## Validation

- **Build & full test suite green** (561/0).
- **Live**: reproduced the dogfood scenario by rebuilding trading-host while matching held the previous session (now visible in real time via #139's badge). Pre-fix the badge stuck on `gateway: disconnected`; post-fix the firm auto-recovers within the backoff window.

## Out of scope

- **Watchdog** for missed-Terminated cases (where the SDK appears to skip the event after some peer rejects). The hot-path reconnect already covers what we can reliably detect; a watchdog would be a separate observability-driven addition once we understand the SDK state machine better.
- Refactoring `B3EntryPointClientGateway` to expose a single "ensure-connected" API. Worth doing eventually but the surgical fix preserves the existing abstraction.