### PR TITLE
feat(frontend): stale-data overlay on data panels (T2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
         run: node --test frontend/test/decoder.test.mjs
 
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs
+        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -159,6 +159,25 @@ body {
   background: var(--panel-2); color: var(--text); border-radius: 999px;
   padding: 0 .5rem; font-size: .7rem;
 }
+/* Stale-data overlay (T2). Dim the data area but keep the header
+   readable so the trader can still see the panel title + the bright
+   "stale" tag explaining why interaction is risky. The data zone is
+   pointer-events:none so accidental clicks on frozen rows can't
+   issue actions during a flap. */
+.panel--stale > table,
+.panel--stale .table-scroll,
+.panel--stale .executions-log,
+.panel--stale .dob-grid,
+.panel--stale .chart-canvas,
+.panel--stale .tape-list {
+  opacity: .5; pointer-events: none; transition: opacity .15s ease-in;
+}
+.stale-tag {
+  margin-left: .5rem; padding: 0 .5rem;
+  background: var(--warn, #c97a1a); color: #fff;
+  border-radius: 999px; font-size: .7rem; font-weight: 600;
+  letter-spacing: .04em; text-transform: none; line-height: 1.4;
+}
 .ticket     { grid-area: ticket; overflow-y: auto; overflow-x: hidden; min-width: 0; }
 .blotter    { grid-area: blotter; min-height: 0; }
 .positions  { grid-area: positions; }

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -13,6 +13,13 @@ const state = {
   user: null,              // { username, expiresAt, token, backend, firm, role }
   marketData: new Map(),   // Symbol -> { lastPrice, lastQty, lastTradeId, updatedAt, info }
   marketDataStatus: "disconnected", // disconnected | connecting | connected | not_ready
+  // Stale-data tracking (T2 of the trader-ui ergonomics review). Stamps
+  // the last time we received any data over the trader WS / MD WS.
+  // Drives the "stale" overlay that flips on whenever the corresponding
+  // WS isn't `connected`, so a trader can't act on rows that look
+  // authoritative but are actually frozen during a flap.
+  lastWsActivity: null,    // ms epoch | null
+  lastMdActivity: null,    // ms epoch | null
   watchlist: [],           // [string] symbols (UPPERCASE)
   // Depth-of-Book slice (T2). One book entry per symbol; sides are
   // Map<priceKey, { qty, count }>. `ready` flips false on book.snapshot
@@ -96,7 +103,17 @@ export function subscribe(fn) {
   return () => listeners.delete(fn);
 }
 
+// Stale-data tracking (T2). Tapped into notify() so any slice update
+// covered by WS_NOTIFY_SLICES / MD_NOTIFY_SLICES implicitly stamps
+// the last-activity timestamp — keeps the freshness signal tightly
+// coupled to the actual data flow without a separate instrumentation
+// surface every applyX has to remember to call.
+const WS_NOTIFY_SLICES = new Set(["orders", "positions", "executions"]);
+const MD_NOTIFY_SLICES = new Set(["marketData", "book", "candles", "tape"]);
+
 function notify(slice) {
+  if (WS_NOTIFY_SLICES.has(slice)) state.lastWsActivity = Date.now();
+  if (MD_NOTIFY_SLICES.has(slice)) state.lastMdActivity = Date.now();
   for (const fn of listeners) fn(slice);
 }
 
@@ -147,6 +164,10 @@ export function applyExecutionsSnapshot(rows) {
   if (Array.isArray(rows) && rows.length > 0) {
     state.executions = rows.slice(-EXECUTIONS_CAPACITY);
     notify("executions");
+  } else {
+    // Even an empty snapshot proves the WS is alive — stamp activity
+    // explicitly so the staleness overlay clears on subscribe.
+    state.lastWsActivity = Date.now();
   }
 }
 export function applyExecutionsDelta(row) {
@@ -169,6 +190,8 @@ export function clearAll() {
   state.pendingFatFinger = null;
   state.inflightCancels.clear();
   state.inflightModifies.clear();
+  state.lastWsActivity = null;
+  state.lastMdActivity = null;
   notify("all");
 }
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -735,10 +735,15 @@ function renderForSlice(slice) {
   if (slice === "status") {
     setStatusPill(getState().status);
     renderReconnect(); // pill change usually correlates with countdown reset
+    renderStaleness("ws");
   }
   if (slice === "user")   setUserLabel(getState().user);
   if (slice === "marketData" || slice === "all") renderMarketData();
-  if (slice === "marketDataStatus") setMdStatusPill(getState().marketDataStatus);
+  if (slice === "marketDataStatus") {
+    setMdStatusPill(getState().marketDataStatus);
+    renderStaleness("md");
+  }
+  if (slice === "all") { renderStaleness("ws"); renderStaleness("md"); }
   if (slice === "submitInflight") renderInflight();
   if (slice === "wsReconnect") renderReconnect();
   if (slice === "firmsHealth" || slice === "all") renderFirmsHealth();
@@ -748,6 +753,53 @@ function renderForSlice(slice) {
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "book" || slice === "all") renderDob();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "tapeShowAll" || slice === "tape" || slice === "all") scheduleTapeRender();
+}
+
+// ── Stale-data overlay (T2) ────────────────────────────────────────
+// Panels fed by the trader WS go stale whenever `state.status !==
+// "connected"`; panels fed by the MD WS go stale on
+// `state.marketDataStatus !== "connected"`. The visual cue is two-
+// part: a `panel--stale` class (dims the data area in CSS) + an
+// injected `<span class="stale-tag">stale · HH:MM:SS</span>` next to
+// the panel's `<h2>` showing the last successful update timestamp.
+// The timestamp is captured at the moment of staleness, not animated,
+// so a frozen-but-still-mounted UI is unambiguous.
+const WS_PANEL_SELECTORS = [".panel.blotter", ".panel.positions", ".panel.executions"];
+const MD_PANEL_SELECTORS = [".panel.market-data", ".panel.dob", ".panel.chart", ".panel.tape"];
+
+function fmtStaleTimestamp(ms) {
+  if (!ms) return "no data";
+  return new Date(ms).toLocaleTimeString("pt-BR", { hour12: false });
+}
+
+function renderStaleness(kind) {
+  const s = getState();
+  const isStale = kind === "ws"
+    ? s.status !== "connected"
+    : s.marketDataStatus !== "connected";
+  const lastAt = kind === "ws" ? s.lastWsActivity : s.lastMdActivity;
+  const selectors = kind === "ws" ? WS_PANEL_SELECTORS : MD_PANEL_SELECTORS;
+  const label = isStale ? `stale · ${fmtStaleTimestamp(lastAt)}` : null;
+  for (const sel of selectors) {
+    const panel = document.querySelector(sel);
+    if (!panel) continue;
+    panel.classList.toggle("panel--stale", isStale);
+    let tag = panel.querySelector(":scope > h2 > .stale-tag");
+    if (label) {
+      const h2 = panel.querySelector(":scope > h2");
+      if (!h2) continue;
+      if (!tag) {
+        tag = document.createElement("span");
+        tag.className = "stale-tag";
+        tag.setAttribute("role", "status");
+        tag.setAttribute("aria-live", "polite");
+        h2.appendChild(tag);
+      }
+      tag.textContent = label;
+    } else if (tag) {
+      tag.remove();
+    }
+  }
 }
 
 function renderAll() {

--- a/frontend/test/state-staleness.test.mjs
+++ b/frontend/test/state-staleness.test.mjs
@@ -1,0 +1,57 @@
+// T2 — verify the notify hook stamps lastWsActivity / lastMdActivity
+// for the right slices, so the stale overlay can rely on it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import * as state from "../js/state.js";
+
+function reset() {
+  state.clearAll();
+  state.setStatus("disconnected");
+}
+
+test("WS data setters stamp lastWsActivity and not lastMdActivity", () => {
+  reset();
+  const before = state.getState().lastWsActivity;
+  state.applyOrdersDelta({ clOrdId: "X1", symbol: "PETR4", status: "New" });
+  const ws = state.getState().lastWsActivity;
+  const md = state.getState().lastMdActivity;
+  assert.notEqual(ws, before);
+  assert.equal(typeof ws, "number");
+  assert.equal(md, null);
+});
+
+test("MD setters stamp lastMdActivity and not lastWsActivity", () => {
+  reset();
+  state.applyMdTrade({ symbol: "PETR4", price: 32.5, qty: 100, tradeId: 1 });
+  const ws = state.getState().lastWsActivity;
+  const md = state.getState().lastMdActivity;
+  assert.equal(typeof md, "number");
+  assert.equal(ws, null);
+});
+
+test("setStatus and setMarketDataStatus do NOT stamp activity timestamps", () => {
+  reset();
+  state.setStatus("connected");
+  state.setMarketDataStatus("connected");
+  assert.equal(state.getState().lastWsActivity, null);
+  assert.equal(state.getState().lastMdActivity, null);
+});
+
+test("clearAll resets both activity timestamps", () => {
+  reset();
+  state.applyOrdersDelta({ clOrdId: "X2", symbol: "VALE3", status: "New" });
+  state.applyMdTrade({ symbol: "VALE3", price: 65, qty: 100, tradeId: 1 });
+  assert.notEqual(state.getState().lastWsActivity, null);
+  assert.notEqual(state.getState().lastMdActivity, null);
+  state.clearAll();
+  assert.equal(state.getState().lastWsActivity, null);
+  assert.equal(state.getState().lastMdActivity, null);
+});
+
+test("empty executions snapshot still stamps WS activity (proof-of-life)", () => {
+  reset();
+  state.applyExecutionsSnapshot([]);
+  assert.equal(typeof state.getState().lastWsActivity, "number");
+});


### PR DESCRIPTION
Closes T2 from trader-ui-ergonomics-review.md.

When the trader WS or MD WS isn't connected, the affected panels are visibly stale: 50% opacity on the data area, pointer-events disabled (no accidental clicks on frozen rows), and a 'stale · HH:MM:SS' pill in the panel header showing the last good update.

## Why
Today, when the WS flaps, the blotter / positions / executions / DOB / chart / tape keep showing the last snapshot indefinitely with no visual cue. A trader can act on stale data without realizing it — the most-cited risk in the ergonomics review.

## What
- **state.js**: `notify()` taps `lastWsActivity` (orders/positions/executions) and `lastMdActivity` (marketData/book/candles/tape). One source of truth, can't drift from the actual data.
- **ui.js**: `renderStaleness(kind)` walks WS-fed and MD-fed panels, toggles `panel--stale` class and injects/removes a `.stale-tag` in each `<h2>`. Wired into `renderForSlice` on `status` / `marketDataStatus` / `all`.
- **styles.css**: `.panel--stale` dims tables, lists, DOB grid, chart canvas, tape list to 50% with `pointer-events: none`. `.stale-tag` is a warn-coloured pill using the existing `--warn` token.

## Behavior
- WS connected + MD connected → no overlay (current behavior).
- WS `disconnected/connecting` → blotter, positions, executions go stale.
- MD anything other than `connected` → market-data, dob, chart, tape go stale.
- Timestamp in tag is captured at the moment of staleness (pt-BR HH:MM:SS); doesn't animate to keep frozen-but-mounted UI unambiguous.
- Empty executions snapshot still stamps WS activity (subscribe-time proof of life).

## Tests
- 5 new `node:test` cases in `frontend/test/state-staleness.test.mjs` (88/88 frontend tests green).
- Wired into CI alongside the existing state-modify run.
- `node --check` clean for state.js / ui.js / app.js.

## Out of scope (future)
- Individual row staleness within a panel (e.g., a single position row gone stale while others fresh) — would need per-key timestamps.
- Auto-recovery toast — covered by the existing reconnect countdown pill.