### PR TITLE
feat(frontend): dynamic lot/tick on order ticket per symbol (T4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
         run: node --test frontend/test/decoder.test.mjs
 
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs
+        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -490,6 +490,13 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 /* ---------- Session-expiry modal + helpers (section 4 of #30) ---------- */
 .muted-cell { color: var(--muted); }
 .muted-line { color: var(--muted); margin: 0 0 .4rem; font-size: .8rem; }
+/* Order ticket lot/tick hint (T4). Driven by rulesFor(symbol) so the
+   trader sees the lot size before submit-time validation rejects the
+   order. Subdued so it doesn't compete with the form labels. */
+.field-hint {
+  margin: -.2rem 0 .2rem; font-size: .7rem; color: var(--muted);
+  letter-spacing: .03em;
+}
 .login-card label.remember { flex-direction: row; align-items: center; gap: .5rem; font-size: .8rem; color: var(--muted); }
 .login-card label.remember input { width: auto; }
 .modal-backdrop {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,6 +131,7 @@
               <input id="ticket-price" type="number" min="0" step="0.01" />
             </label>
           </div>
+          <p id="ticket-rules-hint" class="field-hint" aria-live="polite">lot 100 · tick 0.01</p>
           <button type="submit" id="ticket-submit">Submit</button>
           <p id="ticket-inflight" class="inflight" hidden></p>
           <p id="ticket-feedback" class="feedback" role="status" aria-live="polite" hidden></p>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -4,6 +4,7 @@
 import {
   getState, subscribe, isTerminalOrderStatus,
 } from "./state.js";
+import { rulesFor } from "./validation.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -436,11 +437,16 @@ export function bindUi() {
         e.target.value = upper;
         try { e.target.setSelectionRange(pos, pos); } catch {}
       }
+      syncTicketRules();
     });
     symEl.addEventListener("compositionend", (e) => {
       const upper = e.target.value.toUpperCase();
       if (e.target.value !== upper) e.target.value = upper;
+      syncTicketRules();
     });
+    symEl.addEventListener("change", syncTicketRules);
+    // Initial paint so the hint reflects defaults before any input.
+    syncTicketRules();
   }
 
   $("logout").addEventListener("click", () => onLogout());
@@ -711,6 +717,32 @@ export function clearTicket() {
   $("ticket-symbol").value = "";
   $("ticket-qty").value = "";
   $("ticket-price").value = "";
+  syncTicketRules();
+}
+
+// T4 — reflect the per-symbol lot/tick on the qty/price inputs and
+// in the hint line. The qty input's step+min match the lot size so
+// browser arrow-up/down increments by the right amount and the
+// HTML5 validation message matches what validateOrder() will say
+// at submit-time. Hint format is intentionally short ("lot 100 ·
+// tick 0.01") so it doesn't crowd the small ticket panel.
+function syncTicketRules() {
+  const symEl = $("ticket-symbol");
+  const qtyEl = $("ticket-qty");
+  const pxEl  = $("ticket-price");
+  const hint  = $("ticket-rules-hint");
+  const sym = (symEl?.value ?? "").trim().toUpperCase();
+  const r = rulesFor(sym);
+  if (qtyEl) {
+    qtyEl.step = String(r.lotSize);
+    qtyEl.min  = String(r.lotSize);
+  }
+  if (pxEl) {
+    pxEl.step = String(r.tickSize);
+  }
+  if (hint) {
+    hint.textContent = `lot ${r.lotSize} · tick ${r.tickSize}`;
+  }
 }
 
 export function setStatusPill(status) {

--- a/frontend/test/validation-rules.test.mjs
+++ b/frontend/test/validation-rules.test.mjs
@@ -1,0 +1,40 @@
+// T4 — lock the rulesFor() contract that syncTicketRules() relies on
+// in the order ticket. Defensive smoke tests so a future refactor
+// doesn't change the shape and silently break the qty step / hint.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { rulesFor, validateOrder } from "../js/validation.js";
+
+test("rulesFor returns lot/tick/threshold defaults for unknown symbol", () => {
+  const r = rulesFor("PETR4");
+  assert.equal(r.lotSize, 100);
+  assert.equal(r.tickSize, 0.01);
+  assert.equal(typeof r.fatFingerThreshold, "number");
+});
+
+test("rulesFor defaults apply to empty / null symbol", () => {
+  for (const s of ["", null, undefined]) {
+    const r = rulesFor(s);
+    assert.equal(r.lotSize, 100);
+    assert.equal(r.tickSize, 0.01);
+  }
+});
+
+test("rulesFor is case-insensitive on symbol", () => {
+  const upper = rulesFor("VALE3");
+  const lower = rulesFor("vale3");
+  assert.deepEqual(upper, lower);
+});
+
+test("validateOrder rejects sub-lot quantities using rulesFor", () => {
+  const err = validateOrder({ symbol: "PETR4", quantity: 150, type: "Market" });
+  assert.ok(err);
+  assert.equal(err.code, "lot_size");
+});
+
+test("validateOrder accepts lot-aligned market quantities", () => {
+  const err = validateOrder({ symbol: "PETR4", quantity: 100, type: "Market" });
+  assert.equal(err, null);
+});


### PR DESCRIPTION
Closes T4 from trader-ui-ergonomics-review.md.

The order ticket's qty input now syncs `step` + `min` from `rulesFor(symbol)` whenever the symbol field changes, and a 'lot 100 · tick 0.01' hint sits between the qty/price row and the submit button. Browser arrow-up/down on qty now increments by the lot size instead of 1, so the trader sees a lot violation at edit time rather than after submit.

## Why
Today `#ticket-qty` is hard-coded `step=100`, but lot size is per-symbol via `rulesFor()` (already used by `validateOrder`). When B3 lists a symbol with a non-100 lot (e.g. an ETF lot=10), the input would mislead. The hint also surfaces lot/tick before submit-time validation rejects the order.

## What
- **index.html**: new `<p id="ticket-rules-hint" class="field-hint" aria-live="polite">` between the qty/price row and the submit button.
- **ui.js**: `syncTicketRules()` reads `rulesFor(symbol)` and writes `qtyEl.step/min`, `pxEl.step`, and the hint text. Wired into the existing `#ticket-symbol` input/compositionend/change listeners + `clearTicket()`. Initial paint in `bindUi` so defaults show before any input. Imports `rulesFor` from `./validation.js`.
- **styles.css**: `.field-hint` (subdued, small, sits flush under the row).

## T5 — already shipped
T5 (login inflight + role=alert) was investigated during this PR and is already in main:
- `ui.js setLoginSubmitting(true)` is called around the `await login(...)` in `app.js onLogin`, disabling `#login-submit` and flipping its label to 'Signing in…'.
- `#login-error` already carries `role="alert"`.
The review file is stale on this point. Marked done in the queue.

## Tests
- 5 new `node:test` cases (`validation-rules.test.mjs`) locking `rulesFor()` shape (defaults, null/empty input, case-insensitivity) and the `validateOrder` lot path that the dynamic hint stays in sync with.
- 97/97 frontend tests green; `node --check` clean.

## Out of scope
- Populating `PER_SYMBOL` in `validation.js` with real B3 ETF lot sizes — separate config exercise once we agree on a source-of-truth list. The plumbing is in place.