### PR TITLE
fix(chart): surface 'no candles' after 8s instead of indefinite wait

### DIFF
--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -810,6 +810,14 @@ function ensureTicker() {
       const st = getState();
       const entry = st.selectedSymbol ? st.book.get(st.selectedSymbol) : null;
       if (st.selectedSymbol && (!entry || !entry.ready)) renderDob();
+      // Same idea for the chart: tick re-render while waiting so the
+      // copy can flip from "awaiting…" to "no candles — server may not
+      // publish them" once the timeout passes (issue #91).
+      const cperRes = st.selectedSymbol ? st.candles.get(st.selectedSymbol) : null;
+      const centry  = cperRes?.get(st.chartResolution);
+      if (st.selectedSymbol && (!centry || !centry.ready || centry.bars.length === 0)) {
+        scheduleChartRender();
+      }
     }
   }, 250);
 }
@@ -1164,6 +1172,11 @@ const CHART_VISIBLE_BARS = 150;
 const CHART_VIEW_W = 300;
 const CHART_VIEW_H = 100;
 const CHART_PADDING = 4;
+// Mirror DOB_NO_BOOK_AFTER_MS: after this long without a candle frame
+// for the selected symbol, swap the soft "awaiting…" copy for a louder
+// hint that the server probably doesn't publish candles (the current
+// b3-marketdata image has zero candle support — issue #91).
+const CHART_NO_DATA_AFTER_MS = 8_000;
 
 let chartRafHandle = null;
 
@@ -1202,7 +1215,10 @@ function renderChart() {
   const perRes = st.candles.get(st.selectedSymbol);
   const entry = perRes?.get(st.chartResolution);
   if (!entry || !entry.ready || entry.bars.length === 0) {
-    showEmpty("awaiting candle snapshot…");
+    const waited = st.selectedSymbolSetAt ? Date.now() - st.selectedSymbolSetAt : 0;
+    showEmpty(waited > CHART_NO_DATA_AFTER_MS
+      ? "no candles — server may not publish them"
+      : "awaiting candle snapshot…");
     return;
   }
 


### PR DESCRIPTION
Closes #91.

## Root cause confirmed
The current `b3-marketdata` image has **zero candle support**:
```
docker exec b3-marketdata sh -c 'for f in *.dll; do strings $f 2>/dev/null | grep -qi candle && echo "$f"; done'
# (returns nothing)
```
The frontend's `mdProtocol.FLAGS` doesn't even define a CANDLE bit, and `buildSubscribe` defaults to `TRADES | INFO` (no MBP either, so candles can't be derived). Net effect: the trader chart sat on 'awaiting candle snapshot…' forever whenever a symbol was selected, indistinguishable from a hung subscription.

## Fix
Mirror the DOB's existing `DOB_NO_BOOK_AFTER_MS` pattern: after 8s without a candle frame for the selected symbol, flip the empty-state copy to **'no candles — server may not publish them'**. The slow tick in `ensureTicker()` now also re-renders the chart while waiting, so the copy actually flips at the right moment without requiring a slice notify.

This is a UX-only fix. If/when b3-marketdata adds candle frames and `mdProtocol.FLAGS` gains a CANDLE bit + `buildSubscribe` wires it, the 'awaiting…' copy still shows for the first 8s and the timeout copy naturally disappears once frames start arriving. No other behavior changes.

## Out of scope (separate work)
- Adding CANDLE flag + subscribe path on the frontend — depends on whether the upstream B3MarketDataPlatform supports it (the issue's question to upstream).
- Server-side candle aggregation in `b3-marketdata` — backend work, separate RFC if we want it.