### PR TITLE
fix(chart): distinguish empty snapshot from no-snapshot (re #91)

### DIFF
--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -811,11 +811,13 @@ function ensureTicker() {
       const entry = st.selectedSymbol ? st.book.get(st.selectedSymbol) : null;
       if (st.selectedSymbol && (!entry || !entry.ready)) renderDob();
       // Same idea for the chart: tick re-render while waiting so the
-      // copy can flip from "awaiting…" to "no candles — server may not
-      // publish them" once the timeout passes (issue #91).
+      // copy can flip from "awaiting…" to "no candle snapshot received"
+      // once the timeout passes (issue #91). Once a snapshot has arrived
+      // (ready=true), the live render path covers updates — only keep
+      // ticking if we're still waiting for the snapshot itself.
       const cperRes = st.selectedSymbol ? st.candles.get(st.selectedSymbol) : null;
       const centry  = cperRes?.get(st.chartResolution);
-      if (st.selectedSymbol && (!centry || !centry.ready || centry.bars.length === 0)) {
+      if (st.selectedSymbol && (!centry || !centry.ready)) {
         scheduleChartRender();
       }
     }
@@ -1214,11 +1216,18 @@ function renderChart() {
 
   const perRes = st.candles.get(st.selectedSymbol);
   const entry = perRes?.get(st.chartResolution);
-  if (!entry || !entry.ready || entry.bars.length === 0) {
+  if (!entry || !entry.ready) {
     const waited = st.selectedSymbolSetAt ? Date.now() - st.selectedSymbolSetAt : 0;
     showEmpty(waited > CHART_NO_DATA_AFTER_MS
-      ? "no candles — server may not publish them"
+      ? "no candle snapshot received"
       : "awaiting candle snapshot…");
+    return;
+  }
+  if (entry.bars.length === 0) {
+    // Snapshot arrived empty — aggregator has no history yet for this
+    // resolution. The first CandleUpdate will fix this when a trade
+    // closes a window.
+    showEmpty("no candles yet — waiting for first trade");
     return;
   }
 


### PR DESCRIPTION
## Why

Re-investigated #91. Earlier diagnosis (PR #144) was based on grepping the marketdata container for candle symbols, which silently returned empty because `strings` isn't installed in .NET aspnet/runtime base images. After copying DLLs to the host and running `strings` locally — and cross-checking against B3MarketDataPlatform sources + a live WS probe — confirmed:

- Server **does** publish candles. `SubscriptionManager` sends `CandleSnapshot` (even empty) on every subscribe whenever `Mbp` or `Book` flag is set.
- Frontend already subscribes with `TRADES|INFO|MBP` (`app.js`).
- Decoder + worker + `state.js` all handle `CandleSnapshot`/`CandleUpdate` correctly.

What actually happens in dev: the per-resolution aggregator starts empty, so the snapshot arrives with `count=0`. `entry.ready=true, bars=[]`. The first `CandleUpdate` populates it once a trade closes a window.

PR #144's copy ("server may not publish them") was wrong and incorrectly blamed the server.

## What changed

- **`renderChart`**: split the empty branch in two:
  - `ready && bars.length===0` → `no candles yet — waiting for first trade` (legit empty aggregator).
- **Slow-tick** stops after `ready=true`. The live update path covers `CandleUpdate` arrivals; no need to keep RAF-rendering while idle.

## Tests

```
node --test frontend/test/{state-modify,state-staleness,cancel-all,validation-rules}.test.mjs
# 19/19 pass
```

No new tests — change is copy + slow-tick gating; existing chart rendering paths are unchanged.

## Live re-validation (probe)

Sent a proper `ClientHello (0x00A1)` + `Subscribe(PETR4, MBP|BOOK|TRADES|INFO)` against the running marketdata. Server returned, among others, `CandleSnapshot (0x0060)` — confirming candles flow.

re #91