### PR TITLE
feat(frontend): qty soft-cap + market-notional confirm + distinct MD not_ready color

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
         run: node --test frontend/test/decoder.test.mjs
 
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs
+        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -91,7 +91,15 @@ body {
 .status-connected    { background: rgba(54,196,111,.18); color: var(--green); }
 .status-connecting   { background: rgba(245,166,35,.18); color: var(--warn); }
 .status-disconnected { background: rgba(239,83,80,.18);  color: var(--red); }
-.status-not_ready    { background: rgba(245,166,35,.18); color: var(--warn); }
+/* `not_ready` means the WebSocket handshake completed but the server
+   hasn't yet declared itself ready for orders/snapshots. It's a
+   distinct condition from `connecting` (handshake in flight) and
+   needs its own colour so the trader can tell at a glance whether
+   the link is still being negotiated or whether the upstream feed
+   is stalled. Cyan/blue family keeps it visually different from the
+   warm tones used by `connecting` while still reading as "advisory,
+   not an error". */
+.status-not_ready    { background: rgba(74,144,226,.18); color: #4a90e2; }
 .user-label { color: var(--muted); }
 .symbol-select {
   display: inline-flex; align-items: center; gap: .35rem;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -6,7 +6,7 @@ import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cance
          getHaltStatus, haltSymbol, resumeSymbol,
          runEod } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
-import { validateOrder, fatFingerCheck, payloadKey } from "./validation.js";
+import { validateOrder, pretradeWarnings, payloadKey } from "./validation.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
 import * as adminUi from "./adminUi.js";
@@ -485,34 +485,46 @@ function onWorkerMessage(msg) {
   }
 }
 
+function formatPretradeWarning(w) {
+  switch (w.kind) {
+    case "fat_finger": {
+      const pct = (w.deviation * 100).toFixed(1);
+      return `fat-finger: price deviates ${pct}% from last trade ${ui.fmtPx(w.lastPrice)}`;
+    }
+    case "qty":
+      return `large quantity: ${w.qty.toLocaleString("pt-BR")} > ${w.multiple}× lot (${w.threshold.toLocaleString("pt-BR")})`;
+    case "market_notional": {
+      const fmt = (n) => `R$ ${n.toLocaleString("pt-BR", { maximumFractionDigits: 0 })}`;
+      return `market notional ≈ ${fmt(w.notional)} ≥ ${fmt(w.threshold)}`;
+    }
+    default:
+      return "advisory warning";
+  }
+}
+
 async function handleSubmitOrder(payload) {
   if (!session) return;
 
   const error = validateOrder(payload);
-  if (error) return ui.setTicketFeedback(error.message, "error");
-
-  // Fat-finger guard: first attempt with a >threshold deviation from
-  // the last observed trade is rejected with a warning; the same exact
-  // payload submitted again within the pending window goes through.
-  // We TTL the pending guard at 15s so a trader who walks away and
-  // returns later doesn't have an old "armed" override silently apply
-  // to a fresh ticket.
+  if (error) return ui.setTicketFeedback(error.message, "error");  // Pre-trade advisory guards (fat-finger, soft quantity cap, market
+  // notional). The first attempt with one or more warnings is rejected
+  // with a combined message; the same exact payload re-submitted within
+  // the pending window goes through. We TTL the pending guard at 15s so
+  // a trader who walks away and returns later doesn't have an old
+  // "armed" override silently apply to a fresh ticket.
   const FAT_FINGER_TTL_MS = 15_000;
   const lastPrice = state.getState().marketData.get(payload.symbol)?.lastPrice;
-  const ff = fatFingerCheck(payload, lastPrice);
+  const warnings = pretradeWarnings(payload, lastPrice);
   const key = payloadKey(payload);
   let pending = state.getState().pendingFatFinger;
   if (pending && pending.setAt && (Date.now() - pending.setAt) > FAT_FINGER_TTL_MS) {
     state.setPendingFatFinger(null);
     pending = null;
   }
-  if (ff && (!pending || pending.key !== key)) {
+  if (warnings.length > 0 && (!pending || pending.key !== key)) {
     state.setPendingFatFinger(payload, key);
-    const pct = (ff.deviation * 100).toFixed(1);
-    ui.setTicketFeedback(
-      `fat-finger guard: price deviates ${pct}% from last trade ${ui.fmtPx(ff.lastPrice)}. Click Submit again to override.`,
-      "warn",
-    );
+    const msg = warnings.map(w => formatPretradeWarning(w)).join(" · ");
+    ui.setTicketFeedback(`${msg}. Click Submit again to override.`, "warn");
     return;
   }
   // Clear pending guard once the user confirms or moves on.

--- a/frontend/js/validation.js
+++ b/frontend/js/validation.js
@@ -5,6 +5,18 @@ const DEFAULTS = {
   tickSize: 0.01,
   lotSize: 100,
   fatFingerThreshold: 0.10, // 10% deviation from last trade
+  // Soft cap on quantity expressed as a multiple of the lot size. A
+  // ticket above this needs an explicit confirm. 100× lot ≈ 10_000
+  // shares for the typical PETR4/VALE3 lot, which is comfortably
+  // larger than the median manual trade but small enough to catch
+  // an extra zero typo (100k where 10k was meant).
+  maxQuantityLotMultiple: 100,
+  // Notional confirmation threshold for Market orders, in BRL.
+  // Limit orders are already covered by the fat-finger check on
+  // price, but Market orders have no price to compare against — so
+  // we estimate notional from `qty * lastPrice` and arm a confirm
+  // when it crosses this number.
+  marketNotionalConfirm: 500_000,
 };
 
 // Per-symbol overrides — populated as the platform grows. Until then
@@ -16,9 +28,11 @@ const PER_SYMBOL = {
 export function rulesFor(symbol) {
   const o = PER_SYMBOL[symbol?.toUpperCase()] ?? {};
   return {
-    tickSize:           o.tickSize           ?? DEFAULTS.tickSize,
-    lotSize:            o.lotSize            ?? DEFAULTS.lotSize,
-    fatFingerThreshold: o.fatFingerThreshold ?? DEFAULTS.fatFingerThreshold,
+    tickSize:              o.tickSize              ?? DEFAULTS.tickSize,
+    lotSize:               o.lotSize               ?? DEFAULTS.lotSize,
+    fatFingerThreshold:    o.fatFingerThreshold    ?? DEFAULTS.fatFingerThreshold,
+    maxQuantityLotMultiple: o.maxQuantityLotMultiple ?? DEFAULTS.maxQuantityLotMultiple,
+    marketNotionalConfirm: o.marketNotionalConfirm ?? DEFAULTS.marketNotionalConfirm,
   };
 }
 
@@ -73,6 +87,51 @@ export function fatFingerCheck(payload, lastPrice) {
   const deviation = Math.abs(px - lastPrice) / lastPrice;
   if (deviation <= rules.fatFingerThreshold) return null;
   return { warn: true, deviation, lastPrice, threshold: rules.fatFingerThreshold };
+}
+
+// Soft cap on quantity. Returns { warn, qty, lotSize, multiple, threshold }
+// when qty exceeds `maxQuantityLotMultiple × lotSize`, else null. Catches
+// the classic extra-zero typo (100_000 where 10_000 was meant).
+export function quantityGuardCheck(payload) {
+  const qty = Number(payload.quantity);
+  if (!Number.isFinite(qty) || qty <= 0) return null;
+  const rules = rulesFor(payload.symbol);
+  const cap = rules.maxQuantityLotMultiple * rules.lotSize;
+  if (qty <= cap) return null;
+  return {
+    warn: true,
+    qty,
+    lotSize: rules.lotSize,
+    multiple: rules.maxQuantityLotMultiple,
+    threshold: cap,
+  };
+}
+
+// Notional confirmation for Market orders. We have no limit price to
+// fat-finger-check, so the only safety net is "this would spend more
+// than R$ X" — armed once and confirmed on a second click.
+// Returns { warn, notional, lastPrice, threshold } or null.
+export function marketNotionalCheck(payload, lastPrice) {
+  if (payload.type !== "Market") return null;
+  const qty = Number(payload.quantity);
+  if (!Number.isFinite(qty) || qty <= 0) return null;
+  if (!Number.isFinite(lastPrice) || lastPrice <= 0) return null;
+
+  const rules = rulesFor(payload.symbol);
+  const notional = qty * lastPrice;
+  if (notional < rules.marketNotionalConfirm) return null;
+  return { warn: true, notional, lastPrice, threshold: rules.marketNotionalConfirm };
+}
+
+// Run every advisory pre-trade check and return them in a stable order.
+// Callers render a combined warning and arm a single "click again to
+// confirm" override keyed by `payloadKey`.
+export function pretradeWarnings(payload, lastPrice) {
+  const out = [];
+  const q  = quantityGuardCheck(payload);   if (q)  out.push({ kind: "qty", ...q });
+  const ff = fatFingerCheck(payload, lastPrice); if (ff) out.push({ kind: "fat_finger", ...ff });
+  const m  = marketNotionalCheck(payload, lastPrice); if (m) out.push({ kind: "market_notional", ...m });
+  return out;
 }
 
 // Stable key for a payload so the UI can detect "same submission"

--- a/frontend/test/pretrade-guards.test.mjs
+++ b/frontend/test/pretrade-guards.test.mjs
@@ -1,0 +1,114 @@
+// Pre-trade advisory guards — quantity soft-cap and market-order
+// notional confirmation. Pairs with the existing fat-finger check;
+// all three are funnelled through `pretradeWarnings()` so the order
+// ticket can render a single combined message and arm one override.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  rulesFor,
+  quantityGuardCheck,
+  marketNotionalCheck,
+  fatFingerCheck,
+  pretradeWarnings,
+} from "../js/validation.js";
+
+test("rulesFor exposes maxQuantityLotMultiple and marketNotionalConfirm", () => {
+  const r = rulesFor("PETR4");
+  assert.equal(r.maxQuantityLotMultiple, 100);
+  assert.equal(r.marketNotionalConfirm, 500_000);
+});
+
+test("quantityGuardCheck: under cap → null", () => {
+  // 100 lot × 100 multiple = 10_000 cap. 9_900 is below.
+  const out = quantityGuardCheck({ symbol: "PETR4", quantity: 9_900 });
+  assert.equal(out, null);
+});
+
+test("quantityGuardCheck: equal to cap → null (cap is inclusive)", () => {
+  const out = quantityGuardCheck({ symbol: "PETR4", quantity: 10_000 });
+  assert.equal(out, null);
+});
+
+test("quantityGuardCheck: above cap → warn with cap details", () => {
+  const out = quantityGuardCheck({ symbol: "PETR4", quantity: 100_000 });
+  assert.ok(out, "expected a warning for 100k vs 10k cap");
+  assert.equal(out.qty, 100_000);
+  assert.equal(out.multiple, 100);
+  assert.equal(out.threshold, 10_000);
+});
+
+test("quantityGuardCheck: ignores non-positive / NaN quantities", () => {
+  for (const q of [0, -1, NaN, "x"]) {
+    assert.equal(quantityGuardCheck({ symbol: "PETR4", quantity: q }), null);
+  }
+});
+
+test("marketNotionalCheck: only fires for Market orders", () => {
+  const limit = marketNotionalCheck({ symbol: "PETR4", type: "Limit", quantity: 1_000_000 }, 100);
+  assert.equal(limit, null);
+});
+
+test("marketNotionalCheck: requires a positive lastPrice", () => {
+  for (const lp of [undefined, null, 0, -1, NaN]) {
+    assert.equal(
+      marketNotionalCheck({ symbol: "PETR4", type: "Market", quantity: 1_000_000 }, lp),
+      null,
+    );
+  }
+});
+
+test("marketNotionalCheck: under threshold → null", () => {
+  // 100 × 32.50 = 3_250 — well below the 500k threshold
+  const out = marketNotionalCheck({ symbol: "PETR4", type: "Market", quantity: 100 }, 32.5);
+  assert.equal(out, null);
+});
+
+test("marketNotionalCheck: at/above threshold → warn", () => {
+  // 20_000 × 32.50 = 650_000 → above 500k
+  const out = marketNotionalCheck({ symbol: "PETR4", type: "Market", quantity: 20_000 }, 32.5);
+  assert.ok(out);
+  assert.equal(out.notional, 650_000);
+  assert.equal(out.threshold, 500_000);
+});
+
+test("pretradeWarnings: combines all triggered checks in stable order", () => {
+  // Limit, qty=100k (over cap), price 9999 vs lastPrice 32 (huge fat-finger)
+  const warns = pretradeWarnings(
+    { symbol: "PETR4", side: "Buy", type: "Limit", quantity: 100_000, price: 9999 },
+    32,
+  );
+  assert.equal(warns.length, 2);
+  assert.equal(warns[0].kind, "qty");        // qty first
+  assert.equal(warns[1].kind, "fat_finger"); // then fat-finger
+});
+
+test("pretradeWarnings: market+huge notional triggers only market_notional", () => {
+  const warns = pretradeWarnings(
+    { symbol: "PETR4", side: "Buy", type: "Market", quantity: 100 },
+    100_000,
+  );
+  // 100 * 100_000 = 10MM ≥ 500k → market_notional. qty=100 is below cap.
+  assert.equal(warns.length, 1);
+  assert.equal(warns[0].kind, "market_notional");
+});
+
+test("pretradeWarnings: clean payload returns empty array", () => {
+  const warns = pretradeWarnings(
+    { symbol: "PETR4", side: "Buy", type: "Limit", quantity: 100, price: 32.5 },
+    32.5,
+  );
+  assert.deepEqual(warns, []);
+});
+
+test("backwards-compat: fatFingerCheck still callable directly", () => {
+  // Legacy callers that haven't migrated to pretradeWarnings should
+  // keep working — the helper is still exported with the old shape.
+  const ff = fatFingerCheck(
+    { symbol: "PETR4", type: "Limit", quantity: 100, price: 100 },
+    32.5,
+  );
+  assert.ok(ff);
+  assert.equal(ff.warn, true);
+});


### PR DESCRIPTION
Three small ergonomics quick-wins from the trader UI review (the trio that didn't fit T1-T5 but kept showing up in walkthrough notes).

## 1. Quantity soft-cap ("extra-zero typo" guard)

`quantityGuardCheck()` arms a confirm when qty > **100× lot size** (10_000 shares for the typical 100-share lot). Catches the classic 100k-where-10k-was-meant typo without blocking institution-size tickets — second click overrides, same as the existing fat-finger guard. Cap is per-symbol via `rulesFor()`.

## 2. Market-order notional confirm

Limit orders are already covered by fat-finger on price; Market orders had no analog. `marketNotionalCheck()` estimates notional = `qty × lastPrice` and arms a confirm at **R$ 500_000**. Skipped when there's no `lastPrice` reference.

## 3. Combined warning surface

Both new guards funnel through `pretradeWarnings()` alongside fat-finger, so the ticket renders **one combined message** and arms **one override** keyed by `payloadKey`. The TTL on the pending guard is unchanged (15s). Legacy `fatFingerCheck` export kept for any external caller.

## 4. MD `not_ready` distinct colour

`status-not_ready` and `status-connecting` shared the exact same warm pill — impossible to tell at a glance whether the WS handshake was still in flight or whether the upstream feed had connected but declared itself not-ready. Moved `not_ready` to a cyan/blue tone, still reads as advisory.

## Tests

11 new in `pretrade-guards.test.mjs`: defaults exposed, qty cap (under/at/above/NaN), market notional (Limit skipped, missing/zero lastPrice, under/above), combined warnings ordering, market-only path, clean payload returns empty, legacy fatFingerCheck preserved.

```
node --test frontend/test/{state-modify,state-staleness,cancel-all,validation-rules,pretrade-guards}.test.mjs
# 32/32 pass
```

CI workflow updated to include the new test file.