### PR TITLE
feat(orders): order staleness overlay (#132 slice 1)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
+using B3.Trading.Application;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
@@ -52,6 +53,71 @@ public static class AdminEndpoints
 
         group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
             ToggleHalt(dispatcher, symbol, halted: false, ctx, () => svc.Resume(symbol)));
+
+        // ── Order staleness overlay (#132 slice 1) ────────────────
+        // Lets an admin flag a specific working order as
+        // suspected-stale-by-venue (matching restart, FIXP gap, etc.)
+        // so Cancel/Modify return 409 until it's cleared. Cleared
+        // automatically when a real terminal ER arrives. Both routes
+        // are firm-scoped so the same ClOrdID across firms (rare —
+        // ClOrdIDs are per-firm) cannot be addressed from another firm.
+        group.MapPost("/firms/{firmId}/orders/{clOrdId}/mark-stale",
+            (string firmId, string clOrdId, MarkStaleRequest req, HttpContext ctx, OrderStalenessService svc) =>
+            {
+                if (!ulong.TryParse(clOrdId, out var clOrdIdU))
+                    return Results.NotFound();
+                var reason = string.IsNullOrWhiteSpace(req?.Reason) ? "operator-marked-stale" : req!.Reason!;
+                var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+                try
+                {
+                    var result = svc.MarkStale(firmId, clOrdIdU, reason, DateTimeOffset.UtcNow, actor);
+                    return result switch
+                    {
+                        MarkStaleResult.Marked => Results.NoContent(),
+                        MarkStaleResult.AlreadyStale => Results.NoContent(),
+                        MarkStaleResult.NotFound => Results.NotFound(),
+                        MarkStaleResult.WrongFirm => Results.NotFound(),
+                        MarkStaleResult.NotEligible => Results.Conflict(new { error = "order not eligible for stale mark (must be Working or PartiallyFilled)" }),
+                        _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+                    };
+                }
+                catch (WalBackpressureException ex)
+                {
+                    MetricsRegistry.WalBackpressure.Add(1,
+                        new KeyValuePair<string, object?>("call_site", "admin.stale.mark"));
+                    return Results.Json(
+                        new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                        statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+            });
+
+        group.MapPost("/firms/{firmId}/orders/{clOrdId}/clear-stale",
+            (string firmId, string clOrdId, HttpContext ctx, OrderStalenessService svc) =>
+            {
+                if (!ulong.TryParse(clOrdId, out var clOrdIdU))
+                    return Results.NotFound();
+                var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+                try
+                {
+                    var result = svc.ClearStale(firmId, clOrdIdU, actor);
+                    return result switch
+                    {
+                        ClearStaleResult.Cleared => Results.NoContent(),
+                        ClearStaleResult.NotStale => Results.NoContent(),
+                        ClearStaleResult.NotFound => Results.NotFound(),
+                        ClearStaleResult.WrongFirm => Results.NotFound(),
+                        _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+                    };
+                }
+                catch (WalBackpressureException ex)
+                {
+                    MetricsRegistry.WalBackpressure.Add(1,
+                        new KeyValuePair<string, object?>("call_site", "admin.stale.clear"));
+                    return Results.Json(
+                        new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                        statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+            });
 
         group.MapPost("/eod", (EodMaterialiser eod, IOptions<PersistenceOptions> opts) =>
         {
@@ -308,3 +374,8 @@ public static class AdminEndpoints
         }
     }
 }
+
+/// <summary>
+/// Slice 1 of #132. Body for <c>POST /admin/firms/{firmId}/orders/{clOrdId}/mark-stale</c>.
+/// </summary>
+public sealed record MarkStaleRequest(string? Reason);

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -142,6 +142,16 @@ public static class OrdersEndpoints
             if (order.Owner != owner)
                 return Results.NotFound();
 
+            // Slice 1 of #132. Reject Cancel against an order the operator
+            // has flagged as suspected-stale-by-venue: the venue most
+            // likely doesn't know the original ClOrdID either, and we'd
+            // burn a fresh ClOrdID for nothing. Operator must explicitly
+            // clear the stale overlay first (admin endpoint) when the
+            // venue catches up, or rely on the eventual real terminal ER
+            // to auto-clear.
+            if (order.IsStale)
+                return Results.Conflict(new { error = "order is marked stale", reason = order.StaleReason });
+
             var cancelClOrdId = clOrdIds.Generate(owner);
             // Record the cancel-side → original mapping BEFORE sending so
             // the cancel-ack ER can resolve back to the right order even

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -33,7 +33,10 @@ public sealed record OrderDto(
     decimal? Price,
     string Status,
     string? ParentAlgoId = null,
-    int? AlgoSliceSeq = null);
+    int? AlgoSliceSeq = null,
+    bool IsStale = false,
+    string? StaleReason = null,
+    DateTimeOffset? StaledAtUtc = null);
 
 public sealed record PositionDto(
     string Symbol,
@@ -98,7 +101,8 @@ public static class DtoMappings
     public static OrderDto ToDto(this Order o) => new(
         o.ClOrdId.ToString(), o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
         o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
-        o.ParentAlgoId?.ToString(), o.AlgoSliceSeq);
+        o.ParentAlgoId?.ToString(), o.AlgoSliceSeq,
+        o.IsStale, o.StaleReason, o.StaledAtUtc);
 
     public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
 

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -213,6 +213,19 @@ public sealed class ExecutionReportProcessor
                 break;
         }
 
+        // Slice 1 of #132. A real terminal ER means the venue actually
+        // still knew this order — any prior advisory stale flag was a
+        // false positive. Lift it as a side-effect; replay reconstructs
+        // the same end state because the OrderStaledEvent is applied
+        // first and this terminal ER arrives later in the same WAL
+        // stream. Partial fills do NOT clear (the venue may know the
+        // original child but the trader's worry that the rest is
+        // ghosted is still valid).
+        if (order.IsStale && order.Status is OrderStatus.Filled or OrderStatus.Cancelled or OrderStatus.Rejected or OrderStatus.Replaced)
+        {
+            order.ClearStale();
+        }
+
         // Server-side STP detection (#117): if the matching engine
         // emitted a cancel with a SelfTradePrevention restatement
         // reason, mark the outbound event so the UI/logs can surface
@@ -311,6 +324,9 @@ public sealed class ExecutionReportProcessor
             or OrderStatus.Cancelled
             or OrderStatus.Replaced;
         origOrder.MarkReplaced();
+        // Slice 1 of #132: terminalising clears any advisory stale.
+        if (origOrder.IsStale)
+            origOrder.ClearStale();
 
         _sink.Publish(new ExecutionEvent(
             intent.Owner,

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -116,6 +116,14 @@ public sealed class OrderModifyService
             return OrderModifyResult.Conflict("order is terminal");
         }
 
+        // Slice 1 of #132: refuse Modify against a stale-flagged order.
+        // Same rationale as the cancel gate: the venue most likely
+        // doesn't know the original ClOrdID, so a CancelReplace would
+        // just burn a new ID. Operator clears stale (admin endpoint or
+        // real terminal ER auto-clear) before reissuing.
+        if (orig.IsStale)
+            return OrderModifyResult.Conflict("order is marked stale");
+
         if (req.NewQuantity <= orig.CumulativeQuantity)
         {
             // Modifying the total qty to or below already-filled cum

--- a/backend/src/B3.Trading.Application/OrderStalenessService.cs
+++ b/backend/src/B3.Trading.Application/OrderStalenessService.cs
@@ -1,0 +1,122 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Slice 1 of #132. Surfaces the advisory venue-staleness overlay
+/// described on <see cref="Order.IsStale"/>: an admin/operator can flag
+/// a working order as suspected-stale-by-venue (typically after a
+/// venue restart that reset the matching book without our trading-host
+/// noticing) so the platform stops issuing Cancel/Modify against a
+/// phantom while keeping every other accounting concern (positions,
+/// cash, risk, algo parents) untouched.
+///
+/// <para>
+/// Mark/Clear go through <see cref="EventDispatcher"/> so the WAL
+/// records the decision and post-recovery state matches what the
+/// operator saw before the restart. The two paths are idempotent and
+/// honour the domain state-machine: only Working / PartiallyFilled
+/// orders accept a stale mark, and re-marking an already-stale order
+/// is a no-op.
+/// </para>
+///
+/// <para>
+/// Auto-clear on terminal ER (<see cref="ExecKind.Filled"/>,
+/// <see cref="ExecKind.Canceled"/>, <see cref="ExecKind.Rejected"/>,
+/// <see cref="ExecKind.Replaced"/>) is handled in
+/// <see cref="ExecutionReportProcessor"/> — the venue actually still
+/// knew the order, so the stale mark was a false positive and we lift
+/// it as a side-effect of the genuine ER stream.
+/// </para>
+/// </summary>
+public sealed class OrderStalenessService
+{
+    private readonly EventDispatcher _dispatcher;
+    private readonly WorkingOrderBook _orders;
+
+    public OrderStalenessService(EventDispatcher dispatcher, WorkingOrderBook orders)
+    {
+        _dispatcher = dispatcher;
+        _orders = orders;
+    }
+
+    public MarkStaleResult MarkStale(string firmId, ulong clOrdId, string reason, DateTimeOffset atUtc, string? actorUserId)
+    {
+        if (string.IsNullOrWhiteSpace(firmId))
+            throw new ArgumentException("firmId required.", nameof(firmId));
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("reason required.", nameof(reason));
+
+        if (!_orders.TryGet(clOrdId, out var order) || order is null)
+            return MarkStaleResult.NotFound;
+        if (!string.Equals(order.FirmId, firmId, StringComparison.OrdinalIgnoreCase))
+            return MarkStaleResult.WrongFirm;
+        if (order.IsStale)
+            return MarkStaleResult.AlreadyStale;
+        if (order.Status is not (OrderStatus.Working or OrderStatus.PartiallyFilled))
+            return MarkStaleResult.NotEligible;
+
+        var evt = new OrderStaledEvent
+        {
+            ClOrdId = clOrdId,
+            FirmId = order.FirmId,
+            Reason = reason,
+            StaledAtUtc = atUtc,
+            ActorUserId = actorUserId,
+        };
+        var marked = false;
+        _dispatcher.Dispatch(evt, () =>
+        {
+            // Re-check inside the dispatcher lock to defend against a
+            // racing terminal ER that flipped status after the
+            // optimistic check above. ApplyCumulativeFill / MarkCancelled
+            // also run under the same lock via EventDispatcher.Dispatch,
+            // so this is a sufficient barrier.
+            marked = order.MarkStale(reason, atUtc);
+        });
+        return marked ? MarkStaleResult.Marked : MarkStaleResult.NotEligible;
+    }
+
+    public ClearStaleResult ClearStale(string firmId, ulong clOrdId, string? actorUserId)
+    {
+        if (string.IsNullOrWhiteSpace(firmId))
+            throw new ArgumentException("firmId required.", nameof(firmId));
+
+        if (!_orders.TryGet(clOrdId, out var order) || order is null)
+            return ClearStaleResult.NotFound;
+        if (!string.Equals(order.FirmId, firmId, StringComparison.OrdinalIgnoreCase))
+            return ClearStaleResult.WrongFirm;
+        if (!order.IsStale)
+            return ClearStaleResult.NotStale;
+
+        var evt = new OrderStaleClearedEvent
+        {
+            ClOrdId = clOrdId,
+            FirmId = order.FirmId,
+            ResolvedBy = "admin",
+            ActorUserId = actorUserId,
+        };
+        var cleared = false;
+        _dispatcher.Dispatch(evt, () => cleared = order.ClearStale());
+        return cleared ? ClearStaleResult.Cleared : ClearStaleResult.NotStale;
+    }
+}
+
+public enum MarkStaleResult
+{
+    Marked,
+    AlreadyStale,
+    NotFound,
+    WrongFirm,
+    /// <summary>Order exists but is in PendingNew or a terminal status.</summary>
+    NotEligible,
+}
+
+public enum ClearStaleResult
+{
+    Cleared,
+    NotStale,
+    NotFound,
+    WrongFirm,
+}

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -50,7 +50,19 @@ public sealed record OrderSnapshot(
     string Status,
     string FirmId = "DEFAULT",
     ulong? ParentAlgoId = null,
-    int? AlgoSliceSeq = null);
+    int? AlgoSliceSeq = null)
+{
+    /// <summary>
+    /// Slice 1 of #132. Advisory venue-staleness overlay. Older snapshots
+    /// pre-date the field; default of <c>false</c> is correct on restore
+    /// (no stale marks before this slice existed).
+    /// </summary>
+    public bool IsStale { get; init; }
+
+    public string? StaleReason { get; init; }
+
+    public DateTimeOffset? StaledAtUtc { get; init; }
+}
 
 /// <summary>
 /// Captures an <see cref="B3.Trading.Domain.Algo"/> aggregate. Discriminated

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -24,6 +24,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoCreatedEvent), "algo.created")]
 [JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
+[JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
+[JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -201,4 +203,35 @@ public sealed record AlgoTerminalStateRecordedEvent : WalEvent
     public required string Status { get; init; }    // AlgoStatus enum name
     public required string Reason { get; init; }    // AlgoTerminalReason enum name
     public required DateTimeOffset AtUtc { get; init; }
+}
+
+/// <summary>
+/// Slice 1 of #132. Persists an admin / operator decision to flag a
+/// working order as suspected-stale-by-venue (typically after a venue
+/// restart that reset its book without our trading-host noticing). The
+/// underlying business state is unchanged — replay re-applies the
+/// advisory overlay so post-recovery state matches what the operator
+/// saw before the restart.
+/// </summary>
+public sealed record OrderStaledEvent : WalEvent
+{
+    public required ulong ClOrdId { get; init; }
+    public required string FirmId { get; init; }
+    public required string Reason { get; init; }
+    public required DateTimeOffset StaledAtUtc { get; init; }
+    public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Slice 1 of #132. Records that the staleness overlay was lifted —
+/// either because an admin explicitly cleared it or because a real
+/// terminal ER arrived (the venue actually still knew the order, so the
+/// stale mark was a false positive). Idempotent on replay.
+/// </summary>
+public sealed record OrderStaleClearedEvent : WalEvent
+{
+    public required ulong ClOrdId { get; init; }
+    public required string FirmId { get; init; }
+    public required string ResolvedBy { get; init; }    // "admin" or "er-terminal"
+    public string? ActorUserId { get; init; }
 }

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -184,7 +184,12 @@ public sealed class WorkingOrderBook
                 o.ClOrdId, o.Owner.Value, o.Symbol, o.SecurityId,
                 o.Side.ToString(), o.Type.ToString(),
                 o.Quantity, o.Price, o.LeavesQuantity, o.CumulativeQuantity,
-                o.Status.ToString(), o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq);
+                o.Status.ToString(), o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq)
+            {
+                IsStale = o.IsStale,
+                StaleReason = o.StaleReason,
+                StaledAtUtc = o.StaledAtUtc,
+            };
         }
     }
 
@@ -202,7 +207,8 @@ public sealed class WorkingOrderBook
             var status = Enum.Parse<OrderStatus>(s.Status);
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId,
-                s.ParentAlgoId, s.AlgoSliceSeq);
+                s.ParentAlgoId, s.AlgoSliceSeq,
+                isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -108,6 +108,72 @@ public sealed class Order
     public long CumulativeQuantity { get; private set; }
     public OrderStatus Status { get; private set; }
 
+    /// <summary>
+    /// Slice 1 of #132. Advisory flag set when the platform suspects the
+    /// venue no longer knows about this order — typically because the
+    /// matching engine restarted with a fresh book while trading-host
+    /// retained its WAL/snapshot state. Stale orders remain in their
+    /// previous status (Working/PartiallyFilled) so positions/cash/risk
+    /// accounting is unchanged, but Cancel/Modify is blocked at the API
+    /// (409) since sending those against a phantom is wasted bandwidth
+    /// and creates extra ClOrdIDs that the venue will reject. Cleared
+    /// automatically when a real terminal ER arrives (the venue actually
+    /// knew the order — false positive). NOT a status because the
+    /// underlying business state hasn't changed; it's an overlay.
+    /// </summary>
+    public bool IsStale { get; private set; }
+
+    /// <summary>Free-text reason recorded when staleness was set.</summary>
+    public string? StaleReason { get; private set; }
+
+    /// <summary>Wall-clock timestamp of the first stale mark (preserved on idempotent re-marks).</summary>
+    public DateTimeOffset? StaledAtUtc { get; private set; }
+
+    /// <summary>
+    /// Slice 1 of #132. Mark this order as suspected-stale-by-venue.
+    /// Returns <c>true</c> when the call mutated state (i.e. the order
+    /// was restable and not already stale), <c>false</c> otherwise.
+    ///
+    /// <para>
+    /// Only Working / PartiallyFilled orders may be marked stale. We
+    /// deliberately exclude PendingNew (the venue may simply not have
+    /// acked yet — that's a different bug class) and every terminal
+    /// status (Filled/Cancelled/Rejected/Replaced — nothing left to
+    /// be ghosted). Idempotent: re-marking an already-stale order is
+    /// a no-op and preserves the original <see cref="StaledAtUtc"/>.
+    /// </para>
+    /// </summary>
+    public bool MarkStale(string reason, DateTimeOffset atUtc)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("Stale reason required.", nameof(reason));
+        if (IsStale)
+            return false;
+        if (Status is not (OrderStatus.Working or OrderStatus.PartiallyFilled))
+            return false;
+        IsStale = true;
+        StaleReason = reason;
+        StaledAtUtc = atUtc;
+        return true;
+    }
+
+    /// <summary>
+    /// Clears advisory staleness. Called by
+    /// <see cref="ExecutionReportProcessor"/> on terminal ERs (the venue
+    /// actually still knew the order — the stale mark was a false
+    /// positive) and by the admin "clear stale" path. Returns
+    /// <c>true</c> when state changed.
+    /// </summary>
+    public bool ClearStale()
+    {
+        if (!IsStale)
+            return false;
+        IsStale = false;
+        StaleReason = null;
+        StaledAtUtc = null;
+        return true;
+    }
+
     public void ApplyFill(long fillQty)
     {
         if (fillQty <= 0)
@@ -209,12 +275,19 @@ public sealed class Order
     internal static Order Hydrate(
         ulong clOrdId, EndClientId owner, string symbol, ulong securityId, OrderSide side, OrderType type,
         long quantity, decimal? price, long leaves, long cumQty, OrderStatus status, string firmId = "DEFAULT",
-        ulong? parentAlgoId = null, int? algoSliceSeq = null)
+        ulong? parentAlgoId = null, int? algoSliceSeq = null,
+        bool isStale = false, string? staleReason = null, DateTimeOffset? staledAtUtc = null)
     {
         var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;
+        if (isStale)
+        {
+            o.IsStale = true;
+            o.StaleReason = staleReason;
+            o.StaledAtUtc = staledAtUtc;
+        }
         return o;
     }
 

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -151,6 +151,7 @@ builder.Services.AddSingleton<EventDispatcher>();
 // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.
 builder.Services.AddSingleton<KillSwitchService>();
 builder.Services.AddSingleton<SymbolHaltService>();
+builder.Services.AddSingleton<OrderStalenessService>();
 builder.Services.AddTradingMarketData(builder.Configuration);
 builder.Services.AddSingleton<ReserveOnSubmitMarginProvider>(sp =>
     new ReserveOnSubmitMarginProvider(

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -196,6 +196,14 @@ public sealed class EventReplayer
                     algo.RecordTerminal(status, reason, at.AtUtc);
                 }
                 break;
+            case OrderStaledEvent os:
+                if (_orders.TryGet(os.ClOrdId, out var staleOrd) && staleOrd is not null)
+                    staleOrd.MarkStale(os.Reason, os.StaledAtUtc);
+                break;
+            case OrderStaleClearedEvent osc:
+                if (_orders.TryGet(osc.ClOrdId, out var clearOrd) && clearOrd is not null)
+                    clearOrd.ClearStale();
+                break;
         }
     }
 

--- a/backend/tests/B3.Trading.Api.Tests/OrderStaleAdminEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrderStaleAdminEndpointTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Api.Tests;
+
+public class OrderStaleAdminEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+
+    public OrderStaleAdminEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    private static Order SeedWorkingOrder(TestAppFactory factory, ulong clOrdId, string firmId = "TEST")
+    {
+        var book = (WorkingOrderBook)factory.Services.GetService(typeof(WorkingOrderBook))!;
+        var ownership = (OrderOwnershipMap)factory.Services.GetService(typeof(OrderOwnershipMap))!;
+        var registry = (EndClientRegistry)factory.Services.GetService(typeof(EndClientRegistry))!;
+        var owner = registry.Register("alice");
+        var o = new Order(clOrdId, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId);
+        o.MarkWorking();
+        book.TryAdd(o);
+        ownership.Register(clOrdId, owner);
+        return o;
+    }
+
+    [Fact]
+    public async Task MarkStale_RequiresAdminRole()
+    {
+        SeedWorkingOrder(_factory, 9000UL);
+        using var user = await _factory.CreateAuthedClientAsync(); // alice
+        var resp = await user.PostAsJsonAsync("/admin/firms/TEST/orders/9000/mark-stale", new { reason = "x" });
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkStale_HappyPath_ReturnsNoContent_AndSetsFlag()
+    {
+        var order = SeedWorkingOrder(_factory, 9001UL);
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+
+        var resp = await admin.PostAsJsonAsync(
+            "/admin/firms/TEST/orders/9001/mark-stale",
+            new { reason = "matching restart" });
+
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+        Assert.True(order.IsStale);
+        Assert.Equal("matching restart", order.StaleReason);
+    }
+
+    [Fact]
+    public async Task MarkStale_Idempotent_ReturnsNoContent()
+    {
+        SeedWorkingOrder(_factory, 9002UL);
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9002/mark-stale", new { reason = "x" });
+
+        var resp = await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9002/mark-stale", new { reason = "y" });
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkStale_UnknownClOrdId_ReturnsNotFound()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/firms/TEST/orders/99999/mark-stale", new { reason = "x" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MarkStale_WrongFirm_ReturnsNotFound()
+    {
+        SeedWorkingOrder(_factory, 9003UL, firmId: "TEST");
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/firms/OTHER/orders/9003/mark-stale", new { reason = "x" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ClearStale_RemovesFlag()
+    {
+        var order = SeedWorkingOrder(_factory, 9004UL);
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9004/mark-stale", new { reason = "x" });
+        Assert.True(order.IsStale);
+
+        var resp = await admin.PostAsync("/admin/firms/TEST/orders/9004/clear-stale", content: null);
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+        Assert.False(order.IsStale);
+    }
+
+    [Fact]
+    public async Task DeleteOrder_OnStaleOrder_Returns409()
+    {
+        var order = SeedWorkingOrder(_factory, 9005UL);
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9005/mark-stale", new { reason = "x" });
+        Assert.True(order.IsStale);
+
+        // alice owns the order; she gets 409 trying to cancel.
+        using var alice = await _factory.CreateAuthedClientAsync();
+        var resp = await alice.DeleteAsync("/orders/9005");
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ModifyOrder_OnStaleOrder_Returns409()
+    {
+        var order = SeedWorkingOrder(_factory, 9006UL);
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9006/mark-stale", new { reason = "x" });
+
+        using var alice = await _factory.CreateAuthedClientAsync();
+        var resp = await alice.PutAsJsonAsync("/orders/9006", new { quantity = 200, price = 30m });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -293,6 +293,63 @@ public class ExecutionReportProcessorTests
         Assert.False(ev.IsNativeStp);
     }
 
+    [Fact]
+    public void TerminalFill_OnStaleOrder_AutoClearsStale()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+        order.MarkStale("matching restart", DateTimeOffset.UtcNow);
+        Assert.True(order.IsStale);
+
+        proc.Apply(1UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 30m, rejectReason: null);
+
+        // Real fill arrived → venue still knew the order → false-positive
+        // stale flag is auto-lifted (slice 1 of #132).
+        Assert.Equal(OrderStatus.Filled, order.Status);
+        Assert.False(order.IsStale);
+        Assert.Null(order.StaleReason);
+    }
+
+    [Fact]
+    public void TerminalCancel_OnStaleOrder_AutoClearsStale()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+        order.MarkStale("matching restart", DateTimeOffset.UtcNow);
+
+        proc.Apply(1UL, ExecKind.Canceled, leaves: 100, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null);
+
+        Assert.Equal(OrderStatus.Cancelled, order.Status);
+        Assert.False(order.IsStale);
+    }
+
+    [Fact]
+    public void PartialFill_OnStaleOrder_DoesNotClearStale()
+    {
+        var (proc, ownership, book, _, _) = Build();
+        var owner = new EndClientId("alice");
+        var order = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        book.TryAdd(order);
+        ownership.Register(1UL, owner);
+        order.MarkWorking();
+        order.MarkStale("gap", DateTimeOffset.UtcNow);
+
+        proc.Apply(1UL, ExecKind.PartialFill, leaves: 60, cumQty: 40, lastQty: 40, lastPx: 30m, rejectReason: null);
+
+        // Partial fill: venue knew about the original child but the
+        // remainder may still be ghosted; trader's stale concern stands.
+        Assert.Equal(OrderStatus.PartiallyFilled, order.Status);
+        Assert.True(order.IsStale);
+    }
+
     private sealed class RecordingSink : IExecutionEventSink
     {
         public readonly List<ExecutionEvent> Events = new();

--- a/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
@@ -1,0 +1,129 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Application.Tests;
+
+public class OrderStalenessServiceTests
+{
+    private static (OrderStalenessService svc, WorkingOrderBook book, EventDispatcher dispatcher) Build()
+    {
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderStalenessService(dispatcher, book);
+        return (svc, book, dispatcher);
+    }
+
+    private static Order AddWorking(WorkingOrderBook book, ulong clOrdId, string firmId = "FIRM01")
+    {
+        var o = new Order(clOrdId, new EndClientId("alice"), "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId);
+        o.MarkWorking();
+        book.TryAdd(o);
+        return o;
+    }
+
+    [Fact]
+    public void MarkStale_OnWorkingOrder_Marks()
+    {
+        var (svc, book, _) = Build();
+        var order = AddWorking(book, 1UL);
+
+        var r = svc.MarkStale("FIRM01", 1UL, "matching restart", DateTimeOffset.UtcNow, "admin");
+
+        Assert.Equal(MarkStaleResult.Marked, r);
+        Assert.True(order.IsStale);
+        Assert.Equal("matching restart", order.StaleReason);
+    }
+
+    [Fact]
+    public void MarkStale_Idempotent_ReturnsAlreadyStale()
+    {
+        var (svc, book, _) = Build();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+
+        var r = svc.MarkStale("FIRM01", 1UL, "y", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(MarkStaleResult.AlreadyStale, r);
+    }
+
+    [Fact]
+    public void MarkStale_Unknown_ReturnsNotFound()
+    {
+        var (svc, _, _) = Build();
+        Assert.Equal(MarkStaleResult.NotFound, svc.MarkStale("FIRM01", 99UL, "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void MarkStale_WrongFirm_ReturnsWrongFirm()
+    {
+        var (svc, book, _) = Build();
+        AddWorking(book, 1UL, firmId: "FIRM01");
+        Assert.Equal(MarkStaleResult.WrongFirm, svc.MarkStale("FIRM02", 1UL, "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void MarkStale_PendingNew_ReturnsNotEligible()
+    {
+        var (svc, book, _) = Build();
+        var o = new Order(1UL, new EndClientId("alice"), "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM01");
+        book.TryAdd(o);
+        Assert.Equal(OrderStatus.PendingNew, o.Status);
+
+        Assert.Equal(MarkStaleResult.NotEligible, svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void MarkStale_FilledOrder_ReturnsNotEligible()
+    {
+        var (svc, book, _) = Build();
+        var o = AddWorking(book, 1UL);
+        o.ApplyCumulativeFill(100);
+        Assert.Equal(OrderStatus.Filled, o.Status);
+
+        Assert.Equal(MarkStaleResult.NotEligible, svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void ClearStale_OnStaleOrder_Clears()
+    {
+        var (svc, book, _) = Build();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(ClearStaleResult.Cleared, svc.ClearStale("FIRM01", 1UL, "admin"));
+    }
+
+    [Fact]
+    public void ClearStale_NotStale_ReturnsNotStale()
+    {
+        var (svc, book, _) = Build();
+        AddWorking(book, 1UL);
+        Assert.Equal(ClearStaleResult.NotStale, svc.ClearStale("FIRM01", 1UL, null));
+    }
+
+    [Fact]
+    public void Snapshot_RoundTrip_PreservesStaleFields()
+    {
+        var book = new WorkingOrderBook();
+        var o = new Order(1UL, new EndClientId("alice"), "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM01");
+        o.MarkWorking();
+        var at = new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero);
+        o.MarkStale("matching restart", at);
+        book.TryAdd(o);
+
+        var snaps = book.Snapshot().ToList();
+        Assert.True(snaps[0].IsStale);
+        Assert.Equal("matching restart", snaps[0].StaleReason);
+        Assert.Equal(at, snaps[0].StaledAtUtc);
+
+        var book2 = new WorkingOrderBook();
+        book2.Restore(snaps);
+
+        Assert.True(book2.TryGet(1UL, out var restored));
+        Assert.NotNull(restored);
+        Assert.True(restored!.IsStale);
+        Assert.Equal("matching restart", restored.StaleReason);
+        Assert.Equal(at, restored.StaledAtUtc);
+    }
+}

--- a/backend/tests/B3.Trading.Domain.Tests/OrderStaleTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderStaleTests.cs
@@ -1,0 +1,128 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+public class OrderStaleTests
+{
+    private static Order Working()
+    {
+        var o = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        o.MarkWorking();
+        return o;
+    }
+
+    [Fact]
+    public void MarkStale_OnWorking_FlipsFlagAndRecordsMetadata()
+    {
+        var o = Working();
+        var at = new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero);
+
+        var changed = o.MarkStale("matching restart", at);
+
+        Assert.True(changed);
+        Assert.True(o.IsStale);
+        Assert.Equal("matching restart", o.StaleReason);
+        Assert.Equal(at, o.StaledAtUtc);
+        Assert.Equal(OrderStatus.Working, o.Status);
+        Assert.Equal(100, o.LeavesQuantity);
+    }
+
+    [Fact]
+    public void MarkStale_OnPartiallyFilled_AlsoEligible()
+    {
+        var o = Working();
+        o.ApplyCumulativeFill(40);
+        Assert.Equal(OrderStatus.PartiallyFilled, o.Status);
+
+        Assert.True(o.MarkStale("gap", DateTimeOffset.UtcNow));
+        Assert.True(o.IsStale);
+    }
+
+    [Fact]
+    public void MarkStale_OnPendingNew_IsNoOp()
+    {
+        var o = new Order(1UL, new EndClientId("a"), "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 10, 30m);
+        Assert.Equal(OrderStatus.PendingNew, o.Status);
+
+        Assert.False(o.MarkStale("x", DateTimeOffset.UtcNow));
+        Assert.False(o.IsStale);
+    }
+
+    [Fact]
+    public void MarkStale_OnFilled_IsNoOp()
+    {
+        var o = Working();
+        o.ApplyCumulativeFill(100);
+        Assert.Equal(OrderStatus.Filled, o.Status);
+
+        Assert.False(o.MarkStale("x", DateTimeOffset.UtcNow));
+        Assert.False(o.IsStale);
+    }
+
+    [Fact]
+    public void MarkStale_OnCancelled_IsNoOp()
+    {
+        var o = Working();
+        o.MarkCancelled();
+        Assert.False(o.MarkStale("x", DateTimeOffset.UtcNow));
+        Assert.False(o.IsStale);
+    }
+
+    [Fact]
+    public void MarkStale_Idempotent_PreservesOriginalTimestamp()
+    {
+        var o = Working();
+        var first = new DateTimeOffset(2026, 5, 7, 10, 0, 0, TimeSpan.Zero);
+        o.MarkStale("first", first);
+
+        var second = new DateTimeOffset(2026, 5, 7, 11, 0, 0, TimeSpan.Zero);
+        var changed = o.MarkStale("second", second);
+
+        Assert.False(changed);
+        Assert.Equal("first", o.StaleReason);
+        Assert.Equal(first, o.StaledAtUtc);
+    }
+
+    [Fact]
+    public void MarkStale_BlankReason_Throws()
+    {
+        var o = Working();
+        Assert.Throws<ArgumentException>(() => o.MarkStale("   ", DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void ClearStale_OnStale_ResetsAllFields()
+    {
+        var o = Working();
+        o.MarkStale("x", DateTimeOffset.UtcNow);
+
+        Assert.True(o.ClearStale());
+        Assert.False(o.IsStale);
+        Assert.Null(o.StaleReason);
+        Assert.Null(o.StaledAtUtc);
+    }
+
+    [Fact]
+    public void ClearStale_WhenNotStale_IsNoOp()
+    {
+        var o = Working();
+        Assert.False(o.ClearStale());
+    }
+
+    [Fact]
+    public void Hydrate_PreservesStaleFields()
+    {
+        var at = new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero);
+        var hydrated = Order.Hydrate(
+            clOrdId: 42UL, owner: new EndClientId("alice"), symbol: "PETR4", securityId: 1UL,
+            side: OrderSide.Buy, type: OrderType.Limit,
+            quantity: 100, price: 30m, leaves: 60, cumQty: 40,
+            status: OrderStatus.PartiallyFilled,
+            isStale: true, staleReason: "venue-gap", staledAtUtc: at);
+
+        Assert.True(hydrated.IsStale);
+        Assert.Equal("venue-gap", hydrated.StaleReason);
+        Assert.Equal(at, hydrated.StaledAtUtc);
+        Assert.Equal(OrderStatus.PartiallyFilled, hydrated.Status);
+    }
+}


### PR DESCRIPTION
Slice 1 of #132 (working-orders ghost when matching restarts).

Adds an admin-driven advisory overlay (`Order.IsStale` + `StaleReason` + `StaledAtUtc`) so an operator can flag a working order as suspected-stale-by-venue when the matching engine restarts with state loss. While the flag is set, Cancel/Modify return 409 (no point burning a fresh ClOrdID against a phantom). The flag auto-clears when a real terminal ER arrives — venue actually still knew the order, false positive lifted.

## What's in

- **Domain**: `Order.MarkStale` / `ClearStale` (idempotent, only Working/PartiallyFilled, preserves original timestamp on re-marks). `Hydrate` signature extended additively.
- **Persistence**: `OrderStaledEvent` / `OrderStaleClearedEvent` WAL records (`[JsonDerivedType]` registered, additive). `OrderSnapshot` extended with optional stale fields. `EventReplayer` applies both. `WorkingOrderBook.Snapshot`/`Restore` round-trip the overlay.
- **Application**: `OrderStalenessService` — per-firm scoped, idempotent, runs the in-memory mutation under `EventDispatcher.Dispatch` so a racing terminal ER on the same order serialises safely. `ExecutionReportProcessor` auto-clears on Filled/Cancelled/Rejected/Replaced; partial fills do **not** clear (remainder may still be ghosted).
- **API**: `POST /admin/firms/{firmId}/orders/{clOrdId}/mark-stale` and `/clear-stale` (admin only). `DELETE /orders/{id}` and `PUT /orders/{id}` return 409 when `order.IsStale`. `OrderDto` exposes the overlay so the UI can surface it later.

## What's not in (future slices)

- Auto-detection via SDK `InboundGapAtReconnect` (insufficient signal alone — clean restart with state loss doesn't fire it).
- Frontend badge / blotter filter / disable Cancel button on stale.
- Risk/exposure recompute that excludes stale leaves.
- `IExecutionEventSink` synthetic frame for live stale fan-out.

## Tests

- 11 domain tests (state machine + Hydrate round-trip).
- 9 application tests (service idempotency, firm scoping, eligibility, snapshot).
- 3 ER-processor tests (terminal auto-clear, partial-fill no-clear invariant).
- 7 API tests (admin auth, mark/clear happy paths, unknown ClOrdID, wrong firm, DELETE/PUT 409 gating).

Suite: 53 + 342 + 196 = **591 unit tests passing** (was 561). `dotnet format` clean.

Closes part of #132.