### PR TITLE
feat(risk): StaleReferencePrice + OrderTypeAllowed pre-trade checks (#108)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/StaleReferencePriceAndOrderTypeChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/StaleReferencePriceAndOrderTypeChecks.cs
@@ -1,0 +1,122 @@
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Pre-trade gate that blocks Market orders when the platform has no
+/// live reference price for the symbol. "Live" means
+/// <see cref="ReferencePriceSource.Live"/> — a fresh sample from the
+/// MD feed under the configured staleness budget. Static-table
+/// fallback (<see cref="ReferencePriceSource.Fallback"/>) and missing
+/// readings both reject with <c>stale_market_data</c>.
+///
+/// <para>
+/// Limit orders bypass this check entirely: they carry an explicit
+/// price and the band consequence of a degraded feed is already the
+/// concern of <see cref="PriceCollarCheck"/>. Market orders are the
+/// dangerous case — without a live anchor the user is sweeping the
+/// book at whatever's there, which during an MD outage may be a
+/// stale top-of-book that no longer reflects the venue.
+/// </para>
+///
+/// <para>
+/// Default semantics when <see cref="RiskLimits.MarketRequiresLiveRef"/>
+/// is unset everywhere in the precedence chain are conservative
+/// (<c>true</c> — Market requires Live). Set <c>false</c> per-firm /
+/// per-end-client to opt out (e.g. test accounts). Pipeline order=295,
+/// just before <see cref="PriceCollarCheck"/> at 300 — same locality
+/// (both are reference-price-driven) and the cheaper short-circuit
+/// runs first.
+/// </para>
+/// </summary>
+public sealed class StaleReferencePriceCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly IReferencePrice _refPrice;
+
+    public StaleReferencePriceCheck(IOptionsMonitor<RiskOptions> options, IReferencePrice refPrice)
+    {
+        _options = options;
+        _refPrice = refPrice;
+    }
+
+    public int Order => 295;
+    public string Name => "stale_market_data";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        // Only Market orders need a live reference; Limit carries its
+        // own price. The legitimate-Market-with-Price case does not
+        // exist in our intake (OrdersEndpoints normalises Market →
+        // Price=null), but checking Type rather than HasPrice keeps
+        // the rule explicit and survives any future intake change.
+        if (ctx.Type != OrderType.Market)
+            return RiskDecision.Approve;
+
+        var opts = _options.CurrentValue;
+        var requireLive = RiskLimitsResolver.Resolve(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol,
+            l => l.MarketRequiresLiveRef) ?? true;
+
+        var lookup = _refPrice.Lookup(ctx.Symbol);
+
+        // Always reject Missing — even with the toggle off, sweeping
+        // the book against an unknown symbol with zero price context
+        // is never the user's intent. (A market order on a typo
+        // ticker would otherwise reach the venue.)
+        if (lookup.Source == ReferencePriceSource.Missing)
+            return RiskDecision.Reject($"no reference price for '{ctx.Symbol}' — Market blocked");
+
+        if (requireLive && lookup.Source != ReferencePriceSource.Live)
+            return RiskDecision.Reject($"reference price for '{ctx.Symbol}' is not live (source={lookup.Source}); Market blocked");
+
+        return RiskDecision.Approve;
+    }
+}
+
+/// <summary>
+/// Pre-trade gate that enforces an optional whitelist of
+/// <see cref="OrderType"/> values per scope
+/// (<see cref="RiskLimits.AllowedOrderTypes"/>). When the resolved
+/// list is null/empty the check is a no-op (every type the venue
+/// supports passes); otherwise a submission whose type is missing
+/// from the list is rejected with <c>order_type_blocked</c>.
+///
+/// <para>
+/// Pipeline order=15, between <see cref="SymbolHaltedCheck"/>
+/// (order 10) and the per-instrument rules (20+). Cheap to run and
+/// independent of any other state, so it can short-circuit the rest
+/// of the pipeline for misconfigured order types before any allocation
+/// or per-symbol lookup runs.
+/// </para>
+/// </summary>
+public sealed class OrderTypeAllowedCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+
+    public OrderTypeAllowedCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
+
+    public int Order => 15;
+    public string Name => "order_type_blocked";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var opts = _options.CurrentValue;
+        var allowed = RiskLimitsResolver.ResolveRef(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol,
+            l => l.AllowedOrderTypes,
+            v => v.Count > 0);
+
+        if (allowed is null) return RiskDecision.Approve;
+
+        foreach (var name in allowed)
+        {
+            if (Enum.TryParse<OrderType>(name, ignoreCase: true, out var t) && t == ctx.Type)
+                return RiskDecision.Approve;
+        }
+
+        return RiskDecision.Reject(
+            $"order type '{ctx.Type}' not in allowed list for this scope ({string.Join(",", allowed)})");
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -188,6 +188,35 @@ public sealed class RiskLimits
     /// market-maker accounts or test scenarios).
     /// </summary>
     public bool? AllowSelfTrade { get; set; }
+
+    /// <summary>
+    /// Slice of #108. When <c>true</c>, Market orders are rejected
+    /// unless the reference-price lookup returns
+    /// <see cref="ReferencePriceSource.Live"/> — i.e. the live MD feed
+    /// has a fresh sample under the configured <c>MaxStaleness</c>.
+    /// Static config (<see cref="ReferencePriceSource.Fallback"/>) and
+    /// missing readings both reject. Limit orders bypass — they carry
+    /// their own price, and PriceCollar already handles the staleness
+    /// consequence on the band side. Default semantics when unset
+    /// everywhere in the precedence chain are conservative: Market
+    /// **requires** live MD (see
+    /// <see cref="Risk.Checks.StaleReferencePriceCheck"/>). Set to
+    /// <c>false</c> per-firm or per-end-client to opt out (e.g. test
+    /// accounts that legitimately route Market into the fallback path).
+    /// </summary>
+    public bool? MarketRequiresLiveRef { get; set; }
+
+    /// <summary>
+    /// Slice of #108. Optional whitelist of <see cref="OrderType"/>
+    /// values the resolved scope may submit. Case-insensitive enum
+    /// names (e.g. <c>"Limit"</c>, <c>"Market"</c>). <c>null</c> or
+    /// empty means "no whitelist — every type permitted by the venue
+    /// passes". When non-empty, a submission whose type is missing
+    /// from the list is rejected with <c>order_type_blocked</c>.
+    /// Useful for compliance scopes that should only ever use Limit,
+    /// or for staged rollouts of a new order type.
+    /// </summary>
+    public List<string>? AllowedOrderTypes { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -219,6 +248,46 @@ public static class RiskLimitsResolver
     }
 
     /// <summary>
+    /// Reference-type variant of <see cref="Resolve{T}"/> for limits whose
+    /// "unset" sentinel is <c>null</c> at the class-typed level (e.g.
+    /// <see cref="RiskLimits.AllowedOrderTypes"/>). Same precedence
+    /// chain; first non-null value wins. <paramref name="isSet"/> lets
+    /// callers treat empty collections as "not configured" (the typical
+    /// shape coming out of a JSON binder that materialises every key
+    /// even when the operator left the array blank).
+    /// </summary>
+    public static T? ResolveRef<T>(
+        RiskOptions opts,
+        string endClient,
+        string? firmId,
+        string symbol,
+        Func<RiskLimits, T?> selector,
+        Func<T, bool>? isSet = null)
+        where T : class
+    {
+        bool Set(T? v) => v is not null && (isSet is null || isSet(v));
+
+        if (opts.PerEndClient.TryGetValue(endClient, out var ec))
+        {
+            var v = selector(ec);
+            if (Set(v)) return v;
+        }
+        if (!string.IsNullOrWhiteSpace(firmId)
+            && opts.PerFirm.TryGetValue(firmId, out var fi))
+        {
+            var v = selector(fi);
+            if (Set(v)) return v;
+        }
+        if (opts.PerSymbol.TryGetValue(symbol, out var sy))
+        {
+            var v = selector(sy);
+            if (Set(v)) return v;
+        }
+        var def = selector(opts.Default);
+        return Set(def) ? def : null;
+    }
+
+    /// <summary>
     /// Convenience: resolve every <see cref="RiskLimits"/> field in
     /// one pass. Used by <c>GET /admin/risk/limits</c> to surface
     /// what the system actually thinks the cap is for a given
@@ -237,5 +306,9 @@ public static class RiskLimitsResolver
             MaxOpenOrders = Resolve(opts, endClient, firmId, symbol, l => l.MaxOpenOrders),
             AllowShortSell = Resolve(opts, endClient, firmId, symbol, l => l.AllowShortSell),
             AllowSelfTrade = Resolve(opts, endClient, firmId, symbol, l => l.AllowSelfTrade),
+            MarketRequiresLiveRef = Resolve(opts, endClient, firmId, symbol, l => l.MarketRequiresLiveRef),
+            AllowedOrderTypes = ResolveRef(opts, endClient, firmId, symbol,
+                l => l.AllowedOrderTypes,
+                v => v.Count > 0),
         };
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -175,6 +175,7 @@ builder.Services.AddSingleton<IReplaceMarginCoordinator>(sp =>
     sp.GetRequiredService<ReserveOnSubmitMarginProvider>());
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
 builder.Services.AddSingleton<IRiskCheck, SymbolHaltedCheck>();
+builder.Services.AddSingleton<IRiskCheck, OrderTypeAllowedCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MaxQuantityCheck>();
@@ -187,6 +188,7 @@ builder.Services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
 builder.Services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
 builder.Services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
 builder.Services.AddSingleton<IRiskCheck, PriceCollarCheck>();
+builder.Services.AddSingleton<IRiskCheck, StaleReferencePriceCheck>();
 builder.Services.AddSingleton<RiskPipeline>();
 
 // Throttle accountants (slice 7). TimeProvider is fetched from DI so

--- a/backend/tests/B3.Trading.Application.Tests/StaleReferencePriceAndOrderTypeChecksTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StaleReferencePriceAndOrderTypeChecksTests.cs
@@ -1,0 +1,185 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+public class StaleReferencePriceCheckTests
+{
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskContext Ctx(OrderType type = OrderType.Market, decimal? price = null) =>
+        new(new EndClientId("alice"), "default", "PETR4", OrderSide.Buy, type, 100, price);
+
+    private sealed class StubRef : IReferencePrice
+    {
+        private readonly ReferencePriceLookup _lookup;
+        public StubRef(ReferencePriceLookup lookup) => _lookup = lookup;
+        public bool TryGet(string symbol, out decimal price)
+        {
+            price = _lookup.Price;
+            return _lookup.Found;
+        }
+        public ReferencePriceLookup Lookup(string symbol) => _lookup;
+    }
+
+    [Fact]
+    public void Limit_Bypassed_RegardlessOfRefSource()
+    {
+        var check = new StaleReferencePriceCheck(
+            Wrap(new RiskOptions()),
+            new StubRef(ReferencePriceLookup.NotFound));
+
+        var d = check.Check(Ctx(type: OrderType.Limit, price: 30m));
+        Assert.True(d.Approved);
+    }
+
+    [Fact]
+    public void Market_LiveSource_Approves()
+    {
+        var check = new StaleReferencePriceCheck(
+            Wrap(new RiskOptions()),
+            new StubRef(new ReferencePriceLookup(30m, ReferencePriceSource.Live)));
+
+        Assert.True(check.Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void Market_DefaultPolicy_RejectsFallback()
+    {
+        var check = new StaleReferencePriceCheck(
+            Wrap(new RiskOptions()),
+            new StubRef(new ReferencePriceLookup(30m, ReferencePriceSource.Fallback)));
+
+        var d = check.Check(Ctx());
+        Assert.False(d.Approved);
+        Assert.Contains("not live", d.Reason);
+    }
+
+    [Fact]
+    public void Market_DefaultPolicy_RejectsMissing()
+    {
+        var check = new StaleReferencePriceCheck(
+            Wrap(new RiskOptions()),
+            new StubRef(ReferencePriceLookup.NotFound));
+
+        var d = check.Check(Ctx());
+        Assert.False(d.Approved);
+        Assert.Contains("no reference price", d.Reason);
+    }
+
+    [Fact]
+    public void Market_OptOutPerFirm_AcceptsFallback_ButStillRejectsMissing()
+    {
+        var opts = new RiskOptions
+        {
+            PerFirm = { ["default"] = new RiskLimits { MarketRequiresLiveRef = false } },
+        };
+        var fallback = new StaleReferencePriceCheck(
+            Wrap(opts),
+            new StubRef(new ReferencePriceLookup(30m, ReferencePriceSource.Fallback)));
+        Assert.True(fallback.Check(Ctx()).Approved);
+
+        var missing = new StaleReferencePriceCheck(
+            Wrap(opts),
+            new StubRef(ReferencePriceLookup.NotFound));
+        Assert.False(missing.Check(Ctx()).Approved);
+    }
+
+    [Fact]
+    public void Order_IsBeforeCollar()
+    {
+        var check = new StaleReferencePriceCheck(Wrap(new RiskOptions()),
+            new StubRef(ReferencePriceLookup.NotFound));
+        Assert.True(check.Order < 300, "must run before PriceCollarCheck (Order=300)");
+    }
+}
+
+public class OrderTypeAllowedCheckTests
+{
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskContext Ctx(OrderType type, string firm = "default") =>
+        new(new EndClientId("alice"), firm, "PETR4", OrderSide.Buy, type, 100, type == OrderType.Limit ? 30m : null);
+
+    [Fact]
+    public void NullList_ApprovesEverything()
+    {
+        var check = new OrderTypeAllowedCheck(Wrap(new RiskOptions()));
+        Assert.True(check.Check(Ctx(OrderType.Limit)).Approved);
+        Assert.True(check.Check(Ctx(OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void EmptyList_ApprovesEverything()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedOrderTypes = new List<string>() },
+        };
+        var check = new OrderTypeAllowedCheck(Wrap(opts));
+        Assert.True(check.Check(Ctx(OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void Whitelist_ApprovesMember()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedOrderTypes = new List<string> { "Limit" } },
+        };
+        var check = new OrderTypeAllowedCheck(Wrap(opts));
+        Assert.True(check.Check(Ctx(OrderType.Limit)).Approved);
+    }
+
+    [Fact]
+    public void Whitelist_RejectsNonMember()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedOrderTypes = new List<string> { "Limit" } },
+        };
+        var check = new OrderTypeAllowedCheck(Wrap(opts));
+        var d = check.Check(Ctx(OrderType.Market));
+        Assert.False(d.Approved);
+        Assert.Contains("not in allowed list", d.Reason);
+    }
+
+    [Fact]
+    public void Whitelist_CaseInsensitive()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedOrderTypes = new List<string> { "limit", "MARKET" } },
+        };
+        var check = new OrderTypeAllowedCheck(Wrap(opts));
+        Assert.True(check.Check(Ctx(OrderType.Limit)).Approved);
+        Assert.True(check.Check(Ctx(OrderType.Market)).Approved);
+    }
+
+    [Fact]
+    public void PerFirm_OverridesDefault()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedOrderTypes = new List<string> { "Limit", "Market" } },
+            PerFirm =
+            {
+                ["strict"] = new RiskLimits { AllowedOrderTypes = new List<string> { "Limit" } },
+            },
+        };
+        var check = new OrderTypeAllowedCheck(Wrap(opts));
+
+        Assert.True(check.Check(Ctx(OrderType.Market, firm: "default")).Approved);
+        Assert.False(check.Check(Ctx(OrderType.Market, firm: "strict")).Approved);
+    }
+
+    [Fact]
+    public void Order_IsEarly()
+    {
+        var check = new OrderTypeAllowedCheck(Wrap(new RiskOptions()));
+        Assert.True(check.Order > 0 && check.Order < 100,
+            "should run after KillSwitch (0) but before per-instrument checks (>=20)");
+    }
+}


### PR DESCRIPTION
Two new pre-trade gates from the #108 umbrella, combined into one PR (same layer, both small).

## StaleReferencePriceCheck (Order=295)

Blocks Market orders when there's no live reference price.

* Limit orders bypass — `PriceCollarCheck` already governs them and they carry their own price.
* Market + `Source==Missing` always rejects (sweeping the book against an unknown ticker is never the user's intent).
* Market + `Source==Fallback` rejects when `RiskLimits.MarketRequiresLiveRef` (new, default `true`) is on for the resolved scope.
* Default-conservative: an MD outage stops Market fan-out with no operator action; opt out per-firm/per-end-client (e.g. test accounts).

## OrderTypeAllowedCheck (Order=15)

Optional whitelist of `OrderType` values per scope via `RiskLimits.AllowedOrderTypes` (new). Null/empty list = no-op. Case-insensitive. Runs right after `KillSwitch`/`SymbolHalted`, before per-instrument rules — cheap short-circuit for misconfigured order types.

## Resolver

Extended `RiskLimitsResolver` with `ResolveRef<T>` for class-typed limits + optional `isSet` predicate so empty collections are treated as 'not configured' and fall through the precedence chain (per-end-client → per-firm → per-symbol → default).

## Tests

13 new tests (7 stale-ref + 6 order-type). Suite **604 green**, format clean.

Closes part of #108 (StaleReferencePriceCheck + OrderTypeAllowedCheck items).