### PR TITLE
feat(staleness): auto-detect venue desync at FIXP reconnect (#132 slice 2)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -143,6 +143,17 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.entrypoint.reconnect_succeeded");
     public static readonly Counter<long> EntryPointReconnectFailed =
         Meter.CreateCounter<long>("trading.entrypoint.reconnect_failed");
+
+    /// <summary>
+    /// Slice 2 of #132. Counts orders auto-marked stale by the
+    /// <c>OrderStaleningVenueReactor</c> after a venue desync signal
+    /// (FIXP <c>InboundGapAtReconnect</c> or peer-terminate when the
+    /// <c>Trading:AutoStale:OnPeerTerminate</c> flag is on). Tagged
+    /// <c>{firm, reason}</c>; one Add per bulk-mark with the count of
+    /// orders flipped, so a sum gives total ghost candidates.
+    /// </summary>
+    public static readonly Counter<long> OrdersAutoStaledByVenueDesync =
+        Meter.CreateCounter<long>("trading.entrypoint.orders_auto_staled");
     // Last SessionVerId successfully Established for the firm. Reported as
     // an observable gauge so a stuck reconnect (gauge frozen while attempts
     // counter climbs) is visible at a glance.

--- a/backend/src/B3.Trading.Application/OrderStalenessService.cs
+++ b/backend/src/B3.Trading.Application/OrderStalenessService.cs
@@ -78,6 +78,61 @@ public sealed class OrderStalenessService
         return marked ? MarkStaleResult.Marked : MarkStaleResult.NotEligible;
     }
 
+    /// <summary>
+    /// Bulk-mark every Working / PartiallyFilled order for <paramref name="firmId"/>
+    /// as stale, one WAL event per order. Used by slice 2 (#132) to react to
+    /// venue desync signals (peer-initiated termination, FIXP inbound gap at
+    /// reconnect): rather than asking the operator to mark each ghost by hand,
+    /// the platform flags the entire firm's working set defensively. Already-
+    /// stale orders are skipped (idempotent), so calling this twice in a row
+    /// does not write twice.
+    ///
+    /// <para>
+    /// Each order goes through the full <see cref="EventDispatcher.Dispatch"/>
+    /// path — same lock as <see cref="MarkStale"/>, same WAL contract — so a
+    /// concurrent terminal ER for one of the orders cannot race the bulk-mark
+    /// (the ER runs serially under the same lock and triggers
+    /// <see cref="ExecutionReportProcessor"/>'s auto-clear branch). The lock
+    /// is released between orders so the dispatcher stays available for ER
+    /// processing during a long bulk-mark.
+    /// </para>
+    /// </summary>
+    public int MarkAllWorkingByFirm(string firmId, string reason, DateTimeOffset atUtc, string? actorUserId)
+    {
+        if (string.IsNullOrWhiteSpace(firmId))
+            throw new ArgumentException("firmId required.", nameof(firmId));
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("reason required.", nameof(reason));
+
+        var marked = 0;
+        foreach (var order in _orders.EnumerateForFirm(firmId, includeTerminal: false))
+        {
+            if (order.IsStale) continue;
+            if (order.Status is not (OrderStatus.Working or OrderStatus.PartiallyFilled)) continue;
+
+            var clOrdId = order.ClOrdId;
+            var evt = new OrderStaledEvent
+            {
+                ClOrdId = clOrdId,
+                FirmId = order.FirmId,
+                Reason = reason,
+                StaledAtUtc = atUtc,
+                ActorUserId = actorUserId,
+            };
+            var didMark = false;
+            _dispatcher.Dispatch(evt, () =>
+            {
+                // Re-check inside the dispatcher lock (same defence as
+                // single-order MarkStale): a terminal ER queued behind us
+                // may have flipped status / lifted the implicit eligibility
+                // since the optimistic enumerate.
+                didMark = order.MarkStale(reason, atUtc);
+            });
+            if (didMark) marked++;
+        }
+        return marked;
+    }
+
     public ClearStaleResult ClearStale(string firmId, ulong clOrdId, string? actorUserId)
     {
         if (string.IsNullOrWhiteSpace(firmId))

--- a/backend/src/B3.Trading.Application/VenueDisconnectReactor.cs
+++ b/backend/src/B3.Trading.Application/VenueDisconnectReactor.cs
@@ -1,0 +1,139 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Outcome surfaced by the FIXP gateway after a successful reconnect cycle.
+/// Drives the slice 2 (#132) auto-staleness policy.
+/// </summary>
+/// <param name="HadInboundGap">
+/// True when the SDK raised <c>InboundGapAtReconnect</c> during the just-
+/// completed <c>ReconnectAsync</c> call. Indicates an unrecovered
+/// application-frame gap from the prior session — high-confidence "venue
+/// state may diverge from ours".
+/// </param>
+/// <param name="GapFromSeq">First missing inbound seqnum, when <see cref="HadInboundGap"/>.</param>
+/// <param name="GapCount">Length of the missing window, when <see cref="HadInboundGap"/>.</param>
+/// <param name="PriorSessionVerId">SessionVerID of the prior session in which the gap occurred.</param>
+/// <param name="PriorTerminationCode">
+/// Stringified <c>TerminatedEventArgs.Code</c> from the most recent
+/// peer-initiated terminate that triggered this reconnect, or <c>null</c>
+/// if the reconnect was driven by something other than a peer terminate
+/// (e.g. operator-driven). Used to discriminate transport blips from
+/// venue-restart-class events.
+/// </param>
+public sealed record ReconnectOutcome(
+    bool HadInboundGap,
+    ulong? GapFromSeq,
+    uint? GapCount,
+    ulong? PriorSessionVerId,
+    string? PriorTerminationCode);
+
+/// <summary>
+/// Slice 2 (#132) seam: lets the FIXP gateway hand off post-reconnect
+/// venue-divergence signals to the staleness layer without taking a
+/// reference to <see cref="OrderStalenessService"/> directly. The
+/// implementation lives in Application and applies the policy described
+/// on <see cref="OrderStaleningVenueReactor"/>.
+/// </summary>
+public interface IVenueDisconnectReactor
+{
+    /// <summary>
+    /// Called by the gateway on the firm's reconnect-loop background task
+    /// after a successful FIXP reconnect (post-Establish). Implementation
+    /// MUST be idempotent and tolerate being called once per reconnect
+    /// attempt — no state machine on the caller side.
+    /// </summary>
+    void OnPeerReconnected(string firmId, ReconnectOutcome outcome);
+}
+
+/// <summary>
+/// Default <see cref="IVenueDisconnectReactor"/> implementation that
+/// translates the slice 2 (#132) policy into bulk-staleness writes:
+///
+/// <list type="bullet">
+///   <item>If the SDK raised <c>InboundGapAtReconnect</c>, mark every
+///         working order for the firm as stale with reason
+///         <c>inbound_gap:{from}-{to}</c>. This is the high-confidence
+///         signal — peer's <c>SessionVerID</c> bump means the missing
+///         range is unrecoverable in-band, so the venue's view of our
+///         working set may have moved out from under us.</item>
+///   <item>If there was no inbound gap and the previous session ended
+///         with a peer-initiated terminate, only mark stale when the
+///         <c>AutoStaleOnPeerTerminate</c> flag is enabled
+///         (<see cref="AutoStaleOptions.OnPeerTerminate"/>). Default
+///         <c>false</c>, because routine network blips also produce
+///         peer-initiated terminates and we don't want every transport
+///         hiccup to ghost the firm's whole working set.</item>
+/// </list>
+///
+/// <para>
+/// Auto-clear (slice 1) lifts the flag for any order the venue still
+/// knows about as soon as a terminal ER arrives, so a false positive
+/// here is self-healing for fully-filled / cancelled / rejected orders.
+/// PartiallyFilled orders need an operator clear.
+/// </para>
+/// </summary>
+public sealed class OrderStaleningVenueReactor : IVenueDisconnectReactor
+{
+    private readonly OrderStalenessService _staleness;
+    private readonly TimeProvider _clock;
+    private readonly AutoStaleOptions _options;
+
+    public OrderStaleningVenueReactor(
+        OrderStalenessService staleness,
+        AutoStaleOptions options,
+        TimeProvider? clock = null)
+    {
+        _staleness = staleness;
+        _options = options;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public void OnPeerReconnected(string firmId, ReconnectOutcome outcome)
+    {
+        if (string.IsNullOrWhiteSpace(firmId))
+            throw new ArgumentException("firmId required.", nameof(firmId));
+
+        string? reason = null;
+        if (outcome.HadInboundGap && outcome.GapFromSeq is { } from && outcome.GapCount is { } count)
+        {
+            // High-confidence: surface seq window in the reason so the
+            // operator can correlate against SDK logs / per-firm WAL.
+            var to = from + count - 1;
+            reason = $"inbound_gap:{from}-{to}";
+        }
+        else if (!outcome.HadInboundGap && _options.OnPeerTerminate
+                 && !string.IsNullOrWhiteSpace(outcome.PriorTerminationCode))
+        {
+            reason = $"peer_terminated:{outcome.PriorTerminationCode}";
+        }
+
+        if (reason is null) return;
+
+        var marked = _staleness.MarkAllWorkingByFirm(firmId, reason, _clock.GetUtcNow(), actorUserId: null);
+        if (marked > 0)
+        {
+            Observability.MetricsRegistry.OrdersAutoStaledByVenueDesync.Add(marked,
+                new KeyValuePair<string, object?>("firm", firmId),
+                new KeyValuePair<string, object?>("reason", reason));
+        }
+    }
+}
+
+/// <summary>
+/// Bound to <c>Trading:AutoStale</c> in configuration. Controls the
+/// slice 2 (#132) auto-staleness policy on the <see cref="OrderStaleningVenueReactor"/>.
+/// </summary>
+public sealed class AutoStaleOptions
+{
+    public const string SectionName = "Trading:AutoStale";
+
+    /// <summary>
+    /// When <c>true</c>, peer-initiated terminations (FIXP <c>Terminate</c>
+    /// from the venue) trigger a bulk stale-mark even when the SDK does NOT
+    /// raise an inbound gap. Default <c>false</c>: routine transport
+    /// hiccups also produce peer terminates and would otherwise ghost the
+    /// whole firm's working set on every blip. Enable for venues whose
+    /// terminate codes reliably indicate state loss.
+    /// </summary>
+    public bool OnPeerTerminate { get; set; }
+}

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -152,6 +152,13 @@ builder.Services.AddSingleton<EventDispatcher>();
 builder.Services.AddSingleton<KillSwitchService>();
 builder.Services.AddSingleton<SymbolHaltService>();
 builder.Services.AddSingleton<OrderStalenessService>();
+// Slice 2 of #132. Reactor reads the flag set off the Trading:AutoStale section.
+builder.Services.Configure<AutoStaleOptions>(builder.Configuration.GetSection(AutoStaleOptions.SectionName));
+builder.Services.AddSingleton<IVenueDisconnectReactor>(sp =>
+    new OrderStaleningVenueReactor(
+        sp.GetRequiredService<OrderStalenessService>(),
+        sp.GetRequiredService<IOptions<AutoStaleOptions>>().Value,
+        sp.GetService<TimeProvider>()));
 builder.Services.AddTradingMarketData(builder.Configuration);
 builder.Services.AddSingleton<ReserveOnSubmitMarginProvider>(sp =>
     new ReserveOnSubmitMarginProvider(
@@ -329,7 +336,9 @@ if (earlyIsReal)
             };
             var upstream = new B3.EntryPoint.Client.EntryPointClient(clientOpts);
             var gwLogger = lf.CreateLogger<B3EntryPointClientGateway>();
-            return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger);
+            var reactor = sp.GetService<IVenueDisconnectReactor>();
+            return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
+                venueDisconnectReactor: reactor);
         });
         return new FirmGatewayRegistry(gateways);
     });

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -43,6 +43,20 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private ulong _lastInboundSeqNum;
     private volatile bool _disposed;
 
+    // Slice 2 of #132. Captured by the SDK's InboundGapAtReconnect handler
+    // (fires synchronously inside ReconnectAsync, just before the call returns)
+    // and consumed once on the very next post-reconnect call to the reactor.
+    // Single-writer (SDK inbound thread inside ReconnectAsync) / single-reader
+    // (reconnect loop, immediately after ReconnectAsync returns), separated by
+    // the await — no lock needed for the bool/struct fields, but we Volatile.Read
+    // / Write to defend against compiler reordering across the await barrier.
+    private int _lastReconnectHadGap;
+    private ulong _lastGapFromSeq;
+    private uint _lastGapCount;
+    private ulong _lastGapPriorSessionVerId;
+    private string? _lastTerminationCode;
+    private readonly IVenueDisconnectReactor? _reactor;
+
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
         string firmId,
@@ -51,7 +65,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         TimeSpan? initialReconnectDelay = null,
         TimeSpan? maxReconnectDelay = null,
         TimeProvider? clock = null,
-        OrderEntryLatencyProbe? latencyProbe = null)
+        OrderEntryLatencyProbe? latencyProbe = null,
+        IVenueDisconnectReactor? venueDisconnectReactor = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -61,7 +76,9 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _maxReconnectDelay = maxReconnectDelay ?? TimeSpan.FromSeconds(30);
         _clock = clock ?? TimeProvider.System;
         _latencyProbe = latencyProbe ?? new OrderEntryLatencyProbe(_clock);
+        _reactor = venueDisconnectReactor;
         _client.Terminated += OnTerminated;
+        _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
         // Pull-based observable gauges: read SDK state + our reconnect flag on
         // every scrape rather than pushing on every transition. Avoids both
@@ -71,6 +88,21 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             () => FixpStateGaugeProjector.Project(_client.State));
         MetricsRegistry.RegisterReconnectingSource(_firmId,
             () => Volatile.Read(ref _reconnectingState));
+    }
+
+    private void OnInboundGapAtReconnect(object? sender, Up.InboundGapAtReconnectEventArgs e)
+    {
+        // Capture for the post-reconnect reactor invocation; the SDK fires
+        // this exactly once per ReconnectAsync, synchronously inside that call,
+        // BEFORE it returns to ReconnectLoopAsync. No lock needed — see field
+        // declarations.
+        _lastGapFromSeq = e.FromSeqNo;
+        _lastGapCount = e.Count;
+        _lastGapPriorSessionVerId = e.PriorSessionVerId;
+        Volatile.Write(ref _lastReconnectHadGap, 1);
+        _logger.LogWarning(
+            "EntryPoint inbound gap at reconnect for firm {Firm}: priorVer={PriorVer} from={From} count={Count}",
+            _firmId, e.PriorSessionVerId, e.FromSeqNo, e.Count);
     }
 
     public string FirmId => _firmId;
@@ -380,6 +412,11 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         // terminations are the only ones that warrant a reconnect attempt.
         if (e.InitiatedByClient || _disposed || _shutdownCts.IsCancellationRequested) return;
 
+        // Capture the peer terminate code for the post-reconnect reactor
+        // (slice 2 of #132). Stored before kicking the reconnect loop so
+        // the loop sees the latest value when it consults it on success.
+        Volatile.Write(ref _lastTerminationCode, e.Code.ToString());
+
         // Detach from the inbound thread so the event-loop can drain
         // cleanly; the reconnect loop owns its own lifecycle.
         _ = Task.Run(() => ReconnectLoopAsync(_shutdownCts.Token));
@@ -422,6 +459,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
                     _logger.LogInformation("EntryPoint reconnect ok for firm {Firm} on attempt {N} (sessionVerId={Ver}).",
                         _firmId, attempt, nextVerId);
                     OnConnected();
+                    NotifyVenueDisconnectReactor();
                     return;
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -452,6 +490,37 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         }
     }
 
+    /// <summary>
+    /// Slice 2 of #132. After a successful reconnect, drains the
+    /// captured gap / termination signals into a single
+    /// <see cref="ReconnectOutcome"/> and hands it to the configured
+    /// <see cref="IVenueDisconnectReactor"/>. Reactor errors are
+    /// swallowed and logged: a reactor crash MUST NOT bring down the
+    /// gateway. Resets the captured state regardless of reactor
+    /// presence so a subsequent reconnect cycle starts clean.
+    /// </summary>
+    private void NotifyVenueDisconnectReactor()
+    {
+        var hadGap = Interlocked.Exchange(ref _lastReconnectHadGap, 0) == 1;
+        var fromSeq = hadGap ? (ulong?)_lastGapFromSeq : null;
+        var count = hadGap ? (uint?)_lastGapCount : null;
+        var priorVer = hadGap ? (ulong?)_lastGapPriorSessionVerId : null;
+        var priorCode = Interlocked.Exchange(ref _lastTerminationCode, null);
+
+        if (_reactor is null) return;
+
+        try
+        {
+            _reactor.OnPeerReconnected(_firmId,
+                new ReconnectOutcome(hadGap, fromSeq, count, priorVer, priorCode));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "VenueDisconnectReactor threw for firm {Firm}; suppressed to keep gateway alive.", _firmId);
+        }
+    }
+
     private TimeSpan ComputeBackoff(int attempt)
     {
         var basisMs = Math.Min(_maxReconnectDelay.TotalMilliseconds,
@@ -475,6 +544,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             try { await _eventLoop.ConfigureAwait(false); } catch { /* event loop swallows, but be defensive */ }
         }
         _client.Terminated -= OnTerminated;
+        _client.InboundGapAtReconnect -= OnInboundGapAtReconnect;
         await _client.DisposeAsync().ConfigureAwait(false);
         _shutdownCts.Dispose();
         _reconnectLock.Dispose();

--- a/backend/tests/B3.Trading.Application.Tests/OrderStalenessAutoDetectTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderStalenessAutoDetectTests.cs
@@ -1,0 +1,223 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Application.Tests;
+
+public class OrderStalenessServiceBulkTests
+{
+    private static (OrderStalenessService svc, WorkingOrderBook book) Build()
+    {
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderStalenessService(dispatcher, book);
+        return (svc, book);
+    }
+
+    private static Order AddWorking(WorkingOrderBook book, ulong clOrdId, string firmId = "FIRM01")
+    {
+        var o = new Order(clOrdId, new EndClientId("alice"), "PETR4", 1UL,
+            OrderSide.Buy, OrderType.Limit, 100, 30m, firmId);
+        o.MarkWorking();
+        book.TryAdd(o);
+        return o;
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_FlagsEveryWorkingOrderForFirm()
+    {
+        var (svc, book) = Build();
+        var a = AddWorking(book, 1UL, "FIRM01");
+        var b = AddWorking(book, 2UL, "FIRM01");
+        var other = AddWorking(book, 3UL, "FIRM02");
+
+        var n = svc.MarkAllWorkingByFirm("FIRM01", "venue restart", DateTimeOffset.UtcNow, "admin");
+
+        Assert.Equal(2, n);
+        Assert.True(a.IsStale);
+        Assert.True(b.IsStale);
+        Assert.False(other.IsStale);
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_SkipsAlreadyStale()
+    {
+        var (svc, book) = Build();
+        var a = AddWorking(book, 1UL);
+        AddWorking(book, 2UL);
+        svc.MarkStale("FIRM01", 1UL, "manual", DateTimeOffset.UtcNow, "admin");
+
+        var n = svc.MarkAllWorkingByFirm("FIRM01", "auto", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(1, n); // only the second one
+        Assert.Equal("manual", a.StaleReason); // original reason preserved
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_Idempotent()
+    {
+        var (svc, book) = Build();
+        AddWorking(book, 1UL);
+        AddWorking(book, 2UL);
+
+        var first = svc.MarkAllWorkingByFirm("FIRM01", "x", DateTimeOffset.UtcNow, null);
+        var second = svc.MarkAllWorkingByFirm("FIRM01", "x", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(2, first);
+        Assert.Equal(0, second);
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_SkipsTerminalAndPendingNew()
+    {
+        var (svc, book) = Build();
+        // PendingNew (not yet MarkWorking)
+        var pending = new Order(10UL, new EndClientId("alice"), "PETR4", 1UL,
+            OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM01");
+        book.TryAdd(pending);
+
+        // Filled
+        var filled = AddWorking(book, 11UL);
+        filled.ApplyCumulativeFill(100);
+
+        // Working — eligible
+        var working = AddWorking(book, 12UL);
+
+        var n = svc.MarkAllWorkingByFirm("FIRM01", "x", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(1, n);
+        Assert.False(pending.IsStale);
+        Assert.False(filled.IsStale);
+        Assert.True(working.IsStale);
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_UnknownFirm_ReturnsZero()
+    {
+        var (svc, book) = Build();
+        AddWorking(book, 1UL, "FIRM01");
+        Assert.Equal(0, svc.MarkAllWorkingByFirm("NOPE", "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_BlankFirm_Throws()
+    {
+        var (svc, _) = Build();
+        Assert.Throws<ArgumentException>(() => svc.MarkAllWorkingByFirm(" ", "x", DateTimeOffset.UtcNow, null));
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_BlankReason_Throws()
+    {
+        var (svc, _) = Build();
+        Assert.Throws<ArgumentException>(() => svc.MarkAllWorkingByFirm("FIRM01", " ", DateTimeOffset.UtcNow, null));
+    }
+}
+
+public class OrderStaleningVenueReactorTests
+{
+    private sealed class FixedClock : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedClock(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private static (OrderStaleningVenueReactor reactor, WorkingOrderBook book, FixedClock clock)
+        Build(bool onPeerTerminate = false)
+    {
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderStalenessService(dispatcher, book);
+        var clock = new FixedClock(DateTimeOffset.Parse("2026-05-07T20:00:00Z"));
+        var reactor = new OrderStaleningVenueReactor(
+            svc, new AutoStaleOptions { OnPeerTerminate = onPeerTerminate }, clock);
+        return (reactor, book, clock);
+    }
+
+    private static Order AddWorking(WorkingOrderBook book, ulong clOrdId, string firmId = "FIRM01")
+    {
+        var o = new Order(clOrdId, new EndClientId("alice"), "PETR4", 1UL,
+            OrderSide.Buy, OrderType.Limit, 100, 30m, firmId);
+        o.MarkWorking();
+        book.TryAdd(o);
+        return o;
+    }
+
+    [Fact]
+    public void OnPeerReconnected_InboundGap_MarksAllWorkingForFirm()
+    {
+        var (reactor, book, _) = Build();
+        var a = AddWorking(book, 1UL);
+        var b = AddWorking(book, 2UL);
+
+        reactor.OnPeerReconnected("FIRM01",
+            new ReconnectOutcome(HadInboundGap: true, GapFromSeq: 100UL, GapCount: 5u, PriorSessionVerId: 7UL,
+                PriorTerminationCode: "FINISHED"));
+
+        Assert.True(a.IsStale);
+        Assert.True(b.IsStale);
+        Assert.Equal("inbound_gap:100-104", a.StaleReason);
+    }
+
+    [Fact]
+    public void OnPeerReconnected_NoGap_DefaultPolicy_DoesNothing()
+    {
+        var (reactor, book, _) = Build(onPeerTerminate: false);
+        var a = AddWorking(book, 1UL);
+
+        reactor.OnPeerReconnected("FIRM01",
+            new ReconnectOutcome(HadInboundGap: false, null, null, null, PriorTerminationCode: "UnspecifiedError"));
+
+        Assert.False(a.IsStale);
+    }
+
+    [Fact]
+    public void OnPeerReconnected_NoGap_FlagOn_MarksWithPeerTerminatedReason()
+    {
+        var (reactor, book, _) = Build(onPeerTerminate: true);
+        var a = AddWorking(book, 1UL);
+
+        reactor.OnPeerReconnected("FIRM01",
+            new ReconnectOutcome(HadInboundGap: false, null, null, null, PriorTerminationCode: "UnspecifiedError"));
+
+        Assert.True(a.IsStale);
+        Assert.Equal("peer_terminated:UnspecifiedError", a.StaleReason);
+    }
+
+    [Fact]
+    public void OnPeerReconnected_NoGap_FlagOn_NoCode_DoesNothing()
+    {
+        // Reconnect that wasn't preceded by a peer-terminate (e.g. operator-driven).
+        // Without a termination code we have no diagnostic to propagate, so skip.
+        var (reactor, book, _) = Build(onPeerTerminate: true);
+        var a = AddWorking(book, 1UL);
+
+        reactor.OnPeerReconnected("FIRM01",
+            new ReconnectOutcome(HadInboundGap: false, null, null, null, PriorTerminationCode: null));
+
+        Assert.False(a.IsStale);
+    }
+
+    [Fact]
+    public void OnPeerReconnected_GapWinsOverPeerTerminateFlag()
+    {
+        // Both signals present: gap takes precedence (more specific reason).
+        var (reactor, book, _) = Build(onPeerTerminate: true);
+        var a = AddWorking(book, 1UL);
+
+        reactor.OnPeerReconnected("FIRM01",
+            new ReconnectOutcome(true, 50UL, 3u, 2UL, "UnspecifiedError"));
+
+        Assert.True(a.IsStale);
+        Assert.Equal("inbound_gap:50-52", a.StaleReason);
+    }
+
+    [Fact]
+    public void OnPeerReconnected_BlankFirm_Throws()
+    {
+        var (reactor, _, _) = Build();
+        Assert.Throws<ArgumentException>(() =>
+            reactor.OnPeerReconnected("", new ReconnectOutcome(false, null, null, null, null)));
+    }
+}


### PR DESCRIPTION
Slice 2 of #132. Removes the manual-only trigger from slice 1 (PR #147): the platform now reacts to venue-divergence signals from the SDK and bulk-marks the firm's working orders as stale.

## Pipeline

* `B3EntryPointClientGateway` subscribes to the SDK's `InboundGapAtReconnect` event (added in upstream 0.14.x for SDK #138). Captures (FromSeqNo, Count, PriorSessionVerId) into per-instance fields. Also captures the latest peer-initiated `TerminationCode` in `OnTerminated`.
* On successful `ReconnectAsync`, the gateway hands a `ReconnectOutcome` (HadInboundGap, gap window, prior termination code) to the new `IVenueDisconnectReactor` seam injected via the constructor. Reactor exceptions are swallowed + logged so a misbehaving Application layer cannot wedge the gateway.
* Default impl `OrderStaleningVenueReactor` (Application) translates the signals into bulk `OrderStalenessService.MarkAllWorkingByFirm` calls:
  - `InboundGapAtReconnect` → **always** mark, reason `inbound_gap:{from}-{to}`.
  - Peer terminate without gap → only when `AutoStaleOptions.OnPeerTerminate` is enabled (**default false**). Avoids ghosting the firm's whole working set on every routine network blip; ops can opt in per deployment when their venue's terminate codes reliably indicate state loss. Reason: `peer_terminated:{Code}`.
* Stale flag still auto-clears on terminal ER (slice 1), so any false positive self-heals once the genuine ER stream confirms the venue still knows the order.

## Why default-off on peer-terminate

Rubber-duck critique flagged: if we marked stale on every peer-initiated terminate, a transient network blip would ghost every `PartiallyFilled` order until manual clear (the slice 1 auto-clear excludes partials). Default-off avoids that ops burden; the more specific `InboundGapAtReconnect` signal stays default-on because it's high-confidence (peer's SessionVerID bump means the missing range is unrecoverable in-band).

## API additions

* `OrderStalenessService.MarkAllWorkingByFirm(firmId, reason, atUtc, actorUserId)` — one `EventDispatcher.Dispatch` per order so the lock is released between iterations and concurrent ER processing is not blocked for the duration of a long bulk-mark. Idempotent: already-stale orders are skipped.
* `AutoStaleOptions` bound to `Trading:AutoStale` (one bool: `OnPeerTerminate`).
* `IVenueDisconnectReactor` + `ReconnectOutcome` record.

## Metric

`trading.entrypoint.orders_auto_staled` (Counter<long>) tagged `{firm, reason}`, one Add per bulk-mark with the count of orders actually flipped. Lets ops measure which signal fires in prod and tune the `OnPeerTerminate` flag accordingly.

## Out of scope

* PendingNew orders are still excluded from bulk-mark (slice 1 contract). They'll resolve via FIXP retransmit or stay pending — separate cleanup problem.
* No algo-engine-specific test (TWAP child reaction) — the bulk-mark is per-Order and the algo engine already tolerates manual mark-stale on children. Worth a follow-up smoke test if it surfaces in dogfood.
* Frontend stale badge UX (slice 3+).

## Tests

13 new tests (7 bulk + 6 reactor). Suite **617 green**, format clean.