### PR TITLE
feat(frontend): order staleness badge + disabled actions (#132 slice 3)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -318,6 +318,30 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 .status-cell-Filled    { color: var(--accent); }
 .status-cell-Rejected  { color: var(--red); }
 
+/* Slice 3 of #132. Order-row staleness overlay. The row is dimmed
+ * (row dim mirrors the panel--stale convention used elsewhere) and a
+ * compact badge is appended next to the status cell. Cancel/Modify
+ * buttons fall back to the standard :disabled style because the JS
+ * sets `disabled` on them when IsStale is true — backend already 409s,
+ * but gating client-side avoids the round-trip and tells the trader
+ * unambiguously that the venue may not know the order. */
+tr.row-stale > td { opacity: .55; }
+tr.row-stale > td.row-stale-actions { opacity: 1; }
+.order-stale-badge {
+  display: inline-block;
+  margin-left: .35rem;
+  padding: 0 .35rem;
+  border: 1px solid var(--warn);
+  border-radius: 3px;
+  color: var(--warn);
+  font-size: .65rem;
+  font-weight: 600;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  cursor: help;
+}
+
 /* ---------- Executions log ---------- */
 .executions-log {
   list-style: none; padding: 0; margin: 0; overflow: auto; flex: 1;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -562,6 +562,15 @@ async function handleCancelOrder(clOrdId) {
   if (st.inflightCancels && st.inflightCancels.has(clOrdId)) return;
   const order = st.orders.get(clOrdId);
   if (order && ["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(order.status)) return;
+  // Slice 3 of #132. Stale orders are gated client-side: the backend
+  // would 409 with reason "order is marked stale", but skipping the
+  // round-trip keeps the UX honest (the row already shows the badge
+  // and a disabled button — the keyboard Del shortcut routes here too,
+  // so this is the canonical safety point).
+  if (order && order.isStale) {
+    ui.setTicketFeedback(`cannot cancel — order ${clOrdId} is marked stale`, "warn");
+    return;
+  }
   // Both the mouse (blotter Cancel button) and the keyboard (Del)
   // routes funnel through here; confirmation is centralised so the two
   // paths can't drift in safety.
@@ -597,6 +606,7 @@ async function handleCancelAll(clOrdIds) {
     if (st.inflightCancels && st.inflightCancels.has(id)) return false;
     const o = st.orders.get(id);
     if (!o) return false;
+    if (o.isStale) return false; // slice 3 of #132 — gated client-side too
     return !["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(o.status);
   });
   const total = queue.length;
@@ -652,6 +662,12 @@ async function handleModifyOrder(clOrdId, payload) {
   const order = st.orders.get(clOrdId);
   if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) {
     ui.setModifyModalError("Order is no longer modifiable.");
+    return;
+  }
+  if (order.isStale) {
+    // Slice 3 of #132. Modal is open at this point — surface the
+    // reason inline so the trader sees why the submit was blocked.
+    ui.setModifyModalError(`Order is marked stale${order.staleReason ? ` (${order.staleReason})` : ""} — modify disabled.`);
     return;
   }
   state.markModifyInflight(clOrdId, true);

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -1397,8 +1397,19 @@ function orderRow(o, st) {
   const highlightAt = st.ordersHighlight?.get(o.clOrdId);
   const fresh = highlightAt && (Date.now() - highlightAt) < HIGHLIGHT_MS;
   const selected = st.selectedClOrdId === o.clOrdId;
-  const cls = [fresh ? "row-fresh" : "", selected ? "row-selected" : ""].filter(Boolean).join(" ");
-  const cancelDisabled = terminal || cancelInflight || modifyInflight;
+  // Slice 3 of #132. Surfaced from OrderDto.IsStale/StaleReason/StaledAtUtc.
+  // The platform's auto-detect (slice 2) bulk-marks every working order
+  // for a firm when the FIXP gateway sees a venue-divergence signal, so
+  // the trader needs an at-a-glance "this may not be at the venue any
+  // more" cue plus disabled actions (the backend already 409s; we gate
+  // client-side to avoid the round-trip and to show intent honestly).
+  const isStale = !!o.isStale;
+  const cls = [
+    fresh ? "row-fresh" : "",
+    selected ? "row-selected" : "",
+    isStale ? "row-stale" : "",
+  ].filter(Boolean).join(" ");
+  const cancelDisabled = terminal || cancelInflight || modifyInflight || isStale;
   const cancelLabel = cancelInflight ? "Cancelling…" : "Cancel";
   const cancelCls = "cancel-btn" + (cancelInflight ? " cancelling" : "");
   // Slice 5 of #122. Modify button shares row-selection delegation
@@ -1407,9 +1418,16 @@ function orderRow(o, st) {
   // or while either a cancel or another modify is in flight — the
   // backend's in-flight guard would 409 a second modify anyway, but
   // gating client-side avoids the round-trip and keeps the UX honest.
-  const modifyDisabled = terminal || modifyInflight || cancelInflight;
+  const modifyDisabled = terminal || modifyInflight || cancelInflight || isStale;
   const modifyLabel = modifyInflight ? "Modifying…" : "Modify";
   const modifyCls = "modify-btn" + (modifyInflight ? " modifying" : "");
+  const staleTitle = isStale
+    ? `Stale: ${o.staleReason || "venue desync"}${o.staledAtUtc ? ` (${o.staledAtUtc})` : ""}`
+    : "";
+  const staleBadge = isStale
+    ? `<span class="order-stale-badge" title="${escapeHtml(staleTitle)}">stale</span>`
+    : "";
+  const actionTitle = isStale ? `disabled — ${staleTitle}` : "";
   return `<tr data-clordid="${escapeHtml(o.clOrdId)}"${cls ? ` class="${cls}"` : ""}>
     <td><code>${escapeHtml(o.clOrdId)}</code></td>
     <td>${escapeHtml(o.symbol)}</td>
@@ -1419,9 +1437,9 @@ function orderRow(o, st) {
     <td class="num">${fmtQty(o.leavesQuantity)}</td>
     <td class="num">${fmtQty(o.cumulativeQuantity)}</td>
     <td class="num">${price}</td>
-    <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}</td>
-    <td><button class="${modifyCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Modify order ${escapeHtml(o.clOrdId)}" title="Modify" ${modifyDisabled ? "disabled" : ""}>${modifyLabel}</button></td>
-    <td><button class="${cancelCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" title="Cancel (Del)" ${cancelDisabled ? "disabled" : ""}>${cancelLabel}</button></td>
+    <td class="status-cell-${escapeHtml(o.status)}">${escapeHtml(o.status)}${staleBadge}</td>
+    <td class="row-stale-actions"><button class="${modifyCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Modify order ${escapeHtml(o.clOrdId)}" title="${escapeHtml(actionTitle || "Modify")}" ${modifyDisabled ? "disabled" : ""}>${modifyLabel}</button></td>
+    <td class="row-stale-actions"><button class="${cancelCls}" data-clordid="${escapeHtml(o.clOrdId)}" aria-label="Cancel order ${escapeHtml(o.clOrdId)}" title="${escapeHtml(actionTitle || "Cancel (Del)")}" ${cancelDisabled ? "disabled" : ""}>${cancelLabel}</button></td>
   </tr>`;
 }
 

--- a/frontend/test/order-stale-ui.test.mjs
+++ b/frontend/test/order-stale-ui.test.mjs
@@ -1,0 +1,93 @@
+// Slice 3 of #132. Verifies the trader-UI gates for the order-stale
+// overlay introduced by slices 1-2:
+//   * the orders state slice round-trips the `isStale` / `staleReason`
+//     fields surfaced by the backend OrderDto;
+//   * the client-side cancel-all queue excludes stale orders the same
+//     way it excludes terminal/PendingCancel ones (mirrors the inline
+//     filter in app.js so the modal honours the badge).
+//
+// Modify-modal and per-order Cancel gates also live in app.js but are
+// guarded by the same `order.isStale` predicate; covered indirectly
+// here since the predicate is shared.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import * as state from "../js/state.js";
+
+function reset() {
+  state.clearAll();
+  state.setStatus("disconnected");
+}
+
+test("orders state round-trips isStale / staleReason / staledAtUtc", () => {
+  reset();
+  state.applyOrdersDelta({
+    clOrdId: "S1",
+    symbol: "PETR4",
+    side: "Buy",
+    type: "Limit",
+    quantity: 100,
+    leavesQuantity: 100,
+    cumulativeQuantity: 0,
+    price: 30,
+    status: "Working",
+    isStale: true,
+    staleReason: "inbound_gap:50-52",
+    staledAtUtc: "2026-05-07T20:00:00Z",
+  });
+
+  const o = state.getState().orders.get("S1");
+  assert.ok(o, "order present");
+  assert.equal(o.isStale, true);
+  assert.equal(o.staleReason, "inbound_gap:50-52");
+  assert.equal(o.staledAtUtc, "2026-05-07T20:00:00Z");
+});
+
+test("orders state defaults isStale to falsy when backend omits it", () => {
+  reset();
+  state.applyOrdersDelta({ clOrdId: "S2", status: "Working" });
+  const o = state.getState().orders.get("S2");
+  assert.ok(!o.isStale);
+});
+
+// Mirrors the queue filter inside app.js#handleCancelAll. Locks the
+// contract: stale orders are skipped by the burst even when the modal
+// snapshot included them (the badge already disabled the per-row Cancel
+// button, but the panic-button picks up a snapshot so we re-validate).
+function buildCancelAllQueue(ids, ordersMap, inflightCancels = new Set()) {
+  return ids.filter(id => {
+    if (inflightCancels.has(id)) return false;
+    const o = ordersMap.get(id);
+    if (!o) return false;
+    if (o.isStale) return false;
+    return !["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(o.status);
+  });
+}
+
+test("cancel-all queue excludes stale orders alongside terminal ones", () => {
+  const orders = new Map([
+    ["A", { clOrdId: "A", status: "Working" }],
+    ["B", { clOrdId: "B", status: "Working", isStale: true }],
+    ["C", { clOrdId: "C", status: "Filled" }],
+    ["D", { clOrdId: "D", status: "PartiallyFilled", isStale: true }],
+    ["E", { clOrdId: "E", status: "Working" }],
+  ]);
+  const queue = buildCancelAllQueue(["A", "B", "C", "D", "E"], orders);
+  assert.deepEqual(queue, ["A", "E"]);
+});
+
+test("cancel-all queue still drops terminal orders without isStale field", () => {
+  const orders = new Map([
+    ["A", { clOrdId: "A", status: "Cancelled" }],
+    ["B", { clOrdId: "B", status: "Working" }],
+  ]);
+  assert.deepEqual(buildCancelAllQueue(["A", "B"], orders), ["B"]);
+});
+
+test("cancel-all queue treats explicit isStale=false as eligible", () => {
+  const orders = new Map([
+    ["A", { clOrdId: "A", status: "Working", isStale: false }],
+  ]);
+  assert.deepEqual(buildCancelAllQueue(["A"], orders), ["A"]);
+});


### PR DESCRIPTION
Slice 3 of #132 — frontend surfaces order staleness.

## What

* **Badge.** Working orders whose backend DTO carries `isStale=true` get a compact `stale` pill next to the status cell, with a tooltip exposing `staleReason` and `staledAtUtc`.
* **Row dim.** `tr.row-stale > td { opacity: .55 }`; action cells stay at full opacity (`.row-stale-actions`) so the disabled buttons remain legible.
* **Disabled actions.** Cancel and Modify buttons are disabled on stale rows. The backend already 409s (`order is marked stale`), but gating client-side avoids the round-trip and matches the visual cue.
* **Cancel-all guard.** The panic-button queue filter now skips stale orders, mirroring the per-row gate.
* **Modify-modal guard.** If the modal somehow opens for a stale order (e.g. the badge appeared after open), submit shows an inline error and bails.

## Why

Slices 1 (admin mark-stale) and 2 (auto-detect on FIXP venue desync) shipped backend gating + 409 responses, but the trader UI had no visual cue and would let the trader click Cancel / Modify only to see a generic error toast. This closes that gap.

## Tests

* `frontend/test/order-stale-ui.test.mjs` (5 new node:test cases): state-slice round-trips `isStale` / `staleReason` / `staledAtUtc`; cancel-all queue filter excludes stale orders alongside terminal / PendingCancel ones.
* Frontend suite: 115 / 115 green.
* Backend suite: 53 + 368 + 196 green (regression — no backend changes).
* `dotnet format --verify-no-changes` clean.
* `node --check` clean on the touched JS.

## Out of scope (slices 4-5 of #132)

* Risk/Positions exposure discount for stale leaves.
* Synthetic ER (`ExecType=Suspended`) sink for downstream consumers.