### PR TITLE
feat(risk): discount stale leaves from open-order projections (#132 slice 4)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
@@ -82,13 +82,20 @@ public sealed class NoNakedShortCheck : IRiskCheck
             && orig.Owner == ctx.Owner)
         {
             // Only subtract if the original is still counted as open
-            // (matches the predicate used in SumOpenSellLeavesForSymbol).
-            if (orig.Status is not (OrderStatus.Filled or OrderStatus.Rejected
-                or OrderStatus.Cancelled or OrderStatus.Replaced))
-            {
+            // by SumOpenSellLeavesForSymbol — terminal originals are
+            // already absent, and slice 4 of #132 also excludes stale
+            // originals (the ghost Sell does not lock inventory).
+            // The replacement leg is added unconditionally because the
+            // new ClOrdID is NOT in the book yet (OrderModifyService
+            // calls risk before TryAdd of the replacement).
+            var originalCounted =
+                !orig.IsStale &&
+                orig.Status is not (OrderStatus.Filled or OrderStatus.Rejected
+                    or OrderStatus.Cancelled or OrderStatus.Replaced);
+
+            if (originalCounted)
                 projectionAdjustment -= orig.LeavesQuantity;
-                projectionAdjustment += ctx.EffectiveLeavesQuantity ?? ctx.Quantity;
-            }
+            projectionAdjustment += ctx.EffectiveLeavesQuantity ?? ctx.Quantity;
         }
         // The incoming Sell is already counted in openSellLeaves
         // because OrderSubmissionService.TryAdd runs before risk

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -61,6 +61,13 @@ public sealed class WorkingOrderBook
     /// the time the risk pipeline runs (the persistence dispatcher
     /// adds it before evaluation), so callers comparing to a cap
     /// should use strict <c>&gt;</c>, not <c>&gt;=</c>.
+    /// <para>
+    /// Slice 4 of #132. Stale orders (admin mark-stale or auto-detect
+    /// on FIXP venue desync) are skipped: a ghost that the venue does
+    /// not know about must not block the trader's max-open-orders
+    /// budget, otherwise a venue restart would silently freeze new
+    /// trading until every stale order is cancelled.
+    /// </para>
     /// </remarks>
     public int CountOpenForOwner(EndClientId owner)
     {
@@ -69,7 +76,9 @@ public sealed class WorkingOrderBook
         foreach (var clOrdId in set.Keys)
         {
             if (!_orders.TryGetValue(clOrdId, out var order)) continue;
-            if (!IsTerminal(order.Status)) count++;
+            if (IsTerminal(order.Status)) continue;
+            if (order.IsStale) continue;
+            count++;
         }
         return count;
     }
@@ -91,6 +100,14 @@ public sealed class WorkingOrderBook
     /// evaluation). Callers must subtract their own incoming
     /// quantity from the returned sum to avoid double-counting it
     /// against itself.
+    /// <para>
+    /// Slice 4 of #132. Stale orders are excluded from the sum: the
+    /// venue is unlikely to ever execute them, so locking inventory
+    /// against ghost Sell leaves would prevent a trader from selling
+    /// the shares they actually hold after a venue desync. The
+    /// pre-trade naked-short gate (<see cref="Risk.Checks.NoNakedShortCheck"/>)
+    /// applies the matching skip in its replace projection branch.
+    /// </para>
     /// </remarks>
     public long SumOpenSellLeavesForSymbol(EndClientId owner, string symbol)
     {
@@ -103,6 +120,7 @@ public sealed class WorkingOrderBook
             if (order.Side != OrderSide.Sell) continue;
             if (!string.Equals(order.Symbol, symbol, StringComparison.Ordinal)) continue;
             if (IsTerminal(order.Status)) continue;
+            if (order.IsStale) continue;
             total += order.LeavesQuantity;
         }
         return total;

--- a/backend/tests/B3.Trading.Application.Tests/ApplicationTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ApplicationTests.cs
@@ -57,6 +57,35 @@ public class WorkingOrderBookTests
         // longer surfaced as live.
         Assert.True(book.TryGet(1UL, out _));
     }
+
+    [Fact]
+    public void StaleOrders_AreSkipped_ByOpenOrderProjections()
+    {
+        // Slice 4 of #132. A ghost stale order — an order the venue
+        // does not know about, marked via admin or the auto-detect
+        // reactor on FIXP desync — must not lock either the
+        // max-open-orders budget (CountOpenForOwner) or the inventory
+        // available for naked-short (SumOpenSellLeavesForSymbol).
+        var book = new WorkingOrderBook();
+        var alice = new EndClientId("alice");
+        var sell = new Order(1UL, alice, "PETR4", 4321UL, OrderSide.Sell, OrderType.Limit, 100, 30m, "FIRM01");
+        sell.MarkWorking();
+        Assert.True(book.TryAdd(sell));
+        Assert.Equal(1, book.CountOpenForOwner(alice));
+        Assert.Equal(100, book.SumOpenSellLeavesForSymbol(alice, "PETR4"));
+
+        Assert.True(sell.MarkStale("inbound_gap:50-52", DateTimeOffset.UtcNow));
+
+        Assert.Equal(0, book.CountOpenForOwner(alice));
+        Assert.Equal(0, book.SumOpenSellLeavesForSymbol(alice, "PETR4"));
+        // Underlying lookup still resolves — the stale order remains
+        // in the book for admin clear, late ER reconciliation and the
+        // synthetic-Suspended sink (slice 5 of #132).
+        Assert.True(book.TryGet(1UL, out _));
+        // EnumerateForFirm still surfaces the stale order — slice 2's
+        // bulk-mark and the trader UI badge both rely on that path.
+        Assert.Single(book.EnumerateForFirm("FIRM01"));
+    }
 }
 
 public class EndClientRegistryTests

--- a/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
@@ -302,11 +302,20 @@ public class NoNakedShortCheckTests
     }
 
     [Fact]
-    public void Replace_doesNotSubtract_whenOriginalAlreadyTerminal()
+    public void Replace_doesNotSubtract_whenOriginalAlreadyTerminal_butStillProjectsReplacement()
     {
         // Original was just cancelled (status terminal) but caller
-        // still set ReplaceOriginalClOrdId — adjustment must be a
-        // no-op so the check doesn't double-credit inventory.
+        // still set ReplaceOriginalClOrdId. Slice 4 of #132 split the
+        // projection: when the original would not have been counted
+        // by SumOpenSellLeavesForSymbol (terminal or stale), we no
+        // longer subtract it — but the replacement leg is still
+        // projected because the new ClOrdID is not yet in the book
+        // (OrderModifyService calls risk before TryAdd). So the
+        // arithmetic now correctly treats this race as "incoming new
+        // Sell of 100" against current_long=50 → naked short of 50.
+        // OrderModifyService 404s terminal originals before risk in
+        // the happy path; this defends the deeper invariant in case
+        // that gate ever drifts.
         var (check, positions, orders) = Build();
         positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 50, 30m);
         var orig = MakeSell(1UL, 100);
@@ -315,10 +324,62 @@ public class NoNakedShortCheckTests
 
         var ctx = SellReplaceCtx(newQty: 100, origClOrdId: 1UL, effectiveLeaves: 100);
 
-        // currentLong=50, openSellLeaves=0 (orig terminal), no
-        // adjustment → projected sell leaves = 0; sellable = 50.
-        // The new 100 isn't in the book → projection logic doesn't
-        // add it back here either (no-op when terminal). Approved.
+        // currentLong=50, openSellLeaves=0 (orig terminal, skipped),
+        // adjustment = 0 (no subtract) + 100 (replacement projected)
+        // = 100 → sellable = 50 - 100 = -50 → reject.
+        Assert.False(check.Check(ctx).Approved);
+    }
+
+    [Fact]
+    public void Replace_doesNotSubtract_whenOriginalIsStale_butStillProjectsReplacement()
+    {
+        // Slice 4 of #132. The auto-detect bulk-marks every working
+        // order stale on FIXP venue desync; if a trader then submits
+        // a Replace for one of those originals, the original's leaves
+        // must NOT be credited back (they were already excluded from
+        // the openSellLeaves sum). The replacement must still be
+        // projected because it would be a fresh order at the venue.
+        var (check, positions, orders) = Build();
+        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        var orig = MakeSell(1UL, 100);
+        orig.MarkWorking();
+        SubmitInto(orders, orig);
+        Assert.True(orig.MarkStale("inbound_gap:50-52", DateTimeOffset.UtcNow));
+
+        // Trader replaces with newQty=200 against current_long=100.
+        // openSellLeaves=0 (stale, skipped), adjustment=0+200=200,
+        // sellable=100-200=-100 → reject.
+        var rejectCtx = SellReplaceCtx(newQty: 200, origClOrdId: 1UL, effectiveLeaves: 200);
+        Assert.False(check.Check(rejectCtx).Approved);
+
+        // Replace with newQty=60 against current_long=100 → adjustment
+        // = 0 + 60 = 60, sellable = 100 - 60 = 40 → approve. Confirms
+        // the stale original is not double-credited (i.e. we are not
+        // erroneously subtracting its 100 leaves to get sellable=140).
+        var approveCtx = SellReplaceCtx(newQty: 60, origClOrdId: 1UL, effectiveLeaves: 60);
+        Assert.True(check.Check(approveCtx).Approved);
+    }
+
+    [Fact]
+    public void Sell_StaleOpenSells_NotCountedAgainstInventory()
+    {
+        // Slice 4 of #132. A ghost stale Sell must not block a new,
+        // legitimate Sell against held inventory.
+        var (check, positions, orders) = Build();
+        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        var ghost = MakeSell(1UL, 100);
+        ghost.MarkWorking();
+        SubmitInto(orders, ghost);
+        Assert.True(ghost.MarkStale("inbound_gap:50-52", DateTimeOffset.UtcNow));
+
+        // Incoming Sell of 80 is already in the book (mirrors
+        // OrderSubmissionService.TryAdd ordering).
+        var incoming = MakeSell(2UL, 80);
+        SubmitInto(orders, incoming);
+
+        // openSellLeaves should reflect only the incoming 80 because
+        // the ghost is excluded. sellable = 100 - 80 = 20 ≥ 0 → approve.
+        var ctx = SellCtx(80);
         Assert.True(check.Check(ctx).Approved);
     }
 }


### PR DESCRIPTION
Slice 4 of #132 — pre-trade exposure stops locking on stale ghosts.

## What

* `WorkingOrderBook.CountOpenForOwner` skips stale orders → `MaxOpenOrdersCheck` budget no longer freezes after a venue desync.
* `WorkingOrderBook.SumOpenSellLeavesForSymbol` skips stale Sell orders → `NoNakedShortCheck` stops locking inventory the trader actually holds.
* `NoNakedShortCheck` replace projection split: when `ReplaceOriginalClOrdId` points at a stale (or terminal) original, the original's leaves are no longer subtracted (they were already absent from the sum), but the replacement's effective leaves are still projected because the new ClOrdID is not yet in the book. Fixes a latent arithmetic bug from #122 where the all-or-nothing skip would approve a fresh naked short whenever the original was stale.

## Why

Slices 1-2 ship the staleness mark (admin path + auto-detect on FIXP venue desync via `VenueDisconnectReactor`) but the risk pipeline still treated stale orders as live exposure. After a venue restart this would freeze new trading — the trader UI shows the stale badge (slice 3) yet the gate still rejects fresh orders.

## Out of scope (next slice)

* **Cash margin reservation release on stale** — `ReserveOnSubmitMarginProvider` still holds the Buy+Limit notional. Releasing without a re-acquire path through `ClearStale` (admin clear endpoint + auto-clear-on-ER in `ExecutionReportProcessor`) would leave the order live but uncovered. Will land alongside the slice 5 synthetic `ExecType=Suspended` sink so cash + state move together.
* Synthetic ER sink for downstream consumers (slice 5 of #132).

## Tests

* `WorkingOrderBookTests.StaleOrders_AreSkipped_ByOpenOrderProjections` — Count + Sum drop to 0 after MarkStale; `TryGet` and `EnumerateForFirm` still surface the order (admin clear / late ER / UI badge rely on that).
* `NoNakedShortCheckTests.Sell_StaleOpenSells_NotCountedAgainstInventory` — fresh Sell against held inventory is approved despite a ghost stale Sell of the same size.
* `NoNakedShortCheckTests.Replace_doesNotSubtract_whenOriginalIsStale_butStillProjectsReplacement` — replace against stale original rejects when newQty > inventory and approves when newQty fits, proving no double-credit either way.
* `Replace_doesNotSubtract_whenOriginalAlreadyTerminal_butStillProjectsReplacement` — renamed + updated to assert the corrected arithmetic (replacement leg still projected even when original is terminal).
* Suite: 53 + 371 + 196 green; `dotnet format --verify-no-changes` clean.

## Critique

Rubber-duck flagged the replace-projection arithmetic before implementation — the original plan would have skipped the whole block when the original was stale, undercounting the replacement. Fixed via the split shown above. Also flagged that `ClearStale` already exists, which is why cash release is deferred to slice 5.