### PR TITLE
feat(staleness): synthetic Suspended/Restored ER on stale state-change (#132 slice 5)

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -436,4 +436,26 @@ public enum ExecKind
     Canceled,
     Replaced,
     Rejected,
+    /// <summary>
+    /// Slice 5 of #132. Synthetic notification emitted by
+    /// <see cref="OrderStalenessService"/> when an order is flagged as
+    /// suspected-stale-by-venue (admin path or auto-detect on FIXP
+    /// peer desync). Not produced by the venue — it carries
+    /// <c>LastQuantity=0</c>, no fill price, and only changes the
+    /// advisory <c>IsStale</c> overlay on the order. Downstream
+    /// consumers (UI executions log, future risk/positions
+    /// projections) treat it as a state-change ping, not as an
+    /// economic event.
+    /// </summary>
+    Suspended,
+    /// <summary>
+    /// Slice 5 of #132. Synthetic counterpart of <see cref="Suspended"/>:
+    /// emitted when the stale overlay is lifted (admin clear path). The
+    /// auto-clear branch in <see cref="ExecutionReportProcessor"/> does
+    /// NOT publish a separate Restored event — it lifts the stale flag
+    /// as a side-effect of the genuine ER (Filled/Canceled/Rejected/
+    /// Replaced) which already broadcasts; emitting both would
+    /// double-update consumers for the same observation.
+    /// </summary>
+    Restored,
 }

--- a/backend/src/B3.Trading.Application/OrderStalenessService.cs
+++ b/backend/src/B3.Trading.Application/OrderStalenessService.cs
@@ -34,11 +34,13 @@ public sealed class OrderStalenessService
 {
     private readonly EventDispatcher _dispatcher;
     private readonly WorkingOrderBook _orders;
+    private readonly IExecutionEventSink _sink;
 
-    public OrderStalenessService(EventDispatcher dispatcher, WorkingOrderBook orders)
+    public OrderStalenessService(EventDispatcher dispatcher, WorkingOrderBook orders, IExecutionEventSink? sink = null)
     {
         _dispatcher = dispatcher;
         _orders = orders;
+        _sink = sink ?? new NoOpExecutionEventSink();
     }
 
     public MarkStaleResult MarkStale(string firmId, ulong clOrdId, string reason, DateTimeOffset atUtc, string? actorUserId)
@@ -75,6 +77,7 @@ public sealed class OrderStalenessService
             // so this is a sufficient barrier.
             marked = order.MarkStale(reason, atUtc);
         });
+        if (marked) PublishSyntheticEvent(order, ExecKind.Suspended, reason, atUtc);
         return marked ? MarkStaleResult.Marked : MarkStaleResult.NotEligible;
     }
 
@@ -129,6 +132,7 @@ public sealed class OrderStalenessService
                 didMark = order.MarkStale(reason, atUtc);
             });
             if (didMark) marked++;
+            if (didMark) PublishSyntheticEvent(order, ExecKind.Suspended, reason, atUtc);
         }
         return marked;
     }
@@ -154,7 +158,48 @@ public sealed class OrderStalenessService
         };
         var cleared = false;
         _dispatcher.Dispatch(evt, () => cleared = order.ClearStale());
+        if (cleared) PublishSyntheticEvent(order, ExecKind.Restored, reason: "admin_clear", atUtc: DateTimeOffset.UtcNow);
         return cleared ? ClearStaleResult.Cleared : ClearStaleResult.NotStale;
+    }
+
+    /// <summary>
+    /// Slice 5 of #132. Publishes a synthetic ExecutionEvent so
+    /// downstream consumers (UI executions log + orders.me, future
+    /// risk/positions projections) observe the staleness state-change
+    /// in real-time rather than waiting for the next reconnect /
+    /// refresh. Carries <c>LastQuantity=0</c> and no fill price
+    /// because no economic event occurred — the order's
+    /// <c>IsStale</c> overlay is the only mutation. The published
+    /// event runs OUTSIDE the dispatcher lock (after the WAL write)
+    /// so a slow subscriber cannot back-pressure the staleness path.
+    /// Sink failures are swallowed: WAL state is already authoritative
+    /// and a missed broadcast is fixable on the next reconnect.
+    /// </summary>
+    private void PublishSyntheticEvent(Order order, ExecKind kind, string reason, DateTimeOffset atUtc)
+    {
+        try
+        {
+            _sink.Publish(new ExecutionEvent(
+                Owner: order.Owner,
+                ClOrdId: order.ClOrdId,
+                Symbol: order.Symbol,
+                Side: order.Side,
+                Status: order.Status,
+                Kind: kind,
+                LeavesQuantity: order.LeavesQuantity,
+                CumulativeQuantity: order.CumulativeQuantity,
+                LastQuantity: 0,
+                LastPrice: 0m,
+                RejectReason: reason,
+                TimestampUtc: atUtc));
+        }
+        catch
+        {
+            // Intentionally swallowed — the WAL event is already
+            // committed and re-attempting the broadcast here would
+            // risk a duplicate. Operators see staleness via the
+            // metrics counter and the next reload of orders.me.
+        }
     }
 }
 

--- a/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
@@ -126,4 +126,139 @@ public class OrderStalenessServiceTests
         Assert.Equal("matching restart", restored.StaleReason);
         Assert.Equal(at, restored.StaledAtUtc);
     }
+
+    private sealed class CapturingSink : IExecutionEventSink
+    {
+        public List<ExecutionEvent> Events { get; } = new();
+        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    private static (OrderStalenessService svc, WorkingOrderBook book, CapturingSink sink) BuildWithSink()
+    {
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var sink = new CapturingSink();
+        var svc = new OrderStalenessService(dispatcher, book, sink);
+        return (svc, book, sink);
+    }
+
+    [Fact]
+    public void MarkStale_PublishesSyntheticSuspendedEvent()
+    {
+        // Slice 5 of #132. Downstream consumers (UI executions log,
+        // orders.me push, future risk projections) need a real-time
+        // signal, otherwise the trader only sees the badge after a
+        // refresh / reconnect.
+        var (svc, book, sink) = BuildWithSink();
+        var order = AddWorking(book, 1UL);
+        var at = DateTimeOffset.Parse("2026-05-07T20:00:00Z");
+
+        var r = svc.MarkStale("FIRM01", 1UL, "inbound_gap:50-52", at, "admin");
+
+        Assert.Equal(MarkStaleResult.Marked, r);
+        var ev = Assert.Single(sink.Events);
+        Assert.Equal(ExecKind.Suspended, ev.Kind);
+        Assert.Equal(1UL, ev.ClOrdId);
+        Assert.Equal(order.Owner, ev.Owner);
+        Assert.Equal("PETR4", ev.Symbol);
+        Assert.Equal(0, ev.LastQuantity);
+        Assert.Equal(0m, ev.LastPrice);
+        Assert.Equal(order.LeavesQuantity, ev.LeavesQuantity);
+        Assert.Equal("inbound_gap:50-52", ev.RejectReason);
+        Assert.Equal(at, ev.TimestampUtc);
+    }
+
+    [Fact]
+    public void MarkStale_DoesNotPublish_WhenAlreadyStale()
+    {
+        // Idempotency invariant: a re-mark must not produce a second
+        // synthetic Suspended event, otherwise the executions log
+        // would grow on every duplicate admin click / bulk re-run.
+        var (svc, book, sink) = BuildWithSink();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+        sink.Events.Clear();
+
+        var r = svc.MarkStale("FIRM01", 1UL, "y", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(MarkStaleResult.AlreadyStale, r);
+        Assert.Empty(sink.Events);
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_PublishesOneSuspendedPerNewlyMarkedOrder()
+    {
+        // Slice 2's bulk path must fan out one event per actually-
+        // marked order (no event for the already-stale one) so the UI
+        // updates each row independently.
+        var (svc, book, sink) = BuildWithSink();
+        AddWorking(book, 1UL);
+        AddWorking(book, 2UL);
+        var pre = AddWorking(book, 3UL);
+        Assert.True(pre.MarkStale("preexisting", DateTimeOffset.UtcNow));
+
+        var marked = svc.MarkAllWorkingByFirm("FIRM01", "venue_desync", DateTimeOffset.UtcNow, "auto");
+
+        Assert.Equal(2, marked);
+        Assert.Equal(2, sink.Events.Count);
+        Assert.All(sink.Events, e => Assert.Equal(ExecKind.Suspended, e.Kind));
+        Assert.All(sink.Events, e => Assert.Equal("venue_desync", e.RejectReason));
+        Assert.DoesNotContain(sink.Events, e => e.ClOrdId == 3UL);
+    }
+
+    [Fact]
+    public void ClearStale_PublishesSyntheticRestoredEvent()
+    {
+        // Admin clear path: mirror the Suspended publish so the UI
+        // can lift the badge without a refresh. Auto-clear via genuine
+        // ER (ExecutionReportProcessor) intentionally does NOT publish
+        // a Restored — the genuine ER already broadcasts the new state.
+        var (svc, book, sink) = BuildWithSink();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+        sink.Events.Clear();
+
+        var r = svc.ClearStale("FIRM01", 1UL, "admin");
+
+        Assert.Equal(ClearStaleResult.Cleared, r);
+        var ev = Assert.Single(sink.Events);
+        Assert.Equal(ExecKind.Restored, ev.Kind);
+        Assert.Equal(1UL, ev.ClOrdId);
+        Assert.Equal(0, ev.LastQuantity);
+    }
+
+    [Fact]
+    public void ClearStale_DoesNotPublish_WhenNotStale()
+    {
+        var (svc, book, sink) = BuildWithSink();
+        AddWorking(book, 1UL);
+
+        var r = svc.ClearStale("FIRM01", 1UL, "admin");
+
+        Assert.Equal(ClearStaleResult.NotStale, r);
+        Assert.Empty(sink.Events);
+    }
+
+    [Fact]
+    public void PublishSyntheticEvent_SwallowsSinkExceptions()
+    {
+        // Sink failures must NOT bubble up: the WAL event is already
+        // committed at this point and re-attempting would risk a
+        // duplicate. The mark/clear API contract should still report
+        // success so admin tooling does not retry endlessly.
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var throwing = new ThrowingSink();
+        var svc = new OrderStalenessService(dispatcher, book, throwing);
+        AddWorking(book, 1UL);
+
+        var r = svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(MarkStaleResult.Marked, r);
+    }
+
+    private sealed class ThrowingSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) => throw new InvalidOperationException("subscriber down");
+    }
 }


### PR DESCRIPTION
Slice 5 of #132 — synthetic ER for staleness state-change.

## What

`OrderStalenessService` now publishes through `IExecutionEventSink` whenever it flips an order's `IsStale` overlay:

* `MarkStale` / `MarkAllWorkingByFirm` → `ExecKind.Suspended` (one per newly marked order; idempotent re-marks emit nothing).
* `ClearStale` (admin path) → `ExecKind.Restored`.
* Auto-clear in `ExecutionReportProcessor` (terminal ER for a previously-stale order) intentionally does NOT emit Restored — the genuine ER already broadcasts the new state.

Synthetic events carry `LastQuantity=0`, `LastPrice=0` and use the stale reason as `RejectReason`. They are state-change pings, not economic events.

## Why

Slices 1-4 mark stale + dim the row + skip stale leaves in pre-trade gates, but the trader had to refresh / reconnect to see the badge appear. The synthetic event closes that loop: `WebSocketExecutionEventSink` already routes to `executions.me` (log entry) and `orders.me` (push the updated DTO carrying `isStale=true`), so the badge now lights up in real time when the auto-detect fires after a venue desync.

## Implementation notes

* Publishing happens OUTSIDE the dispatcher lock so a slow subscriber cannot back-pressure the staleness path.
* Sink exceptions are swallowed: the WAL event is already authoritative and a missed broadcast self-heals on the next `orders.me` reload.
* New `ExecKind.Suspended` / `ExecKind.Restored` enum values, documented inline.

## Tests

6 new `OrderStalenessServiceTests` cases:
* `MarkStale_PublishesSyntheticSuspendedEvent` — verifies full event shape (Owner / ClOrdId / Status / LeavesQuantity / RejectReason / TimestampUtc).
* `MarkStale_DoesNotPublish_WhenAlreadyStale` — idempotency.
* `MarkAllWorkingByFirm_PublishesOneSuspendedPerNewlyMarkedOrder` — fan-out skips the already-stale order.
* `ClearStale_PublishesSyntheticRestoredEvent`.
* `ClearStale_DoesNotPublish_WhenNotStale`.
* `PublishSyntheticEvent_SwallowsSinkExceptions` — sink failures do not break the admin API contract.

Suite: 53 + 377 + 196 green; `dotnet format --verify-no-changes` clean.

## Out of scope (follow-up)

Cash margin reservation release on stale — needs `ReserveOnSubmitMarginProvider.OnExecution` to handle Suspended/Restored, plus a re-acquire path through `ClearStale` to handle the case where the freed cash has been claimed by other orders by the time the original is restored. Tracked separately so this slice can ship the high-leverage UX win without coupling to the cash-ledger redesign.