### PR TITLE
feat(margin): release cash reservation on stale (#153)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -154,6 +154,32 @@ public static class MetricsRegistry
     /// </summary>
     public static readonly Counter<long> OrdersAutoStaledByVenueDesync =
         Meter.CreateCounter<long>("trading.entrypoint.orders_auto_staled");
+
+    /// <summary>
+    /// #153. Counts cash-margin reservation Restore calls (admin
+    /// clear-stale path) that pushed the per-owner reserved figure
+    /// above the resolved base capacity. Restore intentionally never
+    /// fails (an admin clear must succeed once the WAL event is
+    /// committed) so overcommit is the safety valve — operators
+    /// should monitor this counter and reconcile by cancelling stale
+    /// orders. Tagged <c>{owner}</c>.
+    /// </summary>
+    public static readonly Counter<long> MarginOvercommitOnRestore =
+        Meter.CreateCounter<long>("trading.risk.margin_overcommit_on_restore");
+
+    /// <summary>
+    /// #153. Counts margin-side stale-transition failures (the
+    /// <see cref="OrderStalenessService"/> committed the WAL event and
+    /// then could not apply <see cref="ExecKind.Suspended"/> /
+    /// <see cref="ExecKind.Restored"/> to the in-process reservation
+    /// ledger). The WAL state stays authoritative and the next
+    /// process restart reconstructs reservations from scratch via ER
+    /// replay, so this is a recoverable inconsistency — but a
+    /// non-zero rate signals a code bug or a misbehaving sink.
+    /// Tagged <c>{kind}</c>.
+    /// </summary>
+    public static readonly Counter<long> MarginStaleTransitionFailed =
+        Meter.CreateCounter<long>("trading.risk.margin_stale_transition_failed");
     // Last SessionVerId successfully Established for the firm. Reported as
     // an observable gauge so a stuck reconnect (gauge frozen while attempts
     // counter climbs) is visible at a glance.

--- a/backend/src/B3.Trading.Application/OrderStalenessService.cs
+++ b/backend/src/B3.Trading.Application/OrderStalenessService.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics;
+using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Application;
 
@@ -35,12 +39,21 @@ public sealed class OrderStalenessService
     private readonly EventDispatcher _dispatcher;
     private readonly WorkingOrderBook _orders;
     private readonly IExecutionEventSink _sink;
+    private readonly IMarginProvider _margin;
+    private readonly ILogger<OrderStalenessService>? _logger;
 
-    public OrderStalenessService(EventDispatcher dispatcher, WorkingOrderBook orders, IExecutionEventSink? sink = null)
+    public OrderStalenessService(
+        EventDispatcher dispatcher,
+        WorkingOrderBook orders,
+        IExecutionEventSink? sink = null,
+        IMarginProvider? margin = null,
+        ILogger<OrderStalenessService>? logger = null)
     {
         _dispatcher = dispatcher;
         _orders = orders;
         _sink = sink ?? new NoOpExecutionEventSink();
+        _margin = margin ?? new NoOpMarginProvider();
+        _logger = logger;
     }
 
     public MarkStaleResult MarkStale(string firmId, ulong clOrdId, string reason, DateTimeOffset atUtc, string? actorUserId)
@@ -78,6 +91,7 @@ public sealed class OrderStalenessService
             marked = order.MarkStale(reason, atUtc);
         });
         if (marked) PublishSyntheticEvent(order, ExecKind.Suspended, reason, atUtc);
+        if (marked) NotifyMargin(clOrdId, ExecKind.Suspended);
         return marked ? MarkStaleResult.Marked : MarkStaleResult.NotEligible;
     }
 
@@ -133,6 +147,7 @@ public sealed class OrderStalenessService
             });
             if (didMark) marked++;
             if (didMark) PublishSyntheticEvent(order, ExecKind.Suspended, reason, atUtc);
+            if (didMark) NotifyMargin(clOrdId, ExecKind.Suspended);
         }
         return marked;
     }
@@ -159,6 +174,7 @@ public sealed class OrderStalenessService
         var cleared = false;
         _dispatcher.Dispatch(evt, () => cleared = order.ClearStale());
         if (cleared) PublishSyntheticEvent(order, ExecKind.Restored, reason: "admin_clear", atUtc: DateTimeOffset.UtcNow);
+        if (cleared) NotifyMargin(clOrdId, ExecKind.Restored);
         return cleared ? ClearStaleResult.Cleared : ClearStaleResult.NotStale;
     }
 
@@ -199,6 +215,33 @@ public sealed class OrderStalenessService
             // committed and re-attempting the broadcast here would
             // risk a duplicate. Operators see staleness via the
             // metrics counter and the next reload of orders.me.
+        }
+    }
+
+    /// <summary>
+    /// #153. Mirrors the synthetic event publish but for the cash
+    /// reservation ledger: a stale flip releases the cash hold so
+    /// ghosts stop blocking new trading; an admin clear-stale
+    /// re-acquires the hold (with overcommit metric if cash is no
+    /// longer available). Margin failures are logged + counted but
+    /// MUST NOT bubble — the WAL event is already committed and
+    /// failing the admin call would leave the operator thinking the
+    /// stale state never changed when in fact it did.
+    /// </summary>
+    private void NotifyMargin(ulong clOrdId, ExecKind kind)
+    {
+        Debug.Assert(kind is ExecKind.Suspended or ExecKind.Restored);
+        try
+        {
+            _margin.OnExecution(clOrdId, kind, 0);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex,
+                "Margin {Kind} failed for {ClOrdId}; WAL state is authoritative, ledger will reconcile on next process restart via ER replay.",
+                kind, clOrdId);
+            MetricsRegistry.MarginStaleTransitionFailed.Add(
+                1, new KeyValuePair<string, object?>("kind", kind.ToString()));
         }
     }
 }

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -112,64 +113,126 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
 
     public void OnExecution(ulong clOrdId, ExecKind kind, long lastQty)
     {
-        if (!_reservations.TryGetValue(clOrdId, out var entry))
-            return; // unknown order (Sell, Market, or never reserved here)
-
-        switch (kind)
+        // #153. Every state lookup happens INSIDE _gate so a
+        // Suspended/Restored race with a genuine ER for the same
+        // ClOrdID cannot read a stale snapshot and double-decrement
+        // (the rubber-duck flagged that scenario where DecrementReserved's
+        // clamp-to-zero would silently consume another order's hold).
+        lock (_gate)
         {
-            case ExecKind.PartialFill:
-                if (lastQty > 0) ReleasePartial(clOrdId, entry, lastQty);
-                break;
+            if (!_reservations.TryGetValue(clOrdId, out var entry))
+                return; // unknown order (Sell, Market, never reserved here, or already terminalized)
 
-            case ExecKind.Fill:
-                if (lastQty > 0) ReleasePartial(clOrdId, entry, lastQty);
-                ReleaseRemaining(clOrdId);
-                break;
+            switch (kind)
+            {
+                case ExecKind.PartialFill:
+                    if (lastQty > 0) ReleasePartial_Locked(clOrdId, entry, lastQty);
+                    break;
 
-            case ExecKind.Canceled:
-            case ExecKind.Rejected:
-                ReleaseRemaining(clOrdId);
-                break;
+                case ExecKind.Fill:
+                    if (lastQty > 0)
+                    {
+                        ReleasePartial_Locked(clOrdId, entry, lastQty);
+                        // Re-fetch — ReleasePartial_Locked rewrote the entry.
+                        if (!_reservations.TryGetValue(clOrdId, out entry)) break;
+                    }
+                    ReleaseRemaining_Locked(clOrdId, entry);
+                    break;
 
-                // New / Replaced: nothing to release. Replaced is handled
-                // by the gateway re-issuing under a fresh ClOrdID; the
-                // original reservation stays with the original ID.
+                case ExecKind.Canceled:
+                case ExecKind.Rejected:
+                    ReleaseRemaining_Locked(clOrdId, entry);
+                    break;
+
+                case ExecKind.Suspended:
+                    // #153. Stale flip: release the cash hold so the
+                    // ghost stops blocking new trading. Idempotent: a
+                    // second Suspended on an already-suspended entry
+                    // is a no-op (the flag prevents double-decrement).
+                    if (!entry.IsSuspended && entry.RemainingNotional > 0m)
+                    {
+                        DecrementReserved(entry.Owner, entry.RemainingNotional);
+                    }
+                    _reservations[clOrdId] = entry with { IsSuspended = true };
+                    break;
+
+                case ExecKind.Restored:
+                    // #153. Admin clear-stale: re-acquire the hold.
+                    // Restore never fails — the WAL event is already
+                    // committed and refusing to track the cash would
+                    // leave the ledger inconsistent with the WAL. If
+                    // the increment exceeds the owner's base
+                    // capacity, log + emit the overcommit metric so
+                    // operators can reconcile by cancelling other
+                    // stale orders.
+                    if (entry.IsSuspended && entry.RemainingNotional > 0m)
+                    {
+                        var current = _reserved.GetValueOrDefault(entry.Owner, 0m);
+                        var next = current + entry.RemainingNotional;
+                        var baseCap = ResolveBaseAvailable(entry.Owner);
+                        if (next > baseCap)
+                        {
+                            _logger.LogWarning(
+                                "Margin restore for {ClOrdId} overcommits owner {Owner}: reserved {Current} + restored {Restored} > base {Base}.",
+                                clOrdId, entry.Owner, current, entry.RemainingNotional, baseCap);
+                            MetricsRegistry.MarginOvercommitOnRestore.Add(
+                                1, new KeyValuePair<string, object?>("owner", entry.Owner));
+                        }
+                        _reserved[entry.Owner] = next;
+                    }
+                    _reservations[clOrdId] = entry with { IsSuspended = false };
+                    break;
+
+                    // New / Replaced: nothing to release. Replaced is handled
+                    // by the gateway re-issuing under a fresh ClOrdID; the
+                    // original reservation stays with the original ID.
+            }
         }
     }
 
-    public void ReleaseReservation(ulong clOrdId) => ReleaseRemaining(clOrdId);
+    public void ReleaseReservation(ulong clOrdId)
+    {
+        lock (_gate)
+        {
+            if (_reservations.TryGetValue(clOrdId, out var entry))
+                ReleaseRemaining_Locked(clOrdId, entry);
+        }
+    }
 
-    private void ReleasePartial(ulong clOrdId, ReservationEntry entry, long lastQty)
+    private void ReleasePartial_Locked(ulong clOrdId, ReservationEntry entry, long lastQty)
     {
         var amount = entry.Price * lastQty;
         if (amount <= 0m) return;
-        lock (_gate)
+        var newRemaining = entry.RemainingNotional - amount;
+        if (newRemaining < 0m)
         {
-            // Update the per-clordid entry so a subsequent partial
-            // releases against the still-reserved remainder, never the
-            // original.
-            var newRemaining = entry.RemainingNotional - amount;
-            if (newRemaining < 0m)
-            {
-                // Should not happen if the exchange respects our qty,
-                // but defend against a misbehaving venue rather than
-                // letting reserved go negative.
-                _logger.LogWarning(
-                    "Margin partial-release for {ClOrdId} would exceed remaining ({Amount} > {Remaining}); clamping.",
-                    clOrdId, amount, entry.RemainingNotional);
-                amount = entry.RemainingNotional;
-                newRemaining = 0m;
-            }
-            DecrementReserved(entry.Owner, amount);
-            _reservations[clOrdId] = entry with { RemainingNotional = newRemaining };
+            // Should not happen if the exchange respects our qty,
+            // but defend against a misbehaving venue rather than
+            // letting reserved go negative.
+            _logger.LogWarning(
+                "Margin partial-release for {ClOrdId} would exceed remaining ({Amount} > {Remaining}); clamping.",
+                clOrdId, amount, entry.RemainingNotional);
+            amount = entry.RemainingNotional;
+            newRemaining = 0m;
         }
+        // #153. Suspended entries already had their cash released by
+        // ExecKind.Suspended; partial fills must reduce the tracked
+        // remaining notional (so a later Restored re-acquires only the
+        // post-fill leaves) WITHOUT decrementing _reserved again.
+        if (!entry.IsSuspended)
+        {
+            DecrementReserved(entry.Owner, amount);
+        }
+        _reservations[clOrdId] = entry with { RemainingNotional = newRemaining };
     }
 
-    private void ReleaseRemaining(ulong clOrdId)
+    private void ReleaseRemaining_Locked(ulong clOrdId, ReservationEntry entry)
     {
-        if (!_reservations.TryRemove(clOrdId, out var entry)) return;
+        if (!_reservations.TryRemove(clOrdId, out _)) return;
         if (entry.RemainingNotional <= 0m) return;
-        lock (_gate)
+        // #153. Suspended entries' cash was already released; only
+        // remove the tracking entry, do not double-decrement.
+        if (!entry.IsSuspended)
         {
             DecrementReserved(entry.Owner, entry.RemainingNotional);
         }
@@ -247,15 +310,23 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         var ownerKey = owner.Value;
         lock (_gate)
         {
-            var oldRemaining = _reservations.TryGetValue(originalClOrdId, out var origEntry)
-                ? origEntry.RemainingNotional
-                : 0m;
+            // #153. A suspended original held no cash in _reserved, so
+            // the upsize-delta math must treat its tracked remaining as
+            // zero. Otherwise we'd approve a replace that, at commit
+            // time, restores the missing notional and pushes the owner
+            // over their cap. Same predicate applied in CommitReplace
+            // below — keep them in sync.
+            decimal oldHeldRemaining = 0m;
+            if (_reservations.TryGetValue(originalClOrdId, out var origEntry) && !origEntry.IsSuspended)
+            {
+                oldHeldRemaining = origEntry.RemainingNotional;
+            }
 
             // Delta semantics: we only need to reserve *additional*
             // capacity when scaling up. Downsize / same / sell-side
             // replace requires no extra reserve at Prepare time;
             // Commit will rebalance to the venue-confirmed figure.
-            var delta = newRemainingNotional - oldRemaining;
+            var delta = newRemainingNotional - oldHeldRemaining;
             if (delta <= 0m)
             {
                 // Track the in-flight intent with a zero-notional entry
@@ -301,10 +372,15 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
             }
 
             // Release the original entry entirely (returns oldRemaining).
+            // #153. As in PrepareReplaceAsync, a suspended original
+            // held no cash in _reserved — the adjustment math must
+            // not subtract its remaining notional, otherwise the
+            // owner's reserved figure would be over-released.
             decimal oldRemaining = 0m;
             if (_reservations.TryRemove(originalClOrdId, out var origEntry))
             {
-                oldRemaining = origEntry.RemainingNotional;
+                if (!origEntry.IsSuspended)
+                    oldRemaining = origEntry.RemainingNotional;
                 owner ??= origEntry.Owner;
             }
 
@@ -352,8 +428,12 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
     public void AbortReplace(ulong newClOrdId)
     {
         // Releases the upsize delta only; original reservation untouched.
-        ReleaseRemaining(newClOrdId);
+        lock (_gate)
+        {
+            if (_reservations.TryGetValue(newClOrdId, out var entry))
+                ReleaseRemaining_Locked(newClOrdId, entry);
+        }
     }
 
-    private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional);
+    private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional, bool IsSuspended = false);
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderStalenessServiceTests.cs
@@ -261,4 +261,117 @@ public class OrderStalenessServiceTests
     {
         public void Publish(ExecutionEvent ev) => throw new InvalidOperationException("subscriber down");
     }
+
+    private sealed class CapturingMargin : Risk.IMarginProvider
+    {
+        public List<(ulong ClOrdId, ExecKind Kind, long LastQty)> Calls { get; } = new();
+        public Task<Risk.RiskDecision> TryReserveAsync(ulong clOrdId, Risk.RiskContext ctx, CancellationToken ct)
+            => Task.FromResult(Risk.RiskDecision.Approve);
+        public void OnExecution(ulong clOrdId, ExecKind kind, long lastQty)
+            => Calls.Add((clOrdId, kind, lastQty));
+        public void ReleaseReservation(ulong clOrdId) { }
+    }
+
+    private sealed class ThrowingMargin : Risk.IMarginProvider
+    {
+        public Task<Risk.RiskDecision> TryReserveAsync(ulong clOrdId, Risk.RiskContext ctx, CancellationToken ct)
+            => Task.FromResult(Risk.RiskDecision.Approve);
+        public void OnExecution(ulong clOrdId, ExecKind kind, long lastQty)
+            => throw new InvalidOperationException("ledger down");
+        public void ReleaseReservation(ulong clOrdId) { }
+    }
+
+    private static (OrderStalenessService svc, WorkingOrderBook book, CapturingSink sink, CapturingMargin margin) BuildWithSinkAndMargin()
+    {
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var sink = new CapturingSink();
+        var margin = new CapturingMargin();
+        var svc = new OrderStalenessService(dispatcher, book, sink, margin);
+        return (svc, book, sink, margin);
+    }
+
+    [Fact]
+    public void MarkStale_NotifiesMarginWithSuspended()
+    {
+        // #153. The cash hold for a stale order must be released so
+        // ghosts stop blocking new trading. The margin call mirrors
+        // the synthetic event publish: one Suspended notification per
+        // mark, lastQty=0 (the staleness flip carries no fill data).
+        var (svc, book, _, margin) = BuildWithSinkAndMargin();
+        AddWorking(book, 1UL);
+
+        var r = svc.MarkStale("FIRM01", 1UL, "venue_desync", DateTimeOffset.UtcNow, "auto");
+
+        Assert.Equal(MarkStaleResult.Marked, r);
+        var call = Assert.Single(margin.Calls);
+        Assert.Equal((1UL, ExecKind.Suspended, 0L), call);
+    }
+
+    [Fact]
+    public void MarkStale_DoesNotNotifyMargin_WhenAlreadyStale()
+    {
+        // Idempotency: a duplicate mark must not double-release cash
+        // (the margin provider is itself idempotent on Suspended, but
+        // we do not want to spend the call either).
+        var (svc, book, _, margin) = BuildWithSinkAndMargin();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+        margin.Calls.Clear();
+
+        var r = svc.MarkStale("FIRM01", 1UL, "y", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(MarkStaleResult.AlreadyStale, r);
+        Assert.Empty(margin.Calls);
+    }
+
+    [Fact]
+    public void ClearStale_NotifiesMarginWithRestored()
+    {
+        var (svc, book, _, margin) = BuildWithSinkAndMargin();
+        AddWorking(book, 1UL);
+        svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+        margin.Calls.Clear();
+
+        var r = svc.ClearStale("FIRM01", 1UL, "admin");
+
+        Assert.Equal(ClearStaleResult.Cleared, r);
+        var call = Assert.Single(margin.Calls);
+        Assert.Equal((1UL, ExecKind.Restored, 0L), call);
+    }
+
+    [Fact]
+    public void MarkAllWorkingByFirm_NotifiesMarginPerNewlyMarkedOrder()
+    {
+        var (svc, book, _, margin) = BuildWithSinkAndMargin();
+        AddWorking(book, 1UL);
+        AddWorking(book, 2UL);
+        var pre = AddWorking(book, 3UL);
+        Assert.True(pre.MarkStale("preexisting", DateTimeOffset.UtcNow));
+        margin.Calls.Clear();
+
+        var marked = svc.MarkAllWorkingByFirm("FIRM01", "venue_desync", DateTimeOffset.UtcNow, "auto");
+
+        Assert.Equal(2, marked);
+        Assert.Equal(2, margin.Calls.Count);
+        Assert.All(margin.Calls, c => Assert.Equal(ExecKind.Suspended, c.Kind));
+        Assert.DoesNotContain(margin.Calls, c => c.ClOrdId == 3UL);
+    }
+
+    [Fact]
+    public void MarkStale_SwallowsMarginException_StillReturnsMarked()
+    {
+        // #153. Margin failures must NOT bubble: the WAL event for
+        // MarkStale is already committed; if the admin call faulted
+        // here, the operator would think the stale state never changed
+        // when in fact it did. We log + emit a metric instead.
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderStalenessService(dispatcher, book, sink: null, margin: new ThrowingMargin());
+        AddWorking(book, 1UL);
+
+        var r = svc.MarkStale("FIRM01", 1UL, "x", DateTimeOffset.UtcNow, null);
+
+        Assert.Equal(MarkStaleResult.Marked, r);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
@@ -136,12 +136,199 @@ public class ReserveOnSubmitMarginProviderTests
     }
 
     [Fact]
-    public async Task NoOpProvider_always_approves()
+    public async Task Suspended_releasesCashHold_butKeepsTrackingEntry()
     {
-        IMarginProvider noop = new NoOpMarginProvider();
-        var d = await noop.TryReserveAsync(1, Buy("alice", 999_999m, 999_999), CancellationToken.None);
-        Assert.True(d.Approved);
-        noop.OnExecution(1, ExecKind.Canceled, 0);
-        noop.ReleaseReservation(1);
+        // #153. The whole point of a stale flip: the order ghost must
+        // stop blocking new trading. ReservedForTesting drops; available
+        // returns to base. The tracking entry stays so a Restored can
+        // re-acquire later.
+        var (p, _) = Build(initial: 1_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        Assert.Equal(0m, p.AvailableForTesting("alice"));
+
+        p.OnExecution(1, ExecKind.Suspended, 0);
+
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+        // Reservation entry is still tracked (we can verify by Restored re-acquiring exactly).
+        p.OnExecution(1, ExecKind.Restored, 0);
+        Assert.Equal(0m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Suspended_isIdempotent_doesNotDoubleRelease()
+    {
+        // Race guard: if Suspended fires twice (e.g. retry on a sink
+        // failure), the second call must be a no-op. Without the
+        // IsSuspended flag, the second decrement would clamp to zero
+        // and silently release another order's hold.
+        var (p, _) = Build(initial: 2_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None);
+        Assert.Equal(500m, p.AvailableForTesting("alice"));
+
+        p.OnExecution(1, ExecKind.Suspended, 0);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+
+        // Order 2's hold is intact: 2000 - 500 (still held by #2) = 1500.
+        Assert.Equal(1_500m, p.AvailableForTesting("alice"));
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Suspended_doesNotCorrupt_otherOrderForSameOwner()
+    {
+        // Critical: the corruption guard. Two orders, same owner —
+        // suspending one must not leak into the other's reservation.
+        var (p, _) = Build(initial: 2_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None); // 1000 held
+        await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None);  // 500 held
+
+        p.OnExecution(1, ExecKind.Suspended, 0);
+
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
+        // Order 2 still terminalizes correctly.
+        p.OnExecution(2, ExecKind.Canceled, 0);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task PartialFillWhileSuspended_doesNotDecrementReserved_butReducesRemaining()
+    {
+        // Stale order partial-fills while suspended (rare but possible
+        // if the venue ER lands during the staleness window). Cash was
+        // already released by Suspended; the partial must NOT decrement
+        // again, but it must reduce RemainingNotional so a later
+        // Restored re-acquires only the post-fill leaves.
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+
+        p.OnExecution(1, ExecKind.PartialFill, 30);
+
+        // No double decrement.
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+        // Restored should re-acquire only 700 (10 * 70 leaves).
+        p.OnExecution(1, ExecKind.Restored, 0);
+        Assert.Equal(700m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task SuspendedThenFilled_noDoubleDecrement()
+    {
+        // Auto-clear path in ExecutionReportProcessor: a stale order
+        // fills before admin clears it. ER processor calls OnExecution
+        // BEFORE ClearStale (no Restored fires). Cash already released
+        // by Suspended; Fill must not double-decrement.
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+
+        p.OnExecution(1, ExecKind.Fill, 100);
+
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+        // Tracking entry removed.
+        p.OnExecution(1, ExecKind.Restored, 0);
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task CancelWhileSuspended_removesEntry_withoutTouchingOtherReservations()
+    {
+        var (p, _) = Build(initial: 2_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+
+        p.OnExecution(1, ExecKind.Canceled, 0);
+
+        // Order 2 still held; alice's reserved exactly = 500.
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task RestoredAfterTerminalRemoval_isNoOp()
+    {
+        // If the entry was already removed (auto-clear path consumed
+        // it via terminal ER), a late Restored must be safe.
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+        p.OnExecution(1, ExecKind.Fill, 100);
+
+        p.OnExecution(1, ExecKind.Restored, 0);
+
+        Assert.Equal(1_000m, p.AvailableForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Restored_overcommitsSilently_butStillRestoresLedger()
+    {
+        // #153. The WAL event is already committed when Restored
+        // fires; refusing to track the cash here would leave the
+        // ledger inconsistent with the WAL. We restore even when it
+        // pushes past base capacity (operator must reconcile by
+        // cancelling other holds; the metric flags the situation).
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None); // 1000 held, all cash
+        p.OnExecution(1, ExecKind.Suspended, 0); // released
+        // Operator (or a racing flow) consumes the freed cash with another order.
+        Assert.True((await p.TryReserveAsync(2, Buy("alice", 10m, 100), CancellationToken.None)).Approved);
+        Assert.Equal(1_000m, p.ReservedForTesting("alice"));
+
+        p.OnExecution(1, ExecKind.Restored, 0);
+
+        // Reserved now exceeds base — overcommit.
+        Assert.Equal(2_000m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task PrepareReplace_originalSuspended_treatsOldHeldAsZero()
+    {
+        // #153. PrepareReplaceAsync must NOT credit the suspended
+        // original's tracked remaining, because that cash is no
+        // longer held in _reserved. Treating it as old-held would
+        // approve a replace that, at commit, restores the missing
+        // notional and pushes past cap.
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 50), CancellationToken.None); // 500 held
+        p.OnExecution(1, ExecKind.Suspended, 0); // released
+        // Use the freed cash on another order.
+        await p.TryReserveAsync(2, Buy("alice", 10m, 100), CancellationToken.None); // 1000 held, 0 available
+        Assert.Equal(0m, p.AvailableForTesting("alice"));
+
+        // Replace #1 with full new notional: must be rejected because
+        // delta = 500 - 0 = 500 > 0 available.
+        var d = await p.PrepareReplaceAsync(1, 99, new EndClientId("alice"), 500m, CancellationToken.None);
+
+        Assert.False(d.Approved);
+        Assert.Contains("delta", d.Reason);
+    }
+
+    [Fact]
+    public async Task CommitReplace_originalSuspended_doesNotDoubleCredit()
+    {
+        // CommitReplace's adjustment math: subtracting the suspended
+        // original's tracked remaining would over-release reserved
+        // (the cash was never there). Adjustment must be computed
+        // against an effective-old of zero.
+        var (p, _) = Build(initial: 2_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 50), CancellationToken.None); // 500 held
+        p.OnExecution(1, ExecKind.Suspended, 0); // released, 2000 available
+        // PrepareReplace on the suspended original to a same-size order.
+        var prep = await p.PrepareReplaceAsync(1, 99, new EndClientId("alice"), 500m, CancellationToken.None);
+        Assert.True(prep.Approved);
+        // Delta path was 500 - 0 = 500: alice has 500 reserved (the new transient).
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
+
+        p.CommitReplace(originalClOrdId: 1, newClOrdId: 99, confirmedRemainingNotional: 500m);
+
+        // Reserved must be exactly 500 (the new order's held notional).
+        // If we had credited oldRemaining=500 in CommitReplace, the
+        // adjustment would be 500-500-500 = -500 → reserved = 0,
+        // which is wrong (the order is live).
+        Assert.Equal(500m, p.ReservedForTesting("alice"));
     }
 }


### PR DESCRIPTION
Closes #153.

## What

Cash margin reservation is now released when an order is marked stale and re-acquired when the staleness is cleared. Closes the gap left by #132 slice 5 (synthetic Suspended/Restored ER) where the cash hold stayed put while the order ghost was already broadcasting Suspended.

## Implementation

**`ReserveOnSubmitMarginProvider`** (the meat):
- `ReservationEntry` gains `IsSuspended` flag.
- `OnExecution` refactored: ALL state lookups happen INSIDE `_gate` so a Suspended/Restored fired from outside the dispatcher path cannot race with a genuine ER for the same ClOrdID and double-decrement (rubber-duck flagged this — clamp-to-zero would silently consume another order's hold).
- `Suspended`: releases the cash hold once, idempotent on re-mark.
- `Restored`: re-acquires the hold; if cash is no longer available, logs warn + emits `trading.margin.overcommit_on_restore` (WAL is authoritative; refusing to track here would diverge ledger from WAL).
- `PartialFill`/`Fill`/`Canceled`/`Rejected` skip `DecrementReserved` when `IsSuspended` (cash already released) but still reduce `RemainingNotional` / remove the entry. Auto-clear path in `ExecutionReportProcessor` stays untouched.
- `PrepareReplaceAsync` + `CommitReplace` treat a suspended original's `oldHeldRemaining` as zero, preventing over-release at commit and false-approve at prepare.

**`OrderStalenessService`**:
- New optional `IMarginProvider` ctor param.
- `NotifyMargin` helper invoked alongside `PublishSyntheticEvent` in `MarkStale`, `MarkAllWorkingByFirm` (per newly-marked order), and `ClearStale`.
- Margin failures logged + counted via `trading.margin.stale_transition_failed` but never bubble — the WAL event is already committed; failing here would leave the operator thinking the stale state never changed when in fact it did.

## Tests

+14 cases:
- 5 in `OrderStalenessServiceTests`: `CapturingMargin`/`ThrowingMargin` fixtures, mark→Suspended, idempotency, clear→Restored, bulk per-newly-marked, swallow exception.
- 9 in `ReserveOnSubmitMarginProviderTests`: Suspended releases hold, idempotent, doesn't corrupt sibling, partial-while-suspended doesn't double-decrement, Suspended→Fill no double-decrement, cancel-while-suspended, Restored after terminal removal is no-op, Restored overcommits silently, PrepareReplace original-suspended treats old-held as zero, CommitReplace original-suspended doesn't double-credit.

Suite **53 + 391 + 196 green**. `dotnet format` clean.

## Out of scope (future)

- Memory growth from suspended entries left forever — flagged for a future observability slice (probably a periodic cleanup or count gauge).
- Genuine-ER auto-clear path (in `ExecutionReportProcessor`) intentionally does NOT publish Restored or call `NotifyMargin` — the genuine ER's terminal branch already updates margin via the existing `PartialFill`/`Fill`/`Canceled`/`Rejected` cases (which now correctly handle `IsSuspended`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>