### PR TITLE
feat(margin): observability gauge for reservation counts (#153 follow-up)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -180,6 +180,35 @@ public static class MetricsRegistry
     /// </summary>
     public static readonly Counter<long> MarginStaleTransitionFailed =
         Meter.CreateCounter<long>("trading.risk.margin_stale_transition_failed");
+
+    /// <summary>
+    /// Memory-growth observability for the cash-margin reservation
+    /// ledger (#153 follow-up). Tagged <c>{state=active|suspended}</c>:
+    /// <list type="bullet">
+    /// <item><description><c>active</c>: live working / partially-filled orders that hold cash in <c>_reserved</c>.</description></item>
+    /// <item><description><c>suspended</c>: stale-flagged orders whose cash was released but whose tracking entry stays so a future <see cref="ExecKind.Restored"/> can re-acquire. A sustained climb of this count signals stale orders that admin never cleared and the venue never terminalized — the dictionary leaks until host restart.</description></item>
+    /// </list>
+    /// Source registered by the host once at startup via
+    /// <see cref="RegisterMarginReservationCountsSource"/>; absent
+    /// when the provider is not wired (tests, NoOp mode).
+    /// </summary>
+    private static volatile Func<(int Active, int Suspended)>? _marginReservationCountsSource;
+    public static readonly ObservableGauge<int> MarginReservations =
+        Meter.CreateObservableGauge<int>(
+            "trading.risk.margin_reservations",
+            () =>
+            {
+                var src = _marginReservationCountsSource;
+                if (src is null) return Array.Empty<Measurement<int>>();
+                var (active, suspended) = src();
+                return new[]
+                {
+                    new Measurement<int>(active, new KeyValuePair<string, object?>("state", "active")),
+                    new Measurement<int>(suspended, new KeyValuePair<string, object?>("state", "suspended")),
+                };
+            });
+    public static void RegisterMarginReservationCountsSource(Func<(int Active, int Suspended)> source) =>
+        _marginReservationCountsSource = source;
     // Last SessionVerId successfully Established for the firm. Reported as
     // an observable gauge so a stuck reconnect (gauge frozen while attempts
     // counter climbs) is visible at a glance.

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -283,6 +283,33 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
     internal decimal AvailableForTesting(string owner) =>
         ResolveBaseAvailable(owner) - ReservedForTesting(owner);
 
+    /// <summary>
+    /// Memory-growth observability for the suspended-reservation
+    /// path (#153 follow-up). A reservation entry that flipped to
+    /// <c>IsSuspended</c> stays in the dictionary until either an
+    /// admin clear-stale fires <see cref="ExecKind.Restored"/>, the
+    /// venue eventually delivers a terminal ER, or the host
+    /// restarts. If the venue never recovers and admin never acts,
+    /// those entries leak. Operators can watch the suspended count
+    /// here (gauge <c>trading.risk.margin_reservations{state}</c>)
+    /// to spot accumulation; the value should track the number of
+    /// flagged-stale orders visible in the trader UI.
+    /// </summary>
+    public (int Active, int Suspended) GetReservationCounts()
+    {
+        // No lock needed: ConcurrentDictionary's enumerator is
+        // weakly-consistent and a snapshot count is good enough for
+        // an observability gauge sampled every few seconds.
+        var suspended = 0;
+        var active = 0;
+        foreach (var kv in _reservations)
+        {
+            if (kv.Value.IsSuspended) suspended++;
+            else active++;
+        }
+        return (active, suspended);
+    }
+
     // ----- IReplaceMarginCoordinator (slice 2 of #122) -----
 
     /// <inheritdoc />

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -421,6 +421,15 @@ var app = builder.Build();
     B3.Trading.Application.Observability.MetricsRegistry.RegisterOrderRateSources(
         () => rate.EndClientLedger.ActiveBucketCount,
         () => rate.FirmLedger.ActiveBucketCount);
+    var marginProvider = app.Services.GetService<ReserveOnSubmitMarginProvider>();
+    if (marginProvider is not null)
+    {
+        // #153 follow-up: only register when the concrete provider
+        // is in the container (Margin.Enabled=true). NoOp mode has
+        // no reservations to count.
+        B3.Trading.Application.Observability.MetricsRegistry.RegisterMarginReservationCountsSource(
+            () => marginProvider.GetReservationCounts());
+    }
 }
 
 // Fail-fast on weak / missing JWT signing key outside Development. The

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
@@ -308,6 +308,47 @@ public class ReserveOnSubmitMarginProviderTests
     }
 
     [Fact]
+    public async Task GetReservationCounts_TracksActiveAndSuspendedSeparately()
+    {
+        // #153 follow-up. Memory-growth gauge: operators need to see
+        // suspended entries accumulating so a venue that never recovers
+        // doesn't quietly leak the reservation dictionary.
+        var (p, _) = Build(initial: 10_000m);
+        Assert.Equal((0, 0), p.GetReservationCounts());
+
+        await p.TryReserveAsync(1, Buy("alice", 10m, 50), CancellationToken.None);
+        await p.TryReserveAsync(2, Buy("alice", 10m, 50), CancellationToken.None);
+        Assert.Equal((2, 0), p.GetReservationCounts());
+
+        p.OnExecution(1, ExecKind.Suspended, 0);
+        Assert.Equal((1, 1), p.GetReservationCounts());
+
+        // Restored flips back to active without changing total.
+        p.OnExecution(1, ExecKind.Restored, 0);
+        Assert.Equal((2, 0), p.GetReservationCounts());
+
+        // Terminal removes the entry entirely.
+        p.OnExecution(2, ExecKind.Canceled, 0);
+        Assert.Equal((1, 0), p.GetReservationCounts());
+    }
+
+    [Fact]
+    public async Task GetReservationCounts_SuspendedThenFilled_DoesNotLeak()
+    {
+        // The auto-clear path (terminal ER on a suspended order) must
+        // remove the entry, otherwise the gauge would grow without
+        // bound on every venue restart.
+        var (p, _) = Build(initial: 1_000m);
+        await p.TryReserveAsync(1, Buy("alice", 10m, 100), CancellationToken.None);
+        p.OnExecution(1, ExecKind.Suspended, 0);
+        Assert.Equal((0, 1), p.GetReservationCounts());
+
+        p.OnExecution(1, ExecKind.Fill, 100);
+
+        Assert.Equal((0, 0), p.GetReservationCounts());
+    }
+
+    [Fact]
     public async Task CommitReplace_originalSuspended_doesNotDoubleCredit()
     {
         // CommitReplace's adjustment math: subtracting the suspended


### PR DESCRIPTION
Memory-growth observability for the cash-margin reservation ledger, the follow-up flagged in #154's PR body.

## Why

Suspended entries (orders that flipped stale and had their cash released via #153) stay in the reservation dictionary until either:
1. Admin fires `ClearStale` → `Restored` → entry flips back to active.
2. The venue eventually delivers a terminal ER → entry removed.
3. The host restarts → state rebuilt from WAL replay.

If the venue never recovers AND admin never acts, those entries leak. Today there's no signal beyond manually inspecting process memory.

## What

New `ObservableGauge<int>` `trading.risk.margin_reservations{state=active|suspended}`:
- `active`: live working/PartiallyFilled orders holding cash in `_reserved`.
- `suspended`: stale-flagged ghost entries with cash already released.

Fed by `ReserveOnSubmitMarginProvider.GetReservationCounts()` which enumerates the `ConcurrentDictionary` snapshot (no lock — weakly-consistent count is fine for a gauge sampled every few seconds). Source registered in `Program.cs` only when the concrete provider is in the container (Margin.Enabled=true).

A sustained climb of `state=suspended` is the alert: stale orders that nobody is reconciling. The gauge value should track the count of stale-badged orders visible in the trader UI.

## Tests

+2 cases:
- `GetReservationCounts_TracksActiveAndSuspendedSeparately`: active vs suspended split across submit / Suspended / Restored / Canceled transitions.
- `GetReservationCounts_SuspendedThenFilled_DoesNotLeak`: terminal ER on a suspended order auto-removes the entry.

Suite **53 + 393 + 196 green**. `dotnet format` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>