### PR TITLE
feat(risk): defensive DuplicateClOrdID guard (#108)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -73,6 +73,8 @@ public static class OrdersEndpoints
                         statusCode: StatusCodes.Status503ServiceUnavailable),
                 OrderSubmissionResultKind.BadRequest =>
                     Results.BadRequest(new { error = result.Reason }),
+                OrderSubmissionResultKind.DuplicateClOrdId =>
+                    Results.Conflict(new { error = result.Reason, clOrdId = result.ClOrdId.ToString() }),
                 _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
             };
         });
@@ -118,6 +120,8 @@ public static class OrdersEndpoints
                     Results.Json(
                         new { error = "service draining" },
                         statusCode: StatusCodes.Status503ServiceUnavailable),
+                OrderModifyResultKind.DuplicateClOrdId =>
+                    Results.Conflict(new { error = result.Reason, newClOrdId = result.NewClOrdId.ToString() }),
                 _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
             };
         });

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -164,6 +164,20 @@ public static class MetricsRegistry
     /// should monitor this counter and reconcile by cancelling stale
     /// orders. Tagged <c>{owner}</c>.
     /// </summary>
+    /// <summary>
+    /// #108 — DuplicateClOrdID guard. Counts pre-flight rejections
+    /// where <see cref="ClOrdIdPrefixRegistry"/> generated a ClOrdID
+    /// that collided with an existing entry in
+    /// <see cref="WorkingOrderBook"/> (or, for modify, also in
+    /// <see cref="PendingReplacementRegistry"/>). This counter MUST
+    /// be flat at zero in healthy operation; non-zero indicates a
+    /// registry/snapshot/WAL-replay regression where the per-end-client
+    /// counter watermark fell behind the persisted state — alert and
+    /// investigate. Tagged <c>{op=submit|modify, scope=book|pending}</c>.
+    /// </summary>
+    public static readonly Counter<long> ClOrdIdDuplicateDetected =
+        Meter.CreateCounter<long>("trading.orders.duplicate_clordid");
+
     public static readonly Counter<long> MarginOvercommitOnRestore =
         Meter.CreateCounter<long>("trading.risk.margin_overcommit_on_restore");
 

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -140,6 +140,34 @@ public sealed class OrderModifyService
         }
 
         var newClOrdId = _clOrdIds.Generate(req.Owner);
+        // #108 — DuplicateClOrdID defensive guard. The new ID must
+        // be unique against BOTH the working book AND in-flight
+        // pending replacements (an upstream NewClOrdId collision in
+        // PendingReplacementRegistry.TryAdd would otherwise be
+        // silently lost in the dispatch callback). Reject before
+        // risk/margin to avoid burning a margin reserve we'd then
+        // have to abort. See rubber-duck critique on PR for #153
+        // follow-up — same class of "ignored TryAdd return" bug.
+        if (_book.TryGet(newClOrdId, out _))
+        {
+            MetricsRegistry.ClOrdIdDuplicateDetected.Add(1,
+                new KeyValuePair<string, object?>("op", "modify"),
+                new KeyValuePair<string, object?>("scope", "book"));
+            _logger.LogError(
+                "Duplicate ClOrdID {NewClOrdId} for modify of {OriginalClOrdId} (owner {Owner}); refusing.",
+                newClOrdId, req.OriginalClOrdId, req.Owner.Value);
+            return OrderModifyResult.DuplicateClOrdId(newClOrdId);
+        }
+        if (_replacements.TryGet(newClOrdId, out _))
+        {
+            MetricsRegistry.ClOrdIdDuplicateDetected.Add(1,
+                new KeyValuePair<string, object?>("op", "modify"),
+                new KeyValuePair<string, object?>("scope", "pending"));
+            _logger.LogError(
+                "Duplicate ClOrdID {NewClOrdId} collides with in-flight pending replacement; refusing modify of {OriginalClOrdId}.",
+                newClOrdId, req.OriginalClOrdId);
+            return OrderModifyResult.DuplicateClOrdId(newClOrdId);
+        }
         var effectiveLeaves = req.NewQuantity - orig.CumulativeQuantity;
         var riskCtx = new RiskContext(
             req.Owner, orig.FirmId, orig.Symbol, orig.Side, orig.Type,
@@ -299,6 +327,14 @@ public sealed class OrderModifyResult
         new(OrderModifyResultKind.NotFound, 0, null, null);
     public static OrderModifyResult Drained { get; } =
         new(OrderModifyResultKind.Drained, 0, "service draining", null);
+    /// <summary>
+    /// #108 — DuplicateClOrdID guard. The just-allocated new ClOrdID
+    /// already exists in <see cref="WorkingOrderBook"/> or
+    /// <see cref="PendingReplacementRegistry"/>. No risk/margin run,
+    /// no WAL event, no gateway call. Endpoints map to <c>409 Conflict</c>.
+    /// </summary>
+    public static OrderModifyResult DuplicateClOrdId(ulong newClOrdId) =>
+        new(OrderModifyResultKind.DuplicateClOrdId, newClOrdId, "duplicate_clordid", null);
 }
 
 public enum OrderModifyResultKind
@@ -311,4 +347,5 @@ public enum OrderModifyResultKind
     GatewayFailed,
     WalBackpressure,
     Drained,
+    DuplicateClOrdId,
 }

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -88,6 +88,26 @@ public sealed class OrderSubmissionService
             return OrderSubmissionResult.BadRequest("symbol is required");
 
         var clOrdId = _clOrdIds.Generate(req.Owner);
+        // #108 — DuplicateClOrdID defensive guard. The registry's
+        // per-end-client counter is allocated atomically, so two
+        // concurrent submits never collide here. The realistic
+        // failure mode is a snapshot/WAL-replay regression where
+        // the counter watermark fell behind the persisted state at
+        // recovery — we'd then re-allocate IDs already in the book.
+        // Reject pre-WAL: no event appended, no order created, no
+        // gateway message sent. Operators alert on the metric and
+        // the next host restart with a fixed snapshot recovers.
+        if (_book.TryGet(clOrdId, out _))
+        {
+            MetricsRegistry.ClOrdIdDuplicateDetected.Add(1,
+                new KeyValuePair<string, object?>("op", "submit"),
+                new KeyValuePair<string, object?>("scope", "book"));
+            _logger.LogError(
+                "Duplicate ClOrdID {ClOrdId} for end-client {Owner} (firm {Firm}); refusing submit. " +
+                "Likely snapshot/WAL-replay regression — investigate ClOrdIdPrefixRegistry watermark.",
+                clOrdId, req.Owner.Value, req.FirmId);
+            return OrderSubmissionResult.DuplicateClOrdId(clOrdId);
+        }
         var order = new Order(
             clOrdId, req.Owner, req.Symbol, req.SecurityId, req.Side, req.Type,
             req.Quantity, req.Price, req.FirmId,
@@ -112,7 +132,20 @@ public sealed class OrderSubmissionService
                 },
                 () =>
                 {
-                    _book.TryAdd(order);
+                    if (!_book.TryAdd(order))
+                    {
+                        // Belt-and-suspenders: pre-flight TryGet
+                        // already handled the expected case. If we
+                        // somehow reach here with a collision, the
+                        // WAL is already appended — log critical so
+                        // the inconsistency surfaces in postmortem.
+                        MetricsRegistry.ClOrdIdDuplicateDetected.Add(1,
+                            new KeyValuePair<string, object?>("op", "submit"),
+                            new KeyValuePair<string, object?>("scope", "callback"));
+                        _logger.LogCritical(
+                            "WorkingOrderBook.TryAdd failed for {ClOrdId} after pre-flight passed; book/WAL diverged.",
+                            clOrdId);
+                    }
                     _ownership.Register(clOrdId, req.Owner);
                 });
         }
@@ -255,6 +288,16 @@ public sealed class OrderSubmissionResult
         new(OrderSubmissionResultKind.BadRequest, 0, reason, null);
     public static OrderSubmissionResult Drained { get; } =
         new(OrderSubmissionResultKind.Drained, 0, "service draining", null);
+    /// <summary>
+    /// #108 — DuplicateClOrdID guard. The just-allocated ClOrdID
+    /// already exists in the <see cref="WorkingOrderBook"/>. No WAL
+    /// event was appended, no order was created, no gateway call was
+    /// made. Endpoints should map this to <c>409 Conflict</c> so
+    /// callers can distinguish it from ordinary input validation
+    /// failures and so operators can spot the invariant breach.
+    /// </summary>
+    public static OrderSubmissionResult DuplicateClOrdId(ulong clOrdId) =>
+        new(OrderSubmissionResultKind.DuplicateClOrdId, clOrdId, "duplicate_clordid", null);
 }
 
 public enum OrderSubmissionResultKind
@@ -265,4 +308,5 @@ public enum OrderSubmissionResultKind
     WalBackpressure,
     BadRequest,
     Drained,
+    DuplicateClOrdId,
 }

--- a/backend/tests/B3.Trading.Api.Tests/DuplicateClOrdIdGuardTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DuplicateClOrdIdGuardTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// #108 — defensive DuplicateClOrdID guard. The
+/// <see cref="ClOrdIdPrefixRegistry"/>'s per-end-client counter is
+/// allocated atomically, so two concurrent submits never collide on
+/// the hot path. The realistic failure mode is a snapshot/WAL-replay
+/// regression where the counter watermark falls behind the persisted
+/// state at recovery — Restore() then re-allocates IDs already in
+/// the book. These tests force that scenario by Restoring the
+/// registry to an older snapshot and asserting submit/modify both
+/// reject with 409 + reason <c>duplicate_clordid</c> (no WAL append,
+/// no gateway dispatch).
+/// </summary>
+public class DuplicateClOrdIdGuardTests
+{
+    [Fact]
+    public async Task POST_orders_DuplicateClOrdId_Returns409Conflict()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // First submit — establishes the order in the book and
+        // advances the registry counter to 1.
+        var first = await PostOrder(http, token, qty: 100, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+
+        // Snapshot the registry, then roll the per-end-client counter
+        // back to 0 so the next Generate() returns the same packed
+        // ulong as the order we just submitted.
+        var registry = f.Services.GetRequiredService<ClOrdIdPrefixRegistry>();
+        var snap = registry.Snapshot();
+        Assert.NotEmpty(snap.Counters);
+        var rolled = new ClOrdIdRegistrySnapshot
+        {
+            NextPrefix = snap.NextPrefix,
+            Counters = snap.Counters
+                .Select(c => new ClOrdIdCounterSnapshot(c.EndClientId, c.PrefixIdx, Counter: 0))
+                .ToList(),
+        };
+        registry.Restore(rolled);
+
+        // Second submit must trip the pre-flight guard.
+        var second = await PostOrder(http, token, qty: 50, price: 30m);
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+        var body = await second.Content.ReadFromJsonAsync<ConflictBody>();
+        Assert.NotNull(body);
+        Assert.Equal("duplicate_clordid", body!.Error);
+        Assert.False(string.IsNullOrEmpty(body.ClOrdId));
+    }
+
+    [Fact]
+    public async Task PUT_orders_DuplicateClOrdId_Returns409Conflict()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Submit order #1 (counter advances to 1).
+        var p1 = await PostOrder(http, token, qty: 100, price: 30m);
+        Assert.Equal(HttpStatusCode.Accepted, p1.StatusCode);
+        var ack1 = await p1.Content.ReadFromJsonAsync<OrderAck>();
+
+        // Submit order #2 (counter advances to 2).
+        var p2 = await PostOrder(http, token, qty: 200, price: 31m);
+        Assert.Equal(HttpStatusCode.Accepted, p2.StatusCode);
+
+        // Roll the counter back to 1 — next Generate() returns the
+        // same packed ulong as order #2 (which is in the book).
+        var registry = f.Services.GetRequiredService<ClOrdIdPrefixRegistry>();
+        var snap = registry.Snapshot();
+        var rolled = new ClOrdIdRegistrySnapshot
+        {
+            NextPrefix = snap.NextPrefix,
+            Counters = snap.Counters
+                .Select(c => new ClOrdIdCounterSnapshot(c.EndClientId, c.PrefixIdx, Counter: 1))
+                .ToList(),
+        };
+        registry.Restore(rolled);
+
+        // Modify order #1: generates new ClOrdId = counter 2 = order
+        // #2's ID. Pre-flight must reject before risk/margin/gateway.
+        var put = await PutModify(http, token, ack1!.ClOrdId, qty: 150, price: 30m);
+        Assert.Equal(HttpStatusCode.Conflict, put.StatusCode);
+        var body = await put.Content.ReadFromJsonAsync<ModifyConflictBody>();
+        Assert.NotNull(body);
+        Assert.Equal("duplicate_clordid", body!.Error);
+    }
+
+    private static async Task<HttpResponseMessage> PostOrder(
+        HttpClient http, string token, int qty, decimal price)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+            })
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<HttpResponseMessage> PutModify(
+        HttpClient http, string token, string clOrdId, int qty, decimal? price)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{clOrdId}")
+        {
+            Content = JsonContent.Create(new { Quantity = qty, Price = price })
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason);
+    private sealed record ConflictBody(string Error, string ClOrdId);
+    private sealed record ModifyConflictBody(string Error, string NewClOrdId);
+}


### PR DESCRIPTION
Closes the **DuplicateClOrdID** sub-item of the #108 tracking issue.

## Why

`ClOrdIdPrefixRegistry`'s per-end-client counter is allocated atomically (`Interlocked.Increment`), so two concurrent submits for the same end-client never collide on the hot path. The realistic failure mode is a snapshot/WAL-replay regression where the counter watermark falls behind the persisted state at recovery — `Restore()` then re-allocates IDs already in the book.

Today, both `OrderSubmissionService` and `OrderModifyService` ignored the `bool` returned by `WorkingOrderBook.TryAdd` / `PendingReplacementRegistry.TryAdd`, so a collision silently kept the OLD entry and lost the new one — a subtle audit/lifecycle divergence with no signal.

## Plan validated by rubber-duck

Key blocking findings adopted:
1. **Modify must check both `_book` AND `_replacements`.** PendingReplacement IDs live there first, not in the book.
2. **Don't ignore `TryAdd` return** in dispatch callbacks. Pre-flight is the primary path; defensive belt-and-suspenders log critical + emit metric if it ever trips after pre-flight passed.
3. **Place modify check BEFORE risk/margin** so we never burn a margin reserve on a doomed request.
4. **Distinct result kinds + 409 Conflict** so this is grep-able from input-validation 400s.

Deferred (out of scope, separate follow-up): advancing the registry counter watermark during WAL replay so `Restore + replay` are consistent end-to-end. The defensive guard is a stopgap; without watermark advancement, post-recovery every subsequent request for that end-client may keep generating duplicates until the counter passes the WAL/book max.

## What

- `OrderSubmissionService`: `_book.TryGet` after `Generate()`. On collision: log error, emit metric, return new `DuplicateClOrdId` result. No WAL append, no Order created, no gateway call.
- `OrderModifyService`: `_book.TryGet` AND `_replacements.TryGet` after `Generate()`. Pre-flight before risk/margin.
- `OrderSubmissionService` dispatch callback: log critical + emit metric on unexpected `TryAdd=false` (the WAL-already-appended divergence case).
- New `OrderSubmissionResultKind.DuplicateClOrdId` and `OrderModifyResultKind.DuplicateClOrdId`. Endpoints map to **409 Conflict**.
- New metric `trading.orders.duplicate_clordid` tagged `{op=submit|modify, scope=book|pending|callback}`. **MUST be flat at zero in healthy operation**; non-zero alerts on registry/snapshot/WAL-replay regression.

## Tests

+2 integration tests in `DuplicateClOrdIdGuardTests` that force the collision via `ClOrdIdPrefixRegistry.Restore()` (rolling the per-end-client counter back) and assert 409 Conflict + reason `duplicate_clordid` for both submit and modify endpoints.

Suite **53 + 393 + 198 green**. `dotnet format` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>