### PR TITLE
feat(risk): SessionPhaseCheck pre-trade gate (#108)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -54,6 +54,34 @@ public static class AdminEndpoints
         group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
             ToggleHalt(dispatcher, symbol, halted: false, ctx, () => svc.Resume(symbol)));
 
+        // ── Session phase (#108) ──────────────────────────────────
+        // Per-symbol override + global default trading phase. Drives
+        // SessionPhaseCheck; auctions reject Market, Closed rejects
+        // everything. Persisted via SessionPhaseChangedEvent so a
+        // restart restores the last known restriction — losing a
+        // non-Continuous phase on crash would silently revert to the
+        // least restrictive mode.
+        group.MapGet("/session-phase", (SessionPhaseService svc) => Results.Ok(new
+        {
+            Default = svc.DefaultPhase.ToString(),
+            Overrides = svc.ListOverrides().ToDictionary(kv => kv.Key, kv => kv.Value.ToString()),
+        }));
+
+        group.MapPost("/session-phase/default", (SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
+            ChangeSessionPhase(dispatcher, symbol: null, cleared: false, req?.Phase, ctx,
+                phase => svc.SetDefaultPhase(phase),
+                requirePhase: true));
+
+        group.MapPost("/session-phase/{symbol}", (string symbol, SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
+            ChangeSessionPhase(dispatcher, symbol, cleared: false, req?.Phase, ctx,
+                phase => svc.SetPhase(symbol, phase),
+                requirePhase: true));
+
+        group.MapDelete("/session-phase/{symbol}", (string symbol, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
+            ChangeSessionPhase(dispatcher, symbol, cleared: true, phaseStr: null, ctx,
+                _ => svc.ClearPhase(symbol),
+                requirePhase: false));
+
         // ── Order staleness overlay (#132 slice 1) ────────────────
         // Lets an admin flag a specific working order as
         // suspected-stale-by-venue (matching restart, FIXP gap, etc.)
@@ -373,9 +401,59 @@ public static class AdminEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable);
         }
     }
+    private static IResult ChangeSessionPhase(
+        EventDispatcher dispatcher,
+        string? symbol,
+        bool cleared,
+        string? phaseStr,
+        HttpContext ctx,
+        Action<SessionPhase> mutate,
+        bool requirePhase)
+    {
+        SessionPhase parsed = SessionPhase.Continuous;
+        if (requirePhase)
+        {
+            if (string.IsNullOrWhiteSpace(phaseStr) || !Enum.TryParse(phaseStr, ignoreCase: true, out parsed))
+                return Results.BadRequest(new { error = "phase must be one of: Closed, PreOpening, OpeningAuction, Continuous, ClosingAuction, AfterHours" });
+        }
+
+        var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+        try
+        {
+            dispatcher.Dispatch(
+                new SessionPhaseChangedEvent
+                {
+                    Symbol = symbol,
+                    Phase = parsed.ToString(),
+                    Cleared = cleared,
+                    ActorUserId = actor,
+                },
+                () => mutate(parsed));
+            MetricsRegistry.SessionPhaseChanged.Add(1,
+                new KeyValuePair<string, object?>("scope", string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol"),
+                new KeyValuePair<string, object?>("phase", cleared ? "cleared" : parsed.ToString()));
+            return Results.NoContent();
+        }
+        catch (WalBackpressureException ex)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "admin.session-phase"));
+            return Results.Json(
+                new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
 }
 
 /// <summary>
-/// Slice 1 of #132. Body for <c>POST /admin/firms/{firmId}/orders/{clOrdId}/mark-stale</c>.
+/// Body for <c>POST /admin/session-phase[/{symbol}|/default]</c> (#108).
+/// </summary>
+public sealed class SessionPhasePayload
+{
+    public string? Phase { get; set; }
+}
+
+/// <summary>
+/// Body for <c>POST /admin/firms/{firmId}/orders/{clOrdId}/mark-stale</c> (#132 slice 1).
 /// </summary>
 public sealed record MarkStaleRequest(string? Reason);

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -57,6 +57,16 @@ public static class MetricsRegistry
     public static readonly Counter<long> SymbolHaltToggled =
         Meter.CreateCounter<long>("trading.symbol_halt.toggled");
 
+    /// <summary>
+    /// Session-phase change counter (#108). Tagged <c>scope=default|symbol</c>
+    /// and <c>phase</c> with the new value (or <c>cleared</c> when an
+    /// override is removed). Drives ops dashboards for "did the venue
+    /// transition into/out of an auction" and audit-trail correlation
+    /// with reject spikes.
+    /// </summary>
+    public static readonly Counter<long> SessionPhaseChanged =
+        Meter.CreateCounter<long>("trading.session_phase.changed");
+
     // WAL
     public static readonly Counter<long> WalAppended =
         Meter.CreateCounter<long>("trading.wal.appended");

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -21,6 +21,23 @@ public sealed class PlatformSnapshot
     /// "no halts" semantics they actually carried.
     /// </summary>
     public List<string> HaltedSymbols { get; init; } = new();
+
+    /// <summary>
+    /// Global default <see cref="B3.Trading.Domain.SessionPhase"/>
+    /// (#108) — applied when a symbol has no override. Older snapshots
+    /// pre-date the field and deserialise as <c>"Continuous"</c>, which
+    /// matches the implicit "trading is on" semantics they carried.
+    /// Stored as the enum name to keep the wire format stable across
+    /// future enum renumberings.
+    /// </summary>
+    public string DefaultSessionPhase { get; init; } = "Continuous";
+
+    /// <summary>
+    /// Per-symbol session-phase overrides (#108). Empty on snapshots
+    /// pre-dating the field, which collapses to "everything follows
+    /// the default" — same behaviour as before the slice existed.
+    /// </summary>
+    public List<SessionPhaseOverrideSnapshot> SessionPhaseOverrides { get; init; } = new();
     public ClOrdIdRegistrySnapshot ClOrdIds { get; init; } = new();
     public List<OwnershipMappingSnapshot> Ownership { get; init; } = new();
     public List<AlgoSnapshot> Algos { get; init; } = new();
@@ -123,3 +140,9 @@ public sealed class AlgoIdRegistrySnapshot
 }
 
 public sealed record AlgoIdCounterSnapshot(string FirmId, long Counter);
+
+/// <summary>
+/// One per-symbol session-phase override (#108). Phase stored as the
+/// enum name for forward-compat across reorderings.
+/// </summary>
+public sealed record SessionPhaseOverrideSnapshot(string Symbol, string Phase);

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -21,6 +21,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
 [JsonDerivedType(typeof(SymbolHaltToggledEvent), "symbol-halt.toggled")]
+[JsonDerivedType(typeof(SessionPhaseChangedEvent), "session-phase.changed")]
 [JsonDerivedType(typeof(AlgoCreatedEvent), "algo.created")]
 [JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
@@ -141,6 +142,27 @@ public sealed record SymbolHaltToggledEvent : WalEvent
 {
     public required string Symbol { get; init; }
     public required bool Halted { get; init; }    // true=halt, false=resume
+    public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Trading session phase change for a symbol or the venue default
+/// (#108). Mirrors the audit-trail posture of <see cref="SymbolHaltToggledEvent"/>:
+/// "who moved which scope into which phase, when". Recovery rebuilds
+/// the per-symbol overrides + global default by replaying these in
+/// arrival order on top of the snapshot.
+///
+/// <para>When <see cref="Symbol"/> is null/empty the event sets the
+/// global default (<c>SetDefaultPhase</c>); otherwise it sets/clears
+/// a per-symbol override. <see cref="Cleared"/> = true means "remove
+/// the override" (the per-symbol path falls back to the default);
+/// the <see cref="Phase"/> field is then advisory only.</para>
+/// </summary>
+public sealed record SessionPhaseChangedEvent : WalEvent
+{
+    public string? Symbol { get; init; }
+    public required string Phase { get; init; }
+    public bool Cleared { get; init; }
     public string? ActorUserId { get; init; }
 }
 

--- a/backend/src/B3.Trading.Application/Risk/Checks/SessionPhaseCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SessionPhaseCheck.cs
@@ -1,0 +1,51 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Pre-trade gate that rejects orders incompatible with the current
+/// <see cref="SessionPhase"/> for the symbol (#108).
+///
+/// <para><b>Rules</b> (deliberately conservative — auctions only accept
+/// limit orders in B3 reality, after-hours is limit-only too, and a
+/// closed venue accepts nothing):</para>
+/// <list type="bullet">
+///   <item><description><c>Closed</c> → reject every order. Reason: <c>phase_not_allowed:closed</c>.</description></item>
+///   <item><description><c>PreOpening</c>, <c>OpeningAuction</c>, <c>ClosingAuction</c> → reject <c>Market</c>; allow <c>Limit</c>. Reason: <c>phase_not_allowed:auction</c>.</description></item>
+///   <item><description><c>AfterHours</c> → reject <c>Market</c>; allow <c>Limit</c>. Reason: <c>phase_not_allowed:after_hours</c>.</description></item>
+///   <item><description><c>Continuous</c> → approve.</description></item>
+/// </list>
+///
+/// <para>Pipeline order is 12 — after the kill-switch (0) and the
+/// halt check (10), before tick/lot/notional and any throttle. We
+/// fail fast on the cheapest binary control once the symbol is known
+/// not halted; no need to spend cycles on instrument rules for an
+/// order the venue won't even consider.</para>
+///
+/// <para>If/when <c>TimeInForce</c> lands on the order model, this
+/// check should be extended to reject IOC/FOK in auction phases too.</para>
+/// </summary>
+public sealed class SessionPhaseCheck : IRiskCheck
+{
+    private readonly SessionPhaseService _phases;
+    public SessionPhaseCheck(SessionPhaseService phases) => _phases = phases;
+
+    public int Order => 12;
+    public string Name => "phase_not_allowed";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        var phase = _phases.GetPhase(ctx.Symbol);
+        return phase switch
+        {
+            SessionPhase.Closed =>
+                RiskDecision.Reject($"phase_not_allowed:closed (symbol '{ctx.Symbol}' venue closed)"),
+            SessionPhase.PreOpening or SessionPhase.OpeningAuction or SessionPhase.ClosingAuction
+                when ctx.Type == OrderType.Market =>
+                RiskDecision.Reject($"phase_not_allowed:auction (market orders not accepted in {phase} for '{ctx.Symbol}')"),
+            SessionPhase.AfterHours when ctx.Type == OrderType.Market =>
+                RiskDecision.Reject($"phase_not_allowed:after_hours (market orders not accepted after-hours for '{ctx.Symbol}')"),
+            _ => RiskDecision.Approve,
+        };
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/SessionPhaseService.cs
+++ b/backend/src/B3.Trading.Application/Risk/SessionPhaseService.cs
@@ -1,0 +1,81 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Tracks the current trading <see cref="SessionPhase"/> for the venue
+/// (default) and per-symbol overrides. Backs <see cref="Checks.SessionPhaseCheck"/>.
+///
+/// <para><b>Hierarchy:</b> a per-symbol override always wins; otherwise
+/// the global <see cref="DefaultPhase"/> applies. This matches B3
+/// reality where the venue moves through phases as a whole but a
+/// single ticker can be pinned in a circuit-breaker auction while the
+/// rest stays continuous.</para>
+///
+/// <para><b>Default-of-default:</b> a fresh process starts at
+/// <see cref="SessionPhase.Continuous"/>. This is fail-open and
+/// chosen for back-compat — every existing test path implicitly
+/// assumes "trading is on". Production deployments that want the
+/// stricter posture (start <see cref="SessionPhase.Closed"/> until
+/// operator/feed flips it) configure that via <c>Trading:SessionPhase:Default</c>
+/// in the host. Phase changes are persisted via <c>SessionPhaseChangedEvent</c>
+/// so a restart restores the last known state — losing a non-Continuous
+/// phase on crash would silently revert to the least restrictive mode.</para>
+///
+/// <para>Symbol comparisons are case-insensitive (PETR4 == petr4) to
+/// match the rest of the platform's symbol handling.</para>
+/// </summary>
+public sealed class SessionPhaseService
+{
+    private readonly ConcurrentDictionary<string, SessionPhase> _overrides =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private SessionPhase _default;
+
+    public SessionPhaseService(SessionPhase defaultPhase = SessionPhase.Continuous)
+    {
+        _default = defaultPhase;
+    }
+
+    /// <summary>Current global default phase (applied when no symbol override is set).</summary>
+    public SessionPhase DefaultPhase => _default;
+
+    /// <summary>Resolves the effective phase for <paramref name="symbol"/>: override if any, else default.</summary>
+    public SessionPhase GetPhase(string symbol)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        return _overrides.TryGetValue(symbol, out var p) ? p : _default;
+    }
+
+    /// <summary>Sets a per-symbol override.</summary>
+    public void SetPhase(string symbol, SessionPhase phase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        _overrides[symbol] = phase;
+    }
+
+    /// <summary>Removes the per-symbol override; the symbol falls back to <see cref="DefaultPhase"/>.</summary>
+    public bool ClearPhase(string symbol)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        return _overrides.TryRemove(symbol, out _);
+    }
+
+    /// <summary>Sets the global default phase (applies to symbols without an explicit override).</summary>
+    public void SetDefaultPhase(SessionPhase phase) => _default = phase;
+
+    /// <summary>Snapshot of all per-symbol overrides for capture.</summary>
+    public IReadOnlyDictionary<string, SessionPhase> ListOverrides() =>
+        _overrides.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Replaces overrides + default from a snapshot. Used during recovery.</summary>
+    public void Restore(SessionPhase defaultPhase, IEnumerable<KeyValuePair<string, SessionPhase>> overrides)
+    {
+        ArgumentNullException.ThrowIfNull(overrides);
+        _default = defaultPhase;
+        _overrides.Clear();
+        foreach (var kv in overrides)
+            _overrides[kv.Key] = kv.Value;
+    }
+}

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -12,6 +12,34 @@ public enum OrderType
     Market,
 }
 
+/// <summary>
+/// Trading session phase for an instrument (or the venue as a whole).
+/// Drives the <c>SessionPhaseCheck</c> pre-trade gate (#108): every
+/// phase admits a different subset of order types.
+///
+/// <para>B3 cash-equities reality has more granular sub-phases (e.g.
+/// random opening window, post-trade), but for pre-trade routing what
+/// matters is whether a continuous match or a call-auction is on, and
+/// whether the venue is open at all. The six values below cover that
+/// product surface without leaking match-engine internals into the
+/// risk model.</para>
+/// </summary>
+public enum SessionPhase
+{
+    /// <summary>Venue closed — no orders accepted.</summary>
+    Closed,
+    /// <summary>Pre-opening cancel-and-amend window before the call.</summary>
+    PreOpening,
+    /// <summary>Opening call auction — limit orders only, no market.</summary>
+    OpeningAuction,
+    /// <summary>Continuous matching — all order types allowed.</summary>
+    Continuous,
+    /// <summary>Closing call auction — limit orders only, no market.</summary>
+    ClosingAuction,
+    /// <summary>After-hours session — limit orders only, no market.</summary>
+    AfterHours,
+}
+
 public enum OrderStatus
 {
     PendingNew,

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -151,6 +151,17 @@ builder.Services.AddSingleton<EventDispatcher>();
 // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.
 builder.Services.AddSingleton<KillSwitchService>();
 builder.Services.AddSingleton<SymbolHaltService>();
+builder.Services.AddSingleton<SessionPhaseService>(_ =>
+{
+    // #108 SessionPhase. Default is Continuous (back-compat); ops can pin
+    // production to a stricter posture (e.g. Closed at boot, then flip via
+    // the admin endpoint or feed) by setting Trading:SessionPhase:Default.
+    var raw = builder.Configuration["Trading:SessionPhase:Default"];
+    var def = !string.IsNullOrWhiteSpace(raw)
+        && Enum.TryParse<SessionPhase>(raw, ignoreCase: true, out var parsed)
+        ? parsed : SessionPhase.Continuous;
+    return new SessionPhaseService(def);
+});
 builder.Services.AddSingleton<OrderStalenessService>();
 // Slice 2 of #132. Reactor reads the flag set off the Trading:AutoStale section.
 builder.Services.Configure<AutoStaleOptions>(builder.Configuration.GetSection(AutoStaleOptions.SectionName));
@@ -182,6 +193,7 @@ builder.Services.AddSingleton<IReplaceMarginCoordinator>(sp =>
     sp.GetRequiredService<ReserveOnSubmitMarginProvider>());
 builder.Services.AddSingleton<IRiskCheck, KillSwitchCheck>();
 builder.Services.AddSingleton<IRiskCheck, SymbolHaltedCheck>();
+builder.Services.AddSingleton<IRiskCheck, SessionPhaseCheck>();
 builder.Services.AddSingleton<IRiskCheck, OrderTypeAllowedCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
 builder.Services.AddSingleton<IRiskCheck, MinLotSizeCheck>();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -71,6 +71,7 @@ public sealed class EodMaterialiser
                         break;
                     case KillSwitchToggledEvent: report.KillSwitchToggleCount++; break;
                     case SymbolHaltToggledEvent: report.SymbolHaltToggleCount++; break;
+                    case SessionPhaseChangedEvent: report.SessionPhaseChangeCount++; break;
                 }
             }
         }
@@ -101,6 +102,7 @@ public sealed class EodReport
     public long RejectedCount { get; set; }
     public long KillSwitchToggleCount { get; set; }
     public long SymbolHaltToggleCount { get; set; }
+    public long SessionPhaseChangeCount { get; set; }
     public string Sha256 { get; set; } = "";
     public string Path { get; set; } = "";
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -18,6 +18,7 @@ public sealed class StateSnapshotter
     private readonly PositionKeeper _positions;
     private readonly KillSwitchService _killSwitch;
     private readonly SymbolHaltService _symbolHalts;
+    private readonly SessionPhaseService _sessionPhases;
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly OrderOwnershipMap _ownership;
     private readonly AlgoBook _algos;
@@ -29,6 +30,7 @@ public sealed class StateSnapshotter
         PositionKeeper positions,
         KillSwitchService killSwitch,
         SymbolHaltService symbolHalts,
+        SessionPhaseService sessionPhases,
         ClOrdIdPrefixRegistry clOrdIds,
         OrderOwnershipMap ownership,
         AlgoBook algos,
@@ -39,6 +41,7 @@ public sealed class StateSnapshotter
         _positions = positions;
         _killSwitch = killSwitch;
         _symbolHalts = symbolHalts;
+        _sessionPhases = sessionPhases;
         _clOrdIds = clOrdIds;
         _ownership = ownership;
         _algos = algos;
@@ -55,6 +58,10 @@ public sealed class StateSnapshotter
         KilledEndClients = _killSwitch.ListKilledEndClients().ToList(),
         KilledFirms = _killSwitch.ListKilledFirms().ToList(),
         HaltedSymbols = _symbolHalts.ListHalted().ToList(),
+        DefaultSessionPhase = _sessionPhases.DefaultPhase.ToString(),
+        SessionPhaseOverrides = _sessionPhases.ListOverrides()
+            .Select(kv => new SessionPhaseOverrideSnapshot(kv.Key, kv.Value.ToString()))
+            .ToList(),
         ClOrdIds = _clOrdIds.Snapshot(),
         Ownership = _ownership.Snapshot().ToList(),
         Algos = _algos.Snapshot().ToList(),
@@ -69,6 +76,13 @@ public sealed class StateSnapshotter
         _positions.Restore(snap.Positions);
         _killSwitch.Restore(snap.KilledEndClients, snap.KilledFirms);
         _symbolHalts.Restore(snap.HaltedSymbols);
+        var defaultPhase = Enum.TryParse<SessionPhase>(snap.DefaultSessionPhase, ignoreCase: true, out var dp)
+            ? dp : SessionPhase.Continuous;
+        var overrides = snap.SessionPhaseOverrides
+            .Select(o => new KeyValuePair<string, SessionPhase>(
+                o.Symbol,
+                Enum.TryParse<SessionPhase>(o.Phase, ignoreCase: true, out var p) ? p : SessionPhase.Continuous));
+        _sessionPhases.Restore(defaultPhase, overrides);
         _clOrdIds.Restore(snap.ClOrdIds);
         _ownership.Restore(snap.Ownership);
         _algos.Restore(snap.Algos);
@@ -90,6 +104,7 @@ public sealed class EventReplayer
     private readonly OrderOwnershipMap _ownership;
     private readonly KillSwitchService _killSwitch;
     private readonly SymbolHaltService _symbolHalts;
+    private readonly SessionPhaseService _sessionPhases;
     private readonly ExecutionReportProcessor _processor;
     private readonly AlgoBook _algos;
     private readonly PendingReplacementRegistry? _replacements;
@@ -99,6 +114,7 @@ public sealed class EventReplayer
         OrderOwnershipMap ownership,
         KillSwitchService killSwitch,
         SymbolHaltService symbolHalts,
+        SessionPhaseService sessionPhases,
         ExecutionReportProcessor processor,
         AlgoBook algos,
         PendingReplacementRegistry? replacements = null)
@@ -107,6 +123,7 @@ public sealed class EventReplayer
         _ownership = ownership;
         _killSwitch = killSwitch;
         _symbolHalts = symbolHalts;
+        _sessionPhases = sessionPhases;
         _processor = processor;
         _algos = algos;
         _replacements = replacements;
@@ -180,6 +197,21 @@ public sealed class EventReplayer
             case SymbolHaltToggledEvent sh:
                 if (sh.Halted) _symbolHalts.Halt(sh.Symbol);
                 else _symbolHalts.Resume(sh.Symbol);
+                break;
+            case SessionPhaseChangedEvent sp:
+                if (string.IsNullOrWhiteSpace(sp.Symbol))
+                {
+                    if (Enum.TryParse<SessionPhase>(sp.Phase, ignoreCase: true, out var defPhase))
+                        _sessionPhases.SetDefaultPhase(defPhase);
+                }
+                else if (sp.Cleared)
+                {
+                    _sessionPhases.ClearPhase(sp.Symbol);
+                }
+                else if (Enum.TryParse<SessionPhase>(sp.Phase, ignoreCase: true, out var symPhase))
+                {
+                    _sessionPhases.SetPhase(sp.Symbol, symPhase);
+                }
                 break;
             case AlgoCreatedEvent ac:
                 ApplyAlgoCreated(ac);

--- a/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
@@ -139,6 +139,73 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
         }
     }
 
+    [Fact]
+    public async Task AdminSessionPhaseEndpoints_RequireAdminRole()
+    {
+        using var userClient = await _factory.CreateAuthedClientAsync(); // alice (user role)
+        var get = await userClient.GetAsync("/admin/session-phase");
+        Assert.Equal(HttpStatusCode.Forbidden, get.StatusCode);
+        var post = await userClient.PostAsJsonAsync("/admin/session-phase/PETR4", new { phase = "Closed" });
+        Assert.Equal(HttpStatusCode.Forbidden, post.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminSessionPhase_SetGetClear_RoundTrips()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        await admin.DeleteAsync("/admin/session-phase/WEGE3"); // clean
+
+        var setResp = await admin.PostAsJsonAsync("/admin/session-phase/WEGE3", new { phase = "OpeningAuction" });
+        Assert.Equal(HttpStatusCode.NoContent, setResp.StatusCode);
+
+        var state = await admin.GetFromJsonAsync<SessionPhaseStateDto>("/admin/session-phase");
+        Assert.NotNull(state);
+        Assert.Equal("OpeningAuction", state!.Overrides["WEGE3"]);
+
+        var clr = await admin.DeleteAsync("/admin/session-phase/WEGE3");
+        Assert.Equal(HttpStatusCode.NoContent, clr.StatusCode);
+
+        state = await admin.GetFromJsonAsync<SessionPhaseStateDto>("/admin/session-phase");
+        Assert.False(state!.Overrides.ContainsKey("WEGE3"));
+    }
+
+    [Fact]
+    public async Task AdminSessionPhase_RejectsBadPhase()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/session-phase/PETR4", new { phase = "Banana" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SessionPhase_OpeningAuction_RejectsMarketOrder_ThenResumes()
+    {
+        // Use a unique symbol to avoid colliding with other tests/clients on the shared factory.
+        const string sym = "PHASE_TEST";
+        using var http = _factory.CreateClient();
+        var token = await _factory.LoginAsync(http, "bob");
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+
+        var ws = await OpenSubscribedAsync(token, Channels.ExecutionsMe);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await admin.PostAsJsonAsync($"/admin/session-phase/{sym}", new { phase = "OpeningAuction" });
+        try
+        {
+            // Market order in auction → reject with phase_not_allowed:auction.
+            var blocked = await PostAsync(http, token, "/orders",
+                new { Symbol = sym, SecurityId = 4321UL, Side = "Buy", Type = "Market", Quantity = 1, Price = (decimal?)null });
+            Assert.Equal(HttpStatusCode.Accepted, blocked.StatusCode);
+            var delta = await ReadJsonAsync(ws, cts.Token);
+            Assert.Equal("Rejected", delta.GetProperty("data").GetProperty("kind").GetString());
+            Assert.Contains("phase_not_allowed", delta.GetProperty("data").GetProperty("rejectReason").GetString());
+        }
+        finally
+        {
+            await admin.DeleteAsync($"/admin/session-phase/{sym}");
+        }
+    }
+
     private async Task<WebSocket> OpenSubscribedAsync(string token, string channel)
     {
         var wsClient = _factory.Server.CreateWebSocketClient();
@@ -181,4 +248,5 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
 
     private sealed record KillStateDto(string[] EndClients, string[] Firms);
     private sealed record HaltStateDto(string[] Symbols);
+    private sealed record SessionPhaseStateDto(string Default, Dictionary<string, string> Overrides);
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -117,8 +117,8 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, processor, algos, _) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -151,7 +151,7 @@ public class AlgoRecoveryTests : IDisposable
         {
             var (book, ownership, killSwitch, _, algos, dispatcher) = Build(store);
             var algoIds = new AlgoIdRegistry();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
 
             dispatcher.Dispatch(
                 new AlgoCreatedEvent

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -66,7 +66,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, positions, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos);
             var recovery = new PersistenceRecovery(store,
                 snapshotter,
                 replayer,
@@ -120,7 +120,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -179,7 +179,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
             var replacements = new PendingReplacementRegistry();
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos, replacements);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, replacements);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -226,7 +226,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), processor, algos);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -255,7 +255,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var sink = new TestSink();
         var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
             new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
-        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(), clOrdIds, ownership, algos, new AlgoIdRegistry(), new CashLedger());
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(), new SessionPhaseService(), clOrdIds, ownership, algos, new AlgoIdRegistry(), new CashLedger());
         var dispatcher = new EventDispatcher(store);
         return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
     }
@@ -301,6 +301,67 @@ public class RecoveryAndSnapshotTests : IDisposable
                 Synthetic = false,
             },
             () => proc.Apply(clOrdId, kind, leaves, cum, last, lastPx, null));
+    }
+
+    [Fact]
+    public void EventReplayer_AppliesSessionPhaseChangedEvents()
+    {
+        // #108 — verify replayer rebuilds default + per-symbol phase state
+        // from the WAL stream alone (no snapshot).
+        var book = new WorkingOrderBook();
+        var ownership = new OrderOwnershipMap();
+        var killSwitch = new KillSwitchService();
+        var phases = new SessionPhaseService(SessionPhase.Continuous);
+        var algos = new AlgoBook();
+        var processor = new ExecutionReportProcessor(ownership, book, new PositionKeeper(),
+            new TestSink(), new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+            phases, processor, algos);
+
+        replayer.Apply(new SessionPhaseChangedEvent { Symbol = null, Phase = "Closed" });
+        Assert.Equal(SessionPhase.Closed, phases.DefaultPhase);
+
+        replayer.Apply(new SessionPhaseChangedEvent { Symbol = "PETR4", Phase = "OpeningAuction" });
+        Assert.Equal(SessionPhase.OpeningAuction, phases.GetPhase("PETR4"));
+        Assert.Equal(SessionPhase.Closed, phases.GetPhase("VALE3")); // no override → default
+
+        replayer.Apply(new SessionPhaseChangedEvent { Symbol = "PETR4", Phase = "Continuous", Cleared = true });
+        Assert.Equal(SessionPhase.Closed, phases.GetPhase("PETR4")); // override removed → default
+    }
+
+    [Fact]
+    public void StateSnapshotter_RoundTripsSessionPhase()
+    {
+        // #108 — the snapshot must carry the default + per-symbol overrides,
+        // otherwise the WAL+snapshot recovery path drops phase state every
+        // time the snapshot rotates.
+        var phases1 = new SessionPhaseService(SessionPhase.Continuous);
+        phases1.SetDefaultPhase(SessionPhase.AfterHours);
+        phases1.SetPhase("PETR4", SessionPhase.OpeningAuction);
+        phases1.SetPhase("VALE3", SessionPhase.Closed);
+
+        var snapshotter1 = new StateSnapshotter(
+            new WorkingOrderBook(), new PositionKeeper(), new KillSwitchService(),
+            new SymbolHaltService(), phases1,
+            new ClOrdIdPrefixRegistry(), new OrderOwnershipMap(), new AlgoBook(),
+            new AlgoIdRegistry(), new CashLedger());
+        var snap = snapshotter1.Capture(seq: 42);
+
+        // Round-trip through JSON to mimic file-store materialisation.
+        var json = System.Text.Json.JsonSerializer.Serialize(snap);
+        var snapBack = System.Text.Json.JsonSerializer.Deserialize<PlatformSnapshot>(json)!;
+
+        var phases2 = new SessionPhaseService(SessionPhase.Continuous);
+        var snapshotter2 = new StateSnapshotter(
+            new WorkingOrderBook(), new PositionKeeper(), new KillSwitchService(),
+            new SymbolHaltService(), phases2,
+            new ClOrdIdPrefixRegistry(), new OrderOwnershipMap(), new AlgoBook(),
+            new AlgoIdRegistry(), new CashLedger());
+        snapshotter2.Restore(snapBack);
+
+        Assert.Equal(SessionPhase.AfterHours, phases2.DefaultPhase);
+        Assert.Equal(SessionPhase.OpeningAuction, phases2.GetPhase("PETR4"));
+        Assert.Equal(SessionPhase.Closed, phases2.GetPhase("VALE3"));
     }
 
     private sealed class TestSink : IExecutionEventSink

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -93,6 +93,113 @@ public class RiskPipelineTests
         Assert.True(halts.IsHalted("ITUB4"));
     }
 
+    // ── SessionPhase (#108) ────────────────────────────────────────────────
+
+    [Fact]
+    public void SessionPhase_DefaultContinuous_ApprovesEverything()
+    {
+        var svc = new SessionPhaseService(); // default = Continuous
+        var check = new SessionPhaseCheck(svc);
+        Assert.True(check.Check(Ctx(type: OrderType.Limit)).Approved);
+        Assert.True(check.Check(Ctx(type: OrderType.Market, price: null)).Approved);
+    }
+
+    [Fact]
+    public void SessionPhase_Closed_RejectsAll()
+    {
+        var svc = new SessionPhaseService(SessionPhase.Closed);
+        var check = new SessionPhaseCheck(svc);
+        var lim = check.Check(Ctx(type: OrderType.Limit));
+        var mkt = check.Check(Ctx(type: OrderType.Market, price: null));
+        Assert.False(lim.Approved);
+        Assert.False(mkt.Approved);
+        Assert.Contains("phase_not_allowed:closed", lim.Reason);
+        Assert.Contains("phase_not_allowed:closed", mkt.Reason);
+    }
+
+    [Theory]
+    [InlineData(SessionPhase.PreOpening)]
+    [InlineData(SessionPhase.OpeningAuction)]
+    [InlineData(SessionPhase.ClosingAuction)]
+    public void SessionPhase_Auction_RejectsMarketAllowsLimit(SessionPhase phase)
+    {
+        var svc = new SessionPhaseService();
+        svc.SetPhase("PETR4", phase);
+        var check = new SessionPhaseCheck(svc);
+        Assert.True(check.Check(Ctx(symbol: "PETR4", type: OrderType.Limit)).Approved);
+        var mkt = check.Check(Ctx(symbol: "PETR4", type: OrderType.Market, price: null));
+        Assert.False(mkt.Approved);
+        Assert.Contains("phase_not_allowed:auction", mkt.Reason);
+    }
+
+    [Fact]
+    public void SessionPhase_AfterHours_RejectsMarketAllowsLimit()
+    {
+        var svc = new SessionPhaseService();
+        svc.SetPhase("PETR4", SessionPhase.AfterHours);
+        var check = new SessionPhaseCheck(svc);
+        Assert.True(check.Check(Ctx(symbol: "PETR4", type: OrderType.Limit)).Approved);
+        var mkt = check.Check(Ctx(symbol: "PETR4", type: OrderType.Market, price: null));
+        Assert.False(mkt.Approved);
+        Assert.Contains("phase_not_allowed:after_hours", mkt.Reason);
+    }
+
+    [Fact]
+    public void SessionPhase_PerSymbolOverrideWinsOverDefault()
+    {
+        // Default closed; PETR4 explicitly continuous → only PETR4 trades.
+        var svc = new SessionPhaseService(SessionPhase.Closed);
+        svc.SetPhase("PETR4", SessionPhase.Continuous);
+        var check = new SessionPhaseCheck(svc);
+        Assert.True(check.Check(Ctx(symbol: "PETR4")).Approved);
+        Assert.False(check.Check(Ctx(symbol: "VALE3")).Approved);
+    }
+
+    [Fact]
+    public void SessionPhase_ClearOverride_FallsBackToDefault()
+    {
+        var svc = new SessionPhaseService(SessionPhase.Closed);
+        svc.SetPhase("PETR4", SessionPhase.Continuous);
+        Assert.Equal(SessionPhase.Continuous, svc.GetPhase("PETR4"));
+        Assert.True(svc.ClearPhase("PETR4"));
+        Assert.Equal(SessionPhase.Closed, svc.GetPhase("PETR4"));
+    }
+
+    [Fact]
+    public void SessionPhase_IsCaseInsensitive()
+    {
+        var svc = new SessionPhaseService();
+        svc.SetPhase("petr4", SessionPhase.OpeningAuction);
+        Assert.Equal(SessionPhase.OpeningAuction, svc.GetPhase("PETR4"));
+    }
+
+    [Fact]
+    public void SessionPhase_Restore_ReplacesAllState()
+    {
+        var svc = new SessionPhaseService(SessionPhase.Continuous);
+        svc.SetPhase("PETR4", SessionPhase.OpeningAuction);
+        svc.Restore(SessionPhase.Closed, new[]
+        {
+            new KeyValuePair<string, SessionPhase>("VALE3", SessionPhase.AfterHours),
+        });
+        Assert.Equal(SessionPhase.Closed, svc.DefaultPhase);
+        Assert.Equal(SessionPhase.AfterHours, svc.GetPhase("VALE3"));
+        Assert.Equal(SessionPhase.Closed, svc.GetPhase("PETR4")); // override gone, falls back
+    }
+
+    [Fact]
+    public void SessionPhase_DefaultPhaseChange_AffectsUnoverriddenSymbols()
+    {
+        var svc = new SessionPhaseService(SessionPhase.Continuous);
+        svc.SetPhase("PETR4", SessionPhase.AfterHours);
+        svc.SetDefaultPhase(SessionPhase.Closed);
+        var check = new SessionPhaseCheck(svc);
+        // VALE3 has no override → uses new default Closed → reject.
+        Assert.False(check.Check(Ctx(symbol: "VALE3")).Approved);
+        // PETR4 retains explicit AfterHours override → limit ok.
+        Assert.True(check.Check(Ctx(symbol: "PETR4", type: OrderType.Limit)).Approved);
+    }
+
     [Fact]
     public void KillSwitch_PerFirm_Blocks()
     {


### PR DESCRIPTION
Closes the **SessionPhase** sub-item of the #108 tracking issue.

Pre-trade gate that rejects orders incompatible with the current trading phase for a symbol — auctions only accept limit orders in B3 reality, after-hours is limit-only too, and a closed venue accepts nothing.

## Model

- New `SessionPhase` enum in Domain: `Closed, PreOpening, OpeningAuction, Continuous, ClosingAuction, AfterHours`.
- `SessionPhaseService` — global default + per-symbol overrides (case-insensitive). **Hierarchy**: per-symbol override wins; otherwise default. Default-of-default is `Continuous` (back-compat); production sets a stricter posture via `Trading:SessionPhase:Default` (e.g. `Closed` at boot, then flipped via admin endpoint or — when it lands — the SDK feed).
- `SessionPhaseCheck` Order=12 (between halt 10 and tick 20):
  - `Closed` → reject all (`phase_not_allowed:closed`).
  - `PreOpening / OpeningAuction / ClosingAuction` → reject `Market`, allow `Limit` (`phase_not_allowed:auction`).
  - `AfterHours` → reject `Market`, allow `Limit` (`phase_not_allowed:after_hours`).
  - `Continuous` → approve.
- Reasons embed the bucket so ops can grep `phase_not_allowed:auction` separately from `:closed`, while the check `Name` stays the stable `phase_not_allowed` code.

## Persistence (rubber-duck-blocking finding)

Losing a non-Continuous phase on crash would silently revert to the **least restrictive** mode — exactly the wrong direction for a safety control. Wired same as `SymbolHalt`:

- `SessionPhaseChangedEvent` in WAL (symbol-or-default + phase + cleared flag + actor).
- `PlatformSnapshot` adds `DefaultSessionPhase` and `SessionPhaseOverrides`; older snapshots deserialise as `Continuous` / empty (same semantics as before).
- `StateSnapshotter` captures + restores; `EventReplayer` applies `SessionPhaseChangedEvent` (null symbol = global default convention shared with the producer).
- `EodMaterialiser` tracks `SessionPhaseChangeCount`.

## API + observability

- Admin endpoints under `/admin/session-phase` (admin role only): GET state, POST `/default` to set global, POST `/{symbol}` to set override, DELETE `/{symbol}` to clear override → falls back to default.
- New metric `trading.session_phase.changed{scope=default|symbol, phase=<value>|cleared}`.

## Tests

- `RiskPipelineTests`: +9 unit tests — per-phase / per-order-type matrix, override precedence, default-change propagation, case-insensitivity, ClearPhase fallback, Restore round-trip.
- `RecoveryAndSnapshotTests`: +2 — EventReplayer applies set/clear events; StateSnapshotter Capture→JSON→Restore preserves both default and overrides.
- `RiskAndAdminEndpointsTests`: +4 — admin-role gate, set/get/clear via REST, bad phase → 400, end-to-end auction Market rejection surfaces `phase_not_allowed` on `executions.me`.

## Trade-offs / out of scope

- `TimeInForce` isn't in the order model yet; auction phases reject `Market` only. When TIF lands, extend to reject IOC/FOK in auction.
- Phase transitions today are operator-driven; SDK-fed market-state → `SessionPhaseService` is a follow-up once the upstream signal is available.

Suite **53+406+202 green**; `dotnet format` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>