### PR TITLE
feat(persistence): advance AlgoId watermark during WAL replay (#160)

### DIFF
--- a/backend/src/B3.Trading.Application/AlgoIdRegistry.cs
+++ b/backend/src/B3.Trading.Application/AlgoIdRegistry.cs
@@ -51,6 +51,45 @@ public sealed class AlgoIdRegistry
         }
     }
 
+    /// <summary>
+    /// Monotonically advances the per-firm counter to reflect an
+    /// <c>AlgoId</c> observed during WAL replay (#160). Mirrors the
+    /// fix from <see cref="ClOrdIdPrefixRegistry.AdvanceCounterTo"/>:
+    /// without this, after a snapshot+replay roundtrip the next
+    /// <see cref="Generate"/> for a firm whose post-snapshot activity
+    /// advanced its counter would re-issue an <c>AlgoId</c> already
+    /// owned by an algo restored from the WAL.
+    ///
+    /// <para><b>Replay-only.</b> Single-threaded at startup, before
+    /// the host accepts traffic. Not safe to interleave with concurrent
+    /// <see cref="Generate"/>.</para>
+    ///
+    /// <para><b>Validation.</b> Zero is never produced by
+    /// <see cref="Generate"/> and is treated as corrupt — emits the
+    /// <c>AlgoIdRegistryCorruption</c> metric and is dropped.</para>
+    /// </summary>
+    public void AdvanceCounterTo(string firmId, ulong observedAlgoId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+
+        if (observedAlgoId == 0)
+        {
+            Observability.MetricsRegistry.AlgoIdRegistryCorruption.Add(1,
+                new KeyValuePair<string, object?>("firm", firmId),
+                new KeyValuePair<string, object?>("reason", "invalid_observed_algoid"));
+            return;
+        }
+
+        var target = (long)observedAlgoId;
+        var entry = _counters.GetOrAdd(firmId, static _ => new FirmCounter());
+        long current;
+        do
+        {
+            current = Interlocked.Read(ref entry.Counter);
+            if (current >= target) return;
+        } while (Interlocked.CompareExchange(ref entry.Counter, target, current) != current);
+    }
+
     private sealed class FirmCounter
     {
         public long Counter;

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -200,6 +200,15 @@ public static class MetricsRegistry
     public static readonly Counter<long> ClOrdIdRegistryCorruption =
         Meter.CreateCounter<long>("trading.orders.clordid_registry_corruption");
 
+    /// <summary>
+    /// #160. Counts AlgoIdRegistry watermark-advance refusals during WAL
+    /// replay (mirror of <see cref="ClOrdIdRegistryCorruption"/> for the
+    /// per-firm AlgoId counter). MUST be flat at zero in healthy
+    /// operation. Tagged <c>{firm, reason=invalid_observed_algoid}</c>.
+    /// </summary>
+    public static readonly Counter<long> AlgoIdRegistryCorruption =
+        Meter.CreateCounter<long>("trading.algos.algoid_registry_corruption");
+
     public static readonly Counter<long> MarginOvercommitOnRestore =
         Meter.CreateCounter<long>("trading.risk.margin_overcommit_on_restore");
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -108,6 +108,7 @@ public sealed class EventReplayer
     private readonly ExecutionReportProcessor _processor;
     private readonly AlgoBook _algos;
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
+    private readonly AlgoIdRegistry _algoIds;
     private readonly PendingReplacementRegistry? _replacements;
 
     public EventReplayer(
@@ -119,6 +120,7 @@ public sealed class EventReplayer
         ExecutionReportProcessor processor,
         AlgoBook algos,
         ClOrdIdPrefixRegistry clOrdIds,
+        AlgoIdRegistry algoIds,
         PendingReplacementRegistry? replacements = null)
     {
         _orders = orders;
@@ -129,6 +131,7 @@ public sealed class EventReplayer
         _processor = processor;
         _algos = algos;
         _clOrdIds = clOrdIds;
+        _algoIds = algoIds;
         _replacements = replacements;
     }
 
@@ -266,6 +269,7 @@ public sealed class EventReplayer
 
     private void ApplyAlgoCreated(AlgoCreatedEvent ac)
     {
+        _algoIds.AdvanceCounterTo(ac.FirmId, ac.AlgoId);
         var owner = new EndClientId(ac.EndClientId);
         var side = Enum.Parse<OrderSide>(ac.Side, ignoreCase: true);
         var type = Enum.Parse<AlgoType>(ac.Type, ignoreCase: true);

--- a/backend/tests/B3.Trading.Application.Tests/AlgoIdRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/AlgoIdRegistryTests.cs
@@ -57,4 +57,67 @@ public class AlgoIdRegistryTests
         reg.Restore(emptySnap);
         Assert.Equal(1UL, reg.Generate("FIRM-A"));
     }
+
+    [Fact]
+    public void AdvanceCounterTo_NewFirm_AdoptsObservedWatermark()
+    {
+        var reg = new AlgoIdRegistry();
+        reg.AdvanceCounterTo("FIRM-A", 7UL);
+        Assert.Equal(8UL, reg.Generate("FIRM-A"));
+    }
+
+    [Fact]
+    public void AdvanceCounterTo_Monotonic_DoesNotRegress()
+    {
+        var reg = new AlgoIdRegistry();
+        reg.AdvanceCounterTo("FIRM-A", 10UL);
+        reg.AdvanceCounterTo("FIRM-A", 5UL);
+        Assert.Equal(11UL, reg.Generate("FIRM-A"));
+    }
+
+    [Fact]
+    public void AdvanceCounterTo_Idempotent()
+    {
+        var reg = new AlgoIdRegistry();
+        reg.AdvanceCounterTo("FIRM-A", 4UL);
+        reg.AdvanceCounterTo("FIRM-A", 4UL);
+        Assert.Equal(5UL, reg.Generate("FIRM-A"));
+    }
+
+    [Fact]
+    public void AdvanceCounterTo_ZeroObservedAlgoId_Dropped()
+    {
+        var reg = new AlgoIdRegistry();
+        reg.Generate("FIRM-A"); // counter=1
+        reg.AdvanceCounterTo("FIRM-A", 0UL);
+        // State unchanged; next Generate proceeds from 1.
+        Assert.Equal(2UL, reg.Generate("FIRM-A"));
+    }
+
+    [Fact]
+    public void AdvanceCounterTo_BlankFirm_Throws()
+    {
+        var reg = new AlgoIdRegistry();
+        Assert.Throws<ArgumentException>(() => reg.AdvanceCounterTo("", 1UL));
+    }
+
+    [Fact]
+    public void AdvanceCounterTo_AfterRestore_NextGenerateSkipsPast()
+    {
+        // Models the snapshot+WAL replay flow: snapshot at watermark N,
+        // then replay advances past N via AdvanceCounterTo, then live
+        // Generate must continue past the replayed watermark.
+        var reg = new AlgoIdRegistry();
+        reg.Generate("FIRM-A"); // 1
+        reg.Generate("FIRM-A"); // 2
+        var snap = reg.Snapshot();
+
+        var restored = new AlgoIdRegistry();
+        restored.Restore(snap);
+        // Replay sees AlgoCreatedEvent.AlgoId=3 then 4.
+        restored.AdvanceCounterTo("FIRM-A", 3UL);
+        restored.AdvanceCounterTo("FIRM-A", 4UL);
+
+        Assert.Equal(5UL, restored.Generate("FIRM-A"));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -118,7 +118,7 @@ public class AlgoRecoveryTests : IDisposable
             var (book, ownership, killSwitch, processor, algos, _) = Build(store);
             var algoIds = new AlgoIdRegistry();
             var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -66,7 +66,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, positions, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
             var recovery = new PersistenceRecovery(store,
                 snapshotter,
                 replayer,
@@ -120,7 +120,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -179,7 +179,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
             var replacements = new PendingReplacementRegistry();
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), replacements);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(), replacements);
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -226,7 +226,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) = BuildState(store);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
             var recovery = new PersistenceRecovery(store, snapshotter, replayer,
                 new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
             await recovery.RunAsync();
@@ -316,7 +316,7 @@ public class RecoveryAndSnapshotTests : IDisposable
         var processor = new ExecutionReportProcessor(ownership, book, new PositionKeeper(),
             new TestSink(), new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
-            phases, processor, algos, new ClOrdIdPrefixRegistry());
+            phases, processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
 
         replayer.Apply(new SessionPhaseChangedEvent { Symbol = null, Phase = "Closed" });
         Assert.Equal(SessionPhase.Closed, phases.DefaultPhase);
@@ -381,7 +381,7 @@ public class RecoveryAndSnapshotTests : IDisposable
             new TestSink(), new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         var replacements = new PendingReplacementRegistry();
         var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
-            phases, processor, algos, clOrdIds, replacements);
+            phases, processor, algos, clOrdIds, new AlgoIdRegistry(), replacements);
 
         var alice = new EndClientId("alice");
         // Synthesise the kind of IDs the live registry would have produced
@@ -436,6 +436,44 @@ public class RecoveryAndSnapshotTests : IDisposable
         var next = clOrdIds.Generate(alice);
         Assert.Equal(prefix, next >> ClOrdIdPrefixRegistry.CounterBits);
         Assert.Equal(13UL, next & ClOrdIdPrefixRegistry.CounterMask);
+    }
+
+    [Fact]
+    public void EventReplayer_AdvancesAlgoIdWatermark_FromAlgoCreatedEvent()
+    {
+        // #160 — replay of AlgoCreatedEvent must advance AlgoIdRegistry's
+        // per-firm counter so the next live Generate doesn't regress and
+        // re-issue an AlgoId already owned by a restored algo.
+        var book = new WorkingOrderBook();
+        var ownership = new OrderOwnershipMap();
+        var killSwitch = new KillSwitchService();
+        var phases = new SessionPhaseService();
+        var algos = new AlgoBook();
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algoIds = new AlgoIdRegistry();
+        var processor = new ExecutionReportProcessor(ownership, book, new PositionKeeper(),
+            new TestSink(), new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+            phases, processor, algos, clOrdIds, algoIds);
+
+        replayer.Apply(new AlgoCreatedEvent
+        {
+            AlgoId = 42UL,
+            EndClientId = "alice",
+            FirmId = "TEST",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Iceberg",
+            TotalQuantity = 1000,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            IcebergDisplayQuantity = 100,
+            IcebergLimitPrice = 30m,
+        });
+
+        Assert.Equal(43UL, algoIds.Generate("TEST"));
+        // Other firms unaffected.
+        Assert.Equal(1UL, algoIds.Generate("OTHER"));
     }
 
     private sealed class TestSink : IExecutionEventSink


### PR DESCRIPTION
Closes #160. Mirror of #157 for AlgoIdRegistry.

## Problem

Same WAL-replay regression as ClOrdID had (#157), on the per-firm `AlgoId` counter. After a snapshot at `AlgoId=N`, replay of `AlgoCreatedEvent`s with `AlgoId>N` rebuilds `AlgoBook` correctly but `AlgoIdRegistry`'s counter stays at `N` — the next `Generate(firm)` returns `N+1` and collides with an already-restored algo.

## Fix

- `AlgoIdRegistry.AdvanceCounterTo(firmId, observedAlgoId)` — replay-only, monotonic-max via CAS, validates input (`0` is never produced by `Generate` so it's treated as corrupt and dropped).
- `EventReplayer` takes `AlgoIdRegistry` and calls `AdvanceCounterTo` from the `AlgoCreatedEvent` switch case.
- New metric `trading.algos.algoid_registry_corruption{firm,reason}`.

## Tests

- 6 unit tests on `AdvanceCounterTo` (adoption, monotonic, idempotent, zero rejected, blank firm, snapshot+replay roundtrip).
- 1 integration test exercising `EventReplayer` end-to-end via `AlgoCreatedEvent`.
- Suite: 53 + 421 + 202 green; `dotnet format` clean.