### PR TITLE
feat(simulator-bot): external FIXP bot replaces in-process synth ER (#134, slice 1)

### DIFF
--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -11,8 +11,10 @@
     <Project Path="backend/tests/B3.Trading.Application.Tests/B3.Trading.Application.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj" />
+    <Project Path="backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj" />
   </Folder>
   <Folder Name="/backend/tools/">
     <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />
+    <Project Path="backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj" />
   </Folder>
 </Solution>

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -142,6 +142,17 @@ public static class MetricsRegistry
     public static readonly UpDownCounter<int> SimulatorModeActive =
         Meter.CreateUpDownCounter<int>("trading.simulator.mode_active");
 
+    /// <summary>
+    /// 1 when the host booted with <c>ExchangeMode.Simulator</c>, which is
+    /// on the deprecation ramp toward removal (#134). Mirrors
+    /// <see cref="SimulatorModeActive"/> shape so the deprecation warning
+    /// can fire from a separate Prometheus alert without disturbing the
+    /// existing operational gauge. Will go away when Simulator mode is
+    /// removed in the follow-up slice.
+    /// </summary>
+    public static readonly UpDownCounter<int> SimulatorModeDeprecated =
+        Meter.CreateUpDownCounter<int>("trading.simulator.mode_deprecated");
+
     // EntryPoint upstream client (real adapter)
     public static readonly UpDownCounter<int> EntryPointConnected =
         Meter.CreateUpDownCounter<int>("trading.entrypoint.connected");

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -470,6 +470,7 @@ var app = builder.Build();
         if (warning is not null)
             app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Simulator").LogWarning("{Warning}", warning);
         B3.Trading.Application.Observability.MetricsRegistry.SimulatorModeActive.Add(1);
+        B3.Trading.Application.Observability.MetricsRegistry.SimulatorModeDeprecated.Add(1);
     }
 }
 

--- a/backend/src/B3.Trading.Infrastructure/SimulatorBootGuard.cs
+++ b/backend/src/B3.Trading.Infrastructure/SimulatorBootGuard.cs
@@ -42,6 +42,11 @@ public static class SimulatorBootGuard
         var prodNote = isProduction && allowInProduction
             ? " AllowSimulatorInProduction=true is currently set — opt-out is ACTIVE."
             : string.Empty;
-        return $"⚠ EXCHANGE MODE: SIMULATOR — synthetic ER injection enabled. NEVER USE IN PRODUCTION.{prodNote}";
+        // #134: this in-process synthetic-ER path is on the deprecation
+        // ramp; the external SimulatorBot (docker-compose.simulator-bot.yml)
+        // is the supported replacement and goes through real FIXP.
+        return $"⚠ EXCHANGE MODE: SIMULATOR — synthetic ER injection enabled. " +
+            $"DEPRECATED (#134): use the external SimulatorBot via " +
+            $"docker/docker-compose.simulator-bot.yml instead. NEVER USE IN PRODUCTION.{prodNote}";
     }
 }

--- a/backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj
+++ b/backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Trading.SimulatorBot.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
+    <PackageReference Include="xunit" Version="*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\B3.Trading.SimulatorBot\B3.Trading.SimulatorBot.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/B3.Trading.SimulatorBot.Tests/OrderPatternTests.cs
+++ b/backend/tests/B3.Trading.SimulatorBot.Tests/OrderPatternTests.cs
@@ -1,0 +1,110 @@
+using B3.Trading.SimulatorBot;
+
+namespace B3.Trading.SimulatorBot.Tests;
+
+public class OrderPatternTests
+{
+    private static InstrumentConfig PETR4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = 4321UL,
+        RefPrice = 30m,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinLots = 1,
+        MaxLots = 5,
+    };
+
+    [Fact]
+    public void Next_RespectsInFlightCap()
+    {
+        var rng = new Random(42);
+        Assert.Null(OrderPattern.Next(rng, PETR4, 0.25, inFlight: 5, cap: 5));
+        Assert.Null(OrderPattern.Next(rng, PETR4, 0.25, inFlight: 6, cap: 5));
+    }
+
+    [Fact]
+    public void Next_QuantityIsLotMultipleWithinRange()
+    {
+        var rng = new Random(42);
+        for (var i = 0; i < 200; i++)
+        {
+            var d = OrderPattern.Next(rng, PETR4, 0.25, inFlight: 0, cap: 10);
+            Assert.NotNull(d);
+            Assert.Equal(0, d!.Value.Quantity % PETR4.LotSize);
+            var lots = d.Value.Quantity / PETR4.LotSize;
+            Assert.InRange(lots, PETR4.MinLots, PETR4.MaxLots);
+        }
+    }
+
+    [Fact]
+    public void Next_PriceIsTickAlignedAndPositive()
+    {
+        var rng = new Random(42);
+        for (var i = 0; i < 200; i++)
+        {
+            var d = OrderPattern.Next(rng, PETR4, 0.25, inFlight: 0, cap: 10);
+            Assert.NotNull(d);
+            Assert.True(d!.Value.Price > 0m);
+            // Tick alignment: price/tickSize must be (close to) integral.
+            var ticks = d.Value.Price / PETR4.TickSize;
+            Assert.Equal(0m, ticks - Math.Round(ticks));
+        }
+    }
+
+    [Fact]
+    public void Next_CrossProbabilityZero_NeverCrossesMid()
+    {
+        // With crossProbability=0 every order is passive (own side of mid).
+        var rng = new Random(7);
+        for (var i = 0; i < 200; i++)
+        {
+            var d = OrderPattern.Next(rng, PETR4, crossProbability: 0.0,
+                inFlight: 0, cap: 10);
+            Assert.NotNull(d);
+            if (d!.Value.IsBuy) Assert.True(d.Value.Price <= PETR4.RefPrice);
+            else Assert.True(d.Value.Price >= PETR4.RefPrice);
+        }
+    }
+
+    [Fact]
+    public void Next_CrossProbabilityOne_AlwaysCrossesMid()
+    {
+        var rng = new Random(7);
+        for (var i = 0; i < 200; i++)
+        {
+            var d = OrderPattern.Next(rng, PETR4, crossProbability: 1.0,
+                inFlight: 0, cap: 10);
+            Assert.NotNull(d);
+            if (d!.Value.IsBuy) Assert.True(d.Value.Price > PETR4.RefPrice);
+            else Assert.True(d.Value.Price < PETR4.RefPrice);
+        }
+    }
+
+    [Fact]
+    public void Next_DeterministicForSeededRandom()
+    {
+        var a = new Random(123);
+        var b = new Random(123);
+        for (var i = 0; i < 50; i++)
+        {
+            var da = OrderPattern.Next(a, PETR4, 0.3, 0, 10);
+            var db = OrderPattern.Next(b, PETR4, 0.3, 0, 10);
+            Assert.Equal(da, db);
+        }
+    }
+
+    [Fact]
+    public void RoundToTick_RoundsHalfAwayFromZero()
+    {
+        Assert.Equal(0.05m, OrderPattern.RoundToTick(0.04999m, 0.01m));
+        Assert.Equal(0.05m, OrderPattern.RoundToTick(0.05m, 0.01m));
+        Assert.Equal(30.13m, OrderPattern.RoundToTick(30.131m, 0.01m));
+    }
+
+    [Fact]
+    public void RoundToTick_ZeroTick_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => OrderPattern.RoundToTick(1m, 0m));
+    }
+}

--- a/backend/tests/B3.Trading.SimulatorBot.Tests/OrderTrackerTests.cs
+++ b/backend/tests/B3.Trading.SimulatorBot.Tests/OrderTrackerTests.cs
@@ -1,0 +1,96 @@
+using B3.Trading.SimulatorBot;
+
+namespace B3.Trading.SimulatorBot.Tests;
+
+public class OrderTrackerTests
+{
+    [Fact]
+    public void RegisterSubmit_ReflectedInInFlightCount()
+    {
+        var t = new OrderTracker();
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, isBuy: true);
+        t.RegisterSubmit(2UL, "PETR4", 30m, 100, isBuy: true);
+        t.RegisterSubmit(3UL, "VALE3", 70m, 100, isBuy: false);
+        Assert.Equal(2, t.InFlightCount("PETR4"));
+        Assert.Equal(1, t.InFlightCount("VALE3"));
+        Assert.Equal(0, t.InFlightCount("MGLU3"));
+    }
+
+    [Fact]
+    public void OnTrade_LeavesZero_ClosesOrder()
+    {
+        var t = new OrderTracker();
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, true);
+        t.OnTrade(1UL, leaves: 0);
+        Assert.Equal(0, t.InFlightCount("PETR4"));
+    }
+
+    [Fact]
+    public void OnTrade_PartialFill_StaysOpen()
+    {
+        var t = new OrderTracker();
+        t.RegisterSubmit(1UL, "PETR4", 30m, 200, true);
+        t.OnTrade(1UL, leaves: 100);
+        Assert.Equal(1, t.InFlightCount("PETR4"));
+    }
+
+    [Fact]
+    public void OnTerminal_ClosesOrder()
+    {
+        var t = new OrderTracker();
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, true);
+        t.OnTerminal(1UL);
+        Assert.Equal(0, t.InFlightCount("PETR4"));
+    }
+
+    [Fact]
+    public void OnAccepted_NoFill_StaysOpenWithLeaves()
+    {
+        var t = new OrderTracker();
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, true);
+        t.OnAccepted(1UL, leaves: 100);
+        Assert.Equal(1, t.InFlightCount("PETR4"));
+    }
+
+    [Fact]
+    public void TryGet_UnknownClOrdId_ReturnsFalse()
+    {
+        var t = new OrderTracker();
+        Assert.False(t.TryGet(999UL, out _));
+    }
+
+    [Fact]
+    public void SnapshotStaleOpen_OnlyReturnsOldEnoughOpenOrders()
+    {
+        var clock = new FakeClock(DateTimeOffset.UtcNow);
+        var t = new OrderTracker(clock);
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, true);  // submitted now
+        clock.Advance(TimeSpan.FromSeconds(40));
+        t.RegisterSubmit(2UL, "PETR4", 30m, 100, true);  // submitted at +40s
+        clock.Advance(TimeSpan.FromSeconds(10));         // now at +50s
+
+        // Threshold = 30s ⇒ only order #1 (submitted 50s ago) qualifies.
+        var stale = t.SnapshotStaleOpen(TimeSpan.FromSeconds(30));
+        Assert.Single(stale);
+        Assert.Equal(1UL, stale[0].ClOrdId);
+    }
+
+    [Fact]
+    public void SnapshotStaleOpen_SkipsClosedOrders()
+    {
+        var clock = new FakeClock(DateTimeOffset.UtcNow);
+        var t = new OrderTracker(clock);
+        t.RegisterSubmit(1UL, "PETR4", 30m, 100, true);
+        t.OnTerminal(1UL);
+        clock.Advance(TimeSpan.FromMinutes(5));
+        Assert.Empty(t.SnapshotStaleOpen(TimeSpan.FromSeconds(30)));
+    }
+
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeClock(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
+}

--- a/backend/tests/B3.Trading.SimulatorBot.Tests/WorkerEndpointParseTests.cs
+++ b/backend/tests/B3.Trading.SimulatorBot.Tests/WorkerEndpointParseTests.cs
@@ -1,0 +1,26 @@
+using B3.Trading.SimulatorBot;
+
+namespace B3.Trading.SimulatorBot.Tests;
+
+public class WorkerEndpointParseTests
+{
+    [Fact]
+    public void ParseEndpoint_HostAndPort_Ok()
+    {
+        var ep = EndpointParser.Parse("matching-platform:9876");
+        Assert.Equal("matching-platform", ep.Host);
+        Assert.Equal(9876, ep.Port);
+    }
+
+    [Theory]
+    [InlineData("matching-platform")]
+    [InlineData("matching-platform:")]
+    [InlineData(":9876")]
+    [InlineData("matching-platform:0")]
+    [InlineData("matching-platform:99999")]
+    [InlineData("matching-platform:abc")]
+    public void ParseEndpoint_Invalid_Throws(string endpoint)
+    {
+        Assert.Throws<ArgumentException>(() => EndpointParser.Parse(endpoint));
+    }
+}

--- a/backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj
+++ b/backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Trading.SimulatorBot</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.3" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tools/B3.Trading.SimulatorBot/Dockerfile
+++ b/backend/tools/B3.Trading.SimulatorBot/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+#
+# Simulator-bot console — connects to matching-platform via FIXP and
+# generates a steady flow of orders so the trading-host blotter looks
+# alive without anyone touching the UI. Replaces the trading-host's
+# in-process synthetic-ER injector (Mode=Simulator), which is on the
+# deprecation path (issue #134).
+
+# ---------- build ----------
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201 AS build
+WORKDIR /src
+
+COPY global.json Directory.Build.props ./
+COPY backend/tools/B3.Trading.SimulatorBot ./backend/tools/B3.Trading.SimulatorBot
+
+WORKDIR /src/backend/tools/B3.Trading.SimulatorBot
+RUN dotnet restore --use-current-runtime
+RUN dotnet publish \
+        --configuration Release \
+        --use-current-runtime \
+        --no-restore \
+        --output /app/publish \
+        -p:PublishSingleFile=false \
+        -p:UseAppHost=false
+
+# ---------- runtime ----------
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+RUN groupadd --system --gid 10001 bot \
+ && useradd  --system --uid 10001 --gid bot --home /app bot \
+ && mkdir -p /var/lib/b3-simulator-bot \
+ && chown bot:bot /var/lib/b3-simulator-bot
+
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+ENV DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_EnableDiagnostics=0
+
+USER bot
+ENTRYPOINT ["dotnet", "B3.Trading.SimulatorBot.dll"]

--- a/backend/tools/B3.Trading.SimulatorBot/EndpointParser.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/EndpointParser.cs
@@ -1,0 +1,20 @@
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>Pure host:port parser. Returns a <see cref="System.Net.DnsEndPoint"/>
+/// (no DNS resolution). The worker DNS-resolves at connect time
+/// because matching-platform's docker hostname only exists on the
+/// b3-net network.</summary>
+public static class EndpointParser
+{
+    public static System.Net.DnsEndPoint Parse(string endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        var colon = endpoint.LastIndexOf(':');
+        if (colon <= 0 || colon == endpoint.Length - 1)
+            throw new ArgumentException($"Endpoint '{endpoint}' must be host:port.", nameof(endpoint));
+        var host = endpoint[..colon];
+        if (!int.TryParse(endpoint[(colon + 1)..], out var port) || port is <= 0 or > 65535)
+            throw new ArgumentException($"Endpoint '{endpoint}' has invalid port.", nameof(endpoint));
+        return new System.Net.DnsEndPoint(host, port);
+    }
+}

--- a/backend/tools/B3.Trading.SimulatorBot/OrderPattern.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/OrderPattern.cs
@@ -1,0 +1,63 @@
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>
+/// Stateless price/quantity generator. Decoupled from the worker so
+/// it's deterministic-testable with a seeded <see cref="Random"/>.
+/// </summary>
+public static class OrderPattern
+{
+    /// <summary>
+    /// Draws the next order for an instrument. Returns <c>null</c> when
+    /// the in-flight cap is reached for this symbol.
+    /// </summary>
+    /// <param name="rng">Seeded for deterministic tests.</param>
+    /// <param name="instr">Instrument config (ref-price, tick, lot).</param>
+    /// <param name="crossProbability">0..1; chance the order crosses
+    /// the bot's own ref-price symmetric quote (becoming an aggressive
+    /// taker rather than passive resting liquidity).</param>
+    /// <param name="inFlight">Current open count for the symbol.</param>
+    /// <param name="cap">Max in-flight per symbol.</param>
+    public static OrderDraft? Next(Random rng, InstrumentConfig instr,
+        double crossProbability, int inFlight, int cap)
+    {
+        ArgumentNullException.ThrowIfNull(rng);
+        ArgumentNullException.ThrowIfNull(instr);
+        if (inFlight >= cap) return null;
+
+        var isBuy = rng.NextDouble() < 0.5;
+        var lots = rng.Next(instr.MinLots, instr.MaxLots + 1);
+        var quantity = checked(lots * instr.LotSize);
+
+        // Resting orders sit just inside the spread (passive). Crossing
+        // orders sit on the OPPOSITE side of mid — a buy crosses by
+        // pricing above ref, a sell by pricing below — so they have a
+        // chance of immediate match against working liquidity.
+        var crosses = rng.NextDouble() < crossProbability;
+        decimal raw;
+        if (crosses)
+        {
+            // ±0.1% across mid (always crossing direction).
+            var bps = (decimal)(rng.NextDouble() * 0.001 + 0.0005);
+            raw = isBuy ? instr.RefPrice * (1m + bps) : instr.RefPrice * (1m - bps);
+        }
+        else
+        {
+            // ±0.5% inside spread (resting on own side of mid).
+            var bps = (decimal)(rng.NextDouble() * 0.005);
+            raw = isBuy ? instr.RefPrice * (1m - bps) : instr.RefPrice * (1m + bps);
+        }
+
+        var price = RoundToTick(raw, instr.TickSize);
+        if (price <= 0m) return null; // pathological config; skip silently.
+        return new OrderDraft(instr.Symbol, instr.SecurityId, isBuy, quantity, price);
+    }
+
+    public static decimal RoundToTick(decimal value, decimal tickSize)
+    {
+        if (tickSize <= 0m) throw new ArgumentOutOfRangeException(nameof(tickSize));
+        var ticks = Math.Round(value / tickSize, MidpointRounding.AwayFromZero);
+        return ticks * tickSize;
+    }
+}
+
+public readonly record struct OrderDraft(string Symbol, ulong SecurityId, bool IsBuy, long Quantity, decimal Price);

--- a/backend/tools/B3.Trading.SimulatorBot/OrderTracker.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/OrderTracker.cs
@@ -1,0 +1,118 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>
+/// In-memory ClOrdID-keyed view of bot-submitted orders. The bot needs
+/// to (a) cap in-flight per symbol, (b) recognise cancels/fills from
+/// the ER stream, and (c) discover candidates for auto-cancel —
+/// <see cref="OrderTracker"/> is the single source of truth for all
+/// three. State lives in process; no persistence beyond what the SDK's
+/// session state store gives us for SessionVerId.
+/// </summary>
+public sealed class OrderTracker
+{
+    private readonly ConcurrentDictionary<ulong, TrackedOrder> _orders = new();
+    private readonly TimeProvider _clock;
+
+    public OrderTracker(TimeProvider? clock = null)
+    {
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public int InFlightCount(string symbol)
+    {
+        var count = 0;
+        foreach (var o in _orders.Values)
+        {
+            if (o.IsOpen && string.Equals(o.Symbol, symbol, StringComparison.Ordinal))
+                count++;
+        }
+        return count;
+    }
+
+    public void RegisterSubmit(ulong clOrdId, string symbol, decimal price, long quantity, bool isBuy)
+    {
+        var now = _clock.GetUtcNow();
+        _orders[clOrdId] = new TrackedOrder
+        {
+            ClOrdId = clOrdId,
+            Symbol = symbol,
+            Price = price,
+            Quantity = quantity,
+            IsBuy = isBuy,
+            SubmittedAtUtc = now,
+            // Treat as open until we learn otherwise. A fill or reject ER
+            // closes it; an explicit cancel ER closes it.
+            IsOpen = true,
+            Leaves = quantity,
+        };
+    }
+
+    /// <summary>Returns true when this order is currently tracked as the
+    /// bot's own (so the caller should react). False for stale/unknown
+    /// IDs (e.g. ER for an order from a previous run).</summary>
+    public bool TryGet(ulong clOrdId, out TrackedOrder order)
+    {
+        if (_orders.TryGetValue(clOrdId, out var found))
+        {
+            order = found;
+            return true;
+        }
+        order = default!;
+        return false;
+    }
+
+    public void OnAccepted(ulong clOrdId, long leaves)
+    {
+        if (_orders.TryGetValue(clOrdId, out var o))
+        {
+            o.Leaves = leaves;
+            o.IsOpen = leaves > 0;
+        }
+    }
+
+    public void OnTrade(ulong clOrdId, long leaves)
+    {
+        if (_orders.TryGetValue(clOrdId, out var o))
+        {
+            o.Leaves = leaves;
+            o.IsOpen = leaves > 0;
+        }
+    }
+
+    public void OnTerminal(ulong clOrdId)
+    {
+        if (_orders.TryGetValue(clOrdId, out var o))
+        {
+            o.Leaves = 0;
+            o.IsOpen = false;
+        }
+    }
+
+    /// <summary>Snapshot the open orders older than <paramref name="threshold"/>
+    /// at the current clock — candidates for auto-cancel.</summary>
+    public IReadOnlyList<TrackedOrder> SnapshotStaleOpen(TimeSpan threshold)
+    {
+        var cutoff = _clock.GetUtcNow() - threshold;
+        var result = new List<TrackedOrder>();
+        foreach (var o in _orders.Values)
+        {
+            if (o.IsOpen && o.SubmittedAtUtc <= cutoff)
+                result.Add(o);
+        }
+        return result;
+    }
+}
+
+public sealed class TrackedOrder
+{
+    public ulong ClOrdId { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public long Quantity { get; set; }
+    public long Leaves { get; set; }
+    public bool IsBuy { get; set; }
+    public DateTimeOffset SubmittedAtUtc { get; set; }
+    public bool IsOpen { get; set; }
+}

--- a/backend/tools/B3.Trading.SimulatorBot/Program.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/Program.cs
@@ -1,0 +1,33 @@
+using B3.Trading.SimulatorBot;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+var builder = Host.CreateApplicationBuilder(args);
+// Host.CreateApplicationBuilder already adds environment variables with
+// no prefix to Configuration, so Bot__* env vars (set in
+// docker/docker-compose.simulator-bot.yml) bind to SimulatorBotOptions
+// without any extra wiring.
+
+builder.Logging.ClearProviders();
+builder.Logging.AddSimpleConsole(o =>
+{
+    o.SingleLine = true;
+    o.TimestampFormat = "HH:mm:ss ";
+});
+
+builder.Services
+    .AddOptions<SimulatorBotOptions>()
+    .Bind(builder.Configuration.GetSection(SimulatorBotOptions.SectionName))
+    .ValidateDataAnnotations()
+    .Validate(o => o.Instruments.Count > 0, "Bot:Instruments must be non-empty.")
+    .Validate(o => o.TickInterval > TimeSpan.Zero, "Bot:TickInterval must be positive.")
+    .Validate(o => o.MaxInFlightPerSymbol > 0, "Bot:MaxInFlightPerSymbol must be > 0.")
+    .Validate(o => o.CrossProbability is >= 0 and <= 1, "Bot:CrossProbability must be in [0, 1].")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<OrderTracker>();
+builder.Services.AddHostedService<SimulatorBotWorker>();
+
+await builder.Build().RunAsync();

--- a/backend/tools/B3.Trading.SimulatorBot/SimulatorBotMetrics.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/SimulatorBotMetrics.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.Metrics;
+
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>
+/// <see cref="System.Diagnostics.Metrics"/> instruments emitted by the
+/// bot. Visible to any host that registers the meter
+/// <c>"B3.Trading.SimulatorBot"</c> with an OpenTelemetry exporter.
+/// MVP scope: log-shaped only — wiring an OTLP exporter is left to a
+/// follow-up if/when the bot lands in observability dashboards.
+/// </summary>
+public static class SimulatorBotMetrics
+{
+    public const string MeterName = "B3.Trading.SimulatorBot";
+
+    public static readonly Meter Meter = new(MeterName, "0.1.0");
+
+    /// <summary>Orders accepted by the bot for transmission. Tagged
+    /// <c>{symbol, side}</c>.</summary>
+    public static readonly Counter<long> OrdersSubmitted =
+        Meter.CreateCounter<long>("bot.orders.submitted");
+
+    /// <summary>Outbound submit attempts that the SDK rejected synchronously
+    /// (transport error, terminated session, etc).</summary>
+    public static readonly Counter<long> OrdersSubmitFailed =
+        Meter.CreateCounter<long>("bot.orders.submit_failed");
+
+    /// <summary>Cancel requests sent. Tagged <c>{reason=auto|shutdown}</c>.</summary>
+    public static readonly Counter<long> CancelsSent =
+        Meter.CreateCounter<long>("bot.orders.cancels_sent");
+
+    /// <summary>Trades observed via OrderTrade events. Tagged <c>{symbol}</c>.</summary>
+    public static readonly Counter<long> Fills =
+        Meter.CreateCounter<long>("bot.fills.received");
+
+    /// <summary>OrderRejected events received. Tagged <c>{symbol}</c>.</summary>
+    public static readonly Counter<long> Rejects =
+        Meter.CreateCounter<long>("bot.orders.rejected");
+
+    /// <summary>OrderCancelled events received.</summary>
+    public static readonly Counter<long> Cancelled =
+        Meter.CreateCounter<long>("bot.orders.cancelled");
+}

--- a/backend/tools/B3.Trading.SimulatorBot/SimulatorBotOptions.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/SimulatorBotOptions.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>
+/// Bound from the <c>Bot:</c> section of configuration. The bot opens a
+/// single FIXP session against matching-platform and submits a steady
+/// flow of orders against a pre-configured instrument list. See
+/// <c>docker/docker-compose.simulator-bot.yml</c> for the canonical
+/// docker-side wiring.
+/// </summary>
+public sealed class SimulatorBotOptions
+{
+    public const string SectionName = "Bot";
+
+    /// <summary>FIXP TCP listener exposed by matching-platform (host:port).</summary>
+    [Required] public string Endpoint { get; set; } = "matching-platform:9876";
+
+    /// <summary>Matching FIXP session id (must exist in matching's <c>sessions[]</c>).</summary>
+    [Required] public uint SessionId { get; set; }
+
+    /// <summary>EnteringFirm code from matching's <c>firms[].enteringFirmCode</c>.</summary>
+    [Required] public uint EnteringFirm { get; set; }
+
+    /// <summary>Configured floor for the FIXP <c>SessionVerId</c>; the SDK's
+    /// <c>FileSessionStateStore</c> bumps from this on warm restart.</summary>
+    public uint SessionVerId { get; set; } = 1;
+
+    /// <summary>Verbatim JSON credential payload — matching's FixpSession
+    /// expects <c>{"auth_type","username","access_key"}</c>.</summary>
+    [Required] public string AccessKey { get; set; } = string.Empty;
+
+    public string SenderLocation { get; set; } = "BOT";
+    public string EnteringTrader { get; set; } = "BOT";
+
+    /// <summary>Local directory for the SDK's session state store. Mount to
+    /// a docker volume so SessionVerId survives container restarts.</summary>
+    public string StateDirectory { get; set; } = "/var/lib/b3-simulator-bot";
+
+    /// <summary>How often the submit loop wakes up. Each tick may submit
+    /// zero or more orders depending on <see cref="MaxInFlightPerSymbol"/>.</summary>
+    public TimeSpan TickInterval { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>Cap on working orders per symbol. The bot stops submitting
+    /// for that symbol when the cap is hit; cancels free up slots.</summary>
+    public int MaxInFlightPerSymbol { get; set; } = 5;
+
+    /// <summary>If &gt; 0, the bot cancels still-working orders older than
+    /// this. Keeps the book from accumulating stale resting volume.</summary>
+    public TimeSpan AutoCancelAfter { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Probability a tick produces a crossing (taker) order
+    /// instead of resting liquidity. 0..1.</summary>
+    public double CrossProbability { get; set; } = 0.25;
+
+    /// <summary>Optional deterministic seed for the Random used by the
+    /// pattern generator. <c>null</c> seeds from the system clock.</summary>
+    public int? RandomSeed { get; set; }
+
+    [Required, MinLength(1)]
+    public List<InstrumentConfig> Instruments { get; set; } = new();
+}
+
+/// <summary>One instrument the bot trades. <see cref="SecurityId"/> must
+/// match matching's <c>instruments-eqt.json</c>; <see cref="RefPrice"/>
+/// anchors the random-walk pricing.</summary>
+public sealed class InstrumentConfig
+{
+    [Required] public string Symbol { get; set; } = string.Empty;
+    [Required] public ulong SecurityId { get; set; }
+    [Required, Range(typeof(decimal), "0.01", "1000000")]
+    public decimal RefPrice { get; set; }
+
+    /// <summary>Minimum price increment. Prices are rounded to this.</summary>
+    public decimal TickSize { get; set; } = 0.01m;
+
+    /// <summary>Round-lot size; quantities are multiples of this.</summary>
+    public long LotSize { get; set; } = 100;
+
+    /// <summary>Min lots per order (inclusive).</summary>
+    public int MinLots { get; set; } = 1;
+
+    /// <summary>Max lots per order (inclusive).</summary>
+    public int MaxLots { get; set; } = 5;
+}

--- a/backend/tools/B3.Trading.SimulatorBot/SimulatorBotWorker.cs
+++ b/backend/tools/B3.Trading.SimulatorBot/SimulatorBotWorker.cs
@@ -1,0 +1,256 @@
+using B3.EntryPoint.Client;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Up = B3.EntryPoint.Client;
+using UpModels = B3.EntryPoint.Client.Models;
+using UpState = B3.EntryPoint.Client.State;
+
+namespace B3.Trading.SimulatorBot;
+
+/// <summary>
+/// The bot's main loop. Single FIXP session against matching-platform;
+/// concurrent submit + receive paths separated by the SDK's own
+/// channels:
+/// <list type="bullet">
+///   <item><see cref="ReceiveLoopAsync"/> drains <c>_client.Events()</c>
+///         and feeds the <see cref="OrderTracker"/>.</item>
+///   <item><see cref="SubmitLoopAsync"/> ticks on
+///         <see cref="SimulatorBotOptions.TickInterval"/>; each tick walks
+///         the configured instrument list and submits at most one new
+///         order per instrument (subject to the in-flight cap), then
+///         emits auto-cancels for stale open orders.</item>
+/// </list>
+/// </summary>
+internal sealed class SimulatorBotWorker : BackgroundService
+{
+    private readonly SimulatorBotOptions _options;
+    private readonly OrderTracker _tracker;
+    private readonly ILogger<SimulatorBotWorker> _log;
+    private readonly Random _rng;
+    private long _nextClOrdId;
+    private EntryPointClient? _client;
+
+    public SimulatorBotWorker(IOptions<SimulatorBotOptions> options, OrderTracker tracker,
+        ILogger<SimulatorBotWorker> log)
+    {
+        _options = options.Value;
+        _tracker = tracker;
+        _log = log;
+        _rng = _options.RandomSeed is { } seed ? new Random(seed) : new Random();
+        // Time-of-day high bits + monotonic low bits give unique ClOrdIDs
+        // across restarts within the same SessionVerId. The SDK's
+        // FileSessionStateStore handles SessionVerId itself, but ClOrdID
+        // uniqueness is ours to defend.
+        _nextClOrdId = (long)(((ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) << 20);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Directory.CreateDirectory(_options.StateDirectory);
+        var stateStore = new UpState.FileSessionStateStore(_options.StateDirectory);
+        uint? persisted = null;
+        try
+        {
+            var snap = await stateStore.LoadAsync(stoppingToken);
+            if (snap is not null) persisted = snap.SessionVerId;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "[bot] failed to load persisted SessionState; falling back to configured SessionVerId.");
+        }
+        var resolvedVerId = persisted is { } p
+            ? (_options.SessionVerId > checked(p + 1) ? _options.SessionVerId : checked(p + 1))
+            : _options.SessionVerId;
+
+        var ep = EndpointParser.Parse(_options.Endpoint);
+        var addrs = System.Net.Dns.GetHostAddresses(ep.Host);
+        if (addrs.Length == 0)
+            throw new InvalidOperationException($"Could not resolve bot endpoint host '{ep.Host}'.");
+        var ipEndpoint = new System.Net.IPEndPoint(addrs[0], ep.Port);
+        var clientOpts = new EntryPointClientOptions
+        {
+            Endpoint = ipEndpoint,
+            SessionId = _options.SessionId,
+            SessionVerId = resolvedVerId,
+            EnteringFirm = _options.EnteringFirm,
+            Credentials = EntryPointClientOptions.AccessKey(_options.AccessKey),
+            SenderLocation = _options.SenderLocation,
+            EnteringTrader = _options.EnteringTrader,
+            SessionStateStore = stateStore,
+            Logger = _log,
+        };
+
+        _client = new EntryPointClient(clientOpts);
+        try
+        {
+            _log.LogInformation("[bot] connecting to {Endpoint} session={Session} verId={VerId}",
+                _options.Endpoint, _options.SessionId, resolvedVerId);
+            await _client.ConnectAsync(stoppingToken);
+            _log.LogInformation("[bot] connected; instruments={Count} tick={Tick} cap={Cap}",
+                _options.Instruments.Count, _options.TickInterval, _options.MaxInFlightPerSymbol);
+
+            var receive = ReceiveLoopAsync(_client, stoppingToken);
+            var submit = SubmitLoopAsync(_client, stoppingToken);
+            await Task.WhenAny(receive, submit);
+            // Surface the failing task's exception (if any).
+            await Task.WhenAll(receive, submit);
+        }
+        catch (OperationCanceledException) { /* expected on shutdown */ }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "[bot] fatal error in main loop");
+            throw;
+        }
+        finally
+        {
+            try { await _client.DisposeAsync(); } catch { /* ignore */ }
+        }
+    }
+
+    private async Task ReceiveLoopAsync(EntryPointClient client, CancellationToken ct)
+    {
+        await foreach (var ev in client.Events(ct).ConfigureAwait(false))
+        {
+            try
+            {
+                HandleEvent(ev);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError(ex, "[bot] failed to handle event {Event}", ev.GetType().Name);
+            }
+        }
+    }
+
+    private void HandleEvent(UpModels.EntryPointEvent ev)
+    {
+        switch (ev)
+        {
+            case UpModels.OrderAccepted a:
+                _tracker.OnAccepted(a.ClOrdID.Value, (long)(a.LeavesQty ?? 0UL));
+                break;
+            case UpModels.OrderTrade t:
+                {
+                    var symbol = _tracker.TryGet(t.ClOrdID.Value, out var o) ? o.Symbol : "?";
+                    SimulatorBotMetrics.Fills.Add(1,
+                        new KeyValuePair<string, object?>("symbol", symbol));
+                    _tracker.OnTrade(t.ClOrdID.Value, (long)(t.LeavesQty ?? 0UL));
+                    break;
+                }
+            case UpModels.OrderCancelled c:
+                SimulatorBotMetrics.Cancelled.Add(1);
+                _tracker.OnTerminal(c.ClOrdID.Value);
+                break;
+            case UpModels.OrderRejected r:
+                {
+                    var symbol = _tracker.TryGet(r.ClOrdID.Value, out var o) ? o.Symbol : "?";
+                    SimulatorBotMetrics.Rejects.Add(1,
+                        new KeyValuePair<string, object?>("symbol", symbol));
+                    _tracker.OnTerminal(r.ClOrdID.Value);
+                    break;
+                }
+            case UpModels.OrderModified m:
+                _tracker.OnAccepted(m.ClOrdID.Value, (long)(m.LeavesQty ?? 0UL));
+                break;
+        }
+    }
+
+    private async Task SubmitLoopAsync(EntryPointClient client, CancellationToken ct)
+    {
+        // First tick after a small delay so the receive loop is up.
+        await Task.Delay(TimeSpan.FromMilliseconds(250), ct);
+        while (!ct.IsCancellationRequested)
+        {
+            foreach (var instr in _options.Instruments)
+            {
+                var open = _tracker.InFlightCount(instr.Symbol);
+                var draft = OrderPattern.Next(_rng, instr, _options.CrossProbability,
+                    open, _options.MaxInFlightPerSymbol);
+                if (draft is { } d)
+                {
+                    await TrySubmitAsync(client, d, ct);
+                }
+            }
+
+            if (_options.AutoCancelAfter > TimeSpan.Zero)
+            {
+                foreach (var stale in _tracker.SnapshotStaleOpen(_options.AutoCancelAfter))
+                {
+                    await TryCancelAsync(client, stale, "auto", ct);
+                }
+            }
+
+            try { await Task.Delay(_options.TickInterval, ct); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private async Task TrySubmitAsync(EntryPointClient client, OrderDraft d, CancellationToken ct)
+    {
+        var clOrdId = (ulong)Interlocked.Increment(ref _nextClOrdId);
+        // Register BEFORE the SDK await — the matching ER can race ahead
+        // of the await on a fast wire (mirrors trading-host's pattern).
+        _tracker.RegisterSubmit(clOrdId, d.Symbol, d.Price, d.Quantity, d.IsBuy);
+        var req = new UpModels.NewOrderRequest
+        {
+            ClOrdID = new UpModels.ClOrdID(clOrdId),
+            SecurityId = d.SecurityId,
+            Side = d.IsBuy ? UpModels.Side.Buy : UpModels.Side.Sell,
+            OrderType = UpModels.OrderType.Limit,
+            Price = d.Price,
+            OrderQty = (ulong)d.Quantity,
+            TimeInForce = UpModels.TimeInForce.Day,
+        };
+        try
+        {
+            await client.SubmitAsync(req, ct);
+            SimulatorBotMetrics.OrdersSubmitted.Add(1,
+                new KeyValuePair<string, object?>("symbol", d.Symbol),
+                new KeyValuePair<string, object?>("side", d.IsBuy ? "buy" : "sell"));
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _tracker.OnTerminal(clOrdId);
+            SimulatorBotMetrics.OrdersSubmitFailed.Add(1,
+                new KeyValuePair<string, object?>("symbol", d.Symbol));
+            _log.LogWarning(ex, "[bot] submit failed for {Symbol} clordid={ClOrdId}", d.Symbol, clOrdId);
+        }
+    }
+
+    private async Task TryCancelAsync(EntryPointClient client, TrackedOrder order, string reason, CancellationToken ct)
+    {
+        var cancelClOrdId = (ulong)Interlocked.Increment(ref _nextClOrdId);
+        var req = new UpModels.CancelOrderRequest
+        {
+            ClOrdID = new UpModels.ClOrdID(cancelClOrdId),
+            OrigClOrdID = new UpModels.ClOrdID(order.ClOrdId),
+            SecurityId = LookupSecurityId(order.Symbol),
+            Side = order.IsBuy ? UpModels.Side.Buy : UpModels.Side.Sell,
+        };
+        try
+        {
+            await client.CancelAsync(req, ct);
+            SimulatorBotMetrics.CancelsSent.Add(1,
+                new KeyValuePair<string, object?>("reason", reason));
+            // Don't mark the original as terminal here — wait for the
+            // OrderCancelled ER. The cancel may yet be rejected.
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex, "[bot] cancel failed for clordid={ClOrdId}", order.ClOrdId);
+        }
+    }
+
+    private ulong LookupSecurityId(string symbol)
+    {
+        foreach (var i in _options.Instruments)
+            if (string.Equals(i.Symbol, symbol, StringComparison.Ordinal)) return i.SecurityId;
+        return 0UL;
+    }
+
+    internal static System.Net.DnsEndPoint ParseEndpoint(string endpoint) =>
+        EndpointParser.Parse(endpoint);
+}

--- a/docker/docker-compose.simulator-bot.yml
+++ b/docker/docker-compose.simulator-bot.yml
@@ -1,0 +1,85 @@
+# Simulator-bot overlay (#134). Stacks on top of the default real
+# stack to add a single external FIXP client that submits a steady flow
+# of orders against matching-platform. Replaces the in-process
+# `Mode=Simulator` synthetic-ER injector — the trading-host stays Real,
+# the bot generates traffic from the outside.
+#
+# Usage:
+#   docker compose \
+#       -f docker/docker-compose.yml \
+#       -f docker/docker-compose.simulator-bot.yml \
+#       up -d
+#
+# This overlay is ADDITIVE — it does NOT replace docker-compose.demo.yml.
+# Stacking demo + simulator-bot is supported but redundant: pick one.
+#
+# The bot connects on FIXP session 10102 (NOT 10101 — that one belongs to
+# trading-host's FIRM01 wiring). Both sessions are pre-declared in
+# docker/real/exchange-simulator.bridge.json so matching-platform accepts
+# the bot's Negotiate without operator intervention.
+
+name: b3trading
+
+services:
+  simulator-bot:
+    build:
+      context: ..
+      dockerfile: backend/tools/B3.Trading.SimulatorBot/Dockerfile
+    image: ${SIMULATOR_BOT_IMAGE:-b3-simulator-bot:dev}
+    container_name: b3-simulator-bot
+    restart: unless-stopped
+    networks:
+      - b3-net
+    depends_on:
+      matching-platform:
+        condition: service_healthy
+    environment:
+      # ── FIXP session ───────────────────────────────────────────────
+      Bot__Endpoint: matching-platform:9876
+      Bot__SessionId: "10102"
+      Bot__SessionVerId: "1"
+      Bot__EnteringFirm: "100"  # FIRM01 enteringFirmCode
+      # Matching's FixpSession parses Credentials as JSON expecting
+      # {auth_type, username, access_key} — see docker/docker-compose.yml
+      # for the same shape on trading-host's session 10101.
+      Bot__AccessKey: '{"auth_type":"basic","username":"10102","access_key":"dev-key-2"}'
+      Bot__SenderLocation: SP
+      Bot__EnteringTrader: BOT
+
+      # ── Behaviour ──────────────────────────────────────────────────
+      Bot__StateDirectory: /var/lib/b3-simulator-bot
+      Bot__TickInterval: "00:00:00.500"
+      Bot__MaxInFlightPerSymbol: "5"
+      Bot__AutoCancelAfter: "00:00:30"
+      Bot__CrossProbability: "0.25"
+
+      # ── Instruments (must match docker/real/instruments-eqt.json) ──
+      Bot__Instruments__0__Symbol: PETR4
+      Bot__Instruments__0__SecurityId: "900000000001"
+      Bot__Instruments__0__RefPrice: "30.00"
+      Bot__Instruments__0__TickSize: "0.01"
+      Bot__Instruments__0__LotSize: "100"
+      Bot__Instruments__0__MinLots: "1"
+      Bot__Instruments__0__MaxLots: "5"
+
+      Bot__Instruments__1__Symbol: VALE3
+      Bot__Instruments__1__SecurityId: "900000000002"
+      Bot__Instruments__1__RefPrice: "70.00"
+      Bot__Instruments__1__TickSize: "0.01"
+      Bot__Instruments__1__LotSize: "100"
+      Bot__Instruments__1__MinLots: "1"
+      Bot__Instruments__1__MaxLots: "3"
+
+      Bot__Instruments__2__Symbol: ITUB4
+      Bot__Instruments__2__SecurityId: "900000000003"
+      Bot__Instruments__2__RefPrice: "32.00"
+      Bot__Instruments__2__TickSize: "0.01"
+      Bot__Instruments__2__LotSize: "100"
+      Bot__Instruments__2__MinLots: "1"
+      Bot__Instruments__2__MaxLots: "5"
+    volumes:
+      - simulator-bot-state:/var/lib/b3-simulator-bot
+
+volumes:
+  simulator-bot-state:
+    driver: local

--- a/docker/real/exchange-simulator.bridge.json
+++ b/docker/real/exchange-simulator.bridge.json
@@ -38,7 +38,11 @@
     { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 }
   ],
   "sessions": [
-    { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" }
+    { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" },
+    // Reserved for the external simulator bot (issue #134). Lets the
+    // bot connect to matching-platform on its own FIXP session without
+    // colliding with trading-host's 10101.
+    { "sessionId": "10102", "firmId": "FIRM01", "accessKey": "dev-key-2" }
   ],
   "http": {
     "listen": "0.0.0.0:8080",


### PR DESCRIPTION
Closes part of #134 (Sprint N — bot ships, Mode=Simulator deprecated; Sprint N+1 follow-up will remove Mode=Simulator).

## What

New `backend/tools/B3.Trading.SimulatorBot/` console app — connects to matching-platform via FIXP and submits a steady flow of orders against a configured instrument list. The trading-host stays Real; the bot generates traffic from the **outside**, exercising the same FIXP wire that human traders use.

## Why

Today, `Mode=Simulator` makes the trading-host both "the institution" and "the venue" by injecting synthetic ERs in-process. That:
- Breaks role separation.
- Leaks demo-only surface into production (`AllowSimulatorInProduction`, `/admin/simulator/er`, `SimulatorBootGuard`).
- Doesn't exercise the FIXP/SBE transport — bugs at the wire boundary slip through.

The external bot fixes all three: trading-host becomes honest (Real-only), the FIXP path always runs, and multi-client scenarios become natural.

## Design highlights

- **Own FIXP session**: `docker/real/exchange-simulator.bridge.json` now declares `{sessionId:10102, accessKey:dev-key-2}` alongside trading-host's `10101` — no collision.
- **Persistent SessionVerId**: SDK `FileSessionStateStore` mounted on a docker volume so warm restarts don't wedge with `InvalidSessionVerId`.
- **In-flight cap + auto-cancel**: `OrderTracker` keeps ClOrdID-keyed state from the ER stream so the book doesn't grow unbounded.
- **Per-instrument config** (symbol→SecurityId, refPrice, tick, lot, qty range) — orders are wire-valid against `instruments-eqt.json`.
- **Resting + crossing mix**: configurable `CrossProbability` — most orders rest passively; a fraction crosses mid to actually trade against trading-host liquidity.
- **Deterministic generator**: `OrderPattern` is stateless and seeded for testability.

## Trading-host changes

- `SimulatorBootGuard.BuildWarning` now points operators at the bot overlay.
- New gauge `trading.simulator.mode_deprecated` (mirrors `mode_active`) so the deprecation can be alerted independently.

## Compose

```
docker compose -f docker/docker-compose.yml -f docker/docker-compose.simulator-bot.yml up -d
```

Additive — does NOT replace `docker-compose.demo.yml` (kept for the migration window).

## Tests

23 unit tests (pattern generator bounds + determinism + tick/lot alignment, tracker in-flight/partial-fill/terminal/stale-snapshot, endpoint parser). Suite: 53 + 421 + 202 + 23 + 12 skipped (conformance). `dotnet format` clean. `docker build` of the bot image green end-to-end.

No integration test against a live matching-platform in this slice — covered by manual `docker compose up`.

## Out of scope

- Removing `Mode=Simulator` (Sprint N+1).
- Migrating `docker-compose.demo.yml` to use the bot.
- Multi-session / multi-bot scenarios.
- L2 market-data driven pricing.
- OTLP exporter wiring on the bot.

## Rubber-duck pass

Plan was reviewed before implementation. Adopted findings: avoid 10101 collision (declared 10102), persist SessionVerId via FileSessionStateStore, configure SecurityId per instrument (not just symbol), JSON credentials (`{auth_type,username,access_key}`), and make ER tracking real (not fire-and-forget). Deferred: OTLP wiring (logs-only MVP); separate `docker-compose.demo.yml` migration.