### PR TITLE
feat(conformance): expired-JWT rejection scenarios (#22)

### DIFF
--- a/backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj
+++ b/backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/ConformanceFactAttribute.cs
@@ -43,6 +43,14 @@ public sealed class ConformanceFactAttribute : FactAttribute
     /// </summary>
     public bool RequiresSandboxMatching { get; init; }
 
+    /// <summary>
+    /// When true, the scenario needs the host's HS256 JWT signing key
+    /// (env <c>B3T_AUTH_SIGNING_KEY</c>) so it can mint authentically
+    /// signed tokens with custom claims/expiry. Skipped at discovery
+    /// time when not configured.
+    /// </summary>
+    public bool RequiresAuthSigningKey { get; init; }
+
     public ConformanceFactAttribute()
     {
         var peer = PlatformEndpoint.TryResolve();
@@ -86,6 +94,8 @@ public sealed class ConformanceFactAttribute : FactAttribute
                 return PlatformEndpoint.SimulatorSkipReason;
             if (RequiresSandboxMatching && !PlatformEndpoint.IsRealStackConformance())
                 return PlatformEndpoint.RealStackConformanceSkipReason;
+            if (RequiresAuthSigningKey && !PlatformEndpoint.IsAuthSigningKeyConfigured())
+                return PlatformEndpoint.AuthSigningKeySkipReason;
             return null;
         }
         set => base.Skip = value;

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/JwtMinter.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/JwtMinter.cs
@@ -1,0 +1,78 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace B3.Trading.Conformance.Infrastructure;
+
+/// <summary>
+/// Mints HS256-signed JWTs deterministically against the host's signing
+/// key (env <c>B3T_AUTH_SIGNING_KEY</c>). Used by scenarios that need a
+/// token with custom claims/expiry — most notably "expired-but-otherwise-
+/// authentic JWT must be rejected", which can only be expressed when the
+/// suite is signing with the same key the host validates with.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>B3.Trading.Api.Auth.JwtIssuer</c> on purpose: same algorithm,
+/// same default issuer/audience. Diverging here would just produce
+/// false-positive 401s and obscure what the spec is actually asserting.
+/// </remarks>
+internal static class JwtMinter
+{
+    public const string RoleClaim = "role";
+    public const string FirmClaim = "firm";
+
+    public static string Mint(
+        string subject,
+        string role,
+        string firm,
+        DateTimeOffset notBefore,
+        DateTimeOffset expires)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(PlatformEndpoint.GetAuthSigningKey());
+        if (keyBytes.Length < 32)
+        {
+            throw new InvalidOperationException(
+                $"{PlatformEndpoint.EnvAuthSigningKey} must be at least 32 bytes (256 bits) — must mirror the host's Trading:Auth:SigningKey.");
+        }
+        var creds = new SigningCredentials(
+            new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            new(RoleClaim, role),
+            new(FirmClaim, firm),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: PlatformEndpoint.GetAuthIssuer(),
+            audience: PlatformEndpoint.GetAuthAudience(),
+            claims: claims,
+            notBefore: notBefore.UtcDateTime,
+            expires: expires.UtcDateTime,
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// Convenience: mint a token whose <c>exp</c> claim is already in the
+    /// past. The returned token is signature-valid; the host must reject
+    /// it on the lifetime check, not on the signature check.
+    /// </summary>
+    public static string MintExpired(
+        string subject = "conformance-expired",
+        string role = "user",
+        string firm = "default")
+    {
+        var now = DateTimeOffset.UtcNow;
+        // Generous lifetime that still ends in the past, comfortably outside
+        // any clock-skew tolerance the JWT bearer middleware might apply
+        // (default 5 minutes in Microsoft.IdentityModel).
+        return Mint(subject, role, firm,
+            notBefore: now.AddHours(-2),
+            expires: now.AddHours(-1));
+    }
+}

--- a/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
+++ b/backend/tests/B3.Trading.Conformance/Infrastructure/PlatformEndpoint.cs
@@ -35,6 +35,9 @@ public sealed record PlatformEndpoint(
     public const string EnvAdminPassword = "B3T_ADMIN_PASS";
     public const string EnvSimulatorMode = "B3T_SIMULATOR_MODE";
     public const string EnvRealStackConformance = "B3T_REAL_STACK_CONFORMANCE";
+    public const string EnvAuthSigningKey = "B3T_AUTH_SIGNING_KEY";
+    public const string EnvAuthIssuer = "B3T_AUTH_ISSUER";
+    public const string EnvAuthAudience = "B3T_AUTH_AUDIENCE";
 
     public static PlatformEndpoint? TryResolve()
     {
@@ -94,6 +97,33 @@ public sealed record PlatformEndpoint(
         return string.Equals(v, "true", StringComparison.OrdinalIgnoreCase) || v == "1";
     }
 
+    /// <summary>
+    /// True when the operator wired the host's HS256 JWT signing key into
+    /// the conformance environment via <c>B3T_AUTH_SIGNING_KEY</c>. Tests
+    /// that need to mint deterministic tokens (e.g. expired-JWT rejection
+    /// scenarios) require the same key the host validates with — that's
+    /// the only way to assert that an authentically-signed-but-expired
+    /// token is rejected vs. just an unsigned/garbage one.
+    /// </summary>
+    public static bool IsAuthSigningKeyConfigured() =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvAuthSigningKey));
+
+    public static string GetAuthSigningKey() =>
+        Environment.GetEnvironmentVariable(EnvAuthSigningKey)
+            ?? throw new InvalidOperationException(
+                $"{EnvAuthSigningKey} not set. Gate the test with RequiresAuthSigningKey=true.");
+
+    /// <summary>
+    /// Issuer claim the host validates against. Defaults to the upstream
+    /// <see cref="JwtIssuer"/> default; override via env if the operator
+    /// changed <c>Trading:Auth:Issuer</c>.
+    /// </summary>
+    public static string GetAuthIssuer() =>
+        Environment.GetEnvironmentVariable(EnvAuthIssuer) ?? "b3-trading";
+
+    public static string GetAuthAudience() =>
+        Environment.GetEnvironmentVariable(EnvAuthAudience) ?? "b3-trading-clients";
+
     public const string SkipReason =
         "Conformance platform not configured. Set B3T_BASE_URL, B3T_AUTH_USER, B3T_AUTH_PASS to run.";
 
@@ -105,4 +135,7 @@ public sealed record PlatformEndpoint(
 
     public const string RealStackConformanceSkipReason =
         "Real-stack scenario skipped: B3T_REAL_STACK_CONFORMANCE=true not set (host is not the docker-compose real-stack sandbox).";
+
+    public const string AuthSigningKeySkipReason =
+        "Signing-key scenario skipped: B3T_AUTH_SIGNING_KEY not set (operator must mirror the host's Trading:Auth:SigningKey to mint deterministic tokens).";
 }

--- a/backend/tests/B3.Trading.Conformance/Spec_HTTP_Auth/ExpiredTokenTests.cs
+++ b/backend/tests/B3.Trading.Conformance/Spec_HTTP_Auth/ExpiredTokenTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http.Headers;
+using B3.Trading.Conformance.Infrastructure;
+
+namespace B3.Trading.Conformance.Spec_HTTP_Auth;
+
+/// <summary>
+/// Spec — Auth (expired tokens). An authentically-signed JWT whose
+/// <c>exp</c> claim is in the past must be rejected by every protected
+/// surface — HTTP and WebSocket alike. Asserting this requires the
+/// suite to mint tokens with the same key the host validates against;
+/// scenarios skip when <c>B3T_AUTH_SIGNING_KEY</c> isn't wired in.
+/// </summary>
+/// <remarks>
+/// The failure mode this guards is subtle: garbage-bearer rejection
+/// (covered by <see cref="AuthRejectionTests"/>) only proves that
+/// signature validation runs. It does NOT prove that lifetime validation
+/// is wired. A misconfiguration where <c>ValidateLifetime=false</c>
+/// (e.g. someone debugging in production) would let a valid-signed
+/// token live forever — these tests catch exactly that regression.
+/// </remarks>
+[Trait("Category", "Conformance")]
+public class ExpiredTokenTests
+{
+    [ConformanceFact(RequiresAuthSigningKey = true)]
+    public async Task ProtectedHttp_WithExpiredToken_Returns401()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var expired = JwtMinter.MintExpired();
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/orders");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", expired);
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [ConformanceFact(RequiresAuthSigningKey = true)]
+    public async Task WebSocketUpgrade_WithExpiredToken_Returns401()
+    {
+        var peer = PlatformEndpoint.TryResolve()!;
+        using var http = new HttpClient { BaseAddress = peer.BaseUrl };
+
+        var expired = JwtMinter.MintExpired();
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/ws");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", expired);
+        // Standard WS upgrade hint set: even with a "valid-looking" upgrade
+        // request, an expired token must short-circuit at the auth layer
+        // before the handshake gets a chance to switch protocols.
+        req.Headers.Add("Upgrade", "websocket");
+        req.Headers.Add("Connection", "Upgrade");
+        req.Headers.Add("Sec-WebSocket-Version", "13");
+        req.Headers.Add("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}

--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -52,5 +52,11 @@ services:
       # password material, different username + admin role.
       B3T_ADMIN_USER: ${TRADING_ADMIN_USER:-carol}
       B3T_ADMIN_PASS: ${TRADING_SEED_PASSWORD:-wonderland}
+      # Mirror the host's HS256 signing key into the conformance container
+      # so scenarios that need to mint deterministic tokens (e.g. expired-
+      # JWT rejection, see Spec_HTTP_Auth/ExpiredTokenTests) can sign with
+      # the same key the host validates against. Without this, those
+      # scenarios skip cleanly — they're optional, not gated.
+      B3T_AUTH_SIGNING_KEY: ${TRADING_AUTH_SIGNING_KEY:-}
     networks:
       - b3-net


### PR DESCRIPTION
Partial close of #22 (expand HTTP/WS conformance — 'no-blocker' items).

## What

Adds two new specs under `Spec_HTTP_Auth/ExpiredTokenTests`:

- `ProtectedHttp_WithExpiredToken_Returns401`
- `WebSocketUpgrade_WithExpiredToken_Returns401`

Both mint an authentically-signed HS256 token with `exp` in the past
and assert the host rejects it (401) on protected HTTP and on the WS
upgrade path.

## Why

Existing `AuthRejectionTests` only assert garbage-bearer rejection —
that proves *signature* validation runs but does NOT prove that
*lifetime* validation is wired. A misconfiguration like
`ValidateLifetime=false` would pass the garbage-bearer specs and let
authentically-signed-but-expired tokens live forever. These tests
catch exactly that regression.

## Mechanics

- New `JwtMinter` helper mirrors `B3.Trading.Api.Auth.JwtIssuer`
  (HS256, same default issuer/audience). Diverging would just
  produce false-positive 401s and obscure the assertion.
- New env vars on `PlatformEndpoint`: `B3T_AUTH_SIGNING_KEY`
  (required for these specs; clean skip when unset),
  `B3T_AUTH_ISSUER`, `B3T_AUTH_AUDIENCE` (optional overrides).
- New `ConformanceFactAttribute.RequiresAuthSigningKey` gate, same
  shape as `RequiresAdmin` / `RequiresSimulator` / `RequiresSandboxMatching`.
- `docker-compose.conformance.yml` threads `TRADING_AUTH_SIGNING_KEY`
  into the conformance service as `B3T_AUTH_SIGNING_KEY`.
- `System.IdentityModel.Tokens.Jwt 8.18.0` added to the conformance
  csproj (matches the host).

## Out of scope

The other two no-blocker items in #22 stay open for follow-ups:

- **Multi-firm isolation** — needs a second firm seeded into the
  conformance compose (bigger slice).
- **Per-firm-scope URL gating** — not enforceable as a black-box
  conformance assertion today: the firm comes from the JWT `firm`
  claim, not the URL route, so there's no per-firm endpoint to gate.

## Verification

- Suite: 53 + 421 + 202 + 23 unit, +14 conformance skipped (was 12,
  +2 new ExpiredToken specs that skip cleanly without
  `B3T_AUTH_SIGNING_KEY`). Format clean.
- `docker compose ... config` confirms
  `B3T_AUTH_SIGNING_KEY: dev-not-for-production-32bytesplus` lands
  on the conformance service env when `TRADING_AUTH_SIGNING_KEY` is
  set in `.env`.

Refs #22.