### PR TITLE
feat(user-bots): credential CRUD endpoints + registry (#169)

### DIFF
--- a/backend/src/B3.Trading.Api/UserBotCredentialsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/UserBotCredentialsEndpoints.cs
@@ -1,0 +1,110 @@
+using System.Security.Claims;
+using B3.Trading.Application.UserBots;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// REST surface for user-issued bot credentials (sub-issue #169 of
+/// RFC user-bot-fixp-listener-v0). The endpoint group is <c>[Authorize]</c>
+/// — every operation acts on the authenticated user's <c>sub</c> claim.
+/// Cross-user reads/writes always return 404 so the surface cannot be
+/// used as a credential-id oracle.
+/// </summary>
+public static class UserBotCredentialsEndpoints
+{
+    /// <summary>
+    /// Hard cap on the human-friendly label, enforced server-side.
+    /// Picked deliberately low — labels are pure UI affordance, not
+    /// content; the SBE Credentials field on FIXP Negotiate is 255
+    /// bytes total and we have no reason to come close.
+    /// </summary>
+    public const int MaxLabelLength = 128;
+
+    public static IEndpointRouteBuilder MapUserBotCredentials(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/user-bot-credentials").RequireAuthorization();
+
+        group.MapPost("/", async (
+            HttpContext ctx,
+            CreateUserBotCredentialRequest req,
+            IUserBotCredentialRegistry registry,
+            CancellationToken ct) =>
+        {
+            var sub = RequireSub(ctx);
+
+            if (req is null) return Results.BadRequest(new { error = "Body required." });
+            var label = req.Label?.Trim();
+            if (string.IsNullOrWhiteSpace(label))
+                return Results.BadRequest(new { error = "Label is required." });
+            if (label.Length > MaxLabelLength)
+                return Results.BadRequest(new { error = $"Label exceeds {MaxLabelLength} characters." });
+
+            var created = await registry.CreateAsync(sub, label, ct);
+            var dto = new CreatedUserBotCredentialDto(
+                Id: created.Credential.Id,
+                Label: created.Credential.Label,
+                CredShortId: created.Credential.CredShortId,
+                CreatedAtUtc: created.Credential.CreatedAtUtc,
+                PlainSecret: created.PlainToken);
+            return Results.Created($"/api/user-bot-credentials/{dto.Id}", dto);
+        });
+
+        group.MapGet("/", (HttpContext ctx, IUserBotCredentialRegistry registry) =>
+        {
+            var sub = RequireSub(ctx);
+            var rows = registry.ListByUser(sub)
+                .Select(c => new UserBotCredentialDto(
+                    c.Id, c.Label, c.CredShortId, c.CreatedAtUtc, c.RevokedAtUtc))
+                .ToList();
+            return Results.Ok(rows);
+        });
+
+        group.MapDelete("/{id:guid}", async (
+            Guid id,
+            HttpContext ctx,
+            IUserBotCredentialRegistry registry,
+            CancellationToken ct) =>
+        {
+            var sub = RequireSub(ctx);
+            var ok = await registry.RevokeAsync(sub, id, ct);
+            return ok ? Results.NoContent() : Results.NotFound();
+        });
+
+        return app;
+    }
+
+    private static string RequireSub(HttpContext ctx)
+    {
+        var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+        if (string.IsNullOrWhiteSpace(sub))
+            throw new InvalidOperationException("Authenticated request missing sub claim.");
+        return sub;
+    }
+}
+
+/// <summary>POST body for creating a credential.</summary>
+public sealed record CreateUserBotCredentialRequest(string Label);
+
+/// <summary>
+/// 201 response from POST. <c>PlainSecret</c> is the only place the
+/// platform ever returns the bearer half of the PAT — list/get never
+/// include it.
+/// </summary>
+public sealed record CreatedUserBotCredentialDto(
+    Guid Id,
+    string Label,
+    string CredShortId,
+    DateTimeOffset CreatedAtUtc,
+    string PlainSecret);
+
+/// <summary>Public read-side DTO. No secret material.</summary>
+public sealed record UserBotCredentialDto(
+    Guid Id,
+    string Label,
+    string CredShortId,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? RevokedAt);

--- a/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
+++ b/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -51,7 +51,29 @@ public sealed class PlatformSnapshot
     /// or a fill arrives).
     /// </summary>
     public List<CashBalanceSnapshot> CashBalances { get; init; } = new();
+
+    /// <summary>
+    /// User-issued bot credentials (sub-issue #169). Empty on snapshots
+    /// pre-dating the field — credentials are reconstructed instead by
+    /// the WAL replay path on top of the empty list, which matches the
+    /// "no PATs minted" semantics those snapshots actually carried.
+    /// </summary>
+    public List<UserBotCredentialSnapshot> UserBotCredentials { get; init; } = new();
 }
+
+/// <summary>
+/// Captures one row from <c>InMemoryUserBotCredentialRegistry</c>.
+/// Mirrors the <c>UserBotCredential</c> record one-to-one; the secret
+/// is stored only as the bcrypt hash (never plaintext).
+/// </summary>
+public sealed record UserBotCredentialSnapshot(
+    Guid Id,
+    string UserId,
+    string CredShortId,
+    string Label,
+    string SecretHash,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? RevokedAtUtc);
 
 public sealed record OrderSnapshot(
     ulong ClOrdId,

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -27,6 +27,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
+[JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
+[JsonDerivedType(typeof(UserBotCredentialRevokedEvent), "userbot.cred.revoked")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -256,4 +258,33 @@ public sealed record OrderStaleClearedEvent : WalEvent
     public required string FirmId { get; init; }
     public required string ResolvedBy { get; init; }    // "admin" or "er-terminal"
     public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #169. Recorded the moment a user mints a new bot
+/// credential. Replay reconstructs the credential row in
+/// <c>InMemoryUserBotCredentialRegistry</c>; the plaintext secret is
+/// shown to the caller exactly once at create time and is never
+/// included on the WAL. The bcrypt(cost=12) hash is the only secret-
+/// derived material persisted.
+/// </summary>
+public sealed record UserBotCredentialCreatedEvent : WalEvent
+{
+    public required Guid Id { get; init; }
+    public required string UserId { get; init; }
+    public required string CredShortId { get; init; }
+    public required string Label { get; init; }
+    public required string SecretHash { get; init; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #169. Soft-revoke audit record. Replay flips the row's
+/// <c>RevokedAtUtc</c> field — listeners reject the PAT after restore.
+/// </summary>
+public sealed record UserBotCredentialRevokedEvent : WalEvent
+{
+    public required Guid Id { get; init; }
+    public required string UserId { get; init; }
+    public required DateTimeOffset RevokedAtUtc { get; init; }
 }

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotCredentialRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotCredentialRegistry.cs
@@ -1,0 +1,46 @@
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Storage and lifecycle surface for user-issued bot credentials
+/// (sub-issue #169 of RFC user-bot-fixp-listener-v0). The interface
+/// keeps the read-side stable for the future FIXP listener
+/// (sub-issue D) which only ever calls <see cref="TryAuthenticateAsync"/>.
+/// </summary>
+public interface IUserBotCredentialRegistry
+{
+    /// <summary>
+    /// Mints a new PAT for <paramref name="userId"/>, persists the
+    /// bcrypt hash + metadata to the WAL, and returns the plaintext
+    /// secret exactly once. Caller must surface the secret to the
+    /// human user and not log it.
+    /// </summary>
+    Task<CreatedUserBotCredential> CreateAsync(
+        string userId,
+        string label,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Soft-revoke (sets <c>RevokedAtUtc</c>). Returns <c>false</c>
+    /// when the credential id does not exist OR is already revoked OR
+    /// belongs to a different user — the caller cannot distinguish
+    /// these cases (404 either way) so a cross-user probe leaks
+    /// nothing.
+    /// </summary>
+    Task<bool> RevokeAsync(string userId, Guid credentialId, CancellationToken ct);
+
+    /// <summary>
+    /// All credentials minted by <paramref name="userId"/>, including
+    /// revoked ones (the UI shows a strike-through audit trail). Never
+    /// includes the plaintext secret — only the public metadata.
+    /// </summary>
+    IReadOnlyList<UserBotCredential> ListByUser(string userId);
+
+    /// <summary>
+    /// Resolves the PAT presented by an incoming FIXP Negotiate (or any
+    /// other authenticator) back to the registered credential. Returns
+    /// <c>null</c> when the token is malformed, the short-id is unknown,
+    /// the credential is revoked, or the secret half does not bcrypt-verify.
+    /// Sub-issue D will call this from <c>EntryPointListener.HandleNegotiate</c>.
+    /// </summary>
+    Task<UserBotCredential?> TryAuthenticateAsync(string presentedToken, CancellationToken ct);
+}

--- a/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotCredentialRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotCredentialRegistry.cs
@@ -1,0 +1,267 @@
+using System.Security.Cryptography;
+using B3.Trading.Application.Persistence;
+using BCrypt.Net;
+
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// In-memory implementation of <see cref="IUserBotCredentialRegistry"/>
+/// that is reconstructed on cold start by replaying
+/// <see cref="UserBotCredentialCreatedEvent"/> +
+/// <see cref="UserBotCredentialRevokedEvent"/> on top of the latest
+/// snapshot. Mutations go through <see cref="EventDispatcher"/> so the
+/// (WAL append, in-memory mutation) pair is atomic with respect to
+/// snapshot capture (RFC §4.9 invariant).
+/// </summary>
+public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegistry
+{
+    /// <summary>
+    /// Length of the public, embeddable short-id portion of the PAT.
+    /// Fixed-length parsing is required because the secret half is
+    /// base64url-encoded and may itself contain <c>_</c>, so a simple
+    /// <c>IndexOf('_')</c> split would break.
+    /// </summary>
+    internal const int ShortIdChars = 10;
+
+    /// <summary>RFC §4.5 — bcrypt cost factor. ≈250ms/op on commodity HW.</summary>
+    internal const int BcryptCost = 12;
+
+    private const string TokenPrefix = "b3t_";
+
+    private readonly EventDispatcher? _dispatcher;
+    private readonly object _gate = new();
+    // Indexed both by primary id (for revoke-by-id) and by short-id (for
+    // FIXP authenticate, which only sees the short-id half of the PAT).
+    private readonly Dictionary<Guid, UserBotCredential> _byId = new();
+    private readonly Dictionary<string, UserBotCredential> _byShortId =
+        new(StringComparer.Ordinal);
+
+    public InMemoryUserBotCredentialRegistry() : this(null) { }
+
+    public InMemoryUserBotCredentialRegistry(EventDispatcher? dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public Task<CreatedUserBotCredential> CreateAsync(
+        string userId, string label, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(label);
+
+        var shortId = MintShortId();
+        var secret = MintSecret();
+        var hash = BCrypt.Net.BCrypt.HashPassword(secret, workFactor: BcryptCost);
+
+        var credential = new UserBotCredential(
+            Id: Guid.NewGuid(),
+            UserId: userId,
+            CredShortId: shortId,
+            Label: label.Trim(),
+            SecretHash: hash,
+            CreatedAtUtc: DateTimeOffset.UtcNow,
+            RevokedAtUtc: null);
+
+        var evt = new UserBotCredentialCreatedEvent
+        {
+            Id = credential.Id,
+            UserId = credential.UserId,
+            CredShortId = credential.CredShortId,
+            Label = credential.Label,
+            SecretHash = credential.SecretHash,
+            CreatedAtUtc = credential.CreatedAtUtc,
+        };
+
+        if (_dispatcher is not null)
+            _dispatcher.Dispatch(evt, () => ApplyCreated(credential));
+        else
+            ApplyCreated(credential);
+
+        var plainToken = $"{TokenPrefix}{shortId}_{secret}";
+        return Task.FromResult(new CreatedUserBotCredential(credential, plainToken));
+    }
+
+    public Task<bool> RevokeAsync(string userId, Guid credentialId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        lock (_gate)
+        {
+            if (!_byId.TryGetValue(credentialId, out var existing))
+                return Task.FromResult(false);
+            // Cross-user lookups must be indistinguishable from missing.
+            if (!string.Equals(existing.UserId, userId, StringComparison.Ordinal))
+                return Task.FromResult(false);
+            if (existing.RevokedAtUtc is not null)
+                return Task.FromResult(false);
+        }
+
+        var revokedAt = DateTimeOffset.UtcNow;
+        var evt = new UserBotCredentialRevokedEvent
+        {
+            Id = credentialId,
+            UserId = userId,
+            RevokedAtUtc = revokedAt,
+        };
+
+        if (_dispatcher is not null)
+            _dispatcher.Dispatch(evt, () => ApplyRevoked(credentialId, revokedAt));
+        else
+            ApplyRevoked(credentialId, revokedAt);
+
+        return Task.FromResult(true);
+    }
+
+    public IReadOnlyList<UserBotCredential> ListByUser(string userId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        lock (_gate)
+        {
+            return _byId.Values
+                .Where(c => string.Equals(c.UserId, userId, StringComparison.Ordinal))
+                .OrderBy(c => c.CreatedAtUtc)
+                .ToList();
+        }
+    }
+
+    public Task<UserBotCredential?> TryAuthenticateAsync(
+        string presentedToken, CancellationToken ct)
+    {
+        if (!TryParseToken(presentedToken, out var shortId, out var secret))
+            return Task.FromResult<UserBotCredential?>(null);
+
+        UserBotCredential? candidate;
+        lock (_gate)
+        {
+            if (!_byShortId.TryGetValue(shortId, out candidate))
+                return Task.FromResult<UserBotCredential?>(null);
+            if (candidate.RevokedAtUtc is not null)
+                return Task.FromResult<UserBotCredential?>(null);
+        }
+
+        // bcrypt verify is intentionally outside the lock — it's the
+        // hot path for the listener and would otherwise serialise every
+        // FIXP Negotiate behind the registry mutex.
+        bool ok;
+        try
+        {
+            ok = BCrypt.Net.BCrypt.Verify(secret, candidate.SecretHash);
+        }
+        catch (SaltParseException)
+        {
+            // Defensive: a malformed hash on disk should not crash the
+            // listener — treat as auth failure and let the credential
+            // surface naturally as "won't authenticate" from the UI.
+            ok = false;
+        }
+        return Task.FromResult(ok ? candidate : null);
+    }
+
+    /// <summary>
+    /// Snapshot capture hook (called by <c>StateSnapshotter</c> under
+    /// the dispatcher lock). Returns a deterministic, ordered copy of
+    /// the persistent fields.
+    /// </summary>
+    public IReadOnlyList<UserBotCredentialSnapshot> Snapshot()
+    {
+        lock (_gate)
+        {
+            return _byId.Values
+                .OrderBy(c => c.CreatedAtUtc)
+                .ThenBy(c => c.Id)
+                .Select(c => new UserBotCredentialSnapshot(
+                    c.Id, c.UserId, c.CredShortId, c.Label, c.SecretHash,
+                    c.CreatedAtUtc, c.RevokedAtUtc))
+                .ToList();
+        }
+    }
+
+    /// <summary>Snapshot restore hook (single-threaded at startup).</summary>
+    public void Restore(IEnumerable<UserBotCredentialSnapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+        lock (_gate)
+        {
+            _byId.Clear();
+            _byShortId.Clear();
+            foreach (var s in snapshots)
+            {
+                var c = new UserBotCredential(
+                    s.Id, s.UserId, s.CredShortId, s.Label, s.SecretHash,
+                    s.CreatedAtUtc, s.RevokedAtUtc);
+                _byId[c.Id] = c;
+                _byShortId[c.CredShortId] = c;
+            }
+        }
+    }
+
+    /// <summary>Replay hook for <see cref="UserBotCredentialCreatedEvent"/>.</summary>
+    internal void ApplyCreated(UserBotCredential credential)
+    {
+        lock (_gate)
+        {
+            _byId[credential.Id] = credential;
+            _byShortId[credential.CredShortId] = credential;
+        }
+    }
+
+    /// <summary>Replay hook for <see cref="UserBotCredentialRevokedEvent"/>.</summary>
+    internal void ApplyRevoked(Guid credentialId, DateTimeOffset revokedAtUtc)
+    {
+        lock (_gate)
+        {
+            if (!_byId.TryGetValue(credentialId, out var existing)) return;
+            var updated = existing with { RevokedAtUtc = revokedAtUtc };
+            _byId[credentialId] = updated;
+            _byShortId[updated.CredShortId] = updated;
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>b3t_&lt;shortId&gt;_&lt;secret&gt;</c>. Uses the fixed
+    /// <see cref="ShortIdChars"/> length rather than splitting on the
+    /// first <c>_</c> because base64url-encoded secrets legitimately
+    /// contain <c>_</c> characters.
+    /// </summary>
+    internal static bool TryParseToken(string token, out string shortId, out string secret)
+    {
+        shortId = string.Empty;
+        secret = string.Empty;
+        if (string.IsNullOrEmpty(token)) return false;
+        if (!token.StartsWith(TokenPrefix, StringComparison.Ordinal)) return false;
+
+        var rest = token.AsSpan(TokenPrefix.Length);
+        // shortId + '_' + at least one secret char
+        if (rest.Length < ShortIdChars + 2) return false;
+        if (rest[ShortIdChars] != '_') return false;
+
+        shortId = rest[..ShortIdChars].ToString();
+        secret = rest[(ShortIdChars + 1)..].ToString();
+        return true;
+    }
+
+    private static string MintShortId()
+    {
+        // 8 random bytes → 11 base64url chars; trim to fixed ShortIdChars
+        // length. ≈60 bits of entropy is plenty for an O(N) lookup table
+        // that holds at most a few credentials per user.
+        Span<byte> bytes = stackalloc byte[8];
+        RandomNumberGenerator.Fill(bytes);
+        return Base64Url(bytes)[..ShortIdChars];
+    }
+
+    private static string MintSecret()
+    {
+        // 24 random bytes → 32 base64url chars (≈192 bits). bcrypt-cost-12
+        // verify on the listener side gates brute force.
+        Span<byte> bytes = stackalloc byte[24];
+        RandomNumberGenerator.Fill(bytes);
+        return Base64Url(bytes);
+    }
+
+    private static string Base64Url(ReadOnlySpan<byte> bytes)
+    {
+        var s = Convert.ToBase64String(bytes);
+        return s.Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+}

--- a/backend/src/B3.Trading.Application/UserBots/UserBotCredential.cs
+++ b/backend/src/B3.Trading.Application/UserBots/UserBotCredential.cs
@@ -1,0 +1,39 @@
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Persistent registration of a user-issued bot credential
+/// (RFC user-bot-fixp-listener-v0 §4.5, sub-issue #169).
+/// The plaintext PAT secret is shown to the caller exactly once at
+/// creation time and is never retained by the platform — only the
+/// bcrypt(cost=12) <see cref="SecretHash"/> is persisted to the WAL
+/// and snapshot store. <see cref="CredShortId"/> is the public
+/// identifier embedded in the PAT (<c>b3t_&lt;shortId&gt;_&lt;secret&gt;</c>)
+/// so the FIXP listener (sub-issue D) can locate the matching record
+/// in O(1) without scanning every credential.
+/// </summary>
+/// <remarks>
+/// <see cref="UserId"/> is the JWT <c>sub</c> claim of the human user
+/// that created this credential. The wider RFC text refers to a
+/// <c>UserId</c> "Guid" but the platform has no Guid user identifier;
+/// the <c>sub</c>-string convention is the same one used by every
+/// other per-user surface (cash ledger, positions, kill-switch).
+/// Sub-issue D's listener must look up the human owner via this field.
+/// </remarks>
+public sealed record UserBotCredential(
+    Guid Id,
+    string UserId,
+    string CredShortId,
+    string Label,
+    string SecretHash,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? RevokedAtUtc = null);
+
+/// <summary>
+/// One-shot DTO returned by <see cref="IUserBotCredentialRegistry.CreateAsync"/>.
+/// Carries the plaintext PAT (<see cref="PlainToken"/>) for the caller
+/// to display once. Subsequent reads via <c>ListByUser</c> never expose
+/// this field — the registry only stores the bcrypt hash.
+/// </summary>
+public sealed record CreatedUserBotCredential(
+    UserBotCredential Credential,
+    string PlainToken);

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -11,6 +11,7 @@ using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using B3.Trading.Host.Observability;
 using B3.Trading.Host.MarketData;
@@ -97,6 +98,9 @@ builder.Services.AddSingleton<AlgoBook>();
 builder.Services.AddSingleton<AlgoIdRegistry>();
 builder.Services.AddSingleton<PositionKeeper>();
 builder.Services.AddSingleton<CashLedger>();
+builder.Services.AddSingleton<InMemoryUserBotCredentialRegistry>();
+builder.Services.AddSingleton<IUserBotCredentialRegistry>(sp =>
+    sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
@@ -613,6 +617,7 @@ app.MapAlgo();
 app.MapPositions();
 app.MapBalance();
 app.MapAdmin();
+app.MapUserBotCredentials();
 app.MapWebSocketHub();
 
 app.Run();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -1,6 +1,7 @@
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 
 namespace B3.Trading.Infrastructure.Persistence;
@@ -24,6 +25,7 @@ public sealed class StateSnapshotter
     private readonly AlgoBook _algos;
     private readonly AlgoIdRegistry _algoIds;
     private readonly CashLedger _cash;
+    private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -35,7 +37,8 @@ public sealed class StateSnapshotter
         OrderOwnershipMap ownership,
         AlgoBook algos,
         AlgoIdRegistry algoIds,
-        CashLedger cash)
+        CashLedger cash,
+        InMemoryUserBotCredentialRegistry? userBotCredentials = null)
     {
         _orders = orders;
         _positions = positions;
@@ -47,6 +50,7 @@ public sealed class StateSnapshotter
         _algos = algos;
         _algoIds = algoIds;
         _cash = cash;
+        _userBotCredentials = userBotCredentials;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -67,6 +71,7 @@ public sealed class StateSnapshotter
         Algos = _algos.Snapshot().ToList(),
         AlgoIds = _algoIds.Snapshot(),
         CashBalances = _cash.Snapshot().ToList(),
+        UserBotCredentials = _userBotCredentials?.Snapshot().ToList() ?? new(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -88,6 +93,7 @@ public sealed class StateSnapshotter
         _algos.Restore(snap.Algos);
         _algoIds.Restore(snap.AlgoIds);
         _cash.Restore(snap.CashBalances);
+        _userBotCredentials?.Restore(snap.UserBotCredentials);
     }
 }
 
@@ -110,6 +116,7 @@ public sealed class EventReplayer
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly AlgoIdRegistry _algoIds;
     private readonly PendingReplacementRegistry? _replacements;
+    private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -121,7 +128,8 @@ public sealed class EventReplayer
         AlgoBook algos,
         ClOrdIdPrefixRegistry clOrdIds,
         AlgoIdRegistry algoIds,
-        PendingReplacementRegistry? replacements = null)
+        PendingReplacementRegistry? replacements = null,
+        InMemoryUserBotCredentialRegistry? userBotCredentials = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -133,6 +141,7 @@ public sealed class EventReplayer
         _clOrdIds = clOrdIds;
         _algoIds = algoIds;
         _replacements = replacements;
+        _userBotCredentials = userBotCredentials;
     }
 
     public void Apply(WalEvent evt)
@@ -263,6 +272,14 @@ public sealed class EventReplayer
             case OrderStaleClearedEvent osc:
                 if (_orders.TryGet(osc.ClOrdId, out var clearOrd) && clearOrd is not null)
                     clearOrd.ClearStale();
+                break;
+            case UserBotCredentialCreatedEvent ubc:
+                _userBotCredentials?.ApplyCreated(new UserBotCredential(
+                    ubc.Id, ubc.UserId, ubc.CredShortId, ubc.Label, ubc.SecretHash,
+                    ubc.CreatedAtUtc, RevokedAtUtc: null));
+                break;
+            case UserBotCredentialRevokedEvent ubr:
+                _userBotCredentials?.ApplyRevoked(ubr.Id, ubr.RevokedAtUtc);
                 break;
         }
     }

--- a/backend/tests/B3.Trading.Api.Tests/UserBotCredentialsEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/UserBotCredentialsEndpointsTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Application.UserBots;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// REST integration tests for <c>/api/user-bot-credentials</c>
+/// (sub-issue C, RFC §4.5). Covers auth gating, the create-then-list
+/// secret-shown-once contract, soft revoke, and cross-user isolation.
+/// </summary>
+public class UserBotCredentialsEndpointsTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+
+    public UserBotCredentialsEndpointsTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Unauthenticated_ReturnsUnauthorized_OnAllVerbs()
+    {
+        var client = _factory.CreateClient();
+
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await client.GetAsync("/api/user-bot-credentials")).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await client.PostAsJsonAsync("/api/user-bot-credentials", new { label = "x" })).StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized,
+            (await client.DeleteAsync($"/api/user-bot-credentials/{Guid.NewGuid()}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateListRevoke_HappyPath()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var createResp = await client.PostAsJsonAsync(
+            "/api/user-bot-credentials", new CreateUserBotCredentialRequest("morning bot"));
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<CreatedUserBotCredentialDto>();
+        Assert.NotNull(created);
+        Assert.StartsWith("b3t_", created!.PlainSecret);
+        Assert.Equal("morning bot", created.Label);
+        Assert.Contains(created.CredShortId, created.PlainSecret);
+
+        var list = await client.GetFromJsonAsync<List<UserBotCredentialDto>>("/api/user-bot-credentials");
+        Assert.NotNull(list);
+        var entry = Assert.Single(list!);
+        Assert.Equal(created.Id, entry.Id);
+        Assert.Equal(created.CredShortId, entry.CredShortId);
+        Assert.Null(entry.RevokedAt);
+
+        var del = await client.DeleteAsync($"/api/user-bot-credentials/{created.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var afterRevoke = await client.GetFromJsonAsync<List<UserBotCredentialDto>>("/api/user-bot-credentials");
+        Assert.NotNull(afterRevoke!.Single().RevokedAt);
+
+        // Re-revoke is 404 (registry returns false on the no-op).
+        var redel = await client.DeleteAsync($"/api/user-bot-credentials/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, redel.StatusCode);
+    }
+
+    [Fact]
+    public async Task ListResponse_NeverIncludesSecretFields()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var createResp = await client.PostAsJsonAsync(
+            "/api/user-bot-credentials", new CreateUserBotCredentialRequest("scan bot"));
+        var created = await createResp.Content.ReadFromJsonAsync<CreatedUserBotCredentialDto>();
+
+        var raw = await client.GetStringAsync("/api/user-bot-credentials");
+        Assert.DoesNotContain("plainSecret", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secretHash", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(created!.PlainSecret, raw);
+    }
+
+    [Fact]
+    public async Task CrossUser_IsolationIsEnforced()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var alice = await factory.CreateAuthedClientAsync(TestAppFactory.TestUser);
+        var bob = await factory.CreateAuthedClientAsync("bob");
+
+        var aliceCreate = await alice.PostAsJsonAsync(
+            "/api/user-bot-credentials", new CreateUserBotCredentialRequest("alice's bot"));
+        var aliceCred = await aliceCreate.Content.ReadFromJsonAsync<CreatedUserBotCredentialDto>();
+
+        var bobList = await bob.GetFromJsonAsync<List<UserBotCredentialDto>>("/api/user-bot-credentials");
+        Assert.Empty(bobList!);
+
+        var bobRevokeAttempt = await bob.DeleteAsync($"/api/user-bot-credentials/{aliceCred!.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, bobRevokeAttempt.StatusCode);
+
+        var registry = factory.Services.GetRequiredService<IUserBotCredentialRegistry>();
+        Assert.NotNull(await registry.TryAuthenticateAsync(aliceCred.PlainSecret, default));
+    }
+
+    [Fact]
+    public async Task Create_RejectsBlankAndOversizedLabel()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var blank = await client.PostAsJsonAsync(
+            "/api/user-bot-credentials", new CreateUserBotCredentialRequest("   "));
+        Assert.Equal(HttpStatusCode.BadRequest, blank.StatusCode);
+
+        var oversized = new string('x', UserBotCredentialsEndpoints.MaxLabelLength + 1);
+        var big = await client.PostAsJsonAsync(
+            "/api/user-bot-credentials", new CreateUserBotCredentialRequest(oversized));
+        Assert.Equal(HttpStatusCode.BadRequest, big.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
@@ -1,0 +1,259 @@
+using System.Threading;
+using System.Threading.Tasks;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryUserBotCredentialRegistry"/>
+/// (sub-issue #169). Covers PAT shape, bcrypt persistence, list scoping,
+/// soft-revoke semantics, malformed-token rejection, and
+/// snapshot/WAL-replay reconstruction.
+/// </summary>
+public class InMemoryUserBotCredentialRegistryTests
+{
+    private static InMemoryUserBotCredentialRegistry Reg() => new();
+
+    [Fact]
+    public async Task Create_ReturnsPlainTokenInExpectedShape()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "morning bot", default);
+
+        Assert.StartsWith("b3t_", c.PlainToken);
+        Assert.Matches(@"^b3t_[A-Za-z0-9_\-]{10}_[A-Za-z0-9_\-]{32}$", c.PlainToken);
+        Assert.Equal(c.Credential.CredShortId, c.PlainToken.Substring(4, 10));
+        Assert.Equal("morning bot", c.Credential.Label);
+        Assert.Equal("alice", c.Credential.UserId);
+        Assert.Null(c.Credential.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Create_DoesNotPersistPlaintextSecret()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+
+        // Bcrypt hash on the credential — not the secret itself.
+        Assert.StartsWith("$2", c.Credential.SecretHash);
+        var split = c.PlainToken.Split('_', 3);
+        Assert.Equal(3, split.Length);
+        var plainSecret = split[2];
+        Assert.DoesNotContain(plainSecret, c.Credential.SecretHash);
+    }
+
+    [Fact]
+    public async Task ListByUser_OnlyReturnsCallersCredentials()
+    {
+        var r = Reg();
+        var a1 = await r.CreateAsync("alice", "a1", default);
+        await Task.Delay(2); // keep ordering stable across timestamps
+        var a2 = await r.CreateAsync("alice", "a2", default);
+        var b1 = await r.CreateAsync("bob", "b1", default);
+
+        var alice = r.ListByUser("alice");
+        Assert.Equal(2, alice.Count);
+        Assert.All(alice, c => Assert.Equal("alice", c.UserId));
+        Assert.Contains(alice, c => c.Id == a1.Credential.Id);
+        Assert.Contains(alice, c => c.Id == a2.Credential.Id);
+
+        var bob = r.ListByUser("bob");
+        Assert.Single(bob, c => c.Id == b1.Credential.Id);
+    }
+
+    [Fact]
+    public async Task ListByUser_IncludesRevokedRows()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+        Assert.True(await r.RevokeAsync("alice", c.Credential.Id, default));
+
+        var rows = r.ListByUser("alice");
+        var row = Assert.Single(rows);
+        Assert.NotNull(row.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Revoke_OtherUsersCredential_ReturnsFalseAndDoesNotMutate()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+
+        Assert.False(await r.RevokeAsync("bob", c.Credential.Id, default));
+
+        var alice = Assert.Single(r.ListByUser("alice"));
+        Assert.Null(alice.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Revoke_UnknownId_ReturnsFalse()
+    {
+        var r = Reg();
+        Assert.False(await r.RevokeAsync("alice", Guid.NewGuid(), default));
+    }
+
+    [Fact]
+    public async Task Revoke_TwiceReturnsFalseSecondTime()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+        Assert.True(await r.RevokeAsync("alice", c.Credential.Id, default));
+        Assert.False(await r.RevokeAsync("alice", c.Credential.Id, default));
+    }
+
+    [Fact]
+    public async Task TryAuthenticate_ResolvesValidToken()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+
+        var auth = await r.TryAuthenticateAsync(c.PlainToken, default);
+        Assert.NotNull(auth);
+        Assert.Equal(c.Credential.Id, auth!.Id);
+    }
+
+    [Fact]
+    public async Task TryAuthenticate_RejectsRevokedCredential()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+        await r.RevokeAsync("alice", c.Credential.Id, default);
+
+        Assert.Null(await r.TryAuthenticateAsync(c.PlainToken, default));
+    }
+
+    [Fact]
+    public async Task TryAuthenticate_RejectsWrongSecretForKnownShortId()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+        var split = c.PlainToken.Split('_', 3);
+        var bad = $"{split[0]}_{split[1]}_{new string('A', split[2].Length)}";
+
+        Assert.Null(await r.TryAuthenticateAsync(bad, default));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-token")]
+    [InlineData("b3t_short")]
+    [InlineData("b3t_aaaaaaaaaa")] // 10 char shortId but no '_' separator + secret
+    [InlineData("b3t_aaaaaaaaaaXsecret")] // wrong separator at position 10
+    public async Task TryAuthenticate_RejectsMalformedTokens(string token)
+    {
+        var r = Reg();
+        await r.CreateAsync("alice", "x", default); // populate registry
+
+        Assert.Null(await r.TryAuthenticateAsync(token, default));
+    }
+
+    [Fact]
+    public async Task TryAuthenticate_RejectsUnknownShortId()
+    {
+        var r = Reg();
+        await r.CreateAsync("alice", "x", default);
+
+        var unknown = "b3t_AAAAAAAAAA_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        Assert.Null(await r.TryAuthenticateAsync(unknown, default));
+    }
+
+    [Fact]
+    public void TryParseToken_RoundTripsSecretContainingUnderscore()
+    {
+        // Secret half is base64url and may contain '_'. Parser must
+        // not split on first '_' (regression: original IndexOf split
+        // truncated such secrets).
+        var token = "b3t_ABCDEFGHIJ_secret_with_underscores_xyz";
+        Assert.True(InMemoryUserBotCredentialRegistry.TryParseToken(token, out var sid, out var sec));
+        Assert.Equal("ABCDEFGHIJ", sid);
+        Assert.Equal("secret_with_underscores_xyz", sec);
+    }
+
+    [Fact]
+    public async Task SnapshotRoundTrip_PreservesAllRows()
+    {
+        var src = Reg();
+        var c1 = await src.CreateAsync("alice", "a1", default);
+        var c2 = await src.CreateAsync("alice", "a2", default);
+        var c3 = await src.CreateAsync("bob", "b1", default);
+        await src.RevokeAsync("alice", c1.Credential.Id, default);
+
+        var snap = src.Snapshot();
+        Assert.Equal(3, snap.Count);
+
+        var dst = Reg();
+        dst.Restore(snap);
+
+        Assert.Equal(2, dst.ListByUser("alice").Count);
+        Assert.Single(dst.ListByUser("bob"));
+
+        // Auth still works post-restore for the un-revoked row.
+        Assert.NotNull(await dst.TryAuthenticateAsync(c2.PlainToken, default));
+        Assert.Null(await dst.TryAuthenticateAsync(c1.PlainToken, default));
+        Assert.NotNull(await dst.TryAuthenticateAsync(c3.PlainToken, default));
+    }
+
+    [Fact]
+    public async Task EventReplay_ReconstructsRegistryFromWal()
+    {
+        // Mint via a registry wired to a real EventDispatcher so the
+        // WAL is populated, then replay those events into a brand-new
+        // registry via the internal Apply hooks. The reconstructed
+        // state must authenticate the original tokens.
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var producer = new InMemoryUserBotCredentialRegistry(dispatcher);
+
+        var c1 = await producer.CreateAsync("alice", "a1", default);
+        var c2 = await producer.CreateAsync("bob", "b1", default);
+        await producer.RevokeAsync("alice", c1.Credential.Id, default);
+
+        var consumer = new InMemoryUserBotCredentialRegistry();
+        foreach (var e in store.Events)
+        {
+            switch (e)
+            {
+                case UserBotCredentialCreatedEvent created:
+                    consumer.ApplyCreated(new UserBotCredential(
+                        created.Id, created.UserId, created.CredShortId, created.Label,
+                        created.SecretHash, created.CreatedAtUtc, RevokedAtUtc: null));
+                    break;
+                case UserBotCredentialRevokedEvent revoked:
+                    consumer.ApplyRevoked(revoked.Id, revoked.RevokedAtUtc);
+                    break;
+            }
+        }
+
+        var aliceRows = consumer.ListByUser("alice");
+        Assert.Single(aliceRows);
+        Assert.NotNull(aliceRows[0].RevokedAtUtc);
+
+        Assert.Null(await consumer.TryAuthenticateAsync(c1.PlainToken, default));
+        Assert.NotNull(await consumer.TryAuthenticateAsync(c2.PlainToken, default));
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        public List<WalEvent> Events { get; } = new();
+        public long CurrentSeq { get; private set; }
+        public long Append(WalEvent evt)
+        {
+            Events.Add(evt);
+            return ++CurrentSeq;
+        }
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.Yield();
+            for (var i = 0; i < Events.Count; i++)
+            {
+                var seq = i + 1;
+                if (seq > sinceSeqExclusive) yield return (seq, Events[i]);
+            }
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #169. Sub-issue C of #166 / RFC `docs/rfcs/user-bot-fixp-listener-v0.md` §4.5.

## What ships

**Domain (`B3.Trading.Application/UserBots/`)**
- `UserBotCredential` record + `IUserBotCredentialRegistry`.
- `InMemoryUserBotCredentialRegistry`:
  - bcrypt(cost=12) hash on create; plaintext PAT shown to caller exactly once.
  - PAT format `b3t_<10-char shortId>_<32-char base64url secret>`.
  - `TryParseToken` parses by fixed length — base64url secrets may legitimately contain `_`, so `IndexOf('_')` would truncate.
  - bcrypt verify happens **outside** the registry lock so the listener (sub-issue D) hot path doesn't serialise.
  - Cross-user revoke is indistinguishable from missing (404 either way) — no credential-id oracle.

**Persistence**
- `UserBotCredentialCreatedEvent` / `UserBotCredentialRevokedEvent` WAL records with `JsonDerivedType` discriminators `userbot.cred.created` / `userbot.cred.revoked`.
- `PlatformSnapshot.UserBotCredentials` list + matching snapshot record.
- `StateSnapshotter` and `EventReplayer` extended via **optional** ctor params (`InMemoryUserBotCredentialRegistry? = null`) so existing direct-construction tests stay green; DI auto-injects when registered.

**REST (`B3.Trading.Api/UserBotCredentialsEndpoints.cs`)**
- POST/GET/DELETE under `/api/user-bot-credentials`.
- `[Authorize]` group, resolves user via JWT `sub`.
- POST returns plaintext secret once; GET never includes secret material.
- Label trimmed and capped at 128 chars.

**Tests**
- 19 Application unit tests: PAT shape, bcrypt persistence, list scoping, revoke semantics, malformed/unknown/wrong-secret rejection, snapshot round-trip, WAL replay reconstruction, **regression** for secrets containing `_`.
- 5 Api integration tests: 401 unauthenticated, happy-path create/list/revoke, secret never echoed in list, cross-user isolation, label validation.

## Intentionally out of scope
- FIXP wiring on `Negotiate` — that's sub-issue D.
- Frontend UI — deferred (the REST surface is the primary deliverable; UI work tracked separately under #166 if desired).

## Deviation from task spec
The RFC text describes `UserId` as a `Guid`, but **the platform has no Guid user identifier**. Auth is JWT `sub` (string), the same convention used by every other per-user surface (cash ledger, positions, kill-switch). The field is therefore `string UserId` here, and sub-issue D's listener should resolve the human owner via this string.

## Verification
- `dotnet test B3TradingPlatform.slnx -c Release` — **all green** (445 Application + 203 Api + others).
- `dotnet format --verify-no-changes B3TradingPlatform.slnx` — clean.

Refs #166.