### PR TITLE
feat(fixp): skeleton FIXP listener + handshake (#168)

### DIFF
--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -5,6 +5,7 @@
     <Project Path="backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj" />
     <Project Path="backend/src/B3.Trading.Api/B3.Trading.Api.csproj" />
     <Project Path="backend/src/B3.Trading.Host/B3.Trading.Host.csproj" />
+    <Project Path="backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj" />
   </Folder>
   <Folder Name="/backend/tests/">
     <Project Path="backend/tests/B3.Trading.Domain.Tests/B3.Trading.Domain.Tests.csproj" />
@@ -12,6 +13,7 @@
     <Project Path="backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj" />
     <Project Path="backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj" />
+    <Project Path="backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj" />
   </Folder>
   <Folder Name="/backend/tools/">
     <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />

--- a/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
+++ b/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Trading.EntryPointListener</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="B3.EntryPoint.Sbe" Version="0.14.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Trading.EntryPointListener.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerBootGuard.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerBootGuard.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Hosting;
+
+namespace B3.Trading.EntryPointListener;
+
+/// <summary>
+/// Production safeguard for the inbound FIXP listener.  Mirrors the shape
+/// of <c>ErInjectionBootGuard</c>: pure static, no DI dependencies,
+/// unit-testable in isolation.
+///
+/// <para>
+/// The listener has catastrophic blast radius if exposed in Production
+/// without TLS — any network client could send orders as any platform user.
+/// Therefore the host refuses to boot when
+/// <c>Enabled=true + Environment=Production</c> unless the operator has
+/// explicitly opted in via <see cref="EntryPointListenerOptions.AllowInProduction"/>
+/// AND has configured TLS (<see cref="EntryPointListenerOptions.TlsOptions.Required"/>
+/// plus valid cert/key paths).
+/// </para>
+/// </summary>
+public static class EntryPointListenerBootGuard
+{
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> when the listener is
+    /// enabled in Production without the full safety set.  No-op when
+    /// disabled or when the environment is not Production.
+    /// </summary>
+    public static void Validate(string environmentName, EntryPointListenerOptions opts)
+    {
+        if (!opts.Enabled) return;
+
+        var isProduction = string.Equals(
+            environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase);
+
+        if (!isProduction) return;
+
+        if (!opts.AllowInProduction)
+        {
+            throw new InvalidOperationException(
+                "Trading:EntryPointListener:Enabled=true is not allowed in Production without " +
+                "Trading:EntryPointListener:AllowInProduction=true. " +
+                "Additionally, Tls.Required=true and valid Tls.CertPath/KeyPath are required.");
+        }
+
+        if (!opts.Tls.Required)
+        {
+            throw new InvalidOperationException(
+                "Trading:EntryPointListener:Enabled=true in Production requires " +
+                "Trading:EntryPointListener:Tls:Required=true. " +
+                "Serving unencrypted FIXP sessions in Production is not permitted.");
+        }
+
+        if (string.IsNullOrWhiteSpace(opts.Tls.CertPath) || string.IsNullOrWhiteSpace(opts.Tls.KeyPath))
+        {
+            throw new InvalidOperationException(
+                "Trading:EntryPointListener:Enabled=true in Production requires non-empty " +
+                "Trading:EntryPointListener:Tls:CertPath and Tls:KeyPath.");
+        }
+    }
+
+    /// <summary>
+    /// Returns a multi-line boot-time warning banner when the listener is
+    /// active. Returns <c>null</c> when disabled so the caller can skip
+    /// the log call entirely.
+    /// </summary>
+    public static string? BuildWarning(string environmentName, EntryPointListenerOptions opts)
+    {
+        if (!opts.Enabled) return null;
+
+        var isProduction = string.Equals(
+            environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase);
+
+        var tlsNote = opts.Tls.Required
+            ? " TLS.Required=true (in-socket TLS not yet active — serving plaintext; see sub-issue E)."
+            : " ⚠ TLS.Required=false — listener is serving PLAINTEXT. Do NOT use in Production.";
+
+        var prodNote = isProduction
+            ? " ‼ PRODUCTION ENVIRONMENT — AllowInProduction=true is set. Verify TLS configuration."
+            : string.Empty;
+
+        return "⚠ FIXP LISTENER ENABLED on " + opts.Endpoint + "." + tlsNote + prodNote +
+               " Auth is STUBBED (always-accept). Real auth added in sub-issue C.";
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
@@ -1,0 +1,47 @@
+namespace B3.Trading.EntryPointListener;
+
+/// <summary>
+/// Configuration for the inbound FIXP/SBE listener that lets external bots
+/// connect to the trading-host using native B3 EntryPoint protocol.
+/// </summary>
+public sealed class EntryPointListenerOptions
+{
+    public const string SectionName = "Trading:EntryPointListener";
+
+    /// <summary>Whether the FIXP listener is enabled at all.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Bind address in <c>host:port</c> form. Use <c>*:port</c> or
+    /// <c>0.0.0.0:port</c> to bind on all interfaces. Port 0 lets the OS
+    /// pick a free port (useful in tests).
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>TLS configuration for the listener socket.</summary>
+    public TlsOptions Tls { get; set; } = new();
+
+    /// <summary>
+    /// Explicit opt-in required for <c>Environment=Production</c>.
+    /// Must be combined with <see cref="TlsOptions.Required"/>=true and
+    /// valid cert/key paths to satisfy the boot guard.
+    /// </summary>
+    public bool AllowInProduction { get; set; }
+
+    /// <summary>Nested TLS configuration.</summary>
+    public sealed class TlsOptions
+    {
+        /// <summary>Path to the PEM certificate file.</summary>
+        public string? CertPath { get; set; }
+
+        /// <summary>Path to the PEM private-key file.</summary>
+        public string? KeyPath { get; set; }
+
+        /// <summary>
+        /// When true the host refuses to serve unencrypted sessions.
+        /// TLS in-socket is deferred to sub-issue E; the boot guard
+        /// enforces this flag but no <c>SslStream</c> wrapping occurs yet.
+        /// </summary>
+        public bool Required { get; set; }
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptionsValidator.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptionsValidator.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener;
+
+/// <summary>
+/// Eager-fail validation for <see cref="EntryPointListenerOptions"/>.
+/// Registered via <see cref="EntryPointListenerServiceCollectionExtensions.AddEntryPointListener"/>.
+/// </summary>
+public sealed class EntryPointListenerOptionsValidator : IValidateOptions<EntryPointListenerOptions>
+{
+    public ValidateOptionsResult Validate(string? name, EntryPointListenerOptions options)
+    {
+        if (options is null)
+            return ValidateOptionsResult.Fail("EntryPointListenerOptions is null.");
+
+        if (!options.Enabled)
+            return ValidateOptionsResult.Success;
+
+        if (string.IsNullOrWhiteSpace(options.Endpoint))
+            return ValidateOptionsResult.Fail(
+                "Trading:EntryPointListener:Endpoint must be set when Enabled=true.");
+
+        if (!TryParseEndpoint(options.Endpoint, out _))
+            return ValidateOptionsResult.Fail(
+                $"Trading:EntryPointListener:Endpoint '{options.Endpoint}' is not a valid " +
+                "IP-literal endpoint. Use 'ip:port', '*:port', or '[ipv6]:port'. DNS names are not accepted.");
+
+        if (options.Tls.Required)
+        {
+            var failures = new List<string>();
+            if (string.IsNullOrWhiteSpace(options.Tls.CertPath))
+                failures.Add("Trading:EntryPointListener:Tls:CertPath must be set when Tls:Required=true.");
+            if (string.IsNullOrWhiteSpace(options.Tls.KeyPath))
+                failures.Add("Trading:EntryPointListener:Tls:KeyPath must be set when Tls:Required=true.");
+            if (!string.IsNullOrWhiteSpace(options.Tls.CertPath) && !File.Exists(options.Tls.CertPath))
+                failures.Add($"Trading:EntryPointListener:Tls:CertPath '{options.Tls.CertPath}' does not exist.");
+            if (!string.IsNullOrWhiteSpace(options.Tls.KeyPath) && !File.Exists(options.Tls.KeyPath))
+                failures.Add($"Trading:EntryPointListener:Tls:KeyPath '{options.Tls.KeyPath}' does not exist.");
+            if (failures.Count > 0)
+                return ValidateOptionsResult.Fail(failures);
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+
+    /// <summary>
+    /// Parses an endpoint string into an <see cref="IPEndPoint"/>.
+    /// Accepts IPv4 literals (<c>192.168.1.1:5001</c>), IPv6 literals
+    /// (<c>[::1]:5001</c>), wildcard (<c>*:5001</c> / <c>0.0.0.0:5001</c>
+    /// / <c>:::5001</c>), and port zero for OS-assigned ports.
+    /// DNS names are explicitly rejected.
+    /// </summary>
+    public static bool TryParseEndpoint(
+        string? input,
+        [NotNullWhen(true)] out IPEndPoint? endpoint)
+    {
+        endpoint = null;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+
+        string host;
+        int port;
+
+        if (input.StartsWith('['))
+        {
+            var closeBracket = input.IndexOf(']', StringComparison.Ordinal);
+            if (closeBracket < 0) return false;
+            if (closeBracket + 1 >= input.Length || input[closeBracket + 1] != ':') return false;
+            host = input[1..closeBracket];
+            if (!int.TryParse(input[(closeBracket + 2)..], out port)) return false;
+        }
+        else
+        {
+            var lastColon = input.LastIndexOf(':');
+            if (lastColon < 0) return false;
+            host = input[..lastColon];
+            if (!int.TryParse(input[(lastColon + 1)..], out port)) return false;
+        }
+
+        if (port is < 0 or > 65535) return false;
+
+        if (host is "*" or "0.0.0.0")
+        {
+            endpoint = new IPEndPoint(IPAddress.Any, port);
+            return true;
+        }
+
+        if (host is "::")
+        {
+            endpoint = new IPEndPoint(IPAddress.IPv6Any, port);
+            return true;
+        }
+
+        if (!IPAddress.TryParse(host, out var addr)) return false;
+
+        endpoint = new IPEndPoint(addr, port);
+        return true;
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener;
+
+/// <summary>
+/// IServiceCollection extension for wiring the FIXP listener into the host.
+/// </summary>
+public static class EntryPointListenerServiceCollectionExtensions
+{
+    /// <summary>
+    /// Binds <see cref="EntryPointListenerOptions"/> and — when
+    /// <c>Trading:EntryPointListener:Enabled=true</c> — registers
+    /// <see cref="Hosting.FixpListenerHostedService"/> as a hosted service.
+    /// </summary>
+    public static IServiceCollection AddEntryPointListener(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services
+            .AddOptions<EntryPointListenerOptions>()
+            .Bind(configuration.GetSection(EntryPointListenerOptions.SectionName))
+            .ValidateOnStart();
+
+        services.AddSingleton<IValidateOptions<EntryPointListenerOptions>,
+            EntryPointListenerOptionsValidator>();
+
+        var enabled = configuration
+            .GetSection(EntryPointListenerOptions.SectionName)
+            .GetValue<bool>("Enabled");
+
+        if (enabled)
+        {
+            services.AddSingleton<Hosting.FixpListenerHostedService>();
+            services.AddHostedService(sp =>
+                sp.GetRequiredService<Hosting.FixpListenerHostedService>());
+        }
+
+        return services;
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrame.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrame.cs
@@ -1,0 +1,42 @@
+namespace B3.Trading.EntryPointListener.Framing;
+
+/// <summary>
+/// A decoded SOFH-framed SBE message, returned by
+/// <see cref="SofhFrameReader.TryReadFrame"/>.
+/// The <see cref="Payload"/> span is valid until the next
+/// <see cref="SofhFrameReader.Append"/> call.
+/// </summary>
+internal readonly ref struct SofhFrame
+{
+    public SofhFrame(
+        ushort blockLength,
+        ushort templateId,
+        ushort schemaId,
+        ushort version,
+        ReadOnlySpan<byte> payload)
+    {
+        BlockLength = blockLength;
+        TemplateId = templateId;
+        SchemaId = schemaId;
+        Version = version;
+        Payload = payload;
+    }
+
+    /// <summary>SBE message block length (from the SBE message header).</summary>
+    public ushort BlockLength { get; }
+
+    /// <summary>SBE template ID — used for message dispatch.</summary>
+    public ushort TemplateId { get; }
+
+    /// <summary>SBE schema ID.</summary>
+    public ushort SchemaId { get; }
+
+    /// <summary>SBE schema version.</summary>
+    public ushort Version { get; }
+
+    /// <summary>
+    /// Bytes after the 8-byte SBE message header up to the end of the frame.
+    /// Length = messageLength − SofhHeaderSize(4) − SbeMessageHeaderSize(8).
+    /// </summary>
+    public ReadOnlySpan<byte> Payload { get; }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrameReader.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrameReader.cs
@@ -1,0 +1,121 @@
+using System.Buffers.Binary;
+
+namespace B3.Trading.EntryPointListener.Framing;
+
+/// <summary>
+/// Stateful byte accumulator that reassembles SOFH-framed SBE messages from
+/// an arbitrary stream of raw bytes (e.g. TCP segments that arrive in
+/// fragments or batches).
+///
+/// <para>Usage contract: call <see cref="Append"/> after every network read,
+/// then drain with <see cref="TryReadFrame"/> in a loop.  The
+/// <see cref="SofhFrame.Payload"/> span returned by <c>TryReadFrame</c> is
+/// valid until the next <c>Append</c> call.</para>
+/// </summary>
+internal sealed class SofhFrameReader
+{
+    private const int InitialCapacity = 4096;
+
+    private byte[] _buf = new byte[InitialCapacity];
+    private int _head; // index of first unread byte
+    private int _tail; // index past the last written byte
+
+    /// <summary>
+    /// Set when the reader encounters an unrecoverable framing error
+    /// (invalid encoding type, frame too small, frame too large).
+    /// The connection should be terminated immediately.
+    /// </summary>
+    public bool HasProtocolError { get; private set; }
+
+    /// <summary>Human-readable description of the first framing error, when any.</summary>
+    public string? ProtocolErrorMessage { get; private set; }
+
+    /// <summary>Copy <paramref name="data"/> into the internal buffer.</summary>
+    public void Append(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty) return;
+
+        var current = _tail - _head;
+        var available = _buf.Length - _tail;
+
+        if (available < data.Length)
+        {
+            // Try in-place compaction first when buffer is at least half-empty.
+            if (_head > 0 && _buf.Length - current >= data.Length)
+            {
+                _buf.AsSpan(_head, current).CopyTo(_buf);
+                _tail = current;
+                _head = 0;
+            }
+            else
+            {
+                var newSize = Math.Max(_buf.Length * 2, current + data.Length);
+                var newBuf = new byte[newSize];
+                _buf.AsSpan(_head, current).CopyTo(newBuf);
+                _tail = current;
+                _head = 0;
+                _buf = newBuf;
+            }
+        }
+
+        data.CopyTo(_buf.AsSpan(_tail));
+        _tail += data.Length;
+    }
+
+    /// <summary>
+    /// Attempts to read the next complete SOFH-framed message.
+    /// Returns <c>false</c> when more data is needed or a protocol error
+    /// occurred (check <see cref="HasProtocolError"/>).
+    /// The returned <see cref="SofhFrame.Payload"/> span is valid until
+    /// the next <see cref="Append"/> call.
+    /// </summary>
+    public bool TryReadFrame(out SofhFrame frame)
+    {
+        frame = default;
+        if (HasProtocolError) return false;
+
+        var dataLen = _tail - _head;
+        if (dataLen < SofhFraming.MinFrameSize) return false;
+
+        var span = _buf.AsSpan(_head, dataLen);
+
+        var messageLength = BinaryPrimitives.ReadUInt16LittleEndian(span);
+        var encodingType = BinaryPrimitives.ReadUInt16LittleEndian(span[2..]);
+
+        if (encodingType != SofhFraming.SbeLittleEndianEncodingType)
+        {
+            SetError($"Invalid SOFH encodingType 0x{encodingType:X4}; expected 0x{SofhFraming.SbeLittleEndianEncodingType:X4}.");
+            return false;
+        }
+
+        if (messageLength < SofhFraming.MinFrameSize)
+        {
+            SetError($"SOFH messageLength {messageLength} is less than minimum frame size {SofhFraming.MinFrameSize}.");
+            return false;
+        }
+
+        if (messageLength > SofhFraming.MaxFrameSize)
+        {
+            SetError($"SOFH messageLength {messageLength} exceeds maximum {SofhFraming.MaxFrameSize}.");
+            return false;
+        }
+
+        if (dataLen < messageLength) return false; // wait for more data
+
+        var blockLength = BinaryPrimitives.ReadUInt16LittleEndian(span[4..]);
+        var templateId = BinaryPrimitives.ReadUInt16LittleEndian(span[6..]);
+        var schemaId = BinaryPrimitives.ReadUInt16LittleEndian(span[8..]);
+        var version = BinaryPrimitives.ReadUInt16LittleEndian(span[10..]);
+        var payload = span[SofhFraming.MinFrameSize..messageLength];
+
+        frame = new SofhFrame(blockLength, templateId, schemaId, version, payload);
+        _head += messageLength;
+        return true;
+    }
+
+    private void SetError(string message)
+    {
+        HasProtocolError = true;
+        ProtocolErrorMessage = message;
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrameWriter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Framing/SofhFrameWriter.cs
@@ -1,0 +1,45 @@
+using System.Buffers.Binary;
+
+namespace B3.Trading.EntryPointListener.Framing;
+
+/// <summary>
+/// Helpers for writing SOFH-framed SBE messages into a destination buffer.
+/// All multi-byte fields are written little-endian per the B3 FIXP V6 spec.
+/// </summary>
+internal static class SofhFrameWriter
+{
+    /// <summary>Total byte count for a frame whose SBE body is <paramref name="sbeBodyLength"/> bytes.</summary>
+    public static int FrameSize(int sbeBodyLength)
+        => SofhFraming.SofhHeaderSize + SofhFraming.SbeMessageHeaderSize + sbeBodyLength;
+
+    /// <summary>
+    /// Writes only the 4-byte SOFH header (messageLength + encodingType) into
+    /// the start of <paramref name="destination"/>.
+    /// </summary>
+    public static void WriteHeader(Span<byte> destination, ushort messageLength)
+    {
+        BinaryPrimitives.WriteUInt16LittleEndian(destination, messageLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(destination[2..], SofhFraming.SbeLittleEndianEncodingType);
+    }
+
+    /// <summary>
+    /// Writes a complete SOFH-framed SBE message into <paramref name="destination"/>.
+    /// The destination must be at least <see cref="FrameSize"/>(<paramref name="body"/>.Length) bytes.
+    /// </summary>
+    public static void WriteFrame(
+        Span<byte> destination,
+        ushort blockLength,
+        ushort templateId,
+        ushort schemaId,
+        ushort version,
+        ReadOnlySpan<byte> body)
+    {
+        var messageLength = (ushort)(SofhFraming.SofhHeaderSize + SofhFraming.SbeMessageHeaderSize + body.Length);
+        WriteHeader(destination, messageLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(destination[4..], blockLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(destination[6..], templateId);
+        BinaryPrimitives.WriteUInt16LittleEndian(destination[8..], schemaId);
+        BinaryPrimitives.WriteUInt16LittleEndian(destination[10..], version);
+        body.CopyTo(destination[12..]);
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Framing/SofhFraming.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Framing/SofhFraming.cs
@@ -1,0 +1,20 @@
+namespace B3.Trading.EntryPointListener.Framing;
+
+/// <summary>Constants for the Simple Open Framing Header (SOFH) + SBE layout.</summary>
+internal static class SofhFraming
+{
+    /// <summary>Size of the SOFH prefix: 2-byte messageLength + 2-byte encodingType.</summary>
+    public const int SofhHeaderSize = 4;
+
+    /// <summary>Size of the SBE message header: 4 × uint16 (blockLength, templateId, schemaId, version).</summary>
+    public const int SbeMessageHeaderSize = 8;
+
+    /// <summary>SBE little-endian encoding type magic value embedded in the SOFH encodingType field.</summary>
+    public const ushort SbeLittleEndianEncodingType = 0xEB50;
+
+    /// <summary>Minimum valid frame size: SOFH + SBE header, zero-length payload.</summary>
+    public const int MinFrameSize = SofhHeaderSize + SbeMessageHeaderSize;
+
+    /// <summary>Maximum accepted frame size (prevents unbounded buffer growth on a malformed peer).</summary>
+    public const int MaxFrameSize = 16_384;
+}

--- a/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachine.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachine.cs
@@ -1,0 +1,85 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Trading.EntryPointListener.Handshake;
+
+/// <summary>
+/// Pure state machine for the FIXP V6 session-control handshake.
+/// One instance per connection; not thread-safe.
+///
+/// <para>Transitions per RFC §4.4:</para>
+/// <list type="bullet">
+///   <item>Idle      → Negotiated  on Negotiate (valid)</item>
+///   <item>Negotiated → Established on Establish (SessionId/VerID match)</item>
+///   <item>* → Terminated           on Terminate</item>
+/// </list>
+/// </summary>
+internal sealed class FixpHandshakeStateMachine
+{
+    private FixpSessionState _state = FixpSessionState.Idle;
+    private SessionID _sessionId;
+    private SessionVerID _sessionVerId;
+
+    public FixpSessionState State => _state;
+
+    /// <summary>Session ID echoed from the client's Negotiate — valid after first successful <see cref="OnNegotiate"/>.</summary>
+    public SessionID SessionId => _sessionId;
+
+    /// <summary>Session version ID echoed from the client's Negotiate — valid after first successful <see cref="OnNegotiate"/>.</summary>
+    public SessionVerID SessionVerId => _sessionVerId;
+
+    public HandshakeAction OnNegotiate(in NegotiateData msg)
+    {
+        switch (_state)
+        {
+            case FixpSessionState.Negotiated:
+            case FixpSessionState.Established:
+                return HandshakeAction.Terminate(TerminationCode.NEGOTIATION_IN_PROGRESS);
+
+            case FixpSessionState.Terminated:
+                return HandshakeAction.Terminate(TerminationCode.UNSPECIFIED);
+
+            default: // Idle
+                _sessionId = msg.SessionID;
+                _sessionVerId = msg.SessionVerID;
+                _state = FixpSessionState.Negotiated;
+                return HandshakeAction.SendNegotiateResponse;
+        }
+    }
+
+    public HandshakeAction OnEstablish(in EstablishData msg)
+    {
+        switch (_state)
+        {
+            case FixpSessionState.Idle:
+                return HandshakeAction.Terminate(TerminationCode.UNNEGOTIATED);
+
+            case FixpSessionState.Established:
+                return HandshakeAction.Terminate(TerminationCode.ESTABLISH_IN_PROGRESS);
+
+            case FixpSessionState.Terminated:
+                return HandshakeAction.Terminate(TerminationCode.UNSPECIFIED);
+
+            default: // Negotiated
+                if ((uint)msg.SessionID != (uint)_sessionId)
+                    return HandshakeAction.Terminate(TerminationCode.INVALID_SESSIONID);
+                if ((ulong)msg.SessionVerID != (ulong)_sessionVerId)
+                    return HandshakeAction.Terminate(TerminationCode.INVALID_SESSIONVERID);
+                _state = FixpSessionState.Established;
+                return HandshakeAction.SendEstablishAck;
+        }
+    }
+
+    public HandshakeAction OnTerminate(in TerminateData msg)
+    {
+        _ = msg.SessionID; // documented but not validated in stub; sub-issue C adds auth checks
+        _state = FixpSessionState.Terminated;
+        return HandshakeAction.AckTerminateAndClose;
+    }
+
+    /// <summary>
+    /// Called when an application-layer message arrives before the session
+    /// is established.  Always terminates with UNNEGOTIATED.
+    /// </summary>
+    public HandshakeAction OnApplicationMessageBeforeEstablished()
+        => HandshakeAction.Terminate(TerminationCode.UNNEGOTIATED);
+}

--- a/backend/src/B3.Trading.EntryPointListener/Handshake/FixpSessionState.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Handshake/FixpSessionState.cs
@@ -1,0 +1,17 @@
+namespace B3.Trading.EntryPointListener.Handshake;
+
+/// <summary>Per-connection FIXP session state machine states.</summary>
+public enum FixpSessionState
+{
+    /// <summary>No session negotiated yet — initial state.</summary>
+    Idle,
+
+    /// <summary>Negotiate accepted; awaiting Establish.</summary>
+    Negotiated,
+
+    /// <summary>Establish accepted; application messages may flow.</summary>
+    Established,
+
+    /// <summary>Terminate sent or received; connection is closing.</summary>
+    Terminated,
+}

--- a/backend/src/B3.Trading.EntryPointListener/Handshake/HandshakeAction.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Handshake/HandshakeAction.cs
@@ -1,0 +1,49 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Trading.EntryPointListener.Handshake;
+
+/// <summary>Discriminator for <see cref="HandshakeAction"/>.</summary>
+internal enum HandshakeActionKind
+{
+    SendNegotiateResponse,
+    SendEstablishAck,
+    AckTerminateAndClose,
+    Terminate,
+    NoOp,
+}
+
+/// <summary>
+/// Result of a state-machine transition — tells
+/// <c>FixpSessionConnection</c> what to send back on the wire.
+/// </summary>
+internal readonly struct HandshakeAction
+{
+    private HandshakeAction(HandshakeActionKind kind, TerminationCode termCode = default)
+    {
+        Kind = kind;
+        TermCode = termCode;
+    }
+
+    public HandshakeActionKind Kind { get; }
+
+    /// <summary>Only meaningful when <see cref="Kind"/> is <see cref="HandshakeActionKind.Terminate"/>.</summary>
+    public TerminationCode TermCode { get; }
+
+    public bool IsTerminating =>
+        Kind is HandshakeActionKind.AckTerminateAndClose or HandshakeActionKind.Terminate;
+
+    public static readonly HandshakeAction SendNegotiateResponse =
+        new(HandshakeActionKind.SendNegotiateResponse);
+
+    public static readonly HandshakeAction SendEstablishAck =
+        new(HandshakeActionKind.SendEstablishAck);
+
+    public static readonly HandshakeAction AckTerminateAndClose =
+        new(HandshakeActionKind.AckTerminateAndClose);
+
+    public static readonly HandshakeAction NoOp =
+        new(HandshakeActionKind.NoOp);
+
+    public static HandshakeAction Terminate(TerminationCode code) =>
+        new(HandshakeActionKind.Terminate, code);
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// <see cref="BackgroundService"/> that binds a <see cref="TcpListener"/>,
+/// accepts inbound FIXP connections, and dispatches each to a new
+/// <see cref="FixpSessionConnection"/> running on the thread-pool.
+///
+/// <para>The service is only registered when
+/// <c>Trading:EntryPointListener:Enabled=true</c>.</para>
+///
+/// <para>TLS in-socket is deferred to sub-issue E.  When
+/// <see cref="EntryPointListenerOptions.TlsOptions.Required"/> is set the
+/// boot guard has already enforced the configuration, but connections are
+/// still served over plaintext; a loud warning is logged at startup.</para>
+/// </summary>
+public sealed class FixpListenerHostedService : BackgroundService
+{
+    private readonly EntryPointListenerOptions _opts;
+    private readonly ILogger<FixpListenerHostedService> _logger;
+    private readonly TaskCompletionSource<IPEndPoint> _boundTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private TcpListener? _listener;
+
+    public FixpListenerHostedService(
+        IOptions<EntryPointListenerOptions> opts,
+        ILogger<FixpListenerHostedService> logger)
+    {
+        _opts = opts.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolves to the actual bound <see cref="IPEndPoint"/> (including
+    /// OS-assigned port when configured with port 0) once the service has
+    /// started listening.  Useful for integration tests.
+    /// </summary>
+    public Task<IPEndPoint> WhenBound => _boundTcs.Task;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!EntryPointListenerOptionsValidator.TryParseEndpoint(_opts.Endpoint, out var endpoint))
+        {
+            _logger.LogError("Cannot start FIXP listener: invalid endpoint '{Ep}'.", _opts.Endpoint);
+            _boundTcs.TrySetException(new InvalidOperationException(
+                $"Invalid FIXP listener endpoint '{_opts.Endpoint}'."));
+            return;
+        }
+
+        if (_opts.Tls.Required)
+        {
+            _logger.LogWarning(
+                "FIXP listener: Tls:Required=true but in-socket TLS is not yet implemented " +
+                "(sub-issue E). Serving PLAINTEXT on {Ep}. Do NOT expose to the public internet.",
+                endpoint);
+        }
+
+        _listener = new TcpListener(endpoint);
+        _listener.Start();
+
+        var bound = (IPEndPoint)_listener.LocalEndpoint;
+        _logger.LogInformation("FIXP listener bound on {Ep}.", bound);
+        _boundTcs.TrySetResult(bound);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "FIXP listener AcceptTcpClientAsync failed; retrying.");
+                    continue;
+                }
+
+                var sessionId = AllocateSessionId();
+                _logger.LogDebug("FIXP connection accepted; internalSessionId={Id}.", sessionId);
+
+                var conn = new FixpSessionConnection(client, _logger);
+                _ = Task.Run(() => conn.RunAsync(stoppingToken), stoppingToken);
+            }
+        }
+        finally
+        {
+            _listener.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Generates a random non-zero uint32 used as an internal connection
+    /// identifier for log correlation.  Sub-issue D will replace this with
+    /// a monotonic sequence-version manager.
+    /// </summary>
+    private static uint AllocateSessionId()
+    {
+        Span<byte> buf = stackalloc byte[4];
+        uint id;
+        do
+        {
+            RandomNumberGenerator.Fill(buf);
+            id = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf);
+        }
+        while (id == 0);
+        return id;
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -101,6 +101,7 @@ internal sealed class FixpSessionConnection
     private struct DecodedFrame
     {
         public ushort TemplateId;
+        public bool DecodeFailed;   // true when a known template has an undersized payload
         public uint SessionId;      // (uint)SessionID
         public ulong SessionVerId;  // (ulong)SessionVerID
         public TerminationCode TermCode;
@@ -134,6 +135,12 @@ internal sealed class FixpSessionConnection
                     d.TermCode = msg.TerminationCode;
                     break;
                 }
+            // Known handshake template with undersized payload — reject rather than dispatch zeroes.
+            case NegotiateData.MESSAGE_ID:
+            case EstablishData.MESSAGE_ID:
+            case TerminateData.MESSAGE_ID:
+                d.DecodeFailed = true;
+                break;
         }
 
         return d;
@@ -141,6 +148,9 @@ internal sealed class FixpSessionConnection
 
     private HandshakeAction Dispatch(in DecodedFrame d)
     {
+        if (d.DecodeFailed)
+            return HandshakeAction.Terminate(TerminationCode.UNSPECIFIED);
+
         switch (d.TemplateId)
         {
             case NegotiateData.MESSAGE_ID:

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -1,0 +1,331 @@
+using System.Buffers;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+using B3.Trading.EntryPointListener.Handshake;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Manages the FIXP session lifecycle for a single accepted TCP connection.
+/// Reads SOFH-framed SBE messages, drives <see cref="FixpHandshakeStateMachine"/>,
+/// and writes responses. Auth is stubbed (always-accept) in sub-issue B.
+/// </summary>
+internal sealed class FixpSessionConnection
+{
+    // SBE MessageHeader fields written into every outbound frame.
+    private const ushort SchemaIdV6 = 1;
+    private const ushort VersionNegotiateResponse = 6;
+    private const ushort VersionEstablishAck = 6;
+    private const ushort VersionTerminate = 0;
+
+    private readonly TcpClient _tcpClient;
+    private readonly ILogger _logger;
+    private readonly FixpHandshakeStateMachine _sm = new();
+
+    public FixpSessionConnection(TcpClient tcpClient, ILogger logger)
+    {
+        _tcpClient = tcpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Runs the connection loop until the peer closes the connection,
+    /// the handshake terminates, or <paramref name="ct"/> is cancelled.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct)
+    {
+        using var client = _tcpClient;
+        var stream = client.GetStream();
+        var reader = new SofhFrameReader();
+        var readBuf = ArrayPool<byte>.Shared.Rent(4096);
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                int n;
+                try
+                {
+                    n = await stream.ReadAsync(readBuf, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "FIXP connection read error; closing.");
+                    break;
+                }
+
+                if (n == 0) break; // peer closed connection
+
+                reader.Append(readBuf.AsSpan(0, n));
+
+                if (reader.HasProtocolError)
+                {
+                    _logger.LogWarning("FIXP framing error: {Msg}", reader.ProtocolErrorMessage);
+                    await BestEffortSendTerminateAsync(stream, TerminationCode.INVALID_SOFH, ct)
+                        .ConfigureAwait(false);
+                    break;
+                }
+
+                while (reader.TryReadFrame(out var frame))
+                {
+                    // Decode synchronously (frame.Payload span must not cross an await).
+                    var decoded = DecodeFrame(frame);
+                    var action = Dispatch(decoded);
+
+                    await SendResponseAsync(stream, action, decoded.SessionId, decoded.SessionVerId, ct)
+                        .ConfigureAwait(false);
+
+                    if (action.IsTerminating) return;
+                }
+
+                if (reader.HasProtocolError)
+                {
+                    await BestEffortSendTerminateAsync(stream, TerminationCode.INVALID_SOFH, ct)
+                        .ConfigureAwait(false);
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(readBuf);
+        }
+    }
+
+    // ─── Synchronous helpers (no await — spans are safe here) ────────────────
+
+    private struct DecodedFrame
+    {
+        public ushort TemplateId;
+        public uint SessionId;      // (uint)SessionID
+        public ulong SessionVerId;  // (ulong)SessionVerID
+        public TerminationCode TermCode;
+    }
+
+    private static DecodedFrame DecodeFrame(SofhFrame frame)
+    {
+        var d = new DecodedFrame { TemplateId = frame.TemplateId };
+
+        switch (frame.TemplateId)
+        {
+            case NegotiateData.MESSAGE_ID when frame.Payload.Length >= NegotiateData.BLOCK_LENGTH:
+                {
+                    var msg = MemoryMarshal.Read<NegotiateData>(frame.Payload);
+                    d.SessionId = (uint)msg.SessionID;
+                    d.SessionVerId = (ulong)msg.SessionVerID;
+                    break;
+                }
+            case EstablishData.MESSAGE_ID when frame.Payload.Length >= EstablishData.BLOCK_LENGTH:
+                {
+                    var msg = MemoryMarshal.Read<EstablishData>(frame.Payload);
+                    d.SessionId = (uint)msg.SessionID;
+                    d.SessionVerId = (ulong)msg.SessionVerID;
+                    break;
+                }
+            case TerminateData.MESSAGE_ID when frame.Payload.Length >= TerminateData.BLOCK_LENGTH:
+                {
+                    var msg = MemoryMarshal.Read<TerminateData>(frame.Payload);
+                    d.SessionId = (uint)msg.SessionID;
+                    d.SessionVerId = (ulong)msg.SessionVerID;
+                    d.TermCode = msg.TerminationCode;
+                    break;
+                }
+        }
+
+        return d;
+    }
+
+    private HandshakeAction Dispatch(in DecodedFrame d)
+    {
+        switch (d.TemplateId)
+        {
+            case NegotiateData.MESSAGE_ID:
+                {
+                    var msg = new NegotiateData
+                    {
+                        SessionID = (SessionID)d.SessionId,
+                        SessionVerID = (SessionVerID)d.SessionVerId,
+                    };
+                    return _sm.OnNegotiate(in msg);
+                }
+            case EstablishData.MESSAGE_ID:
+                {
+                    var msg = new EstablishData
+                    {
+                        SessionID = (SessionID)d.SessionId,
+                        SessionVerID = (SessionVerID)d.SessionVerId,
+                    };
+                    return _sm.OnEstablish(in msg);
+                }
+            case TerminateData.MESSAGE_ID:
+                {
+                    var msg = new TerminateData
+                    {
+                        SessionID = (SessionID)d.SessionId,
+                        SessionVerID = (SessionVerID)d.SessionVerId,
+                        TerminationCode = d.TermCode,
+                    };
+                    return _sm.OnTerminate(in msg);
+                }
+            default:
+                return _sm.State == FixpSessionState.Established
+                    ? HandshakeAction.NoOp
+                    : _sm.OnApplicationMessageBeforeEstablished();
+        }
+    }
+
+    // ─── Async response writers ───────────────────────────────────────────────
+
+    private async Task SendResponseAsync(
+        NetworkStream stream,
+        HandshakeAction action,
+        uint sessionId,
+        ulong sessionVerId,
+        CancellationToken ct)
+    {
+        switch (action.Kind)
+        {
+            case HandshakeActionKind.SendNegotiateResponse:
+                await WriteNegotiateResponseAsync(stream, sessionId, sessionVerId, ct).ConfigureAwait(false);
+                break;
+
+            case HandshakeActionKind.SendEstablishAck:
+                await WriteEstablishAckAsync(stream, sessionId, sessionVerId, ct).ConfigureAwait(false);
+                break;
+
+            case HandshakeActionKind.AckTerminateAndClose:
+                await WriteTerminateAsync(stream, sessionId, sessionVerId, TerminationCode.FINISHED, ct)
+                    .ConfigureAwait(false);
+                break;
+
+            case HandshakeActionKind.Terminate:
+                await WriteTerminateAsync(stream, sessionId, sessionVerId, action.TermCode, ct)
+                    .ConfigureAwait(false);
+                break;
+
+            case HandshakeActionKind.NoOp:
+            default:
+                break;
+        }
+    }
+
+    private static async Task WriteNegotiateResponseAsync(
+        NetworkStream stream, uint sessionId, ulong sessionVerId, CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(NegotiateResponseData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            BuildNegotiateResponseFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buf);
+        }
+    }
+
+    private static void BuildNegotiateResponseFrame(Span<byte> dest, uint sessionId, ulong sessionVerId)
+    {
+        Span<byte> body = stackalloc byte[NegotiateResponseData.BLOCK_LENGTH];
+        body.Clear();
+        ref var resp = ref MemoryMarshal.AsRef<NegotiateResponseData>(body);
+        resp.SessionID = (SessionID)sessionId;
+        resp.SessionVerID = (SessionVerID)sessionVerId;
+        SofhFrameWriter.WriteFrame(dest,
+            (ushort)NegotiateResponseData.BLOCK_LENGTH,
+            (ushort)NegotiateResponseData.MESSAGE_ID,
+            SchemaIdV6, VersionNegotiateResponse,
+            body);
+    }
+
+    private static async Task WriteEstablishAckAsync(
+        NetworkStream stream, uint sessionId, ulong sessionVerId, CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(EstablishAckData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            BuildEstablishAckFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buf);
+        }
+    }
+
+    private static void BuildEstablishAckFrame(Span<byte> dest, uint sessionId, ulong sessionVerId)
+    {
+        Span<byte> body = stackalloc byte[EstablishAckData.BLOCK_LENGTH];
+        body.Clear();
+        ref var resp = ref MemoryMarshal.AsRef<EstablishAckData>(body);
+        resp.SessionID = (SessionID)sessionId;
+        resp.SessionVerID = (SessionVerID)sessionVerId;
+        SofhFrameWriter.WriteFrame(dest,
+            (ushort)EstablishAckData.BLOCK_LENGTH,
+            (ushort)EstablishAckData.MESSAGE_ID,
+            SchemaIdV6, VersionEstablishAck,
+            body);
+    }
+
+    private static async Task WriteTerminateAsync(
+        NetworkStream stream,
+        uint sessionId,
+        ulong sessionVerId,
+        TerminationCode code,
+        CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(TerminateData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            BuildTerminateFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId, code);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buf);
+        }
+    }
+
+    private static void BuildTerminateFrame(
+        Span<byte> dest, uint sessionId, ulong sessionVerId, TerminationCode code)
+    {
+        Span<byte> body = stackalloc byte[TerminateData.BLOCK_LENGTH];
+        body.Clear();
+        ref var msg = ref MemoryMarshal.AsRef<TerminateData>(body);
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        msg.TerminationCode = code;
+        SofhFrameWriter.WriteFrame(dest,
+            (ushort)TerminateData.BLOCK_LENGTH,
+            (ushort)TerminateData.MESSAGE_ID,
+            SchemaIdV6, VersionTerminate,
+            body);
+    }
+
+    private static async Task BestEffortSendTerminateAsync(
+        NetworkStream stream, TerminationCode code, CancellationToken ct)
+    {
+        try
+        {
+            var frameSize = SofhFrameWriter.FrameSize(TerminateData.BLOCK_LENGTH);
+            var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+            try
+            {
+                BuildTerminateFrame(buf.AsSpan(0, frameSize), 0, 0, code);
+                await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buf);
+            }
+        }
+        catch { /* best effort */ }
+    }
+}

--- a/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
+++ b/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\B3.Trading.Application\B3.Trading.Application.csproj" />
     <ProjectReference Include="..\B3.Trading.Infrastructure\B3.Trading.Infrastructure.csproj" />
     <ProjectReference Include="..\B3.Trading.Api\B3.Trading.Api.csproj" />
+    <ProjectReference Include="..\B3.Trading.EntryPointListener\B3.Trading.EntryPointListener.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -12,6 +12,7 @@ using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Accounting;
 using B3.Trading.Application.Risk.Checks;
 using B3.Trading.Domain;
+using B3.Trading.EntryPointListener;
 using B3.Trading.Host.Observability;
 using B3.Trading.Host.MarketData;
 using B3.Trading.Infrastructure;
@@ -48,6 +49,7 @@ builder.Services.Configure<PositionSeedOptions>(
     builder.Configuration.GetSection(PositionSeedOptions.SectionName));
 builder.Services.Configure<CashSeedOptions>(
     builder.Configuration.GetSection(CashSeedOptions.SectionName));
+builder.Services.AddEntryPointListener(builder.Configuration);
 
 // CORS: opt-in allowlist for the dev/prod frontend origins. Empty list
 // disables CORS entirely (server-only deploys, integration tests).
@@ -471,6 +473,16 @@ var app = builder.Build();
             app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("ErInjection").LogWarning("{Warning}", warning);
         B3.Trading.Application.Observability.MetricsRegistry.ErInjectionEnabled.Add(1);
     }
+}
+
+// FIXP listener boot guard: enforce Production safety rules and emit a
+// warning banner when the listener is active. Mirrors ErInjectionBootGuard.
+{
+    var listenerOpts = app.Services.GetRequiredService<IOptions<EntryPointListenerOptions>>().Value;
+    EntryPointListenerBootGuard.Validate(app.Environment.EnvironmentName, listenerOpts);
+    var listenerWarning = EntryPointListenerBootGuard.BuildWarning(app.Environment.EnvironmentName, listenerOpts);
+    if (listenerWarning is not null)
+        app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("EntryPointListener").LogWarning("{Warning}", listenerWarning);
 }
 
 // Synchronous recovery before any traffic is accepted: load latest

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Trading.EntryPointListener\B3.Trading.EntryPointListener.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/EntryPointListenerBootGuardTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/EntryPointListenerBootGuardTests.cs
@@ -1,0 +1,126 @@
+using B3.Trading.EntryPointListener;
+using Microsoft.Extensions.Hosting;
+
+namespace B3.Trading.EntryPointListener.Tests;
+
+public class EntryPointListenerBootGuardTests
+{
+    // ─── Validate: production + enabled ──────────────────────────────────────
+
+    [Fact]
+    public void Validate_Production_Enabled_NoOptIn_Throws()
+    {
+        var opts = new EntryPointListenerOptions { Enabled = true, Endpoint = "127.0.0.1:5001" };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            EntryPointListenerBootGuard.Validate(Environments.Production, opts));
+        Assert.Contains("AllowInProduction", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_Production_Enabled_OptIn_NoTls_Throws()
+    {
+        var opts = new EntryPointListenerOptions
+        {
+            Enabled = true,
+            Endpoint = "127.0.0.1:5001",
+            AllowInProduction = true,
+            // Tls.Required = false (default)
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            EntryPointListenerBootGuard.Validate(Environments.Production, opts));
+        Assert.Contains("Tls:Required=true", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_Production_Enabled_OptIn_TlsRequired_MissingPaths_Throws()
+    {
+        var opts = new EntryPointListenerOptions
+        {
+            Enabled = true,
+            Endpoint = "127.0.0.1:5001",
+            AllowInProduction = true,
+            Tls = new EntryPointListenerOptions.TlsOptions { Required = true },
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            EntryPointListenerBootGuard.Validate(Environments.Production, opts));
+        Assert.Contains("CertPath", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_Production_Enabled_FullTls_DoesNotThrow()
+    {
+        var opts = new EntryPointListenerOptions
+        {
+            Enabled = true,
+            Endpoint = "127.0.0.1:5001",
+            AllowInProduction = true,
+            Tls = new EntryPointListenerOptions.TlsOptions
+            {
+                Required = true,
+                CertPath = "/etc/ssl/server.crt",
+                KeyPath = "/etc/ssl/server.key",
+            },
+        };
+        // Should not throw — path existence is checked by IValidateOptions, not the boot guard.
+        EntryPointListenerBootGuard.Validate(Environments.Production, opts);
+    }
+
+    // ─── Validate: non-production ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Staging")]
+    [InlineData("Testing")]
+    public void Validate_NonProduction_Enabled_NeverThrows(string env)
+    {
+        var opts = new EntryPointListenerOptions { Enabled = true, Endpoint = "127.0.0.1:5001" };
+        EntryPointListenerBootGuard.Validate(env, opts);
+    }
+
+    // ─── Validate: disabled ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    public void Validate_Disabled_NeverThrows(string env)
+    {
+        var opts = new EntryPointListenerOptions { Enabled = false };
+        EntryPointListenerBootGuard.Validate(env, opts);
+    }
+
+    // ─── BuildWarning ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildWarning_Disabled_ReturnsNull()
+    {
+        var opts = new EntryPointListenerOptions { Enabled = false };
+        Assert.Null(EntryPointListenerBootGuard.BuildWarning("Development", opts));
+        Assert.Null(EntryPointListenerBootGuard.BuildWarning(Environments.Production, opts));
+    }
+
+    [Fact]
+    public void BuildWarning_Enabled_Development_ReturnsNonNull_WithEndpoint()
+    {
+        var opts = new EntryPointListenerOptions { Enabled = true, Endpoint = "127.0.0.1:5001" };
+        var msg = EntryPointListenerBootGuard.BuildWarning("Development", opts);
+        Assert.NotNull(msg);
+        Assert.Contains("FIXP LISTENER ENABLED", msg);
+        Assert.Contains("127.0.0.1:5001", msg!);
+    }
+
+    [Fact]
+    public void BuildWarning_Enabled_Production_ContainsProductionNote()
+    {
+        var opts = new EntryPointListenerOptions
+        {
+            Enabled = true,
+            Endpoint = "0.0.0.0:5001",
+            AllowInProduction = true,
+            Tls = new EntryPointListenerOptions.TlsOptions { Required = true },
+        };
+        var msg = EntryPointListenerBootGuard.BuildWarning(Environments.Production, opts);
+        Assert.NotNull(msg);
+        Assert.Contains("PRODUCTION ENVIRONMENT", msg!);
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Framing/SbeHeaderTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Framing/SbeHeaderTests.cs
@@ -1,0 +1,49 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+
+namespace B3.Trading.EntryPointListener.Tests.Framing;
+
+public class SbeHeaderTests
+{
+    /// <summary>
+    /// Verifies the SBE MessageHeader wire layout: 4 consecutive uint16 LE fields
+    /// at offsets 0 (blockLength), 2 (templateId), 4 (schemaId), 6 (version).
+    /// </summary>
+    [Fact]
+    public void MessageHeader_WireLayout_IsFourConsecutiveUInt16LE()
+    {
+        var hdr = new MessageHeader
+        {
+            BlockLength = 0x1234,
+            TemplateId = 0x5678,
+            SchemaId = 0x9ABC,
+            Version = 0xDEF0,
+        };
+
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref hdr, 1));
+
+        Assert.Equal(8, bytes.Length);
+        Assert.Equal(0x1234, BinaryPrimitives.ReadUInt16LittleEndian(bytes));
+        Assert.Equal(0x5678, BinaryPrimitives.ReadUInt16LittleEndian(bytes[2..]));
+        Assert.Equal(0x9ABC, BinaryPrimitives.ReadUInt16LittleEndian(bytes[4..]));
+        Assert.Equal(0xDEF0, BinaryPrimitives.ReadUInt16LittleEndian(bytes[6..]));
+    }
+
+    [Fact]
+    public void FramingHeader_WireLayout_IsMessageLengthThenEncodingType()
+    {
+        var hdr = new FramingHeader
+        {
+            MessageLength = 0x0028,
+            EncodingType = SofhFraming.SbeLittleEndianEncodingType,
+        };
+
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref hdr, 1));
+
+        Assert.Equal(4, bytes.Length);
+        Assert.Equal(0x0028, BinaryPrimitives.ReadUInt16LittleEndian(bytes));
+        Assert.Equal(SofhFraming.SbeLittleEndianEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(bytes[2..]));
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Framing/SofhFramerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Framing/SofhFramerTests.cs
@@ -1,0 +1,193 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+
+namespace B3.Trading.EntryPointListener.Tests.Framing;
+
+public class SofhFramerTests
+{
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static byte[] BuildFrame(ushort blockLength, ushort templateId, ushort schemaId, ushort version, byte[] body)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf, blockLength, templateId, schemaId, version, body);
+        return buf;
+    }
+
+    private static byte[] NegotiateBody(uint sessionId = 1, ulong sessionVerId = 1)
+    {
+        var body = new byte[NegotiateData.BLOCK_LENGTH];
+        BinaryPrimitives.WriteUInt32LittleEndian(body, sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4), sessionVerId);
+        return body;
+    }
+
+    private static byte[] TerminateBody(uint sessionId = 1, ulong sessionVerId = 1, byte code = 1)
+    {
+        var body = new byte[TerminateData.BLOCK_LENGTH];
+        BinaryPrimitives.WriteUInt32LittleEndian(body, sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4), sessionVerId);
+        body[12] = code;
+        return body;
+    }
+
+    // ─── Roundtrip ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Negotiate_Roundtrip_WriteThenRead()
+    {
+        var body = NegotiateBody(sessionId: 42, sessionVerId: 7);
+        var frame = BuildFrame(
+            (ushort)NegotiateData.BLOCK_LENGTH,
+            (ushort)NegotiateData.MESSAGE_ID,
+            1, 6, body);
+
+        var reader = new SofhFrameReader();
+        reader.Append(frame);
+
+        Assert.True(reader.TryReadFrame(out var f));
+        Assert.Equal((ushort)NegotiateData.BLOCK_LENGTH, f.BlockLength);
+        Assert.Equal((ushort)NegotiateData.MESSAGE_ID, f.TemplateId);
+        Assert.Equal((ushort)1, f.SchemaId);
+        Assert.Equal((ushort)6, f.Version);
+        Assert.Equal(body.Length, f.Payload.Length);
+
+        var msg = MemoryMarshal.Read<NegotiateData>(f.Payload);
+        Assert.Equal((uint)42, (uint)msg.SessionID);
+        Assert.Equal((ulong)7, (ulong)msg.SessionVerID);
+    }
+
+    [Fact]
+    public void Establish_Roundtrip_WriteThenRead()
+    {
+        var body = new byte[EstablishData.BLOCK_LENGTH];
+        BinaryPrimitives.WriteUInt32LittleEndian(body, 99);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4), 2);
+
+        var frame = BuildFrame(
+            (ushort)EstablishData.BLOCK_LENGTH,
+            (ushort)EstablishData.MESSAGE_ID,
+            1, 6, body);
+
+        var reader = new SofhFrameReader();
+        reader.Append(frame);
+
+        Assert.True(reader.TryReadFrame(out var f));
+        Assert.Equal((ushort)EstablishData.MESSAGE_ID, f.TemplateId);
+        var msg = MemoryMarshal.Read<EstablishData>(f.Payload);
+        Assert.Equal((uint)99, (uint)msg.SessionID);
+    }
+
+    [Fact]
+    public void Terminate_Roundtrip_WriteThenRead()
+    {
+        var body = TerminateBody(sessionId: 5, code: (byte)TerminationCode.FINISHED);
+        var frame = BuildFrame(
+            (ushort)TerminateData.BLOCK_LENGTH,
+            (ushort)TerminateData.MESSAGE_ID,
+            1, 0, body);
+
+        var reader = new SofhFrameReader();
+        reader.Append(frame);
+
+        Assert.True(reader.TryReadFrame(out var f));
+        Assert.Equal((ushort)TerminateData.MESSAGE_ID, f.TemplateId);
+        var msg = MemoryMarshal.Read<TerminateData>(f.Payload);
+        Assert.Equal(TerminationCode.FINISHED, msg.TerminationCode);
+    }
+
+    // ─── Multi-frame in single Append ────────────────────────────────────────
+
+    [Fact]
+    public void MultiFrameInSingleAppend_BothFramesReturned()
+    {
+        var body1 = NegotiateBody(sessionId: 1);
+        var body2 = NegotiateBody(sessionId: 2);
+        var frame1 = BuildFrame((ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID, 1, 6, body1);
+        var frame2 = BuildFrame((ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID, 1, 6, body2);
+
+        var combined = frame1.Concat(frame2).ToArray();
+        var reader = new SofhFrameReader();
+        reader.Append(combined);
+
+        Assert.True(reader.TryReadFrame(out var f1));
+        Assert.True(reader.TryReadFrame(out var f2));
+        Assert.False(reader.TryReadFrame(out _));
+
+        var m1 = MemoryMarshal.Read<NegotiateData>(f1.Payload);
+        var m2 = MemoryMarshal.Read<NegotiateData>(f2.Payload);
+        Assert.Equal((uint)1, (uint)m1.SessionID);
+        Assert.Equal((uint)2, (uint)m2.SessionID);
+    }
+
+    // ─── Partial-frame split across N appends ─────────────────────────────────
+
+    [Fact]
+    public void PartialFrame_OneByteAtATime_Reassembled()
+    {
+        var body = NegotiateBody(sessionId: 77);
+        var frame = BuildFrame((ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID, 1, 6, body);
+
+        var reader = new SofhFrameReader();
+        for (var i = 0; i < frame.Length - 1; i++)
+        {
+            reader.Append(frame.AsSpan(i, 1));
+            Assert.False(reader.TryReadFrame(out _), $"Should not have a frame yet at byte {i + 1}");
+        }
+
+        reader.Append(frame.AsSpan(frame.Length - 1, 1));
+        Assert.True(reader.TryReadFrame(out var f));
+        var msg = MemoryMarshal.Read<NegotiateData>(f.Payload);
+        Assert.Equal((uint)77, (uint)msg.SessionID);
+    }
+
+    // ─── Error cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void InvalidEncodingType_SetsProtocolError()
+    {
+        var buf = new byte[SofhFraming.MinFrameSize];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)SofhFraming.MinFrameSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0xDEAD); // wrong encoding type
+
+        var reader = new SofhFrameReader();
+        reader.Append(buf);
+
+        Assert.False(reader.TryReadFrame(out _));
+        Assert.True(reader.HasProtocolError);
+        Assert.Contains("encodingType", reader.ProtocolErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OversizedFrame_SetsProtocolError()
+    {
+        var buf = new byte[SofhFraming.MinFrameSize];
+        // Write messageLength > MaxFrameSize
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)(SofhFraming.MaxFrameSize + 1));
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), SofhFraming.SbeLittleEndianEncodingType);
+
+        var reader = new SofhFrameReader();
+        reader.Append(buf);
+
+        Assert.False(reader.TryReadFrame(out _));
+        Assert.True(reader.HasProtocolError);
+        Assert.Contains("maximum", reader.ProtocolErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ZeroLengthPayload_ValidFrame()
+    {
+        var frame = BuildFrame(0, 7, 1, 0, Array.Empty<byte>());
+        var reader = new SofhFrameReader();
+        reader.Append(frame);
+
+        Assert.True(reader.TryReadFrame(out var f));
+        Assert.Equal((ushort)0, f.BlockLength);
+        Assert.Equal((ushort)7, f.TemplateId);
+        Assert.Equal(0, f.Payload.Length);
+        Assert.False(reader.HasProtocolError);
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Handshake/FixpHandshakeStateMachineTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Handshake/FixpHandshakeStateMachineTests.cs
@@ -1,0 +1,144 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Handshake;
+
+namespace B3.Trading.EntryPointListener.Tests.Handshake;
+
+public class FixpHandshakeStateMachineTests
+{
+    private static NegotiateData MakeNegotiate(uint sessionId = 1, ulong sessionVerId = 1)
+        => new() { SessionID = (SessionID)sessionId, SessionVerID = (SessionVerID)sessionVerId };
+
+    private static EstablishData MakeEstablish(uint sessionId = 1, ulong sessionVerId = 1)
+        => new() { SessionID = (SessionID)sessionId, SessionVerID = (SessionVerID)sessionVerId };
+
+    private static TerminateData MakeTerminate(uint sessionId = 1, ulong sessionVerId = 1)
+        => new() { SessionID = (SessionID)sessionId, SessionVerID = (SessionVerID)sessionVerId, TerminationCode = TerminationCode.FINISHED };
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HappyPath_Idle_Negotiated_Established_Terminated()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        Assert.Equal(FixpSessionState.Idle, sm.State);
+
+        var neg = MakeNegotiate(sessionId: 42, sessionVerId: 7);
+        var a1 = sm.OnNegotiate(in neg);
+        Assert.Equal(HandshakeActionKind.SendNegotiateResponse, a1.Kind);
+        Assert.Equal(FixpSessionState.Negotiated, sm.State);
+
+        var est = MakeEstablish(sessionId: 42, sessionVerId: 7);
+        var a2 = sm.OnEstablish(in est);
+        Assert.Equal(HandshakeActionKind.SendEstablishAck, a2.Kind);
+        Assert.Equal(FixpSessionState.Established, sm.State);
+
+        var term = MakeTerminate(sessionId: 42, sessionVerId: 7);
+        var a3 = sm.OnTerminate(in term);
+        Assert.Equal(HandshakeActionKind.AckTerminateAndClose, a3.Kind);
+        Assert.Equal(FixpSessionState.Terminated, sm.State);
+    }
+
+    // ─── Error paths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EstablishBeforeNegotiate_ReturnsUnnegotiated()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var est = MakeEstablish();
+        var action = sm.OnEstablish(in est);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.UNNEGOTIATED, action.TermCode);
+    }
+
+    [Fact]
+    public void DoubleEstablish_ReturnsEstablishInProgress()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate();
+        sm.OnNegotiate(in neg);
+
+        var est = MakeEstablish();
+        sm.OnEstablish(in est);
+        Assert.Equal(FixpSessionState.Established, sm.State);
+
+        var est2 = MakeEstablish();
+        var action = sm.OnEstablish(in est2);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.ESTABLISH_IN_PROGRESS, action.TermCode);
+    }
+
+    [Fact]
+    public void DoubleNegotiate_ReturnsNegotiationInProgress()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate();
+        sm.OnNegotiate(in neg);
+        Assert.Equal(FixpSessionState.Negotiated, sm.State);
+
+        var neg2 = MakeNegotiate();
+        var action = sm.OnNegotiate(in neg2);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.NEGOTIATION_IN_PROGRESS, action.TermCode);
+    }
+
+    [Fact]
+    public void DoubleNegotiate_AfterEstablish_ReturnsNegotiationInProgress()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate();
+        sm.OnNegotiate(in neg);
+        var est = MakeEstablish();
+        sm.OnEstablish(in est);
+
+        var neg2 = MakeNegotiate();
+        var action = sm.OnNegotiate(in neg2);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.NEGOTIATION_IN_PROGRESS, action.TermCode);
+    }
+
+    [Fact]
+    public void MismatchedSessionId_OnEstablish_ReturnsInvalidSessionId()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate(sessionId: 100, sessionVerId: 1);
+        sm.OnNegotiate(in neg);
+
+        var est = MakeEstablish(sessionId: 999, sessionVerId: 1); // wrong sessionId
+        var action = sm.OnEstablish(in est);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.INVALID_SESSIONID, action.TermCode);
+    }
+
+    [Fact]
+    public void MismatchedSessionVerId_OnEstablish_ReturnsInvalidSessionVerId()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate(sessionId: 100, sessionVerId: 1);
+        sm.OnNegotiate(in neg);
+
+        var est = MakeEstablish(sessionId: 100, sessionVerId: 999); // wrong verId
+        var action = sm.OnEstablish(in est);
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.INVALID_SESSIONVERID, action.TermCode);
+    }
+
+    [Fact]
+    public void ApplicationMessageBeforeEstablished_ReturnsUnnegotiated()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var action = sm.OnApplicationMessageBeforeEstablished();
+        Assert.Equal(HandshakeActionKind.Terminate, action.Kind);
+        Assert.Equal(TerminationCode.UNNEGOTIATED, action.TermCode);
+    }
+
+    [Fact]
+    public void SessionIdAndVerIdStoredAfterNegotiate()
+    {
+        var sm = new FixpHandshakeStateMachine();
+        var neg = MakeNegotiate(sessionId: 77, sessionVerId: 88);
+        sm.OnNegotiate(in neg);
+
+        Assert.Equal((uint)77, (uint)sm.SessionId);
+        Assert.Equal((ulong)88, (ulong)sm.SessionVerId);
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
@@ -141,5 +141,33 @@ public class FixpListenerIntegrationTests
 
         await host.StopAsync(cts.Token);
     }
+
+    [Fact(Timeout = 10_000)]
+    public async Task TruncatedNegotiateFrame_ServerTerminates()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+
+        using var host = BuildHost(out var listenerService);
+        await host.StartAsync(cts.Token);
+
+        var endpoint = await listenerService.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+        using var tcpClient = new TcpClient();
+        await tcpClient.ConnectAsync(endpoint.Address, endpoint.Port, cts.Token);
+        var stream = tcpClient.GetStream();
+        var reader = new SofhFrameReader();
+
+        // Send a Negotiate frame whose body is 1 byte shorter than BLOCK_LENGTH.
+        var truncatedBody = new byte[NegotiateData.BLOCK_LENGTH - 1];
+        await SendFrameAsync(stream,
+            (ushort)(NegotiateData.BLOCK_LENGTH - 1), (ushort)NegotiateData.MESSAGE_ID,
+            1, 6, truncatedBody, cts.Token);
+
+        var response = await ReadFrameAsync(reader, stream, cts.Token);
+        Assert.True(response.IsValid, "Server should respond to a truncated frame");
+        Assert.Equal((ushort)TerminateData.MESSAGE_ID, response.TemplateId);
+
+        await host.StopAsync(cts.Token);
+    }
 }
 

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
@@ -1,0 +1,145 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.EntryPointListener.Tests.Integration;
+
+public class FixpListenerIntegrationTests
+{
+    private static IHost BuildHost(out FixpListenerHostedService listenerService)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:EntryPointListener:Enabled"] = "true",
+                ["Trading:EntryPointListener:Endpoint"] = "127.0.0.1:0",
+            })
+            .Build();
+
+        var host = new HostBuilder()
+            .ConfigureServices((_, s) =>
+            {
+                s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                s.AddEntryPointListener(config);
+            })
+            .Build();
+
+        listenerService = host.Services.GetRequiredService<FixpListenerHostedService>();
+        return host;
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static async Task SendFrameAsync(
+        NetworkStream stream,
+        ushort blockLength,
+        ushort templateId,
+        ushort schemaId,
+        ushort version,
+        byte[] body,
+        CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf, blockLength, templateId, schemaId, version, body);
+        await stream.WriteAsync(buf, ct).ConfigureAwait(false);
+    }
+
+    private readonly record struct FrameData(bool IsValid, ushort TemplateId, byte[] Payload);
+
+    private static async Task<FrameData> ReadFrameAsync(
+        SofhFrameReader reader,
+        NetworkStream stream,
+        CancellationToken ct)
+    {
+        var buf = new byte[4096];
+        while (true)
+        {
+            if (reader.TryReadFrame(out var frame))
+                return new FrameData(true, frame.TemplateId, frame.Payload.ToArray());
+            if (reader.HasProtocolError) return default;
+
+            var n = await stream.ReadAsync(buf, ct).ConfigureAwait(false);
+            if (n == 0) return default;
+            reader.Append(buf.AsSpan(0, n));
+        }
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task FullHandshake_NegotiateEstablishTerminate_HappyPath()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+
+        using var host = BuildHost(out var listenerService);
+        await host.StartAsync(cts.Token);
+
+        var endpoint = await listenerService.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+        using var tcpClient = new TcpClient();
+        await tcpClient.ConnectAsync(endpoint.Address, endpoint.Port, cts.Token);
+        var stream = tcpClient.GetStream();
+        var reader = new SofhFrameReader();
+
+        const uint SessionId = 0xDEADBEEF;
+        const ulong SessionVerId = 1;
+
+        // ── Negotiate ──────────────────────────────────────────────────────────
+        var negBody = new byte[NegotiateData.BLOCK_LENGTH];
+        ref var neg = ref MemoryMarshal.AsRef<NegotiateData>(negBody.AsSpan());
+        neg.SessionID = (SessionID)SessionId;
+        neg.SessionVerID = (SessionVerID)SessionVerId;
+
+        await SendFrameAsync(stream,
+            (ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID,
+            1, 6, negBody, cts.Token);
+
+        var negRespFrame = await ReadFrameAsync(reader, stream, cts.Token);
+        Assert.True(negRespFrame.IsValid);
+        Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, negRespFrame.TemplateId);
+        var negRespData = MemoryMarshal.Read<NegotiateResponseData>(negRespFrame.Payload);
+        Assert.Equal(SessionId, (uint)negRespData.SessionID);
+        Assert.Equal(SessionVerId, (ulong)negRespData.SessionVerID);
+
+        // ── Establish ─────────────────────────────────────────────────────────
+        var estBody = new byte[EstablishData.BLOCK_LENGTH];
+        ref var est = ref MemoryMarshal.AsRef<EstablishData>(estBody.AsSpan());
+        est.SessionID = (SessionID)SessionId;
+        est.SessionVerID = (SessionVerID)SessionVerId;
+
+        await SendFrameAsync(stream,
+            (ushort)EstablishData.BLOCK_LENGTH, (ushort)EstablishData.MESSAGE_ID,
+            1, 6, estBody, cts.Token);
+
+        var estAckFrame = await ReadFrameAsync(reader, stream, cts.Token);
+        Assert.True(estAckFrame.IsValid);
+        Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, estAckFrame.TemplateId);
+        var estAckData = MemoryMarshal.Read<EstablishAckData>(estAckFrame.Payload);
+        Assert.Equal(SessionId, (uint)estAckData.SessionID);
+
+        // ── Terminate ─────────────────────────────────────────────────────────
+        var termBody = new byte[TerminateData.BLOCK_LENGTH];
+        ref var term = ref MemoryMarshal.AsRef<TerminateData>(termBody.AsSpan());
+        term.SessionID = (SessionID)SessionId;
+        term.SessionVerID = (SessionVerID)SessionVerId;
+        term.TerminationCode = TerminationCode.FINISHED;
+
+        await SendFrameAsync(stream,
+            (ushort)TerminateData.BLOCK_LENGTH, (ushort)TerminateData.MESSAGE_ID,
+            1, 0, termBody, cts.Token);
+
+        var echoTermFrame = await ReadFrameAsync(reader, stream, cts.Token);
+        Assert.True(echoTermFrame.IsValid);
+        Assert.Equal((ushort)TerminateData.MESSAGE_ID, echoTermFrame.TemplateId);
+
+        await host.StopAsync(cts.Token);
+    }
+}
+


### PR DESCRIPTION
## Summary

Implements sub-issue #168 — skeleton TCP listener with SOFH framing and FIXP session handshake state machine.

Closes #168
Refs #166

## What's in scope
- `B3.Trading.EntryPointListener` project: TCP listener, SOFH framer, SBE handshake state machine, boot guard, DI wiring
- 34 tests: unit tests for framing, state machine, boot guard, and a full end-to-end TCP handshake integration test
- Wired into `B3.Trading.Host` via `AddEntryPointListener()`

## What's NOT in scope (deferred)
- Real auth (sub-issue C)
- TLS/SslStream (boot guard enforces config but SslStream is not wired yet)
- Application-level message routing (post-handshake)

## Code-review pass
gpt-5.5 code-review: found one medium issue — truncated handshake frames were dispatched with zero-valued SessionId/SessionVerId instead of being rejected. Fixed: `DecodeFrame` now sets `DecodeFailed=true` for known templates with undersized payloads; `Dispatch` returns `Terminate(UNSPECIFIED)` in that case. Regression test added.