### PR TITLE
feat(frontend): bot credentials management page (#169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
         run: node --test frontend/test/decoder.test.mjs
 
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs
+        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs frontend/test/bot-credentials-ui.test.mjs

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -552,3 +552,27 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
   border-radius: 4px; font-weight: 600; cursor: pointer; font: inherit;
 }
 .modal-actions button[type="submit"]:hover { filter: brightness(1.1); }
+
+/* ---------- Bot credentials view (sub-issue #169) ---------- */
+.bot-credentials-view {
+  display: flex; flex-direction: column; height: 100vh; overflow: auto;
+  padding: 1rem; gap: 1rem;
+}
+.bot-credentials-view .admin-actions { display: flex; gap: .75rem; }
+.bot-credentials-secret-card { width: min(440px, 92vw); }
+.bot-credentials-secret-card input[readonly] {
+  font: 13px/1.4 ui-monospace, Menlo, Consolas, monospace;
+  user-select: all;
+}
+.bot-credentials-secret-warning {
+  margin: 0; padding: .5rem .6rem; border-radius: 4px;
+  background: rgba(245,166,35,.12); border: 1px solid var(--warn);
+  color: var(--warn); font-size: .8rem;
+}
+.bot-credentials-secret-card .modal-actions button[type="button"] {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  border-radius: 4px; padding: .4rem .8rem; font: inherit; font-size: .8rem; cursor: pointer;
+}
+.bot-credentials-secret-card .modal-actions button[type="button"]:hover {
+  background: rgba(255,255,255,.05);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,6 +91,8 @@
         <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
         <span id="user-label" class="user-label"></span>
         <span id="user-role" class="role-badge" hidden></span>
+        <button id="bot-credentials-open" class="link-button" type="button"
+                aria-label="Bot credentials">Bot credentials</button>
         <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
       </div>
     </header>
@@ -425,6 +427,78 @@
       <div class="modal-actions">
         <button type="button" id="cancel-all-close" class="link-button">Close</button>
         <button type="submit" id="cancel-all-submit" disabled>Cancel orders</button>
+      </div>
+    </form>
+  </div>
+
+  <!-- BOT CREDENTIALS VIEW (sub-issue #169 of user-bot-fixp-listener-v0)
+       Manage user-issued PATs that authenticate external FIXP bots.
+       Visible to every authenticated user (no admin gate). -->
+  <section id="bot-credentials-view" class="view bot-credentials-view" hidden>
+    <header class="admin-subbar">
+      <h2>Bot credentials</h2>
+      <div class="admin-actions">
+        <button id="bot-credentials-back" type="button" class="link-button">Back to trader</button>
+        <button id="bot-credentials-refresh" type="button" class="link-button">Refresh</button>
+      </div>
+    </header>
+    <p id="bot-credentials-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
+
+    <section class="panel admin-panel">
+      <h3>Create credential</h3>
+      <form id="bot-credentials-create-form" class="admin-inline-form">
+        <input id="bot-credentials-label" type="text" placeholder="label (e.g. my-bot)"
+               maxlength="128" autocomplete="off" required />
+        <button type="submit" id="bot-credentials-create-submit">Create credential</button>
+      </form>
+      <p class="muted-line">
+        The plaintext token is shown only once, immediately after creation —
+        copy it before dismissing the dialog.
+      </p>
+    </section>
+
+    <section class="panel admin-panel">
+      <h3>Your credentials</h3>
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Label</th><th>CredShortId</th><th>Created</th>
+              <th>Status</th><th></th>
+            </tr>
+          </thead>
+          <tbody id="bot-credentials-body">
+            <tr><td colspan="5" class="muted">loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </section>
+
+  <!-- "Shown once" PAT modal — surfaces the plaintext secret returned by
+       POST /api/user-bot-credentials. The secret lives in this dialog's
+       DOM only; it is never persisted to storage, never rendered into a
+       URL, and never logged to the console. Dismissing the modal drops
+       the value from memory. -->
+  <div id="bot-credentials-secret-modal" class="modal-backdrop" hidden role="dialog"
+       aria-modal="true" aria-labelledby="bot-credentials-secret-title">
+    <form id="bot-credentials-secret-form" class="modal-card bot-credentials-secret-card">
+      <h2 id="bot-credentials-secret-title">New credential created</h2>
+      <p class="muted-line">
+        Label: <strong id="bot-credentials-secret-label"></strong>
+      </p>
+      <p class="bot-credentials-secret-warning" role="alert">
+        Save this token now. It will not be shown again.
+      </p>
+      <label>
+        <span>Personal access token</span>
+        <input id="bot-credentials-secret-value" type="text" readonly spellcheck="false"
+               autocomplete="off" aria-describedby="bot-credentials-secret-copy-status" />
+      </label>
+      <p id="bot-credentials-secret-copy-status" class="feedback" role="status" aria-live="polite" hidden></p>
+      <div class="modal-actions">
+        <button type="button" id="bot-credentials-secret-copy">Copy to clipboard</button>
+        <button type="submit" id="bot-credentials-secret-done">Done</button>
       </div>
     </form>
   </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4,12 +4,14 @@ import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cance
          validateSession,
          getKillStatus, killFirm, reviveFirm, killEndClient, reviveEndClient,
          getHaltStatus, haltSymbol, resumeSymbol,
-         runEod } from "./protocol.js";
+         runEod,
+         listUserBotCredentials, createUserBotCredential, deleteUserBotCredential } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
 import { validateOrder, pretradeWarnings, payloadKey } from "./validation.js";
 import * as state from "./state.js";
 import * as ui from "./ui.js";
 import * as adminUi from "./adminUi.js";
+import * as botCredentialsUi from "./botCredentialsUi.js";
 import { FLAGS } from "./mdProtocol.js";
 
 const SESSION_KEY = "b3tp.session";
@@ -60,6 +62,7 @@ function init() {
   document.getElementById("signup-go-login")?.addEventListener("click", () => showSignupCard(false));
   ui.bindUi();
   adminUi.bindAdminUi();
+  botCredentialsUi.bindBotCredentialsUi();
   ui.setHandlers({
     onSubmitOrder: handleSubmitOrder,
     onCancelOrder: handleCancelOrder,
@@ -84,6 +87,13 @@ function init() {
     onAddHalt:         handleAddHalt,
     onRunEod:          handleRunEod,
     onRefresh:         refreshAdminData,
+  });
+  botCredentialsUi.setBotCredentialsHandlers({
+    onOpenView: () => handleSwitchView("bot-credentials"),
+    onBack:     () => handleSwitchView("trader"),
+    onRefresh:  refreshBotCredentials,
+    onCreate:   handleCreateBotCredential,
+    onRevoke:   handleRevokeBotCredential,
   });
 
   const stored = readSession();
@@ -767,6 +777,7 @@ function logout() {
   state.setHaltStatus(null);
   state.setEodReport(null);
   state.setCurrentView("trader");
+  botCredentialsUi.clearBotCredentials();
   state.setBlotterFilter(readBlotterFilter());
   state.setSelectedOrder(null);
   state.setPendingFatFinger(null);
@@ -879,10 +890,94 @@ function handleSwitchView(view) {
   if (view === "admin" && session?.role !== "admin") return; // safety
   state.setCurrentView(view);
   if (view === "admin") refreshAdminData();
+  if (view === "bot-credentials") refreshBotCredentials();
 }
 
 async function refreshAdminData() {
   await pollFirmsOnce();
+}
+
+// ── User-bot credentials (sub-issue #169) ──────────────────────────
+//
+// All three operations rely on the JWT — the backend scopes by `sub`,
+// so we never pass a user id. The plaintext PAT returned by POST is
+// handed straight to the modal and dropped from memory once the user
+// dismisses it; nothing is persisted.
+
+async function refreshBotCredentials() {
+  if (!session) return;
+  const captured = session;
+  botCredentialsUi.setBotCredentialsLoading(true);
+  botCredentialsUi.setBotCredentialsFeedback(null);
+  try {
+    const rows = await listUserBotCredentials(captured.backend, captured.token);
+    // Discard the response if the session changed under us (logout, or
+    // another user signed in on the same tab). Otherwise we'd write
+    // the previous session's credential metadata into the DOM after
+    // logout, or leak it across user switches.
+    if (session !== captured) return;
+    botCredentialsUi.setBotCredentialsRows(rows ?? []);
+  } catch (err) {
+    if (session !== captured) return;
+    if (err?.status === 401) { logout(); return; }
+    botCredentialsUi.setBotCredentialsRows([]);
+    botCredentialsUi.setBotCredentialsFeedback(
+      err?.message || "Failed to load credentials.", "error");
+  }
+}
+
+async function handleCreateBotCredential({ label }) {
+  if (!session) return;
+  const captured = session;
+  botCredentialsUi.setCreateSubmitting(true);
+  botCredentialsUi.setBotCredentialsFeedback(null);
+  try {
+    const created = await createUserBotCredential(captured.backend, captured.token, label);
+    // Critical: if the user logged out (or a new user signed in) while
+    // the POST was in flight, drop the plaintext PAT on the floor —
+    // surfacing it to whoever is now in front of the browser would
+    // violate the "shown once, to the issuing user only" invariant.
+    if (session !== captured) return;
+    botCredentialsUi.resetCreateForm();
+    // The plaintext secret only lives inside the modal's input element.
+    // Do not log it, do not stash it on `session`, do not put it in state.
+    botCredentialsUi.openBotCredentialsSecretModal({
+      label: created?.label ?? label,
+      plainSecret: created?.plainSecret ?? "",
+    });
+    botCredentialsUi.setBotCredentialsFeedback(
+      `Credential "${created?.label ?? label}" created.`, "ok");
+    // Refresh asynchronously — do not await; the modal stays up while
+    // the table updates underneath.
+    refreshBotCredentials();
+  } catch (err) {
+    if (session !== captured) return;
+    if (err?.status === 401) { logout(); return; }
+    botCredentialsUi.setBotCredentialsFeedback(
+      err?.message || "Failed to create credential.", "error");
+  } finally {
+    if (session === captured) {
+      botCredentialsUi.setCreateSubmitting(false);
+    }
+  }
+}
+
+async function handleRevokeBotCredential({ id, label }) {
+  if (!session) return;
+  const captured = session;
+  botCredentialsUi.setBotCredentialsFeedback(null);
+  try {
+    await deleteUserBotCredential(captured.backend, captured.token, id);
+    if (session !== captured) return;
+    botCredentialsUi.setBotCredentialsFeedback(
+      `Credential "${label}" revoked.`, "ok");
+    await refreshBotCredentials();
+  } catch (err) {
+    if (session !== captured) return;
+    if (err?.status === 401) { logout(); return; }
+    botCredentialsUi.setBotCredentialsFeedback(
+      err?.message || "Failed to revoke credential.", "error");
+  }
 }
 
 async function withAdminCall(fn, okMessage) {

--- a/frontend/js/botCredentialsUi.js
+++ b/frontend/js/botCredentialsUi.js
@@ -1,0 +1,285 @@
+// User-bot credentials view (sub-issue #169 of RFC user-bot-fixp-listener-v0).
+//
+// Render-only DOM layer for the credentials list, the create form, and
+// the "shown once" plaintext-PAT modal. Network calls are owned by app.js;
+// this module exposes handlers + render hooks the same way adminUi.js
+// does so the auth/fetch path stays in one place.
+//
+// SECURITY INVARIANTS (do not break these without re-reviewing #169):
+//   * The plaintext PAT (`b3t_xxx_yyy`) returned by POST /api/user-bot-credentials
+//     lives ONLY in the secret-modal input element while the modal is
+//     open. It is never written to localStorage / sessionStorage /
+//     IndexedDB / cookies, never appended to a URL, and never logged.
+//   * Dismissing the modal blanks the input value so the secret leaves
+//     the DOM as soon as the user is done with it.
+//   * The list endpoint never returns the secret, so the table can
+//     safely be re-rendered from server state without leaking anything.
+
+const $ = (id) => document.getElementById(id);
+
+let onCreate = () => {};
+let onRevoke = () => {};
+let onRefresh = () => {};
+let onBack = () => {};
+let onOpenView = () => {};
+
+// In-memory only. Rows are mirrored from /api/user-bot-credentials each
+// refresh; never serialised, never inspected for secret material.
+let rowsCache = null;
+let loading = false;
+
+export function setBotCredentialsHandlers(handlers) {
+  onCreate   = handlers.onCreate   ?? onCreate;
+  onRevoke   = handlers.onRevoke   ?? onRevoke;
+  onRefresh  = handlers.onRefresh  ?? onRefresh;
+  onBack     = handlers.onBack     ?? onBack;
+  onOpenView = handlers.onOpenView ?? onOpenView;
+}
+
+export function bindBotCredentialsUi() {
+  const openBtn = $("bot-credentials-open");
+  if (openBtn) {
+    openBtn.addEventListener("click", () => onOpenView());
+  }
+
+  const backBtn = $("bot-credentials-back");
+  if (backBtn) {
+    backBtn.addEventListener("click", () => onBack());
+  }
+
+  const refreshBtn = $("bot-credentials-refresh");
+  if (refreshBtn) {
+    refreshBtn.addEventListener("click", () => onRefresh());
+  }
+
+  const form = $("bot-credentials-create-form");
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const labelEl = $("bot-credentials-label");
+      const label = (labelEl?.value ?? "").trim();
+      if (!label) {
+        setBotCredentialsFeedback("Label is required.", "error");
+        return;
+      }
+      onCreate({ label });
+    });
+  }
+
+  const body = $("bot-credentials-body");
+  if (body) {
+    body.addEventListener("click", (e) => {
+      const btn = e.target.closest(".bot-cred-revoke");
+      if (!btn) return;
+      const id = btn.dataset.id;
+      const label = btn.dataset.label || id;
+      if (!id) return;
+      if (!window.confirm(
+        `Revoke credential ${label}? This cannot be undone.`,
+      )) return;
+      onRevoke({ id, label });
+    });
+  }
+
+  bindSecretModal();
+}
+
+// ── List render ────────────────────────────────────────────────────
+
+export function setBotCredentialsLoading(isLoading) {
+  loading = !!isLoading;
+  renderList();
+}
+
+export function setBotCredentialsRows(rows) {
+  rowsCache = Array.isArray(rows) ? rows : [];
+  loading = false;
+  renderList();
+}
+
+export function clearBotCredentials() {
+  rowsCache = null;
+  loading = false;
+  setBotCredentialsFeedback(null);
+  resetCreateForm();
+  closeBotCredentialsSecretModal();
+}
+
+export function resetCreateForm() {
+  const labelEl = $("bot-credentials-label");
+  if (labelEl) labelEl.value = "";
+  setCreateSubmitting(false);
+}
+
+export function setCreateSubmitting(submitting) {
+  const btn = $("bot-credentials-create-submit");
+  if (!btn) return;
+  btn.disabled = !!submitting;
+  btn.textContent = submitting ? "Creating…" : "Create credential";
+}
+
+export function setBotCredentialsFeedback(message, kind) {
+  const el = $("bot-credentials-feedback");
+  if (!el) return;
+  if (!message) { el.hidden = true; el.textContent = ""; el.className = "feedback"; return; }
+  el.hidden = false;
+  el.textContent = message;
+  el.className = `feedback ${kind === "ok" ? "ok" : kind === "warn" ? "warn" : "error"}`;
+}
+
+function renderList() {
+  const body = $("bot-credentials-body");
+  if (!body) return;
+  if (loading && rowsCache == null) {
+    body.innerHTML = `<tr><td colspan="5" class="muted">loading…</td></tr>`;
+    return;
+  }
+  const rows = rowsCache ?? [];
+  if (rows.length === 0) {
+    body.innerHTML =
+      `<tr><td colspan="5" class="muted">You have no bot credentials. Create one to get started.</td></tr>`;
+    return;
+  }
+  // Active rows first, then revoked. Within each group, newest first.
+  const sorted = [...rows].sort((a, b) => {
+    const ar = a.revokedAt ? 1 : 0;
+    const br = b.revokedAt ? 1 : 0;
+    if (ar !== br) return ar - br;
+    return String(b.createdAtUtc).localeCompare(String(a.createdAtUtc));
+  });
+  body.innerHTML = sorted.map(renderRow).join("");
+}
+
+function renderRow(c) {
+  const revoked = !!c.revokedAt;
+  const created = formatDate(c.createdAtUtc);
+  const statusBadge = revoked
+    ? `<span class="killed-tag">Revoked</span>`
+    : `<span class="status-pill status-connected">Active</span>`;
+  const actions = revoked
+    ? ""
+    : `<button type="button" class="bot-cred-revoke danger-btn engage"
+              data-id="${escapeHtml(c.id)}" data-label="${escapeHtml(c.label)}">
+         Revoke
+       </button>`;
+  return `<tr>
+    <td>${escapeHtml(c.label)}</td>
+    <td><code>${escapeHtml(c.credShortId)}</code></td>
+    <td>${escapeHtml(created)}</td>
+    <td>${statusBadge}</td>
+    <td>${actions}</td>
+  </tr>`;
+}
+
+// ── "Shown once" secret modal ──────────────────────────────────────
+
+let secretModalSubmit = null;
+let secretModalCopy = null;
+let secretCopyTimer = null;
+
+function bindSecretModal() {
+  const form = $("bot-credentials-secret-form");
+  const copyBtn = $("bot-credentials-secret-copy");
+  if (form && !secretModalSubmit) {
+    secretModalSubmit = (e) => {
+      e.preventDefault();
+      closeBotCredentialsSecretModal();
+    };
+    form.addEventListener("submit", secretModalSubmit);
+  }
+  if (copyBtn && !secretModalCopy) {
+    secretModalCopy = async () => {
+      const input = $("bot-credentials-secret-value");
+      if (!input) return;
+      const value = input.value;
+      if (!value) return;
+      const ok = await copyToClipboard(value, input);
+      setSecretCopyStatus(ok ? "Copied!" : "Copy failed — please copy manually.", ok ? "ok" : "error");
+    };
+    copyBtn.addEventListener("click", secretModalCopy);
+  }
+}
+
+export function openBotCredentialsSecretModal({ label, plainSecret }) {
+  const modal = $("bot-credentials-secret-modal");
+  const labelEl = $("bot-credentials-secret-label");
+  const input = $("bot-credentials-secret-value");
+  if (!modal || !input) return;
+  if (labelEl) labelEl.textContent = label ?? "";
+  // The secret never enters any storage — it's pushed directly into the
+  // input's value property and dropped on close. Do not log this value.
+  input.value = plainSecret ?? "";
+  setSecretCopyStatus(null);
+  modal.hidden = false;
+  // Defer focus so the readonly input is selected and ready to copy.
+  requestAnimationFrame(() => {
+    try {
+      input.focus();
+      input.select();
+    } catch { /* ignore — focus is a nice-to-have */ }
+  });
+}
+
+export function closeBotCredentialsSecretModal() {
+  const modal = $("bot-credentials-secret-modal");
+  const input = $("bot-credentials-secret-value");
+  const labelEl = $("bot-credentials-secret-label");
+  if (input) input.value = "";
+  if (labelEl) labelEl.textContent = "";
+  setSecretCopyStatus(null);
+  if (modal) modal.hidden = true;
+}
+
+function setSecretCopyStatus(message, kind) {
+  const el = $("bot-credentials-secret-copy-status");
+  if (!el) return;
+  if (secretCopyTimer) { clearTimeout(secretCopyTimer); secretCopyTimer = null; }
+  if (!message) { el.hidden = true; el.textContent = ""; el.className = "feedback"; return; }
+  el.hidden = false;
+  el.textContent = message;
+  el.className = `feedback ${kind === "ok" ? "ok" : "error"}`;
+  if (kind === "ok") {
+    secretCopyTimer = setTimeout(() => {
+      el.hidden = true;
+      el.textContent = "";
+      secretCopyTimer = null;
+    }, 2_500);
+  }
+}
+
+async function copyToClipboard(value, fallbackInput) {
+  // Prefer the modern async Clipboard API (requires a secure context).
+  // Fall back to selecting the input + execCommand("copy") so http://
+  // dev hosts and older browsers still work without leaking the value.
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch { /* fall through to legacy path */ }
+  try {
+    if (fallbackInput) {
+      fallbackInput.focus();
+      fallbackInput.select();
+      const ok = document.execCommand && document.execCommand("copy");
+      return !!ok;
+    }
+  } catch { /* ignore */ }
+  return false;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function formatDate(s) {
+  if (!s) return "—";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return String(s);
+  // ISO-ish, seconds-precision; matches the look of the executions log.
+  return d.toISOString().replace("T", " ").slice(0, 19) + "Z";
+}
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[c]
+  ));
+}

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -175,3 +175,45 @@ export async function runEod(backend, token) {
   });
   return jsonOrThrow(resp);
 }
+
+// ── User-bot credentials (sub-issue #169 of RFC user-bot-fixp-listener-v0).
+// All operations act on the authenticated user's `sub` claim — the backend
+// scopes by JWT, so no user-id parameter is sent. Cross-user reads/writes
+// always 404, so the UI only ever sees its own caller's rows.
+
+// GET /api/user-bot-credentials -> [{ id, label, credShortId, createdAtUtc, revokedAt }]
+// Read-side DTO; never includes the bearer secret.
+export async function listUserBotCredentials(backend, token) {
+  const resp = await fetch(`${backend}/api/user-bot-credentials`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}
+
+// POST /api/user-bot-credentials { label } -> 201 with the same shape
+// PLUS a `plainSecret` field. This is the ONLY response that carries
+// the plaintext PAT (`b3t_xxx_yyy`) — the platform discards the secret
+// after returning it, so callers MUST surface it to the user immediately.
+// Never persist `plainSecret` to storage; keep it in component state and
+// drop it as soon as the user dismisses the "shown once" modal.
+export async function createUserBotCredential(backend, token, label) {
+  const resp = await fetch(`${backend}/api/user-bot-credentials`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ label }),
+  });
+  return jsonOrThrow(resp);
+}
+
+// DELETE /api/user-bot-credentials/{id} -> 204 on success, 404 if
+// the credential never belonged to this user (oracle-safe). Idempotent.
+export async function deleteUserBotCredential(backend, token, id) {
+  const resp = await fetch(
+    `${backend}/api/user-bot-credentials/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  if (resp.status === 204 || resp.status === 404) return null;
+  return jsonOrThrow(resp);
+}

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -64,7 +64,7 @@ const state = {
   killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
   haltStatus: null,        // { symbols: [], fetchedAt } | null — admin-only
   eodReport: null,         // { ranAt, report } | null — last EOD response in this session
-  currentView: "trader",   // "trader" | "admin" — which view is mounted
+  currentView: "trader",   // "trader" | "admin" | "bot-credentials" — which view is mounted
   // Blotter UX (section 3 of #30).
   blotterFilter: { text: "", status: "" }, // { text: substring, status: "" | <OrderStatus> }
   // Per-ClOrdID monotonic arrival sequence. Newly-seen orders get the

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -61,6 +61,8 @@ export function showLogin() {
   $("login-view").hidden = false;
   $("trader-view").hidden = true;
   $("admin-view").hidden = true;
+  const cred = $("bot-credentials-view");
+  if (cred) cred.hidden = true;
   // Default to the login card; a user that previously toggled to the
   // signup card and was bumped back to login (e.g. logout, expiry)
   // shouldn't land staring at the signup form.
@@ -75,6 +77,8 @@ export function showTrader() {
   $("login-view").hidden = true;
   $("trader-view").hidden = false;
   $("admin-view").hidden = true;
+  const cred = $("bot-credentials-view");
+  if (cred) cred.hidden = true;
 }
 
 function setViewToggleVisible(visible, current) {
@@ -779,15 +783,22 @@ export function setUserLabel(user) {
 function applyCurrentView(view) {
   const trader = $("trader-view");
   const admin = $("admin-view");
+  const credentials = $("bot-credentials-view");
   if (!trader || !admin) return;
-  if (view === "admin") {
-    trader.hidden = true;
-    admin.hidden = false;
+  const showTraderView = view === "trader";
+  const showAdminView = view === "admin";
+  const showCredentialsView = view === "bot-credentials";
+  trader.hidden = !showTraderView;
+  admin.hidden = !showAdminView;
+  if (credentials) credentials.hidden = !showCredentialsView;
+  // The trader/admin pill toggle stays hidden when the credentials
+  // view is up — it's a self-contained sub-page reached via the
+  // header link, not a sibling of trader/admin.
+  if (showCredentialsView) {
+    setViewToggleVisible(false, view);
   } else {
-    trader.hidden = false;
-    admin.hidden = true;
+    setViewToggleVisible(getState().user?.role === "admin", view);
   }
-  setViewToggleVisible(getState().user?.role === "admin", view);
 }
 
 // Periodic UI tick for time-based elements (in-flight elapsed, reconnect

--- a/frontend/test/bot-credentials-ui.test.mjs
+++ b/frontend/test/bot-credentials-ui.test.mjs
@@ -1,0 +1,119 @@
+// Bot credentials UI smoke tests (sub-issue #169 of user-bot-fixp-listener-v0).
+//
+// The frontend is plain ES modules with DOM access — there is no jsdom
+// in CI today, so we drive the module against a tiny hand-rolled DOM
+// stub. The goal is the same as cancel-all.test.mjs: lock the contract
+// the real renderer relies on without dragging in a heavier harness.
+//
+// What we verify here:
+//   * `setBotCredentialsRows([])` renders the empty-state copy.
+//   * Active rows render an Active badge AND a Revoke button; revoked
+//     rows render a Revoked tag and NO action button.
+//   * `openBotCredentialsSecretModal({ label, plainSecret })` reveals
+//     the modal and pushes the plaintext PAT into the input value —
+//     this is the "shown once" surface; if it ever silently fails the
+//     user can never use the secret.
+//   * `closeBotCredentialsSecretModal()` blanks the input value so
+//     the secret leaves the DOM (matches the security invariant in
+//     botCredentialsUi.js: never persisted, dropped on dismiss).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+
+installDomStub({
+  ids: {
+    "bot-credentials-open":            { tag: "button" },
+    "bot-credentials-back":            { tag: "button" },
+    "bot-credentials-refresh":         { tag: "button" },
+    "bot-credentials-create-form":     { tag: "form" },
+    "bot-credentials-label":           { tag: "input" },
+    "bot-credentials-create-submit":   { tag: "button" },
+    "bot-credentials-body":            { tag: "tbody" },
+    "bot-credentials-feedback":        { tag: "p" },
+    "bot-credentials-secret-modal":    { tag: "div", hidden: true },
+    "bot-credentials-secret-form":     { tag: "form" },
+    "bot-credentials-secret-label":    { tag: "strong" },
+    "bot-credentials-secret-value":    { tag: "input" },
+    "bot-credentials-secret-copy-status": { tag: "p" },
+    "bot-credentials-secret-copy":     { tag: "button" },
+    "bot-credentials-secret-done":     { tag: "button" },
+  },
+});
+
+const mod = await import("../js/botCredentialsUi.js");
+
+test("empty state copy renders when there are no credentials", () => {
+  mod.setBotCredentialsRows([]);
+  const body = document.getElementById("bot-credentials-body");
+  assert.match(body.innerHTML, /You have no bot credentials/);
+});
+
+test("active rows render badge + revoke button; revoked rows do not", () => {
+  mod.setBotCredentialsRows([
+    {
+      id: "11111111-1111-1111-1111-111111111111",
+      label: "active-bot",
+      credShortId: "AAAA1111",
+      createdAtUtc: "2025-01-02T03:04:05Z",
+      revokedAt: null,
+    },
+    {
+      id: "22222222-2222-2222-2222-222222222222",
+      label: "old-bot",
+      credShortId: "BBBB2222",
+      createdAtUtc: "2025-01-01T00:00:00Z",
+      revokedAt: "2025-01-03T00:00:00Z",
+    },
+  ]);
+  const body = document.getElementById("bot-credentials-body");
+  const html = body.innerHTML;
+  assert.match(html, /active-bot/);
+  assert.match(html, /old-bot/);
+  assert.match(html, /Active/);
+  assert.match(html, /Revoked/);
+  // Revoke button only appears for the active row.
+  const revokeMatches = html.match(/bot-cred-revoke/g) || [];
+  assert.equal(revokeMatches.length, 1, "exactly one revoke button");
+  // Revoke button targets the active credential id.
+  assert.match(html, /data-id="11111111-1111-1111-1111-111111111111"/);
+  assert.doesNotMatch(html, /data-id="22222222-2222-2222-2222-222222222222"/);
+});
+
+test("openBotCredentialsSecretModal exposes the PAT once and close drops it", () => {
+  const modal = document.getElementById("bot-credentials-secret-modal");
+  const input = document.getElementById("bot-credentials-secret-value");
+  const labelEl = document.getElementById("bot-credentials-secret-label");
+  assert.equal(modal.hidden, true, "modal starts hidden");
+
+  mod.openBotCredentialsSecretModal({
+    label: "my-bot",
+    plainSecret: "b3t_abcd1234_xxxxxxxxxxxxxxxxxxxxxxxx",
+  });
+  assert.equal(modal.hidden, false, "modal is visible after open");
+  assert.equal(labelEl.textContent, "my-bot");
+  assert.equal(
+    input.value,
+    "b3t_abcd1234_xxxxxxxxxxxxxxxxxxxxxxxx",
+    "PAT pushed into the modal input — this is the 'shown once' surface",
+  );
+
+  mod.closeBotCredentialsSecretModal();
+  assert.equal(modal.hidden, true, "modal is hidden after close");
+  assert.equal(input.value, "", "secret cleared from the DOM on close");
+  assert.equal(labelEl.textContent, "", "label cleared on close");
+});
+
+test("clearBotCredentials closes the modal and wipes the secret", () => {
+  mod.openBotCredentialsSecretModal({
+    label: "another",
+    plainSecret: "b3t_zzz_yyy",
+  });
+  const input = document.getElementById("bot-credentials-secret-value");
+  assert.notEqual(input.value, "");
+  mod.clearBotCredentials();
+  assert.equal(input.value, "", "clearBotCredentials wipes the modal secret");
+  const modal = document.getElementById("bot-credentials-secret-modal");
+  assert.equal(modal.hidden, true);
+});

--- a/frontend/test/dom-stub.mjs
+++ b/frontend/test/dom-stub.mjs
@@ -1,0 +1,81 @@
+// Minimal DOM stub for node:test runs of the credentials UI module.
+//
+// We intentionally avoid pulling in jsdom — the rest of frontend/test/
+// uses pure node:test against plain functions, and the CI step only
+// runs `node --test` with no install step. This stub mimics just the
+// subset of the DOM surface botCredentialsUi.js touches: getElementById,
+// addEventListener (no-op), focus()/select() (no-op), classList,
+// dataset, .innerHTML / .textContent / .value / .hidden / .className,
+// requestAnimationFrame (sync), and document.execCommand (no-op).
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(...c) { for (const x of c) this._set.add(x); }
+  remove(...c) { for (const x of c) this._set.delete(x); }
+  toggle(c, on) {
+    if (on === undefined) on = !this._set.has(c);
+    if (on) this._set.add(c); else this._set.delete(c);
+  }
+  contains(c) { return this._set.has(c); }
+  toString() { return [...this._set].join(" "); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = String(tag || "div").toUpperCase();
+    this._listeners = new Map();
+    this._dataset = {};
+    this.classList = new FakeClassList();
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.textContent = "";
+    this.innerHTML = "";
+    this.className = "";
+    this.children = [];
+  }
+  get dataset() { return this._dataset; }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  removeEventListener(type, fn) {
+    const l = this._listeners.get(type);
+    if (!l) return;
+    const i = l.indexOf(fn);
+    if (i >= 0) l.splice(i, 1);
+  }
+  setAttribute() {}
+  removeAttribute() {}
+  focus() {}
+  select() {}
+  closest() { return null; }
+  querySelectorAll() { return []; }
+  appendChild(c) { this.children.push(c); return c; }
+}
+
+export function installDomStub({ ids = {} } = {}) {
+  const elements = new Map();
+  for (const [id, spec] of Object.entries(ids)) {
+    const el = new FakeElement(spec?.tag);
+    if (spec?.hidden !== undefined) el.hidden = !!spec.hidden;
+    elements.set(id, el);
+  }
+
+  const documentStub = {
+    getElementById: (id) => elements.get(id) ?? null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    execCommand: () => false,
+  };
+
+  globalThis.document = documentStub;
+  globalThis.window = globalThis.window ?? {
+    confirm: () => true,
+  };
+  globalThis.requestAnimationFrame =
+    globalThis.requestAnimationFrame ?? ((fn) => { try { fn(0); } catch { /* ignore */ } return 0; });
+  globalThis.navigator = globalThis.navigator ?? {};
+
+  return { elements };
+}


### PR DESCRIPTION
## Scope

Frontend UI half of sub-issue **#169 [C] UserBotCredential CRUD (API + UI)**, parent **#166** user-bot FIXP listener. Backend (registry + REST endpoints + tests) shipped in #176; this PR completes the deliverable.

Refs #169
Refs #166

## What's in

- **New view** at `id=\"bot-credentials-view\"` reachable from a *Bot credentials* link in the trader top-bar (visible to every authenticated user).
- **List**: table with Label, CredShortId, Created, Status (Active / Revoked badge), Actions (Revoke). Empty / loading / error states.
- **Create form** + \"shown once\" modal that surfaces the plaintext PAT (`b3t_<credShortId>_<secret>`) returned by `POST /api/user-bot-credentials`. Modal has the warning copy from the RFC (\"Save this token now. It will not be shown again.\"), a Copy-to-clipboard button (`navigator.clipboard.writeText` with a legacy `execCommand('copy')` fallback for non-secure-context dev hosts), a transient \"Copied!\" status, and a Done button.
- **Revoke** with `window.confirm` and `DELETE /api/user-bot-credentials/{id}`.
- **Race-safe handlers**: every list/create/revoke captures `session` before `await` and discards the response if `session` changed, so a pending create cannot leak the PAT after logout and a pending list cannot repaint the previous user's rows.
- **node:test** smoke (`frontend/test/bot-credentials-ui.test.mjs` + a tiny DOM stub) covering empty state, active vs revoked rendering, modal open/close, and verifying the secret is wiped from the DOM on dismiss. Wired into the existing CI step.

## What's out (intentional)

- No backend changes — this PR is UI only.
- No \"regenerate\" endpoint (would need a backend op; out of scope, file separately if needed).

## Security invariants

The plaintext PAT:
- lives **only** in the modal `<input>` element while open,
- is **never** persisted to `localStorage` / `sessionStorage` / `IndexedDB` / cookies,
- is **never** appended to a URL or logged to the console,
- is wiped by `closeBotCredentialsSecretModal()` and by `clearBotCredentials()` on logout,
- in-flight create/list/revoke responses are dropped if the session changed under them.

## gpt-5.5 code-review status

Ran `agent_type: code-review, model: gpt-5.5` against the diff with focus on (a) plaintext-secret persistence, (b) clipboard accessibility, (c) auth header flow.

- 2 × **High** raised on missing session-generation guards for in-flight create + list (could leak PAT or repaint stale rows after logout). **Both fixed** in this PR before commit.
- No Critical issues.
- Style/nits skipped per request.

## CI

Local: `node --test frontend/test/*.mjs` → 72/72 pass. `node --check` clean on every edited JS file.