### PR TITLE
feat(fixp): wire real credential auth + per-credential session registry (#170)

### DIFF
--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -59,7 +59,28 @@ public sealed class PlatformSnapshot
     /// "no PATs minted" semantics those snapshots actually carried.
     /// </summary>
     public List<UserBotCredentialSnapshot> UserBotCredentials { get; init; } = new();
+
+    /// <summary>
+    /// Per-credential FIXP session state (sub-issue #170 / RFC §4.8
+    /// "Snapshot scope"). Empty on snapshots pre-dating the field — the
+    /// state is then reconstructed by WAL replay of
+    /// <c>BotSessionInitializedEvent</c> +
+    /// <c>BotSessionVerAdvancedEvent</c>, which yields the same shape.
+    /// </summary>
+    public List<BotSessionStateSnapshot> BotSessions { get; init; } = new();
 }
+
+/// <summary>
+/// Captures one per-credential FIXP session row. The active-connection
+/// slot is intentionally <b>not</b> persisted — single-active enforcement
+/// is per-process and any in-flight TCP connection is gone after a
+/// restart anyway.
+/// </summary>
+public sealed record BotSessionStateSnapshot(
+    Guid CredentialId,
+    uint SessionId,
+    ulong CurrentVer,
+    ulong LastCheckpointedOutboundSeq);
 
 /// <summary>
 /// Captures one row from <c>InMemoryUserBotCredentialRegistry</c>.

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -29,6 +29,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
 [JsonDerivedType(typeof(UserBotCredentialRevokedEvent), "userbot.cred.revoked")]
+[JsonDerivedType(typeof(BotSessionInitializedEvent), "userbot.session.initialized")]
+[JsonDerivedType(typeof(BotSessionVerAdvancedEvent), "userbot.session.ver-advanced")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -287,4 +289,34 @@ public sealed record UserBotCredentialRevokedEvent : WalEvent
     public required Guid Id { get; init; }
     public required string UserId { get; init; }
     public required DateTimeOffset RevokedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #170. First-access allocation of a per-credential FIXP
+/// session: the platform mints a stable <see cref="SessionId"/> (uint32,
+/// non-zero) and seeds <see cref="InitialVer"/>=1. Replay reconstructs
+/// the row in <c>InMemoryUserBotSessionRegistry</c>.
+/// </summary>
+public sealed record BotSessionInitializedEvent : WalEvent
+{
+    public required Guid CredentialId { get; init; }
+    public required uint SessionId { get; init; }
+    public required ulong InitialVer { get; init; }
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #170. Forced version bump (RFC §4.8). Persisted **before**
+/// the platform sends any bot-observable response carrying the new ver,
+/// guarded by an explicit <c>FlushAsync</c> fence so a crash cannot let
+/// the bot observe a newVer that recovery would roll back. Reasons in
+/// v0: <c>"single-active-violation"</c> (sub-issue D),
+/// <c>"overflow"</c> (sub-issue G), <c>"operator"</c> (admin endpoint).
+/// </summary>
+public sealed record BotSessionVerAdvancedEvent : WalEvent
+{
+    public required Guid CredentialId { get; init; }
+    public required ulong OldVer { get; init; }
+    public required ulong NewVer { get; init; }
+    public required string Reason { get; init; }
 }

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
@@ -1,0 +1,87 @@
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Synthetic principal attached to a FIXP connection after a successful
+/// <c>Negotiate</c>. Mirrors the user-claim shape produced by JWT auth
+/// elsewhere in the platform — sub-issue D wires it onto the listener
+/// connection scope so subsequent code (sub-issue E onward) can reuse the
+/// same per-user isolation primitives REST and WS already use.
+/// </summary>
+/// <remarks>
+/// <see cref="UserId"/> is the JWT <c>sub</c> string of the credential's
+/// owner (see <see cref="UserBotCredential"/>). Logging a principal is
+/// safe — none of these fields are secret.
+/// </remarks>
+public sealed record BotSessionPrincipal(
+    string UserId,
+    Guid CredentialId,
+    string CredShortId,
+    string Label);
+
+/// <summary>
+/// Persistent per-credential state managed by
+/// <see cref="IUserBotSessionRegistry"/>: the platform-allocated FIXP
+/// <see cref="SessionId"/> (uint32, stable for the credential lifetime),
+/// the monotonically advancing <see cref="CurrentVer"/> (uint64,
+/// RFC §4.5), and the most recently checkpointed outbound seq watermark
+/// used by sub-issues E/G for replay bound checks.
+/// </summary>
+public sealed record BotSessionState(
+    Guid CredentialId,
+    uint SessionId,
+    ulong CurrentVer,
+    ulong LastCheckpointedOutboundSeq);
+
+/// <summary>
+/// Per-credential session bookkeeping for the FIXP listener
+/// (RFC user-bot-fixp-listener-v0 §4.5 + §4.8). Implementations enforce
+/// single-active-session-per-credential, allocate a stable
+/// <see cref="BotSessionState.SessionId"/> on first access, and expose a
+/// version-bump path that durably advances <see cref="BotSessionState.CurrentVer"/>
+/// **before** any bot-observable side effect (the explicit
+/// <c>FlushAsync</c> fence per RFC §4.8).
+/// </summary>
+public interface IUserBotSessionRegistry
+{
+    /// <summary>
+    /// Returns the current state for <paramref name="credentialId"/>,
+    /// allocating a fresh <c>(SessionId, CurrentVer=1)</c> tuple on first
+    /// access and emitting a <c>BotSessionInitializedEvent</c> via the
+    /// dispatcher so the allocation survives restart.
+    /// </summary>
+    Task<BotSessionState> GetOrCreateAsync(Guid credentialId, CancellationToken ct);
+
+    /// <summary>
+    /// Single-active-session enforcement. Returns <c>true</c> when the
+    /// caller's <paramref name="connectionId"/> wins ownership of the
+    /// session and <paramref name="attemptedVer"/> matches the current
+    /// version. Returns <c>false</c> when another connection is already
+    /// active OR when <paramref name="attemptedVer"/> is stale; the
+    /// caller is responsible for invoking <see cref="BumpVersionAsync"/>
+    /// per RFC §4.5 ("kick the squatter") in the in-use case.
+    /// </summary>
+    Task<bool> TryClaimActiveAsync(
+        Guid credentialId,
+        ulong attemptedVer,
+        string connectionId,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Releases the active-session slot when <paramref name="connectionId"/>
+    /// matches the current owner. Called on Terminate or socket close so
+    /// a subsequent reconnect can re-claim. Idempotent — releasing a slot
+    /// already owned by a different connection (or none) is a no-op.
+    /// </summary>
+    Task ReleaseAsync(Guid credentialId, string connectionId, CancellationToken ct);
+
+    /// <summary>
+    /// Persists a <c>BotSessionVerAdvancedEvent</c>, mutates the in-memory
+    /// state to <c>oldVer+1</c>, and **awaits an explicit
+    /// <c>IEventStore.FlushAsync</c>** before returning — the durability
+    /// fence required by RFC §4.8 so the next bot-observable response
+    /// (typically an <c>EstablishReject(InvalidSessionVerId)</c>) cannot
+    /// roll back across a crash. Returns the new (post-bump) version so
+    /// the caller can echo it on the very reject that follows.
+    /// </summary>
+    Task<ulong> BumpVersionAsync(Guid credentialId, string reason, CancellationToken ct);
+}

--- a/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotSessionRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotSessionRegistry.cs
@@ -1,0 +1,241 @@
+using System.Security.Cryptography;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// In-memory <see cref="IUserBotSessionRegistry"/>. Mutations go through
+/// <see cref="EventDispatcher"/> so each (WAL append, in-memory mutation)
+/// pair is atomic with respect to snapshot capture. Replay reconstructs
+/// state from <see cref="BotSessionInitializedEvent"/> +
+/// <see cref="BotSessionVerAdvancedEvent"/> on top of the latest snapshot.
+/// Single-active enforcement is in-process; a second host instance would
+/// need a distributed lease, out of scope for v0.
+/// </summary>
+public sealed class InMemoryUserBotSessionRegistry : IUserBotSessionRegistry
+{
+    private readonly EventDispatcher? _dispatcher;
+    private readonly IEventStore? _store;
+    private readonly object _gate = new();
+
+    private readonly Dictionary<Guid, BotSessionState> _byCredentialId = new();
+    private readonly HashSet<uint> _allocatedSessionIds = new();
+    private readonly Dictionary<Guid, string> _activeConnectionByCredentialId = new();
+
+    public InMemoryUserBotSessionRegistry() : this(null, null) { }
+
+    public InMemoryUserBotSessionRegistry(EventDispatcher? dispatcher, IEventStore? store)
+    {
+        _dispatcher = dispatcher;
+        _store = store;
+    }
+
+    public Task<BotSessionState> GetOrCreateAsync(Guid credentialId, CancellationToken ct)
+    {
+        if (credentialId == Guid.Empty)
+            throw new ArgumentException("CredentialId must not be empty.", nameof(credentialId));
+
+        // Hold _gate across the (check → allocate → dispatch → apply)
+        // critical section so concurrent first-access calls for the same
+        // credential cannot each allocate a fresh SessionId and emit
+        // duplicate BotSessionInitializedEvent records. Monitor is
+        // recursive so the apply callback re-entering _gate is safe.
+        lock (_gate)
+        {
+            if (_byCredentialId.TryGetValue(credentialId, out var existing))
+                return Task.FromResult(existing);
+
+            var sessionId = AllocateSessionId();
+            var created = new BotSessionState(credentialId, sessionId, CurrentVer: 1, LastCheckpointedOutboundSeq: 0);
+            var evt = new BotSessionInitializedEvent
+            {
+                CredentialId = credentialId,
+                SessionId = sessionId,
+                InitialVer = 1,
+                CreatedAtUtc = DateTimeOffset.UtcNow,
+            };
+
+            // Reserve the session id eagerly so a future concurrent
+            // allocator under the same gate doesn't reuse it before the
+            // ApplyInitialized callback runs.
+            _allocatedSessionIds.Add(sessionId);
+
+            try
+            {
+                if (_dispatcher is not null)
+                    _dispatcher.Dispatch(evt, () => ApplyInitialized(created));
+                else
+                    ApplyInitialized(created);
+            }
+            catch
+            {
+                // Dispatch failed (WAL backpressure) — release the speculative
+                // SessionId reservation so a retry doesn't leak the id.
+                if (!_byCredentialId.ContainsKey(credentialId))
+                    _allocatedSessionIds.Remove(sessionId);
+                throw;
+            }
+
+            return Task.FromResult(created);
+        }
+    }
+
+    public Task<bool> TryClaimActiveAsync(
+        Guid credentialId, ulong attemptedVer, string connectionId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(connectionId);
+
+        lock (_gate)
+        {
+            if (!_byCredentialId.TryGetValue(credentialId, out var state))
+                return Task.FromResult(false);
+            if (attemptedVer != state.CurrentVer)
+                return Task.FromResult(false);
+            if (_activeConnectionByCredentialId.TryGetValue(credentialId, out var existing)
+                && !string.Equals(existing, connectionId, StringComparison.Ordinal))
+                return Task.FromResult(false);
+
+            _activeConnectionByCredentialId[credentialId] = connectionId;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task ReleaseAsync(Guid credentialId, string connectionId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(connectionId);
+
+        lock (_gate)
+        {
+            if (_activeConnectionByCredentialId.TryGetValue(credentialId, out var existing)
+                && string.Equals(existing, connectionId, StringComparison.Ordinal))
+            {
+                _activeConnectionByCredentialId.Remove(credentialId);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task<ulong> BumpVersionAsync(Guid credentialId, string reason, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        // Hold _gate across the read + dispatch so concurrent bumps cannot
+        // both observe the same oldVer and emit duplicate (oldVer, oldVer+1)
+        // events. The dispatcher's lock is acquired *inside* this gate (and
+        // its apply callback re-enters _gate, which is safe — Monitor is
+        // recursive), giving a strict (read → append → apply) critical
+        // section per credential. FlushAsync is awaited *outside* the gate
+        // because it is an async I/O fence, not state mutation.
+        ulong oldVer;
+        ulong newVer;
+        BotSessionVerAdvancedEvent evt;
+
+        lock (_gate)
+        {
+            if (!_byCredentialId.TryGetValue(credentialId, out var state))
+                throw new InvalidOperationException(
+                    $"Cannot bump version for unknown credential {credentialId}.");
+
+            oldVer = state.CurrentVer;
+            newVer = checked(oldVer + 1);
+            evt = new BotSessionVerAdvancedEvent
+            {
+                CredentialId = credentialId,
+                OldVer = oldVer,
+                NewVer = newVer,
+                Reason = reason,
+            };
+
+            if (_dispatcher is not null)
+                _dispatcher.Dispatch(evt, () => ApplyVerAdvanced(credentialId, newVer));
+            else
+                ApplyVerAdvanced(credentialId, newVer);
+        }
+
+        // RFC §4.8 mandatory durability fence: the bot must not observe
+        // newVer (e.g. via EstablishReject) before the WAL has guaranteed
+        // it. A crash in this window would otherwise resurrect oldVer on
+        // recovery and the bot's reconnect logic would loop indefinitely.
+        if (_store is not null)
+            await _store.FlushAsync(ct).ConfigureAwait(false);
+
+        return newVer;
+    }
+
+    /// <summary>Snapshot capture (called under <c>EventDispatcher.WithSnapshotLock</c>).</summary>
+    public IReadOnlyList<BotSessionStateSnapshot> Snapshot()
+    {
+        lock (_gate)
+        {
+            return _byCredentialId.Values
+                .OrderBy(s => s.CredentialId)
+                .Select(s => new BotSessionStateSnapshot(
+                    s.CredentialId, s.SessionId, s.CurrentVer, s.LastCheckpointedOutboundSeq))
+                .ToList();
+        }
+    }
+
+    /// <summary>Snapshot restore hook — single-threaded at startup.</summary>
+    public void Restore(IEnumerable<BotSessionStateSnapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+        lock (_gate)
+        {
+            _byCredentialId.Clear();
+            _allocatedSessionIds.Clear();
+            _activeConnectionByCredentialId.Clear();
+            foreach (var s in snapshots)
+            {
+                var state = new BotSessionState(
+                    s.CredentialId, s.SessionId, s.CurrentVer, s.LastCheckpointedOutboundSeq);
+                _byCredentialId[s.CredentialId] = state;
+                _allocatedSessionIds.Add(s.SessionId);
+            }
+        }
+    }
+
+    /// <summary>Replay hook for <see cref="BotSessionInitializedEvent"/>.</summary>
+    internal void ApplyInitialized(BotSessionState state)
+    {
+        lock (_gate)
+        {
+            _byCredentialId[state.CredentialId] = state;
+            _allocatedSessionIds.Add(state.SessionId);
+        }
+    }
+
+    /// <summary>Replay hook for <see cref="BotSessionVerAdvancedEvent"/>.</summary>
+    internal void ApplyVerAdvanced(Guid credentialId, ulong newVer)
+    {
+        lock (_gate)
+        {
+            if (_byCredentialId.TryGetValue(credentialId, out var existing))
+            {
+                _byCredentialId[credentialId] = existing with { CurrentVer = newVer };
+            }
+            // A bump for an unknown credential during replay would mean a
+            // missing initialised event upstream; tolerate silently rather
+            // than crash recovery — the next live bump will re-emit if the
+            // credential is still in use.
+        }
+    }
+
+    // RFC §4.5: SessionId is non-zero uint32. Birthday-collisions on
+    // 2^32 minus-one are negligible at participant counts; a defensive
+    // collision check still avoids re-issuing an id while the lock is held.
+    private uint AllocateSessionId()
+    {
+        Span<byte> buf = stackalloc byte[4];
+        for (var attempt = 0; attempt < 64; attempt++)
+        {
+            RandomNumberGenerator.Fill(buf);
+            var id = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf);
+            if (id == 0) continue;
+            if (_allocatedSessionIds.Contains(id)) continue;
+            return id;
+        }
+        throw new InvalidOperationException(
+            "Exhausted SessionId allocation attempts — the credential pool is implausibly large.");
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
+++ b/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\B3.Trading.Application\B3.Trading.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="B3.EntryPoint.Sbe" Version="0.14.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="*" />

--- a/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachine.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachine.cs
@@ -21,6 +21,13 @@ internal sealed class FixpHandshakeStateMachine
 
     public FixpSessionState State => _state;
 
+    /// <summary>
+    /// Internal hook for the connection layer (sub-issue #170) — lets the
+    /// async auth/session-registry post-checks force a terminal state
+    /// after the FSM has otherwise approved a transition.
+    /// </summary>
+    internal void SetState(FixpSessionState state) => _state = state;
+
     /// <summary>Session ID echoed from the client's Negotiate — valid after first successful <see cref="OnNegotiate"/>.</summary>
     public SessionID SessionId => _sessionId;
 

--- a/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachineExtensions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Handshake/FixpHandshakeStateMachineExtensions.cs
@@ -1,0 +1,20 @@
+namespace B3.Trading.EntryPointListener.Handshake;
+
+/// <summary>
+/// Add-ons applied by <c>FixpSessionConnection</c> to
+/// <see cref="FixpHandshakeStateMachine"/> so that asynchronous
+/// auth + session-registry checks can layer on top of the synchronous
+/// FIXP-shape state machine without forking the FSM. Sub-issue #170.
+/// </summary>
+internal static class FixpHandshakeStateMachineExtensions
+{
+    /// <summary>
+    /// Forces the state machine into <see cref="FixpSessionState.Terminated"/>.
+    /// Used after the connection layer overrides an FSM-approved Establish
+    /// with a registry-level reject (single-active violation, stale
+    /// SessionVerId) so the next inbound frame is short-circuited rather
+    /// than being interpreted on a stale state.
+    /// </summary>
+    public static void ForceTerminated(this FixpHandshakeStateMachine sm)
+        => sm.SetState(FixpSessionState.Terminated);
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpConnectionScope.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpConnectionScope.cs
@@ -1,0 +1,20 @@
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Per-connection scope established once a FIXP <c>Negotiate</c> has
+/// authenticated. Bundles the resolved <see cref="BotSessionPrincipal"/>
+/// with the connection identifier used for single-active-session claims
+/// and the <see cref="ConnectionId"/> threaded through the structured
+/// auth log lines.
+///
+/// <para>This is the in-process equivalent of the JWT-issued
+/// <c>ClaimsPrincipal</c> attached to REST/WS requests — it is what the
+/// future order pipeline (sub-issue E) reads to enforce per-user
+/// isolation on FIXP-originated <c>NewOrderSingle</c>s.</para>
+/// </summary>
+internal sealed record FixpConnectionScope(
+    string ConnectionId,
+    BotSessionPrincipal Principal,
+    BotSessionState SessionState);

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
-using System.Security.Cryptography;
+using B3.Trading.Application.UserBots;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,6 +23,8 @@ namespace B3.Trading.EntryPointListener.Hosting;
 public sealed class FixpListenerHostedService : BackgroundService
 {
     private readonly EntryPointListenerOptions _opts;
+    private readonly IUserBotCredentialRegistry _credentials;
+    private readonly IUserBotSessionRegistry _sessions;
     private readonly ILogger<FixpListenerHostedService> _logger;
     private readonly TaskCompletionSource<IPEndPoint> _boundTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -31,9 +33,13 @@ public sealed class FixpListenerHostedService : BackgroundService
 
     public FixpListenerHostedService(
         IOptions<EntryPointListenerOptions> opts,
+        IUserBotCredentialRegistry credentials,
+        IUserBotSessionRegistry sessions,
         ILogger<FixpListenerHostedService> logger)
     {
         _opts = opts.Value;
+        _credentials = credentials;
+        _sessions = sessions;
         _logger = logger;
     }
 
@@ -85,10 +91,7 @@ public sealed class FixpListenerHostedService : BackgroundService
                     continue;
                 }
 
-                var sessionId = AllocateSessionId();
-                _logger.LogDebug("FIXP connection accepted; internalSessionId={Id}.", sessionId);
-
-                var conn = new FixpSessionConnection(client, _logger);
+                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger);
                 _ = Task.Run(() => conn.RunAsync(stoppingToken), stoppingToken);
             }
         }
@@ -96,23 +99,5 @@ public sealed class FixpListenerHostedService : BackgroundService
         {
             _listener.Stop();
         }
-    }
-
-    /// <summary>
-    /// Generates a random non-zero uint32 used as an internal connection
-    /// identifier for log correlation.  Sub-issue D will replace this with
-    /// a monotonic sequence-version manager.
-    /// </summary>
-    private static uint AllocateSessionId()
-    {
-        Span<byte> buf = stackalloc byte[4];
-        uint id;
-        do
-        {
-            RandomNumberGenerator.Fill(buf);
-            id = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf);
-        }
-        while (id == 0);
-        return id;
     }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -1,7 +1,10 @@
 using System.Buffers;
+using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Application.UserBots;
 using B3.Trading.EntryPointListener.Framing;
 using B3.Trading.EntryPointListener.Handshake;
 using Microsoft.Extensions.Logging;
@@ -9,36 +12,64 @@ using Microsoft.Extensions.Logging;
 namespace B3.Trading.EntryPointListener.Hosting;
 
 /// <summary>
-/// Manages the FIXP session lifecycle for a single accepted TCP connection.
-/// Reads SOFH-framed SBE messages, drives <see cref="FixpHandshakeStateMachine"/>,
-/// and writes responses. Auth is stubbed (always-accept) in sub-issue B.
+/// Manages the FIXP session lifecycle for a single accepted TCP
+/// connection. Reads SOFH-framed SBE messages, drives
+/// <see cref="FixpHandshakeStateMachine"/>, and writes responses.
+///
+/// <para>Sub-issue #170 (<c>D</c>): authenticates the
+/// <c>Negotiate.Credentials</c> buffer against
+/// <see cref="IUserBotCredentialRegistry"/>, attaches the resulting
+/// <see cref="FixpConnectionScope"/> to the connection, and on
+/// <c>Establish</c> claims the per-credential session via
+/// <see cref="IUserBotSessionRegistry"/> with single-active enforcement.
+/// </para>
 /// </summary>
 internal sealed class FixpSessionConnection
 {
-    // SBE MessageHeader fields written into every outbound frame.
     private const ushort SchemaIdV6 = 1;
     private const ushort VersionNegotiateResponse = 6;
+    private const ushort VersionNegotiateReject = 6;
     private const ushort VersionEstablishAck = 6;
+    private const ushort VersionEstablishReject = 6;
     private const ushort VersionTerminate = 0;
+
+    /// <summary>
+    /// Hard ceiling on the credential buffer length we will UTF-8 decode.
+    /// The PAT shape is ≤ 50 bytes (<c>b3t_</c> + 10 short-id + <c>_</c> +
+    /// 32 base64url secret); we stay generous to absorb future format
+    /// growth without lifting the cap into config. Anything larger is
+    /// rejected without allocation as a malformed buffer.
+    /// </summary>
+    private const int MaxCredentialBufferBytes = 256;
 
     private readonly TcpClient _tcpClient;
     private readonly ILogger _logger;
+    private readonly IUserBotCredentialRegistry _credentials;
+    private readonly IUserBotSessionRegistry _sessions;
+    private readonly string _connectionId;
     private readonly FixpHandshakeStateMachine _sm = new();
 
-    public FixpSessionConnection(TcpClient tcpClient, ILogger logger)
+    private FixpConnectionScope? _scope;
+    private bool _slotClaimed;
+
+    public FixpSessionConnection(
+        TcpClient tcpClient,
+        IUserBotCredentialRegistry credentials,
+        IUserBotSessionRegistry sessions,
+        ILogger logger)
     {
         _tcpClient = tcpClient;
+        _credentials = credentials;
+        _sessions = sessions;
         _logger = logger;
+        _connectionId = Guid.NewGuid().ToString("N");
     }
 
-    /// <summary>
-    /// Runs the connection loop until the peer closes the connection,
-    /// the handshake terminates, or <paramref name="ct"/> is cancelled.
-    /// </summary>
     public async Task RunAsync(CancellationToken ct)
     {
         using var client = _tcpClient;
         var stream = client.GetStream();
+        var remote = SafeRemote(client);
         var reader = new SofhFrameReader();
         var readBuf = ArrayPool<byte>.Shared.Rent(4096);
 
@@ -58,7 +89,7 @@ internal sealed class FixpSessionConnection
                     break;
                 }
 
-                if (n == 0) break; // peer closed connection
+                if (n == 0) break; // peer closed
 
                 reader.Append(readBuf.AsSpan(0, n));
 
@@ -67,130 +98,280 @@ internal sealed class FixpSessionConnection
                     _logger.LogWarning("FIXP framing error: {Msg}", reader.ProtocolErrorMessage);
                     await BestEffortSendTerminateAsync(stream, TerminationCode.INVALID_SOFH, ct)
                         .ConfigureAwait(false);
-                    break;
+                    return;
                 }
 
                 while (reader.TryReadFrame(out var frame))
                 {
-                    // Decode synchronously (frame.Payload span must not cross an await).
-                    var decoded = DecodeFrame(frame);
-                    var action = Dispatch(decoded);
-
-                    await SendResponseAsync(stream, action, decoded.SessionId, decoded.SessionVerId, ct)
-                        .ConfigureAwait(false);
-
-                    if (action.IsTerminating) return;
+                    var decoded = ExtractFrame(frame);
+                    var keepGoing = await HandleFrameAsync(stream, decoded, remote, ct).ConfigureAwait(false);
+                    if (!keepGoing) return;
                 }
 
                 if (reader.HasProtocolError)
                 {
                     await BestEffortSendTerminateAsync(stream, TerminationCode.INVALID_SOFH, ct)
                         .ConfigureAwait(false);
-                    break;
+                    return;
                 }
             }
         }
         finally
         {
             ArrayPool<byte>.Shared.Return(readBuf);
+            // Always release any single-active slot we hold, even on
+            // abrupt close — otherwise a crashed bot would lock its own
+            // credential out until the next version bump.
+            if (_slotClaimed && _scope is not null)
+            {
+                try
+                {
+                    await _sessions.ReleaseAsync(_scope.Principal.CredentialId, _connectionId, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "FIXP single-active slot release failed (best-effort).");
+                }
+            }
         }
     }
 
-    // ─── Synchronous helpers (no await — spans are safe here) ────────────────
-
-    private struct DecodedFrame
+    /// <summary>
+    /// Heap-copy of a <see cref="SofhFrame"/> so the connection's async
+    /// dispatch can survive across <c>await</c>s without holding a span
+    /// into the reader's rotating buffer.
+    /// </summary>
+    private readonly struct DecodedFrame
     {
-        public ushort TemplateId;
-        public bool DecodeFailed;   // true when a known template has an undersized payload
-        public uint SessionId;      // (uint)SessionID
-        public ulong SessionVerId;  // (ulong)SessionVerID
-        public TerminationCode TermCode;
+        public ushort TemplateId { get; init; }
+        public byte[] Payload { get; init; }
     }
 
-    private static DecodedFrame DecodeFrame(SofhFrame frame)
+    private static DecodedFrame ExtractFrame(SofhFrame frame) => new()
     {
-        var d = new DecodedFrame { TemplateId = frame.TemplateId };
+        TemplateId = frame.TemplateId,
+        Payload = frame.Payload.ToArray(),
+    };
 
+    /// <summary>
+    /// Returns <c>true</c> to keep the connection loop running, <c>false</c>
+    /// to terminate the session and close the socket.
+    /// </summary>
+    private async Task<bool> HandleFrameAsync(
+        NetworkStream stream, DecodedFrame frame, string remote, CancellationToken ct)
+    {
         switch (frame.TemplateId)
         {
-            case NegotiateData.MESSAGE_ID when frame.Payload.Length >= NegotiateData.BLOCK_LENGTH:
-                {
-                    var msg = MemoryMarshal.Read<NegotiateData>(frame.Payload);
-                    d.SessionId = (uint)msg.SessionID;
-                    d.SessionVerId = (ulong)msg.SessionVerID;
-                    break;
-                }
-            case EstablishData.MESSAGE_ID when frame.Payload.Length >= EstablishData.BLOCK_LENGTH:
-                {
-                    var msg = MemoryMarshal.Read<EstablishData>(frame.Payload);
-                    d.SessionId = (uint)msg.SessionID;
-                    d.SessionVerId = (ulong)msg.SessionVerID;
-                    break;
-                }
-            case TerminateData.MESSAGE_ID when frame.Payload.Length >= TerminateData.BLOCK_LENGTH:
-                {
-                    var msg = MemoryMarshal.Read<TerminateData>(frame.Payload);
-                    d.SessionId = (uint)msg.SessionID;
-                    d.SessionVerId = (ulong)msg.SessionVerID;
-                    d.TermCode = msg.TerminationCode;
-                    break;
-                }
-            // Known handshake template with undersized payload — reject rather than dispatch zeroes.
             case NegotiateData.MESSAGE_ID:
+                return await HandleNegotiateAsync(stream, frame, remote, ct).ConfigureAwait(false);
+
             case EstablishData.MESSAGE_ID:
+                return await HandleEstablishAsync(stream, frame, ct).ConfigureAwait(false);
+
             case TerminateData.MESSAGE_ID:
-                d.DecodeFailed = true;
-                break;
-        }
+                return await HandleTerminateAsync(stream, frame, ct).ConfigureAwait(false);
 
-        return d;
-    }
-
-    private HandshakeAction Dispatch(in DecodedFrame d)
-    {
-        if (d.DecodeFailed)
-            return HandshakeAction.Terminate(TerminationCode.UNSPECIFIED);
-
-        switch (d.TemplateId)
-        {
-            case NegotiateData.MESSAGE_ID:
-                {
-                    var msg = new NegotiateData
-                    {
-                        SessionID = (SessionID)d.SessionId,
-                        SessionVerID = (SessionVerID)d.SessionVerId,
-                    };
-                    return _sm.OnNegotiate(in msg);
-                }
-            case EstablishData.MESSAGE_ID:
-                {
-                    var msg = new EstablishData
-                    {
-                        SessionID = (SessionID)d.SessionId,
-                        SessionVerID = (SessionVerID)d.SessionVerId,
-                    };
-                    return _sm.OnEstablish(in msg);
-                }
-            case TerminateData.MESSAGE_ID:
-                {
-                    var msg = new TerminateData
-                    {
-                        SessionID = (SessionID)d.SessionId,
-                        SessionVerID = (SessionVerID)d.SessionVerId,
-                        TerminationCode = d.TermCode,
-                    };
-                    return _sm.OnTerminate(in msg);
-                }
             default:
-                return _sm.State == FixpSessionState.Established
-                    ? HandshakeAction.NoOp
-                    : _sm.OnApplicationMessageBeforeEstablished();
+                if (_sm.State == FixpSessionState.Established)
+                {
+                    // Application-message paths land here; sub-issue E adds
+                    // NewOrderSingle/Cancel handling. v0 ignores them.
+                    return true;
+                }
+                var pre = _sm.OnApplicationMessageBeforeEstablished();
+                await SendActionAsync(stream, pre, sessionId: 0, sessionVerId: 0, ct).ConfigureAwait(false);
+                return false;
         }
     }
 
-    // ─── Async response writers ───────────────────────────────────────────────
+    // ─── Negotiate ───────────────────────────────────────────────────────
 
-    private async Task SendResponseAsync(
+    private async Task<bool> HandleNegotiateAsync(
+        NetworkStream stream, DecodedFrame frame, string remote, CancellationToken ct)
+    {
+        if (frame.Payload.Length < NegotiateData.BLOCK_LENGTH)
+        {
+            _logger.LogInformation(
+                "fixp.negotiate.reject reason=INVALID_FRAME remote={Remote}", remote);
+            await SendActionAsync(stream, HandshakeAction.Terminate(TerminationCode.UNSPECIFIED),
+                sessionId: 0, sessionVerId: 0, ct).ConfigureAwait(false);
+            return false;
+        }
+
+        var msg = MemoryMarshal.Read<NegotiateData>(frame.Payload);
+        var sessionId = (uint)msg.SessionID;
+        var sessionVerId = (ulong)msg.SessionVerID;
+
+        // Drive FSM first so out-of-order Negotiates (e.g. after Establish)
+        // get the right termination code regardless of credentials state.
+        var fsmAction = _sm.OnNegotiate(in msg);
+        if (fsmAction.Kind != HandshakeActionKind.SendNegotiateResponse)
+        {
+            await SendActionAsync(stream, fsmAction, sessionId, sessionVerId, ct).ConfigureAwait(false);
+            return !fsmAction.IsTerminating;
+        }
+
+        // Auth: pull the Credentials var-data field from the SBE payload
+        // and resolve it through the credential registry. The token itself
+        // is intentionally never logged — only the public CredShortId.
+        if (!TryReadCredentials(frame.Payload, out var token))
+        {
+            _logger.LogInformation(
+                "fixp.negotiate.reject reason=CREDENTIALS detail=malformed-buffer remote={Remote}",
+                remote);
+            await WriteNegotiateRejectAsync(stream, sessionId, sessionVerId,
+                NegotiationRejectCode.CREDENTIALS, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        var credential = await _credentials.TryAuthenticateAsync(token, ct).ConfigureAwait(false);
+        if (credential is null)
+        {
+            _logger.LogInformation(
+                "fixp.negotiate.reject reason=CREDENTIALS remote={Remote}",
+                remote);
+            await WriteNegotiateRejectAsync(stream, sessionId, sessionVerId,
+                NegotiationRejectCode.CREDENTIALS, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        // Allocate (or load) the per-credential session state up-front so
+        // Establish can validate sid/ver synchronously off the resolved
+        // scope without re-querying the registry.
+        var sessionState = await _sessions.GetOrCreateAsync(credential.Id, ct).ConfigureAwait(false);
+        var principal = new BotSessionPrincipal(
+            credential.UserId, credential.Id, credential.CredShortId, credential.Label);
+        _scope = new FixpConnectionScope(_connectionId, principal, sessionState);
+
+        _logger.LogInformation(
+            "fixp.negotiate.ok credShortId={CredShortId} userId={UserId} remote={Remote} connectionId={ConnectionId}",
+            credential.CredShortId, credential.UserId, remote, _connectionId);
+
+        await WriteNegotiateResponseAsync(stream, sessionId, sessionVerId, ct).ConfigureAwait(false);
+        return true;
+    }
+
+    // ─── Establish ───────────────────────────────────────────────────────
+
+    private async Task<bool> HandleEstablishAsync(
+        NetworkStream stream, DecodedFrame frame, CancellationToken ct)
+    {
+        if (frame.Payload.Length < EstablishData.BLOCK_LENGTH)
+        {
+            await SendActionAsync(stream, HandshakeAction.Terminate(TerminationCode.UNSPECIFIED),
+                sessionId: 0, sessionVerId: 0, ct).ConfigureAwait(false);
+            return false;
+        }
+
+        var msg = MemoryMarshal.Read<EstablishData>(frame.Payload);
+        var requestedSid = (uint)msg.SessionID;
+        var requestedVer = (ulong)msg.SessionVerID;
+
+        var fsmAction = _sm.OnEstablish(in msg);
+        if (fsmAction.Kind != HandshakeActionKind.SendEstablishAck)
+        {
+            await SendActionAsync(stream, fsmAction, requestedSid, requestedVer, ct).ConfigureAwait(false);
+            return !fsmAction.IsTerminating;
+        }
+
+        // FSM said OK → registry-level checks. The scope must exist by
+        // construction (Negotiated state implies a successful Negotiate
+        // populated _scope); a missing scope here is a bug, not user
+        // error, but we defend with a CREDENTIALS reject just in case.
+        if (_scope is null)
+        {
+            await WriteEstablishRejectAsync(stream, requestedSid, requestedVer,
+                EstablishRejectCode.CREDENTIALS, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        var credentialId = _scope.Principal.CredentialId;
+        var serverState = await _sessions.GetOrCreateAsync(credentialId, ct).ConfigureAwait(false);
+
+        if (requestedSid != serverState.SessionId)
+        {
+            _logger.LogInformation(
+                "fixp.establish.reject reason=INVALID_SESSIONID credShortId={CredShortId} requested={Sid} expected={ExpectedSid}",
+                _scope.Principal.CredShortId, requestedSid, serverState.SessionId);
+            await WriteEstablishRejectAsync(stream, requestedSid, requestedVer,
+                EstablishRejectCode.INVALID_SESSIONID, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        if (requestedVer != serverState.CurrentVer)
+        {
+            _logger.LogInformation(
+                "fixp.establish.reject reason=INVALID_SESSIONVERID credShortId={CredShortId} requested={Ver} expected={ExpectedVer}",
+                _scope.Principal.CredShortId, requestedVer, serverState.CurrentVer);
+            // Echo the server-side current ver so the bot's reconnect
+            // logic can resync without having to trigger a fresh
+            // Negotiate purely to discover the value.
+            await WriteEstablishRejectAsync(stream, requestedSid, serverState.CurrentVer,
+                EstablishRejectCode.INVALID_SESSIONVERID, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        var claimed = await _sessions.TryClaimActiveAsync(credentialId, requestedVer, _connectionId, ct)
+            .ConfigureAwait(false);
+        if (!claimed)
+        {
+            // RFC §4.5 "kick the squatter": bump the version durably (the
+            // BumpVersionAsync contract is "WAL append + FlushAsync fence
+            // before returning") *then* send the reject. The reject must
+            // carry the **new** ver so the squatter learns the value it
+            // would otherwise have to discover via a fresh Negotiate; a
+            // second bot attempt with the now-stale ver will fail the
+            // version check above without further bumping.
+            var bumpedVer = await _sessions.BumpVersionAsync(credentialId, "single-active-violation", ct)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "fixp.establish.reject reason=SESSION_BLOCKED credShortId={CredShortId} cause=single-active-violation oldVer={OldVer} newVer={NewVer}",
+                _scope.Principal.CredShortId, requestedVer, bumpedVer);
+            await WriteEstablishRejectAsync(stream, requestedSid, bumpedVer,
+                EstablishRejectCode.SESSION_BLOCKED, ct).ConfigureAwait(false);
+            _sm.ForceTerminated();
+            return false;
+        }
+
+        _slotClaimed = true;
+        _logger.LogInformation(
+            "fixp.establish.ok credShortId={CredShortId} userId={UserId} sessionId={Sid} sessionVerId={Ver} connectionId={ConnectionId}",
+            _scope.Principal.CredShortId, _scope.Principal.UserId,
+            serverState.SessionId, serverState.CurrentVer, _connectionId);
+        await WriteEstablishAckAsync(stream, requestedSid, requestedVer, ct).ConfigureAwait(false);
+        return true;
+    }
+
+    // ─── Terminate ───────────────────────────────────────────────────────
+
+    private async Task<bool> HandleTerminateAsync(
+        NetworkStream stream, DecodedFrame frame, CancellationToken ct)
+    {
+        TerminateData msg = default;
+        uint sid = 0;
+        ulong ver = 0;
+        if (frame.Payload.Length >= TerminateData.BLOCK_LENGTH)
+        {
+            msg = MemoryMarshal.Read<TerminateData>(frame.Payload);
+            sid = (uint)msg.SessionID;
+            ver = (ulong)msg.SessionVerID;
+        }
+
+        var action = _sm.OnTerminate(in msg);
+        await SendActionAsync(stream, action, sid, ver, ct).ConfigureAwait(false);
+        return false; // always close after Terminate
+    }
+
+    // ─── Async response writers ──────────────────────────────────────────
+
+    private static async Task SendActionAsync(
         NetworkStream stream,
         HandshakeAction action,
         uint sessionId,
@@ -202,21 +383,17 @@ internal sealed class FixpSessionConnection
             case HandshakeActionKind.SendNegotiateResponse:
                 await WriteNegotiateResponseAsync(stream, sessionId, sessionVerId, ct).ConfigureAwait(false);
                 break;
-
             case HandshakeActionKind.SendEstablishAck:
                 await WriteEstablishAckAsync(stream, sessionId, sessionVerId, ct).ConfigureAwait(false);
                 break;
-
             case HandshakeActionKind.AckTerminateAndClose:
                 await WriteTerminateAsync(stream, sessionId, sessionVerId, TerminationCode.FINISHED, ct)
                     .ConfigureAwait(false);
                 break;
-
             case HandshakeActionKind.Terminate:
                 await WriteTerminateAsync(stream, sessionId, sessionVerId, action.TermCode, ct)
                     .ConfigureAwait(false);
                 break;
-
             case HandshakeActionKind.NoOp:
             default:
                 break;
@@ -230,27 +407,43 @@ internal sealed class FixpSessionConnection
         var buf = ArrayPool<byte>.Shared.Rent(frameSize);
         try
         {
-            BuildNegotiateResponseFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId);
+            Span<byte> body = stackalloc byte[NegotiateResponseData.BLOCK_LENGTH];
+            body.Clear();
+            ref var resp = ref MemoryMarshal.AsRef<NegotiateResponseData>(body);
+            resp.SessionID = (SessionID)sessionId;
+            resp.SessionVerID = (SessionVerID)sessionVerId;
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)NegotiateResponseData.BLOCK_LENGTH,
+                (ushort)NegotiateResponseData.MESSAGE_ID,
+                SchemaIdV6, VersionNegotiateResponse,
+                body);
             await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buf);
-        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
     }
 
-    private static void BuildNegotiateResponseFrame(Span<byte> dest, uint sessionId, ulong sessionVerId)
+    private static async Task WriteNegotiateRejectAsync(
+        NetworkStream stream, uint sessionId, ulong sessionVerId,
+        NegotiationRejectCode code, CancellationToken ct)
     {
-        Span<byte> body = stackalloc byte[NegotiateResponseData.BLOCK_LENGTH];
-        body.Clear();
-        ref var resp = ref MemoryMarshal.AsRef<NegotiateResponseData>(body);
-        resp.SessionID = (SessionID)sessionId;
-        resp.SessionVerID = (SessionVerID)sessionVerId;
-        SofhFrameWriter.WriteFrame(dest,
-            (ushort)NegotiateResponseData.BLOCK_LENGTH,
-            (ushort)NegotiateResponseData.MESSAGE_ID,
-            SchemaIdV6, VersionNegotiateResponse,
-            body);
+        var frameSize = SofhFrameWriter.FrameSize(NegotiateRejectData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            Span<byte> body = stackalloc byte[NegotiateRejectData.BLOCK_LENGTH];
+            body.Clear();
+            ref var resp = ref MemoryMarshal.AsRef<NegotiateRejectData>(body);
+            resp.SessionID = (SessionID)sessionId;
+            resp.SessionVerID = (SessionVerID)sessionVerId;
+            resp.NegotiationRejectCode = code;
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)NegotiateRejectData.BLOCK_LENGTH,
+                (ushort)NegotiateRejectData.MESSAGE_ID,
+                SchemaIdV6, VersionNegotiateReject,
+                body);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
     }
 
     private static async Task WriteEstablishAckAsync(
@@ -260,27 +453,43 @@ internal sealed class FixpSessionConnection
         var buf = ArrayPool<byte>.Shared.Rent(frameSize);
         try
         {
-            BuildEstablishAckFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId);
+            Span<byte> body = stackalloc byte[EstablishAckData.BLOCK_LENGTH];
+            body.Clear();
+            ref var resp = ref MemoryMarshal.AsRef<EstablishAckData>(body);
+            resp.SessionID = (SessionID)sessionId;
+            resp.SessionVerID = (SessionVerID)sessionVerId;
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)EstablishAckData.BLOCK_LENGTH,
+                (ushort)EstablishAckData.MESSAGE_ID,
+                SchemaIdV6, VersionEstablishAck,
+                body);
             await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buf);
-        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
     }
 
-    private static void BuildEstablishAckFrame(Span<byte> dest, uint sessionId, ulong sessionVerId)
+    private static async Task WriteEstablishRejectAsync(
+        NetworkStream stream, uint sessionId, ulong sessionVerId,
+        EstablishRejectCode code, CancellationToken ct)
     {
-        Span<byte> body = stackalloc byte[EstablishAckData.BLOCK_LENGTH];
-        body.Clear();
-        ref var resp = ref MemoryMarshal.AsRef<EstablishAckData>(body);
-        resp.SessionID = (SessionID)sessionId;
-        resp.SessionVerID = (SessionVerID)sessionVerId;
-        SofhFrameWriter.WriteFrame(dest,
-            (ushort)EstablishAckData.BLOCK_LENGTH,
-            (ushort)EstablishAckData.MESSAGE_ID,
-            SchemaIdV6, VersionEstablishAck,
-            body);
+        var frameSize = SofhFrameWriter.FrameSize(EstablishRejectData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            Span<byte> body = stackalloc byte[EstablishRejectData.BLOCK_LENGTH];
+            body.Clear();
+            ref var resp = ref MemoryMarshal.AsRef<EstablishRejectData>(body);
+            resp.SessionID = (SessionID)sessionId;
+            resp.SessionVerID = (SessionVerID)sessionVerId;
+            resp.EstablishmentRejectCode = code;
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)EstablishRejectData.BLOCK_LENGTH,
+                (ushort)EstablishRejectData.MESSAGE_ID,
+                SchemaIdV6, VersionEstablishReject,
+                body);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
     }
 
     private static async Task WriteTerminateAsync(
@@ -294,48 +503,72 @@ internal sealed class FixpSessionConnection
         var buf = ArrayPool<byte>.Shared.Rent(frameSize);
         try
         {
-            BuildTerminateFrame(buf.AsSpan(0, frameSize), sessionId, sessionVerId, code);
+            Span<byte> body = stackalloc byte[TerminateData.BLOCK_LENGTH];
+            body.Clear();
+            ref var msg = ref MemoryMarshal.AsRef<TerminateData>(body);
+            msg.SessionID = (SessionID)sessionId;
+            msg.SessionVerID = (SessionVerID)sessionVerId;
+            msg.TerminationCode = code;
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)TerminateData.BLOCK_LENGTH,
+                (ushort)TerminateData.MESSAGE_ID,
+                SchemaIdV6, VersionTerminate,
+                body);
             await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buf);
-        }
-    }
-
-    private static void BuildTerminateFrame(
-        Span<byte> dest, uint sessionId, ulong sessionVerId, TerminationCode code)
-    {
-        Span<byte> body = stackalloc byte[TerminateData.BLOCK_LENGTH];
-        body.Clear();
-        ref var msg = ref MemoryMarshal.AsRef<TerminateData>(body);
-        msg.SessionID = (SessionID)sessionId;
-        msg.SessionVerID = (SessionVerID)sessionVerId;
-        msg.TerminationCode = code;
-        SofhFrameWriter.WriteFrame(dest,
-            (ushort)TerminateData.BLOCK_LENGTH,
-            (ushort)TerminateData.MESSAGE_ID,
-            SchemaIdV6, VersionTerminate,
-            body);
+        finally { ArrayPool<byte>.Shared.Return(buf); }
     }
 
     private static async Task BestEffortSendTerminateAsync(
         NetworkStream stream, TerminationCode code, CancellationToken ct)
     {
+        try { await WriteTerminateAsync(stream, 0, 0, code, ct).ConfigureAwait(false); }
+        catch { /* best effort */ }
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts the <c>Credentials</c> var-data group that follows the
+    /// fixed-size block of a Negotiate body. The SBE encoding for this
+    /// field is <c>byte length || varData[length]</c> — a malformed,
+    /// truncated, or oversized buffer fails closed (no UTF-8 decoding,
+    /// no allocation of an unbounded string).
+    /// </summary>
+    private static bool TryReadCredentials(ReadOnlySpan<byte> payload, out string token)
+    {
+        token = string.Empty;
+        var blockLen = NegotiateData.BLOCK_LENGTH;
+        if (payload.Length < blockLen + 1) return false;
+
+        int len = payload[blockLen];
+        if (len == 0) return false;
+        if (len > MaxCredentialBufferBytes) return false;
+        if (payload.Length < blockLen + 1 + len) return false;
+
+        var bytes = payload.Slice(blockLen + 1, len);
         try
         {
-            var frameSize = SofhFrameWriter.FrameSize(TerminateData.BLOCK_LENGTH);
-            var buf = ArrayPool<byte>.Shared.Rent(frameSize);
-            try
-            {
-                BuildTerminateFrame(buf.AsSpan(0, frameSize), 0, 0, code);
-                await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buf);
-            }
+            token = Encoding.UTF8.GetString(bytes);
+            return token.Length > 0;
         }
-        catch { /* best effort */ }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    private static string SafeRemote(TcpClient client)
+    {
+        try
+        {
+            return client.Client.RemoteEndPoint switch
+            {
+                IPEndPoint ip => $"{ip.Address}:{ip.Port}",
+                { } ep => ep.ToString() ?? "?",
+                _ => "?",
+            };
+        }
+        catch { return "?"; }
     }
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -103,6 +103,9 @@ builder.Services.AddSingleton<CashLedger>();
 builder.Services.AddSingleton<InMemoryUserBotCredentialRegistry>();
 builder.Services.AddSingleton<IUserBotCredentialRegistry>(sp =>
     sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
+builder.Services.AddSingleton<InMemoryUserBotSessionRegistry>();
+builder.Services.AddSingleton<IUserBotSessionRegistry>(sp =>
+    sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -26,6 +26,7 @@ public sealed class StateSnapshotter
     private readonly AlgoIdRegistry _algoIds;
     private readonly CashLedger _cash;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
+    private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -38,7 +39,8 @@ public sealed class StateSnapshotter
         AlgoBook algos,
         AlgoIdRegistry algoIds,
         CashLedger cash,
-        InMemoryUserBotCredentialRegistry? userBotCredentials = null)
+        InMemoryUserBotCredentialRegistry? userBotCredentials = null,
+        InMemoryUserBotSessionRegistry? userBotSessions = null)
     {
         _orders = orders;
         _positions = positions;
@@ -51,6 +53,7 @@ public sealed class StateSnapshotter
         _algoIds = algoIds;
         _cash = cash;
         _userBotCredentials = userBotCredentials;
+        _userBotSessions = userBotSessions;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -72,6 +75,7 @@ public sealed class StateSnapshotter
         AlgoIds = _algoIds.Snapshot(),
         CashBalances = _cash.Snapshot().ToList(),
         UserBotCredentials = _userBotCredentials?.Snapshot().ToList() ?? new(),
+        BotSessions = _userBotSessions?.Snapshot().ToList() ?? new(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -94,6 +98,7 @@ public sealed class StateSnapshotter
         _algoIds.Restore(snap.AlgoIds);
         _cash.Restore(snap.CashBalances);
         _userBotCredentials?.Restore(snap.UserBotCredentials);
+        _userBotSessions?.Restore(snap.BotSessions);
     }
 }
 
@@ -117,6 +122,7 @@ public sealed class EventReplayer
     private readonly AlgoIdRegistry _algoIds;
     private readonly PendingReplacementRegistry? _replacements;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
+    private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -129,7 +135,8 @@ public sealed class EventReplayer
         ClOrdIdPrefixRegistry clOrdIds,
         AlgoIdRegistry algoIds,
         PendingReplacementRegistry? replacements = null,
-        InMemoryUserBotCredentialRegistry? userBotCredentials = null)
+        InMemoryUserBotCredentialRegistry? userBotCredentials = null,
+        InMemoryUserBotSessionRegistry? userBotSessions = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -142,6 +149,7 @@ public sealed class EventReplayer
         _algoIds = algoIds;
         _replacements = replacements;
         _userBotCredentials = userBotCredentials;
+        _userBotSessions = userBotSessions;
     }
 
     public void Apply(WalEvent evt)
@@ -280,6 +288,13 @@ public sealed class EventReplayer
                 break;
             case UserBotCredentialRevokedEvent ubr:
                 _userBotCredentials?.ApplyRevoked(ubr.Id, ubr.RevokedAtUtc);
+                break;
+            case BotSessionInitializedEvent bsi:
+                _userBotSessions?.ApplyInitialized(new BotSessionState(
+                    bsi.CredentialId, bsi.SessionId, bsi.InitialVer, LastCheckpointedOutboundSeq: 0));
+                break;
+            case BotSessionVerAdvancedEvent bsv:
+                _userBotSessions?.ApplyVerAdvanced(bsv.CredentialId, bsv.NewVer);
                 break;
         }
     }

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotSessionRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotSessionRegistryTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryUserBotSessionRegistry"/>
+/// (sub-issue #170, RFC user-bot-fixp-listener-v0 §4.5/§4.8). Covers
+/// idempotent allocation, single-active enforcement, the version-bump
+/// durability fence, snapshot+replay round-trip, and concurrent-bump
+/// safety.
+/// </summary>
+public class InMemoryUserBotSessionRegistryTests
+{
+    [Fact]
+    public async Task GetOrCreate_AllocatesStableSessionAndEmitsInitEvent()
+    {
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+        var credId = Guid.NewGuid();
+
+        var first = await reg.GetOrCreateAsync(credId, default);
+        var second = await reg.GetOrCreateAsync(credId, default);
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(0u, first.SessionId);
+        Assert.Equal(1ul, first.CurrentVer);
+
+        // Idempotent: only one init event ever emitted.
+        var inits = store.Recorded.OfType<BotSessionInitializedEvent>().ToList();
+        Assert.Single(inits);
+        Assert.Equal(credId, inits[0].CredentialId);
+        Assert.Equal(first.SessionId, inits[0].SessionId);
+        Assert.Equal(1ul, inits[0].InitialVer);
+    }
+
+    [Fact]
+    public async Task TryClaimActive_RejectsStaleVer_AndSecondConnection()
+    {
+        var reg = new InMemoryUserBotSessionRegistry();
+        var credId = Guid.NewGuid();
+        var state = await reg.GetOrCreateAsync(credId, default);
+
+        Assert.False(await reg.TryClaimActiveAsync(credId, state.CurrentVer + 1, "c1", default));
+        Assert.True(await reg.TryClaimActiveAsync(credId, state.CurrentVer, "c1", default));
+        // Same connection re-claim is idempotent.
+        Assert.True(await reg.TryClaimActiveAsync(credId, state.CurrentVer, "c1", default));
+        // Different connection while c1 holds the slot is denied.
+        Assert.False(await reg.TryClaimActiveAsync(credId, state.CurrentVer, "c2", default));
+
+        await reg.ReleaseAsync(credId, "c1", default);
+        Assert.True(await reg.TryClaimActiveAsync(credId, state.CurrentVer, "c2", default));
+    }
+
+    [Fact]
+    public async Task BumpVersion_AppendsEventThenFlushes_FenceOrdering()
+    {
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+        var credId = Guid.NewGuid();
+        var state = await reg.GetOrCreateAsync(credId, default);
+
+        await reg.BumpVersionAsync(credId, "single-active-violation", default);
+
+        // RFC §4.8 fence: the FlushAsync call must happen *after* the
+        // BotSessionVerAdvancedEvent has been queued. Snapshot the
+        // chronological action log and assert the order.
+        var actions = store.Actions;
+        var bumpIdx = actions.FindIndex(a => a is RecordingEventStore.AppendAction app
+            && app.Event is BotSessionVerAdvancedEvent);
+        var flushIdx = actions.FindLastIndex(a => a is RecordingEventStore.FlushAction);
+        Assert.True(bumpIdx >= 0, "BotSessionVerAdvancedEvent was not appended.");
+        Assert.True(flushIdx > bumpIdx, "FlushAsync must follow the WAL append.");
+
+        var afterBump = await reg.GetOrCreateAsync(credId, default);
+        Assert.Equal(state.CurrentVer + 1, afterBump.CurrentVer);
+    }
+
+    [Fact]
+    public async Task ConcurrentBumps_AreSerialisedAndStrictlyMonotonic()
+    {
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+        var credId = Guid.NewGuid();
+        await reg.GetOrCreateAsync(credId, default);
+
+        var tasks = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(() => reg.BumpVersionAsync(credId, "test", default)))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        var advances = store.Recorded.OfType<BotSessionVerAdvancedEvent>().ToList();
+        Assert.Equal(32, advances.Count);
+
+        // Each advance must be (oldVer, oldVer+1) and the chain must
+        // cover [1..33] without gaps regardless of dispatch order.
+        var sortedByNew = advances.OrderBy(e => e.NewVer).ToList();
+        for (var i = 0; i < sortedByNew.Count; i++)
+        {
+            Assert.Equal((ulong)(i + 1), sortedByNew[i].OldVer);
+            Assert.Equal((ulong)(i + 2), sortedByNew[i].NewVer);
+        }
+
+        var final = await reg.GetOrCreateAsync(credId, default);
+        Assert.Equal(33ul, final.CurrentVer);
+    }
+
+    [Fact]
+    public async Task SnapshotAndRestore_RoundTripPreservesState()
+    {
+        var src = new InMemoryUserBotSessionRegistry();
+        var credA = Guid.NewGuid();
+        var credB = Guid.NewGuid();
+        var stateA = await src.GetOrCreateAsync(credA, default);
+        var stateB = await src.GetOrCreateAsync(credB, default);
+        await src.BumpVersionAsync(credA, "test", default);
+
+        var snap = src.Snapshot();
+
+        var dst = new InMemoryUserBotSessionRegistry();
+        dst.Restore(snap);
+
+        var restoredA = await dst.GetOrCreateAsync(credA, default);
+        var restoredB = await dst.GetOrCreateAsync(credB, default);
+        Assert.Equal(stateA.SessionId, restoredA.SessionId);
+        Assert.Equal(stateB.SessionId, restoredB.SessionId);
+        Assert.Equal(stateA.CurrentVer + 1, restoredA.CurrentVer);
+        Assert.Equal(stateB.CurrentVer, restoredB.CurrentVer);
+    }
+
+    [Fact]
+    public async Task Replay_ReconstructsStateFromInitAndAdvanceEvents()
+    {
+        var reg = new InMemoryUserBotSessionRegistry();
+        var credId = Guid.NewGuid();
+
+        // Simulate event-store replay (no dispatcher in the loop).
+        var state = new BotSessionState(credId, SessionId: 12345, CurrentVer: 1, LastCheckpointedOutboundSeq: 0);
+        reg.ApplyInitialized(state);
+        reg.ApplyVerAdvanced(credId, 2);
+        reg.ApplyVerAdvanced(credId, 3);
+
+        var got = await reg.GetOrCreateAsync(credId, default);
+        Assert.Equal(12345u, got.SessionId);
+        Assert.Equal(3ul, got.CurrentVer);
+    }
+
+    [Fact]
+    public async Task BumpVersion_OnUnknownCredential_Throws()
+    {
+        var reg = new InMemoryUserBotSessionRegistry();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reg.BumpVersionAsync(Guid.NewGuid(), "test", default));
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IEventStore"/> double that records every
+    /// <c>Append</c>/<c>FlushAsync</c> call in chronological order so
+    /// tests can assert RFC §4.8 ordering invariants.
+    /// </summary>
+    private sealed class RecordingEventStore : IEventStore
+    {
+        public abstract record StoreAction;
+        public sealed record AppendAction(long Seq, WalEvent Event) : StoreAction;
+        public sealed record FlushAction : StoreAction;
+
+        private readonly object _gate = new();
+        public List<StoreAction> Actions { get; } = new();
+        public ConcurrentQueue<WalEvent> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+
+        public long Append(WalEvent evt)
+        {
+            var s = Interlocked.Increment(ref _seq);
+            Recorded.Enqueue(evt);
+            lock (_gate) Actions.Add(new AppendAction(s, evt));
+            return s;
+        }
+
+        public ValueTask FlushAsync(CancellationToken ct = default)
+        {
+            lock (_gate) Actions.Add(new FlushAction());
+            return ValueTask.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.Trading.EntryPointListener\B3.Trading.EntryPointListener.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.Application\B3.Trading.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpListenerIntegrationTests.cs
@@ -1,8 +1,9 @@
-using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Application.UserBots;
 using B3.Trading.EntryPointListener.Framing;
 using B3.Trading.EntryPointListener.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -12,9 +13,23 @@ using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.EntryPointListener.Tests.Integration;
 
+/// <summary>
+/// Sub-issue #170 (D) integration tests. Wires a real listener with the
+/// in-memory credential + session registries and exercises the auth +
+/// single-active enforcement paths over a TCP socket. Frames are written
+/// and parsed with the same SOFH/SBE codecs the production listener uses.
+/// </summary>
 public class FixpListenerIntegrationTests
 {
-    private static IHost BuildHost(out FixpListenerHostedService listenerService)
+    private const ushort SchemaIdV6 = 1;
+
+    private sealed record HostBundle(
+        IHost Host,
+        FixpListenerHostedService Listener,
+        InMemoryUserBotCredentialRegistry Credentials,
+        InMemoryUserBotSessionRegistry Sessions);
+
+    private static HostBundle BuildHost()
     {
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -28,37 +43,80 @@ public class FixpListenerIntegrationTests
             .ConfigureServices((_, s) =>
             {
                 s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                s.AddSingleton<InMemoryUserBotCredentialRegistry>();
+                s.AddSingleton<IUserBotCredentialRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
+                s.AddSingleton<InMemoryUserBotSessionRegistry>();
+                s.AddSingleton<IUserBotSessionRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
                 s.AddEntryPointListener(config);
             })
             .Build();
 
-        listenerService = host.Services.GetRequiredService<FixpListenerHostedService>();
-        return host;
+        return new HostBundle(
+            host,
+            host.Services.GetRequiredService<FixpListenerHostedService>(),
+            host.Services.GetRequiredService<InMemoryUserBotCredentialRegistry>(),
+            host.Services.GetRequiredService<InMemoryUserBotSessionRegistry>());
     }
 
-    // ─── Helpers ──────────────────────────────────────────────────────────────
+    // ─── Wire helpers ────────────────────────────────────────────────────
 
-    private static async Task SendFrameAsync(
-        NetworkStream stream,
-        ushort blockLength,
-        ushort templateId,
-        ushort schemaId,
-        ushort version,
-        byte[] body,
-        CancellationToken ct)
+    private static byte[] BuildNegotiateFrame(uint sessionId, ulong sessionVerId, string token)
     {
+        var tokenBytes = Encoding.UTF8.GetBytes(token);
+        if (tokenBytes.Length > 255)
+            throw new ArgumentException("Token too long for single-byte length prefix.", nameof(token));
+
+        var bodyLen = NegotiateData.BLOCK_LENGTH + 1 + tokenBytes.Length;
+        var body = new byte[bodyLen];
+        ref var msg = ref MemoryMarshal.AsRef<NegotiateData>(body.AsSpan(0, NegotiateData.BLOCK_LENGTH));
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        body[NegotiateData.BLOCK_LENGTH] = (byte)tokenBytes.Length;
+        tokenBytes.CopyTo(body, NegotiateData.BLOCK_LENGTH + 1);
+
         var frameSize = SofhFrameWriter.FrameSize(body.Length);
         var buf = new byte[frameSize];
-        SofhFrameWriter.WriteFrame(buf, blockLength, templateId, schemaId, version, body);
-        await stream.WriteAsync(buf, ct).ConfigureAwait(false);
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID,
+            SchemaIdV6, version: 6, body);
+        return buf;
+    }
+
+    private static byte[] BuildEstablishFrame(uint sessionId, ulong sessionVerId)
+    {
+        var body = new byte[EstablishData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<EstablishData>(body.AsSpan());
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)EstablishData.BLOCK_LENGTH, (ushort)EstablishData.MESSAGE_ID,
+            SchemaIdV6, version: 6, body);
+        return buf;
+    }
+
+    private static byte[] BuildTerminateFrame(uint sessionId, ulong sessionVerId)
+    {
+        var body = new byte[TerminateData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<TerminateData>(body.AsSpan());
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        msg.TerminationCode = TerminationCode.FINISHED;
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)TerminateData.BLOCK_LENGTH, (ushort)TerminateData.MESSAGE_ID,
+            SchemaIdV6, version: 0, body);
+        return buf;
     }
 
     private readonly record struct FrameData(bool IsValid, ushort TemplateId, byte[] Payload);
 
     private static async Task<FrameData> ReadFrameAsync(
-        SofhFrameReader reader,
-        NetworkStream stream,
-        CancellationToken ct)
+        SofhFrameReader reader, NetworkStream stream, CancellationToken ct)
     {
         var buf = new byte[4096];
         while (true)
@@ -73,101 +131,328 @@ public class FixpListenerIntegrationTests
         }
     }
 
+    private static async Task<TcpClient> ConnectAsync(IPEndPoint endpoint, CancellationToken ct)
+    {
+        var c = new TcpClient();
+        await c.ConnectAsync(endpoint.Address, endpoint.Port, ct).ConfigureAwait(false);
+        return c;
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────
+
     [Fact(Timeout = 10_000)]
-    public async Task FullHandshake_NegotiateEstablishTerminate_HappyPath()
+    public async Task ValidPat_FullHandshake_HappyPath()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
 
-        using var host = BuildHost(out var listenerService);
-        await host.StartAsync(cts.Token);
+            var created = await bundle.Credentials.CreateAsync("user-1", "happy-path", cts.Token);
+            var serverState = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
 
-        var endpoint = await listenerService.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+            using var tcp = await ConnectAsync(endpoint, cts.Token);
+            var stream = tcp.GetStream();
+            var reader = new SofhFrameReader();
 
-        using var tcpClient = new TcpClient();
-        await tcpClient.ConnectAsync(endpoint.Address, endpoint.Port, cts.Token);
-        var stream = tcpClient.GetStream();
-        var reader = new SofhFrameReader();
+            await stream.WriteAsync(BuildNegotiateFrame(serverState.SessionId, serverState.CurrentVer, created.PlainToken), cts.Token);
+            var negResp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(negResp.IsValid);
+            Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, negResp.TemplateId);
 
-        const uint SessionId = 0xDEADBEEF;
-        const ulong SessionVerId = 1;
+            await stream.WriteAsync(BuildEstablishFrame(serverState.SessionId, serverState.CurrentVer), cts.Token);
+            var estAck = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(estAck.IsValid);
+            Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, estAck.TemplateId);
 
-        // ── Negotiate ──────────────────────────────────────────────────────────
-        var negBody = new byte[NegotiateData.BLOCK_LENGTH];
-        ref var neg = ref MemoryMarshal.AsRef<NegotiateData>(negBody.AsSpan());
-        neg.SessionID = (SessionID)SessionId;
-        neg.SessionVerID = (SessionVerID)SessionVerId;
+            await stream.WriteAsync(BuildTerminateFrame(serverState.SessionId, serverState.CurrentVer), cts.Token);
+            var termAck = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(termAck.IsValid);
+            Assert.Equal((ushort)TerminateData.MESSAGE_ID, termAck.TemplateId);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
 
-        await SendFrameAsync(stream,
-            (ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID,
-            1, 6, negBody, cts.Token);
+    [Fact(Timeout = 10_000)]
+    public async Task UnknownPat_NegotiateRejectedWithCredentials()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
 
-        var negRespFrame = await ReadFrameAsync(reader, stream, cts.Token);
-        Assert.True(negRespFrame.IsValid);
-        Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, negRespFrame.TemplateId);
-        var negRespData = MemoryMarshal.Read<NegotiateResponseData>(negRespFrame.Payload);
-        Assert.Equal(SessionId, (uint)negRespData.SessionID);
-        Assert.Equal(SessionVerId, (ulong)negRespData.SessionVerID);
+            using var tcp = await ConnectAsync(endpoint, cts.Token);
+            var stream = tcp.GetStream();
+            var reader = new SofhFrameReader();
 
-        // ── Establish ─────────────────────────────────────────────────────────
-        var estBody = new byte[EstablishData.BLOCK_LENGTH];
-        ref var est = ref MemoryMarshal.AsRef<EstablishData>(estBody.AsSpan());
-        est.SessionID = (SessionID)SessionId;
-        est.SessionVerID = (SessionVerID)SessionVerId;
+            await stream.WriteAsync(BuildNegotiateFrame(1, 1, "b3t_doesnotexist_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(resp.IsValid);
+            Assert.Equal((ushort)NegotiateRejectData.MESSAGE_ID, resp.TemplateId);
+            var rejectData = MemoryMarshal.Read<NegotiateRejectData>(resp.Payload);
+            Assert.Equal(NegotiationRejectCode.CREDENTIALS, rejectData.NegotiationRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
 
-        await SendFrameAsync(stream,
-            (ushort)EstablishData.BLOCK_LENGTH, (ushort)EstablishData.MESSAGE_ID,
-            1, 6, estBody, cts.Token);
+    [Fact(Timeout = 10_000)]
+    public async Task RevokedPat_NegotiateRejected()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
 
-        var estAckFrame = await ReadFrameAsync(reader, stream, cts.Token);
-        Assert.True(estAckFrame.IsValid);
-        Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, estAckFrame.TemplateId);
-        var estAckData = MemoryMarshal.Read<EstablishAckData>(estAckFrame.Payload);
-        Assert.Equal(SessionId, (uint)estAckData.SessionID);
+            var created = await bundle.Credentials.CreateAsync("user-r", "revoked", cts.Token);
+            await bundle.Credentials.RevokeAsync("user-r", created.Credential.Id, cts.Token);
 
-        // ── Terminate ─────────────────────────────────────────────────────────
-        var termBody = new byte[TerminateData.BLOCK_LENGTH];
-        ref var term = ref MemoryMarshal.AsRef<TerminateData>(termBody.AsSpan());
-        term.SessionID = (SessionID)SessionId;
-        term.SessionVerID = (SessionVerID)SessionVerId;
-        term.TerminationCode = TerminationCode.FINISHED;
+            using var tcp = await ConnectAsync(endpoint, cts.Token);
+            var stream = tcp.GetStream();
+            var reader = new SofhFrameReader();
 
-        await SendFrameAsync(stream,
-            (ushort)TerminateData.BLOCK_LENGTH, (ushort)TerminateData.MESSAGE_ID,
-            1, 0, termBody, cts.Token);
+            await stream.WriteAsync(BuildNegotiateFrame(1, 1, created.PlainToken), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(resp.IsValid);
+            Assert.Equal((ushort)NegotiateRejectData.MESSAGE_ID, resp.TemplateId);
+            var rejectData = MemoryMarshal.Read<NegotiateRejectData>(resp.Payload);
+            Assert.Equal(NegotiationRejectCode.CREDENTIALS, rejectData.NegotiationRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
 
-        var echoTermFrame = await ReadFrameAsync(reader, stream, cts.Token);
-        Assert.True(echoTermFrame.IsValid);
-        Assert.Equal((ushort)TerminateData.MESSAGE_ID, echoTermFrame.TemplateId);
+    [Fact(Timeout = 15_000)]
+    public async Task SimultaneousEstablish_SecondRejectsAndBumpsVersion()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
 
-        await host.StopAsync(cts.Token);
+            var created = await bundle.Credentials.CreateAsync("user-a", "single-active", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            // First connection establishes and stays connected.
+            using var first = await ConnectAsync(endpoint, cts.Token);
+            var firstStream = first.GetStream();
+            var firstReader = new SofhFrameReader();
+            await firstStream.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, created.PlainToken), cts.Token);
+            var firstNeg = await ReadFrameAsync(firstReader, firstStream, cts.Token);
+            Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, firstNeg.TemplateId);
+            await firstStream.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), cts.Token);
+            var firstEst = await ReadFrameAsync(firstReader, firstStream, cts.Token);
+            Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, firstEst.TemplateId);
+
+            // Second connection with the same (still-current) ver must be rejected
+            // with SESSION_BLOCKED, and the server-side ver must advance.
+            using var second = await ConnectAsync(endpoint, cts.Token);
+            var secondStream = second.GetStream();
+            var secondReader = new SofhFrameReader();
+            await secondStream.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, created.PlainToken), cts.Token);
+            var secondNeg = await ReadFrameAsync(secondReader, secondStream, cts.Token);
+            Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, secondNeg.TemplateId);
+            await secondStream.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), cts.Token);
+            var secondEst = await ReadFrameAsync(secondReader, secondStream, cts.Token);
+            Assert.Equal((ushort)EstablishRejectData.MESSAGE_ID, secondEst.TemplateId);
+            var secondReject = MemoryMarshal.Read<EstablishRejectData>(secondEst.Payload);
+            Assert.Equal(EstablishRejectCode.SESSION_BLOCKED, secondReject.EstablishmentRejectCode);
+            // Reject must carry the post-bump ver so the squatter can
+            // resync without a fresh Negotiate (RFC §4.5/§4.8).
+            Assert.Equal((ulong)(SessionVerID)(state.CurrentVer + 1), (ulong)secondReject.SessionVerID);
+
+            // Server advanced the version durably (RFC §4.8 fence) before sending the reject.
+            var afterBump = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+            Assert.Equal(state.CurrentVer + 1, afterBump.CurrentVer);
+
+            // A third attempt from yet another connection that still uses the
+            // pre-bump ver also fails — but with INVALID_SESSIONVERID this time
+            // (the version is now stale, not duplicate).
+            using var third = await ConnectAsync(endpoint, cts.Token);
+            var thirdStream = third.GetStream();
+            var thirdReader = new SofhFrameReader();
+            await thirdStream.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, created.PlainToken), cts.Token);
+            _ = await ReadFrameAsync(thirdReader, thirdStream, cts.Token);
+            await thirdStream.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), cts.Token);
+            var thirdEst = await ReadFrameAsync(thirdReader, thirdStream, cts.Token);
+            Assert.Equal((ushort)EstablishRejectData.MESSAGE_ID, thirdEst.TemplateId);
+            var thirdReject = MemoryMarshal.Read<EstablishRejectData>(thirdEst.Payload);
+            Assert.Equal(EstablishRejectCode.INVALID_SESSIONVERID, thirdReject.EstablishmentRejectCode);
+            // Stale-ver reject also echoes the server-current ver so the
+            // bot can resync. After the bump, that's `state.CurrentVer + 1`.
+            Assert.Equal((ulong)(SessionVerID)(state.CurrentVer + 1), (ulong)thirdReject.SessionVerID);
+
+            // Stale-ver path must NOT have bumped again.
+            var afterStale = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+            Assert.Equal(afterBump.CurrentVer, afterStale.CurrentVer);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task StaleSessionVerId_EstablishRejected_NoBump()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-s", "stale", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            using var tcp = await ConnectAsync(endpoint, cts.Token);
+            var stream = tcp.GetStream();
+            var reader = new SofhFrameReader();
+
+            // Both Negotiate and Establish carry the same stale ver so the
+            // shape FSM (Negotiate↔Establish must match) passes; the registry
+            // check then sees a ver that does not match the server-side
+            // current ver and must reject with INVALID_SESSIONVERID without
+            // bumping.
+            var staleVer = state.CurrentVer + 99;
+            await stream.WriteAsync(BuildNegotiateFrame(state.SessionId, staleVer, created.PlainToken), cts.Token);
+            _ = await ReadFrameAsync(reader, stream, cts.Token);
+            await stream.WriteAsync(BuildEstablishFrame(state.SessionId, staleVer), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(resp.IsValid);
+            Assert.Equal((ushort)EstablishRejectData.MESSAGE_ID, resp.TemplateId);
+            var reject = MemoryMarshal.Read<EstablishRejectData>(resp.Payload);
+            Assert.Equal(EstablishRejectCode.INVALID_SESSIONVERID, reject.EstablishmentRejectCode);
+
+            var after = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+            Assert.Equal(state.CurrentVer, after.CurrentVer);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task ReconnectAfterTerminate_Succeeds()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-rc", "reconnect", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            // First connection: full handshake then Terminate.
+            using (var first = await ConnectAsync(endpoint, cts.Token))
+            {
+                var s = first.GetStream();
+                var r = new SofhFrameReader();
+                await s.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, created.PlainToken), cts.Token);
+                _ = await ReadFrameAsync(r, s, cts.Token);
+                await s.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), cts.Token);
+                var ack = await ReadFrameAsync(r, s, cts.Token);
+                Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, ack.TemplateId);
+                await s.WriteAsync(BuildTerminateFrame(state.SessionId, state.CurrentVer), cts.Token);
+                _ = await ReadFrameAsync(r, s, cts.Token);
+            }
+
+            // Allow the listener's release-on-close path to run before
+            // the next connection attempts to claim the slot.
+            await WaitForSlotReleaseAsync(bundle.Sessions, created.Credential.Id, state.CurrentVer, cts.Token);
+
+            using var second = await ConnectAsync(endpoint, cts.Token);
+            var s2 = second.GetStream();
+            var r2 = new SofhFrameReader();
+            await s2.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, created.PlainToken), cts.Token);
+            _ = await ReadFrameAsync(r2, s2, cts.Token);
+            await s2.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), cts.Token);
+            var ack2 = await ReadFrameAsync(r2, s2, cts.Token);
+            Assert.True(ack2.IsValid);
+            Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, ack2.TemplateId);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
     }
 
     [Fact(Timeout = 10_000)]
     public async Task TruncatedNegotiateFrame_ServerTerminates()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
 
-        using var host = BuildHost(out var listenerService);
-        await host.StartAsync(cts.Token);
+            using var tcp = await ConnectAsync(endpoint, cts.Token);
+            var stream = tcp.GetStream();
+            var reader = new SofhFrameReader();
 
-        var endpoint = await listenerService.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+            var truncatedBody = new byte[NegotiateData.BLOCK_LENGTH - 1];
+            var frameSize = SofhFrameWriter.FrameSize(truncatedBody.Length);
+            var buf = new byte[frameSize];
+            SofhFrameWriter.WriteFrame(buf,
+                (ushort)(NegotiateData.BLOCK_LENGTH - 1), (ushort)NegotiateData.MESSAGE_ID,
+                SchemaIdV6, version: 6, truncatedBody);
+            await stream.WriteAsync(buf, cts.Token);
 
-        using var tcpClient = new TcpClient();
-        await tcpClient.ConnectAsync(endpoint.Address, endpoint.Port, cts.Token);
-        var stream = tcpClient.GetStream();
-        var reader = new SofhFrameReader();
+            var response = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.True(response.IsValid);
+            Assert.Equal((ushort)TerminateData.MESSAGE_ID, response.TemplateId);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
 
-        // Send a Negotiate frame whose body is 1 byte shorter than BLOCK_LENGTH.
-        var truncatedBody = new byte[NegotiateData.BLOCK_LENGTH - 1];
-        await SendFrameAsync(stream,
-            (ushort)(NegotiateData.BLOCK_LENGTH - 1), (ushort)NegotiateData.MESSAGE_ID,
-            1, 6, truncatedBody, cts.Token);
-
-        var response = await ReadFrameAsync(reader, stream, cts.Token);
-        Assert.True(response.IsValid, "Server should respond to a truncated frame");
-        Assert.Equal((ushort)TerminateData.MESSAGE_ID, response.TemplateId);
-
-        await host.StopAsync(cts.Token);
+    /// <summary>
+    /// Polls until the single-active slot is released. The release path
+    /// runs in the listener's connection task <c>finally</c> block, which
+    /// is concurrent with the test's next TCP connect — without this
+    /// barrier the reconnect can race the release and see a stale claim.
+    /// </summary>
+    private static async Task WaitForSlotReleaseAsync(
+        InMemoryUserBotSessionRegistry sessions, Guid credentialId, ulong attemptedVer, CancellationToken ct)
+    {
+        var probe = $"probe-{Guid.NewGuid():N}";
+        for (var i = 0; i < 200; i++)
+        {
+            if (await sessions.TryClaimActiveAsync(credentialId, attemptedVer, probe, ct).ConfigureAwait(false))
+            {
+                await sessions.ReleaseAsync(credentialId, probe, ct).ConfigureAwait(false);
+                return;
+            }
+            await Task.Delay(20, ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException("Single-active slot never released after Terminate.");
     }
 }
-


### PR DESCRIPTION
Sub-issue **#170 (D)** of the user-bot FIXP listener (RFC \`docs/rfcs/user-bot-fixp-listener-v0.md\` §4.5 + §4.8).

## What

- **Real credential auth on Negotiate.** Decodes the SBE \`Credentials\` var-data buffer, validates it via \`IUserBotCredentialRegistry.TryAuthenticateAsync\`, and rejects malformed/unknown/revoked tokens with \`NegotiationRejectCode.CREDENTIALS\`. The PAT itself is never logged — only the public \`credShortId\`.
- **New \`IUserBotSessionRegistry\`** with an in-memory implementation that:
  - allocates a stable uint32 \`SessionId\` per credential on first access (collision-checked under lock),
  - enforces single-active-session per credential,
  - exposes \`BumpVersionAsync\` that dispatches a \`BotSessionVerAdvancedEvent\` to the WAL **and awaits \`IEventStore.FlushAsync\`** before returning — the RFC §4.8 durability fence so the bot cannot observe a \`newVer\` that recovery would roll back.
- **Establish flow.** Validates requested \`SessionId\`/\`Ver\` against server state, claims the active slot, and on a single-active collision durably bumps the version then emits an \`EstablishReject(SESSION_BLOCKED)\` whose payload carries the **bumped** ver (so the squatter can resync without a fresh Negotiate). Stale-ver rejects similarly echo the server-current ver.
- **WAL + snapshot.** New \`BotSessionInitializedEvent\` + \`BotSessionVerAdvancedEvent\` polymorphic events; new \`BotSessionStateSnapshot\` field on \`PlatformSnapshot\`. \`StateSnapshotter\` + \`EventReplayer\` wire both for round-trip parity.
- **DI.** Both registries are singletons in \`Program.cs\`; greedy ctor selection picks the \`(EventDispatcher, IEventStore)\` overload at runtime, while tests can use the parameterless ctor for in-memory fakes.
- **Concurrency hardening.** Read+dispatch is serialised under a single registry gate (Monitor is recursive, so the dispatcher's apply callback re-enters the gate safely). Concurrent first-access calls cannot allocate two SessionIds for the same credential, and concurrent bumps cannot emit duplicate \`(oldVer, oldVer+1)\` events.

## Tests

\`InMemoryUserBotSessionRegistryTests\` covers idempotent allocation, single-active enforcement, FlushAsync ordering fence (\`RecordingEventStore\` records every Append/Flush in chronological order), 32-way concurrent bump serialisation, snapshot/replay round-trip, and replay-only state reconstruction.

\`FixpListenerIntegrationTests\` (real TCP socket against the hosted listener) covers the happy-path full handshake, unknown/revoked PAT, simultaneous Establish (asserts \`SESSION_BLOCKED\` reject **with bumped ver in the payload**, then a third connection still on the pre-bump ver gets \`INVALID_SESSIONVERID\` without further bumping), stale ver no-bump, reconnect-after-Terminate, and the truncated-frame protocol error path.

770 backend tests green, including 39 listener and 452 application tests.

## Out of scope

Order flow, ER routing, retransmit, in-socket TLS, frontend — all reserved for sub-issues E–H.

Closes #170. Refs #166.