### PR TITLE
feat(fixp): SBE NewOrderSingle/Cancel adapter + bot ClOrdId mapping (#171)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using B3.Trading.Api.Auth;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
-using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -130,42 +129,33 @@ public static class OrdersEndpoints
             string clOrdId,
             HttpContext ctx,
             EndClientRegistry registry,
-            ClOrdIdPrefixRegistry clOrdIds,
-            WorkingOrderBook book,
-            OrderOwnershipMap ownership,
-            IExchangeGateway gateway,
+            OrderCancelService canceller,
             CancellationToken ct) =>
         {
             if (!ulong.TryParse(clOrdId, out var clOrdIdU))
                 return Results.NotFound();
 
             var owner = ResolveOwner(ctx, registry);
-            if (!book.TryGet(clOrdIdU, out var order) || order is null)
-                return Results.NotFound();
-
-            if (order.Owner != owner)
-                return Results.NotFound();
-
-            // Slice 1 of #132. Reject Cancel against an order the operator
-            // has flagged as suspected-stale-by-venue: the venue most
-            // likely doesn't know the original ClOrdID either, and we'd
-            // burn a fresh ClOrdID for nothing. Operator must explicitly
-            // clear the stale overlay first (admin endpoint) when the
-            // venue catches up, or rely on the eventual real terminal ER
-            // to auto-clear.
-            if (order.IsStale)
-                return Results.Conflict(new { error = "order is marked stale", reason = order.StaleReason });
-
-            var cancelClOrdId = clOrdIds.Generate(owner);
-            // Record the cancel-side → original mapping BEFORE sending so
-            // the cancel-ack ER can resolve back to the right order even
-            // when upstream omits OrigClOrdID on the wire.
-            ownership.RegisterCancelLink(cancelClOrdId, order.ClOrdId);
-            await gateway.CancelAsync(order, cancelClOrdId, ct);
-            MetricsRegistry.OrdersCancelRequested.Add(1);
-            // Status transition to Cancelled happens when the exchange ER
-            // arrives, not synchronously here.
-            return Results.NoContent();
+            // Sub-issue #171 (E): REST cancels now go through the WAL-
+            // durable OrderCancelRequestedEvent path (RFC §4.6 / §4.8).
+            // botOrigin is null — REST is not a bot session.
+            var result = await canceller.CancelAsync(owner, clOrdIdU, ct);
+            return result.Kind switch
+            {
+                OrderCancelResultKind.Accepted => Results.NoContent(),
+                OrderCancelResultKind.NotFound => Results.NotFound(),
+                OrderCancelResultKind.Stale =>
+                    Results.Conflict(new { error = "order is marked stale", reason = result.Reason }),
+                OrderCancelResultKind.WalBackpressure =>
+                    Results.Json(
+                        new { error = "system busy (WAL backpressure)", detail = result.Reason },
+                        statusCode: StatusCodes.Status503ServiceUnavailable),
+                OrderCancelResultKind.GatewayFailed =>
+                    Results.Json(
+                        new { error = "gateway unavailable", clOrdId = result.CancelClOrdId.ToString() },
+                        statusCode: StatusCodes.Status502BadGateway),
+                _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+            };
         });
 
         return app;

--- a/backend/src/B3.Trading.Application/OrderCancelService.cs
+++ b/backend/src/B3.Trading.Application/OrderCancelService.cs
@@ -1,0 +1,179 @@
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Sub-issue #171 (E). Centralised cancel-order pipeline shared by both
+/// <c>DELETE /orders/{clOrdId}</c> (REST) and the FIXP listener's
+/// <c>OrderCancelRequest</c> handler. Replaces the previous in-memory-only
+/// path (<c>OwnershipMap.RegisterCancelLink</c>) with a WAL-durable
+/// <see cref="OrderCancelRequestedEvent"/> append, so cancel-side state
+/// (cancel-link, ClOrdID watermark, optional bot-cancel-mapping) survives
+/// restart per RFC user-bot-fixp-listener-v0 §4.6 and §4.8.
+///
+/// <para>The dispatcher <c>apply</c> callback runs synchronous in-memory
+/// mutations only; the async <c>gateway.CancelAsync</c> I/O is invoked
+/// AFTER <see cref="EventDispatcher.Dispatch"/> returns, OUTSIDE the
+/// dispatcher lock — the dispatcher protects synchronous in-memory work
+/// only. On replay the same callback runs and rebuilds in-memory state
+/// without re-issuing the gateway call.</para>
+/// </summary>
+public sealed class OrderCancelService
+{
+    private readonly ClOrdIdPrefixRegistry _clOrdIds;
+    private readonly OrderOwnershipMap _ownership;
+    private readonly WorkingOrderBook _book;
+    private readonly IExchangeGateway _gateway;
+    private readonly EventDispatcher _dispatcher;
+    private readonly IUserBotOrderMappingRegistry? _botMappings;
+    private readonly ILogger<OrderCancelService> _logger;
+
+    public OrderCancelService(
+        ClOrdIdPrefixRegistry clOrdIds,
+        OrderOwnershipMap ownership,
+        WorkingOrderBook book,
+        IExchangeGateway gateway,
+        EventDispatcher dispatcher,
+        ILogger<OrderCancelService> logger,
+        IUserBotOrderMappingRegistry? botMappings = null)
+    {
+        _clOrdIds = clOrdIds;
+        _ownership = ownership;
+        _book = book;
+        _gateway = gateway;
+        _dispatcher = dispatcher;
+        _botMappings = botMappings;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Cancels the order owned by <paramref name="owner"/> with id
+    /// <paramref name="originalClOrdId"/>. Returns the platform-allocated
+    /// cancel-side internal ClOrdID on accept, or a discriminated failure
+    /// otherwise. The caller (REST endpoint or FIXP listener) translates
+    /// the result into its own transport response.
+    /// </summary>
+    public async Task<OrderCancelResult> CancelAsync(
+        EndClientId owner,
+        ulong originalClOrdId,
+        CancellationToken ct,
+        BotOrigin? botOrigin = null)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+
+        if (!_book.TryGet(originalClOrdId, out var order) || order is null)
+            return OrderCancelResult.NotFound;
+        if (order.Owner != owner)
+            return OrderCancelResult.NotFound;
+        if (order.IsStale)
+            return OrderCancelResult.Stale(order.StaleReason ?? "stale");
+
+        var cancelClOrdId = _clOrdIds.Generate(owner);
+        BotOrderMapping? botMapping = botOrigin is { } o
+            ? new BotOrderMapping(o.CredentialId, o.ExternalClOrdId)
+            : null;
+
+        try
+        {
+            _dispatcher.Dispatch(
+                new OrderCancelRequestedEvent
+                {
+                    CancelClOrdId = cancelClOrdId,
+                    OriginalClOrdId = originalClOrdId,
+                    OwnerEndClientId = owner.Value,
+                    BotMapping = botMapping,
+                },
+                () =>
+                {
+                    // RFC §4.6 step 3 — synchronous in-memory mutations
+                    // only. Three things in lockstep with the WAL append:
+                    _ownership.RegisterCancelLink(cancelClOrdId, originalClOrdId);
+                    // Watermark advance so a post-restart Generate cannot
+                    // re-allocate this cancel-side id (#157 invariant for
+                    // cancels — mirrors OrderReplaceRequestedEvent path).
+                    _clOrdIds.AdvanceCounterTo(owner, cancelClOrdId);
+                    if (botMapping is not null && _botMappings is not null)
+                    {
+                        _botMappings.RegisterCancelInternal(
+                            cancelInternalClOrdId: cancelClOrdId,
+                            originalInternalClOrdId: originalClOrdId,
+                            credentialId: botMapping.CredentialId,
+                            externalCancelClOrdId: botMapping.ExternalClOrdId);
+                    }
+                });
+        }
+        catch (WalBackpressureException ex)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "orders.cancel"));
+            return OrderCancelResult.WalBackpressure(ex.Message);
+        }
+
+        try
+        {
+            // RFC §4.6 step 4: gateway call OUTSIDE the dispatcher lock
+            // — Dispatch has already returned and the WAL record is
+            // enqueued + the in-memory state is consistent.
+            await _gateway.CancelAsync(order, cancelClOrdId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The cancel WAL record is already durable; leaving it as
+            // "in-flight" is the same posture the legacy in-memory path
+            // had on a gateway hiccup — eventual ER reconciliation or
+            // operator intervention resolves it.
+            _logger.LogError(ex,
+                "Gateway cancel failed for {ClOrdId} (orig {Orig}); WAL already durable.",
+                cancelClOrdId, originalClOrdId);
+            return OrderCancelResult.GatewayFailed(cancelClOrdId, ex);
+        }
+
+        MetricsRegistry.OrdersCancelRequested.Add(1);
+        return OrderCancelResult.Accepted(cancelClOrdId);
+    }
+}
+
+/// <summary>
+/// Outcome of <see cref="OrderCancelService.CancelAsync"/>.
+/// Discriminated on <see cref="Kind"/>; callers (REST endpoint, FIXP
+/// listener) map each case to their own transport.
+/// </summary>
+public sealed class OrderCancelResult
+{
+    public OrderCancelResultKind Kind { get; }
+    public ulong CancelClOrdId { get; }
+    public string? Reason { get; }
+    public Exception? GatewayException { get; }
+
+    private OrderCancelResult(OrderCancelResultKind kind, ulong cancelClOrdId, string? reason, Exception? ex)
+    {
+        Kind = kind;
+        CancelClOrdId = cancelClOrdId;
+        Reason = reason;
+        GatewayException = ex;
+    }
+
+    public static OrderCancelResult Accepted(ulong cancelClOrdId) =>
+        new(OrderCancelResultKind.Accepted, cancelClOrdId, null, null);
+    public static OrderCancelResult NotFound { get; } =
+        new(OrderCancelResultKind.NotFound, 0, null, null);
+    public static OrderCancelResult Stale(string reason) =>
+        new(OrderCancelResultKind.Stale, 0, reason, null);
+    public static OrderCancelResult WalBackpressure(string detail) =>
+        new(OrderCancelResultKind.WalBackpressure, 0, detail, null);
+    public static OrderCancelResult GatewayFailed(ulong cancelClOrdId, Exception ex) =>
+        new(OrderCancelResultKind.GatewayFailed, cancelClOrdId, "gateway_unavailable", ex);
+}
+
+public enum OrderCancelResultKind
+{
+    Accepted,
+    NotFound,
+    Stale,
+    WalBackpressure,
+    GatewayFailed,
+}

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -2,6 +2,7 @@ using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 
@@ -35,6 +36,7 @@ public sealed class OrderSubmissionService
     private readonly CompositeRiskAccountant _accountant;
     private readonly EventDispatcher _dispatcher;
     private readonly Lifecycle.IDrainGate _drain;
+    private readonly IUserBotOrderMappingRegistry? _botMappings;
     private readonly ILogger<OrderSubmissionService> _logger;
 
     public OrderSubmissionService(
@@ -48,7 +50,8 @@ public sealed class OrderSubmissionService
         CompositeRiskAccountant accountant,
         EventDispatcher dispatcher,
         Lifecycle.IDrainGate drain,
-        ILogger<OrderSubmissionService> logger)
+        ILogger<OrderSubmissionService> logger,
+        IUserBotOrderMappingRegistry? botMappings = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -60,6 +63,7 @@ public sealed class OrderSubmissionService
         _accountant = accountant;
         _dispatcher = dispatcher;
         _drain = drain;
+        _botMappings = botMappings;
         _logger = logger;
     }
 
@@ -115,6 +119,16 @@ public sealed class OrderSubmissionService
 
         try
         {
+            // Sub-issue #171 (E): when the order originates from the FIXP
+            // listener, the WAL event carries the BotMapping side-record
+            // (RFC §4.6 / §4.8) and the apply callback registers the
+            // forward+reverse lookups in the in-memory registry under the
+            // same dispatcher lock as the WAL append. REST/WS submissions
+            // pass req.BotOrigin == null and the field serialises as null.
+            BotOrderMapping? botMapping = req.BotOrigin is { } origin
+                ? new BotOrderMapping(origin.CredentialId, origin.ExternalClOrdId)
+                : null;
+
             _dispatcher.Dispatch(
                 new OrderSubmittedEvent
                 {
@@ -129,6 +143,7 @@ public sealed class OrderSubmissionService
                     Price = req.Price,
                     ParentAlgoId = req.ParentAlgoId,
                     AlgoSliceSeq = req.AlgoSliceSeq,
+                    BotMapping = botMapping,
                 },
                 () =>
                 {
@@ -147,6 +162,15 @@ public sealed class OrderSubmissionService
                             clOrdId);
                     }
                     _ownership.Register(clOrdId, req.Owner);
+                    if (botMapping is not null && _botMappings is not null)
+                    {
+                        // Same lock-held call shape on live submit and on
+                        // WAL replay (EventReplayer invokes the same
+                        // method) so the registry is rehydrated by exactly
+                        // the same code path that populated it originally.
+                        _botMappings.RegisterOrderInternal(
+                            clOrdId, botMapping.CredentialId, botMapping.ExternalClOrdId);
+                    }
                 });
         }
         catch (WalBackpressureException ex)
@@ -251,7 +275,28 @@ public sealed record OrderSubmissionRequest(
     decimal? Price,
     OrderSubmissionSource Source = OrderSubmissionSource.Manual,
     ulong? ParentAlgoId = null,
-    int? AlgoSliceSeq = null);
+    int? AlgoSliceSeq = null)
+{
+    /// <summary>
+    /// Sub-issue #171 (E). When non-null, the request originates from
+    /// the FIXP listener on behalf of a user-bot credential. The submit
+    /// pipeline ignores this for matching/risk purposes; it is recorded
+    /// on the <see cref="Persistence.OrderSubmittedEvent.BotMapping"/>
+    /// side-record so sub-issue F can reverse-route ERs back to the
+    /// originating bot session. REST/WS callers pass <c>null</c>.
+    /// </summary>
+    public BotOrigin? BotOrigin { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #171 (E). FIXP-origin annotation on
+/// <see cref="OrderSubmissionRequest"/>. <see cref="ExternalClOrdId"/>
+/// is the bot's own wire ClOrdID (uint64 per the SBE schema); the
+/// platform's internal <c>ulong</c> ClOrdID is allocated independently
+/// by <see cref="ClOrdIdPrefixRegistry"/> and remains the on-the-wire
+/// identifier for the gateway and the WAL.
+/// </summary>
+public sealed record BotOrigin(Guid CredentialId, ulong ExternalClOrdId);
 
 /// <summary>
 /// Outcome of <see cref="OrderSubmissionService.SubmitAsync"/>. The

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -68,7 +68,46 @@ public sealed class PlatformSnapshot
     /// <c>BotSessionVerAdvancedEvent</c>, which yields the same shape.
     /// </summary>
     public List<BotSessionStateSnapshot> BotSessions { get; init; } = new();
+
+    /// <summary>
+    /// Sub-issue #171 (E). FIXP order mappings — one entry per live
+    /// (non-reaped) bot-origin order, keyed by internal ClOrdID. Empty
+    /// on snapshots pre-dating the field; reconstructed on replay from
+    /// <see cref="OrderSubmittedEvent.BotMapping"/> entries past the
+    /// snapshot seq.
+    /// </summary>
+    public List<BotOrderMappingSnapshot> BotOrderMappings { get; init; } = new();
+
+    /// <summary>
+    /// Sub-issue #171 (E). FIXP cancel-side mappings — one entry per
+    /// in-flight bot-origin cancel keyed by cancel-side internal ClOrdID,
+    /// pointing at both the original internal ClOrdID and the bot's
+    /// external cancel ClOrdID. Empty on snapshots pre-dating the field.
+    /// </summary>
+    public List<BotCancelMappingSnapshot> BotCancelMappings { get; init; } = new();
 }
+
+/// <summary>
+/// Sub-issue #171 (E). One row of the
+/// <c>internalClOrdId → (credentialId, externalClOrdId)</c> bot-origin
+/// order map.
+/// </summary>
+public sealed record BotOrderMappingSnapshot(
+    ulong InternalClOrdId,
+    Guid CredentialId,
+    ulong ExternalClOrdId);
+
+/// <summary>
+/// Sub-issue #171 (E). One row of the bot-origin cancel-side map. The
+/// cancel's internal ClOrdID resolves to both the original internal
+/// ClOrdID (so cancel-ack ER routing can find the original order) and
+/// the bot's external cancel ClOrdID (so F can echo it back to the bot).
+/// </summary>
+public sealed record BotCancelMappingSnapshot(
+    ulong CancelInternalClOrdId,
+    ulong OriginalInternalClOrdId,
+    Guid CredentialId,
+    ulong ExternalCancelClOrdId);
 
 /// <summary>
 /// Captures one per-credential FIXP session row. The active-connection

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -31,6 +31,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(UserBotCredentialRevokedEvent), "userbot.cred.revoked")]
 [JsonDerivedType(typeof(BotSessionInitializedEvent), "userbot.session.initialized")]
 [JsonDerivedType(typeof(BotSessionVerAdvancedEvent), "userbot.session.ver-advanced")]
+[JsonDerivedType(typeof(OrderCancelRequestedEvent), "order.cancel-requested")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -64,6 +65,52 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// </summary>
     public ulong? ParentAlgoId { get; init; }
     public int? AlgoSliceSeq { get; init; }
+
+    /// <summary>
+    /// Sub-issue #171 (E). When non-null, the order was submitted via
+    /// the FIXP listener on behalf of a user-bot credential. Carries
+    /// the side-mapping needed by <c>IUserBotOrderMappingRegistry</c>
+    /// to reverse-route subsequent ERs back to the originating bot
+    /// session (sub-issue F #172). Field is purely informational for
+    /// REST/WS submissions where it serialises as <c>null</c>; older
+    /// WAL segments without the field deserialise as <c>null</c> too,
+    /// matching the manual-order semantics they actually carried.
+    /// </summary>
+    public BotOrderMapping? BotMapping { get; init; }
+}
+
+/// <summary>
+/// Sub-record carried by <see cref="OrderSubmittedEvent"/> /
+/// <see cref="OrderCancelRequestedEvent"/> when the order originates from
+/// the FIXP listener (RFC §4.6 ClOrdId / §4.8 persistence). The pair
+/// <c>(CredentialId, ExternalClOrdId)</c> is the bot-visible identity
+/// for the order; the platform's internal <c>ulong</c> ClOrdID continues
+/// to be the on-the-wire and on-WAL identifier.
+/// </summary>
+public sealed record BotOrderMapping(Guid CredentialId, ulong ExternalClOrdId);
+
+/// <summary>
+/// Sub-issue #171 (E). Recorded the moment a cancel request reaches the
+/// platform — REST <c>DELETE /orders/{clOrdId}</c> or a FIXP
+/// <c>OrderCancelRequest</c>. The previous in-memory-only path
+/// (<c>OwnershipMap.RegisterCancelLink</c>) lost cancel-side state on
+/// restart; persisting it as a WAL event closes the FIXP-cancel ER
+/// round-trip across restart per RFC §4.6.
+///
+/// <para>The dispatcher <c>apply</c> callback runs the in-memory
+/// mutations under the lock: ownership cancel-link, ClOrdID watermark
+/// advance, and (when <see cref="BotMapping"/> is set) the bot
+/// cancel-mapping registration. The async <c>gateway.CancelAsync</c>
+/// I/O is invoked OUTSIDE the dispatcher lock per the dispatcher's
+/// "synchronous in-memory work only" contract. On replay only the
+/// in-memory mutation runs (no gateway call).</para>
+/// </summary>
+public sealed record OrderCancelRequestedEvent : WalEvent
+{
+    public required ulong CancelClOrdId { get; init; }
+    public required ulong OriginalClOrdId { get; init; }
+    public required string OwnerEndClientId { get; init; }
+    public BotOrderMapping? BotMapping { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -30,6 +30,7 @@ namespace B3.Trading.Application;
 public sealed class SymbolDirectory
 {
     private readonly IReadOnlyDictionary<string, ulong> _byName;
+    private readonly IReadOnlyDictionary<ulong, string> _bySecurityId;
     private readonly IReadOnlyDictionary<string, InstrumentSpec> _specs;
 
     public SymbolDirectory(SymbolDirectoryOptions options)
@@ -38,12 +39,24 @@ public sealed class SymbolDirectory
         // Always copy to enforce case-insensitive comparison even if
         // the binder produced a culture-sensitive dictionary.
         var copy = new Dictionary<string, ulong>(StringComparer.OrdinalIgnoreCase);
+        // Sub-issue #171 (E): inverse lookup (SecurityId → Symbol) for the
+        // FIXP adapter, which receives orders by numeric SecurityId on the
+        // wire and must translate to the Symbol the submit pipeline
+        // expects. Computed at construction time from the same forward
+        // map — no extra config surface.
+        var inverse = new Dictionary<ulong, string>();
         foreach (var kv in options.SecurityIds)
         {
             if (string.IsNullOrWhiteSpace(kv.Key) || kv.Value == 0) continue;
             copy[kv.Key] = kv.Value;
+            // First-write-wins: if two symbols claim the same SecurityId
+            // (configuration mistake), the inverse map keeps the first
+            // one we saw rather than silently overwriting. The forward
+            // map remains correct for both.
+            inverse.TryAdd(kv.Value, kv.Key);
         }
         _byName = copy;
+        _bySecurityId = inverse;
 
         var specs = new Dictionary<string, InstrumentSpec>(StringComparer.OrdinalIgnoreCase);
         foreach (var kv in options.Specs)
@@ -71,6 +84,32 @@ public sealed class SymbolDirectory
             return false;
         }
         return _byName.TryGetValue(symbol, out securityId);
+    }
+
+    /// <summary>
+    /// Sub-issue #171 (E). Inverse of <see cref="TryResolve(string, out ulong)"/>:
+    /// resolves a numeric SecurityId back to its configured symbol. The
+    /// FIXP listener calls this on every <c>NewOrderSingle</c> /
+    /// <c>OrderCancelRequest</c> because the SBE wire only carries the
+    /// SecurityId, but <c>OrderSubmissionService</c> requires a non-empty
+    /// symbol. Returns <c>false</c> for unknown ids — the listener turns
+    /// that into a <c>BusinessMessageReject(UnknownSecurity)</c> without
+    /// touching the submit pipeline.
+    /// </summary>
+    public bool TryGetSymbolBySecurityId(ulong securityId, out string? symbol)
+    {
+        if (securityId == 0)
+        {
+            symbol = null;
+            return false;
+        }
+        if (_bySecurityId.TryGetValue(securityId, out var found))
+        {
+            symbol = found;
+            return true;
+        }
+        symbol = null;
+        return false;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotOrderMappingRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotOrderMappingRegistry.cs
@@ -1,0 +1,112 @@
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Sub-issue #171 (E). Side-mapping between the platform's internal
+/// <c>ulong</c> ClOrdID (allocated by <see cref="ClOrdIdPrefixRegistry"/>)
+/// and the bot-visible <c>(CredentialId, ExternalClOrdId)</c> identity
+/// for FIXP-origin orders. Lookups are on the hot ER processing path
+/// (<see cref="TryGetOrderMapping"/> is synchronous) so implementations
+/// must avoid async I/O on the read side.
+///
+/// <para>State is rebuilt at startup by the snapshot+replay machinery —
+/// snapshot capture/restore covers live mappings, and post-snapshot
+/// <see cref="OrderSubmittedEvent"/> /
+/// <see cref="OrderCancelRequestedEvent"/> events further mutate the
+/// registry via the existing replay path. The registry never originates
+/// a WAL append on its own; the order/cancel events are the source of
+/// truth and the registry is just a queryable cache rebuilt from them.</para>
+/// </summary>
+public interface IUserBotOrderMappingRegistry
+{
+    /// <summary>
+    /// Synchronous lookup used by sub-issue F (#172) to reverse-route an
+    /// already-normalised <see cref="ExecutionEvent"/> ClOrdID back to
+    /// the originating bot session. Returns <c>false</c> when the
+    /// internal id is not bot-origin (REST/WS orders) — F treats that
+    /// as "not for me" and skips.
+    /// </summary>
+    bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping);
+
+    /// <summary>
+    /// Synchronous reverse lookup used by the FIXP listener on inbound
+    /// <c>OrderCancelRequest</c> to resolve the bot's
+    /// <c>(credentialId, externalOrigClOrdId)</c> back to the platform's
+    /// internal original ClOrdID. Returns <c>false</c> when no live
+    /// mapping exists OR when the credential does not own the order
+    /// (cross-user isolation guard, RFC §4.6).
+    /// </summary>
+    bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId);
+
+    /// <summary>
+    /// Synchronous lookup for sub-issue F to recover the bot's external
+    /// cancel ClOrdID when an ER references a cancel-side internal
+    /// ClOrdID. Returns <c>false</c> when the cancel-side id is not
+    /// bot-origin.
+    /// </summary>
+    bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping);
+
+    /// <summary>
+    /// Drops a forward order mapping. Sub-issue F (or a future janitor)
+    /// calls this on terminal ER kinds (Filled, Cancelled, Rejected).
+    /// Idempotent — reaping an unknown id is a no-op.
+    /// </summary>
+    void Reap(ulong internalClOrdId);
+
+    /// <summary>
+    /// Drops a cancel-side mapping. Sub-issue F calls this once the
+    /// cancel-ack ER is forwarded.
+    /// </summary>
+    void ReapCancel(ulong cancelInternalClOrdId);
+
+    /// <summary>
+    /// In-memory mutation invoked from the
+    /// <see cref="EventDispatcher"/> apply callback for an
+    /// <see cref="OrderSubmittedEvent"/> with a non-null
+    /// <see cref="OrderSubmittedEvent.BotMapping"/>. Synchronous —
+    /// runs under the dispatcher lock alongside the WAL append.
+    /// </summary>
+    void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId);
+
+    /// <summary>
+    /// In-memory mutation invoked from the
+    /// <see cref="EventDispatcher"/> apply callback for an
+    /// <see cref="OrderCancelRequestedEvent"/> with a non-null
+    /// <see cref="OrderCancelRequestedEvent.BotMapping"/>. Synchronous —
+    /// runs under the dispatcher lock alongside the WAL append.
+    /// </summary>
+    void RegisterCancelInternal(
+        ulong cancelInternalClOrdId,
+        ulong originalInternalClOrdId,
+        Guid credentialId,
+        ulong externalCancelClOrdId);
+
+    /// <summary>Snapshot capture — called under <c>WithSnapshotLock</c>.</summary>
+    IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders();
+
+    /// <summary>Snapshot capture — called under <c>WithSnapshotLock</c>.</summary>
+    IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels();
+
+    /// <summary>Snapshot restore — single-threaded at startup.</summary>
+    void Restore(
+        IEnumerable<BotOrderMappingSnapshot> orders,
+        IEnumerable<BotCancelMappingSnapshot> cancels);
+}
+
+/// <summary>
+/// Forward-routing tuple returned by
+/// <see cref="IUserBotOrderMappingRegistry.TryGetOrderMapping"/>.
+/// </summary>
+public readonly record struct OrderMapping(Guid CredentialId, ulong ExternalClOrdId);
+
+/// <summary>
+/// Cancel-side routing tuple. <see cref="OriginalInternalClOrdId"/> is
+/// kept on the cancel record so F can correlate a cancel-ack ER (whose
+/// raw <c>ClOrdId</c> is the cancel-side id) with the original order's
+/// bot-visible identity in a single lookup.
+/// </summary>
+public readonly record struct CancelMapping(
+    ulong OriginalInternalClOrdId,
+    Guid CredentialId,
+    ulong ExternalCancelClOrdId);

--- a/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotOrderMappingRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotOrderMappingRegistry.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// In-memory <see cref="IUserBotOrderMappingRegistry"/> backed by
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/>. Reads
+/// (<see cref="TryGetOrderMapping"/>, <see cref="TryGetByExternal"/>,
+/// <see cref="TryGetCancelMapping"/>) are lock-free; writes are coarse-
+/// grained per-dictionary and called from the dispatcher's apply lock,
+/// so the registry adds no lock contention to the submit path.
+///
+/// <para>Snapshot capture is called under
+/// <c>EventDispatcher.WithSnapshotLock</c>, which excludes concurrent
+/// <c>RegisterOrderInternal</c>/<c>RegisterCancelInternal</c> writes —
+/// so the captured view is consistent with the WAL seq written into the
+/// snapshot envelope.</para>
+/// </summary>
+public sealed class InMemoryUserBotOrderMappingRegistry : IUserBotOrderMappingRegistry
+{
+    // Forward map: internalClOrdId → (credentialId, externalClOrdId).
+    private readonly ConcurrentDictionary<ulong, OrderMapping> _byInternal = new();
+
+    // Reverse map for FIXP cancel inbound: (credentialId, externalClOrdId) → internalClOrdId.
+    // Keyed by a composite struct to avoid string allocation on the hot path.
+    private readonly ConcurrentDictionary<ExternalKey, ulong> _byExternal = new();
+
+    // Cancel-side map: cancelInternalClOrdId → (originalInternal, credentialId, externalCancel).
+    private readonly ConcurrentDictionary<ulong, CancelMapping> _cancelsByInternal = new();
+
+    public bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping)
+        => _byInternal.TryGetValue(internalClOrdId, out mapping);
+
+    public bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId)
+        => _byExternal.TryGetValue(new ExternalKey(credentialId, externalClOrdId), out internalClOrdId);
+
+    public bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping)
+        => _cancelsByInternal.TryGetValue(cancelInternalClOrdId, out mapping);
+
+    public void Reap(ulong internalClOrdId)
+    {
+        if (_byInternal.TryRemove(internalClOrdId, out var mapping))
+            _byExternal.TryRemove(new ExternalKey(mapping.CredentialId, mapping.ExternalClOrdId), out _);
+    }
+
+    public void ReapCancel(ulong cancelInternalClOrdId)
+        => _cancelsByInternal.TryRemove(cancelInternalClOrdId, out _);
+
+    public void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId)
+    {
+        if (internalClOrdId == 0) throw new ArgumentOutOfRangeException(nameof(internalClOrdId));
+        if (credentialId == Guid.Empty) throw new ArgumentException("CredentialId must not be empty.", nameof(credentialId));
+        var mapping = new OrderMapping(credentialId, externalClOrdId);
+        _byInternal[internalClOrdId] = mapping;
+        _byExternal[new ExternalKey(credentialId, externalClOrdId)] = internalClOrdId;
+    }
+
+    public void RegisterCancelInternal(
+        ulong cancelInternalClOrdId,
+        ulong originalInternalClOrdId,
+        Guid credentialId,
+        ulong externalCancelClOrdId)
+    {
+        if (cancelInternalClOrdId == 0) throw new ArgumentOutOfRangeException(nameof(cancelInternalClOrdId));
+        if (originalInternalClOrdId == 0) throw new ArgumentOutOfRangeException(nameof(originalInternalClOrdId));
+        if (credentialId == Guid.Empty) throw new ArgumentException("CredentialId must not be empty.", nameof(credentialId));
+        _cancelsByInternal[cancelInternalClOrdId] =
+            new CancelMapping(originalInternalClOrdId, credentialId, externalCancelClOrdId);
+    }
+
+    public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders()
+        => _byInternal
+            .Select(kv => new BotOrderMappingSnapshot(kv.Key, kv.Value.CredentialId, kv.Value.ExternalClOrdId))
+            .OrderBy(s => s.InternalClOrdId)
+            .ToList();
+
+    public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels()
+        => _cancelsByInternal
+            .Select(kv => new BotCancelMappingSnapshot(
+                kv.Key, kv.Value.OriginalInternalClOrdId, kv.Value.CredentialId, kv.Value.ExternalCancelClOrdId))
+            .OrderBy(s => s.CancelInternalClOrdId)
+            .ToList();
+
+    public void Restore(
+        IEnumerable<BotOrderMappingSnapshot> orders,
+        IEnumerable<BotCancelMappingSnapshot> cancels)
+    {
+        ArgumentNullException.ThrowIfNull(orders);
+        ArgumentNullException.ThrowIfNull(cancels);
+        _byInternal.Clear();
+        _byExternal.Clear();
+        _cancelsByInternal.Clear();
+        foreach (var s in orders)
+            RegisterOrderInternal(s.InternalClOrdId, s.CredentialId, s.ExternalClOrdId);
+        foreach (var c in cancels)
+            RegisterCancelInternal(
+                c.CancelInternalClOrdId, c.OriginalInternalClOrdId,
+                c.CredentialId, c.ExternalCancelClOrdId);
+    }
+
+    private readonly record struct ExternalKey(Guid CredentialId, ulong ExternalClOrdId);
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using B3.Trading.Application;
 using B3.Trading.Application.UserBots;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,7 @@ public sealed class FixpListenerHostedService : BackgroundService
     private readonly EntryPointListenerOptions _opts;
     private readonly IUserBotCredentialRegistry _credentials;
     private readonly IUserBotSessionRegistry _sessions;
+    private readonly FixpOrderAdapter? _orders;
     private readonly ILogger<FixpListenerHostedService> _logger;
     private readonly TaskCompletionSource<IPEndPoint> _boundTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -35,12 +37,25 @@ public sealed class FixpListenerHostedService : BackgroundService
         IOptions<EntryPointListenerOptions> opts,
         IUserBotCredentialRegistry credentials,
         IUserBotSessionRegistry sessions,
-        ILogger<FixpListenerHostedService> logger)
+        ILogger<FixpListenerHostedService> logger,
+        SymbolDirectory? symbols = null,
+        OrderSubmissionService? submit = null,
+        OrderCancelService? cancel = null,
+        IUserBotOrderMappingRegistry? botMappings = null)
     {
         _opts = opts.Value;
         _credentials = credentials;
         _sessions = sessions;
         _logger = logger;
+        // Sub-issue #171 (E): the order/cancel adapter is only wired when
+        // the host has registered the full submit pipeline. Tests (and
+        // any future handshake-only mode) leave the deps null and the
+        // listener falls back to the v0 "ignore application messages"
+        // behaviour.
+        if (symbols is not null && submit is not null && cancel is not null && botMappings is not null)
+        {
+            _orders = new FixpOrderAdapter(symbols, submit, cancel, botMappings, logger);
+        }
     }
 
     /// <summary>
@@ -91,7 +106,7 @@ public sealed class FixpListenerHostedService : BackgroundService
                     continue;
                 }
 
-                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger);
+                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger, _orders);
                 _ = Task.Run(() => conn.RunAsync(stoppingToken), stoppingToken);
             }
         }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
@@ -1,0 +1,379 @@
+using System.Buffers;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Application;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Framing;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #171 (E). Adapter that translates inbound SBE
+/// <c>NewOrderSingle</c> / <c>OrderCancelRequest</c> messages into the
+/// platform's <see cref="OrderSubmissionService"/> /
+/// <see cref="OrderCancelService"/> calls, and writes back synthetic
+/// <c>BusinessMessageReject</c> / <c>ExecutionReport_Reject</c> frames
+/// for the failure paths described in RFC user-bot-fixp-listener-v0
+/// §4.6 / §4.7.
+///
+/// <para>Stateless: all per-connection state lives in the
+/// <see cref="FixpConnectionScope"/> (principal) and the platform-side
+/// registries. The adapter holds only the cross-connection singletons
+/// it dispatches into. <c>Handle...Async</c> takes the
+/// <see cref="NetworkStream"/> from <see cref="FixpSessionConnection"/>
+/// to write the synchronous transport-level reject paths.</para>
+/// </summary>
+internal sealed class FixpOrderAdapter
+{
+    private const ushort SchemaIdV6 = 1;
+    private const ushort VersionApp = 6;
+
+    /// <summary>
+    /// RFC §4.6 / §4.7. Synthetic rejection reason codes the listener
+    /// emits in <c>BusinessMessageReject.businessRejectReason</c> and
+    /// <c>ExecutionReport_Reject.ordRejReason</c>. Values are local to
+    /// the platform — the FIXP spec leaves the field as a free-form
+    /// uint32 reason code and bots only need them to be stable for
+    /// log-correlation.
+    /// </summary>
+    private static class RejectReason
+    {
+        public const uint UnknownSecurity = 1001;
+        public const uint InvalidShape = 1002;
+        public const uint DuplicateClOrdId = 1003;
+        public const uint UnknownOrder = 1004;
+        public const uint Drained = 1005;
+        public const uint WalBackpressure = 1006;
+        public const uint RiskRejected = 1007;
+        public const uint GatewayFailed = 1008;
+        public const uint BadRequest = 1009;
+        public const uint StaleOrder = 1010;
+    }
+
+    private readonly SymbolDirectory _symbols;
+    private readonly OrderSubmissionService _submit;
+    private readonly OrderCancelService _cancel;
+    private readonly IUserBotOrderMappingRegistry _botMappings;
+    private readonly ILogger _logger;
+
+    public FixpOrderAdapter(
+        SymbolDirectory symbols,
+        OrderSubmissionService submit,
+        OrderCancelService cancel,
+        IUserBotOrderMappingRegistry botMappings,
+        ILogger logger)
+    {
+        _symbols = symbols;
+        _submit = submit;
+        _cancel = cancel;
+        _botMappings = botMappings;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Decode an inbound <c>NewOrderSingle</c> (id=102) and dispatch it
+    /// through <see cref="OrderSubmissionService.SubmitAsync"/>. Returns
+    /// <c>true</c> to keep the connection alive; the only failures that
+    /// terminate the session are framing-level (those are handled by the
+    /// caller, not here).
+    /// </summary>
+    public async Task HandleNewOrderSingleAsync(
+        NetworkStream stream,
+        ReadOnlyMemory<byte> payload,
+        FixpConnectionScope scope,
+        CancellationToken ct)
+    {
+        if (payload.Length < NewOrderSingleData.BLOCK_LENGTH)
+        {
+            await WriteBusinessMessageRejectAsync(stream,
+                refMsgType: MessageType.NewOrderSingle,
+                refSeqNum: 0, businessRejectRefID: 0,
+                reason: RejectReason.InvalidShape, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var msg = MemoryMarshal.Read<NewOrderSingleData>(payload.Span);
+        var externalClOrdId = (ulong)msg.ClOrdID;
+        var securityId = (ulong)msg.SecurityID;
+        var refSeqNum = (uint)msg.BusinessHeader.MsgSeqNum;
+
+        // 1. Resolve SecurityId → Symbol. Without a directory entry the
+        //    submit pipeline would reject anyway with "symbol is required";
+        //    we short-circuit with the more precise UnknownSecurity reason.
+        if (!_symbols.TryGetSymbolBySecurityId(securityId, out var symbol) || symbol is null)
+        {
+            _logger.LogInformation(
+                "fixp.order.reject reason=unknown_security cred={Cred} clOrdId={ClOrdId} securityId={SecId}",
+                scope.Principal.CredShortId, externalClOrdId, securityId);
+            await WriteBusinessMessageRejectAsync(stream,
+                MessageType.NewOrderSingle, refSeqNum, externalClOrdId,
+                RejectReason.UnknownSecurity, ct).ConfigureAwait(false);
+            return;
+        }
+
+        // 2. Validate side/ordType up-front so a malformed wire byte is
+        //    a clean BMR rather than a generic BadRequest from the
+        //    pipeline. Only the LIMIT/MARKET subset is supported by the
+        //    domain model in v0; everything else is rejected.
+        if (!TryMapSide(msg.Side, out var side) || !TryMapOrdType(msg.OrdType, out var type))
+        {
+            await WriteBusinessMessageRejectAsync(stream,
+                MessageType.NewOrderSingle, refSeqNum, externalClOrdId,
+                RejectReason.InvalidShape, ct).ConfigureAwait(false);
+            return;
+        }
+
+        // 3. Pre-emptive duplicate check — a bot retrying the same
+        //    ExternalClOrdId is the most likely cause of #108 firing
+        //    deep inside Submit. Catching it here lets us send back a
+        //    BusinessMessageReject(DuplicateClOrdId) keyed off the
+        //    external id without consuming a platform internal id.
+        if (_botMappings.TryGetByExternal(scope.Principal.CredentialId, externalClOrdId, out _))
+        {
+            await WriteBusinessMessageRejectAsync(stream,
+                MessageType.NewOrderSingle, refSeqNum, externalClOrdId,
+                RejectReason.DuplicateClOrdId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var owner = OwnerFor(scope);
+        var qty = (long)(ulong)msg.OrderQty;
+        decimal? price = msg.Price.Mantissa is { } m
+            ? m / (decimal)PriceOptional.Multiplier
+            : null;
+
+        var req = new OrderSubmissionRequest(
+            Owner: owner,
+            FirmId: "default",
+            Symbol: symbol,
+            SecurityId: securityId,
+            Side: side,
+            Type: type,
+            Quantity: qty,
+            Price: price)
+        {
+            BotOrigin = new BotOrigin(scope.Principal.CredentialId, externalClOrdId),
+        };
+
+        var result = await _submit.SubmitAsync(req, ct).ConfigureAwait(false);
+        if (result.Kind == OrderSubmissionResultKind.Accepted) return;
+
+        // RFC §4.7 — submit-time rejections produce a synthetic
+        // ExecutionReport_Reject so the bot sees the same shape it would
+        // have seen for a venue-side reject (consistent ER stream).
+        var reason = result.Kind switch
+        {
+            OrderSubmissionResultKind.Drained => RejectReason.Drained,
+            OrderSubmissionResultKind.BadRequest => RejectReason.BadRequest,
+            OrderSubmissionResultKind.WalBackpressure => RejectReason.WalBackpressure,
+            OrderSubmissionResultKind.DuplicateClOrdId => RejectReason.DuplicateClOrdId,
+            OrderSubmissionResultKind.Rejected => RejectReason.RiskRejected,
+            OrderSubmissionResultKind.GatewayFailed => RejectReason.GatewayFailed,
+            _ => RejectReason.BadRequest,
+        };
+
+        _logger.LogInformation(
+            "fixp.order.reject reason={Reason} kind={Kind} cred={Cred} clOrdId={ClOrdId}",
+            reason, result.Kind, scope.Principal.CredShortId, externalClOrdId);
+
+        await WriteExecutionReportRejectAsync(stream,
+            externalClOrdId: externalClOrdId,
+            origExternalClOrdId: 0,
+            securityId: securityId,
+            side: msg.Side,
+            ordType: msg.OrdType,
+            qty: (ulong)msg.OrderQty,
+            priceMantissa: msg.Price.Mantissa ?? PriceOptional.MantissaNullValue,
+            ordRejReason: reason,
+            cxlRejResponseTo: CxlRejResponseTo.NEW,
+            ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Decode an inbound <c>OrderCancelRequest</c> (id=105) and dispatch
+    /// it through <see cref="OrderCancelService.CancelAsync"/> after
+    /// resolving the bot's external <c>OrigClOrdID</c> back to the
+    /// platform's internal id via the side-mapping registry.
+    /// </summary>
+    public async Task HandleOrderCancelRequestAsync(
+        NetworkStream stream,
+        ReadOnlyMemory<byte> payload,
+        FixpConnectionScope scope,
+        CancellationToken ct)
+    {
+        if (payload.Length < OrderCancelRequestData.BLOCK_LENGTH)
+        {
+            await WriteBusinessMessageRejectAsync(stream,
+                MessageType.OrderCancelRequest, 0, 0,
+                RejectReason.InvalidShape, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var msg = MemoryMarshal.Read<OrderCancelRequestData>(payload.Span);
+        var externalCancelClOrdId = (ulong)msg.ClOrdID;
+        var externalOrigClOrdId = msg.OrigClOrdID.GetValueOrDefault();
+        var securityId = (ulong)msg.SecurityID;
+        var refSeqNum = (uint)msg.BusinessHeader.MsgSeqNum;
+
+        // Resolve original order via the bot mapping side-registry.
+        // The registry's TryGetByExternal already enforces the
+        // (credentialId, externalOrigClOrdId) → internal lookup, which
+        // doubles as the cross-credential isolation guard (RFC §4.6:
+        // a bot can only cancel orders it submitted).
+        if (!_botMappings.TryGetByExternal(
+                scope.Principal.CredentialId, externalOrigClOrdId, out var internalOrigClOrdId))
+        {
+            _logger.LogInformation(
+                "fixp.cancel.reject reason=unknown_order cred={Cred} clOrdId={ClOrdId} origClOrdId={Orig}",
+                scope.Principal.CredShortId, externalCancelClOrdId, externalOrigClOrdId);
+            await WriteBusinessMessageRejectAsync(stream,
+                MessageType.OrderCancelRequest, refSeqNum, externalCancelClOrdId,
+                RejectReason.UnknownOrder, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var owner = OwnerFor(scope);
+        var botOrigin = new BotOrigin(scope.Principal.CredentialId, externalCancelClOrdId);
+
+        var result = await _cancel.CancelAsync(owner, internalOrigClOrdId, ct, botOrigin)
+            .ConfigureAwait(false);
+        if (result.Kind == OrderCancelResultKind.Accepted) return;
+
+        var reason = result.Kind switch
+        {
+            OrderCancelResultKind.NotFound => RejectReason.UnknownOrder,
+            OrderCancelResultKind.Stale => RejectReason.StaleOrder,
+            OrderCancelResultKind.WalBackpressure => RejectReason.WalBackpressure,
+            OrderCancelResultKind.GatewayFailed => RejectReason.GatewayFailed,
+            _ => RejectReason.BadRequest,
+        };
+
+        _logger.LogInformation(
+            "fixp.cancel.reject reason={Reason} kind={Kind} cred={Cred} clOrdId={ClOrdId} orig={Orig}",
+            reason, result.Kind, scope.Principal.CredShortId, externalCancelClOrdId, externalOrigClOrdId);
+
+        await WriteExecutionReportRejectAsync(stream,
+            externalClOrdId: externalCancelClOrdId,
+            origExternalClOrdId: externalOrigClOrdId,
+            securityId: securityId,
+            side: msg.Side,
+            ordType: 0,
+            qty: 0,
+            priceMantissa: PriceOptional.MantissaNullValue,
+            ordRejReason: reason,
+            cxlRejResponseTo: CxlRejResponseTo.CANCEL,
+            ct).ConfigureAwait(false);
+    }
+
+    private static EndClientId OwnerFor(FixpConnectionScope scope)
+    {
+        // RFC §4.6: bot-origin orders book ownership under a synthetic
+        // "bot:<credShortId>" end-client so they share no namespace with
+        // human users. CredShortId is `b3t_<10>` lowercase already.
+        return new EndClientId("bot:" + scope.Principal.CredShortId.ToLowerInvariant());
+    }
+
+    private static bool TryMapSide(Side raw, out OrderSide side)
+    {
+        switch (raw)
+        {
+            case Side.BUY: side = OrderSide.Buy; return true;
+            case Side.SELL: side = OrderSide.Sell; return true;
+            default: side = default; return false;
+        }
+    }
+
+    private static bool TryMapOrdType(OrdType raw, out OrderType type)
+    {
+        switch (raw)
+        {
+            case OrdType.LIMIT: type = OrderType.Limit; return true;
+            case OrdType.MARKET: type = OrderType.Market; return true;
+            default: type = default; return false;
+        }
+    }
+
+    // ─── Outbound writers ────────────────────────────────────────────────
+
+    private static async Task WriteBusinessMessageRejectAsync(
+        NetworkStream stream,
+        MessageType refMsgType,
+        uint refSeqNum,
+        ulong businessRejectRefID,
+        uint reason,
+        CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(BusinessMessageRejectData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            // Some optional fields on the SBE codegen surface as
+            // read-only `Nullable<T>` properties, so we write the wire
+            // layout via byte-offset MemoryMarshal calls instead. The
+            // outbound business header (offsets 0..17) stays zero.
+            Span<byte> body = stackalloc byte[BusinessMessageRejectData.BLOCK_LENGTH];
+            body.Clear();
+            body[18] = (byte)refMsgType;
+            MemoryMarshal.Write(body[20..], in refSeqNum);
+            MemoryMarshal.Write(body[24..], in businessRejectRefID);
+            MemoryMarshal.Write(body[32..], in reason);
+
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)BusinessMessageRejectData.BLOCK_LENGTH,
+                (ushort)BusinessMessageRejectData.MESSAGE_ID,
+                SchemaIdV6, VersionApp,
+                body);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
+    }
+
+    private static async Task WriteExecutionReportRejectAsync(
+        NetworkStream stream,
+        ulong externalClOrdId,
+        ulong origExternalClOrdId,
+        ulong securityId,
+        Side side,
+        OrdType ordType,
+        ulong qty,
+        long priceMantissa,
+        uint ordRejReason,
+        CxlRejResponseTo cxlRejResponseTo,
+        CancellationToken ct)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(ExecutionReport_RejectData.BLOCK_LENGTH);
+        var buf = ArrayPool<byte>.Shared.Rent(frameSize);
+        try
+        {
+            // See WriteBusinessMessageRejectAsync for rationale on
+            // direct byte-offset writes. Offsets here track the SBE v6
+            // ExecutionReport_Reject schema (size 164).
+            Span<byte> body = stackalloc byte[ExecutionReport_RejectData.BLOCK_LENGTH];
+            body.Clear();
+            body[18] = (byte)side;
+            body[19] = (byte)cxlRejResponseTo;
+            MemoryMarshal.Write(body[20..], in externalClOrdId);
+            MemoryMarshal.Write(body[36..], in securityId);
+            MemoryMarshal.Write(body[44..], in ordRejReason);
+            ulong transactTime = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+            MemoryMarshal.Write(body[48..], in transactTime);
+            MemoryMarshal.Write(body[72..], in origExternalClOrdId);
+            body[84] = (byte)ordType;
+            MemoryMarshal.Write(body[88..], in qty);
+            MemoryMarshal.Write(body[96..], in priceMantissa);
+            long stopMantissaNull = PriceOptional.MantissaNullValue;
+            MemoryMarshal.Write(body[104..], in stopMantissaNull);
+
+            SofhFrameWriter.WriteFrame(buf.AsSpan(0, frameSize),
+                (ushort)ExecutionReport_RejectData.BLOCK_LENGTH,
+                (ushort)ExecutionReport_RejectData.MESSAGE_ID,
+                SchemaIdV6, VersionApp,
+                body);
+            await stream.WriteAsync(buf, 0, frameSize, ct).ConfigureAwait(false);
+        }
+        finally { ArrayPool<byte>.Shared.Return(buf); }
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -46,6 +46,7 @@ internal sealed class FixpSessionConnection
     private readonly ILogger _logger;
     private readonly IUserBotCredentialRegistry _credentials;
     private readonly IUserBotSessionRegistry _sessions;
+    private readonly FixpOrderAdapter? _orders;
     private readonly string _connectionId;
     private readonly FixpHandshakeStateMachine _sm = new();
 
@@ -56,11 +57,13 @@ internal sealed class FixpSessionConnection
         TcpClient tcpClient,
         IUserBotCredentialRegistry credentials,
         IUserBotSessionRegistry sessions,
-        ILogger logger)
+        ILogger logger,
+        FixpOrderAdapter? orders = null)
     {
         _tcpClient = tcpClient;
         _credentials = credentials;
         _sessions = sessions;
+        _orders = orders;
         _logger = logger;
         _connectionId = Guid.NewGuid().ToString("N");
     }
@@ -171,6 +174,24 @@ internal sealed class FixpSessionConnection
 
             case TerminateData.MESSAGE_ID:
                 return await HandleTerminateAsync(stream, frame, ct).ConfigureAwait(false);
+
+            case NewOrderSingleData.MESSAGE_ID:
+                if (_sm.State != FixpSessionState.Established) goto default;
+                if (_orders is not null && _scope is not null)
+                {
+                    await _orders.HandleNewOrderSingleAsync(stream, frame.Payload, _scope, ct)
+                        .ConfigureAwait(false);
+                }
+                return true;
+
+            case OrderCancelRequestData.MESSAGE_ID:
+                if (_sm.State != FixpSessionState.Established) goto default;
+                if (_orders is not null && _scope is not null)
+                {
+                    await _orders.HandleOrderCancelRequestAsync(stream, frame.Payload, _scope, ct)
+                        .ConfigureAwait(false);
+                }
+                return true;
 
             default:
                 if (_sm.State == FixpSessionState.Established)

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -106,11 +106,17 @@ builder.Services.AddSingleton<IUserBotCredentialRegistry>(sp =>
 builder.Services.AddSingleton<InMemoryUserBotSessionRegistry>();
 builder.Services.AddSingleton<IUserBotSessionRegistry>(sp =>
     sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
+// Sub-issue #171 (E): bot order mapping side-registry. Singleton so
+// snapshot capture/restore + WAL replay all share the same instance.
+builder.Services.AddSingleton<InMemoryUserBotOrderMappingRegistry>();
+builder.Services.AddSingleton<IUserBotOrderMappingRegistry>(sp =>
+    sp.GetRequiredService<InMemoryUserBotOrderMappingRegistry>());
 builder.Services.AddSingleton<SubscriptionManager>();
 builder.Services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
 builder.Services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
 builder.Services.AddSingleton<ExecutionReportProcessor>();
 builder.Services.AddSingleton<OrderSubmissionService>();
+builder.Services.AddSingleton<OrderCancelService>();
 builder.Services.AddSingleton<OrderModifyService>();
 
 // Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -27,6 +27,7 @@ public sealed class StateSnapshotter
     private readonly CashLedger _cash;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
+    private readonly IUserBotOrderMappingRegistry? _userBotMappings;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -40,7 +41,8 @@ public sealed class StateSnapshotter
         AlgoIdRegistry algoIds,
         CashLedger cash,
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
-        InMemoryUserBotSessionRegistry? userBotSessions = null)
+        InMemoryUserBotSessionRegistry? userBotSessions = null,
+        IUserBotOrderMappingRegistry? userBotMappings = null)
     {
         _orders = orders;
         _positions = positions;
@@ -54,6 +56,7 @@ public sealed class StateSnapshotter
         _cash = cash;
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
+        _userBotMappings = userBotMappings;
     }
 
     public PlatformSnapshot Capture(long seq) => new()
@@ -76,6 +79,8 @@ public sealed class StateSnapshotter
         CashBalances = _cash.Snapshot().ToList(),
         UserBotCredentials = _userBotCredentials?.Snapshot().ToList() ?? new(),
         BotSessions = _userBotSessions?.Snapshot().ToList() ?? new(),
+        BotOrderMappings = _userBotMappings?.SnapshotOrders().ToList() ?? new(),
+        BotCancelMappings = _userBotMappings?.SnapshotCancels().ToList() ?? new(),
     };
 
     public void Restore(PlatformSnapshot snap)
@@ -99,6 +104,7 @@ public sealed class StateSnapshotter
         _cash.Restore(snap.CashBalances);
         _userBotCredentials?.Restore(snap.UserBotCredentials);
         _userBotSessions?.Restore(snap.BotSessions);
+        _userBotMappings?.Restore(snap.BotOrderMappings, snap.BotCancelMappings);
     }
 }
 
@@ -123,6 +129,7 @@ public sealed class EventReplayer
     private readonly PendingReplacementRegistry? _replacements;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
+    private readonly IUserBotOrderMappingRegistry? _userBotMappings;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -136,7 +143,8 @@ public sealed class EventReplayer
         AlgoIdRegistry algoIds,
         PendingReplacementRegistry? replacements = null,
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
-        InMemoryUserBotSessionRegistry? userBotSessions = null)
+        InMemoryUserBotSessionRegistry? userBotSessions = null,
+        IUserBotOrderMappingRegistry? userBotMappings = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -150,6 +158,7 @@ public sealed class EventReplayer
         _replacements = replacements;
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
+        _userBotMappings = userBotMappings;
     }
 
     public void Apply(WalEvent evt)
@@ -166,10 +175,34 @@ public sealed class EventReplayer
                 // #157: advance the ClOrdID registry watermark so the next
                 // live Generate(owner) cannot re-allocate this ID.
                 _clOrdIds.AdvanceCounterTo(owner, o.ClOrdId);
+                // Sub-issue #171 (E): rebuild the bot order mapping side
+                // record for FIXP-origin orders. Same call shape as the
+                // live submit-time apply callback so a snapshot taken
+                // mid-life and a clean restart from WAL produce identical
+                // registry state.
+                if (o.BotMapping is { } bm && _userBotMappings is not null)
+                    _userBotMappings.RegisterOrderInternal(
+                        o.ClOrdId, bm.CredentialId, bm.ExternalClOrdId);
                 // Parent state-machine progression on first child accept is
                 // engine-side (slice 5/6); replay only re-creates the order
                 // — the parent's Working/Filled state is reconstructed from
                 // the child ER stream through the processor below.
+                break;
+            case OrderCancelRequestedEvent ocr:
+                // Sub-issue #171 (E). Re-runs the same in-memory mutations
+                // the live cancel path's apply callback ran. No gateway
+                // call on replay (the original Cancel was either acked
+                // by the venue and its ER will replay, or it never was
+                // and the operator/bot will retry).
+                var ocrOwner = new EndClientId(ocr.OwnerEndClientId);
+                _ownership.RegisterCancelLink(ocr.CancelClOrdId, ocr.OriginalClOrdId);
+                _clOrdIds.AdvanceCounterTo(ocrOwner, ocr.CancelClOrdId);
+                if (ocr.BotMapping is { } cbm && _userBotMappings is not null)
+                    _userBotMappings.RegisterCancelInternal(
+                        cancelInternalClOrdId: ocr.CancelClOrdId,
+                        originalInternalClOrdId: ocr.OriginalClOrdId,
+                        credentialId: cbm.CredentialId,
+                        externalCancelClOrdId: cbm.ExternalClOrdId);
                 break;
             case OrderReplaceRequestedEvent rr:
                 // Slice 4 of #122. Re-register the in-flight intent and

--- a/backend/tests/B3.Trading.Application.Tests/OrderCancelServiceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderCancelServiceTests.cs
@@ -1,0 +1,160 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Sub-issue #171 (E). Behavioural coverage for the shared cancel
+/// pipeline introduced by this slice. The two invariants that matter
+/// most here:
+///
+/// <list type="number">
+///   <item>The dispatcher <c>apply</c> callback runs synchronous
+///   in-memory mutations only — the async gateway call must happen
+///   AFTER <c>Dispatch</c> returns. A fake gateway that records call
+///   ordering pins this contract.</item>
+///   <item>When a <see cref="BotOrigin"/> is supplied, the bot
+///   cancel-mapping registry is populated atomically with the WAL
+///   record; otherwise it is left untouched (REST/WS unaffected).</item>
+/// </list>
+/// </summary>
+public class OrderCancelServiceTests
+{
+    private static readonly Guid CredA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly EndClientId Owner = new("alice");
+
+    private sealed class RecordingGateway : IExchangeGateway
+    {
+        public List<string> Calls { get; } = new();
+        public TaskCompletionSource? CancelGate { get; set; }
+
+        public Task SubmitAsync(Order order, CancellationToken cancellationToken)
+        {
+            Calls.Add("submit");
+            return Task.CompletedTask;
+        }
+
+        public async Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken)
+        {
+            Calls.Add($"cancel:{newClOrdId}");
+            if (CancelGate is { } g) await g.Task.ConfigureAwait(false);
+        }
+
+        public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private static Order Working(ulong clOrdId)
+        => new(clOrdId, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 10m);
+
+    [Fact]
+    public async Task CancelAsync_HappyPath_AppliesInMemoryMutations_AndCallsGatewayOutsideDispatch()
+    {
+        // The apply callback must mutate ownership/clOrdId/registry
+        // SYNCHRONOUSLY, and the gateway must be hit AFTER dispatch returns.
+        // A blocking gate on the gateway proves the dispatcher lock is
+        // released before the network I/O — otherwise nothing else could
+        // proceed during a flaky cancel.
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var gateway = new RecordingGateway();
+        var bots = new InMemoryUserBotOrderMappingRegistry();
+
+        // Seed an existing order owned by Alice (mimic prior submit).
+        const ulong original = 100UL;
+        Assert.True(book.TryAdd(Working(original)));
+        ownership.Register(original, Owner);
+        bots.RegisterOrderInternal(original, CredA, externalClOrdId: 9UL);
+
+        var sut = new OrderCancelService(clOrdIds, ownership, book, gateway, dispatcher,
+            NullLogger<OrderCancelService>.Instance, bots);
+
+        // Hold the gateway call so the test can observe ordering between
+        // dispatcher-synchronous mutations and the OUTSIDE-the-lock I/O.
+        gateway.CancelGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = sut.CancelAsync(Owner, original, CancellationToken.None,
+            new BotOrigin(CredA, ExternalClOrdId: 77UL));
+
+        for (int i = 0; i < 100 && gateway.Calls.Count == 0; i++)
+            await Task.Yield();
+
+        // Gateway has been called, blocked on the gate — meaning Dispatch
+        // already returned with its in-memory mutations applied.
+        Assert.Single(gateway.Calls);
+        Assert.StartsWith("cancel:", gateway.Calls[0]);
+        var cancelClOrdId = ulong.Parse(gateway.Calls[0]["cancel:".Length..]);
+
+        // ownership cancel-link, watermark advance, and bot mapping all
+        // visible without waiting for the gateway call to complete.
+        Assert.True(ownership.TryResolveOrig(cancelClOrdId, out var origLinked));
+        Assert.Equal(original, origLinked);
+        Assert.True(bots.TryGetCancelMapping(cancelClOrdId, out var cm));
+        Assert.Equal(original, cm.OriginalInternalClOrdId);
+        Assert.Equal(77UL, cm.ExternalCancelClOrdId);
+
+        gateway.CancelGate.SetResult();
+        var result = await pending;
+        Assert.Equal(OrderCancelResultKind.Accepted, result.Kind);
+        Assert.Equal(cancelClOrdId, result.CancelClOrdId);
+    }
+
+    [Fact]
+    public async Task CancelAsync_WithoutBotOrigin_DoesNotTouchBotMappingRegistry()
+    {
+        // REST DELETE path: the registry must not pick up REST-origin
+        // cancels. The OrderCancelService still works without a registry,
+        // and (when one is provided) leaves it untouched for non-bot calls.
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var gateway = new RecordingGateway();
+        var bots = new InMemoryUserBotOrderMappingRegistry();
+
+        const ulong original = 100UL;
+        Assert.True(book.TryAdd(Working(original)));
+        ownership.Register(original, Owner);
+
+        var sut = new OrderCancelService(clOrdIds, ownership, book, gateway, dispatcher,
+            NullLogger<OrderCancelService>.Instance, bots);
+
+        var result = await sut.CancelAsync(Owner, original, CancellationToken.None,
+            botOrigin: null);
+
+        Assert.Equal(OrderCancelResultKind.Accepted, result.Kind);
+        Assert.Empty(bots.SnapshotCancels());
+    }
+
+    [Fact]
+    public async Task CancelAsync_NotFoundOrCrossOwner_ReturnsNotFound_NoWalNoGateway()
+    {
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var gateway = new RecordingGateway();
+        var bots = new InMemoryUserBotOrderMappingRegistry();
+
+        var sut = new OrderCancelService(clOrdIds, ownership, book, gateway, dispatcher,
+            NullLogger<OrderCancelService>.Instance, bots);
+
+        // Unknown id.
+        Assert.Equal(OrderCancelResultKind.NotFound,
+            (await sut.CancelAsync(Owner, 100UL, CancellationToken.None)).Kind);
+
+        // Cross-owner: order exists but is owned by someone else — must
+        // surface as NotFound (info disclosure boundary).
+        Assert.True(book.TryAdd(Working(101UL)));
+        ownership.Register(101UL, Owner);
+        Assert.Equal(OrderCancelResultKind.NotFound,
+            (await sut.CancelAsync(new EndClientId("mallory"), 101UL, CancellationToken.None)).Kind);
+
+        Assert.Empty(gateway.Calls);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/WalEventsBotMappingTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/WalEventsBotMappingTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Sub-issue #171 (E). JSON round-trip + backward-compatibility coverage
+/// for the new <see cref="OrderSubmittedEvent.BotMapping"/> side-record
+/// and the new <see cref="OrderCancelRequestedEvent"/> WAL event.
+///
+/// <para>Schema rule (WalEvents.cs): never rename, only add nullable
+/// fields. These tests pin that rule for the bot-origin additions: an
+/// older WAL segment without the new field deserialises to a record
+/// with <c>BotMapping = null</c>, matching the manual-order semantics
+/// it originally carried.</para>
+/// </summary>
+public class WalEventsBotMappingTests
+{
+    private static JsonSerializerOptions Opts => new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void OrderSubmittedEvent_WithBotMapping_RoundTripsViaPolymorphicBase()
+    {
+        var credId = Guid.NewGuid();
+        var original = new OrderSubmittedEvent
+        {
+            ClOrdId = 42UL,
+            EndClientId = "bot:b3t_abc",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 12.34m,
+            BotMapping = new BotOrderMapping(credId, 9999UL),
+        };
+
+        var json = JsonSerializer.Serialize<WalEvent>(original, Opts);
+        var back = (OrderSubmittedEvent)JsonSerializer.Deserialize<WalEvent>(json, Opts)!;
+
+        Assert.Equal(42UL, back.ClOrdId);
+        Assert.NotNull(back.BotMapping);
+        Assert.Equal(credId, back.BotMapping!.CredentialId);
+        Assert.Equal(9999UL, back.BotMapping.ExternalClOrdId);
+    }
+
+    [Fact]
+    public void OrderSubmittedEvent_WithoutBotMapping_RoundTripsAsNull()
+    {
+        var original = new OrderSubmittedEvent
+        {
+            ClOrdId = 7UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "VALE3",
+            SecurityId = 9876UL,
+            Side = "Sell",
+            Type = "Market",
+            Quantity = 10,
+        };
+
+        var json = JsonSerializer.Serialize<WalEvent>(original, Opts);
+        var back = (OrderSubmittedEvent)JsonSerializer.Deserialize<WalEvent>(json, Opts)!;
+
+        Assert.Null(back.BotMapping);
+    }
+
+    [Fact]
+    public void OrderSubmittedEvent_LegacyJsonWithoutBotMapping_DeserialisesAsNull()
+    {
+        // Pre-#171 WAL segments were written without the BotMapping field.
+        // Replay must accept them silently with BotMapping == null.
+        var legacy = """
+            {
+              "kind":"order.submitted",
+              "ClOrdId":12345,
+              "EndClientId":"alice",
+              "FirmId":"default",
+              "Symbol":"PETR4",
+              "SecurityId":4321,
+              "Side":"Buy",
+              "Type":"Limit",
+              "Quantity":100,
+              "Price":10.0,
+              "TimestampUtc":"2024-01-01T00:00:00Z"
+            }
+            """;
+
+        var back = (OrderSubmittedEvent)JsonSerializer.Deserialize<WalEvent>(legacy, Opts)!;
+
+        Assert.Equal(12345UL, back.ClOrdId);
+        Assert.Null(back.BotMapping);
+    }
+
+    [Fact]
+    public void OrderCancelRequestedEvent_WithBotMapping_RoundTripsViaPolymorphicBase()
+    {
+        var credId = Guid.NewGuid();
+        var evt = new OrderCancelRequestedEvent
+        {
+            CancelClOrdId = 200UL,
+            OriginalClOrdId = 42UL,
+            OwnerEndClientId = "bot:b3t_abc",
+            BotMapping = new BotOrderMapping(credId, 5555UL),
+        };
+
+        var json = JsonSerializer.Serialize<WalEvent>(evt, Opts);
+        Assert.Contains("\"kind\":\"order.cancel-requested\"", json);
+
+        var back = (OrderCancelRequestedEvent)JsonSerializer.Deserialize<WalEvent>(json, Opts)!;
+        Assert.Equal(200UL, back.CancelClOrdId);
+        Assert.Equal(42UL, back.OriginalClOrdId);
+        Assert.Equal("bot:b3t_abc", back.OwnerEndClientId);
+        Assert.NotNull(back.BotMapping);
+        Assert.Equal(credId, back.BotMapping!.CredentialId);
+        Assert.Equal(5555UL, back.BotMapping.ExternalClOrdId);
+    }
+
+    [Fact]
+    public void OrderCancelRequestedEvent_WithoutBotMapping_RoundTrips()
+    {
+        var evt = new OrderCancelRequestedEvent
+        {
+            CancelClOrdId = 200UL,
+            OriginalClOrdId = 42UL,
+            OwnerEndClientId = "alice",
+        };
+
+        var json = JsonSerializer.Serialize<WalEvent>(evt, Opts);
+        var back = (OrderCancelRequestedEvent)JsonSerializer.Deserialize<WalEvent>(json, Opts)!;
+
+        Assert.Null(back.BotMapping);
+        Assert.Equal(200UL, back.CancelClOrdId);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
@@ -175,4 +175,69 @@ public class SymbolDirectoryTests
         Assert.False(sut.TryResolve("VALE3", out _));
         Assert.True(sut.TryGetSpec("VALE3", out _));
     }
+
+    // Sub-issue #171 (E): inverse SecurityId → Symbol lookup added for the
+    // FIXP order adapter, which receives orders by numeric SecurityId.
+
+    [Fact]
+    public void TryGetSymbolBySecurityId_KnownId_ReturnsSymbol()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL, ["VALE3"] = 9876UL },
+        });
+
+        Assert.True(sut.TryGetSymbolBySecurityId(4321UL, out var symbol));
+        Assert.Equal("PETR4", symbol);
+        Assert.True(sut.TryGetSymbolBySecurityId(9876UL, out symbol));
+        Assert.Equal("VALE3", symbol);
+    }
+
+    [Fact]
+    public void TryGetSymbolBySecurityId_UnknownId_ReturnsFalse()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL },
+        });
+
+        Assert.False(sut.TryGetSymbolBySecurityId(9999UL, out var symbol));
+        Assert.Null(symbol);
+    }
+
+    [Fact]
+    public void TryGetSymbolBySecurityId_RoundTripsForwardLookup()
+    {
+        // Inverse map is built from the forward map at construction time;
+        // verify they stay in lockstep.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 4321UL, ["VALE3"] = 9876UL },
+        });
+
+        foreach (var name in new[] { "PETR4", "VALE3" })
+        {
+            Assert.True(sut.TryResolve(name, out var id));
+            Assert.True(sut.TryGetSymbolBySecurityId(id, out var back));
+            Assert.Equal(name, back);
+        }
+    }
+
+    [Fact]
+    public void TryGetSymbolBySecurityId_DuplicateSecurityId_FirstWriteWins()
+    {
+        // Configuration mistake: two symbols claim the same SecurityId.
+        // Forward map keeps both; reverse map keeps the first.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            SecurityIds = { ["PETR4"] = 100UL, ["PETR3"] = 100UL },
+        });
+
+        Assert.True(sut.TryGetSymbolBySecurityId(100UL, out var symbol));
+        Assert.NotNull(symbol);
+        // Either one is acceptable as long as we return a known symbol;
+        // the first-write-wins guarantee is documented but ordering of
+        // dictionary enumeration is implementation defined.
+        Assert.Contains(symbol, new[] { "PETR4", "PETR3" });
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotOrderMappingRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotOrderMappingRegistryTests.cs
@@ -1,0 +1,173 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Sub-issue #171 (E). Behavioural unit tests for the bot ClOrdID
+/// side-mapping registry. The registry never originates a WAL append on
+/// its own; the corresponding <see cref="OrderSubmittedEvent"/> /
+/// <see cref="OrderCancelRequestedEvent"/> are the source of truth.
+/// These tests cover the in-memory invariants the registry must hold for
+/// FIXP cancel-inbound (TryGetByExternal), ER reverse routing
+/// (TryGetOrderMapping / TryGetCancelMapping), the snapshot/restore
+/// round-trip, and the Reap idempotence rule.
+/// </summary>
+public class InMemoryUserBotOrderMappingRegistryTests
+{
+    private static readonly Guid CredA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid CredB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void RegisterOrderInternal_PopulatesBothDirections()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+
+        sut.RegisterOrderInternal(internalClOrdId: 100UL, CredA, externalClOrdId: 9UL);
+
+        Assert.True(sut.TryGetOrderMapping(100UL, out var fwd));
+        Assert.Equal(CredA, fwd.CredentialId);
+        Assert.Equal(9UL, fwd.ExternalClOrdId);
+
+        Assert.True(sut.TryGetByExternal(CredA, 9UL, out var rev));
+        Assert.Equal(100UL, rev);
+    }
+
+    [Fact]
+    public void TryGetByExternal_DifferentCredential_ReturnsFalse()
+    {
+        // Cross-credential isolation: the same external ClOrdID under
+        // a different credential must NOT resolve.
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        sut.RegisterOrderInternal(100UL, CredA, 9UL);
+
+        Assert.False(sut.TryGetByExternal(CredB, 9UL, out _));
+    }
+
+    [Fact]
+    public void TryGetByExternal_UnknownExternal_ReturnsFalse()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        Assert.False(sut.TryGetByExternal(CredA, 9UL, out _));
+    }
+
+    [Fact]
+    public void Reap_RemovesBothDirections_AndIsIdempotent()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        sut.RegisterOrderInternal(100UL, CredA, 9UL);
+
+        sut.Reap(100UL);
+
+        Assert.False(sut.TryGetOrderMapping(100UL, out _));
+        Assert.False(sut.TryGetByExternal(CredA, 9UL, out _));
+
+        // Idempotent: reaping an unknown id is a silent no-op.
+        sut.Reap(100UL);
+        sut.Reap(99999UL);
+    }
+
+    [Fact]
+    public void RegisterCancelInternal_PopulatesCancelMap_OriginalNotAltered()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        sut.RegisterOrderInternal(100UL, CredA, 9UL);
+        sut.RegisterCancelInternal(
+            cancelInternalClOrdId: 200UL,
+            originalInternalClOrdId: 100UL,
+            credentialId: CredA,
+            externalCancelClOrdId: 77UL);
+
+        Assert.True(sut.TryGetCancelMapping(200UL, out var c));
+        Assert.Equal(100UL, c.OriginalInternalClOrdId);
+        Assert.Equal(CredA, c.CredentialId);
+        Assert.Equal(77UL, c.ExternalCancelClOrdId);
+
+        // Forward order mapping is preserved — F still needs it to route
+        // pre-cancel ERs (e.g. partial fills) to the bot.
+        Assert.True(sut.TryGetOrderMapping(100UL, out _));
+    }
+
+    [Fact]
+    public void ReapCancel_OnlyDropsCancelEntry()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        sut.RegisterOrderInternal(100UL, CredA, 9UL);
+        sut.RegisterCancelInternal(200UL, 100UL, CredA, 77UL);
+
+        sut.ReapCancel(200UL);
+
+        Assert.False(sut.TryGetCancelMapping(200UL, out _));
+        Assert.True(sut.TryGetOrderMapping(100UL, out _));
+    }
+
+    [Fact]
+    public void RegisterOrderInternal_RejectsZeroOrEmptyArgs()
+    {
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => sut.RegisterOrderInternal(0UL, CredA, 1UL));
+        Assert.Throws<ArgumentException>(
+            () => sut.RegisterOrderInternal(1UL, Guid.Empty, 1UL));
+    }
+
+    [Fact]
+    public void Snapshot_RoundTripsViaRestore()
+    {
+        var seed = new InMemoryUserBotOrderMappingRegistry();
+        seed.RegisterOrderInternal(100UL, CredA, 9UL);
+        seed.RegisterOrderInternal(101UL, CredB, 10UL);
+        seed.RegisterCancelInternal(200UL, 100UL, CredA, 77UL);
+
+        var orders = seed.SnapshotOrders();
+        var cancels = seed.SnapshotCancels();
+
+        var restored = new InMemoryUserBotOrderMappingRegistry();
+        restored.Restore(orders, cancels);
+
+        Assert.True(restored.TryGetByExternal(CredA, 9UL, out var rev));
+        Assert.Equal(100UL, rev);
+        Assert.True(restored.TryGetByExternal(CredB, 10UL, out rev));
+        Assert.Equal(101UL, rev);
+        Assert.True(restored.TryGetCancelMapping(200UL, out var cm));
+        Assert.Equal(77UL, cm.ExternalCancelClOrdId);
+    }
+
+    [Fact]
+    public void Restore_ClearsExistingState()
+    {
+        // The snapshot is the authoritative truth at startup; any stale
+        // in-memory state from a previous Restore must be wiped first.
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        sut.RegisterOrderInternal(999UL, CredA, 999UL);
+        sut.RegisterCancelInternal(998UL, 999UL, CredA, 998UL);
+
+        sut.Restore(
+            new[] { new BotOrderMappingSnapshot(100UL, CredB, 10UL) },
+            Array.Empty<BotCancelMappingSnapshot>());
+
+        Assert.False(sut.TryGetOrderMapping(999UL, out _));
+        Assert.False(sut.TryGetCancelMapping(998UL, out _));
+        Assert.True(sut.TryGetOrderMapping(100UL, out _));
+    }
+
+    [Fact]
+    public async Task ConcurrentRegistrations_AreThreadSafe()
+    {
+        // Submit pipeline runs apply callbacks under the dispatcher lock,
+        // but reads (TryGetOrderMapping for ER routing) are unsynchronised.
+        // Verify no torn writes / lost updates under contention.
+        var sut = new InMemoryUserBotOrderMappingRegistry();
+        const int n = 5_000;
+
+        var tasks = Enumerable.Range(0, n).Select(i => Task.Run(() =>
+            sut.RegisterOrderInternal((ulong)(i + 1), CredA, (ulong)(i + 1)))).ToArray();
+        await Task.WhenAll(tasks);
+
+        for (int i = 1; i <= n; i++)
+        {
+            Assert.True(sut.TryGetOrderMapping((ulong)i, out var m));
+            Assert.Equal((ulong)i, m.ExternalClOrdId);
+        }
+    }
+}


### PR DESCRIPTION
Closes #171
Refs #166

Sub-issue **#171 (E)** of the user-bot FIXP listener stack. Wires inbound SBE `NewOrderSingle` (id=102) and `OrderCancelRequest` (id=105) frames from the FIXP listener into the existing platform order pipeline, with a side-mapping registry that translates between the platform's internal `ulong` ClOrdID and the bot-visible `(CredentialId, ExternalClOrdId)` identity. The listener emits synthetic `BusinessMessageReject` (validation failures) and `ExecutionReport_Reject` (submit-time rejections) for every failure path.

Cancel-side state is now WAL-durable via a new `OrderCancelRequestedEvent` — the previous in-memory-only cancel-link path lost ownership/watermark/bot-mapping state on restart, which broke the FIXP cancel-ER round-trip across recovery. Both REST `DELETE` and the FIXP cancel handler share the new `OrderCancelService`.

## Highlights
- **WAL extensions** — new `OrderCancelRequestedEvent` + `BotOrderMapping` sub-record on `OrderSubmittedEvent` (backward-compatible: legacy WAL segments deserialise with `BotMapping = null`).
- **`IUserBotOrderMappingRegistry`** + in-memory impl: lock-free reads (hot ER path), apply-callback writes alongside the WAL append, snapshot/restore covered by `StateSnapshotter` + `EventReplayer`.
- **`OrderCancelService`**: shared cancel pipeline; apply callback runs synchronous in-memory mutations only — gateway I/O happens **after** `Dispatch` returns, **outside** the dispatcher lock (see test `CancelAsync_HappyPath_AppliesInMemoryMutations_AndCallsGatewayOutsideDispatch`).
- **`SymbolDirectory.TryGetSymbolBySecurityId`** — reverse lookup for the FIXP adapter (orders arrive by numeric SecurityId on the wire).
- **`OrderSubmissionRequest.BotOrigin`** — optional FIXP-origin annotation; populated into `OrderSubmittedEvent.BotMapping` in the apply callback alongside book/ownership/clOrdId mutations.
- **`FixpOrderAdapter`** — decodes NewOrderSingle/OrderCancelRequest, resolves owner as `bot:<credShortId>`, dispatches into submit/cancel, and writes BMR/ER_Reject frames for the failure paths.
- **`FixpListenerHostedService`** — optional adapter wiring (the handshake-only listener still works when the order pipeline deps are absent — keeps existing handshake tests untouched).
- **DI** in `Host/Program.cs` registers `InMemoryUserBotOrderMappingRegistry` (+ interface alias) and `OrderCancelService`.

## Tests
+22 new tests, **770 → 792 passing**, `dotnet format --verify-no-changes` clean.

| Test class | Coverage |
|---|---|
| `SymbolDirectoryTests` | forward/reverse lookup roundtrip + duplicate SecurityId behaviour |
| `WalEventsBotMappingTests` | JSON polymorphic round-trip + legacy WAL segment compatibility (new field deserialises to null) |
| `InMemoryUserBotOrderMappingRegistryTests` | register/lookup/reap invariants, cross-credential isolation, snapshot/restore roundtrip, concurrent registration thread-safety |
| `OrderCancelServiceTests` | gateway-blocking gate proves dispatcher mutations are visible BEFORE the async gateway call; REST-origin cancels do NOT touch the bot registry; cross-owner cancels surface as NotFound |

## Out of scope
- ER reverse-routing back to the bot session (sub-issue **F #172**) — registry exposes `TryGetOrderMapping` / `TryGetCancelMapping` for that consumer.
- Algo cancel path (`AlgoEngine.cs:457`) still uses the in-memory `OwnershipMap.RegisterCancelLink` directly — left untouched per scope (no behaviour change risk for existing algo tests).

## RFC anchors
`docs/rfcs/user-bot-fixp-listener-v0.md`: §4.6 (ClOrdId), §4.7 (ER routing), §4.8 (persistence).