### PR TITLE
feat(fixp): outbound ExecutionReport multiplexer (#172)

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -1,5 +1,6 @@
 
 using B3.Trading.Application.Observability;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 
@@ -37,6 +38,7 @@ public sealed class ExecutionReportProcessor
     private readonly CashLedger? _cash;
     private readonly PendingReplacementRegistry? _replacements;
     private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
+    private readonly IBotErRouter? _botErRouter;
 
     public ExecutionReportProcessor(
         OrderOwnershipMap ownership,
@@ -48,7 +50,8 @@ public sealed class ExecutionReportProcessor
         IAlgoSignalQueue? algoSignals = null,
         CashLedger? cash = null,
         PendingReplacementRegistry? replacements = null,
-        Risk.IReplaceMarginCoordinator? replaceMargin = null)
+        Risk.IReplaceMarginCoordinator? replaceMargin = null,
+        IBotErRouter? botErRouter = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -60,6 +63,7 @@ public sealed class ExecutionReportProcessor
         _cash = cash;
         _replacements = replacements;
         _replaceMargin = replaceMargin;
+        _botErRouter = botErRouter;
     }
 
     /// <summary>
@@ -242,7 +246,7 @@ public sealed class ExecutionReportProcessor
                 lookupId, owner.Value, order.Symbol, order.Side, rejectReason);
         }
 
-        _sink.Publish(new ExecutionEvent(
+        var ev = new ExecutionEvent(
             owner,
             lookupId,
             order.Symbol,
@@ -255,7 +259,15 @@ public sealed class ExecutionReportProcessor
             lastPx,
             rejectReason,
             DateTimeOffset.UtcNow,
-            isNativeStp));
+            isNativeStp);
+        _sink.Publish(ev);
+
+        // Sub-issue #172 (F): forward to the FIXP outbound multiplexer
+        // when wired. The router enqueues onto an internal channel
+        // drained by a background worker — the call is non-blocking and
+        // safe to make from inside the dispatcher's apply callback (no
+        // async I/O on this thread, no socket writes on this thread).
+        _botErRouter?.Route(ev);
 
         // Algo engine hook: signal AFTER fan-out so the engine reactor
         // sees the same world the WS subscribers see, and so the dispatch
@@ -294,6 +306,29 @@ public sealed class ExecutionReportProcessor
         _logger.LogInformation(
             "event=order.replace.rejected newClOrdId={NewClOrdId} origClOrdId={OrigClOrdId} owner={Owner} symbol={Symbol} reason={Reason}",
             newClOrdId, intent.OriginalClOrdId, intent.Owner.Value, intent.Symbol, rejectReason ?? "(none)");
+
+        // Sub-issue #172 (F): the bot owns the cancel/replace ClOrdID
+        // it issued and must see a terminal Reject for it. Synthesise
+        // a minimal ExecutionEvent — there is no Order in the book for
+        // the replace-side ClOrdID by design (replace requests don't
+        // create an order until accepted).
+        if (_botErRouter is not null)
+        {
+            _botErRouter.Route(new ExecutionEvent(
+                intent.Owner,
+                newClOrdId,
+                intent.Symbol,
+                intent.Side,
+                OrderStatus.Rejected,
+                ExecKind.Rejected,
+                LeavesQuantity: 0,
+                CumulativeQuantity: 0,
+                LastQuantity: 0,
+                LastPrice: 0m,
+                RejectReason: rejectReason,
+                TimestampUtc: DateTimeOffset.UtcNow,
+                IsNativeStp: false));
+        }
     }
 
     private void ApplyReplaceAccepted(
@@ -328,7 +363,7 @@ public sealed class ExecutionReportProcessor
         if (origOrder.IsStale)
             origOrder.ClearStale();
 
-        _sink.Publish(new ExecutionEvent(
+        var origEv = new ExecutionEvent(
             intent.Owner,
             origId,
             origOrder.Symbol,
@@ -341,7 +376,11 @@ public sealed class ExecutionReportProcessor
             0m,
             null,
             DateTimeOffset.UtcNow,
-            false));
+            false);
+        _sink.Publish(origEv);
+        // Sub-issue #172 (F): the bot must observe the original's
+        // terminalisation as part of the replace ack stream.
+        _botErRouter?.Route(origEv);
 
         // 2) Hydrate the replacement with intent metadata + venue's
         //    cum/leaves baseline. Existing fills booked under the
@@ -384,7 +423,7 @@ public sealed class ExecutionReportProcessor
 
         // 4) Publish event for the new order — same shape as a New ack
         //    so WS subscribers see the order appear in the blotter.
-        _sink.Publish(new ExecutionEvent(
+        var newEv = new ExecutionEvent(
             intent.Owner,
             newClOrdId,
             newOrder.Symbol,
@@ -397,7 +436,9 @@ public sealed class ExecutionReportProcessor
             erLastPx,
             null,
             DateTimeOffset.UtcNow,
-            false));
+            false);
+        _sink.Publish(newEv);
+        _botErRouter?.Route(newEv);
 
         // 5) Algo-engine signal: replacement is, for the engine's
         //    purposes, an execution observation on the parent. Mirrors

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -31,6 +31,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(UserBotCredentialRevokedEvent), "userbot.cred.revoked")]
 [JsonDerivedType(typeof(BotSessionInitializedEvent), "userbot.session.initialized")]
 [JsonDerivedType(typeof(BotSessionVerAdvancedEvent), "userbot.session.ver-advanced")]
+[JsonDerivedType(typeof(BotSessionSeqAdvancedEvent), "userbot.session.seq-advanced")]
 [JsonDerivedType(typeof(OrderCancelRequestedEvent), "order.cancel-requested")]
 public abstract record WalEvent
 {
@@ -366,4 +367,22 @@ public sealed record BotSessionVerAdvancedEvent : WalEvent
     public required ulong OldVer { get; init; }
     public required ulong NewVer { get; init; }
     public required string Reason { get; init; }
+}
+
+/// <summary>
+/// Sub-issue #172 (F). Periodic outbound-seq watermark for a credential's
+/// FIXP session. Appended on the cadence defined by RFC §4.8: every 5
+/// seconds OR every 100 outbound messages, whichever comes first. NOT
+/// appended per-ER (would double WAL pressure of FIXP-originated orders).
+///
+/// <para>This event is a "best-effort durability watermark" — it does
+/// NOT need <c>FlushAsync</c>. Recovery seeds the registry with the
+/// most recent value seen; sub-issue G's retransmit treats requests
+/// older than the checkpoint as unreplayable.</para>
+/// </summary>
+public sealed record BotSessionSeqAdvancedEvent : WalEvent
+{
+    public required Guid CredentialId { get; init; }
+    public required ulong CheckpointedOutboundSeq { get; init; }
+    public required DateTimeOffset At { get; init; }
 }

--- a/backend/src/B3.Trading.Application/UserBots/BotOutboundBuffer.cs
+++ b/backend/src/B3.Trading.Application/UserBots/BotOutboundBuffer.cs
@@ -1,0 +1,161 @@
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Sub-issue #172 (F). Per-credential bounded buffer of outbound
+/// application messages awaiting either send (when the bot is offline)
+/// or potential retransmit-on-request (sub-issue G #173). Stores
+/// <c>(seq, rawSbeBytes)</c> pairs in arrival order, keyed by the
+/// allocator-assigned outbound seq. Thread-safe.
+///
+/// <para>v0 is in-memory only — the RFC §4.8 explicitly defers WAL
+/// persistence of the buffer; bots reconcile lost messages via REST
+/// <c>/api/orders</c> on restart. The credential's
+/// <c>LastCheckpointedOutboundSeq</c> watermark is the only thing
+/// surviving restart, and a bot that asks G for a seq older than the
+/// watermark gets a reject.</para>
+///
+/// <para>Overflow path: instead of silently dropping (which would let a
+/// bot observe a gap without warning), <see cref="Append"/> invokes the
+/// <see cref="OnOverflow"/> callback synchronously when the cap is hit.
+/// The expected handler is the multiplexer's overflow path:
+/// <c>BumpVersionAsync(reason="overflow")</c> + force-disconnect.
+/// The callback runs while the buffer's internal lock is held — the
+/// handler must NOT do async I/O inline; F's multiplexer fires the
+/// async work onto a queue that drains outside the lock.</para>
+/// </summary>
+public sealed class BotOutboundBuffer
+{
+    /// <summary>
+    /// Default cap — chosen to absorb several minutes of a high-rate
+    /// bot's ER stream without triggering an overflow during a transient
+    /// disconnect. Operators tune this via <c>BotErMultiplexerOptions</c>.
+    /// </summary>
+    public const int DefaultMaxMessages = 50_000;
+
+    private readonly object _gate = new();
+    private readonly LinkedList<Entry> _entries = new();
+    private readonly Dictionary<ulong, LinkedListNode<Entry>> _index = new();
+    private readonly int _maxMessages;
+    private readonly Action<Guid>? _onOverflow;
+    private readonly Guid _credentialId;
+    private bool _overflowed;
+
+    public BotOutboundBuffer(Guid credentialId, int maxMessages, Action<Guid>? onOverflow = null)
+    {
+        if (maxMessages <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxMessages), "Cap must be positive.");
+        _credentialId = credentialId;
+        _maxMessages = maxMessages;
+        _onOverflow = onOverflow;
+    }
+
+    /// <summary>Current count of buffered entries.</summary>
+    public int Count
+    {
+        get { lock (_gate) return _entries.Count; }
+    }
+
+    /// <summary>
+    /// True once <see cref="Append"/> has tripped the overflow callback.
+    /// Stays true until <see cref="Reset"/> is called by the recovery
+    /// path (after the bot reconnects with the bumped SessionVerId).
+    /// </summary>
+    public bool IsOverflowed
+    {
+        get { lock (_gate) return _overflowed; }
+    }
+
+    /// <summary>
+    /// Appends an outbound message. Returns <c>false</c> when the cap is
+    /// hit — the buffer is cleared and <see cref="OnOverflow"/> fires.
+    /// Subsequent <c>Append</c> calls return <c>false</c> and do nothing
+    /// until <see cref="Reset"/> is called.
+    /// </summary>
+    public bool Append(ulong seq, ReadOnlyMemory<byte> bytes)
+    {
+        lock (_gate)
+        {
+            if (_overflowed) return false;
+            if (_entries.Count >= _maxMessages)
+            {
+                _overflowed = true;
+                _entries.Clear();
+                _index.Clear();
+                _onOverflow?.Invoke(_credentialId);
+                return false;
+            }
+
+            // Defensive copy — the caller's `bytes` may come from a pooled
+            // buffer that gets returned to the pool after the publish call
+            // returns. Holding a reference to a reused span would corrupt
+            // both the buffer and the next caller.
+            var copy = bytes.ToArray();
+            var node = _entries.AddLast(new Entry(seq, copy));
+            _index[seq] = node;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns the buffered messages in <c>[fromSeq, toSeq]</c>, sorted
+    /// by seq ascending. Returns an empty list when no entries match.
+    /// Sub-issue G consumes this for <c>RetransmitRequest</c> handling.
+    /// </summary>
+    public IReadOnlyList<BufferedOutboundMessage> GetRange(ulong fromSeq, ulong toSeq)
+    {
+        if (toSeq < fromSeq) return Array.Empty<BufferedOutboundMessage>();
+        lock (_gate)
+        {
+            var list = new List<BufferedOutboundMessage>();
+            for (var node = _entries.First; node is not null; node = node.Next)
+            {
+                if (node.Value.Seq < fromSeq) continue;
+                if (node.Value.Seq > toSeq) break;
+                list.Add(new BufferedOutboundMessage(node.Value.Seq, node.Value.Bytes));
+            }
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// Drops every entry with <c>seq ≤ throughSeq</c>. Cleanup hook for
+    /// when the bot acknowledges its inbound watermark via the next
+    /// <c>Sequence</c> message it sends (G's responsibility to call).
+    /// Idempotent.
+    /// </summary>
+    public void EvictUpTo(ulong throughSeq)
+    {
+        lock (_gate)
+        {
+            while (_entries.First is { } first && first.Value.Seq <= throughSeq)
+            {
+                _index.Remove(first.Value.Seq);
+                _entries.RemoveFirst();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears the buffer and resets the overflow flag. Called by the
+    /// recovery path after the credential's <c>SessionVerId</c> has been
+    /// bumped and the offending connection forcibly closed — the next
+    /// reconnect attempt fails Establish with the new ver, the bot
+    /// reconciles via REST, and we start fresh.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _entries.Clear();
+            _index.Clear();
+            _overflowed = false;
+        }
+    }
+
+    private readonly record struct Entry(ulong Seq, byte[] Bytes);
+}
+
+/// <summary>
+/// Outbound message returned by <see cref="BotOutboundBuffer.GetRange"/>.
+/// </summary>
+public readonly record struct BufferedOutboundMessage(ulong Seq, ReadOnlyMemory<byte> Bytes);

--- a/backend/src/B3.Trading.Application/UserBots/BotOutboundSeqAllocator.cs
+++ b/backend/src/B3.Trading.Application/UserBots/BotOutboundSeqAllocator.cs
@@ -1,0 +1,42 @@
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Sub-issue #172 (F). Per-credential allocator for the outbound
+/// FIXP application-message sequence number. Seeded from
+/// <c>BotSessionState.LastCheckpointedOutboundSeq</c> on first use; a
+/// concurrent <see cref="Allocate"/> burst from the ER hot path is
+/// safe via <see cref="Interlocked.Increment(ref long)"/>.
+///
+/// <para>The allocator is in-memory only; persistence is handled by
+/// the periodic <c>BotSessionSeqAdvancedEvent</c> checkpointer
+/// (RFC §4.8) — sub-issue G is the consumer that needs the durable
+/// lower bound.</para>
+/// </summary>
+public sealed class BotOutboundSeqAllocator
+{
+    // We use long internally because Interlocked.Increment lacks a ulong
+    // overload; the wire format is uint64 so callers cast to ulong on
+    // the read path. The signed range gives us 2^63 sequence numbers per
+    // credential, which exceeds the FIXP spec's effective lifetime by
+    // many orders of magnitude.
+    private long _next;
+
+    /// <summary>Constructs an allocator seeded so the first <see cref="Allocate"/> returns <paramref name="seedSeq"/> + 1.</summary>
+    public BotOutboundSeqAllocator(ulong seedSeq = 0)
+    {
+        if (seedSeq > long.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(seedSeq),
+                "Seed seq exceeds Int64 range; the in-memory allocator does not support this lifetime.");
+        _next = (long)seedSeq;
+    }
+
+    /// <summary>
+    /// Returns the next monotonically increasing seq number. Concurrent
+    /// callers each get a unique value — the FIXP outbound stream order
+    /// is whatever order the callers' subsequent send observes.
+    /// </summary>
+    public ulong Allocate() => (ulong)Interlocked.Increment(ref _next);
+
+    /// <summary>Current high-watermark (most recently allocated value, or seed if none).</summary>
+    public ulong Current => (ulong)Interlocked.Read(ref _next);
+}

--- a/backend/src/B3.Trading.Application/UserBots/IBotErRouter.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IBotErRouter.cs
@@ -1,0 +1,38 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.UserBots;
+
+/// <summary>
+/// Sub-issue #172 (F). Optional hook into the ER pipeline that gives the
+/// FIXP outbound multiplexer a chance to forward each
+/// <see cref="ExecutionEvent"/> to the originating bot's session. The
+/// router is a separate seam from <see cref="IExecutionEventSink"/> so:
+/// <list type="bullet">
+/// <item>The WS sink and the bot multiplexer are independently wired —
+/// REST/WS-only deployments do not pay for the FIXP listener
+/// machinery, and the listener can be enabled without disturbing the
+/// existing sink registration chain.</item>
+/// <item>The router is invoked AFTER the WS publish so subscribers
+/// see the event in the same world (RFC §4.7 ordering).</item>
+/// </list>
+///
+/// <para><b>Concurrency contract:</b> implementations MUST NOT do
+/// async I/O on this call — it runs on the ER processor thread, which
+/// in turn runs inside an <c>EventDispatcher</c> apply callback under
+/// the dispatcher lock. The standard implementation enqueues to an
+/// internal channel drained by a background worker.</para>
+/// </summary>
+public interface IBotErRouter
+{
+    void Route(ExecutionEvent ev);
+}
+
+/// <summary>
+/// Default no-op router used when the FIXP listener is disabled
+/// (REST/WS-only deployments). Keeps <see cref="ExecutionReportProcessor"/>
+/// agnostic of whether the multiplexer is wired.
+/// </summary>
+public sealed class NoOpBotErRouter : IBotErRouter
+{
+    public void Route(ExecutionEvent ev) { }
+}

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
@@ -84,4 +84,15 @@ public interface IUserBotSessionRegistry
     /// the caller can echo it on the very reject that follows.
     /// </summary>
     Task<ulong> BumpVersionAsync(Guid credentialId, string reason, CancellationToken ct);
+
+    /// <summary>
+    /// Sub-issue #172 (F). Records a periodic checkpoint of the credential's
+    /// outbound seq watermark — see RFC §4.8 cadence (5s OR 100 msgs). The
+    /// implementation appends a <c>BotSessionSeqAdvancedEvent</c> via the
+    /// dispatcher (best-effort durability — no FlushAsync) and updates the
+    /// in-memory <see cref="BotSessionState.LastCheckpointedOutboundSeq"/>
+    /// under the apply callback. No-op when <paramref name="checkpointedSeq"/>
+    /// is <c>≤</c> the existing watermark (idempotent / reordering safe).
+    /// </summary>
+    void UpdateCheckpointedOutboundSeq(Guid credentialId, ulong checkpointedSeq);
 }

--- a/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotSessionRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotSessionRegistry.cs
@@ -221,6 +221,55 @@ public sealed class InMemoryUserBotSessionRegistry : IUserBotSessionRegistry
         }
     }
 
+    /// <summary>
+    /// Replay hook for <see cref="BotSessionSeqAdvancedEvent"/>. Idempotent
+    /// + reordering-safe: only advances the watermark, never regresses it.
+    /// </summary>
+    internal void ApplyCheckpointedSeq(Guid credentialId, ulong checkpointedSeq)
+    {
+        lock (_gate)
+        {
+            if (_byCredentialId.TryGetValue(credentialId, out var existing)
+                && checkpointedSeq > existing.LastCheckpointedOutboundSeq)
+            {
+                _byCredentialId[credentialId] = existing with
+                {
+                    LastCheckpointedOutboundSeq = checkpointedSeq,
+                };
+            }
+        }
+    }
+
+    public void UpdateCheckpointedOutboundSeq(Guid credentialId, ulong checkpointedSeq)
+    {
+        if (credentialId == Guid.Empty) return;
+
+        BotSessionSeqAdvancedEvent? evt = null;
+        lock (_gate)
+        {
+            if (!_byCredentialId.TryGetValue(credentialId, out var existing))
+                return;
+            if (checkpointedSeq <= existing.LastCheckpointedOutboundSeq)
+                return;
+
+            evt = new BotSessionSeqAdvancedEvent
+            {
+                CredentialId = credentialId,
+                CheckpointedOutboundSeq = checkpointedSeq,
+                At = DateTimeOffset.UtcNow,
+            };
+
+            // Dispatch under the gate so the apply callback's mutation
+            // and the WAL append form a single atomic step w.r.t.
+            // snapshot capture (mirrors BumpVersionAsync). No FlushAsync —
+            // RFC §4.8 says this is a best-effort watermark.
+            if (_dispatcher is not null)
+                _dispatcher.Dispatch(evt, () => ApplyCheckpointedSeq(credentialId, checkpointedSeq));
+            else
+                ApplyCheckpointedSeq(credentialId, checkpointedSeq);
+        }
+    }
+
     // RFC §4.5: SessionId is non-zero uint32. Birthday-collisions on
     // 2^32 minus-one are negligible at participant counts; a defensive
     // collision check still avoids re-issuing an id while the lock is held.

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.EntryPointListener;
@@ -32,6 +36,34 @@ public static class EntryPointListenerServiceCollectionExtensions
 
         if (enabled)
         {
+            // Sub-issue #172 (F): outbound ER multiplexer wiring.
+            services
+                .AddOptions<BotErMultiplexerOptions>()
+                .Bind(configuration.GetSection(BotErMultiplexerOptions.SectionName));
+
+            // The mapping registry is the lookup key for routing ERs to
+            // the originating bot. Host.Program.cs already registers it
+            // for the production composition; TryAdd keeps that as the
+            // winning binding while letting handshake-only test hosts
+            // (which never persist mappings anyway) fall through to the
+            // in-memory implementation.
+            services.TryAddSingleton<InMemoryUserBotOrderMappingRegistry>();
+            services.TryAddSingleton<IUserBotOrderMappingRegistry>(sp =>
+                sp.GetRequiredService<InMemoryUserBotOrderMappingRegistry>());
+
+            services.AddSingleton<BotSessionConnectionDirectory>();
+            services.AddSingleton<IBotSessionConnectionDirectory>(sp =>
+                sp.GetRequiredService<BotSessionConnectionDirectory>());
+
+            services.AddSingleton<BotOutboundCoordinator>();
+
+            services.AddSingleton<BotErMultiplexer>();
+            services.AddSingleton<IBotErRouter>(sp => sp.GetRequiredService<BotErMultiplexer>());
+            services.AddHostedService(sp => sp.GetRequiredService<BotErMultiplexer>());
+
+            services.AddSingleton<BotSessionSeqCheckpointer>();
+            services.AddHostedService(sp => sp.GetRequiredService<BotSessionSeqCheckpointer>());
+
             services.AddSingleton<Hosting.FixpListenerHostedService>();
             services.AddHostedService(sp =>
                 sp.GetRequiredService<Hosting.FixpListenerHostedService>());

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -1,0 +1,266 @@
+using System.Threading.Channels;
+using B3.Trading.Application;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Background drain that turns each
+/// <see cref="ExecutionEvent"/> dispatched by
+/// <see cref="ExecutionReportProcessor"/> into a per-bot SBE
+/// ExecutionReport, allocates the next outbound seq from the
+/// credential's allocator, encodes the SOFH-framed bytes, and
+/// either pushes them onto the bot's live connection (when online)
+/// or buffers them for retransmit (when offline).
+///
+/// <para>The drain is single-threaded by design — there is no
+/// per-credential ordering requirement beyond "FIFO within a
+/// credential" and a single drain trivially satisfies it without a
+/// per-credential lock. If the channel ever becomes a throughput
+/// bottleneck, the right move is to shard by credentialId across N
+/// drain tasks (still preserving per-credential order); v0 keeps it
+/// simple.</para>
+///
+/// <para><b>Overflow handling:</b> when the per-credential
+/// <see cref="BotOutboundBuffer"/> hits its cap, its overflow callback
+/// signals back into the multiplexer, which then asynchronously
+/// invokes <see cref="IUserBotSessionRegistry.BumpVersionAsync"/> with
+/// <c>reason="overflow"</c> and force-closes the offending sender.
+/// The version-bump must happen BEFORE the close so the bot's
+/// reconnect attempt fails Establish with the new ver
+/// (<c>InvalidSessionVerId</c>) and the bot reconciles via REST
+/// rather than silently observing a gap (RFC §4.7).</para>
+/// </summary>
+public sealed class BotErMultiplexer : BackgroundService, IBotErRouter
+{
+    private readonly IUserBotOrderMappingRegistry _mappings;
+    private readonly IUserBotSessionRegistry _sessions;
+    private readonly IBotSessionConnectionDirectory _directory;
+    private readonly BotOutboundCoordinator _outbound;
+    private readonly ILogger<BotErMultiplexer> _logger;
+    private readonly Channel<ExecutionEvent> _eventChannel;
+    private readonly Channel<Guid> _overflowChannel;
+
+    public BotErMultiplexer(
+        IUserBotOrderMappingRegistry mappings,
+        IUserBotSessionRegistry sessions,
+        IBotSessionConnectionDirectory directory,
+        BotOutboundCoordinator outbound,
+        ILogger<BotErMultiplexer> logger,
+        IOptions<BotErMultiplexerOptions>? options = null)
+    {
+        _mappings = mappings;
+        _sessions = sessions;
+        _directory = directory;
+        _outbound = outbound;
+        _logger = logger;
+        _ = options; // RouterChannelCapacity is reserved for a future bounded variant; channel is currently unbounded — see comment below.
+
+        // Unbounded so the synchronous Route() from the ER hot path
+        // never blocks and never silently drops. Memory pressure is
+        // bounded by the per-credential outbound buffer caps — when a
+        // bot is offline its ERs accumulate in the Channel only briefly
+        // (single drain pass) before landing in the per-credential
+        // BotOutboundBuffer, which is the layer that observes overflow
+        // and triggers the version-bump path. A bounded channel here
+        // (DropOldest) would silently lose ERs without any sequence-gap
+        // signal to the bot — see code-review concern (1).
+        _eventChannel = Channel.CreateUnbounded<ExecutionEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _overflowChannel = Channel.CreateUnbounded<Guid>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+        // Wire the buffer's overflow callback once. The coordinator
+        // creates buffers lazily per credential, each carrying our
+        // OnOverflow.
+        _outbound.OnBufferOverflow = credentialId =>
+        {
+            // Best-effort enqueue. If the overflow channel itself is
+            // backlogged we still log — overflow handling is rare and
+            // a missed signal would just delay the inevitable Bump on
+            // the next router pass.
+            if (!_overflowChannel.Writer.TryWrite(credentialId))
+            {
+                _logger.LogWarning(
+                    "fixp.outbound.overflow.signal-dropped credentialId={CredentialId}",
+                    credentialId);
+            }
+        };
+    }
+
+    /// <inheritdoc />
+    public void Route(ExecutionEvent ev)
+    {
+        // Synchronous, non-blocking. The bounded channel's DropOldest
+        // policy means a hung drain cannot stall the ER processor.
+        _eventChannel.Writer.TryWrite(ev);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Two cooperating loops: one drains the event channel and
+        // performs the routing/encode work synchronously; the other
+        // handles overflow events out-of-band so the version-bump
+        // FlushAsync does not stall the ER pipeline.
+        var routeLoop = Task.Run(() => RunRouteLoopAsync(stoppingToken), stoppingToken);
+        var overflowLoop = Task.Run(() => RunOverflowLoopAsync(stoppingToken), stoppingToken);
+        await Task.WhenAll(routeLoop, overflowLoop).ConfigureAwait(false);
+    }
+
+    private async Task RunRouteLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var ev in _eventChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                try
+                {
+                    RouteOne(ev);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "fixp.outbound.route.error clOrdId={ClOrdId} kind={Kind}",
+                        ev.ClOrdId, ev.Kind);
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void RouteOne(ExecutionEvent ev)
+    {
+        if (!_mappings.TryGetOrderMapping(ev.ClOrdId, out var mapping))
+        {
+            // REST/WS-origin order — no bot to forward to. Today's behavior.
+            return;
+        }
+
+        // Cancel/replace ERs reference an OrigClOrdID. ExecutionEvent
+        // has already been normalized to the *original* internal id by
+        // ExecutionReportProcessor (cs:95-109), so the forward mapping
+        // we just resolved IS the original. The cancel-side mapping
+        // would carry the bot's separate cancel ClOrdID — F's v0 does
+        // not yet correlate the raw cancel-side id (sub-issue G when
+        // raw side-channel lands), so we omit it for cancel/replace
+        // and the bot reads OrigClOrdID = its original ClOrdID.
+        ulong externalOrig = (ev.Kind is ExecKind.Canceled or ExecKind.Replaced)
+            ? mapping.ExternalClOrdId
+            : 0UL;
+
+        byte[] framed;
+        try
+        {
+            framed = OutboundExecutionReportEncoder.Encode(ev, mapping.ExternalClOrdId, externalOrig);
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogWarning(ex,
+                "fixp.outbound.encode.unsupported credentialId={CredentialId} kind={Kind}",
+                mapping.CredentialId, ev.Kind);
+            return;
+        }
+
+        var seq = _outbound.AllocateNext(mapping.CredentialId);
+
+        // Buffer FIRST, then attempt send. This ordering matters for
+        // the overflow → version-bump sequence: if the buffer Append
+        // trips overflow, we must not also push the message onto a
+        // live connection — the bot would observe an ER and then a
+        // version bump that effectively rolled it back.
+        var buffer = _outbound.GetOrCreateBuffer(mapping.CredentialId);
+        var accepted = buffer.Append(seq, framed);
+        _outbound.RecordOutbound(mapping.CredentialId);
+
+        if (!accepted)
+        {
+            // Overflow — the buffer's callback already enqueued an
+            // overflow signal. Skip the send.
+            _logger.LogWarning(
+                "fixp.outbound.buffer.overflow credentialId={CredentialId} clOrdId={ClOrdId} seq={Seq}",
+                mapping.CredentialId, ev.ClOrdId, seq);
+            return;
+        }
+
+        if (_directory.TryGet(mapping.CredentialId, out var sender))
+        {
+            if (!sender.TryEnqueue(framed))
+            {
+                // Race: the connection went away between TryGet and
+                // TryEnqueue. The buffer already holds the message,
+                // so retransmit (G) will pick it up on reconnect.
+                _logger.LogDebug(
+                    "fixp.outbound.send.race credentialId={CredentialId} seq={Seq}",
+                    mapping.CredentialId, seq);
+            }
+        }
+        // else: bot offline, message is buffered for G's retransmit.
+    }
+
+    private async Task RunOverflowLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var credentialId in _overflowChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                try
+                {
+                    await HandleOverflowAsync(credentialId, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "fixp.outbound.overflow.handle.error credentialId={CredentialId}",
+                        credentialId);
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private async Task HandleOverflowAsync(Guid credentialId, CancellationToken ct)
+    {
+        // RFC §4.5 / §4.7 ordering: bump version FIRST (with the
+        // FlushAsync fence inside BumpVersionAsync) so the bot's
+        // reconnect must observe the new ver. Only after the durable
+        // bump do we evict the in-flight sender so any racing TryEnqueue
+        // returns false and the corresponding ER falls into the cleared
+        // buffer (no replay, no rollback).
+        var newVer = await _sessions.BumpVersionAsync(credentialId, "overflow", ct).ConfigureAwait(false);
+        _logger.LogWarning(
+            "fixp.outbound.overflow.bump credentialId={CredentialId} newVer={NewVer}",
+            credentialId, newVer);
+
+        if (_directory.TryGet(credentialId, out var sender))
+        {
+            // Force-close the live connection. The directory deregister
+            // happens on the connection's own close path (finally block
+            // of FixpSessionConnection.RunAsync) — calling Close here
+            // makes the read loop unblock with 0 bytes / IOException.
+            try
+            {
+                if (sender is IDisposable d) d.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "fixp.outbound.overflow.close.error credentialId={CredentialId}", credentialId);
+            }
+        }
+
+        // Reset the buffer so the next legitimate session starts clean.
+        // The reset must come AFTER the bump+close so a still-running
+        // TryEnqueue from another router pass sees the cleared buffer
+        // and returns false, not a partial state.
+        _outbound.GetOrCreateBuffer(credentialId).Reset();
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
@@ -1,0 +1,36 @@
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Tunables for the bot outbound multiplexer +
+/// checkpointer. All values have safe defaults; production deployments
+/// override from <c>appsettings.json</c>.
+/// </summary>
+public sealed class BotErMultiplexerOptions
+{
+    public const string SectionName = "Trading:EntryPointListener:Outbound";
+
+    /// <summary>
+    /// Per-credential outbound buffer cap. Hitting this cap fires the
+    /// overflow path (BumpVersion + force-close). Default <see cref="BotOutboundBuffer.DefaultMaxMessages"/>.
+    /// </summary>
+    public int OutboundBufferMaxMessages { get; set; } = BotOutboundBuffer.DefaultMaxMessages;
+
+    /// <summary>
+    /// Capacity of the in-process channel between
+    /// <see cref="ExecutionReportProcessor"/> and the routing loop.
+    /// DropOldest on full so the ER processor is never stalled.
+    /// </summary>
+    public int RouterChannelCapacity { get; set; } = 16_384;
+
+    /// <summary>
+    /// Checkpoint cadence (RFC §4.8): every N seconds OR every M
+    /// messages, whichever comes first. Either both at default (5s,
+    /// 100msg) or operator-tuned.
+    /// </summary>
+    public TimeSpan CheckpointPeriod { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Per-credential message count threshold that forces an early checkpoint.</summary>
+    public int CheckpointMessageThreshold { get; set; } = 100;
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotOutboundCoordinator.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotOutboundCoordinator.cs
@@ -1,0 +1,125 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Per-credential outbound state coordinator: holds
+/// a <see cref="BotOutboundSeqAllocator"/>, the
+/// <see cref="BotOutboundBuffer"/>, the count-since-last-checkpoint
+/// counter, and the timestamp of the last outbound message. Singleton —
+/// all access is keyed by <see cref="Guid"/> credentialId.
+///
+/// <para>The coordinator does not know about WAL or about connections;
+/// the multiplexer composes it with <see cref="IBotSessionConnectionDirectory"/>
+/// and <see cref="IUserBotSessionRegistry"/>.</para>
+/// </summary>
+public sealed class BotOutboundCoordinator
+{
+    private readonly ConcurrentDictionary<Guid, PerCredential> _byCredentialId = new();
+    private readonly Func<Guid, ulong> _seedSeqLookup;
+    private readonly int _bufferCap;
+
+    /// <summary>
+    /// Wired by the multiplexer at construction so buffer overflow can
+    /// trigger the version-bump path. The setter contract is "must be
+    /// set before the first <see cref="GetOrCreateBuffer"/> call"; the
+    /// multiplexer's constructor is the single writer.
+    /// </summary>
+    public Action<Guid>? OnBufferOverflow { get; set; }
+
+    public BotOutboundCoordinator(
+        IUserBotSessionRegistry sessions,
+        Microsoft.Extensions.Options.IOptions<BotErMultiplexerOptions> options)
+        : this(sessions, options?.Value ?? throw new ArgumentNullException(nameof(options)))
+    { }
+
+    public BotOutboundCoordinator(
+        IUserBotSessionRegistry sessions,
+        BotErMultiplexerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+        ArgumentNullException.ThrowIfNull(options);
+        _bufferCap = options.OutboundBufferMaxMessages;
+
+        // Seed the allocator from the registry's checkpointed watermark.
+        // GetOrCreateAsync on the session registry is async because it
+        // may dispatch a BotSessionInitializedEvent on first access; by
+        // the time the allocator is consulted (post-Establish), the
+        // session row exists, and we read it via a synchronous Get.
+        _seedSeqLookup = credentialId =>
+        {
+            // We block briefly here because the registry's get-or-create
+            // is the only path; in steady state the row already exists
+            // (Establish ran first) so this is a constant-time hit.
+            var task = sessions.GetOrCreateAsync(credentialId, CancellationToken.None);
+            return task.IsCompletedSuccessfully
+                ? task.Result.LastCheckpointedOutboundSeq
+                : task.GetAwaiter().GetResult().LastCheckpointedOutboundSeq;
+        };
+    }
+
+    /// <summary>Allocates the next outbound seq for <paramref name="credentialId"/>.</summary>
+    public ulong AllocateNext(Guid credentialId) => Get(credentialId).Allocator.Allocate();
+
+    /// <summary>
+    /// Returns the per-credential outbound buffer, creating it on first
+    /// access. The created buffer carries the multiplexer's overflow
+    /// callback.
+    /// </summary>
+    public BotOutboundBuffer GetOrCreateBuffer(Guid credentialId) => Get(credentialId).Buffer;
+
+    /// <summary>
+    /// Returns the count of outbound messages since the last call to
+    /// <see cref="ResetCounter"/>. Read by the checkpointer to decide
+    /// whether to dispatch a <c>BotSessionSeqAdvancedEvent</c>.
+    /// </summary>
+    public long GetCounter(Guid credentialId) => Interlocked.Read(ref Get(credentialId).Counter);
+
+    /// <summary>
+    /// Returns the most recently allocated outbound seq for
+    /// <paramref name="credentialId"/>. Used by the checkpointer to
+    /// stamp the watermark.
+    /// </summary>
+    public ulong GetCurrentSeq(Guid credentialId) => Get(credentialId).Allocator.Current;
+
+    /// <summary>Bumps the per-credential counter (called from the multiplexer's route loop).</summary>
+    public void RecordOutbound(Guid credentialId) => Interlocked.Increment(ref Get(credentialId).Counter);
+
+    /// <summary>Atomically reads the counter and resets it to zero. Returns the prior value.</summary>
+    public long ReadAndResetCounter(Guid credentialId) => Interlocked.Exchange(ref Get(credentialId).Counter, 0);
+
+    /// <summary>Enumerates credentialIds with non-zero counters — checkpointer's iteration target.</summary>
+    public IReadOnlyList<Guid> ListActiveCredentials()
+    {
+        var list = new List<Guid>();
+        foreach (var (cid, state) in _byCredentialId)
+        {
+            if (Interlocked.Read(ref state.Counter) > 0) list.Add(cid);
+        }
+        return list;
+    }
+
+    private PerCredential Get(Guid credentialId)
+    {
+        return _byCredentialId.GetOrAdd(credentialId, cid =>
+        {
+            var seed = _seedSeqLookup(cid);
+            var allocator = new BotOutboundSeqAllocator(seed);
+            var buffer = new BotOutboundBuffer(cid, _bufferCap, c => OnBufferOverflow?.Invoke(c));
+            return new PerCredential(allocator, buffer);
+        });
+    }
+
+    private sealed class PerCredential
+    {
+        public readonly BotOutboundSeqAllocator Allocator;
+        public readonly BotOutboundBuffer Buffer;
+        public long Counter;
+        public PerCredential(BotOutboundSeqAllocator allocator, BotOutboundBuffer buffer)
+        {
+            Allocator = allocator;
+            Buffer = buffer;
+        }
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotSessionConnectionDirectory.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotSessionConnectionDirectory.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// In-process implementation of <see cref="IBotSessionConnectionDirectory"/>.
+/// A future multi-host deployment would need a distributed registration
+/// (out of scope for v0 — single-active enforcement is also in-process,
+/// see <c>IUserBotSessionRegistry</c>).
+/// </summary>
+public sealed class BotSessionConnectionDirectory : IBotSessionConnectionDirectory
+{
+    private readonly ConcurrentDictionary<Guid, IBotSessionOutboundSender> _byCredentialId = new();
+
+    public void Register(Guid credentialId, IBotSessionOutboundSender sender)
+    {
+        ArgumentNullException.ThrowIfNull(sender);
+        if (credentialId == Guid.Empty)
+            throw new ArgumentException("CredentialId must not be empty.", nameof(credentialId));
+        // Last-write-wins. The caller (FixpSessionConnection) only invokes
+        // this after the per-credential session slot has been claimed via
+        // IUserBotSessionRegistry.TryClaimActiveAsync, so two concurrent
+        // Register calls for the same credentialId imply a race the
+        // session registry already serialised — the second one is the
+        // legitimate owner.
+        _byCredentialId[credentialId] = sender;
+    }
+
+    public void Deregister(Guid credentialId, IBotSessionOutboundSender sender)
+    {
+        ArgumentNullException.ThrowIfNull(sender);
+        // Compare-and-swap semantics: only remove if we are still the
+        // recorded sender. A newer connection that already replaced us
+        // must not be evicted by a stale close from the prior socket.
+        var kvp = new KeyValuePair<Guid, IBotSessionOutboundSender>(credentialId, sender);
+        ((ICollection<KeyValuePair<Guid, IBotSessionOutboundSender>>)_byCredentialId).Remove(kvp);
+    }
+
+    public bool TryGet(Guid credentialId, out IBotSessionOutboundSender sender)
+    {
+        if (_byCredentialId.TryGetValue(credentialId, out var found))
+        {
+            sender = found;
+            return true;
+        }
+        sender = null!;
+        return false;
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotSessionSeqCheckpointer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotSessionSeqCheckpointer.cs
@@ -1,0 +1,130 @@
+using B3.Trading.Application.UserBots;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Background checkpointer that periodically
+/// records the credential's outbound seq watermark to WAL via
+/// <see cref="IUserBotSessionRegistry.UpdateCheckpointedOutboundSeq"/>.
+///
+/// <para>RFC §4.8 cadence: every <see cref="BotErMultiplexerOptions.CheckpointPeriod"/>
+/// OR per-credential <see cref="BotErMultiplexerOptions.CheckpointMessageThreshold"/>
+/// outbound messages, whichever comes first. The threshold is checked
+/// each time we wake; it does NOT preempt the timer (good enough for a
+/// best-effort durability watermark — the timer guarantees we never go
+/// longer than the period without a checkpoint).</para>
+///
+/// <para>No checkpoint event is dispatched when the per-credential
+/// counter is zero (RFC §4.10 — keeps the WAL spam-free during quiet
+/// periods).</para>
+/// </summary>
+public sealed class BotSessionSeqCheckpointer : BackgroundService
+{
+    private readonly BotOutboundCoordinator _coordinator;
+    private readonly IUserBotSessionRegistry _sessions;
+    private readonly BotErMultiplexerOptions _opts;
+    private readonly ILogger<BotSessionSeqCheckpointer> _logger;
+    private readonly TimeProvider _clock;
+
+    public BotSessionSeqCheckpointer(
+        BotOutboundCoordinator coordinator,
+        IUserBotSessionRegistry sessions,
+        IOptions<BotErMultiplexerOptions> opts,
+        ILogger<BotSessionSeqCheckpointer> logger,
+        TimeProvider? clock = null)
+    {
+        _coordinator = coordinator;
+        _sessions = sessions;
+        _opts = opts.Value;
+        _logger = logger;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var period = _opts.CheckpointPeriod;
+        // Fast-poll cadence for the message-count threshold: 100ms is
+        // small enough that a high-rate bot's 100-msg threshold is hit
+        // ~within 100ms of the message that crossed it, but coarse
+        // enough to be cheap (10 wakeups/sec/host even when idle). The
+        // periodic full-tick is on the longer cadence so the WAL stays
+        // quiet during low-rate operation.
+        var fastPoll = TimeSpan.FromMilliseconds(100);
+        var nextFullTick = _clock.GetUtcNow() + period;
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(fastPoll, _clock, stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { break; }
+
+                var now = _clock.GetUtcNow();
+                if (now >= nextFullTick)
+                {
+                    Tick();
+                    nextFullTick = now + period;
+                }
+                else if (_opts.CheckpointMessageThreshold > 0)
+                {
+                    TickThresholdOnly();
+                }
+            }
+        }
+        finally
+        {
+            // Final pass on shutdown so a terminating host emits the most
+            // recent watermark before the WAL is closed.
+            try { Tick(); } catch (Exception ex) { _logger.LogDebug(ex, "fixp.checkpoint.shutdown.error"); }
+        }
+    }
+
+    /// <summary>
+    /// Public for tests. Iterates active credentials and dispatches a
+    /// <c>BotSessionSeqAdvancedEvent</c> per credential whose counter
+    /// is non-zero, then resets the counter under the registry's lock.
+    /// </summary>
+    public void Tick() => CheckpointActive(thresholdOnly: false);
+
+    /// <summary>
+    /// Inter-tick fast-pass: only checkpoints credentials whose counter
+    /// has crossed <see cref="BotErMultiplexerOptions.CheckpointMessageThreshold"/>
+    /// since the last checkpoint. Lets a high-rate credential get a
+    /// fresh watermark inside the period without WAL-spamming quiet
+    /// credentials on every fast wakeup.
+    /// </summary>
+    public void TickThresholdOnly() => CheckpointActive(thresholdOnly: true);
+
+    private void CheckpointActive(bool thresholdOnly)
+    {
+        var credentials = _coordinator.ListActiveCredentials();
+        var threshold = _opts.CheckpointMessageThreshold;
+        foreach (var credentialId in credentials)
+        {
+            if (thresholdOnly && _coordinator.GetCounter(credentialId) < threshold)
+                continue;
+
+            var counter = _coordinator.ReadAndResetCounter(credentialId);
+            if (counter <= 0)
+                continue;
+            var watermark = _coordinator.GetCurrentSeq(credentialId);
+            try
+            {
+                _sessions.UpdateCheckpointedOutboundSeq(credentialId, watermark);
+                _logger.LogDebug(
+                    "fixp.checkpoint credentialId={CredentialId} seq={Seq} since={Counter} reason={Reason}",
+                    credentialId, watermark, counter, thresholdOnly ? "threshold" : "period");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "fixp.checkpoint.error credentialId={CredentialId}", credentialId);
+            }
+        }
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -27,6 +27,7 @@ public sealed class FixpListenerHostedService : BackgroundService
     private readonly IUserBotCredentialRegistry _credentials;
     private readonly IUserBotSessionRegistry _sessions;
     private readonly FixpOrderAdapter? _orders;
+    private readonly IBotSessionConnectionDirectory? _connectionDirectory;
     private readonly ILogger<FixpListenerHostedService> _logger;
     private readonly TaskCompletionSource<IPEndPoint> _boundTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -41,12 +42,14 @@ public sealed class FixpListenerHostedService : BackgroundService
         SymbolDirectory? symbols = null,
         OrderSubmissionService? submit = null,
         OrderCancelService? cancel = null,
-        IUserBotOrderMappingRegistry? botMappings = null)
+        IUserBotOrderMappingRegistry? botMappings = null,
+        IBotSessionConnectionDirectory? connectionDirectory = null)
     {
         _opts = opts.Value;
         _credentials = credentials;
         _sessions = sessions;
         _logger = logger;
+        _connectionDirectory = connectionDirectory;
         // Sub-issue #171 (E): the order/cancel adapter is only wired when
         // the host has registered the full submit pipeline. Tests (and
         // any future handshake-only mode) leave the deps null and the
@@ -106,7 +109,7 @@ public sealed class FixpListenerHostedService : BackgroundService
                     continue;
                 }
 
-                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger, _orders);
+                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger, _orders, _connectionDirectory);
                 _ = Task.Run(() => conn.RunAsync(stoppingToken), stoppingToken);
             }
         }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -24,7 +24,7 @@ namespace B3.Trading.EntryPointListener.Hosting;
 /// <see cref="IUserBotSessionRegistry"/> with single-active enforcement.
 /// </para>
 /// </summary>
-internal sealed class FixpSessionConnection
+internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDisposable
 {
     private const ushort SchemaIdV6 = 1;
     private const ushort VersionNegotiateResponse = 6;
@@ -47,8 +47,18 @@ internal sealed class FixpSessionConnection
     private readonly IUserBotCredentialRegistry _credentials;
     private readonly IUserBotSessionRegistry _sessions;
     private readonly FixpOrderAdapter? _orders;
+    private readonly IBotSessionConnectionDirectory? _connectionDirectory;
     private readonly string _connectionId;
     private readonly FixpHandshakeStateMachine _sm = new();
+
+    // Outbound-write serialisation for the multiplexer (sub-issue F).
+    // The handshake/order-ack writers and the multiplexer's enqueue
+    // hand-off both lock on this when emitting bytes to the stream so
+    // partial frames cannot interleave.
+    private readonly SemaphoreSlim _writeMutex = new(1, 1);
+    private NetworkStream? _stream;
+    private volatile bool _registeredInDirectory;
+    private volatile bool _closed;
 
     private FixpConnectionScope? _scope;
     private bool _slotClaimed;
@@ -58,12 +68,14 @@ internal sealed class FixpSessionConnection
         IUserBotCredentialRegistry credentials,
         IUserBotSessionRegistry sessions,
         ILogger logger,
-        FixpOrderAdapter? orders = null)
+        FixpOrderAdapter? orders = null,
+        IBotSessionConnectionDirectory? connectionDirectory = null)
     {
         _tcpClient = tcpClient;
         _credentials = credentials;
         _sessions = sessions;
         _orders = orders;
+        _connectionDirectory = connectionDirectory;
         _logger = logger;
         _connectionId = Guid.NewGuid().ToString("N");
     }
@@ -72,6 +84,7 @@ internal sealed class FixpSessionConnection
     {
         using var client = _tcpClient;
         var stream = client.GetStream();
+        _stream = stream;
         var remote = SafeRemote(client);
         var reader = new SofhFrameReader();
         var readBuf = ArrayPool<byte>.Shared.Rent(4096);
@@ -121,7 +134,18 @@ internal sealed class FixpSessionConnection
         }
         finally
         {
+            _closed = true;
             ArrayPool<byte>.Shared.Return(readBuf);
+            // Deregister BEFORE the stream is closed so a racing ER from
+            // the multiplexer hot path either sees us in the directory
+            // (and TryEnqueue takes the write mutex which we still own)
+            // or sees us absent (and falls through to buffering). Either
+            // outcome is safe; no NRE on a half-disposed stream.
+            if (_registeredInDirectory && _scope is not null && _connectionDirectory is not null)
+            {
+                _connectionDirectory.Deregister(_scope.Principal.CredentialId, this);
+                _registeredInDirectory = false;
+            }
             // Always release any single-active slot we hold, even on
             // abrupt close — otherwise a crashed bot would lock its own
             // credential out until the next version bump.
@@ -179,8 +203,17 @@ internal sealed class FixpSessionConnection
                 if (_sm.State != FixpSessionState.Established) goto default;
                 if (_orders is not null && _scope is not null)
                 {
-                    await _orders.HandleNewOrderSingleAsync(stream, frame.Payload, _scope, ct)
-                        .ConfigureAwait(false);
+                    // Sub-issue #172 (F): the order adapter writes ER
+                    // acks/rejects directly to the same stream the
+                    // multiplexer's TryEnqueue path writes to. Take the
+                    // shared write mutex so frames cannot interleave.
+                    await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+                    try
+                    {
+                        await _orders.HandleNewOrderSingleAsync(stream, frame.Payload, _scope, ct)
+                            .ConfigureAwait(false);
+                    }
+                    finally { _writeMutex.Release(); }
                 }
                 return true;
 
@@ -188,8 +221,13 @@ internal sealed class FixpSessionConnection
                 if (_sm.State != FixpSessionState.Established) goto default;
                 if (_orders is not null && _scope is not null)
                 {
-                    await _orders.HandleOrderCancelRequestAsync(stream, frame.Payload, _scope, ct)
-                        .ConfigureAwait(false);
+                    await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+                    try
+                    {
+                        await _orders.HandleOrderCancelRequestAsync(stream, frame.Payload, _scope, ct)
+                            .ConfigureAwait(false);
+                    }
+                    finally { _writeMutex.Release(); }
                 }
                 return true;
 
@@ -367,6 +405,17 @@ internal sealed class FixpSessionConnection
             _scope.Principal.CredShortId, _scope.Principal.UserId,
             serverState.SessionId, serverState.CurrentVer, _connectionId);
         await WriteEstablishAckAsync(stream, requestedSid, requestedVer, ct).ConfigureAwait(false);
+
+        // Sub-issue #172 (F): make the connection discoverable by the
+        // outbound multiplexer. Registration AFTER EstablishAck is sent
+        // so a racing ER cannot reach the bot before the bot's own
+        // handshake completes — the bot's parser would interpret a
+        // pre-Ack ER as a protocol violation and drop the session.
+        if (_connectionDirectory is not null)
+        {
+            _connectionDirectory.Register(credentialId, this);
+            _registeredInDirectory = true;
+        }
         return true;
     }
 
@@ -591,5 +640,56 @@ internal sealed class FixpSessionConnection
             };
         }
         catch { return "?"; }
+    }
+
+    // ─── IBotSessionOutboundSender (sub-issue F #172) ────────────────────
+
+    /// <summary>
+    /// Synchronously enqueues outbound bytes from the multiplexer. We
+    /// fire a fire-and-forget Task that takes the write mutex and writes
+    /// to the underlying stream — this is the right ordering primitive
+    /// because (a) the multiplexer's drain thread must not block on
+    /// socket I/O, and (b) the write mutex serialises against any
+    /// handshake/order-ack writes the connection's own request loop is
+    /// emitting concurrently.
+    /// </summary>
+    bool IBotSessionOutboundSender.TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+    {
+        if (_closed) return false;
+        var stream = _stream;
+        if (stream is null) return false;
+
+        // Fire-and-forget. Errors land in the catch and quietly close
+        // the connection; the read loop will observe the broken stream
+        // on its next iteration and run the deregister/release path.
+        _ = Task.Run(async () =>
+        {
+            await _writeMutex.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_closed) return;
+                await stream.WriteAsync(framedBytes, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "fixp.outbound.write.error connectionId={ConnectionId}", _connectionId);
+                _closed = true;
+                try { stream.Close(); } catch { /* ignore */ }
+            }
+            finally
+            {
+                _writeMutex.Release();
+            }
+        });
+        return true;
+    }
+
+    public void Dispose()
+    {
+        // Used by the multiplexer's overflow path to force-close.
+        _closed = true;
+        try { _stream?.Close(); } catch { /* ignore */ }
+        try { _tcpClient.Close(); } catch { /* ignore */ }
+        _writeMutex.Dispose();
     }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/IBotSessionConnectionDirectory.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/IBotSessionConnectionDirectory.cs
@@ -1,0 +1,58 @@
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Per-credential lookup of the active FIXP
+/// connection's outbound sender. Populated by
+/// <see cref="FixpSessionConnection"/> on Establish-success and removed
+/// on Terminate or socket-close. Thread-safe — touched both by the
+/// listener accept/close path and by the ER multiplexer's hot path.
+/// </summary>
+public interface IBotSessionConnectionDirectory
+{
+    /// <summary>
+    /// Registers <paramref name="sender"/> as the active outbound channel
+    /// for <paramref name="credentialId"/>. If a different sender is
+    /// already registered, it is evicted (caller's responsibility — by
+    /// the time we get here, the squatter-kick or version-bump path has
+    /// already terminated the prior connection's session-level state).
+    /// </summary>
+    void Register(Guid credentialId, IBotSessionOutboundSender sender);
+
+    /// <summary>
+    /// Removes <paramref name="sender"/> from the directory, but only if
+    /// it is still the active sender for <paramref name="credentialId"/>.
+    /// Idempotent — deregistering a sender that has already been
+    /// replaced by a newer connection is a no-op.
+    /// </summary>
+    void Deregister(Guid credentialId, IBotSessionOutboundSender sender);
+
+    /// <summary>
+    /// Returns the active sender for <paramref name="credentialId"/>, or
+    /// <c>false</c> when the bot is offline. Hot-path lookup from the
+    /// ER multiplexer.
+    /// </summary>
+    bool TryGet(Guid credentialId, out IBotSessionOutboundSender sender);
+}
+
+/// <summary>
+/// Outbound side of a live FIXP connection. The multiplexer pushes
+/// pre-framed SOFH bytes here; the implementation is responsible for
+/// serialising writes against any concurrent handshake/order-ack
+/// writes coming from the connection's own request loop.
+/// </summary>
+public interface IBotSessionOutboundSender
+{
+    /// <summary>
+    /// Synchronously enqueues <paramref name="framedBytes"/> for send.
+    /// Implementations buffer + flush on a background task; this method
+    /// must NOT block on socket I/O so the caller (the ER multiplexer
+    /// drain loop) is not coupled to network latency.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the bytes were accepted; <c>false</c> when the
+    /// sender is closed (the connection went away between the directory
+    /// lookup and the enqueue — the multiplexer falls back to buffering
+    /// for retransmit).
+    /// </returns>
+    bool TryEnqueue(ReadOnlyMemory<byte> framedBytes);
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
@@ -1,0 +1,212 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Application;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Framing;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Encodes a domain <see cref="ExecutionEvent"/> into
+/// the matching SBE ExecutionReport variant and wraps it in a SOFH frame.
+/// The bot's external ClOrdID — restored from
+/// <see cref="IUserBotOrderMappingRegistry"/> — is the only field the
+/// bot strictly needs to correlate its order book with the wire message;
+/// optional fields not derivable from <see cref="ExecutionEvent"/> are
+/// left at their SBE null sentinels.
+///
+/// <para>v0 covers the five execution kinds the platform actually
+/// surfaces today: <c>New</c>, <c>PartialFill</c>, <c>Fill</c>,
+/// <c>Canceled</c>, <c>Rejected</c>. <c>Replaced</c> uses the same
+/// <c>ExecutionReport_Modify</c> path. Any future ER kind that doesn't
+/// map cleanly throws a guarded <see cref="NotSupportedException"/> so
+/// the bug surfaces loudly rather than as silent ER loss.</para>
+///
+/// <para>Field-offset writes mirror the pattern already used by
+/// <c>FixpOrderAdapter.WriteExecutionReportRejectAsync</c> (some SBE
+/// optionals expose only <c>Nullable&lt;T&gt;</c> getters and require
+/// raw memory writes to set the wire layout).</para>
+/// </summary>
+internal static class OutboundExecutionReportEncoder
+{
+    private const ushort SchemaIdV6 = 1;
+    private const ushort VersionApp = 6;
+
+    /// <summary>
+    /// Encodes a SOFH-framed SBE ExecutionReport for the given
+    /// <paramref name="ev"/> + bot mapping. Returns a heap-allocated
+    /// byte array sized exactly to the frame (no slack). The buffer is
+    /// what the multiplexer hands to <c>BotOutboundBuffer.Append</c> and
+    /// to <c>IBotSessionOutboundSender.TryEnqueue</c> simultaneously.
+    /// </summary>
+    public static byte[] Encode(
+        ExecutionEvent ev,
+        ulong externalClOrdId,
+        ulong externalOrigClOrdId)
+    {
+        return ev.Kind switch
+        {
+            ExecKind.New => EncodeNew(ev, externalClOrdId),
+            ExecKind.PartialFill or ExecKind.Fill => EncodeTrade(ev, externalClOrdId),
+            ExecKind.Canceled => EncodeCancel(ev, externalClOrdId, externalOrigClOrdId),
+            ExecKind.Replaced => EncodeModify(ev, externalClOrdId, externalOrigClOrdId),
+            ExecKind.Rejected => EncodeReject(ev, externalClOrdId, externalOrigClOrdId),
+            _ => throw new NotSupportedException(
+                $"ExecKind {ev.Kind} has no SBE ExecutionReport mapping in v0."),
+        };
+    }
+
+    private static byte[] EncodeNew(ExecutionEvent ev, ulong externalClOrdId)
+    {
+        Span<byte> body = stackalloc byte[ExecutionReport_NewData.BLOCK_LENGTH];
+        body.Clear();
+        body[18] = (byte)ToSbeSide(ev.Side);
+        body[19] = (byte)ToSbeOrdStatus(ev.Status);
+        MemoryMarshal.Write(body[20..], in externalClOrdId);
+        ulong transactTime = NanosNow();
+        MemoryMarshal.Write(body[64..], in transactTime);
+
+        return Frame(
+            (ushort)ExecutionReport_NewData.BLOCK_LENGTH,
+            (ushort)ExecutionReport_NewData.MESSAGE_ID,
+            body);
+    }
+
+    private static byte[] EncodeTrade(ExecutionEvent ev, ulong externalClOrdId)
+    {
+        Span<byte> body = stackalloc byte[ExecutionReport_TradeData.BLOCK_LENGTH];
+        body.Clear();
+        body[18] = (byte)ToSbeSide(ev.Side);
+        body[19] = (byte)ToSbeOrdStatus(ev.Status);
+        MemoryMarshal.Write(body[20..], in externalClOrdId);
+        ulong lastQty = (ulong)Math.Max(0, ev.LastQuantity);
+        MemoryMarshal.Write(body[48..], in lastQty);
+        long lastPxMantissa = ToPriceMantissa(ev.LastPrice);
+        MemoryMarshal.Write(body[56..], in lastPxMantissa);
+        ulong transactTime = NanosNow();
+        MemoryMarshal.Write(body[72..], in transactTime);
+        ulong leavesQty = (ulong)Math.Max(0, ev.LeavesQuantity);
+        MemoryMarshal.Write(body[80..], in leavesQty);
+        ulong cumQty = (ulong)Math.Max(0, ev.CumulativeQuantity);
+        MemoryMarshal.Write(body[88..], in cumQty);
+
+        return Frame(
+            (ushort)ExecutionReport_TradeData.BLOCK_LENGTH,
+            (ushort)ExecutionReport_TradeData.MESSAGE_ID,
+            body);
+    }
+
+    private static byte[] EncodeCancel(ExecutionEvent ev, ulong externalClOrdId, ulong externalOrigClOrdId)
+    {
+        Span<byte> body = stackalloc byte[ExecutionReport_CancelData.BLOCK_LENGTH];
+        body.Clear();
+        body[18] = (byte)ToSbeSide(ev.Side);
+        body[19] = (byte)ToSbeOrdStatus(ev.Status);
+        MemoryMarshal.Write(body[20..], in externalClOrdId);
+        ulong cumQty = (ulong)Math.Max(0, ev.CumulativeQuantity);
+        MemoryMarshal.Write(body[44..], in cumQty);
+        ulong transactTime = NanosNow();
+        MemoryMarshal.Write(body[64..], in transactTime);
+        // OrigClOrdID is at offset 88 per the SBE schema. When the multiplexer
+        // could not resolve a separate cancel-side mapping (forward-route
+        // scenarios), we fall back to 0 (= SBE null sentinel for this field).
+        MemoryMarshal.Write(body[88..], in externalOrigClOrdId);
+
+        return Frame(
+            (ushort)ExecutionReport_CancelData.BLOCK_LENGTH,
+            (ushort)ExecutionReport_CancelData.MESSAGE_ID,
+            body);
+    }
+
+    private static byte[] EncodeModify(ExecutionEvent ev, ulong externalClOrdId, ulong externalOrigClOrdId)
+    {
+        Span<byte> body = stackalloc byte[ExecutionReport_ModifyData.BLOCK_LENGTH];
+        body.Clear();
+        body[18] = (byte)ToSbeSide(ev.Side);
+        body[19] = (byte)ToSbeOrdStatus(ev.Status);
+        MemoryMarshal.Write(body[20..], in externalClOrdId);
+        ulong leavesQty = (ulong)Math.Max(0, ev.LeavesQuantity);
+        MemoryMarshal.Write(body[44..], in leavesQty);
+        ulong transactTime = NanosNow();
+        MemoryMarshal.Write(body[64..], in transactTime);
+        ulong cumQty = (ulong)Math.Max(0, ev.CumulativeQuantity);
+        MemoryMarshal.Write(body[72..], in cumQty);
+        // OrigClOrdID offset 96 on the Modify body.
+        MemoryMarshal.Write(body[96..], in externalOrigClOrdId);
+
+        return Frame(
+            (ushort)ExecutionReport_ModifyData.BLOCK_LENGTH,
+            (ushort)ExecutionReport_ModifyData.MESSAGE_ID,
+            body);
+    }
+
+    private static byte[] EncodeReject(ExecutionEvent ev, ulong externalClOrdId, ulong externalOrigClOrdId)
+    {
+        Span<byte> body = stackalloc byte[ExecutionReport_RejectData.BLOCK_LENGTH];
+        body.Clear();
+        body[18] = (byte)ToSbeSide(ev.Side);
+        // body[19] is CxlRejResponseTo on Reject (no OrdStatus field — the
+        // schema constant ORD_STATUS = REJECTED carries the meaning).
+        // Leave it at 0 (= ORDER) for now; cancel/modify rejects are a
+        // dedicated path on the inbound adapter, see FixpOrderAdapter.
+        MemoryMarshal.Write(body[20..], in externalClOrdId);
+        ulong transactTime = NanosNow();
+        MemoryMarshal.Write(body[48..], in transactTime);
+        // OrigClOrdID at offset 72 (optional).
+        MemoryMarshal.Write(body[72..], in externalOrigClOrdId);
+
+        return Frame(
+            (ushort)ExecutionReport_RejectData.BLOCK_LENGTH,
+            (ushort)ExecutionReport_RejectData.MESSAGE_ID,
+            body);
+    }
+
+    private static byte[] Frame(ushort blockLength, ushort templateId, ReadOnlySpan<byte> body)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf, blockLength, templateId, SchemaIdV6, VersionApp, body);
+        return buf;
+    }
+
+    private static Side ToSbeSide(OrderSide side) => side switch
+    {
+        OrderSide.Buy => Side.BUY,
+        OrderSide.Sell => Side.SELL,
+        _ => Side.BUY,
+    };
+
+    private static OrdStatus ToSbeOrdStatus(OrderStatus status) => status switch
+    {
+        OrderStatus.PendingNew => OrdStatus.NEW,
+        OrderStatus.Working => OrdStatus.NEW,
+        OrderStatus.PartiallyFilled => OrdStatus.PARTIALLY_FILLED,
+        OrderStatus.Filled => OrdStatus.FILLED,
+        OrderStatus.Cancelled => OrdStatus.CANCELED,
+        OrderStatus.Rejected => OrdStatus.REJECTED,
+        OrderStatus.Replaced => OrdStatus.REPLACED,
+        _ => OrdStatus.NEW,
+    };
+
+    private static long ToPriceMantissa(decimal price)
+    {
+        // B3 Price scale = 8 decimals (per SBE schema's Price composite).
+        // ExecutionEvent carries a decimal; convert to int64 mantissa.
+        // Saturate on overflow rather than throwing — the encoded ER must
+        // not lose the bot's correlation just because one fill price
+        // exceeded the scaled range.
+        try
+        {
+            return (long)(price * 1_000_000_00m);
+        }
+        catch (OverflowException)
+        {
+            return price > 0 ? long.MaxValue : long.MinValue;
+        }
+    }
+
+    private static ulong NanosNow()
+        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+}

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -329,6 +329,9 @@ public sealed class EventReplayer
             case BotSessionVerAdvancedEvent bsv:
                 _userBotSessions?.ApplyVerAdvanced(bsv.CredentialId, bsv.NewVer);
                 break;
+            case BotSessionSeqAdvancedEvent bss:
+                _userBotSessions?.ApplyCheckpointedSeq(bss.CredentialId, bss.CheckpointedOutboundSeq);
+                break;
         }
     }
 

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferTests.cs
@@ -1,0 +1,78 @@
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Unit tests for <see cref="BotOutboundBuffer"/> (sub-issue #172 F):
+/// FIFO append, range read, evict, overflow callback semantics, reset.
+/// </summary>
+public class BotOutboundBufferTests
+{
+    [Fact]
+    public void Append_StoresEntries_InArrivalOrder()
+    {
+        var buf = new BotOutboundBuffer(Guid.NewGuid(), maxMessages: 100);
+        Assert.True(buf.Append(1, new byte[] { 1 }));
+        Assert.True(buf.Append(2, new byte[] { 2 }));
+        var range = buf.GetRange(1, 2);
+        Assert.Equal(2, range.Count);
+        Assert.Equal(1ul, range[0].Seq);
+        Assert.Equal(2ul, range[1].Seq);
+    }
+
+    [Fact]
+    public void Append_DefensivelyCopiesPayload()
+    {
+        var buf = new BotOutboundBuffer(Guid.NewGuid(), maxMessages: 10);
+        var payload = new byte[] { 1, 2, 3 };
+        Assert.True(buf.Append(1, payload));
+        payload[0] = 99; // mutate caller's array post-Append
+        var range = buf.GetRange(1, 1);
+        Assert.Equal(1, range[0].Bytes.Span[0]);
+    }
+
+    [Fact]
+    public void EvictUpTo_DropsLowSeqs_Idempotent()
+    {
+        var buf = new BotOutboundBuffer(Guid.NewGuid(), maxMessages: 10);
+        for (var i = 1ul; i <= 5; i++) buf.Append(i, new byte[] { (byte)i });
+        buf.EvictUpTo(3);
+        Assert.Equal(2, buf.Count);
+        buf.EvictUpTo(3); // idempotent
+        Assert.Equal(2, buf.Count);
+        var range = buf.GetRange(1, 5);
+        Assert.Equal(new ulong[] { 4, 5 }, range.Select(r => r.Seq));
+    }
+
+    [Fact]
+    public void Append_AtCap_FiresOverflow_AndRefusesUntilReset()
+    {
+        var fired = 0;
+        Guid? gotCred = null;
+        var credId = Guid.NewGuid();
+        var buf = new BotOutboundBuffer(credId, maxMessages: 3, onOverflow: c => { fired++; gotCred = c; });
+
+        Assert.True(buf.Append(1, new byte[] { 1 }));
+        Assert.True(buf.Append(2, new byte[] { 2 }));
+        Assert.True(buf.Append(3, new byte[] { 3 }));
+
+        Assert.False(buf.Append(4, new byte[] { 4 })); // tripped
+        Assert.Equal(1, fired);
+        Assert.Equal(credId, gotCred);
+        Assert.True(buf.IsOverflowed);
+        Assert.Equal(0, buf.Count);
+
+        Assert.False(buf.Append(5, new byte[] { 5 })); // still refusing
+        Assert.Equal(1, fired); // not refired
+
+        buf.Reset();
+        Assert.False(buf.IsOverflowed);
+        Assert.True(buf.Append(6, new byte[] { 6 }));
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCap()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BotOutboundBuffer(Guid.NewGuid(), 0));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundSeqAllocatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundSeqAllocatorTests.cs
@@ -1,0 +1,43 @@
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Unit tests for <see cref="BotOutboundSeqAllocator"/> (sub-issue #172 F).
+/// </summary>
+public class BotOutboundSeqAllocatorTests
+{
+    [Fact]
+    public void Allocate_StartsAtSeedPlusOne()
+    {
+        var a = new BotOutboundSeqAllocator(seedSeq: 7);
+        Assert.Equal(8ul, a.Allocate());
+        Assert.Equal(9ul, a.Allocate());
+    }
+
+    [Fact]
+    public void Current_TracksLastAllocated()
+    {
+        var a = new BotOutboundSeqAllocator();
+        Assert.Equal(0ul, a.Current);
+        a.Allocate();
+        a.Allocate();
+        Assert.Equal(2ul, a.Current);
+    }
+
+    [Fact]
+    public void Allocate_IsThreadSafe_AcrossManyConcurrentCallers()
+    {
+        var a = new BotOutboundSeqAllocator();
+        const int threads = 16;
+        const int perThread = 5_000;
+        var bag = new System.Collections.Concurrent.ConcurrentBag<ulong>();
+        Parallel.For(0, threads, _ =>
+        {
+            for (var i = 0; i < perThread; i++) bag.Add(a.Allocate());
+        });
+        var distinct = bag.Distinct().Count();
+        Assert.Equal(threads * perThread, distinct);
+        Assert.Equal((ulong)(threads * perThread), a.Current);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/BotSessionCheckpointedSeqTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/BotSessionCheckpointedSeqTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+
+namespace B3.Trading.Application.Tests.UserBots;
+
+/// <summary>
+/// Sub-issue #172 (F). Tests covering the durable seq watermark API:
+/// <see cref="IUserBotSessionRegistry.UpdateCheckpointedOutboundSeq"/>.
+///
+/// Mirrors the no-WAL-spam, monotonic-only, replay-restoring guarantees
+/// the multiplexer + checkpointer rely on.
+/// </summary>
+public class BotSessionCheckpointedSeqTests
+{
+    [Fact]
+    public async Task UpdateCheckpointedOutboundSeq_AppendsEvent_AndAdvancesWatermark()
+    {
+        var store = new RecordingStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+        var credId = Guid.NewGuid();
+        await reg.GetOrCreateAsync(credId, default);
+
+        reg.UpdateCheckpointedOutboundSeq(credId, 42);
+
+        var state = await reg.GetOrCreateAsync(credId, default);
+        Assert.Equal(42ul, state.LastCheckpointedOutboundSeq);
+        var evts = store.Recorded.OfType<BotSessionSeqAdvancedEvent>().ToList();
+        Assert.Single(evts);
+        Assert.Equal(42ul, evts[0].CheckpointedOutboundSeq);
+    }
+
+    [Fact]
+    public async Task UpdateCheckpointedOutboundSeq_NonMonotonic_NoOps()
+    {
+        var store = new RecordingStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+        var credId = Guid.NewGuid();
+        await reg.GetOrCreateAsync(credId, default);
+
+        reg.UpdateCheckpointedOutboundSeq(credId, 10);
+        reg.UpdateCheckpointedOutboundSeq(credId, 5); // backwards
+        reg.UpdateCheckpointedOutboundSeq(credId, 10); // equal
+
+        var evts = store.Recorded.OfType<BotSessionSeqAdvancedEvent>().ToList();
+        Assert.Single(evts); // only the original 10
+        var state = await reg.GetOrCreateAsync(credId, default);
+        Assert.Equal(10ul, state.LastCheckpointedOutboundSeq);
+    }
+
+    [Fact]
+    public async Task UpdateCheckpointedOutboundSeq_UnknownCredential_NoOps()
+    {
+        var store = new RecordingStore();
+        var dispatcher = new EventDispatcher(store);
+        var reg = new InMemoryUserBotSessionRegistry(dispatcher, store);
+
+        reg.UpdateCheckpointedOutboundSeq(Guid.NewGuid(), 10);
+
+        Assert.Empty(store.Recorded.OfType<BotSessionSeqAdvancedEvent>());
+    }
+
+    private sealed class RecordingStore : IEventStore
+    {
+        public ConcurrentQueue<WalEvent> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+
+        public long Append(WalEvent evt)
+        {
+            Recorded.Enqueue(evt);
+            return Interlocked.Increment(ref _seq);
+        }
+
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
@@ -1,0 +1,197 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Behavioural tests for <see cref="BotErMultiplexer"/>:
+/// routes by mapping → buffers + sends, drops unmapped, falls back to
+/// buffer-only when bot is offline, and triggers BumpVersion+force-close
+/// on overflow.
+/// </summary>
+public class BotErMultiplexerTests
+{
+    private static ExecutionEvent NewEvent(ulong clOrdId, ExecKind kind = ExecKind.New) =>
+        new(
+            Owner: new EndClientId("u1"),
+            ClOrdId: clOrdId,
+            Symbol: "PETR4",
+            Side: OrderSide.Buy,
+            Status: OrderStatus.Working,
+            Kind: kind,
+            LeavesQuantity: 100,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            TimestampUtc: DateTimeOffset.UtcNow);
+
+    [Fact]
+    public async Task Route_MappedClOrdId_BuffersAndSends()
+    {
+        var (mux, ctx) = await NewMultiplexerAsync();
+        ctx.Mappings.Add(internalId: 100, credId: ctx.CredentialId, externalId: 4242);
+        ctx.Directory.Register(ctx.CredentialId, ctx.Sender);
+
+        mux.Route(NewEvent(100));
+        await ctx.AwaitDrainAsync();
+
+        Assert.Equal(1, ctx.Sender.SentCount);
+        Assert.Equal(1, ctx.Coordinator.GetOrCreateBuffer(ctx.CredentialId).Count);
+        Assert.Equal(1, ctx.Coordinator.GetCounter(ctx.CredentialId));
+    }
+
+    [Fact]
+    public async Task Route_UnmappedClOrdId_NoOps()
+    {
+        var (mux, ctx) = await NewMultiplexerAsync();
+        // No mapping registered.
+
+        mux.Route(NewEvent(404));
+        await ctx.AwaitDrainAsync();
+
+        Assert.Equal(0, ctx.Sender.SentCount);
+    }
+
+    [Fact]
+    public async Task Route_BotOffline_BuffersWithoutSend()
+    {
+        var (mux, ctx) = await NewMultiplexerAsync();
+        ctx.Mappings.Add(internalId: 100, credId: ctx.CredentialId, externalId: 4242);
+        // Sender NOT registered with directory.
+
+        mux.Route(NewEvent(100));
+        await ctx.AwaitDrainAsync();
+
+        Assert.Equal(0, ctx.Sender.SentCount);
+        Assert.Equal(1, ctx.Coordinator.GetOrCreateBuffer(ctx.CredentialId).Count);
+    }
+
+    [Fact]
+    public async Task Overflow_BumpsVersion_DisposesSender_AndResetsBuffer()
+    {
+        var (mux, ctx) = await NewMultiplexerAsync(bufferCap: 2);
+        ctx.Mappings.Add(internalId: 100, credId: ctx.CredentialId, externalId: 4242);
+        ctx.Directory.Register(ctx.CredentialId, ctx.Sender);
+        var startVer = (await ctx.Sessions.GetOrCreateAsync(ctx.CredentialId, default)).CurrentVer;
+
+        // Fill the buffer + one over the cap.
+        mux.Route(NewEvent(100));
+        mux.Route(NewEvent(100));
+        mux.Route(NewEvent(100));
+        await ctx.AwaitDrainAsync(rounds: 5);
+        // Give overflow loop time to handle.
+        for (var i = 0; i < 30 && !ctx.Sender.Disposed; i++)
+            await Task.Delay(50);
+
+        Assert.True(ctx.Sender.Disposed);
+        var newState = await ctx.Sessions.GetOrCreateAsync(ctx.CredentialId, default);
+        Assert.True(newState.CurrentVer > startVer);
+        Assert.False(ctx.Coordinator.GetOrCreateBuffer(ctx.CredentialId).IsOverflowed);
+    }
+
+    private static async Task<(BotErMultiplexer, MuxContext)> NewMultiplexerAsync(int bufferCap = 1000)
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var credId = Guid.NewGuid();
+        await sessions.GetOrCreateAsync(credId, default);
+
+        var mappings = new FakeMappingRegistry();
+        var directory = new BotSessionConnectionDirectory();
+        var opts = Options.Create(new BotErMultiplexerOptions
+        {
+            OutboundBufferMaxMessages = bufferCap,
+            RouterChannelCapacity = 1024,
+        });
+        var coord = new BotOutboundCoordinator(sessions, opts.Value);
+        var mux = new BotErMultiplexer(mappings, sessions, directory, coord,
+            NullLogger<BotErMultiplexer>.Instance, opts);
+        // Start the BackgroundService manually so Tests don't need a host.
+        var cts = new CancellationTokenSource();
+        await mux.StartAsync(cts.Token);
+
+        var sender = new FakeSender();
+        var ctx = new MuxContext(credId, sessions, mappings, directory, coord, sender, mux, cts);
+        return (mux, ctx);
+    }
+
+    private sealed class MuxContext
+    {
+        public Guid CredentialId { get; }
+        public InMemoryUserBotSessionRegistry Sessions { get; }
+        public FakeMappingRegistry Mappings { get; }
+        public BotSessionConnectionDirectory Directory { get; }
+        public BotOutboundCoordinator Coordinator { get; }
+        public FakeSender Sender { get; }
+        private readonly BotErMultiplexer _mux;
+        private readonly CancellationTokenSource _cts;
+
+        public MuxContext(
+            Guid credId,
+            InMemoryUserBotSessionRegistry sessions,
+            FakeMappingRegistry mappings,
+            BotSessionConnectionDirectory directory,
+            BotOutboundCoordinator coordinator,
+            FakeSender sender,
+            BotErMultiplexer mux,
+            CancellationTokenSource cts)
+        {
+            CredentialId = credId;
+            Sessions = sessions;
+            Mappings = mappings;
+            Directory = directory;
+            Coordinator = coordinator;
+            Sender = sender;
+            _mux = mux;
+            _cts = cts;
+        }
+
+        public async Task AwaitDrainAsync(int rounds = 3)
+        {
+            // The route loop is single-threaded; a few yield-roundtrips
+            // give the channel time to drain in the background.
+            for (var i = 0; i < rounds; i++) await Task.Delay(20);
+        }
+    }
+
+    private sealed class FakeSender : IBotSessionOutboundSender, IDisposable
+    {
+        public int SentCount;
+        public bool Disposed;
+        public bool TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+        {
+            if (Disposed) return false;
+            Interlocked.Increment(ref SentCount);
+            return true;
+        }
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class FakeMappingRegistry : IUserBotOrderMappingRegistry
+    {
+        private readonly Dictionary<ulong, OrderMapping> _orders = new();
+
+        public void Add(ulong internalId, Guid credId, ulong externalId)
+            => _orders[internalId] = new OrderMapping(credId, externalId);
+
+        public bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping)
+            => _orders.TryGetValue(internalClOrdId, out mapping);
+
+        public bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId)
+        { internalClOrdId = 0; return false; }
+        public bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping)
+        { mapping = default; return false; }
+        public void Reap(ulong internalClOrdId) { }
+        public void ReapCancel(ulong cancelInternalClOrdId) { }
+        public void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId) { }
+        public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
+        public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
+        public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotOutboundCoordinatorTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotOutboundCoordinatorTests.cs
@@ -1,0 +1,79 @@
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Hosting;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Unit tests for <see cref="BotOutboundCoordinator"/>.
+/// </summary>
+public class BotOutboundCoordinatorTests
+{
+    private static BotOutboundCoordinator NewCoord(IUserBotSessionRegistry? sessions = null, int cap = 1000)
+        => new(sessions ?? new InMemoryUserBotSessionRegistry(),
+               new BotErMultiplexerOptions { OutboundBufferMaxMessages = cap });
+
+    [Fact]
+    public void AllocateNext_IsPerCredential_AndStartsAtOne()
+    {
+        var c = NewCoord();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        Assert.Equal(1ul, c.AllocateNext(a));
+        Assert.Equal(2ul, c.AllocateNext(a));
+        Assert.Equal(1ul, c.AllocateNext(b));
+        Assert.Equal(2ul, c.GetCurrentSeq(a));
+    }
+
+    [Fact]
+    public void RecordOutbound_BumpsCounter_ReadAndResetReturnsPrior()
+    {
+        var c = NewCoord();
+        var cred = Guid.NewGuid();
+        c.RecordOutbound(cred);
+        c.RecordOutbound(cred);
+        c.RecordOutbound(cred);
+        Assert.Equal(3, c.GetCounter(cred));
+        Assert.Equal(3, c.ReadAndResetCounter(cred));
+        Assert.Equal(0, c.GetCounter(cred));
+    }
+
+    [Fact]
+    public void ListActiveCredentials_OnlyReturnsThoseWithNonZeroCounter()
+    {
+        var c = NewCoord();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        c.RecordOutbound(a);
+        _ = c.GetOrCreateBuffer(b);
+        var active = c.ListActiveCredentials();
+        Assert.Contains(a, active);
+        Assert.DoesNotContain(b, active);
+    }
+
+    [Fact]
+    public void OnBufferOverflow_FiresThroughCoordinator()
+    {
+        var c = NewCoord(cap: 2);
+        var caught = new List<Guid>();
+        c.OnBufferOverflow = caught.Add;
+        var cred = Guid.NewGuid();
+        var buf = c.GetOrCreateBuffer(cred);
+        Assert.True(buf.Append(1, new byte[] { 1 }));
+        Assert.True(buf.Append(2, new byte[] { 2 }));
+        Assert.False(buf.Append(3, new byte[] { 3 })); // overflow
+        Assert.Single(caught);
+        Assert.Equal(cred, caught[0]);
+    }
+
+    [Fact]
+    public async Task AllocateNext_SeedsFromCheckpointedSeq()
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var cred = Guid.NewGuid();
+        await sessions.GetOrCreateAsync(cred, default);
+        sessions.UpdateCheckpointedOutboundSeq(cred, 100);
+
+        var c = NewCoord(sessions);
+        Assert.Equal(101ul, c.AllocateNext(cred));
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotSessionSeqCheckpointerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotSessionSeqCheckpointerTests.cs
@@ -1,0 +1,83 @@
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Sub-issue #172 (F). Behavioural tests for <see cref="BotSessionSeqCheckpointer.Tick"/>.
+/// </summary>
+public class BotSessionSeqCheckpointerTests
+{
+    [Fact]
+    public async Task Tick_DispatchesEventForCredentialsWithCounter_AndResetsCounter()
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var cred = Guid.NewGuid();
+        await sessions.GetOrCreateAsync(cred, default);
+
+        var coord = new BotOutboundCoordinator(sessions, new BotErMultiplexerOptions());
+        coord.AllocateNext(cred);
+        coord.AllocateNext(cred);
+        coord.AllocateNext(cred);
+        coord.RecordOutbound(cred);
+        coord.RecordOutbound(cred);
+        coord.RecordOutbound(cred);
+
+        var cp = new BotSessionSeqCheckpointer(coord, sessions,
+            Options.Create(new BotErMultiplexerOptions()),
+            NullLogger<BotSessionSeqCheckpointer>.Instance);
+
+        cp.Tick();
+
+        var state = await sessions.GetOrCreateAsync(cred, default);
+        Assert.Equal(3ul, state.LastCheckpointedOutboundSeq);
+        Assert.Equal(0, coord.GetCounter(cred));
+    }
+
+    [Fact]
+    public async Task TickThresholdOnly_OnlyEmitsForCredentialsAtOrAboveThreshold()
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var credLow = Guid.NewGuid();
+        var credHigh = Guid.NewGuid();
+        await sessions.GetOrCreateAsync(credLow, default);
+        await sessions.GetOrCreateAsync(credHigh, default);
+
+        var coord = new BotOutboundCoordinator(sessions, new BotErMultiplexerOptions());
+        coord.AllocateNext(credLow); coord.RecordOutbound(credLow);
+        for (var i = 0; i < 5; i++) { coord.AllocateNext(credHigh); coord.RecordOutbound(credHigh); }
+
+        var cp = new BotSessionSeqCheckpointer(coord, sessions,
+            Options.Create(new BotErMultiplexerOptions { CheckpointMessageThreshold = 5 }),
+            NullLogger<BotSessionSeqCheckpointer>.Instance);
+
+        cp.TickThresholdOnly();
+
+        Assert.Equal(0ul, (await sessions.GetOrCreateAsync(credLow, default)).LastCheckpointedOutboundSeq);
+        Assert.Equal(5ul, (await sessions.GetOrCreateAsync(credHigh, default)).LastCheckpointedOutboundSeq);
+        Assert.Equal(1, coord.GetCounter(credLow));
+        Assert.Equal(0, coord.GetCounter(credHigh));
+    }
+
+    [Fact]
+    public async Task Tick_DoesNotEmit_WhenCounterIsZero()
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var cred = Guid.NewGuid();
+        await sessions.GetOrCreateAsync(cred, default);
+
+        var coord = new BotOutboundCoordinator(sessions, new BotErMultiplexerOptions());
+        _ = coord.GetOrCreateBuffer(cred);
+
+        var cp = new BotSessionSeqCheckpointer(coord, sessions,
+            Options.Create(new BotErMultiplexerOptions()),
+            NullLogger<BotSessionSeqCheckpointer>.Instance);
+
+        cp.Tick();
+
+        var state = await sessions.GetOrCreateAsync(cred, default);
+        Assert.Equal(0ul, state.LastCheckpointedOutboundSeq);
+    }
+}


### PR DESCRIPTION
Implements sub-issue **F** of #166 / closes #172.

## What
Routes ExecutionReports from the matching engine back to the originating bot's FIXP session, with per-credential outbound seq numbering, an in-memory outbound buffer, periodic seq checkpointing to the WAL, and overflow-triggered version bumps.

## Components

**Application (transport-agnostic)**
- `BotOutboundSeqAllocator` — `Interlocked`-based per-credential seq counter
- `BotOutboundBuffer` — bounded buffer (default 50_000) with overflow callback fired synchronously
- `IBotErRouter` / `NoOpBotErRouter` — optional seam plugged into `ExecutionReportProcessor`
- `UpdateCheckpointedOutboundSeq` — sync API on `IUserBotSessionRegistry`; emits `BotSessionSeqAdvancedEvent` only when counter > 0
- `BotSessionSeqAdvancedEvent` WAL event + replay handler

**EntryPointListener (transport)**
- `BotOutboundCoordinator` — per-credential allocator+buffer+counter glue, lazy seeding from the credential's `LastCheckpointedOutboundSeq` watermark
- `BotErMultiplexer` — `BackgroundService` + `IBotErRouter`. Two cooperating loops drain an unbounded channel: route loop encodes, buffers FIRST, then sends; overflow loop does `BumpVersionAsync` → dispose sender → reset buffer
- `OutboundExecutionReportEncoder` — SBE V6 encoder for 5 ER variants (New/Trade/Cancel/Modify/Reject) via field-offset writes
- `IBotSessionConnectionDirectory` + `BotSessionConnectionDirectory` — per-credential lookup of the active outbound sender; CAS-style deregister
- `BotSessionSeqCheckpointer` — `BackgroundService` ticking on the longer cadence (5s) and a fast-poll path that fires the message-count threshold (100 msgs) for high-rate credentials

**FixpSessionConnection**
- Implements `IBotSessionOutboundSender`, registers in directory after `EstablishAck`, deregisters in `RunAsync`'s finally block (before slot release)
- Single `SemaphoreSlim` serialises every outbound write — handshake, order-adapter, AND multiplexer hand-off — so frames cannot interleave

## Sequence + checkpoint design
Each application message carries an implicit seq from the per-credential `BotOutboundSeqAllocator`. The checkpointer dispatches one `BotSessionSeqAdvancedEvent` per active credential per period (or threshold), which advances `LastCheckpointedOutboundSeq` on the registry under the EventDispatcher's apply lock. On restart the watermark is restored via WAL replay; the allocator seeds from it on first access.

## Overflow semantics
`BotOutboundBuffer.Append` returning `false` fires the overflow callback synchronously. The multiplexer's overflow loop runs the recovery sequence in this order: `BumpVersionAsync("overflow")` (with WAL flush fence inside) → `Dispose()` the sender (force-close the socket) → `Buffer.Reset()`. The bot's reconnect must observe the new `SessionVerId` and reconcile via REST — no in-flight ER can be observed *and then* be rolled back by the version bump.

## Deviation from RFC "no re-encode"
The B3 EntryPoint Client SDK consumed by the gateway parses raw bytes and exposes only the typed `ExecutionReportEnvelope`. The raw SBE bytes are not recoverable, so v0 re-encodes the ER from the parsed `ExecutionEvent` via `OutboundExecutionReportEncoder`. When the SDK is patched to expose raw bytes, the encoder can be deleted in favour of the verbatim-forward path; the field-offset encoder mirrors the SBE V6 schema offsets exactly so a side-by-side regression is straightforward.

## Out of scope (future sub-issues)
- **G #173**: `RetransmitRequest` handling against the in-memory buffer + `Sequence` ack consumption to evict
- WAL persistence of the outbound buffer itself (RFC §4.8 explicitly defers this — bots reconcile via REST on restart instead)

## Tests
- `BotOutboundSeqAllocatorTests` — concurrent allocation, monotonicity, seed
- `BotOutboundBufferTests` — FIFO, defensive copy, evict, overflow cb, refuse-until-reset
- `BotSessionCheckpointedSeqTests` — append+advance, monotonic-only, unknown-credential no-op
- `BotOutboundCoordinatorTests` — per-credential isolation, counter accounting, overflow wiring, watermark seeding
- `BotSessionSeqCheckpointerTests` — period `Tick`, no-emit when counter zero, threshold-only fast pass
- `BotErMultiplexerTests` — routing happy path, unmapped no-op, offline buffering, overflow→bump+dispose

All 815 backend tests pass; `dotnet format --verify-no-changes` clean.
