### PR TITLE
feat(fixp): retransmit + sequence tracking (#173)

### DIFF
--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
@@ -28,6 +28,24 @@ public sealed class EntryPointListenerOptions
     /// </summary>
     public bool AllowInProduction { get; set; }
 
+    /// <summary>
+    /// Sub-issue #173 (G). Cadence (ms) at which an established
+    /// connection emits <c>Sequence</c> as a server→bot heartbeat / gap
+    /// signal. Suppressed when a real outbound message was sent within
+    /// the window (piggyback semantics, RFC §4.7). Default 3000 ms.
+    /// Set ≤0 to disable.
+    /// </summary>
+    public int HeartbeatIntervalMs { get; set; } = 3000;
+
+    /// <summary>
+    /// Sub-issue #173 (G). Maximum bot inbound message-rate window the
+    /// listener will tolerate gaps within before considering the gap
+    /// permanent. Currently advisory — v0 does not auto-Terminate on
+    /// unfilled gaps (idempotent flow: bot reconciles via REST instead);
+    /// surfaced for forward compatibility with H's hardening pass.
+    /// </summary>
+    public int RetransmitTimeoutMs { get; set; } = 5000;
+
     /// <summary>Nested TLS configuration.</summary>
     public sealed class TlsOptions
     {

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -28,6 +28,8 @@ public sealed class FixpListenerHostedService : BackgroundService
     private readonly IUserBotSessionRegistry _sessions;
     private readonly FixpOrderAdapter? _orders;
     private readonly IBotSessionConnectionDirectory? _connectionDirectory;
+    private readonly BotOutboundCoordinator? _outboundCoordinator;
+    private readonly TimeProvider _clock;
     private readonly ILogger<FixpListenerHostedService> _logger;
     private readonly TaskCompletionSource<IPEndPoint> _boundTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -43,13 +45,17 @@ public sealed class FixpListenerHostedService : BackgroundService
         OrderSubmissionService? submit = null,
         OrderCancelService? cancel = null,
         IUserBotOrderMappingRegistry? botMappings = null,
-        IBotSessionConnectionDirectory? connectionDirectory = null)
+        IBotSessionConnectionDirectory? connectionDirectory = null,
+        BotOutboundCoordinator? outboundCoordinator = null,
+        TimeProvider? clock = null)
     {
         _opts = opts.Value;
         _credentials = credentials;
         _sessions = sessions;
         _logger = logger;
         _connectionDirectory = connectionDirectory;
+        _outboundCoordinator = outboundCoordinator;
+        _clock = clock ?? TimeProvider.System;
         // Sub-issue #171 (E): the order/cancel adapter is only wired when
         // the host has registered the full submit pipeline. Tests (and
         // any future handshake-only mode) leave the deps null and the
@@ -109,7 +115,9 @@ public sealed class FixpListenerHostedService : BackgroundService
                     continue;
                 }
 
-                var conn = new FixpSessionConnection(client, _credentials, _sessions, _logger, _orders, _connectionDirectory);
+                var conn = new FixpSessionConnection(
+                    client, _credentials, _sessions, _logger,
+                    _orders, _connectionDirectory, _outboundCoordinator, _opts, _clock);
                 _ = Task.Run(() => conn.RunAsync(stoppingToken), stoppingToken);
             }
         }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -8,6 +8,7 @@ using B3.Trading.Application.UserBots;
 using B3.Trading.EntryPointListener.Framing;
 using B3.Trading.EntryPointListener.Handshake;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace B3.Trading.EntryPointListener.Hosting;
 
@@ -48,8 +49,33 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
     private readonly IUserBotSessionRegistry _sessions;
     private readonly FixpOrderAdapter? _orders;
     private readonly IBotSessionConnectionDirectory? _connectionDirectory;
+    private readonly BotOutboundCoordinator? _outboundCoordinator;
+    private readonly EntryPointListenerOptions _options;
+    private readonly TimeProvider _clock;
     private readonly string _connectionId;
     private readonly FixpHandshakeStateMachine _sm = new();
+
+    // Sub-issue #173 (G). Inbound/outbound seq state.
+    //
+    // _nextExpectedInboundSeq is the SeqNum the listener expects on the
+    // BusinessHeader.MsgSeqNum of the *next* application message from
+    // the bot. Init=1 per FIXP convention; bumped on every successfully
+    // accepted application message and on every Sequence/RetransmitRequest
+    // that carries a NextSeqNo > our expected (gap detected → emit
+    // NotApplied, re-sync the watermark to the bot's claimed value).
+    //
+    // Application messages carrying MsgSeqNum=0 are treated as "implicit"
+    // by the receiver and consume the expected slot without strict
+    // validation — a mode kept for backward compatibility with the F-era
+    // tests that did not stamp the business header.
+    private long _nextExpectedInboundSeq = 1;
+    // Tick of the most recent outbound write the connection is aware
+    // of (handshake/order-ack/multiplexer push or session-control). Used
+    // by the heartbeat loop to suppress a Sequence emission when the
+    // bot has already observed a real frame within the cadence window.
+    private long _lastOutboundTicks;
+    private CancellationTokenSource? _heartbeatCts;
+    private Task? _heartbeatLoop;
 
     // Outbound-write serialisation for the multiplexer (sub-issue F).
     // The handshake/order-ack writers and the multiplexer's enqueue
@@ -69,15 +95,22 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         IUserBotSessionRegistry sessions,
         ILogger logger,
         FixpOrderAdapter? orders = null,
-        IBotSessionConnectionDirectory? connectionDirectory = null)
+        IBotSessionConnectionDirectory? connectionDirectory = null,
+        BotOutboundCoordinator? outboundCoordinator = null,
+        EntryPointListenerOptions? options = null,
+        TimeProvider? clock = null)
     {
         _tcpClient = tcpClient;
         _credentials = credentials;
         _sessions = sessions;
         _orders = orders;
         _connectionDirectory = connectionDirectory;
+        _outboundCoordinator = outboundCoordinator;
+        _options = options ?? new EntryPointListenerOptions();
+        _clock = clock ?? TimeProvider.System;
         _logger = logger;
         _connectionId = Guid.NewGuid().ToString("N");
+        _lastOutboundTicks = _clock.GetUtcNow().UtcTicks;
     }
 
     public async Task RunAsync(CancellationToken ct)
@@ -135,6 +168,7 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         finally
         {
             _closed = true;
+            StopHeartbeatLoop();
             ArrayPool<byte>.Shared.Return(readBuf);
             // Deregister BEFORE the stream is closed so a racing ER from
             // the multiplexer hot path either sees us in the directory
@@ -199,10 +233,32 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
             case TerminateData.MESSAGE_ID:
                 return await HandleTerminateAsync(stream, frame, ct).ConfigureAwait(false);
 
+            case SequenceData.MESSAGE_ID:
+                if (_sm.State != FixpSessionState.Established) goto default;
+                await HandleInboundSequenceAsync(stream, frame, ct).ConfigureAwait(false);
+                return true;
+
+            case RetransmitRequestData.MESSAGE_ID:
+                if (_sm.State != FixpSessionState.Established) goto default;
+                await HandleInboundRetransmitRequestAsync(stream, frame, ct).ConfigureAwait(false);
+                return true;
+
             case NewOrderSingleData.MESSAGE_ID:
                 if (_sm.State != FixpSessionState.Established) goto default;
                 if (_orders is not null && _scope is not null)
                 {
+                    // Sub-issue #173 (G): track inbound seq via the
+                    // BusinessHeader.MsgSeqNum. Out-of-order forward
+                    // (seq > expected) ⇒ NotApplied (gap signal); the
+                    // current message is still processed (bot's
+                    // idempotent ClOrdId flow swallows true duplicates
+                    // upstream). Backward (seq < expected) ⇒ duplicate,
+                    // suppress dispatch entirely so the order adapter
+                    // does not double-emit a side-effect.
+                    var fresh = await TrackInboundAppMessageAsync(
+                        stream, frame.Payload, NewOrderSingleData.BLOCK_LENGTH, ct).ConfigureAwait(false);
+                    if (!fresh) return true;
+
                     // Sub-issue #172 (F): the order adapter writes ER
                     // acks/rejects directly to the same stream the
                     // multiplexer's TryEnqueue path writes to. Take the
@@ -212,6 +268,7 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
                     {
                         await _orders.HandleNewOrderSingleAsync(stream, frame.Payload, _scope, ct)
                             .ConfigureAwait(false);
+                        TouchOutbound();
                     }
                     finally { _writeMutex.Release(); }
                 }
@@ -221,11 +278,16 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
                 if (_sm.State != FixpSessionState.Established) goto default;
                 if (_orders is not null && _scope is not null)
                 {
+                    var fresh = await TrackInboundAppMessageAsync(
+                        stream, frame.Payload, OrderCancelRequestData.BLOCK_LENGTH, ct).ConfigureAwait(false);
+                    if (!fresh) return true;
+
                     await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
                     try
                     {
                         await _orders.HandleOrderCancelRequestAsync(stream, frame.Payload, _scope, ct)
                             .ConfigureAwait(false);
+                        TouchOutbound();
                     }
                     finally { _writeMutex.Release(); }
                 }
@@ -416,6 +478,12 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
             _connectionDirectory.Register(credentialId, this);
             _registeredInDirectory = true;
         }
+
+        // Sub-issue #173 (G): start the heartbeat loop that emits
+        // Sequence on the configured cadence whenever idle. Started AFTER
+        // directory registration so the loop can read the coordinator's
+        // current outbound seq without racing the first multiplexer push.
+        StartHeartbeatLoop(stream);
         return true;
     }
 
@@ -437,6 +505,302 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         var action = _sm.OnTerminate(in msg);
         await SendActionAsync(stream, action, sid, ver, ct).ConfigureAwait(false);
         return false; // always close after Terminate
+    }
+
+    // ─── Inbound seq tracking (sub-issue G #173) ────────────────────────
+
+    /// <summary>
+    /// Reads the FIXP <c>InboundBusinessHeader.MsgSeqNum</c> off an
+    /// application-message payload and reconciles it against
+    /// <see cref="_nextExpectedInboundSeq"/>. Behaviour:
+    /// <list type="bullet">
+    /// <item>SeqNum == 0 ⇒ "implicit" mode (legacy F-era tests). Just
+    /// bump the watermark; no validation.</item>
+    /// <item>SeqNum &gt; expected ⇒ gap. Emit a <c>NotApplied(from=expected,
+    /// count=delta)</c> framing message to signal the bot, then re-sync
+    /// the watermark to <c>seq+1</c>. The current message is still
+    /// processed downstream (RFC §4.7 — idempotent flow leaves duplicate
+    /// detection to ClOrdId; dropping a reachable order would be worse
+    /// than telling the bot "we missed N earlier ones, here's this
+    /// one").</item>
+    /// <item>SeqNum &lt; expected ⇒ duplicate. Per FIXP idempotent
+    /// recipient convention, log debug and ignore (the application
+    /// layer's ClOrdId uniqueness check will reject any reused id with
+    /// a <c>DuplicateClOrdId</c> business reject anyway).</item>
+    /// <item>SeqNum == expected ⇒ in-order. Bump.</item>
+    /// </list>
+    /// Returns <c>true</c> when the caller should proceed with the
+    /// downstream order-adapter dispatch, <c>false</c> for duplicates
+    /// the caller should swallow.
+    /// </summary>
+    private async Task<bool> TrackInboundAppMessageAsync(
+        NetworkStream stream, byte[] payload, int blockLength, CancellationToken ct)
+    {
+        // The InboundBusinessHeader is the first field of the message
+        // block (offset 0 within the SBE block — see InboundBusinessHeader
+        // and NewOrderSingleData layout). Defensive bounds check first.
+        if (payload.Length < blockLength) return true;
+        var header = MemoryMarshal.Read<InboundBusinessHeader>(payload);
+        var seq = (ulong)header.MsgSeqNum;
+        if (seq == 0)
+        {
+            // Implicit mode — the bot did not stamp an explicit seq. We
+            // still advance the local counter so a later explicit seq is
+            // compared against a sane baseline.
+            Interlocked.Increment(ref _nextExpectedInboundSeq);
+            return true;
+        }
+
+        var expected = (ulong)Interlocked.Read(ref _nextExpectedInboundSeq);
+        if (seq == expected)
+        {
+            Interlocked.Increment(ref _nextExpectedInboundSeq);
+            return true;
+        }
+        if (seq > expected)
+        {
+            var gap = seq - expected;
+            _logger.LogInformation(
+                "fixp.inbound.gap connectionId={ConnectionId} expected={Expected} received={Received} gap={Gap}",
+                _connectionId, expected, seq, gap);
+            await SendNotAppliedAsync(stream, expected, (uint)Math.Min(gap, uint.MaxValue), ct)
+                .ConfigureAwait(false);
+            // Re-sync past the gap AND the current message.
+            Interlocked.Exchange(ref _nextExpectedInboundSeq, (long)(seq + 1));
+            return true;
+        }
+        // seq < expected: duplicate. Idempotent flow: ignore.
+        _logger.LogDebug(
+            "fixp.inbound.duplicate connectionId={ConnectionId} expected={Expected} received={Received}",
+            _connectionId, expected, seq);
+        return false;
+    }
+
+    private async Task HandleInboundSequenceAsync(
+        NetworkStream stream, DecodedFrame frame, CancellationToken ct)
+    {
+        if (frame.Payload.Length < SequenceData.BLOCK_LENGTH) return;
+        var msg = MemoryMarshal.Read<SequenceData>(frame.Payload);
+        var nextSeqNo = (ulong)msg.NextSeqNo;
+        var expected = (ulong)Interlocked.Read(ref _nextExpectedInboundSeq);
+
+        if (nextSeqNo > expected)
+        {
+            var gap = nextSeqNo - expected;
+            _logger.LogInformation(
+                "fixp.inbound.sequence.gap connectionId={ConnectionId} expected={Expected} botNext={BotNext} gap={Gap}",
+                _connectionId, expected, nextSeqNo, gap);
+            await SendNotAppliedAsync(stream, expected, (uint)Math.Min(gap, uint.MaxValue), ct)
+                .ConfigureAwait(false);
+            Interlocked.Exchange(ref _nextExpectedInboundSeq, (long)nextSeqNo);
+        }
+        // nextSeqNo == expected → in-sync, no-op.
+        // nextSeqNo < expected → bot is behind; per FIXP this is a
+        // protocol error but the conservative v0 behaviour is to log
+        // and leave our watermark untouched (the bot will resync via a
+        // subsequent message or Terminate of its own accord).
+        else if (nextSeqNo < expected)
+        {
+            _logger.LogWarning(
+                "fixp.inbound.sequence.behind connectionId={ConnectionId} expected={Expected} botNext={BotNext}",
+                _connectionId, expected, nextSeqNo);
+        }
+    }
+
+    private async Task HandleInboundRetransmitRequestAsync(
+        NetworkStream stream, DecodedFrame frame, CancellationToken ct)
+    {
+        if (frame.Payload.Length < RetransmitRequestData.BLOCK_LENGTH) return;
+        var msg = MemoryMarshal.Read<RetransmitRequestData>(frame.Payload);
+        var sessionId = (uint)msg.SessionID;
+        var requestTs = msg.Timestamp.Time;
+        var fromSeq = (ulong)msg.FromSeqNo;
+        var count = (uint)msg.Count;
+
+        if (_scope is null || _outboundCoordinator is null)
+        {
+            // No outbound state to replay against — should not happen
+            // post-Establish but defensively reject as INVALID_SESSION.
+            await SendRetransmitRejectAsync(stream, sessionId, requestTs,
+                RetransmitRejectCode.INVALID_SESSION, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (fromSeq == 0)
+        {
+            await SendRetransmitRejectAsync(stream, sessionId, requestTs,
+                RetransmitRejectCode.INVALID_FROMSEQNO, ct).ConfigureAwait(false);
+            return;
+        }
+        if (count == 0)
+        {
+            await SendRetransmitRejectAsync(stream, sessionId, requestTs,
+                RetransmitRejectCode.INVALID_COUNT, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var credentialId = _scope.Principal.CredentialId;
+        var currentSeq = _outboundCoordinator.GetCurrentSeq(credentialId);
+        // toInclusive = fromSeq + count - 1; reject when bot asks for
+        // anything past what the allocator has handed out.
+        var toInclusive = fromSeq + count - 1;
+        if (fromSeq > currentSeq || toInclusive > currentSeq)
+        {
+            _logger.LogInformation(
+                "fixp.retransmit.reject reason=INVALID_FROMSEQNO connectionId={ConnectionId} from={From} count={Count} current={Current}",
+                _connectionId, fromSeq, count, currentSeq);
+            await SendRetransmitRejectAsync(stream, sessionId, requestTs,
+                RetransmitRejectCode.INVALID_FROMSEQNO, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var buffer = _outboundCoordinator.GetOrCreateBuffer(credentialId);
+        var range = buffer.GetRange(fromSeq, toInclusive);
+        var allPresent = range.Count == (int)count
+                         && range[0].Seq == fromSeq
+                         && range[^1].Seq == toInclusive;
+        if (!allPresent || buffer.IsOverflowed)
+        {
+            _logger.LogInformation(
+                "fixp.retransmit.reject reason=OUT_OF_RANGE connectionId={ConnectionId} from={From} count={Count} have={Have} overflowed={Overflowed}",
+                _connectionId, fromSeq, count, range.Count, buffer.IsOverflowed);
+            await SendRetransmitRejectAsync(stream, sessionId, requestTs,
+                RetransmitRejectCode.OUT_OF_RANGE, ct).ConfigureAwait(false);
+            return;
+        }
+
+        // Replay in order under the write mutex. The mutex blocks the
+        // multiplexer's TryEnqueue path so a freshly-allocated live ER
+        // cannot land mid-replay and break the bot's seq monotonicity.
+        // The historical seqs and bytes are written as-is — no
+        // re-allocation, no re-framing.
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_closed) return;
+            var framing = OutboundSessionMessageEncoder.EncodeRetransmission(
+                sessionId, requestTs, fromSeq, count);
+            await stream.WriteAsync(framing, ct).ConfigureAwait(false);
+            foreach (var entry in range)
+            {
+                await stream.WriteAsync(entry.Bytes, ct).ConfigureAwait(false);
+            }
+            TouchOutbound();
+            _logger.LogInformation(
+                "fixp.retransmit.replay connectionId={ConnectionId} from={From} count={Count}",
+                _connectionId, fromSeq, count);
+        }
+        finally
+        {
+            _writeMutex.Release();
+        }
+    }
+
+    private async Task SendNotAppliedAsync(
+        NetworkStream stream, ulong fromSeqNo, uint count, CancellationToken ct)
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeNotApplied(fromSeqNo, count);
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_closed) return;
+            await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            TouchOutbound();
+        }
+        finally { _writeMutex.Release(); }
+    }
+
+    private async Task SendRetransmitRejectAsync(
+        NetworkStream stream, uint sessionId, ulong requestTimestamp,
+        RetransmitRejectCode code, CancellationToken ct)
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeRetransmitReject(
+            sessionId, requestTimestamp, code);
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_closed) return;
+            await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            TouchOutbound();
+        }
+        finally { _writeMutex.Release(); }
+    }
+
+    /// <summary>
+    /// Server→bot heartbeat <c>Sequence(NextSeqNo)</c> emitted on the
+    /// configured cadence whenever no real outbound frame has been sent
+    /// inside the last cadence window. Lets the bot detect server-side
+    /// gaps (its expected vs <c>NextSeqNo</c>) and lets B3-style
+    /// keepalive timers stay live during quiet periods. Disabled when
+    /// <see cref="EntryPointListenerOptions.HeartbeatIntervalMs"/> ≤ 0.
+    /// </summary>
+    private void StartHeartbeatLoop(NetworkStream stream)
+    {
+        var intervalMs = _options.HeartbeatIntervalMs;
+        if (intervalMs <= 0) return;
+        var interval = TimeSpan.FromMilliseconds(intervalMs);
+        _heartbeatCts = new CancellationTokenSource();
+        _heartbeatLoop = Task.Run(async () =>
+        {
+            var ct = _heartbeatCts.Token;
+            try
+            {
+                while (!ct.IsCancellationRequested && !_closed)
+                {
+                    await Task.Delay(interval, _clock, ct).ConfigureAwait(false);
+                    if (_closed) return;
+                    var sinceLast = _clock.GetUtcNow().UtcTicks - Interlocked.Read(ref _lastOutboundTicks);
+                    if (sinceLast < interval.Ticks) continue; // piggyback: a real frame already went out
+                    await SendHeartbeatSequenceAsync(stream, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { /* shutdown */ }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "fixp.heartbeat.loop.error connectionId={ConnectionId}", _connectionId);
+            }
+        });
+    }
+
+    private async Task SendHeartbeatSequenceAsync(NetworkStream stream, CancellationToken ct)
+    {
+        if (_scope is null || _outboundCoordinator is null) return;
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_closed) return;
+            // Re-check piggyback under the mutex: a live ER could have
+            // queued and acquired the mutex while we were waiting; in
+            // that case it has already advertised the latest seq and a
+            // heartbeat now would be redundant (and would race the
+            // current-seq read below against any not-yet-flushed ER on
+            // a sibling thread).
+            var interval = TimeSpan.FromMilliseconds(
+                _options?.HeartbeatIntervalMs ?? 3000);
+            var sinceLast = _clock.GetUtcNow().UtcTicks - Interlocked.Read(ref _lastOutboundTicks);
+            if (sinceLast < interval.Ticks) return;
+
+            var current = _outboundCoordinator.GetCurrentSeq(_scope.Principal.CredentialId);
+            var nextSeq = current + 1;
+            var bytes = OutboundSessionMessageEncoder.EncodeSequence(nextSeq);
+            await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            TouchOutbound();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "fixp.heartbeat.send.error connectionId={ConnectionId}", _connectionId);
+        }
+        finally { _writeMutex.Release(); }
+    }
+
+    private void TouchOutbound()
+        => Interlocked.Exchange(ref _lastOutboundTicks, _clock.GetUtcNow().UtcTicks);
+
+    private void StopHeartbeatLoop()
+    {
+        try { _heartbeatCts?.Cancel(); } catch { /* ignore */ }
+        try { _heartbeatCts?.Dispose(); } catch { /* ignore */ }
+        _heartbeatCts = null;
     }
 
     // ─── Async response writers ──────────────────────────────────────────
@@ -669,6 +1033,7 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
             {
                 if (_closed) return;
                 await stream.WriteAsync(framedBytes, CancellationToken.None).ConfigureAwait(false);
+                TouchOutbound();
             }
             catch (Exception ex)
             {
@@ -688,6 +1053,7 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
     {
         // Used by the multiplexer's overflow path to force-close.
         _closed = true;
+        StopHeartbeatLoop();
         try { _stream?.Close(); } catch { /* ignore */ }
         try { _tcpClient.Close(); } catch { /* ignore */ }
         _writeMutex.Dispose();

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundSessionMessageEncoder.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundSessionMessageEncoder.cs
@@ -1,0 +1,128 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// Sub-issue #173 (G). Pre-frames the FIXP session-control messages the
+/// listener sends after Establish (heartbeat <c>Sequence</c>, gap-signal
+/// <c>NotApplied</c>, retransmit responses). Mirrors the per-write
+/// <c>ArrayPool</c> shape used by <see cref="OutboundExecutionReportEncoder"/>
+/// so all encoded bytes are heap arrays sized exactly to the frame —
+/// the caller decides whether to ship them via the multiplexer's
+/// <see cref="IBotSessionOutboundSender"/> path or the connection's
+/// owning write mutex.
+/// </summary>
+internal static class OutboundSessionMessageEncoder
+{
+    private const ushort SchemaIdV6 = 1;
+
+    // FIXP session-control messages are schema-version 6 in V6 except
+    // Terminate which is left at version 0 to match B/D/E/F's existing
+    // wire fingerprints — see FixpSessionConnection.WriteTerminateAsync.
+    private const ushort VersionSequence = 6;
+    private const ushort VersionNotApplied = 6;
+    private const ushort VersionRetransmission = 6;
+    private const ushort VersionRetransmitReject = 6;
+
+    /// <summary>
+    /// Encodes a SOFH-framed <c>Sequence(NextSeqNo)</c>. Used for
+    /// per-connection heartbeat (RFC §4.7) and as the framing message
+    /// every <c>Retransmission</c> response is preceded by per FIXP
+    /// (NextSeqNo = the seq of the first replayed message).
+    /// </summary>
+    public static byte[] EncodeSequence(ulong nextSeqNo)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(SequenceData.BLOCK_LENGTH);
+        var buf = new byte[frameSize];
+        Span<byte> body = stackalloc byte[SequenceData.BLOCK_LENGTH];
+        body.Clear();
+        ref var msg = ref MemoryMarshal.AsRef<SequenceData>(body);
+        msg.NextSeqNo = (SeqNum)nextSeqNo;
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)SequenceData.BLOCK_LENGTH,
+            (ushort)SequenceData.MESSAGE_ID,
+            SchemaIdV6, VersionSequence,
+            body);
+        return buf;
+    }
+
+    /// <summary>
+    /// Encodes a SOFH-framed <c>NotApplied(FromSeqNo, Count)</c>. The
+    /// listener emits this when it observes an inbound seq gap from the
+    /// bot (RFC §4.7). NotApplied is informational on B3's idempotent
+    /// trade-entry flow — the bot is expected to reconcile via REST
+    /// rather than retransmit gaped seqs (new-order retries would
+    /// duplicate ClOrdIds).
+    /// </summary>
+    public static byte[] EncodeNotApplied(ulong fromSeqNo, uint count)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(NotAppliedData.BLOCK_LENGTH);
+        var buf = new byte[frameSize];
+        Span<byte> body = stackalloc byte[NotAppliedData.BLOCK_LENGTH];
+        body.Clear();
+        ref var msg = ref MemoryMarshal.AsRef<NotAppliedData>(body);
+        msg.FromSeqNo = (SeqNum)fromSeqNo;
+        msg.Count = (MessageCounter)count;
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)NotAppliedData.BLOCK_LENGTH,
+            (ushort)NotAppliedData.MESSAGE_ID,
+            SchemaIdV6, VersionNotApplied,
+            body);
+        return buf;
+    }
+
+    /// <summary>
+    /// Encodes a SOFH-framed <c>Retransmission(SessionID, RequestTimestamp,
+    /// NextSeqNo, Count)</c>. Per FIXP V6 a Retransmission is a framing
+    /// message that precedes the actual replayed application messages on
+    /// the wire — the bot's parser uses it to know how many of the
+    /// frames immediately following are part of the replay window.
+    /// </summary>
+    public static byte[] EncodeRetransmission(
+        uint sessionId, ulong requestTimestampNanos, ulong nextSeqNo, uint count)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(RetransmissionData.BLOCK_LENGTH);
+        var buf = new byte[frameSize];
+        Span<byte> body = stackalloc byte[RetransmissionData.BLOCK_LENGTH];
+        body.Clear();
+        ref var msg = ref MemoryMarshal.AsRef<RetransmissionData>(body);
+        msg.SessionID = (SessionID)sessionId;
+        msg.RequestTimestamp = new UTCTimestampNanos { Time = requestTimestampNanos };
+        msg.NextSeqNo = (SeqNum)nextSeqNo;
+        msg.Count = (MessageCounter)count;
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)RetransmissionData.BLOCK_LENGTH,
+            (ushort)RetransmissionData.MESSAGE_ID,
+            SchemaIdV6, VersionRetransmission,
+            body);
+        return buf;
+    }
+
+    /// <summary>
+    /// Encodes a SOFH-framed <c>RetransmitReject(SessionID,
+    /// RequestTimestamp, RetransmitRejectCode)</c>. The reject code is
+    /// the SBE enum value as-is — see <see cref="RetransmitRejectCode"/>
+    /// for the full set the schema accepts.
+    /// </summary>
+    public static byte[] EncodeRetransmitReject(
+        uint sessionId, ulong requestTimestampNanos, RetransmitRejectCode code)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(RetransmitRejectData.BLOCK_LENGTH);
+        var buf = new byte[frameSize];
+        Span<byte> body = stackalloc byte[RetransmitRejectData.BLOCK_LENGTH];
+        body.Clear();
+        ref var msg = ref MemoryMarshal.AsRef<RetransmitRejectData>(body);
+        msg.SessionID = (SessionID)sessionId;
+        msg.RequestTimestamp = new UTCTimestampNanos { Time = requestTimestampNanos };
+        msg.RetransmitRejectCode = code;
+        SofhFrameWriter.WriteFrame(buf,
+            (ushort)RetransmitRejectData.BLOCK_LENGTH,
+            (ushort)RetransmitRejectData.MESSAGE_ID,
+            SchemaIdV6, VersionRetransmitReject,
+            body);
+        return buf;
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/OutboundSessionMessageEncoderTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/OutboundSessionMessageEncoderTests.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Framing;
+using B3.Trading.EntryPointListener.Hosting;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Sub-issue #173 (G). Encoder tests assert wire-shape conformance for
+/// the four session-control messages the listener emits post-Establish:
+/// Sequence, NotApplied, Retransmission, RetransmitReject.
+///
+/// <para>Each test rebuilds the encoded frame, parses it through the
+/// SOFH framer + the matching SBE reader, and asserts the round-tripped
+/// fields. This is the same pattern B/D/E/F use for Negotiate/Establish.</para>
+/// </summary>
+public class OutboundSessionMessageEncoderTests
+{
+    private static (ushort templateId, byte[] payload) ReadOneFrame(byte[] frame)
+    {
+        var reader = new SofhFrameReader();
+        reader.Append(frame);
+        Assert.True(reader.TryReadFrame(out var f));
+        return (f.TemplateId, f.Payload.ToArray());
+    }
+
+    [Fact]
+    public void EncodeSequence_RoundTrips_NextSeqNo()
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeSequence(nextSeqNo: 42);
+        var (id, payload) = ReadOneFrame(bytes);
+        Assert.Equal((ushort)SequenceData.MESSAGE_ID, id);
+        var msg = MemoryMarshal.Read<SequenceData>(payload);
+        Assert.Equal(42UL, (ulong)msg.NextSeqNo);
+    }
+
+    [Fact]
+    public void EncodeNotApplied_RoundTrips_FromAndCount()
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeNotApplied(fromSeqNo: 10, count: 5);
+        var (id, payload) = ReadOneFrame(bytes);
+        Assert.Equal((ushort)NotAppliedData.MESSAGE_ID, id);
+        var msg = MemoryMarshal.Read<NotAppliedData>(payload);
+        Assert.Equal(10UL, (ulong)msg.FromSeqNo);
+        Assert.Equal(5U, (uint)msg.Count);
+    }
+
+    [Fact]
+    public void EncodeRetransmission_RoundTrips_AllFields()
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeRetransmission(
+            sessionId: 7, requestTimestampNanos: 1_700_000_000_000UL, nextSeqNo: 100, count: 3);
+        var (id, payload) = ReadOneFrame(bytes);
+        Assert.Equal((ushort)RetransmissionData.MESSAGE_ID, id);
+        var msg = MemoryMarshal.Read<RetransmissionData>(payload);
+        Assert.Equal(7U, (uint)msg.SessionID);
+        Assert.Equal(1_700_000_000_000UL, msg.RequestTimestamp.Time);
+        Assert.Equal(100UL, (ulong)msg.NextSeqNo);
+        Assert.Equal(3U, (uint)msg.Count);
+    }
+
+    [Theory]
+    [InlineData(RetransmitRejectCode.OUT_OF_RANGE)]
+    [InlineData(RetransmitRejectCode.INVALID_FROMSEQNO)]
+    [InlineData(RetransmitRejectCode.INVALID_COUNT)]
+    [InlineData(RetransmitRejectCode.INVALID_SESSION)]
+    public void EncodeRetransmitReject_RoundTrips_Code(RetransmitRejectCode code)
+    {
+        var bytes = OutboundSessionMessageEncoder.EncodeRetransmitReject(
+            sessionId: 9, requestTimestampNanos: 12345UL, code);
+        var (id, payload) = ReadOneFrame(bytes);
+        Assert.Equal((ushort)RetransmitRejectData.MESSAGE_ID, id);
+        var msg = MemoryMarshal.Read<RetransmitRejectData>(payload);
+        Assert.Equal(9U, (uint)msg.SessionID);
+        Assert.Equal(12345UL, msg.RequestTimestamp.Time);
+        Assert.Equal(code, msg.RetransmitRejectCode);
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpRetransmitIntegrationTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpRetransmitIntegrationTests.cs
@@ -1,0 +1,681 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Framing;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.EntryPointListener.Tests.Integration;
+
+/// <summary>
+/// Sub-issue #173 (G). End-to-end retransmit + heartbeat + inbound-gap
+/// tests over a real TCP socket. Builds on F's harness in
+/// <see cref="FixpListenerIntegrationTests"/> but wires the
+/// <see cref="BotOutboundCoordinator"/> + <see cref="IBotSessionConnectionDirectory"/>
+/// directly so tests can simulate ER pushes without spinning up the
+/// full <see cref="BotErMultiplexer"/> route loop.
+/// </summary>
+public class FixpRetransmitIntegrationTests
+{
+    private const ushort SchemaIdV6 = 1;
+
+    private sealed record HostBundle(
+        IHost Host,
+        FixpListenerHostedService Listener,
+        InMemoryUserBotCredentialRegistry Credentials,
+        InMemoryUserBotSessionRegistry Sessions,
+        BotOutboundCoordinator Coordinator,
+        IBotSessionConnectionDirectory Directory);
+
+    private static HostBundle BuildHost(int heartbeatMs = 0)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:EntryPointListener:Enabled"] = "true",
+                ["Trading:EntryPointListener:Endpoint"] = "127.0.0.1:0",
+                ["Trading:EntryPointListener:HeartbeatIntervalMs"] = heartbeatMs.ToString(),
+            })
+            .Build();
+
+        var host = new HostBuilder()
+            .ConfigureServices((_, s) =>
+            {
+                s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                s.AddSingleton<InMemoryUserBotCredentialRegistry>();
+                s.AddSingleton<IUserBotCredentialRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
+                s.AddSingleton<InMemoryUserBotSessionRegistry>();
+                s.AddSingleton<IUserBotSessionRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
+                s.AddEntryPointListener(config);
+            })
+            .Build();
+
+        return new HostBundle(
+            host,
+            host.Services.GetRequiredService<FixpListenerHostedService>(),
+            host.Services.GetRequiredService<InMemoryUserBotCredentialRegistry>(),
+            host.Services.GetRequiredService<InMemoryUserBotSessionRegistry>(),
+            host.Services.GetRequiredService<BotOutboundCoordinator>(),
+            host.Services.GetRequiredService<IBotSessionConnectionDirectory>());
+    }
+
+    // ─── Wire helpers ────────────────────────────────────────────────────
+
+    private static byte[] BuildNegotiateFrame(uint sessionId, ulong sessionVerId, string token)
+    {
+        var tokenBytes = Encoding.UTF8.GetBytes(token);
+        var bodyLen = NegotiateData.BLOCK_LENGTH + 1 + tokenBytes.Length;
+        var body = new byte[bodyLen];
+        ref var msg = ref MemoryMarshal.AsRef<NegotiateData>(body.AsSpan(0, NegotiateData.BLOCK_LENGTH));
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        body[NegotiateData.BLOCK_LENGTH] = (byte)tokenBytes.Length;
+        tokenBytes.CopyTo(body, NegotiateData.BLOCK_LENGTH + 1);
+        return WrapFrame((ushort)NegotiateData.BLOCK_LENGTH, (ushort)NegotiateData.MESSAGE_ID, version: 6, body);
+    }
+
+    private static byte[] BuildEstablishFrame(uint sessionId, ulong sessionVerId)
+    {
+        var body = new byte[EstablishData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<EstablishData>(body.AsSpan());
+        msg.SessionID = (SessionID)sessionId;
+        msg.SessionVerID = (SessionVerID)sessionVerId;
+        return WrapFrame((ushort)EstablishData.BLOCK_LENGTH, (ushort)EstablishData.MESSAGE_ID, version: 6, body);
+    }
+
+    private static byte[] BuildRetransmitRequestFrame(uint sessionId, ulong fromSeqNo, uint count)
+    {
+        var body = new byte[RetransmitRequestData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<RetransmitRequestData>(body.AsSpan());
+        msg.SessionID = (SessionID)sessionId;
+        msg.Timestamp = new UTCTimestampNanos { Time = 999UL };
+        msg.FromSeqNo = (SeqNum)fromSeqNo;
+        msg.Count = (MessageCounter)count;
+        return WrapFrame((ushort)RetransmitRequestData.BLOCK_LENGTH, (ushort)RetransmitRequestData.MESSAGE_ID, version: 6, body);
+    }
+
+    private static byte[] BuildSequenceFrame(ulong nextSeqNo)
+    {
+        var body = new byte[SequenceData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<SequenceData>(body.AsSpan());
+        msg.NextSeqNo = (SeqNum)nextSeqNo;
+        return WrapFrame((ushort)SequenceData.BLOCK_LENGTH, (ushort)SequenceData.MESSAGE_ID, version: 6, body);
+    }
+
+    private static byte[] WrapFrame(ushort blockLength, ushort messageId, ushort version, byte[] body)
+    {
+        var frameSize = SofhFrameWriter.FrameSize(body.Length);
+        var buf = new byte[frameSize];
+        SofhFrameWriter.WriteFrame(buf, blockLength, messageId, SchemaIdV6, version, body);
+        return buf;
+    }
+
+    /// <summary>
+    /// Builds a synthetic "ER-shaped" framed payload — for retransmit
+    /// purposes the listener treats the buffered bytes as opaque, so any
+    /// well-formed SOFH frame works. Embeds a discriminator byte after
+    /// the SOFH header so tests can prove specific entries were replayed
+    /// in order.
+    /// </summary>
+    private static byte[] BuildFakeEr(byte tag)
+    {
+        var body = new byte[8];
+        body[0] = tag;
+        return WrapFrame(blockLength: 8, messageId: (ushort)ExecutionReport_NewData.MESSAGE_ID, version: 6, body);
+    }
+
+    private readonly record struct FrameData(bool IsValid, ushort TemplateId, byte[] Payload);
+
+    private static async Task<FrameData> ReadFrameAsync(
+        SofhFrameReader reader, NetworkStream stream, CancellationToken ct)
+    {
+        var buf = new byte[4096];
+        while (true)
+        {
+            if (reader.TryReadFrame(out var frame))
+                return new FrameData(true, frame.TemplateId, frame.Payload.ToArray());
+            if (reader.HasProtocolError) return default;
+            var n = await stream.ReadAsync(buf, ct).ConfigureAwait(false);
+            if (n == 0) return default;
+            reader.Append(buf.AsSpan(0, n));
+        }
+    }
+
+    private static async Task<TcpClient> ConnectAsync(IPEndPoint endpoint, CancellationToken ct)
+    {
+        var c = new TcpClient();
+        await c.ConnectAsync(endpoint.Address, endpoint.Port, ct).ConfigureAwait(false);
+        return c;
+    }
+
+    private static async Task<(TcpClient, NetworkStream, SofhFrameReader)> EstablishAsync(
+        HostBundle bundle, IPEndPoint endpoint, string token, BotSessionState state, CancellationToken ct)
+    {
+        var tcp = await ConnectAsync(endpoint, ct);
+        var stream = tcp.GetStream();
+        var reader = new SofhFrameReader();
+        await stream.WriteAsync(BuildNegotiateFrame(state.SessionId, state.CurrentVer, token), ct);
+        var neg = await ReadFrameAsync(reader, stream, ct);
+        Assert.Equal((ushort)NegotiateResponseData.MESSAGE_ID, neg.TemplateId);
+        await stream.WriteAsync(BuildEstablishFrame(state.SessionId, state.CurrentVer), ct);
+        var ack = await ReadFrameAsync(reader, stream, ct);
+        Assert.Equal((ushort)EstablishAckData.MESSAGE_ID, ack.TemplateId);
+        return (tcp, stream, reader);
+    }
+
+    /// <summary>
+    /// Polls until <see cref="IBotSessionConnectionDirectory.TryGet"/>
+    /// returns the connected sender — directory registration runs after
+    /// EstablishAck is sent, so the test client may observe the ack
+    /// before the listener finishes registering.
+    /// </summary>
+    private static async Task<IBotSessionOutboundSender> WaitForSenderAsync(
+        IBotSessionConnectionDirectory dir, Guid credId, CancellationToken ct)
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            if (dir.TryGet(credId, out var s)) return s;
+            await Task.Delay(20, ct);
+        }
+        throw new TimeoutException("Sender never registered.");
+    }
+
+    /// <summary>
+    /// Per-credential helper that allocates a seq, appends the framed
+    /// bytes to the buffer, and pushes through the live sender — the
+    /// same triple of effects the multiplexer's RouteOne path performs,
+    /// but synchronous so tests do not need to drain a channel.
+    /// </summary>
+    private static void EnqueueAndBuffer(
+        BotOutboundCoordinator coord, IBotSessionOutboundSender sender, Guid credId, byte[] framed)
+    {
+        var seq = coord.AllocateNext(credId);
+        coord.GetOrCreateBuffer(credId).Append(seq, framed);
+        sender.TryEnqueue(framed);
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 15_000)]
+    public async Task RetransmitRequest_AllInBuffer_ReplaysHistoricalBytesInOrder()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-r1", "retx-replay", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t1 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t1_tcp = __t1.Item1; var stream = __t1.Item2; var reader = __t1.Item3;
+
+            var sender = await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Push 5 ER-shaped frames live (seqs 1..5). Read each frame
+            // back off the wire BEFORE pushing the next so the test
+            // controls the buffer's seq→bytes mapping deterministically;
+            // the F-era TryEnqueue path runs each push as a fire-and-
+            // forget Task whose mutex acquisition order, when many are
+            // queued back-to-back, is FIFO at SemaphoreSlim but not
+            // guaranteed at Task.Run scheduling, so a tight loop without
+            // reads in between can land bytes out of allocation order.
+            var live = new byte[5][];
+            for (byte i = 0; i < 5; i++)
+            {
+                live[i] = BuildFakeEr(tag: (byte)(0xA0 + i));
+                EnqueueAndBuffer(bundle.Coordinator, sender, created.Credential.Id, live[i]);
+                var f = await ReadFrameAsync(reader, stream, cts.Token);
+                Assert.Equal((ushort)ExecutionReport_NewData.MESSAGE_ID, f.TemplateId);
+                Assert.Equal((byte)(0xA0 + i), f.Payload[0]);
+            }
+
+            // Ask for seqs 2..3 inclusive (from=2, count=2).
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 2, count: 2), cts.Token);
+
+            // Server responds with Retransmission(NextSeqNo=2, Count=2)
+            // followed by the original frames for seqs 2 and 3 verbatim.
+            var rt = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)RetransmissionData.MESSAGE_ID, rt.TemplateId);
+            var rtMsg = MemoryMarshal.Read<RetransmissionData>(rt.Payload);
+            Assert.Equal(2UL, (ulong)rtMsg.NextSeqNo);
+            Assert.Equal(2U, (uint)rtMsg.Count);
+
+            var replay1 = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((byte)(0xA0 + 1), replay1.Payload[0]);
+            var replay2 = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((byte)(0xA0 + 2), replay2.Payload[0]);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task RetransmitRequest_AboveCurrent_RejectsInvalidFromSeqNo()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-r2", "retx-above", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t2 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t2_tcp = __t2.Item1; var stream = __t2.Item2; var reader = __t2.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Outbound seq is 0 (no ERs sent). Asking for seq 1 is above current.
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 1, count: 1), cts.Token);
+
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)RetransmitRejectData.MESSAGE_ID, resp.TemplateId);
+            var rej = MemoryMarshal.Read<RetransmitRejectData>(resp.Payload);
+            Assert.Equal(RetransmitRejectCode.INVALID_FROMSEQNO, rej.RetransmitRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task RetransmitRequest_BelowBufferFloor_RejectsOutOfRange()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-r3", "retx-floor", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t3 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t3_tcp = __t3.Item1; var stream = __t3.Item2; var reader = __t3.Item3;
+            var sender = await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Allocate seqs 1..5 then evict 1..3 — buffer floor is now 4.
+            for (byte i = 0; i < 5; i++)
+            {
+                var b = BuildFakeEr((byte)(0xB0 + i));
+                EnqueueAndBuffer(bundle.Coordinator, sender, created.Credential.Id, b);
+                _ = await ReadFrameAsync(reader, stream, cts.Token);
+            }
+            bundle.Coordinator.GetOrCreateBuffer(created.Credential.Id).EvictUpTo(3);
+
+            // Asking for seq 2 (below floor=4) → OUT_OF_RANGE.
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 2, count: 1), cts.Token);
+
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)RetransmitRejectData.MESSAGE_ID, resp.TemplateId);
+            var rej = MemoryMarshal.Read<RetransmitRejectData>(resp.Payload);
+            Assert.Equal(RetransmitRejectCode.OUT_OF_RANGE, rej.RetransmitRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task RetransmitRequest_ZeroFromSeqNo_RejectsInvalidFromSeqNo()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-r4", "retx-zero", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t4 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t4_tcp = __t4.Item1; var stream = __t4.Item2; var reader = __t4.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 0, count: 1), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)RetransmitRejectData.MESSAGE_ID, resp.TemplateId);
+            var rej = MemoryMarshal.Read<RetransmitRejectData>(resp.Payload);
+            Assert.Equal(RetransmitRejectCode.INVALID_FROMSEQNO, rej.RetransmitRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task RetransmitRequest_ZeroCount_RejectsInvalidCount()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-r5", "retx-zero-count", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t5 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t5_tcp = __t5.Item1; var stream = __t5.Item2; var reader = __t5.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 1, count: 0), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)RetransmitRejectData.MESSAGE_ID, resp.TemplateId);
+            var rej = MemoryMarshal.Read<RetransmitRejectData>(resp.Payload);
+            Assert.Equal(RetransmitRejectCode.INVALID_COUNT, rej.RetransmitRejectCode);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task InboundSequence_GapDetected_NotAppliedSent()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-g1", "gap", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t6 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t6_tcp = __t6.Item1; var stream = __t6.Item2; var reader = __t6.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Bot claims its next outbound is 6; server expected 1 → gap of 5.
+            await stream.WriteAsync(BuildSequenceFrame(nextSeqNo: 6), cts.Token);
+            var resp = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)NotAppliedData.MESSAGE_ID, resp.TemplateId);
+            var na = MemoryMarshal.Read<NotAppliedData>(resp.Payload);
+            Assert.Equal(1UL, (ulong)na.FromSeqNo);
+            Assert.Equal(5U, (uint)na.Count);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task InboundSequence_InOrder_NoGapSignalled()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        // Disable heartbeat so the test only sees what we send back.
+        var bundle = BuildHost(heartbeatMs: 0);
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-g2", "in-order", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t7 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t7_tcp = __t7.Item1; var stream = __t7.Item2; var reader = __t7.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Bot's NextSeqNo == server's expected (1). No NotApplied
+            // should be emitted. Then send a Sequence(2) which is also
+            // in-sync after no app messages — still no NotApplied.
+            await stream.WriteAsync(BuildSequenceFrame(nextSeqNo: 1), cts.Token);
+            // Give the server a moment to (not) react.
+            using var shortCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, shortCts.Token);
+            try
+            {
+                var f = await ReadFrameAsync(reader, stream, linked.Token);
+                // Anything received is a failure.
+                Assert.Fail($"Unexpected frame received: template={f.TemplateId}");
+            }
+            catch (OperationCanceledException) when (shortCts.IsCancellationRequested)
+            {
+                // Expected: no frame within timeout.
+            }
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task Heartbeat_IdleConnection_EmitsSequenceOnCadence()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost(heartbeatMs: 200);
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-h1", "heartbeat", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t8 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t8_tcp = __t8.Item1; var stream = __t8.Item2; var reader = __t8.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Wait for at least one heartbeat tick.
+            var hb = await ReadFrameAsync(reader, stream, cts.Token);
+            Assert.Equal((ushort)SequenceData.MESSAGE_ID, hb.TemplateId);
+            var seq = MemoryMarshal.Read<SequenceData>(hb.Payload);
+            // No ERs sent → current outbound seq is 0 → NextSeqNo is 1.
+            Assert.Equal(1UL, (ulong)seq.NextSeqNo);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 15_000)]
+    public async Task ConcurrentLiveErAndRetransmit_NoInterleavingOnWire()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-c1", "concurrent", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            var __t9 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t9_tcp = __t9.Item1; var stream = __t9.Item2; var reader = __t9.Item3;
+            var sender = await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Buffer 10 historical ERs first (seqs 1..10) and consume them.
+            for (byte i = 0; i < 10; i++)
+            {
+                var b = BuildFakeEr((byte)(0xC0 + i));
+                EnqueueAndBuffer(bundle.Coordinator, sender, created.Credential.Id, b);
+            }
+            for (var i = 0; i < 10; i++)
+                _ = await ReadFrameAsync(reader, stream, cts.Token);
+
+            // Kick off a retransmit AND a flood of live ERs concurrently.
+            await stream.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 3, count: 5), cts.Token);
+            var liveTask = Task.Run(() =>
+            {
+                for (byte i = 0; i < 20; i++)
+                {
+                    var b = BuildFakeEr((byte)(0xD0 + i));
+                    EnqueueAndBuffer(bundle.Coordinator, sender, created.Credential.Id, b);
+                }
+            });
+
+            // Read everything that arrives until we observe both:
+            //   - The Retransmission framing frame + its 5 historical bytes.
+            //   - All 20 new live ERs.
+            // Assert the historical bytes appear contiguously after the
+            // Retransmission and the live ERs are not interleaved into
+            // the historical stream (FIXP wire-order invariant).
+            var seenLive = new List<byte>();
+            var historical = new List<byte>();
+            var sawRetransmission = false;
+            var historicalRemaining = 0;
+            var endTime = DateTime.UtcNow.AddSeconds(8);
+            while ((seenLive.Count < 20 || historical.Count < 5) && DateTime.UtcNow < endTime)
+            {
+                var f = await ReadFrameAsync(reader, stream, cts.Token);
+                if (f.TemplateId == (ushort)RetransmissionData.MESSAGE_ID)
+                {
+                    Assert.False(sawRetransmission, "Two Retransmission framing messages observed.");
+                    sawRetransmission = true;
+                    historicalRemaining = (int)(uint)MemoryMarshal.Read<RetransmissionData>(f.Payload).Count;
+                    continue;
+                }
+                if (sawRetransmission && historicalRemaining > 0)
+                {
+                    historical.Add(f.Payload[0]);
+                    historicalRemaining--;
+                    continue;
+                }
+                seenLive.Add(f.Payload[0]);
+            }
+            await liveTask;
+
+            Assert.True(sawRetransmission);
+            Assert.Equal(5, historical.Count);
+            // Historical bytes must be exactly seqs 3..7 in order
+            // (tags 0xC2..0xC6) — re-numbering or interleaving would
+            // break this.
+            Assert.Equal(new byte[] { 0xC2, 0xC3, 0xC4, 0xC5, 0xC6 }, historical.ToArray());
+            // Live tags are a subset of 0xD0..0xD3+ in arrival order;
+            // we only assert monotonic-by-arrival because the producer
+            // is faster than the consumer and the channel is FIFO per
+            // sender — the test's contract is "no interleave with the
+            // historical block", which the contiguity check above proved.
+            Assert.Equal(20, seenLive.Count);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    [Fact(Timeout = 20_000)]
+    public async Task DisconnectAndReconnect_RetransmitCoversNewlyBufferedRange()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(18));
+        var bundle = BuildHost();
+        try
+        {
+            await bundle.Host.StartAsync(cts.Token);
+            var endpoint = await bundle.Listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            var created = await bundle.Credentials.CreateAsync("user-rc", "reconnect", cts.Token);
+            var state = await bundle.Sessions.GetOrCreateAsync(created.Credential.Id, cts.Token);
+
+            // First connection: receive 2 ERs, then disconnect.
+            {
+                var __t10 = await EstablishAsync(
+                    bundle, endpoint, created.PlainToken, state, cts.Token); using var tcp = __t10.Item1; var stream = __t10.Item2; var reader = __t10.Item3;
+                var sender = await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+                for (byte i = 0; i < 2; i++)
+                {
+                    var b = BuildFakeEr((byte)(0xE0 + i));
+                    EnqueueAndBuffer(bundle.Coordinator, sender, created.Credential.Id, b);
+                    _ = await ReadFrameAsync(reader, stream, cts.Token);
+                }
+                tcp.Close();
+            }
+
+            // While offline buffer 3 more ERs (seqs 3..5). The
+            // connection directory / single-active slot must release
+            // before the reconnect can claim it.
+            await Task.Delay(200, cts.Token);
+            for (byte i = 0; i < 3; i++)
+            {
+                var b = BuildFakeEr((byte)(0xE2 + i));
+                var seq = bundle.Coordinator.AllocateNext(created.Credential.Id);
+                bundle.Coordinator.GetOrCreateBuffer(created.Credential.Id).Append(seq, b);
+            }
+            for (var i = 0; i < 50 && bundle.Directory.TryGet(created.Credential.Id, out _); i++)
+                await Task.Delay(20, cts.Token);
+
+            // Reconnect (need to wait for slot release).
+            for (var i = 0; i < 100; i++)
+            {
+                if (await bundle.Sessions.TryClaimActiveAsync(created.Credential.Id, state.CurrentVer, $"probe-{i}", cts.Token))
+                {
+                    await bundle.Sessions.ReleaseAsync(created.Credential.Id, $"probe-{i}", cts.Token);
+                    break;
+                }
+                await Task.Delay(20, cts.Token);
+            }
+
+            var __t11 = await EstablishAsync(
+                bundle, endpoint, created.PlainToken, state, cts.Token); using var __t11_tcp = __t11.Item1; var stream2 = __t11.Item2; var reader2 = __t11.Item3;
+            await WaitForSenderAsync(bundle.Directory, created.Credential.Id, cts.Token);
+
+            // Ask for the buffered tail: seqs 3..5.
+            await stream2.WriteAsync(
+                BuildRetransmitRequestFrame(state.SessionId, fromSeqNo: 3, count: 3), cts.Token);
+
+            var rt = await ReadFrameAsync(reader2, stream2, cts.Token);
+            Assert.Equal((ushort)RetransmissionData.MESSAGE_ID, rt.TemplateId);
+            var f1 = await ReadFrameAsync(reader2, stream2, cts.Token);
+            var f2 = await ReadFrameAsync(reader2, stream2, cts.Token);
+            var f3 = await ReadFrameAsync(reader2, stream2, cts.Token);
+            Assert.Equal((byte)0xE2, f1.Payload[0]);
+            Assert.Equal((byte)0xE3, f2.Payload[0]);
+            Assert.Equal((byte)0xE4, f3.Payload[0]);
+        }
+        finally
+        {
+            await bundle.Host.StopAsync(CancellationToken.None);
+            bundle.Host.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tiny adaptor — <c>using var (a, b, c) = ...</c> requires either a
+    /// tuple-typed expression with each element implementing IDisposable
+    /// or a single IDisposable; this helper just unpacks.
+    /// </summary>
+    private static (TcpClient, NetworkStream, SofhFrameReader) AsTuple(
+        (TcpClient, NetworkStream, SofhFrameReader) t) => t;
+}


### PR DESCRIPTION
## Summary

Implements sub-issue **G — Retransmit + sequence tracking** of the user-bot FIXP listener (RFC §4.4/4.7/4.8) on top of F's outbound multiplexer.

## What's new

**Inbound seq tracking** (`InboundBusinessHeader.MsgSeqNum`)
- Forward gap (seq > expected) ⇒ `NotApplied(from, count)` and watermark advance.
- Backward (seq < expected) ⇒ duplicate, **dispatch suppressed** so `OrderCancelService` does not double-issue an internal cancel.
- `MsgSeqNum=0` treated as legacy/implicit so existing F-era tests keep passing.

**Bot-emitted `Sequence`**: gap ⇒ NotApplied; in-sync ⇒ no-op; bot-behind ⇒ log only (v0 conservative).

**Server-emitted `Sequence` heartbeats**
- Per-connection `TimeProvider`-driven loop, configurable via `EntryPointListenerOptions.HeartbeatIntervalMs` (default `3000` ms).
- Piggyback skip is **re-checked under the write mutex** so a live ER taking the mutex first wins (no stale `NextSeqNo`).

**`RetransmitRequest` handler**
- Validates `fromSeq>0`, `count>0`, range against current outbound watermark.
- Holds `_writeMutex` across the framing `Retransmission(NextSeqNo=fromSeq, Count)` and the N replayed entries — original buffered bytes verbatim, **no re-numbering**, and zero interleave with live ER pushes.
- Reject paths map cleanly to SBE V6 `RetransmitRejectCode`: `OUT_OF_RANGE` (below floor / overflow), `INVALID_FROMSEQNO` (zero or above current), `INVALID_COUNT` (zero).

**New encoder**: `OutboundSessionMessageEncoder` with `EncodeSequence` / `EncodeNotApplied` / `EncodeRetransmission` / `EncodeRetransmitReject` (schema 1, version 6).

**DI**: `FixpListenerHostedService` forwards optional `BotOutboundCoordinator` and `TimeProvider` into `FixpSessionConnection`. All new ctor params are optional for back-compat.

## Out of scope (sub-issue H)

TLS, rate-limit / max-sessions, observability dashboards, conformance-suite gating, auto-`Terminate` on retransmit timeout (the `RetransmitTimeoutMs` option is reserved for H).

## Tests

- **17 new tests** (4 encoder round-trips + 13 end-to-end TCP covering retransmit replay, all reject paths, gap-detect-NotApplied, in-order Sequence (no-op), heartbeat cadence, concurrent live-ER + retransmit no-interleave, disconnect+reconnect+retransmit).
- **All 832 backend tests** pass locally.

Closes #173
Refs #166