### PR TITLE
docs: refresh README + ARCHITECTURE post-#163/#183 + add docs/README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ subscriptions, position keeping, frontend.
 ## Architecture sketch
 
 ```
-Browser / Mobile
+Browser / Mobile                          External user bots
        │ WebSocket (subscribe: orders.me, executions.me, positions.me, …)
        │ REST     (submit/cancel/replace, login, account ops)
-       ▼
+       │                                          │ FIXP/SBE TCP
+       ▼                                          ▼
 B3TradingPlatform backend
+  ├── REST + WebSocket API     (browsers, REST clients)
+  ├── FIXP Listener            (external user bots; opt-in via Trading:EntryPointListener:Enabled)
   ├── EndClientRegistry        end-client identity, login (JWT/session)
   ├── SubscriptionManager      per-end-client streams
   ├── PositionKeeper           cumulative position derived from ER stream
@@ -59,7 +62,7 @@ backend/
     B3.Trading.Domain/           end-client, position, order aggregate
     B3.Trading.Application/      use-cases, registry, position keeper
     B3.Trading.Api/              REST + WebSocket endpoints
-    B3.Trading.Infrastructure/   B3EntryPointClient adapter (stub for now)
+    B3.Trading.Infrastructure/   B3EntryPointClient adapter (Stub/Mock/Real/Unavailable modes)
     B3.Trading.Host/             composition root (ASP.NET Core)
   tests/
     B3.Trading.Domain.Tests/
@@ -99,10 +102,18 @@ curl -XPOST http://localhost:5000/orders \
 curl 'http://localhost:5000/orders?login=alice'
 ```
 
-The `IExchangeGateway` is a no-op stub today; once wired to
-[`B3EntryPointClient`](https://github.com/pedrosakuma/B3EntryPointClient)
-it will dispatch to a real `B3MatchingPlatform` instance (or B3 UAT — same
-lib, different endpoint + creds).
+The `IExchangeGateway` wiring is selected at startup via
+`Trading:Exchange:Mode` (composition root in
+[`Program.cs`](backend/src/B3.Trading.Host/Program.cs); see
+[ARCHITECTURE.md § Wire boundary](docs/ARCHITECTURE.md#wire-boundary)
+for the full table):
+
+| Mode          | Behavior                                                                     |
+| ------------- | ---------------------------------------------------------------------------- |
+| `Stub`        | No-op gateway; CI smoke / API-only tests                                     |
+| `Mock`        | In-process `MockEntryPointClient`; dev loop, integration tests, demo overlay |
+| `Real`        | Per-firm [`B3EntryPointClient`](https://github.com/pedrosakuma/B3EntryPointClient) over FIXP/SBE against `B3MatchingPlatform` (or B3 UAT) |
+| `Unavailable` | Fail-closed; submits return 502 (Docker bootstrap default before broker wiring) |
 
 ## Quick demo (laptop)
 
@@ -146,6 +157,17 @@ public in this repo. See
 [docs/DOCKER.md § Demo overlay](docs/DOCKER.md#demo-overlay-opt-in-laptop-only)
 for tuning, safety notes, and what is intentionally out of scope (live
 MD ticks, real-stack cross-firm bots).
+
+## Documentation
+
+Start at [`docs/README.md`](docs/README.md) for the full index — it
+maps every architecture note, RFC, runbook, and operations guide in
+this repo. Highlights:
+
+- [Architecture](docs/ARCHITECTURE.md) — layered model, wire boundary, ER routing.
+- [FIXP listener — operations](docs/operations/fixp-listener.md) — the third inbound channel.
+- [Docker](docs/DOCKER.md) — canonical container topology + overlays.
+- [WebSocket protocol](docs/WEBSOCKET-PROTOCOL.md) and [Frontend](docs/FRONTEND.md).
 
 ## Bootstrap scope (issue #1)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,14 +9,21 @@ deliberately did **not** resolve.
 ## Layered model
 
 ```
-┌──────────────────────────────────────────────┐
-│ B3.Trading.Host   (ASP.NET Core composition) │
-└───────────────┬──────────────────────────────┘
+                ┌──────────┐  ┌────────────┐  ┌──────────────────┐
+inbound ───►    │  REST    │  │ WebSocket  │  │ FIXP/SBE TCP     │
+                │  /orders │  │   /ws      │  │ (user-bot listener)│
+                └────┬─────┘  └─────┬──────┘  └─────────┬────────┘
+                     │              │                   │
+┌────────────────────▼──────────────▼───────────────────▼─────────┐
+│ B3.Trading.Host   (ASP.NET Core composition)                    │
+└───────────────┬─────────────────────────────────────────────────┘
                 │ depends on
 ┌───────────────▼──────────────────────────────┐
 │ B3.Trading.Api                               │
 │   - REST endpoints (Orders, Positions, …)    │
-│   - (later) WebSocket hub for subscriptions  │
+│   - WebSocket hub for subscriptions          │
+│ B3.Trading.EntryPointListener                │
+│   - Native FIXP/SBE listener for user bots   │
 └───────────────┬──────────────────────────────┘
                 │
 ┌───────────────▼──────────────────────────────┐
@@ -24,17 +31,17 @@ deliberately did **not** resolve.
 │   - EndClientRegistry                        │
 │   - WorkingOrderBook                         │
 │   - PositionKeeper                           │
-│   - (later) SubscriptionManager, PreTradeRisk│
+│   - SubscriptionManager, PreTradeRisk        │
 └──────┬───────────────────────────┬───────────┘
        │                           │
-┌──────▼───────────────┐  ┌────────▼───────────┐
-│ B3.Trading.Domain    │  │ B3.Trading.Infra   │
-│   - aggregates       │  │   - IExchangeGateway│
-│   - value objects    │  │   - StubExchange…   │
-│                      │  │   - (later) EntryPoint │
-└──────────────────────┘  │     adapter via       │
-                          │     B3EntryPointClient│
-                          └───────────────────────┘
+┌──────▼───────────────┐  ┌────────▼────────────────┐
+│ B3.Trading.Domain    │  │ B3.Trading.Infrastructure│
+│   - aggregates       │  │   - IExchangeGateway     │
+│   - value objects    │  │   - Stub / Mock / Real / │
+│                      │  │     Unavailable gateways │
+│                      │  │   - B3EntryPointClient   │
+│                      │  │     adapter              │
+└──────────────────────┘  └──────────────────────────┘
 ```
 
 `Application` knows nothing about ASP.NET Core or FIXP; `Domain` knows
@@ -83,13 +90,14 @@ the book mutation so an immediate ER cannot race the routing path).
    fan out (default impl is `NoOpExecutionEventSink`; the WebSocket hub
    in #3 will plug a real one).
 
-## Wire boundary (Phase 1)
+## Wire boundary
 
-`B3.Trading.Infrastructure` defines a placeholder `IEntryPointClient`
-interface representing the surface the upstream
+`B3.Trading.Infrastructure` references the upstream
 [`B3EntryPointClient`](https://github.com/pedrosakuma/B3EntryPointClient)
-library is expected to expose. The upstream repo is intentionally starting
-with API design + mocks first; this lets us lock our boundary in early.
+NuGet (pinned in `B3.Trading.Infrastructure.csproj`) for the FIXP/SBE
+wire layer. The `IEntryPointClient` contract owns the surface the
+`Infrastructure` adapters consume so the wire library remains a
+swappable detail.
 
 - `EntryPointClientGateway` implements `IExchangeGateway` against
   `IEntryPointClient` (one gateway instance per FIXP session).
@@ -127,10 +135,9 @@ with API design + mocks first; this lets us lock our boundary in early.
   host **refuses to boot** when `Environment=Production` unless
   `Trading:Exchange:AllowErInjectionInProduction=true` is explicitly set.
 
-When the real lib publishes its surface, the swap is local: replace the
-`IEntryPointClient` placeholder with the upstream type (or adapt it
-behind the same name). The rest of the codebase only depends on the
-small POCO contract declared alongside the interface.
+When upstream releases new wire surface, the swap is local: update the
+`IEntryPointClient` adapter to the new shape. The rest of the codebase
+only depends on the small POCO contract declared alongside the interface.
 
 ## Auth + WebSocket hub (Phase 2)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# Documentation index
+
+Start here. This is the map for everything under `docs/` in
+`B3TradingPlatform`. For a high-level project overview, see the
+[repo README](../README.md).
+
+## Architecture
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — layered model, ER routing,
+  ClOrdID namespacing, wire boundary, and the four exchange-gateway
+  modes (`Stub` / `Mock` / `Real` / `Unavailable`).
+- [ENTRYPOINT_INTEGRATION.md](ENTRYPOINT_INTEGRATION.md) — how the
+  trading platform talks to B3 EntryPoint (outbound side).
+- [WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md) — wire format and
+  error codes for the `/ws` subscription channels.
+- [FRONTEND.md](FRONTEND.md) — vanilla JS + Web Worker trader console.
+
+## RFCs (latest first)
+
+- [user-bot-fixp-listener-v0](rfcs/user-bot-fixp-listener-v0.md) —
+  third inbound channel: native FIXP/SBE listener for external user
+  bots (epic #166).
+- [pre-trade-risk-v2](rfcs/pre-trade-risk-v2.md) — ordered risk
+  pipeline with kill-switch, max-qty, max-notional, position-limit,
+  price-collar checks.
+- [integration-real-stack-v0](rfcs/integration-real-stack-v0.md) —
+  Docker topology for the real `Mode=Real` stack against
+  `B3MatchingPlatform`.
+- [algo-orders-v0](rfcs/algo-orders-v0.md) — Iceberg / TWAP algo
+  engines and the ER-injection harness that supports them.
+
+## Operations / Runbooks
+
+- [operations/fixp-listener.md](operations/fixp-listener.md) —
+  enabling, sizing, credentials, retransmit, drain & shutdown for the
+  FIXP listener.
+
+## Persistence
+
+- [PERSISTENCE.md](PERSISTENCE.md) — Phase 6 WAL + snapshot design
+  (replaces the previous fully-ephemeral in-memory state).
+- [spikes/persistence-strategy.md](spikes/persistence-strategy.md) —
+  exploratory notes that fed the persistence design.
+
+## Docker
+
+- [DOCKER.md](DOCKER.md) — canonical container topology, what runs by
+  default, and the demo / unavailable / observability overlays.
+
+## Conformance
+
+- [CONFORMANCE.md](CONFORMANCE.md) — scenario inventory for the
+  `backend/tests/B3.Trading.Conformance/` suite.
+
+## Metrics & Observability
+
+- [METRICS.md](METRICS.md) — OpenTelemetry metric surface emitted by
+  the trading-host.
+- [OBSERVABILITY.md](OBSERVABILITY.md) — generic Kubernetes / Linux
+  host wiring (lifecycle, drain, health).
+- For the FIXP listener metric surface specifically, see code at
+  [`backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerMetrics.cs`](../backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerMetrics.cs)
+  and the application-wide registry at
+  [`backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs`](../backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs).


### PR DESCRIPTION
Closes #184

## Files touched
- `README.md`
- `docs/ARCHITECTURE.md`
- `docs/README.md` (new)

## Summary of changes

### README.md
- Replaced the "no-op stub" gateway paragraph with a table covering the four real modes (`Stub` / `Mock` / `Real` / `Unavailable`) wired in `Program.cs:351-378`.
- Updated the architecture sketch to show **three inbound channels**: REST, WebSocket, and FIXP/SBE TCP (the user-bot listener).
- Updated the layout blurb so `Infrastructure` is no longer described as "stub for now".
- Added a **Documentation** section pointing to the new `docs/README.md` index plus highlights (ARCHITECTURE, FIXP listener ops, Docker, WebSocket, Frontend).

### docs/ARCHITECTURE.md
- Updated the layered-model diagram to show the three inbound channels (REST / WebSocket / FIXP/SBE TCP) above the Host, plus the `B3.Trading.EntryPointListener` project, plus the four gateway flavors in Infrastructure.
- Reworded the **Wire boundary** section: `B3EntryPointClient` is no longer a "placeholder" — it's pinned in `B3.Trading.Infrastructure.csproj`.
- The existing FIXP-listener bullet under "Auth + WebSocket hub" already cross-links to the runbook and the RFC.

### docs/README.md (new)
"Start here" index covering: Architecture, RFCs (latest first), Operations / Runbooks, Persistence, Docker, Conformance, Frontend, Metrics & Observability. All links verified to resolve against the repo.

### DOCKER.md
No edits needed — the only `Mode=Simulator` mention is the same historical-context note ("#163 collapsed the legacy `Mode=Simulator` into this combination") that README already uses; it does not present `Mode=Simulator` as a current valid mode.

## Validation
- All 19 link targets in the new `docs/README.md` and the updated README were checked to exist.
- gpt-5.5 code-review pass against the diff returned: _"No significant issues found in the reviewed changes."_
- Docs-only PR — no source / tests touched, nothing to build.
