### PR TITLE
chore(infra): central package management + version pinning (#186)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.3" />
+    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
+    <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
+++ b/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
+++ b/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="BCrypt.Net-Next" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
+++ b/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="B3.EntryPoint.Sbe" Version="0.14.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="*" />
+    <PackageReference Include="B3.EntryPoint.Sbe" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
+++ b/backend/src/B3.Trading.Host/B3.Trading.Host.csproj
@@ -17,12 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageReference Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="B3.MarketData.WebSocketClient" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/B3.Trading.Host/Dockerfile
+++ b/backend/src/B3.Trading.Host/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /src
 
 # Copy the things that change rarely first so the restore layer caches well.
 COPY global.json Directory.Build.props B3TradingPlatform.slnx ./
+COPY backend/Directory.Packages.props ./backend/
 COPY backend/src ./backend/src
 
 WORKDIR /src/backend/src/B3.Trading.Host

--- a/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
+++ b/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.3" />
-    <PackageReference Include="System.IO.Hashing" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
+    <PackageReference Include="B3.EntryPoint.Client" />
+    <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj
+++ b/backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj
@@ -9,11 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.Application.Tests/B3.Trading.Application.Tests.csproj
+++ b/backend/tests/B3.Trading.Application.Tests/B3.Trading.Application.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj
+++ b/backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.Domain.Tests/B3.Trading.Domain.Tests.csproj
+++ b/backend/tests/B3.Trading.Domain.Tests/B3.Trading.Domain.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
@@ -5,15 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj
+++ b/backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageReference Include="xunit" Version="*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj
+++ b/backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
 </Project>

--- a/backend/tools/B3.Trading.DemoDriver/Dockerfile
+++ b/backend/tools/B3.Trading.DemoDriver/Dockerfile
@@ -9,6 +9,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0.201 AS build
 WORKDIR /src
 
 COPY global.json Directory.Build.props ./
+COPY backend/Directory.Packages.props ./backend/
 COPY backend/tools/B3.Trading.DemoDriver ./backend/tools/B3.Trading.DemoDriver
 
 WORKDIR /src/backend/tools/B3.Trading.DemoDriver

--- a/backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj
+++ b/backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
-    <PackageReference Include="B3.EntryPoint.Client" Version="0.14.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="B3.EntryPoint.Client" />
   </ItemGroup>
 
 </Project>

--- a/backend/tools/B3.Trading.SimulatorBot/Dockerfile
+++ b/backend/tools/B3.Trading.SimulatorBot/Dockerfile
@@ -11,6 +11,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0.201 AS build
 WORKDIR /src
 
 COPY global.json Directory.Build.props ./
+COPY backend/Directory.Packages.props ./backend/
 COPY backend/tools/B3.Trading.SimulatorBot ./backend/tools/B3.Trading.SimulatorBot
 
 WORKDIR /src/backend/tools/B3.Trading.SimulatorBot

--- a/docker/conformance/Dockerfile
+++ b/docker/conformance/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR /src
 # backend/tests/B3.Trading.Conformance/** through and excludes every
 # other test project plus all bin/obj.
 COPY global.json Directory.Build.props ./
+COPY backend/Directory.Packages.props ./backend/
 COPY backend/tests/B3.Trading.Conformance/ ./backend/tests/B3.Trading.Conformance/
 
 # Restore + build the conformance project explicitly. We do NOT restore


### PR DESCRIPTION
Closes #186

## Summary

Introduces `backend/Directory.Packages.props` enabling **NuGet Central Package Management** for the backend solution, and removes `Version` attributes from every `<PackageReference>` under `backend/src`, `backend/tests`, and `backend/tools`. All wildcard (`Version="*"`) pins are eliminated; every direct package now has a single pinned version.

## Pinned versions

| Package | Version |
|---|---|
| B3.EntryPoint.Client | 0.14.3 |
| B3.EntryPoint.Sbe | 0.14.3 |
| B3.MarketData.WebSocketClient | 0.1.0 |
| BCrypt.Net-Next | 4.0.3 |
| coverlet.collector | 6.0.4 |
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.7 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.0 |
| Microsoft.Extensions.Configuration.Binder | 10.0.7 |
| Microsoft.Extensions.Configuration.EnvironmentVariables | 10.0.7 |
| Microsoft.Extensions.Configuration.Json | 10.0.7 |
| Microsoft.Extensions.DependencyInjection | 10.0.7 |
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.7 |
| Microsoft.Extensions.Hosting | 10.0.7 |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.7 |
| Microsoft.Extensions.Http | 10.0.0 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.7 |
| Microsoft.Extensions.Logging.Console | 10.0.7 |
| Microsoft.Extensions.Options | 10.0.7 |
| Microsoft.Extensions.Options.ConfigurationExtensions | 10.0.7 |
| Microsoft.Extensions.Options.DataAnnotations | 10.0.0 |
| Microsoft.NET.Test.Sdk | 18.5.1 |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.3 |
| OpenTelemetry.Extensions.Hosting | 1.15.3 |
| OpenTelemetry.Instrumentation.AspNetCore | 1.15.2 |
| OpenTelemetry.Instrumentation.Runtime | 1.15.1 |
| System.IdentityModel.Tokens.Jwt | 8.18.0 |
| System.IO.Hashing | 10.0.7 |
| xunit | 2.9.3 |
| xunit.runner.visualstudio | 3.1.5 |

Versions reflect what was already resolved on `main`. Where two projects resolved the same package to different versions, the higher version was chosen to avoid any version regression:

- `Microsoft.Extensions.Hosting`: 10.0.7 (was 10.0.0 in tools, 10.0.7 in src/tests via `*`)
- `Microsoft.NET.Test.Sdk`: 18.5.1 (was 17.14.1 explicit, 18.5.1 from `*` in SimulatorBot.Tests)
- `xunit.runner.visualstudio`: 3.1.5 (was 3.1.4 explicit, 3.1.5 from `*` in SimulatorBot.Tests)

## Verification

- ✅ `dotnet restore B3TradingPlatform.slnx --force-evaluate` — clean
- ✅ `dotnet build B3TradingPlatform.slnx --no-restore` — 0 warnings, 0 errors
- ✅ `dotnet test` — **853 tests pass** (485 Application + 206 Api + 86 EntryPointListener + 53 Domain + 23 SimulatorBot; 18 Conformance skipped as on main)
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ gpt-5.5 code-review pass: no version regressions; all referenced packages pinned; no Version attributes remain; test/source projects share versions via CPM

No frontend changes. No new packages. No existing package upgraded beyond reconciling intra-solution conflicts as noted.