### PR TITLE
refactor(api): break B3.Trading.Api dependency on Infrastructure/EntryPointListener (#188)

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -1,13 +1,12 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
 using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
-using B3.Trading.Infrastructure;
-using B3.Trading.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -147,43 +146,35 @@ public static class AdminEndpoints
                 }
             });
 
-        group.MapPost("/eod", (EodMaterialiser eod, IOptions<PersistenceOptions> opts) =>
+        group.MapPost("/eod", (IEodMaterialiser eod) =>
         {
             // EOD materialisation runs against persisted segments, so it
             // is a no-op (and arguably misleading) when persistence is
             // disabled. Surface that as 409 rather than silently producing
             // an empty report.
-            if (!opts.Value.Enabled)
+            if (!eod.IsAvailable)
                 return Results.Conflict(new { error = "persistence_disabled" });
             var report = eod.Materialise(DateOnly.FromDateTime(DateTime.UtcNow));
             return Results.Ok(report);
         });
 
         // Per-firm operator visibility. In Real mode the response folds in
-        // live FIXP state from the FirmGatewayRegistry; in other modes it
+        // live FIXP state from the firm directory; in other modes it
         // returns the configured shape only (state fields are null) — useful
         // both as a config sanity check and as a stable schema for dashboards.
-        group.MapGet("/firms", (IOptions<ExchangeOptions> opts, IServiceProvider sp) =>
+        group.MapGet("/firms", (IFirmDirectory directory) =>
         {
-            var mode = opts.Value.ResolveMode();
-            // Optional injection: FirmGatewayRegistry is only registered in Real mode.
-            var registry = sp.GetService<FirmGatewayRegistry>();
-            var firms = opts.Value.Firms.Select(cfg =>
+            var snapshot = directory.Snapshot();
+            var firms = snapshot.Firms.Select(f => new
             {
-                B3EntryPointClientGateway? live = null;
-                if (registry is not null && registry.TryGet(cfg.FirmId, out var gw))
-                    live = gw;
-                return new
-                {
-                    firmId = cfg.FirmId,
-                    endpoint = cfg.Endpoint,
-                    sessionId = cfg.SessionId,
-                    sessionState = live?.SessionStateTag,
-                    sessionVerId = live?.CurrentSessionVerId,
-                    reconnecting = live?.IsReconnecting,
-                };
+                firmId = f.FirmId,
+                endpoint = f.Endpoint,
+                sessionId = f.SessionId,
+                sessionState = f.SessionState,
+                sessionVerId = f.SessionVerId,
+                reconnecting = f.Reconnecting,
             }).ToArray();
-            return Results.Ok(new { mode = mode.ToString(), firms });
+            return Results.Ok(new { mode = snapshot.Mode, firms });
         });
 
         // Debug helper for ops: surface the *effective* RiskLimits the
@@ -253,7 +244,7 @@ public static class AdminEndpoints
             IServiceProvider sp,
             IOptions<MarketDataOptions> mdOpts,
             IOptionsMonitor<RiskOptions> riskOpts,
-            IOptions<ExchangeOptions> exchangeOpts) =>
+            IFirmDirectory firmDirectory) =>
         {
             // MarketDataReferencePrice is registered only when the WsUrl
             // gate is set (see MarketDataRegistration.cs). When absent,
@@ -300,7 +291,7 @@ public static class AdminEndpoints
 
             return Results.Ok(new
             {
-                mode = exchangeOpts.Value.ResolveMode().ToString(),
+                mode = firmDirectory.Snapshot().Mode,
                 marketDataEnabled = mdRef is not null,
                 symbols = items,
             });
@@ -308,19 +299,11 @@ public static class AdminEndpoints
 
         // POST /admin/simulator/er — synthetic ER injection (formerly the
         // ExchangeMode.Simulator-only route; merged into Mock+AllowErInjection
-        // in #163). URL kept as /admin/simulator/er for conformance-contract
-        // stability. Only mapped when the in-process Mock gateway is active
-        // AND the operator opted in via Trading:Exchange:AllowErInjection;
-        // ExchangeOptionsValidator already refused Mode=Real/Stub/Unavailable
-        // alongside the flag, so reaching this branch implies Mode=Mock and
-        // MockEntryPointClient is in DI. The not-mapped check is the single
-        // source of truth — no second runtime barrier needed.
-        var exchangeOptsValue = app.ServiceProvider.GetRequiredService<IOptions<ExchangeOptions>>().Value;
-        if (exchangeOptsValue.ResolveMode() == ExchangeMode.Mock && exchangeOptsValue.AllowErInjection)
-        {
-            group.MapPost("/simulator/er", SimulatorEndpoint.Inject);
-        }
-
+        // in #163). The route itself moved to the Infrastructure project as
+        // part of the #188 layering refactor — see SimulatorEndpoint.MapSimulatorEndpoints,
+        // which the Host composition root mounts conditionally on
+        // Trading:Exchange:Mode=Mock + AllowErInjection. Kept out of this
+        // file so the Api project no longer references Infrastructure.
         return app;
     }
 

--- a/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
+++ b/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
@@ -12,8 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\B3.Trading.Domain\B3.Trading.Domain.csproj" />
     <ProjectReference Include="..\B3.Trading.Application\B3.Trading.Application.csproj" />
-    <ProjectReference Include="..\B3.Trading.Infrastructure\B3.Trading.Infrastructure.csproj" />
-    <ProjectReference Include="..\B3.Trading.EntryPointListener\B3.Trading.EntryPointListener.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Application/Lifecycle/IFirmDirectory.cs
+++ b/backend/src/B3.Trading.Application/Lifecycle/IFirmDirectory.cs
@@ -1,0 +1,49 @@
+namespace B3.Trading.Application.Lifecycle;
+
+/// <summary>
+/// Single per-firm row exposed by <see cref="IFirmDirectory"/>. Carries the
+/// configured wire identity (always present) plus optional live FIXP session
+/// state that the Real-mode implementation overlays from
+/// <c>FirmGatewayRegistry</c>. Mock/Stub/Unavailable implementations leave
+/// the state-tagged fields null, which the admin endpoint surfaces as
+/// "configured but no live wire to report on".
+/// </summary>
+/// <param name="FirmId">Logical firm identifier (matches <c>FirmConfig.FirmId</c>).</param>
+/// <param name="Endpoint">Gateway endpoint as <c>host:port</c>.</param>
+/// <param name="SessionId">Client connection identification on the gateway.</param>
+/// <param name="SessionState">Lower-snake-case tag of the live SDK
+/// <c>FixpClientState</c> when available; null otherwise.</param>
+/// <param name="SessionVerId">Last <c>SessionVerId</c> the gateway has tried
+/// to use; null when no live status is available.</param>
+/// <param name="Reconnecting">True when the gateway's auto-reconnect loop
+/// is currently running for this firm; null when no live status is available.</param>
+public sealed record FirmDirectoryEntry(
+    string FirmId,
+    string Endpoint,
+    uint SessionId,
+    string? SessionState,
+    uint? SessionVerId,
+    bool? Reconnecting);
+
+/// <summary>
+/// Aggregate snapshot returned by <see cref="IFirmDirectory.Snapshot"/>.
+/// </summary>
+/// <param name="Mode">Effective <c>ExchangeMode</c> name (e.g. <c>Real</c>,
+/// <c>Mock</c>) — surfaced verbatim on <c>/admin/firms</c>.</param>
+/// <param name="Firms">Per-firm entries; empty in <c>Unavailable</c> mode.</param>
+public sealed record FirmDirectorySnapshot(
+    string Mode,
+    IReadOnlyList<FirmDirectoryEntry> Firms);
+
+/// <summary>
+/// Application-layer port that the <c>/admin/firms</c> endpoint consumes to
+/// list per-firm wire configuration plus optional live FIXP session state.
+/// Decouples the Api layer from the Infrastructure-owned
+/// <c>FirmGatewayRegistry</c> / <c>ExchangeOptions</c> concretions.
+/// </summary>
+public interface IFirmDirectory
+{
+    /// <summary>Cheap, allocation-light snapshot of every configured firm.
+    /// Safe to call on the request hot path.</summary>
+    FirmDirectorySnapshot Snapshot();
+}

--- a/backend/src/B3.Trading.Application/Persistence/IEodMaterialiser.cs
+++ b/backend/src/B3.Trading.Application/Persistence/IEodMaterialiser.cs
@@ -1,0 +1,50 @@
+namespace B3.Trading.Application.Persistence;
+
+/// <summary>
+/// End-of-day report produced by <see cref="IEodMaterialiser.Materialise"/>.
+/// Self-describing JSON shape: every field is included even when zero so the
+/// EOD reconciliation tooling can <c>diff</c> two days without missing-key
+/// surprises.
+/// </summary>
+public sealed class EodReport
+{
+    public string Date { get; set; } = "";
+    public string FirmId { get; set; } = "";
+    public DateTimeOffset GeneratedAtUtc { get; set; }
+    public long RecordCount { get; set; }
+    public long OrderSubmittedCount { get; set; }
+    public long ExecutionReportCount { get; set; }
+    public long FilledCount { get; set; }
+    public long PartialFillCount { get; set; }
+    public long CanceledCount { get; set; }
+    public long RejectedCount { get; set; }
+    public long KillSwitchToggleCount { get; set; }
+    public long SymbolHaltToggleCount { get; set; }
+    public long SessionPhaseChangeCount { get; set; }
+    public string Sha256 { get; set; } = "";
+    public string Path { get; set; } = "";
+}
+
+/// <summary>
+/// Application-layer port for materialising the day-segmented WAL into a
+/// single self-describing EOD JSON summary. Decouples the Api layer from
+/// the Infrastructure-owned <c>EodMaterialiser</c> concretion (which also
+/// owns the segment-reader plumbing).
+///
+/// <para>
+/// <see cref="IsAvailable"/> reflects whether persistence is enabled at all.
+/// When <c>false</c>, the admin endpoint surfaces 409 instead of silently
+/// producing an empty report.
+/// </para>
+/// </summary>
+public interface IEodMaterialiser
+{
+    /// <summary>True when persistence is enabled and the segments directory
+    /// is reachable; false when persistence is disabled (no-op store).</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Materialise the EOD summary for <paramref name="date"/>.
+    /// Implementations should throw <see cref="InvalidOperationException"/>
+    /// when called while <see cref="IsAvailable"/> is <c>false</c>.</summary>
+    EodReport Materialise(DateOnly date);
+}

--- a/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
+++ b/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
@@ -5,17 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\B3.Trading.Application\B3.Trading.Application.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="B3.EntryPoint.Sbe" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
@@ -1,17 +1,21 @@
 using B3.Trading.Application.UserBots;
-using B3.Trading.EntryPointListener;
-using B3.Trading.EntryPointListener.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
-namespace B3.Trading.Api;
+namespace B3.Trading.EntryPointListener.Hosting.Admin;
 
 /// <summary>
 /// Admin endpoints for FIXP listener introspection and control.
 /// Mounted at <c>/admin/fixp</c> with admin authorization.
+///
+/// <para>Lives in the EntryPointListener project (#188 layering refactor)
+/// because every consumed type — <see cref="BotSessionConnectionDirectory"/>,
+/// <see cref="BotOutboundCoordinator"/>, the listener-internal session
+/// registry — is owned by this project. The Api layer no longer references
+/// the listener; the Host composition root maps this extension when the
+/// listener is enabled.</para>
 /// </summary>
 public static class AdminFixpEndpoints
 {

--- a/backend/src/B3.Trading.Host/Lifecycle/HealthEndpoints.cs
+++ b/backend/src/B3.Trading.Host/Lifecycle/HealthEndpoints.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Api.Lifecycle;
 using B3.Trading.EntryPointListener;
 using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
@@ -7,7 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace B3.Trading.Api.Lifecycle;
+namespace B3.Trading.Host.Lifecycle;
 
 /// <summary>
 /// Kubernetes-/orchestrator-shaped lifecycle probes:
@@ -21,6 +22,13 @@ namespace B3.Trading.Api.Lifecycle;
 ///   uptime, drain state, persistence config snapshot.</item>
 /// </list>
 /// Mirrors the layout used by <c>B3MarketDataPlatform/WebSocketHost</c>.
+///
+/// <para>Lives in the Host project (#188 layering refactor) because the
+/// rich /health body composes Infrastructure-owned types
+/// (<see cref="ExchangeStatus"/>, <see cref="PersistenceOptions"/>) and
+/// listener-owned types (<see cref="EntryPointListenerOptions"/>,
+/// <see cref="Hosting.BotSessionConnectionDirectory"/>) that the Api layer
+/// must not reference.</para>
 /// </summary>
 public static class HealthEndpoints
 {

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -7,6 +7,7 @@ using B3.Trading.Api.Auth;
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Accounting;
@@ -14,6 +15,8 @@ using B3.Trading.Application.Risk.Checks;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using B3.Trading.EntryPointListener;
+using B3.Trading.EntryPointListener.Hosting.Admin;
+using B3.Trading.Host.Lifecycle;
 using B3.Trading.Host.Observability;
 using B3.Trading.Host.MarketData;
 using B3.Trading.Infrastructure;
@@ -158,6 +161,16 @@ builder.Services.AddSingleton<StateSnapshotter>();
 builder.Services.AddSingleton<EventReplayer>();
 builder.Services.AddSingleton<PersistenceRecovery>();
 builder.Services.AddSingleton<EodMaterialiser>();
+builder.Services.AddSingleton<IEodMaterialiser>(sp =>
+{
+    // #188: Api consumes IEodMaterialiser only; the Persistence-disabled
+    // case is satisfied by DisabledEodMaterialiser whose IsAvailable=false
+    // makes the admin endpoint surface 409 cleanly.
+    var opts = sp.GetRequiredService<IOptions<PersistenceOptions>>().Value;
+    return opts.Enabled
+        ? sp.GetRequiredService<EodMaterialiser>()
+        : new DisabledEodMaterialiser();
+});
 builder.Services.AddHostedService<SnapshotService>();
 builder.Services.AddSingleton<EventDispatcher>();
 
@@ -412,6 +425,15 @@ builder.Services.AddSingleton<ExchangeStatus>(sp =>
     return ExchangeStatus.FromOptions(opts);
 });
 
+// #188: Api consumes IFirmDirectory only. ConfigFirmDirectory always reads
+// per-firm config from ExchangeOptions; FirmGatewayRegistry is optional
+// (only registered in Real mode) and overlays live FIXP session state when
+// present. The endpoint shape is identical regardless of mode.
+builder.Services.AddSingleton<IFirmDirectory>(sp =>
+    new ConfigFirmDirectory(
+        sp.GetRequiredService<IOptions<ExchangeOptions>>(),
+        sp.GetService<FirmGatewayRegistry>()));
+
 // Persist DataProtection keys onto the data volume. JWT auth uses HMAC and
 // doesn't depend on DataProtection, but ASP.NET still spins it up for
 // cookie/antiforgery defaults. Without persistence it logs a warning every
@@ -638,6 +660,17 @@ app.MapAlgo();
 app.MapPositions();
 app.MapBalance();
 app.MapAdmin();
+{
+    // #188: simulator/er moved to Infrastructure (it's the only consumer
+    // of MockEntryPointClient + ExecutionReportEnvelope). Mounted here
+    // conditionally so the Mock-only route stays gated identically to
+    // the legacy in-AdminEndpoints check.
+    var exchangeOpts = app.Services.GetRequiredService<IOptions<ExchangeOptions>>().Value;
+    if (exchangeOpts.ResolveMode() == ExchangeMode.Mock && exchangeOpts.AllowErInjection)
+    {
+        app.MapSimulatorEndpoints();
+    }
+}
 {
     var lo = app.Services.GetRequiredService<IOptions<EntryPointListenerOptions>>().Value;
     if (lo.Enabled) app.MapAdminFixp();

--- a/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
+++ b/backend/src/B3.Trading.Infrastructure/B3.Trading.Infrastructure.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\B3.Trading.Domain\B3.Trading.Domain.csproj" />
     <ProjectReference Include="..\B3.Trading.Application\B3.Trading.Application.csproj" />
   </ItemGroup>
@@ -12,9 +16,6 @@
   <ItemGroup>
     <PackageReference Include="B3.EntryPoint.Client" />
     <PackageReference Include="System.IO.Hashing" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/B3.Trading.Infrastructure/ConfigFirmDirectory.cs
+++ b/backend/src/B3.Trading.Infrastructure/ConfigFirmDirectory.cs
@@ -1,0 +1,43 @@
+using B3.Trading.Application.Lifecycle;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// Default <see cref="IFirmDirectory"/> implementation. Always reads
+/// per-firm wire configuration from <see cref="ExchangeOptions"/>; in Real
+/// mode an injected <see cref="FirmGatewayRegistry"/> overlays live FIXP
+/// session state on top. The endpoint shape is identical regardless of
+/// mode so dashboards consume a single schema.
+/// </summary>
+public sealed class ConfigFirmDirectory : IFirmDirectory
+{
+    private readonly IOptions<ExchangeOptions> _options;
+    private readonly FirmGatewayRegistry? _registry;
+
+    public ConfigFirmDirectory(IOptions<ExchangeOptions> options, FirmGatewayRegistry? registry = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _registry = registry;
+    }
+
+    public FirmDirectorySnapshot Snapshot()
+    {
+        var opts = _options.Value;
+        var mode = opts.ResolveMode();
+        var firms = opts.Firms.Select(cfg =>
+        {
+            B3EntryPointClientGateway? live = null;
+            if (_registry is not null && _registry.TryGet(cfg.FirmId, out var gw))
+                live = gw;
+            return new FirmDirectoryEntry(
+                FirmId: cfg.FirmId,
+                Endpoint: cfg.Endpoint,
+                SessionId: cfg.SessionId,
+                SessionState: live?.SessionStateTag,
+                SessionVerId: live?.CurrentSessionVerId,
+                Reconnecting: live?.IsReconnecting);
+        }).ToArray();
+        return new FirmDirectorySnapshot(mode.ToString(), firms);
+    }
+}

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -20,8 +20,10 @@ namespace B3.Trading.Infrastructure.Persistence;
 /// today?") and for diff'ing against a manually-supplied EP report.
 /// </para>
 /// </summary>
-public sealed class EodMaterialiser
+public sealed class EodMaterialiser : IEodMaterialiser
 {
+    public bool IsAvailable => true;
+
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         WriteIndented = true,
@@ -88,21 +90,17 @@ public sealed class EodMaterialiser
     }
 }
 
-public sealed class EodReport
+/// <summary>
+/// Drop-in <see cref="IEodMaterialiser"/> registered when persistence is
+/// disabled. <see cref="IsAvailable"/> is <c>false</c>, and
+/// <see cref="Materialise"/> throws so any caller that bypasses the
+/// availability check fails loudly instead of producing an empty report.
+/// </summary>
+public sealed class DisabledEodMaterialiser : IEodMaterialiser
 {
-    public string Date { get; set; } = "";
-    public string FirmId { get; set; } = "";
-    public DateTimeOffset GeneratedAtUtc { get; set; }
-    public long RecordCount { get; set; }
-    public long OrderSubmittedCount { get; set; }
-    public long ExecutionReportCount { get; set; }
-    public long FilledCount { get; set; }
-    public long PartialFillCount { get; set; }
-    public long CanceledCount { get; set; }
-    public long RejectedCount { get; set; }
-    public long KillSwitchToggleCount { get; set; }
-    public long SymbolHaltToggleCount { get; set; }
-    public long SessionPhaseChangeCount { get; set; }
-    public string Sha256 { get; set; } = "";
-    public string Path { get; set; } = "";
+    public bool IsAvailable => false;
+
+    public EodReport Materialise(DateOnly date) =>
+        throw new InvalidOperationException(
+            "EOD materialisation is unavailable: persistence is disabled.");
 }

--- a/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
+++ b/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
@@ -1,9 +1,10 @@
 using B3.Trading.Application;
-using B3.Trading.Infrastructure;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 
-namespace B3.Trading.Api;
+namespace B3.Trading.Infrastructure;
 
 /// <summary>
 /// Synthetic ER injection (formerly <see cref="ExchangeMode.Simulator"/>;
@@ -15,6 +16,13 @@ namespace B3.Trading.Api;
 /// <c>leaves</c>/<c>cum</c> server-side. This inverts the failure mode of
 /// "caller forgot to bump cum" — engines like Iceberg refill on
 /// <c>leaves==0</c> and silent drift would be a nasty bug to hunt.
+///
+/// <para>Lives in the Infrastructure project (#188 layering refactor)
+/// because the endpoint is the only consumer of the Mock-mode
+/// <see cref="MockEntryPointClient"/> + <see cref="ExecutionReportEnvelope"/>
+/// concretions. Mapped from the composition root via
+/// <see cref="MapSimulatorEndpoints"/>; the Api layer no longer references
+/// Infrastructure.</para>
 /// </summary>
 public static class SimulatorEndpoint
 {
@@ -24,6 +32,21 @@ public static class SimulatorEndpoint
         long? LastQty,
         decimal? LastPx,
         string? RejectReason);
+
+    /// <summary>
+    /// Maps <c>POST /admin/simulator/er</c> under the admin authorization
+    /// policy. URL kept stable for conformance-contract compatibility
+    /// (#163) — callers must check <c>ExchangeOptions.ResolveMode()==Mock
+    /// &amp;&amp; AllowErInjection</c> before invoking; the validator
+    /// already refuses Mode=Real/Stub/Unavailable + the flag at startup so
+    /// reaching this branch implies a Mock gateway is in DI.
+    /// </summary>
+    public static IEndpointRouteBuilder MapSimulatorEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/admin/simulator/er", Inject)
+            .RequireAuthorization("admin");
+        return app;
+    }
 
     public static IResult Inject(
         [FromBody] InjectRequest req,

--- a/backend/tests/B3.Trading.Api.Tests/Architecture/ApiAssemblyDependenciesArchitectureTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/Architecture/ApiAssemblyDependenciesArchitectureTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+
+namespace B3.Trading.Api.Tests.Architecture;
+
+/// <summary>
+/// Architectural guardrails for the Api assembly (#188).
+///
+/// The Api project is the presentation layer; it must depend only on
+/// <c>B3.Trading.Application</c> (and <c>B3.Trading.Domain</c>) plus the
+/// ASP.NET Core framework. Re-introducing a reference to
+/// <c>B3.Trading.Infrastructure</c> or <c>B3.Trading.EntryPointListener</c>
+/// would let endpoint code reach into concrete adapters again — exactly the
+/// regression this test is here to prevent.
+///
+/// <para>If a future endpoint genuinely needs a type currently in
+/// Infrastructure or the listener, the right answer is to introduce an
+/// Application-layer port (interface) and have the concrete project
+/// implement it — not to re-add the project reference.</para>
+/// </summary>
+public sealed class ApiAssemblyDependenciesArchitectureTests
+{
+    private static readonly string[] ForbiddenAssemblyNames =
+    [
+        "B3.Trading.Infrastructure",
+        "B3.Trading.EntryPointListener",
+    ];
+
+    [Fact]
+    public void ApiAssembly_DoesNotReference_InfrastructureOrEntryPointListener()
+    {
+        var apiAssembly = typeof(B3.Trading.Api.AdminEndpoints).Assembly;
+        var referenced = apiAssembly.GetReferencedAssemblies()
+            .Select(a => a.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var forbidden = ForbiddenAssemblyNames
+            .Where(name => referenced.Contains(name))
+            .ToArray();
+
+        Assert.True(
+            forbidden.Length == 0,
+            $"B3.Trading.Api must not reference {string.Join(", ", forbidden)}. " +
+            "Introduce an Application-layer interface and have the concrete " +
+            "project implement it instead of re-adding the project reference.");
+    }
+}


### PR DESCRIPTION
Closes #188

## Summary
The Api project (presentation layer) was reaching into Infrastructure
(`KillSwitchService` aside, the wire-side concretions like
`FirmGatewayRegistry`, `B3EntryPointClientGateway`, `EodMaterialiser`,
`ExchangeOptions`, `MockEntryPointClient`) and into EntryPointListener
(`BotSessionConnectionDirectory`, `BotOutboundCoordinator`,
`IUserBotSessionRegistry`). That broke the layered architecture and
prevented swapping implementations or testing the endpoints in isolation.

This PR removes both project references from `B3.Trading.Api.csproj`. The
Api now references only `B3.Trading.Application` + `B3.Trading.Domain` +
`Microsoft.AspNetCore.App` + `System.IdentityModel.Tokens.Jwt`.

## Application ports extracted
| Port | Namespace | Replaces direct use of |
|---|---|---|
| `IFirmDirectory` (+`FirmDirectorySnapshot`/`Entry`) | `B3.Trading.Application.Lifecycle` | `ExchangeOptions` + `FirmGatewayRegistry` + `B3EntryPointClientGateway` |
| `IEodMaterialiser` (+`EodReport`) | `B3.Trading.Application.Persistence` | concrete `EodMaterialiser` + `PersistenceOptions` enabled-check |

Both ports return only primitives / records — **no Infrastructure types
leak through their public signatures**, verified by code review.

## Endpoint relocations (URLs/responses unchanged)
| File | New home | Reason |
|---|---|---|
| `AdminFixpEndpoints.cs` | `B3.Trading.EntryPointListener/Hosting/Admin/` | Every type it consumes is owned by the listener. |
| `SimulatorEndpoint.cs` | `B3.Trading.Infrastructure/` | Sole consumer of `MockEntryPointClient` + `ExecutionReportEnvelope`. `Program.cs` mounts it conditionally on `Mode==Mock && AllowErInjection` (same gating as before). |
| `Lifecycle/HealthEndpoints.cs` | `B3.Trading.Host/Lifecycle/` | Composes `ExchangeStatus` + `PersistenceOptions` + `EntryPointListenerOptions` + `BotSessionConnectionDirectory` — Host is the only project allowed to see all four. |

## Architectural test pattern
```csharp
var apiAssembly = typeof(B3.Trading.Api.AdminEndpoints).Assembly;
var referenced = apiAssembly.GetReferencedAssemblies()
    .Select(a => a.Name).ToHashSet(StringComparer.Ordinal);
```
Lives at `backend/tests/B3.Trading.Api.Tests/Architecture/`. Future PRs
that re-add either project reference will fail this test.

## DI changes (lifetimes preserved)
- `AddSingleton<EodMaterialiser>()` kept; `AddSingleton<IEodMaterialiser>(...)` chooses concrete vs `DisabledEodMaterialiser` based on `PersistenceOptions.Enabled`.
- `AddSingleton<IFirmDirectory>(...)` registered everywhere; `ConfigFirmDirectory` reads `ExchangeOptions` and overlays `FirmGatewayRegistry` (optional, only Real mode).

## Validation
- `dotnet build B3TradingPlatform.slnx -c Release` → clean (warnings-as-errors).
- `dotnet test` → **864 passed, 18 skipped, 0 failed** (was 863 + new architectural test).
- `dotnet format --verify-no-changes` → clean.

## Out of scope
This PR is a pure layering refactor. No endpoint URL, method, body
schema, status code, or admin authorization policy was changed; no DI
registration was dropped or had its lifetime altered. Frontend untouched.