### PR TITLE
perf(wal): P2 — WalEventJsonContext source-gen + round-trip tests (#196)

### DIFF
--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.Trading.Application.Persistence;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> covering every
+/// <see cref="WalEvent"/> derived payload. Used by the WAL serialise /
+/// deserialise paths in <c>FileEventStore</c> (and by the EOD materialiser
+/// when it walks segments) to avoid the per-call reflection cost of
+/// <see cref="System.Text.Json.JsonSerializer"/>'s reflection-based
+/// converters. Polymorphic dispatch (the <c>"kind"</c> discriminator) is
+/// preserved by the existing <see cref="JsonPolymorphicAttribute"/> on
+/// <see cref="WalEvent"/>.
+///
+/// <para>
+/// <b>Drop-in compatibility (RFC §6.1).</b> The context inherits the
+/// <see cref="System.Text.Json.JsonSerializerDefaults.Web"/> defaults
+/// (camelCase property names on write, case-insensitive on read,
+/// <c>JsonNumberHandling.AllowReadingFromString</c>) — byte-for-byte the
+/// same options the WAL has used since day one. New segments produced
+/// by the source-generated path are still readable by the old reflection-
+/// based deserialiser, and old segments are still readable by the new
+/// path. Property round-trip tests pin the equivalence so a sourcegen
+/// regression fails CI before recovery breaks at runtime.
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(WalEvent))]
+[JsonSerializable(typeof(OrderSubmittedEvent))]
+[JsonSerializable(typeof(OrderCancelRequestedEvent))]
+[JsonSerializable(typeof(OrderReplaceRequestedEvent))]
+[JsonSerializable(typeof(ExecutionReportReceivedEvent))]
+[JsonSerializable(typeof(KillSwitchToggledEvent))]
+[JsonSerializable(typeof(SymbolHaltToggledEvent))]
+[JsonSerializable(typeof(SessionPhaseChangedEvent))]
+[JsonSerializable(typeof(AlgoCreatedEvent))]
+[JsonSerializable(typeof(AlgoCancelRequestedEvent))]
+[JsonSerializable(typeof(AlgoTerminalStateRecordedEvent))]
+[JsonSerializable(typeof(OrderStaledEvent))]
+[JsonSerializable(typeof(OrderStaleClearedEvent))]
+[JsonSerializable(typeof(UserBotCredentialCreatedEvent))]
+[JsonSerializable(typeof(UserBotCredentialRevokedEvent))]
+[JsonSerializable(typeof(BotSessionInitializedEvent))]
+[JsonSerializable(typeof(BotSessionVerAdvancedEvent))]
+[JsonSerializable(typeof(BotSessionSeqAdvancedEvent))]
+[JsonSerializable(typeof(BotOrderMapping))]
+public sealed partial class WalEventJsonContext : JsonSerializerContext
+{
+}

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -56,7 +56,7 @@ public sealed class EodMaterialiser : IEodMaterialiser
             {
                 report.RecordCount++;
                 sha.TransformBlock(payload, 0, payload.Length, null, 0);
-                var evt = JsonSerializer.Deserialize<WalEvent>(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+                var evt = JsonSerializer.Deserialize(payload, WalEventJsonContext.Default.WalEvent);
                 switch (evt)
                 {
                     case OrderSubmittedEvent: report.OrderSubmittedCount++; break;

--- a/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
@@ -40,7 +40,7 @@ namespace B3.Trading.Infrastructure.Persistence;
 /// </summary>
 public sealed class FileEventStore : IEventStore
 {
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly WalEventJsonContext JsonContext = WalEventJsonContext.Default;
 
     private readonly PersistenceOptions _opts;
     private readonly ILogger<FileEventStore> _logger;
@@ -85,7 +85,7 @@ public sealed class FileEventStore : IEventStore
         ArgumentNullException.ThrowIfNull(evt);
         if (_disposed) throw new ObjectDisposedException(nameof(FileEventStore));
 
-        var payload = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(evt, JsonOptions);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(evt, JsonContext.WalEvent);
         long seq;
         lock (_seqLock)
         {
@@ -122,7 +122,7 @@ public sealed class FileEventStore : IEventStore
         {
             if (ct.IsCancellationRequested) yield break;
             if (seq <= sinceSeqExclusive) continue;
-            var evt = JsonSerializer.Deserialize<WalEvent>(payload, JsonOptions);
+            var evt = JsonSerializer.Deserialize(payload, JsonContext.WalEvent);
             if (evt is not null) yield return (seq, evt);
         }
         await Task.CompletedTask;

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/WalEventJsonContextRoundTripTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/WalEventJsonContextRoundTripTests.cs
@@ -1,0 +1,385 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// P2 (RFC §6.1). Pins the contract that <see cref="WalEventJsonContext"/>
+/// is a drop-in replacement for the reflection-based serialiser the WAL
+/// has used since day one. Every <see cref="WalEvent"/>-derived payload:
+///
+/// <list type="number">
+///   <item>round-trips through the source-generated context (serialise →
+///         deserialise → structural equality);</item>
+///   <item>produces byte-identical UTF-8 JSON to
+///         <c>JsonSerializer.SerializeToUtf8Bytes(payload, JsonSerializerDefaults.Web)</c>,
+///         so existing on-disk segments stay readable by both paths and a
+///         rollback to the reflection path keeps working.</item>
+/// </list>
+///
+/// <para>If a future <see cref="WalEvent"/> subtype is added without being
+/// registered on <see cref="WalEventJsonContext"/>, the polymorphic
+/// dispatch test below will fail loudly — sourcegen polymorphism only
+/// works for types listed via <see cref="System.Text.Json.Serialization.JsonSerializableAttribute"/>.</para>
+/// </summary>
+public class WalEventJsonContextRoundTripTests
+{
+    private static readonly JsonSerializerOptions ReflectionOpts = new(JsonSerializerDefaults.Web);
+
+    public static TheoryData<string, WalEvent> Payloads()
+    {
+        var ts = new DateTimeOffset(2024, 6, 15, 12, 34, 56, 789, TimeSpan.Zero);
+        var credId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var data = new TheoryData<string, WalEvent>();
+
+        data.Add("OrderSubmitted+Bot", new OrderSubmittedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 42UL,
+            EndClientId = "bot:b3t_abc",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 12.34m,
+            ParentAlgoId = 7UL,
+            AlgoSliceSeq = 3,
+            BotMapping = new BotOrderMapping(credId, 9999UL),
+        });
+
+        data.Add("OrderSubmitted+Manual", new OrderSubmittedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 7UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "VALE3",
+            SecurityId = 9876UL,
+            Side = "Sell",
+            Type = "Market",
+            Quantity = 10,
+        });
+
+        data.Add("OrderCancelRequested+Bot", new OrderCancelRequestedEvent
+        {
+            TimestampUtc = ts,
+            CancelClOrdId = 200UL,
+            OriginalClOrdId = 42UL,
+            OwnerEndClientId = "bot:b3t_abc",
+            BotMapping = new BotOrderMapping(credId, 5555UL),
+        });
+
+        data.Add("OrderCancelRequested+Manual", new OrderCancelRequestedEvent
+        {
+            TimestampUtc = ts,
+            CancelClOrdId = 200UL,
+            OriginalClOrdId = 42UL,
+            OwnerEndClientId = "alice",
+        });
+
+        data.Add("OrderReplaceRequested", new OrderReplaceRequestedEvent
+        {
+            TimestampUtc = ts,
+            OriginalClOrdId = 1UL,
+            NewClOrdId = 2UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            NewQuantity = 50,
+            NewPrice = 13.50m,
+            ParentAlgoId = 99UL,
+            AlgoSliceSeq = 1,
+        });
+
+        data.Add("ExecutionReportReceived", new ExecutionReportReceivedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 42UL,
+            ExecKind = "PartialFill",
+            LeavesQuantity = 50,
+            CumulativeQuantity = 50,
+            LastQuantity = 50,
+            LastPrice = 12.30m,
+            RejectReason = null,
+            Synthetic = false,
+            OrigClOrdId = 0UL,
+        });
+
+        data.Add("ExecutionReportReceived+SyntheticReject", new ExecutionReportReceivedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 99UL,
+            ExecKind = "Rejected",
+            LeavesQuantity = 0,
+            CumulativeQuantity = 0,
+            LastQuantity = 0,
+            LastPrice = 0m,
+            RejectReason = "risk-decline",
+            Synthetic = true,
+            OrigClOrdId = 0UL,
+        });
+
+        data.Add("KillSwitchToggled", new KillSwitchToggledEvent
+        {
+            TimestampUtc = ts,
+            Scope = "firm",
+            Target = "default",
+            Killed = true,
+            ActorUserId = "ops",
+        });
+
+        data.Add("SymbolHaltToggled", new SymbolHaltToggledEvent
+        {
+            TimestampUtc = ts,
+            Symbol = "PETR4",
+            Halted = true,
+            ActorUserId = null,
+        });
+
+        data.Add("SessionPhaseChanged+PerSymbol", new SessionPhaseChangedEvent
+        {
+            TimestampUtc = ts,
+            Symbol = "PETR4",
+            Phase = "Continuous",
+            Cleared = false,
+            ActorUserId = "ops",
+        });
+
+        data.Add("SessionPhaseChanged+GlobalCleared", new SessionPhaseChangedEvent
+        {
+            TimestampUtc = ts,
+            Symbol = null,
+            Phase = "Continuous",
+            Cleared = true,
+        });
+
+        data.Add("AlgoCreated+Iceberg", new AlgoCreatedEvent
+        {
+            TimestampUtc = ts,
+            AlgoId = 1001UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Iceberg",
+            TotalQuantity = 1000,
+            CreatedAtUtc = ts,
+            IcebergDisplayQuantity = 100,
+            IcebergLimitPrice = 12.34m,
+        });
+
+        data.Add("AlgoCreated+Twap", new AlgoCreatedEvent
+        {
+            TimestampUtc = ts,
+            AlgoId = 1002UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "VALE3",
+            SecurityId = 9876UL,
+            Side = "Sell",
+            Type = "Twap",
+            TotalQuantity = 5000,
+            CreatedAtUtc = ts,
+            TwapStartUtc = ts,
+            TwapEndUtc = ts.AddMinutes(30),
+            TwapSliceCount = 6,
+            TwapChildOrderType = "Limit",
+            TwapChildPrice = 80.00m,
+        });
+
+        data.Add("AlgoCancelRequested", new AlgoCancelRequestedEvent
+        {
+            TimestampUtc = ts,
+            AlgoId = 1001UL,
+            FirmId = "default",
+            ActorUserId = "alice",
+        });
+
+        data.Add("AlgoTerminalStateRecorded", new AlgoTerminalStateRecordedEvent
+        {
+            TimestampUtc = ts,
+            AlgoId = 1001UL,
+            FirmId = "default",
+            Status = "Cancelled",
+            Reason = "OperatorCancel",
+            AtUtc = ts,
+        });
+
+        data.Add("OrderStaled", new OrderStaledEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 42UL,
+            FirmId = "default",
+            Reason = "venue-restart",
+            StaledAtUtc = ts,
+            ActorUserId = "ops",
+        });
+
+        data.Add("OrderStaleCleared", new OrderStaleClearedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 42UL,
+            FirmId = "default",
+            ResolvedBy = "er-terminal",
+        });
+
+        data.Add("UserBotCredentialCreated", new UserBotCredentialCreatedEvent
+        {
+            TimestampUtc = ts,
+            Id = credId,
+            UserId = "alice",
+            CredShortId = "b3t_abc",
+            Label = "my-bot",
+            SecretHash = "$2a$12$abcdefghijklmnopqrstuv",
+            CreatedAtUtc = ts,
+        });
+
+        data.Add("UserBotCredentialRevoked", new UserBotCredentialRevokedEvent
+        {
+            TimestampUtc = ts,
+            Id = credId,
+            UserId = "alice",
+            RevokedAtUtc = ts,
+        });
+
+        data.Add("BotSessionInitialized", new BotSessionInitializedEvent
+        {
+            TimestampUtc = ts,
+            CredentialId = credId,
+            SessionId = 12345u,
+            InitialVer = 1UL,
+            CreatedAtUtc = ts,
+        });
+
+        data.Add("BotSessionVerAdvanced", new BotSessionVerAdvancedEvent
+        {
+            TimestampUtc = ts,
+            CredentialId = credId,
+            OldVer = 1UL,
+            NewVer = 2UL,
+            Reason = "single-active-violation",
+        });
+
+        data.Add("BotSessionSeqAdvanced", new BotSessionSeqAdvancedEvent
+        {
+            TimestampUtc = ts,
+            CredentialId = credId,
+            CheckpointedOutboundSeq = 100UL,
+            At = ts,
+        });
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Payloads))]
+    public void SourceGen_RoundTrips_Polymorphically(string label, WalEvent original)
+    {
+        _ = label;
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(original, WalEventJsonContext.Default.WalEvent);
+        var back = JsonSerializer.Deserialize(bytes, WalEventJsonContext.Default.WalEvent);
+
+        Assert.NotNull(back);
+        Assert.IsType(original.GetType(), back);
+        // Records implement structural equality by default — every public
+        // property participates, so this asserts every field round-trips.
+        Assert.Equal(original, back);
+    }
+
+    [Theory]
+    [MemberData(nameof(Payloads))]
+    public void SourceGen_OutputIsByteIdenticalToReflectionPath(string label, WalEvent original)
+    {
+        _ = label;
+        var sourceGenBytes = JsonSerializer.SerializeToUtf8Bytes(original, WalEventJsonContext.Default.WalEvent);
+        var reflectionBytes = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(original, ReflectionOpts);
+
+        // Byte-for-byte equality is the strongest guarantee that on-disk
+        // WAL format is unchanged: any divergence (property order, casing,
+        // number formatting, escaping) shows up here before it shows up
+        // as a recovery mismatch on a rolled-back deploy.
+        Assert.Equal(reflectionBytes, sourceGenBytes);
+    }
+
+    [Theory]
+    [MemberData(nameof(Payloads))]
+    public void ReflectionWritten_Bytes_ParseViaSourceGen_BackToSameEvent(string label, WalEvent original)
+    {
+        _ = label;
+        // Existing WAL segments on disk were written by the reflection
+        // path. The source-gen deserialiser must read them back to a
+        // structurally-equal event.
+        var reflectionBytes = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(original, ReflectionOpts);
+        var back = JsonSerializer.Deserialize(reflectionBytes, WalEventJsonContext.Default.WalEvent);
+
+        Assert.NotNull(back);
+        Assert.IsType(original.GetType(), back);
+        Assert.Equal(original, back);
+    }
+
+    [Theory]
+    [MemberData(nameof(Payloads))]
+    public void SourceGenWritten_Bytes_ParseViaReflection_BackToSameEvent(string label, WalEvent original)
+    {
+        _ = label;
+        // Rollback safety: if we revert this PR, the previous reflection
+        // deserialiser must still understand segments that the source-gen
+        // path wrote. (This is implicit in the byte-equivalence test above
+        // but stated independently as an explicit invariant.)
+        var sourceGenBytes = JsonSerializer.SerializeToUtf8Bytes(original, WalEventJsonContext.Default.WalEvent);
+        var back = JsonSerializer.Deserialize<WalEvent>(sourceGenBytes, ReflectionOpts);
+
+        Assert.NotNull(back);
+        Assert.IsType(original.GetType(), back);
+        Assert.Equal(original, back);
+    }
+
+    [Theory]
+    [MemberData(nameof(Payloads))]
+    public void SourceGen_Output_HasSameJsonShape_AsReflection(string label, WalEvent original)
+    {
+        _ = label;
+        // Defence-in-depth alongside the byte-equality test: even when
+        // both paths emit the same bytes, deep-compare the JsonNode tree
+        // so a regression that introduces a cosmetic-only diff (extra
+        // whitespace, different unicode escaping) surfaces with a
+        // readable structural diff message rather than a raw byte length
+        // mismatch.
+        var sourceGenJson = JsonSerializer.Serialize(original, WalEventJsonContext.Default.WalEvent);
+        var reflectionJson = JsonSerializer.Serialize<WalEvent>(original, ReflectionOpts);
+
+        var a = JsonNode.Parse(sourceGenJson);
+        var b = JsonNode.Parse(reflectionJson);
+        Assert.True(JsonNode.DeepEquals(a, b),
+            $"JSON shape mismatch.\n  source-gen: {sourceGenJson}\n  reflection: {reflectionJson}");
+    }
+
+    [Fact]
+    public void Context_RegistersEveryWalEventSubtype()
+    {
+        // Polymorphic dispatch via System.Text.Json source-gen only works
+        // for types that have a JsonSerializable entry on the context.
+        // If a new WalEvent-derived record is added without being
+        // registered on WalEventJsonContext, this test fails loudly —
+        // before recovery starts losing events at runtime.
+        var derived = typeof(WalEvent).Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract && typeof(WalEvent).IsAssignableFrom(t))
+            .ToArray();
+
+        var ctx = WalEventJsonContext.Default;
+        foreach (var t in derived)
+        {
+            var info = ctx.GetTypeInfo(t);
+            Assert.True(info is not null,
+                $"WalEventJsonContext is missing a [JsonSerializable(typeof({t.Name}))] entry.");
+        }
+    }
+}


### PR DESCRIPTION
Implements **P2** of the perf hardening v0 RFC (§6.1).

Adds a `WalEventJsonContext : JsonSerializerContext` partial registering every `WalEvent`-derived payload, and switches the WAL serialise/deserialise call sites in `FileEventStore` (lines 43, 88, 125) and `EodMaterialiser` (line 59) to use the source-generated metadata instead of the reflection-based `JsonSerializer` path. Polymorphic dispatch is preserved by the existing `[JsonPolymorphic]` discriminator on the abstract base.

### Binary-equivalent on-disk format — confirmed

The new context inherits `JsonSerializerDefaults.Web` (camelCase on write, case-insensitive on read, `JsonNumberHandling.AllowReadingFromString`) — the exact options the WAL has used since day one.

Round-trip tests in `WalEventJsonContextRoundTripTests` pin the equivalence with **5 theories × 22 payloads + 1 fact = 111 new test cases**:

1. `SourceGen_RoundTrips_Polymorphically` — serialise → deserialise → structural equality.
2. `SourceGen_OutputIsByteIdenticalToReflectionPath` — `Assert.Equal(reflectionBytes, sourceGenBytes)`.
3. `ReflectionWritten_Bytes_ParseViaSourceGen_BackToSameEvent` — old segments still load.
4. `SourceGenWritten_Bytes_ParseViaReflection_BackToSameEvent` — rollback safety.
5. `SourceGen_Output_HasSameJsonShape_AsReflection` — `JsonNode.DeepEquals` defence-in-depth.
6. `Context_RegistersEveryWalEventSubtype` — reflection over the assembly fails loudly if a future `WalEvent` subtype is added without being registered on the context (sourcegen polymorphism only works for listed types).

### Payload types covered

- `OrderSubmittedEvent` (with + without `BotMapping`)
- `OrderCancelRequestedEvent` (with + without `BotMapping`)
- `OrderReplaceRequestedEvent`
- `ExecutionReportReceivedEvent` (real + synthetic-reject)
- `KillSwitchToggledEvent`
- `SymbolHaltToggledEvent`
- `SessionPhaseChangedEvent` (per-symbol + global-cleared)
- `AlgoCreatedEvent` (Iceberg + Twap)
- `AlgoCancelRequestedEvent`
- `AlgoTerminalStateRecordedEvent`
- `OrderStaledEvent`
- `OrderStaleClearedEvent`
- `UserBotCredentialCreatedEvent`
- `UserBotCredentialRevokedEvent`
- `BotSessionInitializedEvent`
- `BotSessionVerAdvancedEvent`
- `BotSessionSeqAdvancedEvent`
- Plus `BotOrderMapping` sub-record.

### Invariants preserved

- **WAL on-disk format unchanged** — byte-for-byte identical to the reflection writer.
- **RFC §4.1 (Total WAL ordering)** — no changes to seq assignment / channel ordering.
- **RFC §4.2 (Durability)** — no changes to `FlushAsync` fence or ack semantics.
- **Central package management** — no `Version=` added; source-gen is in BCL.

### Test totals

- Baseline: 864 → After: **975** (864 + 111 new). All passing.
- `dotnet format B3TradingPlatform.slnx --verify-no-changes`: clean.

Closes #196.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
