### PR TITLE
perf(net): P11 — TCP NoDelay + send/receive buffer sizing (#205)

### DIFF
--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
@@ -59,6 +59,11 @@ public sealed class EntryPointListenerOptions
     /// <summary>Outbound buffer sizing options.</summary>
     public BuffersOptions Buffers { get; set; } = new();
 
+    /// <summary>
+    /// TCP socket tunables applied to every accepted client (RFC §5.9 / P11).
+    /// </summary>
+    public FixpTcpOptions Tcp { get; set; } = new();
+
     /// <summary>Nested TLS configuration.</summary>
     public sealed class TlsOptions
     {

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptionsValidator.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptionsValidator.cs
@@ -39,6 +39,12 @@ public sealed class EntryPointListenerOptionsValidator : IValidateOptions<EntryP
         if (options.MaxSessionsPerUser <= 0)
             failures.Add("Trading:EntryPointListener:MaxSessionsPerUser must be > 0.");
 
+        // TCP tunables (RFC §5.9 / P11)
+        if (options.Tcp.SendBufferBytes <= 0)
+            failures.Add("Trading:EntryPointListener:Tcp:SendBufferBytes must be > 0.");
+        if (options.Tcp.ReceiveBufferBytes <= 0)
+            failures.Add("Trading:EntryPointListener:Tcp:ReceiveBufferBytes must be > 0.");
+
         // TLS validation
         if (options.Tls.Required)
         {

--- a/backend/src/B3.Trading.EntryPointListener/FixpTcpOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/FixpTcpOptions.cs
@@ -1,0 +1,30 @@
+namespace B3.Trading.EntryPointListener;
+
+/// <summary>
+/// TCP-level socket tunables applied to every <see cref="System.Net.Sockets.TcpClient"/>
+/// accepted by <see cref="Hosting.FixpListenerHostedService"/> (RFC §5.9 / P11).
+///
+/// <para>Defaults disable Nagle (<see cref="NoDelay"/> = true) and pin
+/// 64 KiB send/receive buffers. Default OS buffers vary across platforms
+/// (Linux auto-tunes, Windows defaults to 8 KiB which under-serves the
+/// SOFH frame burst rate) — setting them explicitly makes the listener
+/// behave predictably across deployments.</para>
+/// </summary>
+public sealed class FixpTcpOptions
+{
+    /// <summary>
+    /// Per-connection send buffer (SO_SNDBUF) in bytes. Default 64 KiB.
+    /// </summary>
+    public int SendBufferBytes { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// Per-connection receive buffer (SO_RCVBUF) in bytes. Default 64 KiB.
+    /// </summary>
+    public int ReceiveBufferBytes { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// Disable Nagle's algorithm (TCP_NODELAY). Default <c>true</c> — the
+    /// FIXP/OUCH delivery path must not batch small writes up to 200 ms.
+    /// </summary>
+    public bool NoDelay { get; set; } = true;
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpListenerHostedService.cs
@@ -146,6 +146,7 @@ public sealed class FixpListenerHostedService : BackgroundService
                 try
                 {
                     client = await _listener.AcceptTcpClientAsync(stoppingToken).ConfigureAwait(false);
+                    ApplyTcpOptions(client);
                 }
                 catch (OperationCanceledException) { break; }
                 catch (Exception ex)
@@ -214,6 +215,53 @@ public sealed class FixpListenerHostedService : BackgroundService
             _orders, _connectionDirectory, _outboundCoordinator, _opts, _clock,
             _rateLimiter, _sessionCounter);
         await conn.RunAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Test-only hook fired immediately after
+    /// <see cref="TryApplyTcpOptions"/> runs against an accepted client.
+    /// Lets integration tests observe the accept-path actually applies
+    /// the configured <see cref="FixpTcpOptions"/> (issue #205).
+    /// </summary>
+    internal static event Action<TcpClient>? AcceptedClientConfigured;
+
+    private void ApplyTcpOptions(TcpClient client)
+    {
+        // RFC §5.9 / P11 — disable Nagle and pin SO_SNDBUF / SO_RCVBUF on
+        // every accepted FIXP connection. Failures are logged but
+        // non-fatal: the connection is still functional with OS defaults.
+        if (!TryApplyTcpOptions(client, _opts.Tcp, out var ex))
+        {
+            _logger.LogWarning(ex,
+                "fixp.accept.tcp_options.failed remote={Remote}", SafeRemote(client));
+        }
+
+        AcceptedClientConfigured?.Invoke(client);
+    }
+
+    /// <summary>
+    /// Applies <paramref name="tcp"/> to <paramref name="client"/>
+    /// (NoDelay + send/receive buffer sizing). Returns <c>false</c> and
+    /// surfaces the captured exception when the kernel rejects any of
+    /// the settings — callers may ignore and proceed with OS defaults.
+    /// Exposed <c>internal</c> for direct test coverage of the
+    /// FIXP/OUCH socket-config contract (issue #205).
+    /// </summary>
+    internal static bool TryApplyTcpOptions(TcpClient client, FixpTcpOptions tcp, out Exception? error)
+    {
+        try
+        {
+            client.NoDelay = tcp.NoDelay;
+            client.SendBufferSize = tcp.SendBufferBytes;
+            client.ReceiveBufferSize = tcp.ReceiveBufferBytes;
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+            return false;
+        }
     }
 
     private static X509Certificate2 LoadCertificate(EntryPointListenerOptions.TlsOptions tls)

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hardening/TcpSocketOptionsTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hardening/TcpSocketOptionsTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Tests.Hardening;
+
+/// <summary>
+/// Issue #205 / RFC §5.9 (P11). Verifies that
+/// <see cref="FixpListenerHostedService"/> applies the configured
+/// <c>FixpTcpOptions</c> (NoDelay + send/receive buffer sizing) to every
+/// accepted client socket immediately after <c>AcceptTcpClientAsync</c>.
+/// </summary>
+public class TcpSocketOptionsTests
+{
+    private const int CustomSend = 96 * 1024;
+    private const int CustomRecv = 128 * 1024;
+
+    [Fact]
+    public void DefaultOptions_MatchRfcDefaults()
+    {
+        var opts = new FixpTcpOptions();
+
+        Assert.True(opts.NoDelay);
+        Assert.Equal(64 * 1024, opts.SendBufferBytes);
+        Assert.Equal(64 * 1024, opts.ReceiveBufferBytes);
+    }
+
+    [Fact]
+    public async Task TryApplyTcpOptions_SetsNoDelayAndBufferSizesOnAcceptedSocket()
+    {
+        // White-box exercise of the exact code path
+        // FixpListenerHostedService runs immediately after
+        // AcceptTcpClientAsync. We open a real loopback listener,
+        // accept one client, and assert the kernel echoes back the
+        // configured socket properties.
+        var srvListener = new TcpListener(IPAddress.Loopback, 0);
+        srvListener.Start();
+        try
+        {
+            var port = ((IPEndPoint)srvListener.LocalEndpoint).Port;
+            var acceptTask = srvListener.AcceptTcpClientAsync();
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, port)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            using var server = await acceptTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var tcp = new FixpTcpOptions
+            {
+                NoDelay = true,
+                SendBufferBytes = CustomSend,
+                ReceiveBufferBytes = CustomRecv,
+            };
+
+            var ok = FixpListenerHostedService.TryApplyTcpOptions(server, tcp, out var err);
+
+            Assert.True(ok);
+            Assert.Null(err);
+            Assert.True(server.NoDelay);
+            // Kernels are free to round buffer sizes upward; assert at
+            // least the configured value made it through.
+            Assert.True(server.SendBufferSize >= CustomSend,
+                $"SendBufferSize was {server.SendBufferSize}, expected >= {CustomSend}");
+            Assert.True(server.ReceiveBufferSize >= CustomRecv,
+                $"ReceiveBufferSize was {server.ReceiveBufferSize}, expected >= {CustomRecv}");
+        }
+        finally
+        {
+            srvListener.Stop();
+        }
+    }
+
+    [Fact]
+    public void TryApplyTcpOptions_OnDisposedSocket_FailsGracefully()
+    {
+        var disposed = new TcpClient();
+        disposed.Dispose();
+
+        var ok = FixpListenerHostedService.TryApplyTcpOptions(
+            disposed, new FixpTcpOptions(), out var err);
+
+        Assert.False(ok);
+        Assert.NotNull(err);
+    }
+
+    [Fact]
+    public async Task ListenerAcceptPath_AppliesTcpOptionsToServerSocket()
+    {
+        // Regression guard: asserts the FixpListenerHostedService accept
+        // loop itself (not just the helper) applies FixpTcpOptions to
+        // every accepted client. If the apply call were ever removed
+        // from the accept path, this test would fail.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:EntryPointListener:Enabled"] = "true",
+                ["Trading:EntryPointListener:Endpoint"] = "127.0.0.1:0",
+                ["Trading:EntryPointListener:Tcp:NoDelay"] = "true",
+                ["Trading:EntryPointListener:Tcp:SendBufferBytes"] = CustomSend.ToString(),
+                ["Trading:EntryPointListener:Tcp:ReceiveBufferBytes"] = CustomRecv.ToString(),
+            })
+            .Build();
+
+        using var host = new HostBuilder()
+            .ConfigureServices((_, s) =>
+            {
+                s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                s.AddSingleton<InMemoryUserBotCredentialRegistry>();
+                s.AddSingleton<IUserBotCredentialRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
+                s.AddSingleton<InMemoryUserBotSessionRegistry>();
+                s.AddSingleton<IUserBotSessionRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
+                s.AddNoopOrderPathStubs();
+                s.AddEntryPointListener(config);
+            })
+            .Build();
+
+        var captured = new TaskCompletionSource<(bool noDelay, int snd, int rcv)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Action<TcpClient> handler = c =>
+        {
+            try
+            {
+                captured.TrySetResult((c.NoDelay, c.SendBufferSize, c.ReceiveBufferSize));
+            }
+            catch (Exception ex)
+            {
+                captured.TrySetException(ex);
+            }
+        };
+        FixpListenerHostedService.AcceptedClientConfigured += handler;
+
+        try
+        {
+            await host.StartAsync();
+            var listener = host.Services.GetRequiredService<FixpListenerHostedService>();
+            var bound = await listener.WhenBound.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, bound.Port)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            var snapshot = await captured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.True(snapshot.noDelay);
+            Assert.True(snapshot.snd >= CustomSend,
+                $"server-side SendBufferSize was {snapshot.snd}, expected >= {CustomSend}");
+            Assert.True(snapshot.rcv >= CustomRecv,
+                $"server-side ReceiveBufferSize was {snapshot.rcv}, expected >= {CustomRecv}");
+        }
+        finally
+        {
+            FixpListenerHostedService.AcceptedClientConfigured -= handler;
+            await host.StopAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task ListenerHost_BindsTcpOptionsFromConfiguration()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trading:EntryPointListener:Enabled"] = "true",
+                ["Trading:EntryPointListener:Endpoint"] = "127.0.0.1:0",
+                ["Trading:EntryPointListener:Tcp:NoDelay"] = "true",
+                ["Trading:EntryPointListener:Tcp:SendBufferBytes"] = CustomSend.ToString(),
+                ["Trading:EntryPointListener:Tcp:ReceiveBufferBytes"] = CustomRecv.ToString(),
+            })
+            .Build();
+
+        using var host = new HostBuilder()
+            .ConfigureServices((_, s) =>
+            {
+                s.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                s.AddSingleton<InMemoryUserBotCredentialRegistry>();
+                s.AddSingleton<IUserBotCredentialRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());
+                s.AddSingleton<InMemoryUserBotSessionRegistry>();
+                s.AddSingleton<IUserBotSessionRegistry>(sp =>
+                    sp.GetRequiredService<InMemoryUserBotSessionRegistry>());
+                s.AddNoopOrderPathStubs();
+                s.AddEntryPointListener(config);
+            })
+            .Build();
+
+        await host.StartAsync();
+        try
+        {
+            var opts = host.Services
+                .GetRequiredService<IOptions<EntryPointListenerOptions>>().Value;
+
+            Assert.True(opts.Tcp.NoDelay);
+            Assert.Equal(CustomSend, opts.Tcp.SendBufferBytes);
+            Assert.Equal(CustomRecv, opts.Tcp.ReceiveBufferBytes);
+        }
+        finally
+        {
+            await host.StopAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+}


### PR DESCRIPTION
Implements **P11 / F9** of the perf hardening v0 RFC (§5.9). Closes #205.

## What

After `AcceptTcpClientAsync`, every accepted FIXP/OUCH `TcpClient` is configured per RFC §5.9:

| Setting | Default | Source |
|---|---|---|
| `Socket.NoDelay` | `true` | `Trading:EntryPointListener:Tcp:NoDelay` |
| `SendBufferSize` | `65536` (64 KiB) | `Trading:EntryPointListener:Tcp:SendBufferBytes` |
| `ReceiveBufferSize` | `65536` (64 KiB) | `Trading:EntryPointListener:Tcp:ReceiveBufferBytes` |

Defaults match RFC §5.9 verbatim. NoDelay disables Nagle on the latency-critical ER delivery path; pinned 64 KiB buffers normalize behavior across Linux (auto-tunes) and Windows (default 8 KiB recv buffer under-serves SOFH frame bursts at 100k msg/s).

## How

- New `FixpTcpOptions` (NoDelay / SendBufferBytes / ReceiveBufferBytes) bound at `Trading:EntryPointListener:Tcp` via the existing `EntryPointListenerServiceCollectionExtensions.AddEntryPointListener` config bind — no change required at the host composition root.
- `EntryPointListenerOptionsValidator` rejects non-positive buffer sizes.
- `FixpListenerHostedService.ApplyTcpOptions` runs synchronously on every accept; kernel rejection is logged (`fixp.accept.tcp_options.failed`) and the connection proceeds with OS defaults — zero behavior change beyond the flags.
- Apply logic factored as `internal static TryApplyTcpOptions(TcpClient, FixpTcpOptions, out Exception?)` for direct test coverage.

## Tests

`backend/tests/B3.Trading.EntryPointListener.Tests/Hardening/TcpSocketOptionsTests.cs`:

- `DefaultOptions_MatchRfcDefaults`
- `TryApplyTcpOptions_SetsNoDelayAndBufferSizesOnAcceptedSocket`
- `TryApplyTcpOptions_OnDisposedSocket_FailsGracefully`
- `ListenerAcceptPath_AppliesTcpOptionsToServerSocket` (regression guard — exercises the actual `FixpListenerHostedService` accept loop end-to-end)
- `ListenerHost_BindsTcpOptionsFromConfiguration`

Total suite: **869 passed, 0 failed** (864 baseline + 5 new). `dotnet format --verify-no-changes` clean.

Closes #205

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>