### PR TITLE
perf(bench): P1 — BenchmarkDotNet harness + baseline benches (#195)

### DIFF
--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -15,6 +15,9 @@
     <Project Path="backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj" />
   </Folder>
+  <Folder Name="/backend/bench/">
+    <Project Path="backend/bench/B3.Trading.Benchmarks/B3.Trading.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/backend/tools/">
     <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />
     <Project Path="backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj" />

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />

--- a/backend/bench/B3.Trading.Benchmarks/B3.Trading.Benchmarks.csproj
+++ b/backend/bench/B3.Trading.Benchmarks/B3.Trading.Benchmarks.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Trading.Benchmarks</RootNamespace>
+    <!-- See README.md for runner spec. IsPackable=false keeps the harness out of pack/publish; CI's dotnet test skips it because it is not a test project. -->
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoWarn>$(NoWarn);CA1822;CA1051</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Trading.Domain\B3.Trading.Domain.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.Application\B3.Trading.Application.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.Infrastructure\B3.Trading.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.EntryPointListener\B3.Trading.EntryPointListener.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
@@ -1,0 +1,192 @@
+using BenchmarkDotNet.Attributes;
+
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Benchmarks.Benches;
+
+/// <summary>
+/// RFC §7.1 — baseline for the bot ER router that F4/F5 target.
+/// Measures end-to-end <see cref="BotErMultiplexer.Route"/> + drain +
+/// <see cref="OutboundExecutionReportEncoder.Encode"/> + outbound
+/// enqueue. Each invocation routes <see cref="BatchSize"/> events for
+/// <see cref="MappedCredentials"/> rotating credentials and waits until
+/// the in-process fake sender has observed all of them.
+///
+/// <para>The router is a <c>BackgroundService</c>; we start it in
+/// <see cref="GlobalSetup"/> and reset per-iteration counters in
+/// <see cref="IterationSetup"/> so each benchmark sample is independent.
+/// </para>
+///
+/// <para>Acceptance gates (RFC §7.3): F4 — no throughput regression vs.
+/// F2 baseline; F5 — outbound bytes alloc −95%. P7's PR records
+/// before/after numbers in its body referencing this bench by name.</para>
+/// </summary>
+[MemoryDiagnoser]
+public class BotErRouter_RouteOne_Bench
+{
+    [Params(64, 1024)]
+    public int BatchSize { get; set; }
+
+    [Params(1, 16)]
+    public int MappedCredentials { get; set; }
+
+    private BotErMultiplexer _mux = null!;
+    private CancellationTokenSource _cts = null!;
+    private FakeMappingRegistry _mappings = null!;
+    private BotOutboundCoordinator _coord = null!;
+    private CountingSender[] _senders = null!;
+    private Guid[] _credIds = null!;
+    private ulong[] _internalIds = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var directory = new BotSessionConnectionDirectory();
+        _mappings = new FakeMappingRegistry();
+
+        _credIds = new Guid[MappedCredentials];
+        _senders = new CountingSender[MappedCredentials];
+        _internalIds = new ulong[BatchSize];
+
+        for (var i = 0; i < MappedCredentials; i++)
+        {
+            _credIds[i] = Guid.NewGuid();
+            await sessions.GetOrCreateAsync(_credIds[i], default).ConfigureAwait(false);
+            _senders[i] = new CountingSender();
+            directory.Register(_credIds[i], _senders[i]);
+        }
+
+        for (var i = 0; i < BatchSize; i++)
+        {
+            var internalId = (ulong)(i + 1);
+            _internalIds[i] = internalId;
+            var cred = _credIds[i % MappedCredentials];
+            _mappings.Add(internalId, cred, externalId: 1_000_000UL + internalId);
+        }
+
+        var opts = Options.Create(new BotErMultiplexerOptions
+        {
+            // Big enough to swallow the largest batch without overflow.
+            OutboundBufferMaxMessages = Math.Max(8192, BatchSize * 4),
+            RouterChannelCapacity = 65536,
+        });
+        var coord = new BotOutboundCoordinator(sessions, opts.Value);
+        _coord = coord;
+        _mux = new BotErMultiplexer(_mappings, sessions, directory, coord,
+            NullLogger<BotErMultiplexer>.Instance, opts);
+
+        _cts = new CancellationTokenSource();
+        await _mux.StartAsync(_cts.Token).ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        try { await _mux.StopAsync(CancellationToken.None).ConfigureAwait(false); }
+        catch { /* best-effort */ }
+        _cts.Dispose();
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Resetting both the sender counters AND the per-credential
+        // outbound buffers is required: BotOutboundBuffer permanently
+        // marks itself overflowed once full and would silently make
+        // subsequent RouteOne calls skip TryEnqueue, hanging the
+        // spin-wait below. Resetting here keeps each iteration
+        // independent and isolated from the previous one's buffered
+        // bytes (which are also released, keeping memory bounded).
+        foreach (var s in _senders) s.Reset();
+        foreach (var credId in _credIds) _coord.GetOrCreateBuffer(credId).Reset();
+    }
+
+    [Benchmark]
+    public void RouteBatch()
+    {
+        for (var i = 0; i < BatchSize; i++)
+        {
+            _mux.Route(NewEvent(_internalIds[i]));
+        }
+
+        // Spin-wait until the drain loop has observed every event.
+        // Cap the wait at 30s so a regression that breaks routing
+        // surfaces as a loud failure, not a hung benchmark process.
+        var deadline = Environment.TickCount64 + 30_000;
+        var spin = new SpinWait();
+        while (TotalSent() < BatchSize)
+        {
+            if (Environment.TickCount64 > deadline)
+            {
+                throw new TimeoutException(
+                    $"RouteBatch drain stalled at {TotalSent()}/{BatchSize} after 30s");
+            }
+            spin.SpinOnce();
+        }
+    }
+
+    private int TotalSent()
+    {
+        var sum = 0;
+        foreach (var s in _senders) sum += s.SentCount;
+        return sum;
+    }
+
+    private static ExecutionEvent NewEvent(ulong clOrdId) =>
+        new(
+            Owner: new EndClientId("u1"),
+            ClOrdId: clOrdId,
+            Symbol: "PETR4",
+            Side: OrderSide.Buy,
+            Status: OrderStatus.Working,
+            Kind: ExecKind.New,
+            LeavesQuantity: 100,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            TimestampUtc: DateTimeOffset.UtcNow);
+
+    private sealed class CountingSender : IBotSessionOutboundSender
+    {
+        private int _sent;
+        public int SentCount => Volatile.Read(ref _sent);
+        public void Reset() => Volatile.Write(ref _sent, 0);
+        public bool TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+        {
+            Interlocked.Increment(ref _sent);
+            return true;
+        }
+    }
+
+    private sealed class FakeMappingRegistry : IUserBotOrderMappingRegistry
+    {
+        private readonly Dictionary<ulong, OrderMapping> _orders = new();
+
+        public void Add(ulong internalId, Guid credId, ulong externalId)
+            => _orders[internalId] = new OrderMapping(credId, externalId);
+
+        public bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping)
+            => _orders.TryGetValue(internalClOrdId, out mapping);
+
+        public bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId)
+        { internalClOrdId = 0; return false; }
+        public bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping)
+        { mapping = default; return false; }
+        public void Reap(ulong internalClOrdId) { }
+        public void ReapCancel(ulong cancelInternalClOrdId) { }
+        public void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId) { }
+        public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
+        public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
+        public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
+    }
+}

--- a/backend/bench/B3.Trading.Benchmarks/Benches/EventDispatcher_Dispatch_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/EventDispatcher_Dispatch_Bench.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+
+using B3.Trading.Application.Persistence;
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Benchmarks.Benches;
+
+/// <summary>
+/// RFC §7.1 — baseline for the dispatcher critical section that F1
+/// targets. Measures pure <see cref="EventDispatcher.Dispatch"/> cost
+/// against <see cref="NullEventStore"/> so the number reflects the lock
+/// + delegate invocation, isolated from disk I/O.
+///
+/// <para>Acceptance gate (RFC §7.3 / F1): post-fix throughput must be
+/// ≥3× baseline and AllocatedBytes must drop by ≥50%. P3's PR is
+/// expected to record before/after numbers in its body referencing this
+/// bench by name.</para>
+/// </summary>
+[MemoryDiagnoser]
+public class EventDispatcher_Dispatch_Bench
+{
+    private EventDispatcher _dispatcher = null!;
+    private WalEvent _evt = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var store = new NullEventStore();
+        _dispatcher = new EventDispatcher(store);
+        _evt = new SymbolHaltToggledEvent
+        {
+            Symbol = "PETR4",
+            Halted = true,
+            ActorUserId = "bench",
+        };
+    }
+
+    [Benchmark]
+    public long Dispatch()
+        => _dispatcher.Dispatch(_evt, static () => { });
+}

--- a/backend/bench/B3.Trading.Benchmarks/Benches/OutboundExecutionReportEncoder_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/OutboundExecutionReportEncoder_Bench.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+
+namespace B3.Trading.Benchmarks.Benches;
+
+/// <summary>
+/// RFC §7.1 — baseline for the SBE outbound encode that F5 targets.
+/// Encodes one <see cref="ExecutionEvent"/> per invocation per ExecKind
+/// to keep coverage symmetric with the production path that switches on
+/// <see cref="ExecKind"/>. The encoder is currently a static helper that
+/// returns a heap-allocated byte[]; the post-fix variant is expected to
+/// pool buffers and shrink Gen0 collections by ≥80%.
+///
+/// <para>Encoder type is <c>internal</c>; this project is granted access
+/// via <c>InternalsVisibleTo</c> on
+/// <c>B3.Trading.EntryPointListener.csproj</c>.</para>
+/// </summary>
+[MemoryDiagnoser]
+public class OutboundExecutionReportEncoder_Bench
+{
+    private const ulong ExternalClOrdId = 4242UL;
+    private const ulong ExternalOrigClOrdId = 4241UL;
+
+    [Params(ExecKind.New, ExecKind.PartialFill, ExecKind.Canceled, ExecKind.Rejected)]
+    public ExecKind Kind { get; set; }
+
+    private ExecutionEvent _ev = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _ev = new ExecutionEvent(
+            Owner: new EndClientId("u1"),
+            ClOrdId: 100UL,
+            Symbol: "PETR4",
+            Side: OrderSide.Buy,
+            Status: Kind == ExecKind.Rejected ? OrderStatus.Rejected : OrderStatus.Working,
+            Kind: Kind,
+            LeavesQuantity: 100,
+            CumulativeQuantity: Kind == ExecKind.PartialFill ? 50 : 0,
+            LastQuantity: Kind == ExecKind.PartialFill ? 50 : 0,
+            LastPrice: Kind == ExecKind.PartialFill ? 30.50m : 0m,
+            RejectReason: Kind == ExecKind.Rejected ? "risk" : null,
+            TimestampUtc: DateTimeOffset.UtcNow);
+    }
+
+    [Benchmark]
+    public byte[] Encode()
+        => OutboundExecutionReportEncoder.Encode(_ev, ExternalClOrdId, ExternalOrigClOrdId);
+}

--- a/backend/bench/B3.Trading.Benchmarks/Benches/WAL_Append_Flush_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/WAL_Append_Flush_Bench.cs
@@ -1,0 +1,80 @@
+using BenchmarkDotNet.Attributes;
+
+using B3.Trading.Application.Persistence;
+using B3.Trading.Infrastructure.Persistence;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Benchmarks.Benches;
+
+/// <summary>
+/// RFC §7.1 — baseline for the WAL append + group-commit path that
+/// F1/F7 target. Runs against tmpfs (<c>/dev/shm</c>) when available so
+/// disk seek latency does not dominate; falls back to
+/// <see cref="Path.GetTempPath"/> on platforms without a RAM-disk
+/// (Windows CI). The bench data dir is created per-iteration in
+/// <see cref="GlobalSetup"/> and torn down in <see cref="GlobalCleanup"/>.
+///
+/// <para>Acceptance gate (RFC §7.3 / F7): post-fix saturated Append rate
+/// must be ≥4× baseline. P5/P8 PRs record before/after numbers in their
+/// bodies referencing this bench by name.</para>
+/// </summary>
+[MemoryDiagnoser]
+public class WAL_Append_Flush_Bench
+{
+    /// <summary>
+    /// Records appended per <see cref="AppendBatchThenFlush"/> invocation.
+    /// Two values keep the matrix small while still exercising both the
+    /// "below group-commit window" and "saturating the writer" regimes.
+    /// </summary>
+    [Params(1, 64)]
+    public int BatchSize { get; set; }
+
+    private FileEventStore _store = null!;
+    private string _dataDir = null!;
+    private WalEvent _evt = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var root = Directory.Exists("/dev/shm") ? "/dev/shm" : Path.GetTempPath();
+        _dataDir = Path.Combine(root, "b3-bench-wal-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var opts = new PersistenceOptions
+        {
+            DataDirectory = _dataDir,
+            FirmId = "bench",
+            ChannelCapacity = 16384,
+            GroupCommitMaxRecords = 64,
+            GroupCommitWindow = TimeSpan.FromMilliseconds(10),
+            FsyncOnFlush = true,
+        };
+        _store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        _evt = new SymbolHaltToggledEvent
+        {
+            Symbol = "PETR4",
+            Halted = true,
+            ActorUserId = "bench",
+        };
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        try { _store.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
+        catch { /* best-effort */ }
+        try { Directory.Delete(_dataDir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Benchmark]
+    public async Task AppendBatchThenFlush()
+    {
+        for (var i = 0; i < BatchSize; i++)
+        {
+            _store.Append(_evt);
+        }
+        await _store.FlushAsync().ConfigureAwait(false);
+    }
+}

--- a/backend/bench/B3.Trading.Benchmarks/Program.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Program.cs
@@ -1,0 +1,19 @@
+using BenchmarkDotNet.Running;
+
+namespace B3.Trading.Benchmarks;
+
+/// <summary>
+/// Entry point for the perf-hardening v0 bench harness (RFC §7.1, issue #195).
+/// Delegates to <see cref="BenchmarkSwitcher"/> so callers can use the
+/// standard CLI (e.g. <c>--filter '*DispatcherBench*'</c>, <c>--job Dry</c>,
+/// <c>--list flat</c>). Sub-issue PRs in the perf epic (#194) extend this
+/// project with before/after numbers; the README documents the runner spec.
+/// </summary>
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        return 0;
+    }
+}

--- a/backend/bench/B3.Trading.Benchmarks/README.md
+++ b/backend/bench/B3.Trading.Benchmarks/README.md
@@ -1,0 +1,83 @@
+# B3.Trading.Benchmarks
+
+`BenchmarkDotNet` harness for the perf-hardening v0 RFC
+(`docs/rfcs/perf-hardening-v0.md` §7.1, tracking #194). Each benchmark
+class targets one of the hot paths the RFC's per-finding fixes (P3-P11
+in #194) will touch.
+
+The harness is **on-demand only**. It is wired into `B3TradingPlatform.slnx`
+so `dotnet build` compiles it, but `<IsPackable>false</IsPackable>` keeps
+it out of pack/publish, and CI's `dotnet test` skips it because it is not
+a test project. There is no perf job in `.github/workflows/`; benches
+run on developer hardware (or in a future labelled-dispatch job).
+
+## Registered benchmarks
+
+| Class                                  | Hot path                                                       | Acceptance gate (RFC §7.3) |
+| -------------------------------------- | -------------------------------------------------------------- | -------------------------- |
+| `EventDispatcher_Dispatch_Bench`       | `EventDispatcher.Dispatch` against `NullEventStore`            | F1 — ≥3× ops/s, alloc −50% |
+| `WAL_Append_Flush_Bench`               | `FileEventStore.Append` + group-commit `FlushAsync` (tmpfs)    | F7 — Append rate ≥4×       |
+| `OutboundExecutionReportEncoder_Bench` | `OutboundExecutionReportEncoder.Encode` per `ExecKind`         | F5 — Gen0 −80%             |
+| `BotErRouter_RouteOne_Bench`           | `BotErMultiplexer.Route` end-to-end (drain + encode + send)    | F4/F5 — alloc −95%, no throughput regression |
+
+`OutboundExecutionReportEncoder.Encode` is `internal`; this project is
+granted access via `InternalsVisibleTo` on
+`backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj`.
+
+## Running
+
+```sh
+# List everything
+dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- --list flat
+
+# Run one bench
+dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- \
+  --filter '*DispatcherBench*'
+
+# Smoke run (Dry job — single iteration, ~seconds, NOT for measurement)
+dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- \
+  --filter '*' --job Dry
+
+# Full default job (Release, all benches, ~minutes)
+dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- \
+  --filter '*' --memory
+```
+
+## Runner spec for comparable numbers
+
+Sub-issue PRs (P3-P11 in #194) record before/after numbers in their PR
+bodies. To keep numbers comparable across PRs, run on the same machine
+with these settings:
+
+- **Build:** `dotnet build -c Release` against the bench project.
+- **Process isolation:** close other CPU-heavy work; pin to performance
+  governor on Linux (`cpupower frequency-set -g performance`).
+- **WAL bench:** uses `/dev/shm` when present (Linux). On platforms
+  without a RAM-disk it falls back to `Path.GetTempPath()`; numbers from
+  those runs are NOT comparable with tmpfs runs and must be flagged.
+- **Process count:** the default `Job` already runs benchmarks in a
+  child process per benchmark for isolation — leave it alone unless you
+  have a specific reason.
+- **GC mode:** `<ServerGarbageCollection>true</ServerGarbageCollection>`
+  matches the production host config.
+
+## Where to put before/after numbers in PR bodies
+
+Each P3-P11 PR body must contain a "Bench numbers" section with the
+relevant `BenchmarkDotNet` summary table copy-pasted (or as a fenced
+markdown table) for both `main` baseline and the PR's branch — at
+minimum: `Mean`, `Allocated`, `Gen0`, `Gen1`, and any throughput column
+the per-fix bench class exposes. Sample shape:
+
+```text
+Bench: EventDispatcher_Dispatch_Bench
+
+| Method   | Mean     | Allocated | Gen0  |
+| -------- | -------- | --------- | ----- |
+| baseline |  XX.X ns |    YY B   | 0.00X |
+| this PR  |  XX.X ns |    YY B   | 0.00X |
+```
+
+Acceptance gates per fix are listed in RFC §7.3 — a PR that hits its
+throughput target but regresses any other path's latency by >10% is not
+mergeable without an RFC amendment.

--- a/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
+++ b/backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="B3.Trading.EntryPointListener.Tests" />
+    <InternalsVisibleTo Include="B3.Trading.Benchmarks" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Implements **P1** of the perf-hardening v0 RFC — a `BenchmarkDotNet`
harness + baseline benches for the four hot paths the per-finding fixes
in #194 (P3-P11) will modify. Sub-issue PRs in that epic will reference
these benches by name in their before/after numbers.

## What's in

- New project `backend/bench/B3.Trading.Benchmarks` (Exe, `net10.0`,
  `IsPackable=false`, `[MemoryDiagnoser]` per class).
- Four bench classes (RFC §7.1):
  - `EventDispatcher_Dispatch_Bench` — `EventDispatcher.Dispatch` against `NullEventStore`.
  - `WAL_Append_Flush_Bench` — `FileEventStore.Append` + group-commit `FlushAsync` (writes to `/dev/shm` when present, falls back to `Path.GetTempPath()`).
  - `OutboundExecutionReportEncoder_Bench` — `OutboundExecutionReportEncoder.Encode` parametrised over `ExecKind`.
  - `BotErRouter_RouteOne_Bench` — `BotErMultiplexer.Route` end-to-end (drain + encode + outbound enqueue), parametrised over `BatchSize` × `MappedCredentials`.
- README documenting the runner spec and where to drop before/after numbers in PR bodies.
- `BenchmarkDotNet 0.15.4` added to `backend/Directory.Packages.props` (central package management — no `Version=` in csproj, NU1015 clean).
- `InternalsVisibleTo="B3.Trading.Benchmarks"` added on `B3.Trading.EntryPointListener` so the encoder bench can call the `internal static` encoder.

## CI / build wiring

Project is added to `B3TradingPlatform.slnx` so `dotnet build` covers it,
but it is **not** a test project (no xUnit reference) so the CI `dotnet
test` step skips it. `IsPackable=false` keeps it out of pack/publish.
The CI workflow file is unchanged. Benches are runnable on demand only.

## Smoke run (`--job Dry`, all 11 configurations)

```text
BenchmarkDotNet v0.15.4, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
AMD EPYC 7763 2.45GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.201
  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  Dry    : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3

| Method                   | Params                                | Mean      | Allocated |
| ------------------------ | ------------------------------------- | --------- | --------- |
| Dispatch                 | -                                     | 748.1 us  |        -  |
| AppendBatchThenFlush     | BatchSize=1                           | 121.2 ms  |  2.01 KB  |
| AppendBatchThenFlush     | BatchSize=64                          | 124.2 ms  |  36.7 KB  |
| Encode                   | Kind=New                              | 2.220 ms  |    216 B  |
| Encode                   | Kind=PartialFill                      | 2.865 ms  |    216 B  |
| Encode                   | Kind=Canceled                         | 2.556 ms  |    224 B  |
| Encode                   | Kind=Rejected                         | 2.191 ms  |    200 B  |
| RouteBatch               | BatchSize=64,   MappedCredentials=1   | 7.304 ms  |  53.03 KB |
| RouteBatch               | BatchSize=64,   MappedCredentials=16  | 8.146 ms  |  53.03 KB |
| RouteBatch               | BatchSize=1024, MappedCredentials=1   | 9.399 ms  | 824.09 KB |
| RouteBatch               | BatchSize=1024, MappedCredentials=16  | 8.241 ms  | 824.09 KB |
```

`Dry` numbers are **not** measurements — they confirm the harness wires
each bench end-to-end without crashing. Sub-issue PRs run the default
job for real numbers.

## Registered benchmarks

| Bench class                            | Hot path                                                         | Acceptance gate (RFC §7.3)                  |
| -------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
| `EventDispatcher_Dispatch_Bench`       | `EventDispatcher.Dispatch` against `NullEventStore`              | F1 — ≥3× ops/s, alloc −50%                  |
| `WAL_Append_Flush_Bench`               | `FileEventStore.Append` + group-commit `FlushAsync` (tmpfs)      | F7 — Append rate ≥4×                        |
| `OutboundExecutionReportEncoder_Bench` | `OutboundExecutionReportEncoder.Encode` per `ExecKind`           | F5 — Gen0 −80%                              |
| `BotErRouter_RouteOne_Bench`           | `BotErMultiplexer.Route` end-to-end (drain + encode + send)      | F4/F5 — alloc −95%, no throughput regression |

## Verification

- `dotnet build B3TradingPlatform.slnx -c Release` ✅
- `dotnet test  B3TradingPlatform.slnx -c Release` ✅ (980 passed / 18 conformance skipped — count grew vs. the issue's 864 expectation because P2 and P11 merged ahead of this branch)
- `dotnet format B3TradingPlatform.slnx --verify-no-changes` ✅
- Smoke `dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- --filter '*' --job Dry` ✅ (output above)
- Mandatory gpt-5.5 code review pass: 1 High addressed (router bench buffer reset + bounded spin-wait), 0 Critical/High remaining.

Closes #195
