### PR TITLE
perf(wal): P5 — raise GroupCommitMaxRecords; conditional index fsync (#199)

### DIFF
--- a/backend/src/B3.Trading.Host/appsettings.json
+++ b/backend/src/B3.Trading.Host/appsettings.json
@@ -69,7 +69,7 @@
       "SegmentMaxBytes": 67108864,
       "ChannelCapacity": 4096,
       "GroupCommitWindow": "00:00:00.0100000",
-      "GroupCommitMaxRecords": 64
+      "GroupCommitMaxRecords": 512
     }
   }
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/PersistenceOptions.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/PersistenceOptions.cs
@@ -35,7 +35,15 @@ public sealed class PersistenceOptions
 
     /// <summary>Group-commit window: writer flushes after either limit.</summary>
     public TimeSpan GroupCommitWindow { get; set; } = TimeSpan.FromMilliseconds(10);
-    public int GroupCommitMaxRecords { get; set; } = 64;
+
+    /// <summary>
+    /// Maximum records per group-commit batch. Raised from 64 → 512 in P5/F7
+    /// to amortise fsync over more records at participant-volume throughput
+    /// without breaching the <see cref="GroupCommitWindow"/> latency cap.
+    /// Worst-case crash exposure (acked-but-unfsynced records) is
+    /// <c>ChannelCapacity + GroupCommitMaxRecords</c>; see RFC §4.2 / §5.7.
+    /// </summary>
+    public int GroupCommitMaxRecords { get; set; } = 512;
 
     /// <summary>Snapshot cadence.</summary>
     public TimeSpan SnapshotInterval { get; set; } = TimeSpan.FromMinutes(5);

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SegmentWriter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SegmentWriter.cs
@@ -42,7 +42,16 @@ internal sealed class SegmentWriter : IAsyncDisposable
 
     private long _bytesAtLastIndex;
     private int _recordsSinceIndex;
+    private bool _indexDirty;
     private bool _disposed;
+
+    // Test seam: internal counters of how many times we've actually issued
+    // a Flush(_fsyncOnFlush) on the underlying log/idx streams. Used by
+    // SegmentWriter tests to assert the conditional-index-fsync path
+    // (P5/F7) — we must not fsync .idx on batches that wrote no index
+    // records. Not exposed publicly; gated by InternalsVisibleTo.
+    internal long LogFlushCount;
+    internal long IndexFlushCount;
 
     public SegmentWriter(string logPath, string idxPath, int indexEveryNRecords, int indexEveryNBytes, bool fsyncOnFlush)
     {
@@ -84,12 +93,25 @@ internal sealed class SegmentWriter : IAsyncDisposable
         BinaryPrimitives.WriteInt64LittleEndian(rec[8..], offset);
         BinaryPrimitives.WriteInt64LittleEndian(rec[16..], timestampMs);
         _idx.Write(rec);
+        _indexDirty = true;
     }
 
     public void Flush()
     {
         _log.Flush(_fsyncOnFlush);
-        _idx.Flush(_fsyncOnFlush);
+        LogFlushCount++;
+        // P5/F7: skip the index fsync when no index record has been written
+        // since the last flush. The default index cadence is every 64
+        // records, so on typical 64-record batches this elides ~63 of every
+        // 64 .idx fsyncs. Recovery is unaffected: an unflushed .idx tail
+        // just means the next replay rescans a few more .log records to
+        // rebuild the in-memory index, which it already does on cold start.
+        if (_indexDirty)
+        {
+            _idx.Flush(_fsyncOnFlush);
+            IndexFlushCount++;
+            _indexDirty = false;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/SegmentWriterFsyncTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/SegmentWriterFsyncTests.cs
@@ -1,0 +1,92 @@
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Covers P5/F7's conditional index-fsync change. The contract is:
+/// every batch fsyncs the .log; the .idx is fsync'd only when an index
+/// record was written since the last <see cref="SegmentWriter.Flush"/>.
+/// We assert this via internal counters rather than syscall tracing —
+/// the counters are gated to test/InternalsVisibleTo and exist purely
+/// to verify the elision actually happens.
+/// </summary>
+public class SegmentWriterFsyncTests : IDisposable
+{
+    private readonly string _root;
+
+    public SegmentWriterFsyncTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-segwriter-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private SegmentWriter NewWriter(int indexEveryNRecords = 64, int indexEveryNBytes = 4096)
+    {
+        var log = Path.Combine(_root, "000.log");
+        var idx = Path.Combine(_root, "000.idx");
+        return new SegmentWriter(log, idx, indexEveryNRecords, indexEveryNBytes, fsyncOnFlush: false);
+    }
+
+    private static byte[] Payload(int size)
+    {
+        var p = new byte[size];
+        for (var i = 0; i < size; i++) p[i] = (byte)(i & 0xff);
+        return p;
+    }
+
+    [Fact]
+    public async Task Flush_with_no_index_entry_written_does_not_flush_idx()
+    {
+        // Index cadence high enough that the few records below never trip it.
+        await using var w = NewWriter(indexEveryNRecords: 1024, indexEveryNBytes: 1 << 20);
+
+        for (var seq = 1; seq <= 10; seq++) w.Append(seq, Payload(32), 0);
+        w.Flush();
+
+        Assert.Equal(1, w.LogFlushCount);
+        Assert.Equal(0, w.IndexFlushCount);
+    }
+
+    [Fact]
+    public async Task Flush_after_index_entry_written_flushes_idx_once()
+    {
+        await using var w = NewWriter(indexEveryNRecords: 4, indexEveryNBytes: 1 << 20);
+
+        // 4 records → exactly one index entry written by the cadence.
+        for (var seq = 1; seq <= 4; seq++) w.Append(seq, Payload(32), 0);
+        w.Flush();
+
+        Assert.Equal(1, w.LogFlushCount);
+        Assert.Equal(1, w.IndexFlushCount);
+    }
+
+    [Fact]
+    public async Task Subsequent_flush_after_index_clear_skips_idx_again()
+    {
+        await using var w = NewWriter(indexEveryNRecords: 4, indexEveryNBytes: 1 << 20);
+
+        // First batch: 4 records → index entry → both flushed.
+        for (var seq = 1; seq <= 4; seq++) w.Append(seq, Payload(32), 0);
+        w.Flush();
+
+        // Second batch: 3 records (under cadence) → no index entry → idx fsync elided.
+        for (var seq = 5; seq <= 7; seq++) w.Append(seq, Payload(32), 0);
+        w.Flush();
+
+        Assert.Equal(2, w.LogFlushCount);
+        Assert.Equal(1, w.IndexFlushCount);
+    }
+
+    [Fact]
+    public void GroupCommitMaxRecords_default_is_512()
+    {
+        // Pinned by P5/F7. Tests in this assembly that override it
+        // explicitly continue to do so; this just guards the default.
+        Assert.Equal(512, new PersistenceOptions().GroupCommitMaxRecords);
+    }
+}


### PR DESCRIPTION
Implements **P5 / F7** of the perf hardening v0 RFC (`docs/rfcs/perf-hardening-v0.md` §4.2 / §5.7).

Closes #199

## Changes

1. **`PersistenceOptions.GroupCommitMaxRecords` default 64 → 512.**
   At participant volumes the writer fills a 64-slot batch in <1ms, so the cap was hitting before the 10ms `GroupCommitWindow`. Raising to 512 lets fsync amortise across more records without breaching the window cap. `appsettings.json` updated to match (otherwise the bound config value would override the new code default).

2. **Conditional index fsync in `SegmentWriter.Flush`.**
   `WriteIndexEntry` now sets `_indexDirty = true`. `Flush()` always fsyncs `.log` and only fsyncs `.idx` when `_indexDirty == true`. With the default 64-record index cadence this elides ~63 of every 64 `.idx` fsyncs. Recovery is unaffected — replay rebuilds the in-memory index from `.log` already.

3. **Tests** (`SegmentWriterFsyncTests.cs`, 4 new cases) assert the conditional path via internal `LogFlushCount` / `IndexFlushCount` counters (gated by `InternalsVisibleTo` to the test assembly):
   - no-index-entry batch → 0 idx fsyncs
   - batch crossing index cadence → exactly 1 idx fsync
   - subsequent under-cadence batch after a flushed one → idx fsync elided again
   - pin `GroupCommitMaxRecords` default == 512

## Durability invariant (RFC §4.2) — preserved

v0 explicitly retains **ack-after-enqueue + apply**, NOT ack-after-fsync. This PR does **not** change that contract; it only widens the group-commit batch and elides redundant index fsyncs. Worst-case crash exposure (acked-but-unfsynced records) widens from `ChannelCapacity + 64` to `ChannelCapacity + 512` (4096 + 64 = 4160 → 4096 + 512 = 4608 records on hard kernel crash) — the deliberate, RFC-documented trade-off. Operators tighten the bound by lowering `ChannelCapacity` / `GroupCommitMaxRecords`; ack-after-fsync is a v1 RFC topic (§13).

## Bench (PR #213 `WAL_Append_Flush_Bench`, ShortRun, /dev/shm)

The baseline bench hardcodes `GroupCommitMaxRecords=64` and runs against tmpfs, so fsync is essentially a no-op and `FlushAsync` latency is dominated by the group-commit window fence — both runs land within ShortRun noise:

| BatchSize | Before (Mean) | After (Mean) | Allocated |
|---:|---:|---:|---:|
| 1  | 12.00 ms | 12.34 ms | 1.98 KB |
| 64 | 12.39 ms | 13.24 ms | 34.42 KB |

The 4× target in §7.3 requires both (a) raising the bench's `GroupCommitMaxRecords` to exercise the new ceiling and (b) running against a real-disk store where `_idx.Flush(true)` is not a no-op. Both belong to a follow-up bench tweak in PR #213's harness; this PR delivers the code + test changes and is correct under the existing harness.

## CI

- Build: green (Release + Debug)
- Tests: 984 passed / 0 failed (980 baseline + 4 new)
- `dotnet format --verify-no-changes`: clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>