### PR TITLE
perf(fixp): P10 — zero-copy inbound SBE decode for hot types (#204)

### DIFF
--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
@@ -80,25 +80,40 @@ internal sealed class FixpOrderAdapter
     /// terminate the session are framing-level (those are handled by the
     /// caller, not here).
     /// </summary>
-    public async Task HandleNewOrderSingleAsync(
+    public Task HandleNewOrderSingleAsync(
         Stream stream,
         ReadOnlyMemory<byte> payload,
         FixpConnectionScope scope,
         CancellationToken ct)
     {
-        if (payload.Length < NewOrderSingleData.BLOCK_LENGTH)
+        // Legacy entry point retained for the malformed-length fall-through
+        // and any caller that has not yet adopted the zero-copy decode.
+        // Hot in-Established traffic now flows through the
+        // `in DecodedNewOrderSingle` overload below (RFC §5.6 / P10).
+        if (!InboundDecoders.TryDecodeNewOrderSingle(payload.Span, out var decoded))
         {
-            await WriteBusinessMessageRejectAsync(stream,
+            return WriteBusinessMessageRejectAsync(stream,
                 refMsgType: MessageType.NewOrderSingle,
                 refSeqNum: 0, businessRejectRefID: 0,
-                reason: RejectReason.InvalidShape, ct).ConfigureAwait(false);
-            return;
+                reason: RejectReason.InvalidShape, ct);
         }
+        return HandleNewOrderSingleAsync(stream, decoded, scope, ct);
+    }
 
-        var msg = MemoryMarshal.Read<NewOrderSingleData>(payload.Span);
-        var externalClOrdId = (ulong)msg.ClOrdID;
-        var securityId = (ulong)msg.SecurityID;
-        var refSeqNum = (uint)msg.BusinessHeader.MsgSeqNum;
+    /// <summary>
+    /// RFC §5.6 (P10/F6) zero-copy entry point. The dispatcher has
+    /// already decoded the SBE block into <paramref name="decoded"/>;
+    /// no <c>byte[]</c> survives across the awaits below.
+    /// </summary>
+    public async Task HandleNewOrderSingleAsync(
+        Stream stream,
+        DecodedNewOrderSingle decoded,
+        FixpConnectionScope scope,
+        CancellationToken ct)
+    {
+        var externalClOrdId = decoded.ClOrdId;
+        var securityId = decoded.SecurityId;
+        var refSeqNum = decoded.MsgSeqNum;
 
         // 1. Resolve SecurityId → Symbol. Without a directory entry the
         //    submit pipeline would reject anyway with "symbol is required";
@@ -118,7 +133,7 @@ internal sealed class FixpOrderAdapter
         //    a clean BMR rather than a generic BadRequest from the
         //    pipeline. Only the LIMIT/MARKET subset is supported by the
         //    domain model in v0; everything else is rejected.
-        if (!TryMapSide(msg.Side, out var side) || !TryMapOrdType(msg.OrdType, out var type))
+        if (!TryMapSide(decoded.Side, out var side) || !TryMapOrdType(decoded.OrdType, out var type))
         {
             await WriteBusinessMessageRejectAsync(stream,
                 MessageType.NewOrderSingle, refSeqNum, externalClOrdId,
@@ -140,8 +155,8 @@ internal sealed class FixpOrderAdapter
         }
 
         var owner = OwnerFor(scope);
-        var qty = (long)(ulong)msg.OrderQty;
-        decimal? price = msg.Price.Mantissa is { } m
+        var qty = (long)decoded.OrderQty;
+        decimal? price = decoded.PriceMantissa is { } m
             ? m / (decimal)PriceOptional.Multiplier
             : null;
 
@@ -183,10 +198,10 @@ internal sealed class FixpOrderAdapter
             externalClOrdId: externalClOrdId,
             origExternalClOrdId: 0,
             securityId: securityId,
-            side: msg.Side,
-            ordType: msg.OrdType,
-            qty: (ulong)msg.OrderQty,
-            priceMantissa: msg.Price.Mantissa ?? PriceOptional.MantissaNullValue,
+            side: decoded.Side,
+            ordType: decoded.OrdType,
+            qty: decoded.OrderQty,
+            priceMantissa: decoded.PriceMantissa ?? PriceOptional.MantissaNullValue,
             ordRejReason: reason,
             cxlRejResponseTo: CxlRejResponseTo.NEW,
             ct).ConfigureAwait(false);
@@ -198,25 +213,37 @@ internal sealed class FixpOrderAdapter
     /// resolving the bot's external <c>OrigClOrdID</c> back to the
     /// platform's internal id via the side-mapping registry.
     /// </summary>
-    public async Task HandleOrderCancelRequestAsync(
+    public Task HandleOrderCancelRequestAsync(
         Stream stream,
         ReadOnlyMemory<byte> payload,
         FixpConnectionScope scope,
         CancellationToken ct)
     {
-        if (payload.Length < OrderCancelRequestData.BLOCK_LENGTH)
+        // Legacy entry point retained for the malformed-length fall-through.
+        if (!InboundDecoders.TryDecodeOrderCancelRequest(payload.Span, out var decoded))
         {
-            await WriteBusinessMessageRejectAsync(stream,
+            return WriteBusinessMessageRejectAsync(stream,
                 MessageType.OrderCancelRequest, 0, 0,
-                RejectReason.InvalidShape, ct).ConfigureAwait(false);
-            return;
+                RejectReason.InvalidShape, ct);
         }
+        return HandleOrderCancelRequestAsync(stream, decoded, scope, ct);
+    }
 
-        var msg = MemoryMarshal.Read<OrderCancelRequestData>(payload.Span);
-        var externalCancelClOrdId = (ulong)msg.ClOrdID;
-        var externalOrigClOrdId = msg.OrigClOrdID.GetValueOrDefault();
-        var securityId = (ulong)msg.SecurityID;
-        var refSeqNum = (uint)msg.BusinessHeader.MsgSeqNum;
+    /// <summary>
+    /// RFC §5.6 (P10/F6) zero-copy entry point. The dispatcher has
+    /// already decoded the SBE block into <paramref name="decoded"/>;
+    /// no <c>byte[]</c> survives across the awaits below.
+    /// </summary>
+    public async Task HandleOrderCancelRequestAsync(
+        Stream stream,
+        DecodedOrderCancelRequest decoded,
+        FixpConnectionScope scope,
+        CancellationToken ct)
+    {
+        var externalCancelClOrdId = decoded.ClOrdId;
+        var externalOrigClOrdId = decoded.OrigClOrdId;
+        var securityId = decoded.SecurityId;
+        var refSeqNum = decoded.MsgSeqNum;
 
         // Resolve original order via the bot mapping side-registry.
         // The registry's TryGetByExternal already enforces the
@@ -259,7 +286,7 @@ internal sealed class FixpOrderAdapter
             externalClOrdId: externalCancelClOrdId,
             origExternalClOrdId: externalOrigClOrdId,
             securityId: securityId,
-            side: msg.Side,
+            side: decoded.Side,
             ordType: 0,
             qty: 0,
             priceMantissa: PriceOptional.MantissaNullValue,

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -148,8 +148,13 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
 
                 while (reader.TryReadFrame(out var frame))
                 {
-                    var decoded = ExtractFrame(frame);
-                    var keepGoing = await HandleFrameAsync(stream, decoded, remote, ct).ConfigureAwait(false);
+                    // RFC §5.6 (P10/F6): hot message types are decoded
+                    // synchronously from the framer's rotating span into
+                    // a stack-resident struct *before* the dispatcher's
+                    // first await — no per-frame `byte[]` survives the
+                    // await. Cold types still take the legacy heap-copy
+                    // path inside DispatchFrameAsync.
+                    var keepGoing = await DispatchFrameAsync(stream, in frame, remote, ct).ConfigureAwait(false);
                     if (!keepGoing) return;
                 }
 
@@ -217,6 +222,68 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         TemplateId = frame.TemplateId,
         Payload = frame.Payload.ToArray(),
     };
+
+    /// <summary>
+    /// RFC §5.6 (P10/F6) entry point. Synchronous switch over the SBE
+    /// template id that:
+    ///
+    /// <list type="bullet">
+    ///   <item>Decodes the hot message types (NewOrderSingle,
+    ///     OrderCancelRequest, Sequence) directly from
+    ///     <see cref="SofhFrame.Payload"/> into a stack-resident
+    ///     <c>Decoded*</c> struct and forwards to the matching
+    ///     zero-copy async handler — no <c>byte[]</c> allocated.</item>
+    ///   <item>For the cold/error fall-through (handshake messages,
+    ///     RetransmitRequest, malformed-length frames of hot types)
+    ///     copies the payload through <see cref="ExtractFrame"/> and
+    ///     delegates to the legacy <see cref="HandleFrameAsync"/>.</item>
+    /// </list>
+    ///
+    /// <para>This method is intentionally non-<c>async</c> so it can
+    /// receive the framer's <see cref="SofhFrame"/> ref-struct by
+    /// reference. The first <c>await</c> happens inside the returned
+    /// <see cref="Task{TResult}"/>, by which point the decode has
+    /// already snapshotted every span field the handler needs.</para>
+    /// </summary>
+    private Task<bool> DispatchFrameAsync(
+        Stream stream, in SofhFrame frame, string remote, CancellationToken ct)
+    {
+        switch (frame.TemplateId)
+        {
+            case NewOrderSingleData.MESSAGE_ID:
+                if (_sm.State == FixpSessionState.Established
+                    && InboundDecoders.TryDecodeNewOrderSingle(frame.Payload, out var nos))
+                {
+                    EnsureOrderAdapterWired();
+                    return HandleNewOrderSingleZeroCopyAsync(stream, nos, ct);
+                }
+                break;
+
+            case OrderCancelRequestData.MESSAGE_ID:
+                if (_sm.State == FixpSessionState.Established
+                    && InboundDecoders.TryDecodeOrderCancelRequest(frame.Payload, out var ocr))
+                {
+                    EnsureOrderAdapterWired();
+                    return HandleOrderCancelRequestZeroCopyAsync(stream, ocr, ct);
+                }
+                break;
+
+            case SequenceData.MESSAGE_ID:
+                if (_sm.State == FixpSessionState.Established
+                    && InboundDecoders.TryDecodeSequence(frame.Payload, out var seq))
+                {
+                    return HandleInboundSequenceZeroCopyKeepAliveAsync(stream, seq, ct);
+                }
+                break;
+        }
+
+        // Fall-through for: handshake/control messages, hot-type frames
+        // received outside Established, and malformed-length hot frames
+        // (the legacy adapter path emits the appropriate
+        // BusinessMessageReject(InvalidShape) for the latter).
+        var legacy = ExtractFrame(frame);
+        return HandleFrameAsync(stream, legacy, remote, ct);
+    }
 
     /// <summary>
     /// Issue #185 invariant: by the time we accept an
@@ -617,15 +684,29 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
     /// downstream order-adapter dispatch, <c>false</c> for duplicates
     /// the caller should swallow.
     /// </summary>
-    private async Task<bool> TrackInboundAppMessageAsync(
+    private Task<bool> TrackInboundAppMessageAsync(
         Stream stream, byte[] payload, int blockLength, CancellationToken ct)
     {
         // The InboundBusinessHeader is the first field of the message
         // block (offset 0 within the SBE block — see InboundBusinessHeader
         // and NewOrderSingleData layout). Defensive bounds check first.
-        if (payload.Length < blockLength) return true;
+        if (payload.Length < blockLength) return Task.FromResult(true);
         var header = MemoryMarshal.Read<InboundBusinessHeader>(payload);
-        var seq = (ulong)header.MsgSeqNum;
+        return TrackInboundAppSeqAsync(stream, (uint)header.MsgSeqNum, ct);
+    }
+
+    /// <summary>
+    /// RFC §5.6 (P10/F6) zero-copy entry point for the
+    /// <c>NewOrderSingle</c>/<c>OrderCancelRequest</c> sequence-watermark
+    /// bookkeeping. Identical semantics to
+    /// <see cref="TrackInboundAppMessageAsync"/> but takes the already
+    /// decoded <c>MsgSeqNum</c> field instead of re-decoding the
+    /// inbound business header from a heap-copied payload.
+    /// </summary>
+    private async Task<bool> TrackInboundAppSeqAsync(
+        Stream stream, uint msgSeqNum, CancellationToken ct)
+    {
+        var seq = (ulong)msgSeqNum;
         if (seq == 0)
         {
             // Implicit mode — the bot did not stamp an explicit seq. We
@@ -689,6 +770,95 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
                 "fixp.inbound.sequence.behind connectionId={ConnectionId} expected={Expected} botNext={BotNext}",
                 _connectionId, expected, nextSeqNo);
         }
+    }
+
+    /// <summary>
+    /// RFC §5.6 (P10/F6) zero-copy variant of
+    /// <see cref="HandleInboundSequenceAsync"/>. Behaviour and watermark
+    /// arithmetic are unchanged; the only difference is that
+    /// <see cref="DecodedSequence.NextSeqNo"/> is supplied by the
+    /// dispatcher's synchronous SBE decode instead of being re-read
+    /// from a heap-copied payload.
+    /// </summary>
+    private async Task<bool> HandleInboundSequenceZeroCopyKeepAliveAsync(
+        Stream stream, DecodedSequence decoded, CancellationToken ct)
+    {
+        await HandleInboundSequenceZeroCopyAsync(stream, decoded, ct).ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task HandleInboundSequenceZeroCopyAsync(
+        Stream stream, DecodedSequence decoded, CancellationToken ct)
+    {
+        var nextSeqNo = decoded.NextSeqNo;
+        var expected = (ulong)Interlocked.Read(ref _nextExpectedInboundSeq);
+
+        if (nextSeqNo > expected)
+        {
+            var gap = nextSeqNo - expected;
+            _logger.LogInformation(
+                "fixp.inbound.sequence.gap connectionId={ConnectionId} expected={Expected} botNext={BotNext} gap={Gap}",
+                _connectionId, expected, nextSeqNo, gap);
+            await SendNotAppliedAsync(stream, expected, (uint)Math.Min(gap, uint.MaxValue), ct)
+                .ConfigureAwait(false);
+            Interlocked.Exchange(ref _nextExpectedInboundSeq, (long)nextSeqNo);
+        }
+        else if (nextSeqNo < expected)
+        {
+            _logger.LogWarning(
+                "fixp.inbound.sequence.behind connectionId={ConnectionId} expected={Expected} botNext={BotNext}",
+                _connectionId, expected, nextSeqNo);
+        }
+    }
+
+    /// <summary>
+    /// RFC §5.6 (P10/F6). Zero-copy <c>NewOrderSingle</c> handler. The
+    /// caller (<see cref="DispatchFrameAsync"/>) has already decoded
+    /// the SBE block synchronously into <paramref name="decoded"/>, so
+    /// no <c>byte[]</c> survives across this method's awaits. The
+    /// behaviour mirrors the legacy switch arm: track inbound seq, take
+    /// the shared write mutex, dispatch to the order adapter, then
+    /// touch the outbound timestamp.
+    /// </summary>
+    private async Task<bool> HandleNewOrderSingleZeroCopyAsync(
+        Stream stream, DecodedNewOrderSingle decoded, CancellationToken ct)
+    {
+        var fresh = await TrackInboundAppSeqAsync(stream, decoded.MsgSeqNum, ct)
+            .ConfigureAwait(false);
+        if (!fresh) return true;
+
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _orders!.HandleNewOrderSingleAsync(stream, decoded, _scope!, ct)
+                .ConfigureAwait(false);
+            TouchOutbound();
+        }
+        finally { _writeMutex.Release(); }
+        return true;
+    }
+
+    /// <summary>
+    /// RFC §5.6 (P10/F6). Zero-copy <c>OrderCancelRequest</c> handler.
+    /// Same structural contract as
+    /// <see cref="HandleNewOrderSingleZeroCopyAsync"/>.
+    /// </summary>
+    private async Task<bool> HandleOrderCancelRequestZeroCopyAsync(
+        Stream stream, DecodedOrderCancelRequest decoded, CancellationToken ct)
+    {
+        var fresh = await TrackInboundAppSeqAsync(stream, decoded.MsgSeqNum, ct)
+            .ConfigureAwait(false);
+        if (!fresh) return true;
+
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _orders!.HandleOrderCancelRequestAsync(stream, decoded, _scope!, ct)
+                .ConfigureAwait(false);
+            TouchOutbound();
+        }
+        finally { _writeMutex.Release(); }
+        return true;
     }
 
     private async Task HandleInboundRetransmitRequestAsync(

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/InboundDecoders.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/InboundDecoders.cs
@@ -1,0 +1,124 @@
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// RFC §5.6 (P10/F6). Zero-allocation SBE decoders for the inbound hot
+/// message types: <c>NewOrderSingle</c>, <c>OrderCancelRequest</c>, and
+/// <c>Sequence</c>. Each <c>TryDecode*</c> reads the SBE block layout
+/// directly from a <see cref="ReadOnlySpan{T}"/> over the framer's
+/// rotating buffer (no per-frame <c>byte[]</c> allocation) and copies
+/// only the value-type fields the dispatcher actually needs into a
+/// stack-resident <c>Decoded*</c> struct.
+///
+/// <para>The decoded structs intentionally mirror — but do not extend —
+/// the SBE codegen layout. They contain only blittable value types so
+/// they survive across the dispatcher's <c>await</c> boundary without
+/// keeping any reference into the receive buffer.</para>
+///
+/// <para>Cold message types (Negotiate, Establish, Terminate,
+/// RetransmitRequest) continue to flow through the legacy heap-copy
+/// path in <see cref="FixpSessionConnection"/> — they are infrequent
+/// and not worth the additional surface area.</para>
+/// </summary>
+internal static class InboundDecoders
+{
+    public static bool TryDecodeNewOrderSingle(
+        ReadOnlySpan<byte> payload, out DecodedNewOrderSingle decoded)
+    {
+        if (payload.Length < NewOrderSingleData.BLOCK_LENGTH)
+        {
+            decoded = default;
+            return false;
+        }
+
+        var msg = MemoryMarshal.Read<NewOrderSingleData>(payload);
+        decoded = new DecodedNewOrderSingle
+        {
+            MsgSeqNum = (uint)msg.BusinessHeader.MsgSeqNum,
+            ClOrdId = (ulong)msg.ClOrdID,
+            SecurityId = (ulong)msg.SecurityID,
+            Side = msg.Side,
+            OrdType = msg.OrdType,
+            OrderQty = (ulong)msg.OrderQty,
+            PriceMantissa = msg.Price.Mantissa,
+        };
+        return true;
+    }
+
+    public static bool TryDecodeOrderCancelRequest(
+        ReadOnlySpan<byte> payload, out DecodedOrderCancelRequest decoded)
+    {
+        if (payload.Length < OrderCancelRequestData.BLOCK_LENGTH)
+        {
+            decoded = default;
+            return false;
+        }
+
+        var msg = MemoryMarshal.Read<OrderCancelRequestData>(payload);
+        decoded = new DecodedOrderCancelRequest
+        {
+            MsgSeqNum = (uint)msg.BusinessHeader.MsgSeqNum,
+            ClOrdId = (ulong)msg.ClOrdID,
+            OrigClOrdId = msg.OrigClOrdID.GetValueOrDefault(),
+            SecurityId = (ulong)msg.SecurityID,
+            Side = msg.Side,
+        };
+        return true;
+    }
+
+    public static bool TryDecodeSequence(
+        ReadOnlySpan<byte> payload, out DecodedSequence decoded)
+    {
+        if (payload.Length < SequenceData.BLOCK_LENGTH)
+        {
+            decoded = default;
+            return false;
+        }
+
+        var msg = MemoryMarshal.Read<SequenceData>(payload);
+        decoded = new DecodedSequence
+        {
+            NextSeqNo = (ulong)msg.NextSeqNo,
+        };
+        return true;
+    }
+}
+
+/// <summary>
+/// Stack-resident projection of the SBE <c>NewOrderSingle</c> fields
+/// the dispatcher and <see cref="FixpOrderAdapter"/> consume.
+/// </summary>
+internal readonly struct DecodedNewOrderSingle
+{
+    public uint MsgSeqNum { get; init; }
+    public ulong ClOrdId { get; init; }
+    public ulong SecurityId { get; init; }
+    public Side Side { get; init; }
+    public OrdType OrdType { get; init; }
+    public ulong OrderQty { get; init; }
+    public long? PriceMantissa { get; init; }
+}
+
+/// <summary>
+/// Stack-resident projection of the SBE <c>OrderCancelRequest</c>
+/// fields the dispatcher and <see cref="FixpOrderAdapter"/> consume.
+/// </summary>
+internal readonly struct DecodedOrderCancelRequest
+{
+    public uint MsgSeqNum { get; init; }
+    public ulong ClOrdId { get; init; }
+    public ulong OrigClOrdId { get; init; }
+    public ulong SecurityId { get; init; }
+    public Side Side { get; init; }
+}
+
+/// <summary>
+/// Stack-resident projection of the SBE <c>Sequence</c> field the
+/// session uses to advance its inbound watermark.
+/// </summary>
+internal readonly struct DecodedSequence
+{
+    public ulong NextSeqNo { get; init; }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/InboundDecodersTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/InboundDecodersTests.cs
@@ -1,0 +1,272 @@
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.EntryPointListener.Hosting;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// RFC §5.6 (P10/F6). Round-trip equivalence tests for the zero-copy
+/// inbound SBE decoders. The acceptance criterion the production
+/// adapter cares about is "the zero-copy path produces the same field
+/// values the legacy <c>MemoryMarshal.Read&lt;T&gt;</c> path would have
+/// produced". So for each hot template we:
+///
+/// <list type="number">
+///   <item>Build a wire-shape buffer using the SBE codegen setters
+///     (and raw <c>MemoryMarshal.Write</c> for the read-only optional
+///     fields — backing fields are stable across the schema's
+///     <c>BLOCK_LENGTH</c>).</item>
+///   <item>Decode it through <see cref="InboundDecoders"/>.</item>
+///   <item>Decode the *same* buffer through
+///     <c>MemoryMarshal.Read&lt;T&gt;</c> — the legacy path the
+///     adapter used pre-#204.</item>
+///   <item>Assert every projected field on the
+///     <see cref="DecodedNewOrderSingle"/>/<see cref="DecodedOrderCancelRequest"/>/<see cref="DecodedSequence"/>
+///     struct equals the legacy read.</item>
+/// </list>
+///
+/// <para>This guarantees no behavioural drift between the two paths
+/// for the dispatch fields the adapter actually consumes.</para>
+/// </summary>
+public class InboundDecodersTests
+{
+    private static byte[] BuildNewOrderSingleBody(
+        uint msgSeqNum,
+        ulong clOrdId,
+        ulong securityId,
+        Side side,
+        OrdType ordType,
+        ulong orderQty,
+        long? priceMantissa)
+    {
+        var body = new byte[NewOrderSingleData.BLOCK_LENGTH];
+        var span = body.AsSpan();
+        ref var msg = ref MemoryMarshal.AsRef<NewOrderSingleData>(span);
+        msg.BusinessHeader = new InboundBusinessHeader
+        {
+            SessionID = (SessionID)0u,
+            MsgSeqNum = (SeqNum)msgSeqNum,
+        };
+        msg.ClOrdID = (ClOrdID)clOrdId;
+        msg.SecurityID = (SecurityID)securityId;
+        msg.Side = side;
+        msg.OrdType = ordType;
+        msg.OrderQty = (Quantity)orderQty;
+        // Price.Mantissa has no public setter — write the underlying
+        // SBE Int64 backing field directly. The PriceOptional layout is
+        // a single Int64 located at the SBE-defined offset within the
+        // block; the framework's null sentinel is PriceOptional.MantissaNullValue.
+        var priceOffset = GetPriceOffset();
+        var mantissa = priceMantissa ?? PriceOptional.MantissaNullValue;
+        var mantissaLocal = mantissa; MemoryMarshal.Write(span[priceOffset..], in mantissaLocal);
+        return body;
+    }
+
+    private static int GetPriceOffset()
+    {
+        // Discover the Price field offset by writing a sentinel via the
+        // raw byte buffer and searching the encoded body for it. We use
+        // a value that is guaranteed not to collide with the rest of
+        // the zeroed block.
+        var probe = new byte[NewOrderSingleData.BLOCK_LENGTH];
+        long sentinel = 0x7E5701234ABCDEF0L;
+        // Write sentinel at every long-aligned offset until the round-trip
+        // through MemoryMarshal.Read<NewOrderSingleData>().Price.Mantissa
+        // surfaces it; that offset is the Price.mantissa backing field.
+        for (var off = 0; off + sizeof(long) <= probe.Length; off += 1)
+        {
+            probe.AsSpan().Clear();
+            MemoryMarshal.Write(probe.AsSpan(off), in sentinel);
+            var read = MemoryMarshal.Read<NewOrderSingleData>(probe);
+            if (read.Price.Mantissa == sentinel) return off;
+        }
+        throw new InvalidOperationException("Could not locate Price field offset in NewOrderSingleData layout.");
+    }
+
+    [Fact]
+    public void DecodeNewOrderSingle_MatchesLegacyMemoryMarshalRead()
+    {
+        var body = BuildNewOrderSingleBody(
+            msgSeqNum: 7u,
+            clOrdId: 0xDEADBEEFCAFEBABEUL,
+            securityId: 1234567UL,
+            side: Side.SELL,
+            ordType: OrdType.LIMIT,
+            orderQty: 500UL,
+            priceMantissa: 12_345L);
+
+        Assert.True(InboundDecoders.TryDecodeNewOrderSingle(body, out var decoded));
+
+        var legacy = MemoryMarshal.Read<NewOrderSingleData>(body);
+        Assert.Equal((uint)legacy.BusinessHeader.MsgSeqNum, decoded.MsgSeqNum);
+        Assert.Equal((ulong)legacy.ClOrdID, decoded.ClOrdId);
+        Assert.Equal((ulong)legacy.SecurityID, decoded.SecurityId);
+        Assert.Equal(legacy.Side, decoded.Side);
+        Assert.Equal(legacy.OrdType, decoded.OrdType);
+        Assert.Equal((ulong)legacy.OrderQty, decoded.OrderQty);
+        Assert.Equal(legacy.Price.Mantissa, decoded.PriceMantissa);
+    }
+
+    [Fact]
+    public void DecodeNewOrderSingle_PreservesNullPrice_ForMarketOrder()
+    {
+        var body = BuildNewOrderSingleBody(
+            msgSeqNum: 1u,
+            clOrdId: 1UL,
+            securityId: 1UL,
+            side: Side.BUY,
+            ordType: OrdType.MARKET,
+            orderQty: 10UL,
+            priceMantissa: null);
+
+        Assert.True(InboundDecoders.TryDecodeNewOrderSingle(body, out var decoded));
+        Assert.Null(decoded.PriceMantissa);
+        // And the legacy reader must agree.
+        var legacy = MemoryMarshal.Read<NewOrderSingleData>(body);
+        Assert.Equal(legacy.Price.Mantissa, decoded.PriceMantissa);
+    }
+
+    [Fact]
+    public void DecodeNewOrderSingle_ShortPayload_ReturnsFalse()
+    {
+        Assert.False(InboundDecoders.TryDecodeNewOrderSingle(
+            new byte[NewOrderSingleData.BLOCK_LENGTH - 1], out var decoded));
+        Assert.Equal(0u, decoded.MsgSeqNum);
+        Assert.Equal(0UL, decoded.ClOrdId);
+    }
+
+    [Fact]
+    public void DecodeOrderCancelRequest_MatchesLegacyMemoryMarshalRead()
+    {
+        var body = new byte[OrderCancelRequestData.BLOCK_LENGTH];
+        var span = body.AsSpan();
+        ref var msg = ref MemoryMarshal.AsRef<OrderCancelRequestData>(span);
+        msg.BusinessHeader = new InboundBusinessHeader { MsgSeqNum = (SeqNum)4u };
+        msg.ClOrdID = (ClOrdID)0xAAAAAAAAUL;
+        msg.SecurityID = (SecurityID)777UL;
+        msg.Side = Side.SELL;
+        // OrigClOrdID has no public setter — write the raw UInt64 backing
+        // field. We discover the offset the same way as for Price.
+        var origOffset = GetOrigClOrdIdOffset();
+        ulong origValue = 0xBBBBBBBBUL;
+        MemoryMarshal.Write(span[origOffset..], in origValue);
+
+        Assert.True(InboundDecoders.TryDecodeOrderCancelRequest(body, out var decoded));
+        var legacy = MemoryMarshal.Read<OrderCancelRequestData>(body);
+        Assert.Equal((uint)legacy.BusinessHeader.MsgSeqNum, decoded.MsgSeqNum);
+        Assert.Equal((ulong)legacy.ClOrdID, decoded.ClOrdId);
+        Assert.Equal(legacy.OrigClOrdID.GetValueOrDefault(), decoded.OrigClOrdId);
+        Assert.Equal((ulong)legacy.SecurityID, decoded.SecurityId);
+        Assert.Equal(legacy.Side, decoded.Side);
+        Assert.Equal(0xBBBBBBBBUL, decoded.OrigClOrdId);
+    }
+
+    private static int GetOrigClOrdIdOffset()
+    {
+        var probe = new byte[OrderCancelRequestData.BLOCK_LENGTH];
+        ulong sentinel = 0x7E57_0123_4ABC_DEF0UL;
+        for (var off = 0; off + sizeof(ulong) <= probe.Length; off += 1)
+        {
+            probe.AsSpan().Clear();
+            MemoryMarshal.Write(probe.AsSpan(off), in sentinel);
+            var read = MemoryMarshal.Read<OrderCancelRequestData>(probe);
+            if (read.OrigClOrdID.GetValueOrDefault() == sentinel) return off;
+        }
+        throw new InvalidOperationException("Could not locate OrigClOrdID field offset in OrderCancelRequestData layout.");
+    }
+
+    [Fact]
+    public void DecodeOrderCancelRequest_NullOrigClOrdId_DefaultsToZero()
+    {
+        // Write the SBE null sentinel directly. GetValueOrDefault() on a
+        // null Nullable<ClOrdID> returns 0 — the dispatcher relies on
+        // this so the bot mapping registry's TryGetByExternal lookup
+        // misses cleanly with an UnknownOrder reject.
+        var body = new byte[OrderCancelRequestData.BLOCK_LENGTH];
+        var span = body.AsSpan();
+        ref var msg = ref MemoryMarshal.AsRef<OrderCancelRequestData>(span);
+        msg.BusinessHeader = new InboundBusinessHeader { MsgSeqNum = (SeqNum)1u };
+        msg.ClOrdID = (ClOrdID)1UL;
+        msg.SecurityID = (SecurityID)1UL;
+        msg.Side = Side.BUY;
+        var origOffset = GetOrigClOrdIdOffset();
+        var nullSentinel = OrderCancelRequestData.OrigClOrdIDNullValue;
+        var nullSentinelLocal = nullSentinel; MemoryMarshal.Write(span[origOffset..], in nullSentinelLocal);
+
+        Assert.True(InboundDecoders.TryDecodeOrderCancelRequest(body, out var decoded));
+        Assert.Equal(0UL, decoded.OrigClOrdId);
+        // Legacy parity:
+        var legacy = MemoryMarshal.Read<OrderCancelRequestData>(body);
+        Assert.Equal(legacy.OrigClOrdID.GetValueOrDefault(), decoded.OrigClOrdId);
+    }
+
+    [Fact]
+    public void DecodeOrderCancelRequest_ShortPayload_ReturnsFalse()
+    {
+        Assert.False(InboundDecoders.TryDecodeOrderCancelRequest(
+            new byte[OrderCancelRequestData.BLOCK_LENGTH - 1], out _));
+    }
+
+    [Fact]
+    public void DecodeSequence_MatchesLegacyMemoryMarshalRead()
+    {
+        var body = new byte[SequenceData.BLOCK_LENGTH];
+        ref var msg = ref MemoryMarshal.AsRef<SequenceData>(body.AsSpan());
+        msg.NextSeqNo = (SeqNum)0xCAFEBABEU;
+
+        Assert.True(InboundDecoders.TryDecodeSequence(body, out var decoded));
+        var legacy = MemoryMarshal.Read<SequenceData>(body);
+        Assert.Equal((ulong)legacy.NextSeqNo, decoded.NextSeqNo);
+        Assert.Equal(0xCAFEBABEUL, decoded.NextSeqNo);
+    }
+
+    [Fact]
+    public void DecodeSequence_ShortPayload_ReturnsFalse()
+    {
+        Assert.False(InboundDecoders.TryDecodeSequence(
+            new byte[SequenceData.BLOCK_LENGTH - 1], out _));
+    }
+
+    [Fact]
+    public void DecodeHotTypes_DoNotAllocate_OnSuccessfulPath()
+    {
+        // RFC §5.6 acceptance: zero per-message heap allocations in the
+        // inbound decode path. We measure the per-thread allocation
+        // delta across a tight loop of decodes; the only allocations
+        // permitted on this path are the up-front buffer fixtures
+        // (excluded from the measurement window).
+        var nos = BuildNewOrderSingleBody(
+            msgSeqNum: 1u, clOrdId: 1UL, securityId: 1UL,
+            side: Side.BUY, ordType: OrdType.LIMIT,
+            orderQty: 1UL, priceMantissa: 1L);
+
+        var ocr = new byte[OrderCancelRequestData.BLOCK_LENGTH];
+        ref var ocrMsg = ref MemoryMarshal.AsRef<OrderCancelRequestData>(ocr.AsSpan());
+        ocrMsg.BusinessHeader = new InboundBusinessHeader { MsgSeqNum = (SeqNum)1u };
+        ocrMsg.ClOrdID = (ClOrdID)1UL;
+        ocrMsg.SecurityID = (SecurityID)1UL;
+
+        var seq = new byte[SequenceData.BLOCK_LENGTH];
+        ref var seqMsg = ref MemoryMarshal.AsRef<SequenceData>(seq.AsSpan());
+        seqMsg.NextSeqNo = (SeqNum)1U;
+
+        // Warm up + JIT.
+        for (var i = 0; i < 16; i++)
+        {
+            InboundDecoders.TryDecodeNewOrderSingle(nos, out _);
+            InboundDecoders.TryDecodeOrderCancelRequest(ocr, out _);
+            InboundDecoders.TryDecodeSequence(seq, out _);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1_000; i++)
+        {
+            InboundDecoders.TryDecodeNewOrderSingle(nos, out _);
+            InboundDecoders.TryDecodeOrderCancelRequest(ocr, out _);
+            InboundDecoders.TryDecodeSequence(seq, out _);
+        }
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0L, after - before);
+    }
+}


### PR DESCRIPTION
Closes #204.

Implements RFC §5.6 / F6: decode the hot inbound FIXP message types directly from the SOFH framer's rotating `ReadOnlySpan<byte>` into stack-resident `Decoded*` structs **before** the dispatcher's first `await`, eliminating the per-frame `byte[]` allocation that `FixpSessionConnection.ExtractFrame` introduced via `ToArray()`.

### Message types covered (zero-copy hot path)

| Template | Decoder | Handler |
|---|---|---|
| `NewOrderSingle` (id 100) | `InboundDecoders.TryDecodeNewOrderSingle` → `DecodedNewOrderSingle` | `FixpSessionConnection.HandleNewOrderSingleZeroCopyAsync` → `FixpOrderAdapter.HandleNewOrderSingleAsync(Decoded…)` |
| `OrderCancelRequest` (id 105) | `InboundDecoders.TryDecodeOrderCancelRequest` → `DecodedOrderCancelRequest` | `FixpSessionConnection.HandleOrderCancelRequestZeroCopyAsync` → `FixpOrderAdapter.HandleOrderCancelRequestAsync(Decoded…)` |
| `Sequence` (heartbeat watermark) | `InboundDecoders.TryDecodeSequence` → `DecodedSequence` | `FixpSessionConnection.HandleInboundSequenceZeroCopyAsync` |

### Cold types (legacy heap-copy path retained)

`Negotiate`, `Establish`, `Terminate`, and `RetransmitRequest` continue to flow through `ExtractFrame` + `HandleFrameAsync` per RFC §5.6 (infrequent, not worth the additional surface area). Malformed-length hot frames also fall through to the legacy adapter so the existing `BusinessMessageReject(InvalidShape)` rejection is preserved unchanged.

### Correctness justification

- `Decoded*` structs contain only blittable value-type fields (`uint`/`ulong`/`long?`/`Side`/`OrdType`); no reference into the rotating receive buffer survives.
- The new `DispatchFrameAsync` is intentionally non-async so it can take the framer's `ref struct SofhFrame` by reference; the synchronous SBE decode runs before the returned `Task<bool>` is awaited.
- Sequence-watermark arithmetic is preserved exactly: `TrackInboundAppSeqAsync` is the unchanged body of `TrackInboundAppMessageAsync` after the `InboundBusinessHeader` read; `HandleInboundSequenceZeroCopyAsync` mirrors `HandleInboundSequenceAsync` byte-for-byte except for the `NextSeqNo` source.
- `_writeMutex` is taken in the same scope around adapter calls and `TouchOutbound()` is invoked at the same point.
- `FixpOrderAdapter`'s legacy `ReadOnlyMemory<byte>` overloads now delegate to the new struct-overload via `InboundDecoders.TryDecode*`, so any caller still on the legacy signature gets identical behaviour (incl. the malformed-length InvalidShape BMR).

### Tests

- All **989** tests pass (980 pre-existing + 9 new).
- New tests in `InboundDecodersTests` cover round-trip equivalence against the legacy `MemoryMarshal.Read<T>` path for all three hot types (incl. null `PriceOptional` for market orders and null `OrigClOrdID`), short-payload bounds, and a per-thread `GC.GetAllocatedBytesForCurrentThread` assertion that the decode loop allocates **0 bytes** across 1 000 iterations.
- All existing `FixpListenerIntegrationTests`, `FixpOrderPathRegressionTests`, and `FixpRetransmitIntegrationTests` continue to pass without modification — the zero-copy path is byte-for-byte compatible.

### Scope discipline

This PR stays strictly within the inbound decode path (`FixpSessionConnection.RunAsync` read loop, `InboundDecoders`, the inbound `FixpOrderAdapter` entry points). No outbound writer code is touched (P8 / Wave 4 territory).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>