### PR TITLE
perf(loadtest): P13 — integrated load test harness + baseline (#207)

### DIFF
--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -17,6 +17,7 @@
   </Folder>
   <Folder Name="/backend/bench/">
     <Project Path="backend/bench/B3.Trading.Benchmarks/B3.Trading.Benchmarks.csproj" />
+    <Project Path="backend/bench/B3.Trading.LoadTest/B3.Trading.LoadTest.csproj" />
   </Folder>
   <Folder Name="/backend/tools/">
     <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />

--- a/backend/bench/B3.Trading.LoadTest/B3.Trading.LoadTest.csproj
+++ b/backend/bench/B3.Trading.LoadTest/B3.Trading.LoadTest.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Trading.LoadTest</RootNamespace>
+    <!-- See README.md for runner spec. IsPackable=false keeps the harness out
+         of pack/publish; CI's dotnet test skips it because it is not a test
+         project. The bench harness (B3.Trading.Benchmarks) follows the same
+         pattern — micro-bench there, macro/load here. -->
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Trading.Domain\B3.Trading.Domain.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.Application\B3.Trading.Application.csproj" />
+    <ProjectReference Include="..\..\src\B3.Trading.Infrastructure\B3.Trading.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/bench/B3.Trading.LoadTest/LatencyCapturingSink.cs
+++ b/backend/bench/B3.Trading.LoadTest/LatencyCapturingSink.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+
+using B3.Trading.Application;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// In-memory sample store: one slot per ClOrdId allocated up-front so
+/// the harness avoids per-message allocations on the hot path. Producer
+/// writes <c>T0</c> (submit-call-start tick); the
+/// <see cref="LatencyCapturingSink"/> writes <c>T1</c> (publish-observed
+/// tick). Whichever side observes both fields populated finalises the
+/// sample — recording <c>(T1 − T0)</c> into a flat <c>long[]</c> result
+/// buffer that is sorted at end-of-run for percentiles.
+///
+/// <para>
+/// The sample slot is keyed by the ClOrdId counter portion (low 40
+/// bits) — since the harness uses a single end-client, counters are
+/// strictly monotonic from <c>1</c> and form a dense index into a
+/// pre-sized array. Capacity is set by
+/// <see cref="LoadTestRig.ComputeCapacity"/> with an over-provision
+/// factor so the producer cannot run off the end at the configured
+/// rate × duration.
+/// </para>
+/// </summary>
+public sealed class LatencySampleStore
+{
+    private readonly Sample[] _samples;
+    private readonly long[] _latencies;
+    private readonly ulong _counterMask;
+    // Slot reservation watermark and visible-publish watermark are
+    // separated so consumers (CopyLatencies, the quiesce loop) only
+    // ever see a count that bounds an array region whose writes are
+    // already published (Interlocked.Increment after the store acts as
+    // a release barrier on .NET).
+    private long _reservedCount;
+    private long _publishedCount;
+
+    public LatencySampleStore(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        _samples = new Sample[capacity];
+        _latencies = new long[capacity];
+        _counterMask = (1UL << 40) - 1;
+    }
+
+    public int Capacity => _samples.Length;
+
+    public long FinalisedCount => Interlocked.Read(ref _publishedCount);
+
+    public long[] CopyLatencies()
+    {
+        // Snapshot the published watermark BEFORE reading the array so
+        // we don't accidentally include slots whose underlying tick
+        // value has not yet been published by a racing finaliser.
+        var n = (int)Math.Min(Interlocked.Read(ref _publishedCount), _latencies.LongLength);
+        var copy = new long[n];
+        Array.Copy(_latencies, copy, n);
+        return copy;
+    }
+
+    public void RecordSubmit(ulong clOrdId, long t0)
+    {
+        var idx = IndexFor(clOrdId);
+        if (idx < 0) return;
+        Interlocked.Exchange(ref _samples[idx].T0, t0);
+        TryFinalise(idx);
+    }
+
+    public void RecordPublish(ulong clOrdId, long t1)
+    {
+        var idx = IndexFor(clOrdId);
+        if (idx < 0) return;
+        Interlocked.Exchange(ref _samples[idx].T1, t1);
+        TryFinalise(idx);
+    }
+
+    private int IndexFor(ulong clOrdId)
+    {
+        // Counter occupies the low CounterBits (40) bits; the prefix
+        // sits above. Single-end-client harness ⇒ index is just the
+        // counter minus 1 (counters start at 1).
+        var counter = clOrdId & _counterMask;
+        if (counter == 0 || counter > (ulong)_samples.LongLength) return -1;
+        return (int)(counter - 1);
+    }
+
+    private void TryFinalise(int idx)
+    {
+        ref var s = ref _samples[idx];
+        var t0 = Interlocked.Read(ref s.T0);
+        var t1 = Interlocked.Read(ref s.T1);
+        if (t0 == 0 || t1 == 0) return;
+        if (Interlocked.CompareExchange(ref s.State, 1, 0) != 0) return;
+
+        // Tick deltas are converted to nanoseconds at report time so the
+        // hot path does only an integer subtract + array store.
+        var elapsed = t1 - t0;
+        if (elapsed < 0) elapsed = 0;
+        var slot = Interlocked.Increment(ref _reservedCount) - 1;
+        if (slot < _latencies.LongLength)
+        {
+            // Write the value FIRST; the subsequent
+            // Interlocked.Increment publishes the slot to readers (it
+            // acts as a release fence and bumps the visible watermark).
+            // CopyLatencies and the quiesce loop both gate on
+            // _publishedCount, so they cannot observe a slot whose
+            // value is still the default 0 — eliminating the artificial
+            // zero-latency samples that would otherwise pull p50 down.
+            Volatile.Write(ref _latencies[slot], elapsed);
+            Interlocked.Increment(ref _publishedCount);
+        }
+        else
+        {
+            // Capacity exhausted (rate × duration exceeded the
+            // pre-sized buffer). Drop the sample but DO NOT touch
+            // _publishedCount so the watermark remains a true bound on
+            // the published prefix of the buffer.
+        }
+    }
+
+    private struct Sample
+    {
+        public long T0;
+        public long T1;
+        public int State;
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IExecutionEventSink"/> that records the publish
+/// timestamp for every observed event and forwards it to N "bot" sink
+/// counters so the per-bot fan-out cost is at least represented in the
+/// timing path. The first bot to observe an event is the one whose tick
+/// is recorded as the end-to-end latency reference.
+///
+/// <para>
+/// The <c>--bots N</c> CLI flag drives a tight per-Publish counter loop
+/// of length <c>N</c>; this stands in for the per-session work that
+/// <c>BotErMultiplexer.Route</c> would do in production. The harness
+/// does <b>not</b> spin up real FIXP sessions because the inbound
+/// SOFH/SBE handshake is out of scope for the §7.2 latency
+/// measurement; sub-issues that need to characterise outbound socket
+/// latency specifically should extend the bench harness (PR #213) with
+/// their own fixture.
+/// </para>
+/// </summary>
+public sealed class LatencyCapturingSink : IExecutionEventSink
+{
+    private readonly LatencySampleStore _store;
+    private readonly int _botCount;
+    private readonly long[] _botPublishCounts;
+    public long PublishCount;
+
+    public LatencyCapturingSink(LatencySampleStore store, int botCount = 1)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(botCount, 1);
+        _store = store;
+        _botCount = botCount;
+        _botPublishCounts = new long[botCount];
+    }
+
+    public IReadOnlyList<long> BotPublishCounts => _botPublishCounts;
+
+    public void Publish(ExecutionEvent ev)
+    {
+        // Tick captured first so the per-event work below does not bias
+        // the e2e number with sink-internal accounting.
+        var t1 = Stopwatch.GetTimestamp();
+        Interlocked.Increment(ref PublishCount);
+        _store.RecordPublish(ev.ClOrdId, t1);
+
+        // Per-bot fan-out — Interlocked.Increment per slot to mirror the
+        // shape of BotErMultiplexer.Route's per-session work (one
+        // bookkeeping increment + one queue-enqueue analogue). The
+        // increment is unconditional to keep the loop branch-free under
+        // load; --bots 1 reduces this to a single increment.
+        for (var i = 0; i < _botCount; i++)
+            Interlocked.Increment(ref _botPublishCounts[i]);
+    }
+}

--- a/backend/bench/B3.Trading.LoadTest/LoadTestOptions.cs
+++ b/backend/bench/B3.Trading.LoadTest/LoadTestOptions.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// CLI options for the load-test harness. Parsed from a tiny hand-rolled
+/// argument grammar so we don't pull in another package dependency for
+/// what is a four-flag tool. Flag style mirrors
+/// <c>BenchmarkDotNet</c>'s long-form (<c>--name value</c>) so muscle
+/// memory carries between the bench and load harnesses.
+/// </summary>
+public sealed record LoadTestOptions
+{
+    public TimeSpan Duration { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan Warmup { get; init; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Target sustained submit rate in msg/s. <c>0</c> = unbounded
+    /// (drive as fast as the producers can).
+    /// </summary>
+    public int RatePerSecond { get; init; }
+
+    /// <summary>Number of concurrent submit producers.</summary>
+    public int Concurrency { get; init; } = Environment.ProcessorCount;
+
+    /// <summary>
+    /// Number of synthetic "bot" sinks subscribed to ER fan-out. Each
+    /// observed publish is counted once per bot; latency is recorded once
+    /// per submitted order against the first bot to deliver the matching
+    /// ER (matches the RFC's §7.2 "bot-receives-ER" timing reference).
+    /// </summary>
+    public int Bots { get; init; } = 1;
+
+    /// <summary>Directory for the WAL data dir. Defaults to a per-run temp dir.</summary>
+    public string? WalDirectory { get; init; }
+
+    /// <summary>Path to write the machine-readable results.json.</summary>
+    public string? ResultsPath { get; init; }
+
+    public bool ShowHelp { get; init; }
+
+    public const string Usage = """
+        Usage: dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- [options]
+
+          --duration <span>     Steady-state run length (default: 30s).
+          --warmup <span>       Pre-measurement warmup (default: 2s).
+          --rate <int>          Target submit rate msg/s (0 = unbounded; default: 0).
+          --concurrency <int>   Concurrent submit producers (default: Env.ProcessorCount).
+          --bots <int>          Synthetic ER-receiving bot sinks (default: 1).
+          --wal-dir <path>      WAL data dir (default: per-run temp dir, deleted on exit).
+          --results <path>      Write results.json here (consumed by RFC §7.3 gates).
+          --help                Show this help and exit.
+
+        Time spans accept "30s", "2m", "500ms" or any TimeSpan literal.
+        """;
+
+    public static LoadTestOptions Parse(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        var duration = TimeSpan.FromSeconds(30);
+        var warmup = TimeSpan.FromSeconds(2);
+        var rate = 0;
+        var conc = Environment.ProcessorCount;
+        var bots = 1;
+        string? walDir = null;
+        string? results = null;
+        var help = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var a = args[i];
+            switch (a)
+            {
+                case "--help" or "-h":
+                    help = true;
+                    break;
+                case "--duration":
+                    duration = ParseTimeSpan(NextValue(args, ref i, a));
+                    break;
+                case "--warmup":
+                    warmup = ParseTimeSpan(NextValue(args, ref i, a));
+                    break;
+                case "--rate":
+                    rate = ParseInt(NextValue(args, ref i, a), nonNegative: true);
+                    break;
+                case "--concurrency":
+                    conc = ParseInt(NextValue(args, ref i, a), nonNegative: false);
+                    if (conc < 1) throw new ArgumentException("--concurrency must be ≥1.");
+                    break;
+                case "--bots":
+                    bots = ParseInt(NextValue(args, ref i, a), nonNegative: false);
+                    if (bots < 1) throw new ArgumentException("--bots must be ≥1.");
+                    break;
+                case "--wal-dir":
+                    walDir = NextValue(args, ref i, a);
+                    break;
+                case "--results":
+                    results = NextValue(args, ref i, a);
+                    break;
+                default:
+                    throw new ArgumentException($"unknown argument: '{a}' (use --help)");
+            }
+        }
+
+        return new LoadTestOptions
+        {
+            Duration = duration,
+            Warmup = warmup,
+            RatePerSecond = rate,
+            Concurrency = conc,
+            Bots = bots,
+            WalDirectory = walDir,
+            ResultsPath = results,
+            ShowHelp = help,
+        };
+    }
+
+    private static string NextValue(string[] args, ref int i, string flag)
+    {
+        if (i + 1 >= args.Length)
+            throw new ArgumentException($"{flag} requires a value");
+        return args[++i];
+    }
+
+    private static int ParseInt(string s, bool nonNegative)
+    {
+        if (!int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v))
+            throw new ArgumentException($"expected integer, got '{s}'");
+        if (nonNegative && v < 0)
+            throw new ArgumentException($"expected non-negative integer, got '{s}'");
+        return v;
+    }
+
+    private static TimeSpan ParseTimeSpan(string s)
+    {
+        // Friendly suffixes: "500ms", "30s", "2m", "1h". Falls back to the
+        // standard TimeSpan parser ("00:01:00") so existing config-style
+        // strings work too.
+        var trimmed = s.Trim();
+        if (trimmed.EndsWith("ms", StringComparison.OrdinalIgnoreCase))
+            return TimeSpan.FromMilliseconds(double.Parse(trimmed[..^2], CultureInfo.InvariantCulture));
+        if (trimmed.EndsWith('s'))
+            return TimeSpan.FromSeconds(double.Parse(trimmed[..^1], CultureInfo.InvariantCulture));
+        if (trimmed.EndsWith('m'))
+            return TimeSpan.FromMinutes(double.Parse(trimmed[..^1], CultureInfo.InvariantCulture));
+        if (trimmed.EndsWith('h'))
+            return TimeSpan.FromHours(double.Parse(trimmed[..^1], CultureInfo.InvariantCulture));
+        return TimeSpan.Parse(trimmed, CultureInfo.InvariantCulture);
+    }
+}

--- a/backend/bench/B3.Trading.LoadTest/LoadTestReport.cs
+++ b/backend/bench/B3.Trading.LoadTest/LoadTestReport.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// Aggregated outcome of a load-test run. Exposes both a human-readable
+/// formatter (for stdout / PR bodies) and a JSON serialiser shaped to
+/// the gates in RFC §7.3 — sub-issues P3-P11 read these numbers as the
+/// "before / after" reference for their own throughput + latency
+/// deltas.
+/// </summary>
+public sealed record LoadTestReport
+{
+    public required long SubmittedCount { get; init; }
+    public required long AcceptedCount { get; init; }
+    public required long RejectedCount { get; init; }
+    public required long ErsApplied { get; init; }
+    public required long ErDispatchFailures { get; init; }
+    public required long PublishCount { get; init; }
+    public required double ElapsedSeconds { get; init; }
+    public required long[] LatencyTicks { get; init; }
+    public required long TicksPerSecond { get; init; }
+
+    public double SubmitsPerSecond => ElapsedSeconds > 0 ? AcceptedCount / ElapsedSeconds : 0;
+    public double ErsPerSecond => ElapsedSeconds > 0 ? PublishCount / ElapsedSeconds : 0;
+
+    public LatencyPercentiles Percentiles()
+    {
+        if (LatencyTicks.Length == 0)
+            return LatencyPercentiles.Empty;
+
+        // The harness writes into a pre-sized array indexed by a free
+        // running counter; the active prefix is dense from index 0 so
+        // we sort the live span only.
+        var copy = (long[])LatencyTicks.Clone();
+        Array.Sort(copy);
+        return new LatencyPercentiles(
+            CountSamples: copy.LongLength,
+            P50Ns: TicksToNs(Quantile(copy, 0.50)),
+            P95Ns: TicksToNs(Quantile(copy, 0.95)),
+            P99Ns: TicksToNs(Quantile(copy, 0.99)),
+            P999Ns: TicksToNs(Quantile(copy, 0.999)),
+            MaxNs: TicksToNs(copy[^1]));
+    }
+
+    private long TicksToNs(long ticks) =>
+        TicksPerSecond > 0 ? (long)(ticks * 1_000_000_000d / TicksPerSecond) : 0;
+
+    private static long Quantile(long[] sorted, double q)
+    {
+        if (sorted.Length == 0) return 0;
+        var idx = (int)Math.Clamp(Math.Ceiling(q * sorted.Length) - 1, 0, sorted.Length - 1);
+        return sorted[idx];
+    }
+
+    public string Format(LoadTestOptions opts)
+    {
+        var p = Percentiles();
+        var sb = new StringBuilder();
+        sb.AppendLine("== Results ==");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  elapsed              : {ElapsedSeconds:N3} s");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  submits attempted    : {SubmittedCount:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  submits accepted     : {AcceptedCount:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  submits rejected     : {RejectedCount:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  ERs dispatched (WAL) : {ErsApplied:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  ERs published (sink) : {PublishCount:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  ER dispatch failures : {ErDispatchFailures:N0}");
+        sb.AppendLine();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  throughput  submit  : {SubmitsPerSecond,12:N0} msg/s");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  throughput  ER     : {ErsPerSecond,12:N0} msg/s");
+        sb.AppendLine();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e latency samples : {p.CountSamples:N0}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e p50            : {FormatNs(p.P50Ns)}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e p95            : {FormatNs(p.P95Ns)}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e p99            : {FormatNs(p.P99Ns)}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e p99.9          : {FormatNs(p.P999Ns)}");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  e2e max            : {FormatNs(p.MaxNs)}");
+        sb.AppendLine();
+        var gateMet = SubmitsPerSecond >= 100_000 && p.P99Ns <= 5_000_000;
+        sb.AppendLine(CultureInfo.InvariantCulture,
+            $"  RFC §7.3 composite gate (≥100k msg/s, p99 e2e ≤5ms) : {(gateMet ? "MET" : "NOT MET — expected on baseline pre P3-P11")}");
+        sb.AppendLine();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"  config: rate={opts.RatePerSecond:N0} concurrency={opts.Concurrency} bots={opts.Bots} duration={opts.Duration} warmup={opts.Warmup}");
+        return sb.ToString();
+    }
+
+    public string ToJson(LoadTestOptions opts)
+    {
+        var p = Percentiles();
+        var doc = new
+        {
+            schema = "b3-loadtest/v1",
+            rfc = "perf-hardening-v0 §7.2 (issue #207)",
+            machine = new
+            {
+                processor_count = Environment.ProcessorCount,
+                os = Environment.OSVersion.ToString(),
+                runtime = Environment.Version.ToString(),
+                ticks_per_second = TicksPerSecond,
+                stopwatch_high_res = Stopwatch.IsHighResolution,
+            },
+            config = new
+            {
+                duration_s = opts.Duration.TotalSeconds,
+                warmup_s = opts.Warmup.TotalSeconds,
+                rate_msg_per_s = opts.RatePerSecond,
+                concurrency = opts.Concurrency,
+                bots = opts.Bots,
+                wal_dir = opts.WalDirectory,
+            },
+            counters = new
+            {
+                submitted = SubmittedCount,
+                accepted = AcceptedCount,
+                rejected = RejectedCount,
+                ers_dispatched = ErsApplied,
+                ers_published = PublishCount,
+                er_dispatch_failures = ErDispatchFailures,
+            },
+            throughput = new
+            {
+                submit_msg_per_s = SubmitsPerSecond,
+                er_msg_per_s = ErsPerSecond,
+                elapsed_s = ElapsedSeconds,
+            },
+            latency_e2e_ns = new
+            {
+                count = p.CountSamples,
+                p50 = p.P50Ns,
+                p95 = p.P95Ns,
+                p99 = p.P99Ns,
+                p999 = p.P999Ns,
+                max = p.MaxNs,
+            },
+        };
+        return JsonSerializer.Serialize(doc,
+            new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string FormatNs(long ns)
+    {
+        if (ns >= 1_000_000) return string.Create(CultureInfo.InvariantCulture, $"{ns / 1_000_000d,8:N3} ms");
+        if (ns >= 1_000) return string.Create(CultureInfo.InvariantCulture, $"{ns / 1_000d,8:N3} µs");
+        return string.Create(CultureInfo.InvariantCulture, $"{ns,8:N0} ns");
+    }
+}
+
+public sealed record LatencyPercentiles(
+    long CountSamples,
+    long P50Ns,
+    long P95Ns,
+    long P99Ns,
+    long P999Ns,
+    long MaxNs)
+{
+    public static readonly LatencyPercentiles Empty =
+        new(0, 0, 0, 0, 0, 0);
+}

--- a/backend/bench/B3.Trading.LoadTest/LoadTestRig.cs
+++ b/backend/bench/B3.Trading.LoadTest/LoadTestRig.cs
@@ -1,0 +1,344 @@
+using System.Diagnostics;
+using System.Globalization;
+
+using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// Composes the minimum slice of the platform required to drive the
+/// REST submit → WAL durable → bot ER receive pipeline end-to-end:
+/// dispatcher + WAL (real <see cref="FileEventStore"/>), the books and
+/// registries the submit/ER paths mutate, the
+/// <see cref="OrderSubmissionService"/>, the
+/// <see cref="ExecutionReportProcessor"/>, our synthetic
+/// <see cref="LoopbackFillGateway"/>, and the latency-capturing sink.
+///
+/// <para>
+/// We deliberately do <b>not</b> pull in <c>WebApplicationFactory</c>
+/// or the full <c>HostBuilder</c> stack — the RFC §7.2 charter is to
+/// "isolate platform throughput from Kestrel" and pulling Kestrel into
+/// the timing path would mix the measurement with HTTP overhead. A
+/// follow-up sub-issue can add an <c>--http</c> mode if we ever need
+/// to characterise the API surface specifically.
+/// </para>
+/// </summary>
+public sealed class LoadTestRig : IAsyncDisposable
+{
+    private readonly LoadTestOptions _opts;
+    private readonly string _walDir;
+    private readonly bool _walDirOwned;
+    private readonly FileEventStore _store;
+    private readonly EventDispatcher _dispatcher;
+    private readonly OrderSubmissionService _submitter;
+    private readonly LoopbackFillGateway _gateway;
+    private readonly LatencyCapturingSink _sink;
+    private readonly LatencySampleStore _samples;
+    private readonly EndClientId _endClient;
+    private readonly string _firmId = "LOAD";
+    private readonly string _symbol = "PETR4";
+    private readonly ulong _securityId = 1;
+
+    private LoadTestRig(
+        LoadTestOptions opts,
+        string walDir,
+        bool walDirOwned,
+        FileEventStore store,
+        EventDispatcher dispatcher,
+        OrderSubmissionService submitter,
+        LoopbackFillGateway gateway,
+        LatencyCapturingSink sink,
+        LatencySampleStore samples,
+        EndClientId endClient)
+    {
+        _opts = opts;
+        _walDir = walDir;
+        _walDirOwned = walDirOwned;
+        _store = store;
+        _dispatcher = dispatcher;
+        _submitter = submitter;
+        _gateway = gateway;
+        _sink = sink;
+        _samples = samples;
+        _endClient = endClient;
+    }
+
+    public static Task<LoadTestRig> BootAsync(LoadTestOptions opts, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(opts);
+
+        // Decide WAL dir: caller-supplied OR per-run temp dir we own.
+        // Even when the caller supplies a directory we always create a
+        // fresh per-run subdirectory under it so we cannot append to an
+        // existing WAL with a fresh ClOrdId counter — that combination
+        // would generate ClOrdIds already present in the WAL and
+        // violate the ClOrdId monotonicity invariant from RFC §4.4. The
+        // supplied path then plays the role of a "WAL root" (e.g.
+        // /dev/shm/b3-loadtest) under which each run is isolated.
+        string walDir;
+        bool owned;
+        var runId = "run-" + Guid.NewGuid().ToString("N")[..12];
+        if (opts.WalDirectory is { } supplied)
+        {
+            Directory.CreateDirectory(supplied);
+            walDir = Path.Combine(supplied, runId);
+            Directory.CreateDirectory(walDir);
+            owned = false;
+        }
+        else
+        {
+            walDir = Path.Combine(Path.GetTempPath(), "b3-loadtest-" + runId);
+            Directory.CreateDirectory(walDir);
+            owned = true;
+        }
+
+        var persistence = new PersistenceOptions
+        {
+            Enabled = true,
+            DataDirectory = walDir,
+            FirmId = "loadtest",
+        };
+        var store = new FileEventStore(persistence, NullLogger<FileEventStore>.Instance);
+        var dispatcher = new EventDispatcher(store);
+
+        var endClients = new EndClientRegistry();
+        var endClient = endClients.Register("loadtest");
+
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        // Pre-allocate the prefix so the producer knows the dense
+        // counter-only index space in the sample store.
+        clOrdIds.AllocatePrefix(endClient);
+
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+
+        var samples = new LatencySampleStore(ComputeCapacity(opts));
+        var sink = new LatencyCapturingSink(samples, opts.Bots);
+        var gateway = new LoopbackFillGateway();
+        var margin = new NoOpMarginProvider();
+        var risk = new RiskPipeline(Array.Empty<IRiskCheck>());
+        var accountant = new CompositeRiskAccountant(Array.Empty<IRiskAccountant>());
+        IDrainGate drain = new NeverDrainingGate();
+
+        var processor = new ExecutionReportProcessor(
+            ownership, book, positions, sink, margin,
+            NullLogger<ExecutionReportProcessor>.Instance);
+        gateway.Bind(processor, dispatcher);
+
+        var submitter = new OrderSubmissionService(
+            clOrdIds, ownership, book, gateway, sink, risk, margin, accountant,
+            dispatcher, drain, NullLogger<OrderSubmissionService>.Instance);
+
+        return Task.FromResult(new LoadTestRig(
+            opts, walDir, owned, store, dispatcher, submitter, gateway, sink, samples, endClient));
+    }
+
+    public async Task<LoadTestReport> RunAsync(CancellationToken ct)
+    {
+        // Warmup — drives the JIT, fills caches, primes the WAL writer.
+        if (_opts.Warmup > TimeSpan.Zero)
+        {
+            Console.WriteLine(string.Create(CultureInfo.InvariantCulture,
+                $"[warmup] {_opts.Warmup.TotalSeconds:N1}s @ {_opts.RatePerSecond:N0} msg/s × {_opts.Concurrency}"));
+            await DriveAsync(_opts.Warmup, measure: false, ct).ConfigureAwait(false);
+            // Reset counters so the steady-state report reflects only
+            // measurement-phase activity. Sample slots indexed by ClOrdId
+            // counter are NOT reset — the steady-state allocations write
+            // into fresh slots past the warmup high-water mark, which the
+            // pre-sized capacity in ComputeCapacity already accounts for.
+            Interlocked.Exchange(ref _gateway.ErsApplied, 0);
+            Interlocked.Exchange(ref _gateway.ErDispatchFailures, 0);
+            Interlocked.Exchange(ref _sink.PublishCount, 0);
+        }
+
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture,
+            $"[steady] {_opts.Duration.TotalSeconds:N1}s @ {_opts.RatePerSecond:N0} msg/s × {_opts.Concurrency}"));
+        var (submitted, accepted, rejected, elapsed) =
+            await DriveAsync(_opts.Duration, measure: true, ct).ConfigureAwait(false);
+
+        // Quiesce: give the loopback gateway and the WAL writer a moment
+        // to flush in-flight ERs. Without this the tail of the latency
+        // distribution is empty for samples whose Publish is still
+        // queued behind the dispatcher.
+        var quiesceDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        var lastReady = _samples.FinalisedCount;
+        while (DateTime.UtcNow < quiesceDeadline)
+        {
+            await Task.Delay(50, CancellationToken.None).ConfigureAwait(false);
+            var now = _samples.FinalisedCount;
+            if (now >= accepted) break;
+            if (now == lastReady) break; // no progress for 50ms
+            lastReady = now;
+        }
+
+        await _store.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var latencies = _samples.CopyLatencies();
+        return new LoadTestReport
+        {
+            SubmittedCount = submitted,
+            AcceptedCount = accepted,
+            RejectedCount = rejected,
+            ErsApplied = Interlocked.Read(ref _gateway.ErsApplied),
+            ErDispatchFailures = Interlocked.Read(ref _gateway.ErDispatchFailures),
+            PublishCount = Interlocked.Read(ref _sink.PublishCount),
+            ElapsedSeconds = elapsed.TotalSeconds,
+            LatencyTicks = latencies,
+            TicksPerSecond = Stopwatch.Frequency,
+        };
+    }
+
+    private async Task<(long Submitted, long Accepted, long Rejected, TimeSpan Elapsed)>
+        DriveAsync(TimeSpan duration, bool measure, CancellationToken ct)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(duration.TotalSeconds * Stopwatch.Frequency);
+        // Per-producer interval is computed in floating point off the
+        // global target rate so a target rate that is positive but
+        // smaller than --concurrency does not collapse to "unbounded"
+        // via integer truncation. perProducerIntervalTicks=0 means
+        // "no rate limit" (i.e. --rate 0 / unbounded mode).
+        double perProducerIntervalTicks = 0;
+        if (_opts.RatePerSecond > 0)
+        {
+            var globalIntervalTicks = Stopwatch.Frequency / (double)_opts.RatePerSecond;
+            perProducerIntervalTicks = globalIntervalTicks * Math.Max(1, _opts.Concurrency);
+        }
+
+        var sw = Stopwatch.StartNew();
+        var tasks = new Task<(long Submitted, long Accepted, long Rejected)>[_opts.Concurrency];
+        for (var p = 0; p < _opts.Concurrency; p++)
+        {
+            tasks[p] = Task.Run(() => ProducerLoopAsync(
+                deadline, perProducerIntervalTicks, measure, ct), ct);
+        }
+        var perProducer = await Task.WhenAll(tasks).ConfigureAwait(false);
+        sw.Stop();
+
+        long submitted = 0, accepted = 0, rejected = 0;
+        foreach (var t in perProducer)
+        {
+            submitted += t.Submitted;
+            accepted += t.Accepted;
+            rejected += t.Rejected;
+        }
+        return (submitted, accepted, rejected, sw.Elapsed);
+    }
+
+    private async Task<(long Submitted, long Accepted, long Rejected)> ProducerLoopAsync(
+        long deadlineTick, double perProducerIntervalTicks, bool measure, CancellationToken ct)
+    {
+        long submitted = 0, accepted = 0, rejected = 0;
+        // Track next-dispatch as a double so non-integer intervals
+        // (e.g. 1.5 µs at 100k×8) accumulate without quantisation
+        // bias. Quantisation to an integer tick happens only when
+        // comparing against Stopwatch.GetTimestamp() below.
+        double nextDispatchTick = Stopwatch.GetTimestamp();
+        var req = new OrderSubmissionRequest(
+            Owner: _endClient,
+            FirmId: _firmId,
+            Symbol: _symbol,
+            SecurityId: _securityId,
+            Side: OrderSide.Buy,
+            Type: OrderType.Limit,
+            Quantity: 100,
+            Price: 10m);
+
+        while (!ct.IsCancellationRequested)
+        {
+            var now = Stopwatch.GetTimestamp();
+            if (now >= deadlineTick) break;
+
+            if (perProducerIntervalTicks > 0)
+            {
+                if (now < nextDispatchTick)
+                {
+                    var waitTicks = nextDispatchTick - now;
+                    var waitMs = waitTicks * 1000.0 / Stopwatch.Frequency;
+                    if (waitMs >= 1)
+                        await Task.Delay(TimeSpan.FromMilliseconds(waitMs), ct).ConfigureAwait(false);
+                    else
+                        Thread.SpinWait(50);
+                    continue;
+                }
+                nextDispatchTick += perProducerIntervalTicks;
+            }
+
+            var t0 = Stopwatch.GetTimestamp();
+            OrderSubmissionResult result;
+            try
+            {
+                result = await _submitter.SubmitAsync(req, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch
+            {
+                rejected++;
+                continue;
+            }
+
+            submitted++;
+            if (result.Kind == OrderSubmissionResultKind.Accepted)
+            {
+                accepted++;
+                if (measure)
+                    _samples.RecordSubmit(result.ClOrdId, t0);
+            }
+            else
+            {
+                rejected++;
+            }
+        }
+
+        return (submitted, accepted, rejected);
+    }
+
+    /// <summary>
+    /// Over-provisions sample-store capacity so the dense ClOrdId
+    /// counter index never overflows during warmup + steady state at
+    /// the configured rate. Cap to a sane upper bound so an unbounded
+    /// rate (rate=0) doesn't allocate gigabytes pre-flight.
+    /// </summary>
+    public static int ComputeCapacity(LoadTestOptions opts)
+    {
+        var totalSeconds = (opts.Warmup + opts.Duration).TotalSeconds;
+        // Allow producers to outpace targetRate by 4× before we run off
+        // the end (the loop is best-effort, not strictly capped).
+        long projected = opts.RatePerSecond > 0
+            ? (long)(opts.RatePerSecond * totalSeconds * 4)
+            : 5_000_000;
+        projected = Math.Clamp(projected, 100_000, 50_000_000);
+        return (int)projected;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _store.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // best effort — temp dir cleanup runs regardless
+        }
+
+        if (_walDirOwned)
+        {
+            try { Directory.Delete(_walDir, recursive: true); }
+            catch { /* leave it for postmortem */ }
+        }
+    }
+
+    private sealed class NeverDrainingGate : IDrainGate
+    {
+        public bool IsDraining => false;
+    }
+}

--- a/backend/bench/B3.Trading.LoadTest/LoopbackFillGateway.cs
+++ b/backend/bench/B3.Trading.LoadTest/LoopbackFillGateway.cs
@@ -1,0 +1,89 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// Synthetic <see cref="IExchangeGateway"/> that closes the loop: every
+/// accepted submit triggers an immediate <see cref="ExecKind.Fill"/>
+/// execution-report fed back through the real
+/// <see cref="ExecutionReportProcessor"/> via the real
+/// <see cref="Application.Persistence.EventDispatcher"/>. This makes the
+/// platform exercise the **complete** REST → WAL → ER → publish pipeline
+/// the RFC §7.2 harness is supposed to time, without spinning up an
+/// EntryPoint matching simulator process.
+///
+/// <para>
+/// The ER is dispatched from a thread-pool task (matching the
+/// production gateway, which receives ERs from the EntryPoint client's
+/// background reader) so the producer's submit call completes before
+/// the matching ER is observed at the sink. Latency captured at
+/// <see cref="LatencyCapturingSink"/> therefore reflects the real
+/// dispatcher contention path.
+/// </para>
+/// </summary>
+public sealed class LoopbackFillGateway : IExchangeGateway
+{
+    // Resolved post-construction to break the DI cycle (the processor
+    // depends on the sink which depends on this gateway's wiring).
+    private ExecutionReportProcessor? _processor;
+    private Application.Persistence.EventDispatcher? _dispatcher;
+
+    public long ErsApplied;
+    public long ErDispatchFailures;
+
+    public void Bind(ExecutionReportProcessor processor, Application.Persistence.EventDispatcher dispatcher)
+    {
+        _processor = processor;
+        _dispatcher = dispatcher;
+    }
+
+    public Task SubmitAsync(Order order, CancellationToken cancellationToken)
+    {
+        // Schedule the ER asynchronously so the submit call returns before
+        // the matching publish — same shape as the production EntryPoint
+        // gateway, where ERs arrive on the client's reader thread.
+        _ = Task.Run(() => DispatchFill(order), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private void DispatchFill(Order order)
+    {
+        var processor = _processor;
+        var dispatcher = _dispatcher;
+        if (processor is null || dispatcher is null) return;
+
+        try
+        {
+            var qty = order.Quantity;
+            var px = order.Price ?? 1m;
+            dispatcher.Dispatch(
+                new Application.Persistence.ExecutionReportReceivedEvent
+                {
+                    ClOrdId = order.ClOrdId,
+                    ExecKind = ExecKind.Fill.ToString(),
+                    LeavesQuantity = 0,
+                    CumulativeQuantity = qty,
+                    LastQuantity = qty,
+                    LastPrice = px,
+                    Synthetic = false,
+                    OrigClOrdId = 0,
+                },
+                () => processor.Apply(order.ClOrdId, ExecKind.Fill,
+                    leaves: 0, cumQty: qty, lastQty: qty, lastPx: px,
+                    rejectReason: null, origClOrdId: 0));
+            Interlocked.Increment(ref ErsApplied);
+        }
+        catch (Exception)
+        {
+            // WAL backpressure or transient — record and move on; the
+            // load-test report surfaces the count as a "lost ERs"
+            // diagnostic so the operator can dial the rate down.
+            Interlocked.Increment(ref ErDispatchFailures);
+        }
+    }
+}

--- a/backend/bench/B3.Trading.LoadTest/Program.cs
+++ b/backend/bench/B3.Trading.LoadTest/Program.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using System.Text;
+
+using B3.Trading.LoadTest;
+
+namespace B3.Trading.LoadTest;
+
+/// <summary>
+/// Entry point for the perf-hardening v0 macro/load harness (RFC §7.2,
+/// issue #207). Drives the in-process REST submit → WAL durable → bot
+/// ER receive end-to-end pipeline at a configurable rate/concurrency
+/// for a configurable duration, and emits throughput + latency
+/// percentiles to stdout and (optionally) a JSON results file consumed
+/// by the gates in RFC §7.3.
+///
+/// <para>
+/// This harness is the macro complement to the BenchmarkDotNet micro
+/// suite under <c>backend/bench/B3.Trading.Benchmarks</c> (PR #213). It
+/// is excluded from CI by virtue of being a non-test Exe with
+/// <c>IsPackable=false</c>; run on demand via:
+/// <code>
+/// dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- \
+///     --duration 60s --rate 50000 --concurrency 8 --bots 1
+/// </code>
+/// </para>
+/// </summary>
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        LoadTestOptions opts;
+        try
+        {
+            opts = LoadTestOptions.Parse(args);
+        }
+        catch (ArgumentException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(LoadTestOptions.Usage);
+            return 2;
+        }
+
+        if (opts.ShowHelp)
+        {
+            Console.WriteLine(LoadTestOptions.Usage);
+            return 0;
+        }
+
+        Console.WriteLine("== B3.Trading.LoadTest (RFC §7.2 / issue #207) ==");
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  duration       : {opts.Duration}"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  warmup         : {opts.Warmup}"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  target rate    : {opts.RatePerSecond:N0} msg/s (0 = unbounded)"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  concurrency    : {opts.Concurrency}"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  bots (sinks)   : {opts.Bots}"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  wal directory  : {opts.WalDirectory ?? "<temp>"}"));
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"  results file   : {opts.ResultsPath ?? "<stdout only>"}"));
+        Console.WriteLine();
+
+        using var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            // Best-effort cooperative shutdown; second Ctrl-C exits.
+            if (!cts.IsCancellationRequested) cts.Cancel();
+        };
+
+        await using var rig = await LoadTestRig.BootAsync(opts, cts.Token).ConfigureAwait(false);
+        var report = await rig.RunAsync(cts.Token).ConfigureAwait(false);
+
+        var json = report.ToJson(opts);
+        if (opts.ResultsPath is { } path)
+        {
+            await File.WriteAllTextAsync(path, json, Encoding.UTF8, CancellationToken.None).ConfigureAwait(false);
+            Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"[ok] results written to {path}"));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(report.Format(opts));
+        return 0;
+    }
+}

--- a/backend/bench/B3.Trading.LoadTest/README.md
+++ b/backend/bench/B3.Trading.LoadTest/README.md
@@ -1,0 +1,159 @@
+# B3.Trading.LoadTest
+
+Macro / load-test harness for the perf-hardening v0 RFC
+(`docs/rfcs/perf-hardening-v0.md` §7.2, tracking #194, issue #207). The
+companion to `B3.Trading.Benchmarks` (PR #213) — that project is the
+**micro** harness (BenchmarkDotNet), this one is the **macro** harness
+that drives the full submit → WAL durable → bot ER receive pipeline at
+a sustained rate.
+
+The harness is **on-demand only**. It is wired into `B3TradingPlatform.slnx`
+so `dotnet build` compiles it, but `<IsPackable>false</IsPackable>` keeps
+it out of pack/publish, and CI's `dotnet test` skips it because it is not
+a test project. There is no perf job in `.github/workflows/`; runs happen
+on developer hardware (or in a future labelled-dispatch job).
+
+## What it measures
+
+Per RFC §7.2, the harness drives the in-process platform pipeline at a
+configurable rate × concurrency × duration and captures:
+
+| Metric | Source |
+| --- | --- |
+| **Submit throughput (msg/s)** | accepted submits ÷ steady-state elapsed |
+| **ER throughput (msg/s)** | observed publishes ÷ steady-state elapsed |
+| **End-to-end latency p50 / p95 / p99 / p99.9 / max** | `Stopwatch.GetTimestamp` deltas from submit-call-start to publish-observed, recorded per accepted order |
+| **WAL backpressure** | submit rejections + ER dispatch failures |
+
+End-to-end latency covers exactly the path RFC §7.3 gates on:
+`OrderSubmissionService.SubmitAsync` → `EventDispatcher.Dispatch`
+(WAL append + apply) → `IExchangeGateway.SubmitAsync` → loopback ER →
+`EventDispatcher.Dispatch` (WAL append + apply) →
+`ExecutionReportProcessor.Apply` → `IExecutionEventSink.Publish`.
+
+The HTTP layer is deliberately **out** of the timing path — RFC §7.2's
+charter is "isolate platform throughput from Kestrel". Sub-issues that
+specifically need to characterise the API surface should add an
+`--http` mode in a follow-up.
+
+## Architecture
+
+```
+┌────────────┐  rate-limited  ┌────────────────────────┐
+│  N producer │───────────────▶│ OrderSubmissionService │──┐
+│  Tasks      │                └──────────┬─────────────┘  │
+└────────────┘                            ▼                │
+                                ┌─────────────────┐        │
+                                │ EventDispatcher │        │
+                                │ (WAL append +   │        │
+                                │  apply)         │        │
+                                └────────┬────────┘        │
+                                         ▼                 │
+                              ┌──────────────────────┐     │
+                              │ LoopbackFillGateway  │     │ t0 captured
+                              │ (Task.Run schedules  │     │ here
+                              │  Filled ER)          │     │
+                              └──────────┬───────────┘     │
+                                         ▼                 │
+                                ┌─────────────────┐        │
+                                │ EventDispatcher │        │
+                                │ (WAL ER append) │        │
+                                └────────┬────────┘        │
+                                         ▼                 │
+                            ┌─────────────────────────┐    │
+                            │ ExecutionReportProcessor│    │
+                            └────────────┬────────────┘    │
+                                         ▼                 │
+                              ┌──────────────────────┐     │
+                              │ LatencyCapturingSink │  t1 captured
+                              │ (× --bots fan-out)   │  here
+                              └──────────────────────┘
+```
+
+`LoopbackFillGateway` substitutes the real `IExchangeGateway` so we
+don't depend on an EntryPoint matching simulator. The Filled ER is
+dispatched on a thread-pool task — same shape as the production
+gateway, where ERs arrive on the EntryPoint client's reader thread —
+so the producer's submit call returns before its matching ER fires
+through `Publish`.
+
+`LatencyCapturingSink` records the publish-observed tick in a flat
+pre-sized `Sample[]` keyed by ClOrdId counter. The producer separately
+records `t0` (submit-call-start tick) into the same slot. Whichever
+side observes both sides populated atomically claims the slot and
+appends `(t1 − t0)` into a flat `long[]` results buffer that is sorted
+once at end-of-run for percentiles. This pre-sizing is the only reason
+the harness can run at 100k+ msg/s without polluting the SUT's GC
+profile with sample bookkeeping.
+
+`--bots N` drives an additional per-Publish counter loop of length `N`
+to represent `BotErMultiplexer.Route`'s per-session bookkeeping cost.
+The harness does **not** spin up real FIXP bot sessions — that was an
+RFC §7.2 stretch goal that the §7.3 gates do not depend on.
+
+## Running
+
+```sh
+# 30s smoke at moderate rate — sanity check.
+dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- \
+    --duration 30s --warmup 2s --rate 20000 --concurrency 4 --bots 1
+
+# Sustained baseline against the 100k target. Run on quiet hardware,
+# performance governor pinned. Capture results.json for the gating PRs.
+dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- \
+    --duration 60s --warmup 5s --rate 100000 --concurrency 8 --bots 50 \
+    --results baseline.json
+
+# Unbounded — drive the producers as fast as the platform will accept.
+# Useful for finding the saturation point; not directly comparable
+# across machines.
+dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- \
+    --duration 30s --rate 0 --concurrency 16
+```
+
+`--help` lists the full flag set.
+
+## Runner spec for comparable numbers
+
+Same conventions as the bench harness (`backend/bench/B3.Trading.Benchmarks/README.md`):
+
+- **Build:** `dotnet build -c Release` against the load-test project.
+- **Process isolation:** close other CPU-heavy work; pin the CPU governor
+  to `performance` on Linux (`cpupower frequency-set -g performance`).
+- **WAL directory:** the harness defaults to a unique per-run temp dir
+  it deletes on exit. For comparable WAL fsync numbers, set
+  `--wal-dir /dev/shm/b3-loadtest` on Linux so the WAL lives on tmpfs;
+  numbers from spinning disk / EBS are NOT comparable with tmpfs runs
+  and must be flagged in the PR body.
+- **GC mode:** `<ServerGarbageCollection>true</ServerGarbageCollection>`
+  matches the production host config.
+
+## Where to put before/after numbers in PR bodies
+
+Each P3-P11 PR that targets a gate in RFC §7.3 must include the
+`results.json` deltas in its PR body. Suggested template:
+
+```text
+Bench: B3.Trading.LoadTest, --duration 60s --warmup 5s --rate 100000
+       --concurrency 8 --bots 50
+
+| Metric                | main (baseline) | this PR |
+| --------------------- | --------------- | ------- |
+| accepted msg/s        |          XX,XXX |  XX,XXX |
+| ER msg/s              |          XX,XXX |  XX,XXX |
+| e2e p50               |        XXX µs   |  XXX µs |
+| e2e p99               |        XXX µs   |  XXX µs |
+| e2e p99.9             |        XXX ms   |  XXX ms |
+| WAL backpressure %    |          X.XX % |  X.XX % |
+```
+
+Acceptance gates per fix are listed in RFC §7.3 — a PR that hits its
+throughput target but regresses any other path's latency by >10% is not
+mergeable without an RFC amendment. The composite gate
+(≥100k msg/s sustained, p99 e2e ≤5ms) is the cumulative target P3–P11
+together must hit; no individual sub-issue is expected to clear it
+alone.
+
+The harness prints "RFC §7.3 composite gate : MET / NOT MET" at the
+bottom of each run as a quick visual check; the underlying numbers in
+`results.json` are the source of truth.


### PR DESCRIPTION
Closes #207

## Summary

Adds `backend/bench/B3.Trading.LoadTest`, an in-process load harness that drives the **submit → WAL durable → bot ER receive** pipeline per RFC §7.2. HTTP/Kestrel intentionally bypassed to isolate platform throughput from the wire layer (§7.2 charter). Excluded from CI like the existing bench harness — no `IsTestProject`, just an exe under `backend/bench/`.

## What it does

Wires the **real** `EventDispatcher`, `FileEventStore`, `OrderSubmissionService`, and `ExecutionReportProcessor` together with two synthetic adapters:

- `LoopbackFillGateway` — `IExchangeGateway` substitute. On `SubmitAsync`, schedules an immediate `Filled` ER via `Task.Run` → `EventDispatcher.Dispatch(ExecutionReportReceivedEvent, …)`, mirroring the production gateway's reader-thread shape.
- `LatencyCapturingSink` — `IExecutionEventSink` substitute. Captures `t1` against producer-side `t0` (recorded just before `SubmitAsync`) into a pre-sized `Sample[]` indexed by ClOrdId counter (low 40 bits). Race-safe split: `_reservedCount` (Interlocked claim) vs `_publishedCount` (Volatile.Write + Interlocked release fence) so readers never see uninitialised slots.

Producer loop runs N concurrent generators at a target global `--rate` (or unbounded with `--rate 0`); per-producer pacing uses a double-precision interval so `rate / concurrency` doesn't truncate to zero. Each run lands in a fresh `run-<guid>` subdir under `--wal-dir` to preserve ClOrdId monotonicity (RFC §4.4) when reusing a WAL parent dir.

CLI: `--duration --warmup --rate --concurrency --bots --wal-dir --results --help`. Output: console summary + JSON (`schema=b3-loadtest/v1`).

See `backend/bench/B3.Trading.LoadTest/README.md` for full usage and architecture diagram.

## Baseline (current `main`, /dev/shm WAL)

**Steady-state** — 30 s × 3 runs @ `--rate 4000 --concurrency 4 --bots 4`:
| metric | run 1 | run 2 | run 3 |
|---|---|---|---|
| submit msg/s | 4,000 | 4,000 | 4,000 |
| ER msg/s | 4,000 | 4,000 | 4,000 |
| p50 e2e | ~60 µs | ~75 µs | ~86 µs |
| p99 e2e | 489 µs | 4.3 ms | 7.8 ms |
| rejections | 0 | 0 | 0 |
| ER dispatch failures | 0 | 0 | 0 |

p99 variance reflects noise on shared dev hardware, not the harness.

**Saturation / ceiling probe** — 30 s @ `--rate 0 --concurrency 8 --bots 4`:
- submit/ER throughput: **~96.7k msg/s**
- p50 e2e: **1.34 ms**
- p99 e2e: **702 ms**
- p99.9 e2e: **1.50 s**
- max e2e: **1.59 s**

Consistent with the RFC's 10–50k pre-perf-work ceiling estimate; the saturation latency cliff is exactly the regime P3–P11 will flatten.

**RFC §7.3 composite gate (≥100k msg/s sustained, p99 e2e ≤5 ms): NOT MET** — expected on baseline pre P3–P11. The harness now exists to track the gate for every subsequent perf PR.

## How to run

```bash
dotnet run -c Release --project backend/bench/B3.Trading.LoadTest -- \
  --duration 30s --warmup 3s --rate 4000 --concurrency 4 --bots 4 \
  --wal-dir /dev/shm/b3-loadtest --results loadtest.json
```

For saturation: `--rate 0 --concurrency 8`.

## CI / quality

- `dotnet build -c Release` clean (TreatWarningsAsErrors).
- `dotnet test -c Release` — **998 / 998 passing** (53 + 23 + 207 + 101 + 596 + 18 skipped Conformance).
- `dotnet format --verify-no-changes` clean.
- LoadTest project itself excluded from `dotnet test` (matches `B3.Trading.Benchmarks` convention — no `IsTestProject`).

## Code-review feedback addressed

Pre-PR review (gpt-5.5) caught and fixed:
1. **Sample race** — `_latencyCount++` happened before slot write; `CopyLatencies` could observe zeroed slots. Fixed via reserved/published split with `Volatile.Write` + Interlocked release fence.
2. **WAL dir reuse** — appending to existing WAL with a fresh `ClOrdIdPrefixRegistry` would violate RFC §4.4 monotonicity. Fixed by always creating `run-<guid>` subdir under `--wal-dir`.
3. **Per-producer rate truncation** — integer `rate / concurrency` could yield 0 → unbounded firing. Fixed with double-precision interval in ticks.
