### PR TITLE
perf(fixp): P8 — per-connection outbound channel + drain loop; remove Task.Run-per-send (#202)

### DIFF
--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
@@ -160,7 +160,7 @@ public class BotErRouter_RouteOne_Bench
         private int _sent;
         public int SentCount => Volatile.Read(ref _sent);
         public void Reset() => Volatile.Write(ref _sent, 0);
-        public bool TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+        public bool TryEnqueue(OutboundFrame frame)
         {
             Interlocked.Increment(ref _sent);
             return true;

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs
@@ -115,5 +115,30 @@ public sealed class EntryPointListenerOptions
 
         /// <summary>Idle bot-mapping reap interval.</summary>
         public TimeSpan MappingReapAfter { get; set; } = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// RFC §5.3 / P8 / F3. Capacity of the per-FIXP-connection
+        /// bounded outbound channel that the drain loop reads from.
+        /// When the channel fills up, <c>TryEnqueue</c> returns false
+        /// (RFC §5.3.1 backpressure: surface, never silently drop) —
+        /// the message stays owned by the per-credential
+        /// <see cref="UserBots.BotOutboundBuffer"/> and is replayed via
+        /// retransmit on the next reconnect. Default 4096 — sized to
+        /// absorb a transient socket-write stall of several seconds
+        /// at typical ER rates without surfacing backpressure.
+        /// </summary>
+        public int OutboundChannelCapacity { get; set; } = 4096;
+
+        /// <summary>
+        /// RFC §5.3.2 / P8 / F3. Maximum time the per-connection drain
+        /// loop will spend flushing already-queued outbound frames on
+        /// connection close before giving up and returning. Frames
+        /// still queued when the deadline elapses remain owned by the
+        /// per-credential <see cref="UserBots.BotOutboundBuffer"/> and
+        /// are replayed via retransmit on the next reconnect — they
+        /// are NEVER silently dropped from the bot's perspective.
+        /// Default 1s.
+        /// </summary>
+        public TimeSpan OutboundDrainShutdownTimeout { get; set; } = TimeSpan.FromSeconds(1);
     }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -200,16 +200,19 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter
         if (_directory.TryGet(mapping.CredentialId, out var sender))
         {
             // The buffer is now the sole owner of frame's pooled
-            // memory; the sender only borrows the bytes. Eviction (or
-            // overflow / reset) is what eventually disposes — never
-            // TryEnqueue, never the drain loop.
-            if (!sender.TryEnqueue(frame.Bytes))
+            // memory; the sender only borrows the bytes via the
+            // per-connection drain loop. Eviction (or overflow / reset)
+            // is what eventually disposes — never TryEnqueue, never
+            // the drain loop (RFC §5.3 / §5.5).
+            if (!sender.TryEnqueue(frame))
             {
-                // Race: the connection went away between TryGet and
-                // TryEnqueue. The buffer already holds the message,
+                // Race or backpressure (RFC §5.3.1): the connection
+                // went away between TryGet and TryEnqueue, OR the
+                // per-connection bounded outbound channel is full.
+                // Either way, the buffer already holds the message,
                 // so retransmit (G) will pick it up on reconnect.
                 _logger.LogDebug(
-                    "fixp.outbound.send.race credentialId={CredentialId} seq={Seq}",
+                    "fixp.outbound.send.race-or-backpressure credentialId={CredentialId} seq={Seq}",
                     mapping.CredentialId, seq);
             }
         }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
@@ -1,0 +1,256 @@
+using System.Threading.Channels;
+using B3.Trading.Application.UserBots;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.EntryPointListener.Hosting;
+
+/// <summary>
+/// RFC §5.3 / P8 / F3 — per-FIXP-connection outbound writer. Owns a
+/// bounded <see cref="Channel{T}"/> of <see cref="OutboundFrame"/> and
+/// a single dedicated drain loop (one <see cref="Task"/> per
+/// connection, NOT one per outbound message). Replaces the pre-F3
+/// <c>Task.Run</c>-per-send fire-and-forget allocation in
+/// <c>FixpSessionConnection.IBotSessionOutboundSender.TryEnqueue</c>.
+///
+/// <para><b>Ordering.</b> The channel is FIFO; the drain loop is
+/// single-reader. Any sequence of producer enqueues observed by a
+/// single producer is delivered to the socket in that exact order.
+/// Cross-producer ordering is "as enqueued", which is what FIXP
+/// requires (the per-credential outbound seq is allocated upstream,
+/// in the multiplexer's <c>RouteOne</c>, before <c>TryEnqueue</c>).</para>
+///
+/// <para><b>Backpressure (RFC §5.3.1).</b> The channel uses
+/// <see cref="BoundedChannelFullMode.Wait"/> as its declared full
+/// mode, but producers go through the non-blocking
+/// <see cref="ChannelWriter{T}.TryWrite"/> path so they never await
+/// the channel — when the channel is full, <see cref="TryEnqueue"/>
+/// returns <c>false</c> and the caller (the multiplexer) leaves the
+/// frame in the per-credential <see cref="BotOutboundBuffer"/> for
+/// retransmit on the next reconnect. <c>DropOldest</c> is intentionally
+/// rejected: the FIXP wire requires per-session sequence continuity
+/// and a silent drop would surface only as cancel-rejects with no
+/// diagnosable cause (RFC §5.3.1, code-review concern (1)).</para>
+///
+/// <para><b>Single-disposer rule (RFC §5.5).</b> The drain loop NEVER
+/// disposes <see cref="OutboundFrame.Owner"/>. The frame remains
+/// owned by the per-credential <see cref="BotOutboundBuffer"/> from
+/// the moment <c>buffer.Append</c> succeeded upstream; the buffer is
+/// the sole disposer (on <c>EvictUpTo</c> / overflow / <c>Reset</c>).
+/// This writer only borrows <see cref="OutboundFrame.Bytes"/> for
+/// <see cref="System.IO.Stream.WriteAsync(System.ReadOnlyMemory{byte}, System.Threading.CancellationToken)"/>.</para>
+///
+/// <para><b>Lifetime safety across the awaited write.</b> A bot can
+/// only ack a watermark for sequences it has actually received; an
+/// unsent (still-queued) frame's seq cannot reach
+/// <see cref="BotOutboundBuffer.EvictUpTo"/>. Overflow / version-bump
+/// force-closes the connection (and therefore this writer) BEFORE the
+/// buffer's <see cref="BotOutboundBuffer.Reset"/> clears pooled
+/// owners. Both invariants together are why the drain loop can hold
+/// an <see cref="OutboundFrame"/> across an <c>await</c> without a
+/// defensive heap copy of <c>frame.Bytes</c>.</para>
+///
+/// <para><b>Shutdown drain (RFC §5.3.2).</b> <see cref="CompleteAsync"/>
+/// signals no further enqueues, then waits up to
+/// <c>shutdownTimeout</c> for the drain loop to flush the remaining
+/// queued frames. Frames still queued at the deadline are NOT lost
+/// from the bot's perspective: they remain owned by the per-credential
+/// <see cref="BotOutboundBuffer"/> and are replayed via retransmit on
+/// the next reconnect (sub-issue G). The drain loop returns without
+/// disposing anything.</para>
+/// </summary>
+internal sealed class FixpOutboundChannelWriter
+{
+    /// <summary>
+    /// Synchronous socket-write callback invoked by the drain loop.
+    /// Returning <c>false</c> ends the drain loop (the writer treats
+    /// it as "socket gone"). Throwing is logged and also ends the
+    /// drain loop. The callback is responsible for serialising
+    /// against any concurrent handshake / order-ack writes the
+    /// connection's own request loop is emitting (typically by taking
+    /// the same write mutex).
+    /// </summary>
+    public delegate ValueTask<bool> SocketWriteCallback(
+        ReadOnlyMemory<byte> bytes, CancellationToken ct);
+
+    private readonly Channel<OutboundFrame> _channel;
+    private readonly SocketWriteCallback _writeAsync;
+    private readonly ILogger _logger;
+    private readonly string _connectionId;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _drainLoop;
+    private volatile bool _completed;
+
+    public FixpOutboundChannelWriter(
+        int capacity,
+        SocketWriteCallback writeAsync,
+        string connectionId,
+        ILogger? logger = null)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
+        ArgumentNullException.ThrowIfNull(writeAsync);
+
+        _writeAsync = writeAsync;
+        _logger = logger ?? NullLogger.Instance;
+        _connectionId = connectionId;
+        _channel = Channel.CreateBounded<OutboundFrame>(new BoundedChannelOptions(capacity)
+        {
+            // FullMode = Wait is the *declared* policy; producers always
+            // go through TryWrite so they never actually wait. See the
+            // type-level §5.3.1 note.
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        _cts = new CancellationTokenSource();
+        // Start the dedicated drain loop. One Task per connection,
+        // not per outbound message — that is the entire point of P8.
+        _drainLoop = Task.Run(() => DrainAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Number of frames currently queued. Test-only — the production
+    /// hot path never reads this.
+    /// </summary>
+    internal int QueuedCount => _channel.Reader.CanCount ? _channel.Reader.Count : 0;
+
+    /// <summary>
+    /// Awaitable that completes when the drain loop exits. Test-only.
+    /// </summary>
+    internal Task DrainCompletion => _drainLoop;
+
+    /// <summary>
+    /// Non-blocking enqueue. Returns <c>false</c> when (a) the writer
+    /// has been completed (connection closed) or (b) the bounded
+    /// channel is full (slow-consumer backpressure, RFC §5.3.1). The
+    /// caller MUST NOT dispose <paramref name="frame"/> in either
+    /// branch — single-disposer rule.
+    /// </summary>
+    public bool TryEnqueue(OutboundFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        if (_completed) return false;
+        // TryWrite is non-blocking and returns false when the bounded
+        // channel is full — exactly the surface §5.3.1 wants. We also
+        // get a false return after Complete(), which we treat the same.
+        return _channel.Writer.TryWrite(frame);
+    }
+
+    /// <summary>
+    /// Marks the writer complete (no further enqueues accepted) and
+    /// waits up to <paramref name="shutdownTimeout"/> for the drain
+    /// loop to flush remaining queued frames. Idempotent.
+    /// </summary>
+    public async Task CompleteAsync(TimeSpan shutdownTimeout)
+    {
+        if (_completed)
+        {
+            // Still wait for the loop to finish — callers expect the
+            // returned Task to complete with the drain loop, not to
+            // race with a still-running flush.
+            await WaitForDrainAsync(shutdownTimeout).ConfigureAwait(false);
+            return;
+        }
+        _completed = true;
+        // Complete() lets the foreach in DrainAsync exit cleanly once
+        // the channel is empty. We intentionally do NOT cancel _cts
+        // here — that would abort an in-flight flush mid-message and
+        // leave the bot observing a partially-written frame.
+        _channel.Writer.TryComplete();
+        await WaitForDrainAsync(shutdownTimeout).ConfigureAwait(false);
+    }
+
+    private async Task WaitForDrainAsync(TimeSpan timeout)
+    {
+        try
+        {
+            await _drainLoop.WaitAsync(timeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // The drain loop is still running (peer is stuck or the
+            // socket-write is pathologically slow). Cancel it so the
+            // current WriteAsync observes the cancellation and the
+            // loop returns; remaining queued frames stay owned by the
+            // per-credential BotOutboundBuffer and ride retransmit on
+            // the next reconnect (RFC §5.3.2).
+            try { _cts.Cancel(); } catch { /* ignore */ }
+            // Bounded grace period after cancel — never await the
+            // loop unbounded, otherwise a callback that ignores
+            // cancellation would still hang shutdown despite the
+            // configured timeout.
+            try
+            {
+                await _drainLoop.WaitAsync(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                // Drain still hung — log and abandon. Connection
+                // cleanup proceeds; the (orphaned) drain task will
+                // exit when its WriteAsync eventually unblocks.
+                _logger.LogWarning(
+                    "fixp.outbound.drain.shutdown.abandoned connectionId={ConnectionId} timeoutMs={TimeoutMs}",
+                    _connectionId, (int)timeout.TotalMilliseconds);
+                return;
+            }
+            catch
+            {
+                // swallow shutdown noise
+            }
+            _logger.LogWarning(
+                "fixp.outbound.drain.shutdown.timeout connectionId={ConnectionId} timeoutMs={TimeoutMs}",
+                _connectionId, (int)timeout.TotalMilliseconds);
+        }
+        catch
+        {
+            // The drain loop ended with an exception; CompleteAsync
+            // does not propagate — connection close is best-effort.
+        }
+    }
+
+    private async Task DrainAsync(CancellationToken ct)
+    {
+        try
+        {
+            // foreach over ReadAllAsync naturally completes when the
+            // writer is Complete()'d AND the channel is empty —
+            // exactly the §5.3.2 shutdown drain semantics.
+            await foreach (var frame in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                bool keepGoing;
+                try
+                {
+                    keepGoing = await _writeAsync(frame.Bytes, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Shutdown timeout cancelled us mid-write. The
+                    // frame is NOT disposed here; the buffer still
+                    // owns it (single-disposer rule) and retransmit
+                    // will pick it up on the next reconnect.
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex,
+                        "fixp.outbound.write.error connectionId={ConnectionId}",
+                        _connectionId);
+                    // Socket failed; end the drain loop. Same lifetime
+                    // story as above — the buffer is the sole disposer.
+                    return;
+                }
+                if (!keepGoing) return;
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "fixp.outbound.drain.unexpected connectionId={ConnectionId}",
+                _connectionId);
+        }
+    }
+}

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -52,6 +52,7 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
 
     private readonly SemaphoreSlim _writeMutex = new(1, 1);
     private Stream? _stream;
+    private FixpOutboundChannelWriter? _outboundWriter;
     private volatile bool _registeredInDirectory;
     private volatile bool _closed;
     private volatile bool _userSlotHeld;
@@ -168,14 +169,42 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         }
         finally
         {
-            _closed = true;
             StopHeartbeatLoop();
             ArrayPool<byte>.Shared.Return(readBuf);
+            // RFC §5.3.2 shutdown drain: flush queued outbound frames
+            // BEFORE flipping _closed / tearing down the stream so the
+            // drain callback's WriteAsync calls go to a still-live
+            // socket. Bounded by OutboundDrainShutdownTimeout so a
+            // dead peer cannot stall connection cleanup; remaining
+            // queued frames stay owned by the per-credential
+            // BotOutboundBuffer (drain loop NEVER disposes — RFC §5.5)
+            // and ride retransmit on the next reconnect.
+            //
+            // Drain BEFORE deregister: a frame the multiplexer
+            // enqueued while we were still in the directory must
+            // still get a chance to flush.
+            var writerForDrain = _outboundWriter;
+            if (writerForDrain is not null)
+            {
+                try
+                {
+                    await writerForDrain.CompleteAsync(_options.Buffers.OutboundDrainShutdownTimeout)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex,
+                        "fixp.outbound.drain.shutdown.error connectionId={ConnectionId}",
+                        _connectionId);
+                }
+            }
+            _closed = true;
             // Deregister BEFORE the stream is closed so a racing ER from
             // the multiplexer hot path either sees us in the directory
-            // (and TryEnqueue takes the write mutex which we still own)
-            // or sees us absent (and falls through to buffering). Either
-            // outcome is safe; no NRE on a half-disposed stream.
+            // (and TryEnqueue lands in the now-completed writer, which
+            // returns false → buffer-only path) or sees us absent (and
+            // falls through to buffering). Either outcome is safe; no
+            // NRE on a half-disposed stream.
             if (_registeredInDirectory && _scope is not null && _connectionDirectory is not null)
             {
                 _connectionDirectory.Deregister(_scope.Principal.CredentialId, this);
@@ -626,6 +655,16 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         // pre-Ack ER as a protocol violation and drop the session.
         if (_connectionDirectory is not null)
         {
+            // RFC §5.3 / P8 / F3 — start the per-connection bounded
+            // outbound channel + dedicated drain loop BEFORE we publish
+            // ourselves to the directory, so the very first
+            // multiplexer push lands on a live writer (no race where
+            // TryGet returns us but the writer is not yet wired).
+            _outboundWriter = new FixpOutboundChannelWriter(
+                capacity: Math.Max(1, _options.Buffers.OutboundChannelCapacity),
+                writeAsync: WriteOutboundFromDrainLoopAsync,
+                connectionId: _connectionId,
+                logger: _logger);
             _connectionDirectory.Register(credentialId, this);
             _registeredInDirectory = true;
         }
@@ -654,7 +693,23 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         }
 
         var action = _sm.OnTerminate(in msg);
-        await SendActionAsync(stream, action, sid, ver, ct).ConfigureAwait(false);
+        // RFC §5.3 / P8: post-Establish writes must serialise against
+        // the per-connection drain loop's outbound writes. The pre-P8
+        // path was racy too (drain loop's Task.Run used the mutex but
+        // this call site never did); now that the writer reliably
+        // takes _writeMutex on every drained frame, holding it here
+        // closes the byte-interleave window for free.
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await SendActionAsync(stream, action, sid, ver, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            try { _writeMutex.Release(); }
+            catch (ObjectDisposedException) { }
+            catch (SemaphoreFullException) { }
+        }
         return false; // always close after Terminate
     }
 
@@ -1272,65 +1327,92 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         catch { return null; }
     }
 
-    // ─── IBotSessionOutboundSender (sub-issue F #172) ────────────────────
+    // ─── IBotSessionOutboundSender (sub-issue F #172, RFC §5.3 / P8 / F3) ─
 
     /// <summary>
-    /// Synchronously enqueues outbound bytes from the multiplexer. We
-    /// fire a fire-and-forget Task that takes the write mutex and writes
-    /// to the underlying stream — this is the right ordering primitive
-    /// because (a) the multiplexer's drain thread must not block on
-    /// socket I/O, and (b) the write mutex serialises against any
-    /// handshake/order-ack writes the connection's own request loop is
-    /// emitting concurrently.
+    /// Synchronously hands <paramref name="frame"/> to the
+    /// per-connection bounded outbound channel (RFC §5.3 / P8 / F3).
+    /// Non-blocking: returns <c>false</c> when the connection has
+    /// closed or the channel is full (slow-consumer backpressure,
+    /// §5.3.1).
     ///
-    /// <para><b>Pre-F3 transitional copy (RFC §5.5 / §5.3, issue #201).</b>
-    /// The caller's <paramref name="framedBytes"/> may alias pooled
-    /// memory owned by <c>BotOutboundBuffer</c>. The buffer can dispose
-    /// that memory on the bot's next acked-watermark eviction (or on
-    /// overflow / reset), and the eviction is not synchronised with the
-    /// fire-and-forget write task we schedule below. Until F3 lands —
-    /// where the per-session channel's reader holds the
-    /// <c>OutboundFrame</c> until the write completes — we materialise
-    /// a private heap copy so the async write never observes pooled
-    /// memory after the buffer has released it. The single-disposer
-    /// rule in §5.5 still holds: this method does not touch the
-    /// caller's owner.</para>
+    /// <para>Replaces the pre-F3 <c>Task.Run</c>-per-send fire-and-
+    /// forget path: a single dedicated drain loop now owns the socket
+    /// and writes serially under <see cref="_writeMutex"/> to interleave
+    /// safely with handshake/order-ack writes from the request loop.
+    /// One <see cref="Task"/> per connection, not per outbound message.</para>
+    ///
+    /// <para>The drain loop NEVER disposes <paramref name="frame"/> —
+    /// the per-credential <see cref="BotOutboundBuffer"/> is the sole
+    /// disposer (RFC §5.5 single-disposer rule). Lifetime safety
+    /// across the awaited socket write is guaranteed by the protocol:
+    /// a bot can only ack a watermark for sequences it has actually
+    /// received, so an unsent frame's seq cannot be evicted under us;
+    /// overflow / version-bump force-closes the connection (and ends
+    /// the drain loop) BEFORE the buffer's <c>Reset</c> clears pooled
+    /// owners. See <see cref="FixpOutboundChannelWriter"/> doc.</para>
     /// </summary>
-    bool IBotSessionOutboundSender.TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+    bool IBotSessionOutboundSender.TryEnqueue(OutboundFrame frame)
     {
         if (_closed) return false;
+        var writer = _outboundWriter;
+        if (writer is null) return false;
+        return writer.TryEnqueue(frame);
+    }
+
+    /// <summary>
+    /// Drain-loop callback: serialises writes against handshake /
+    /// order-ack writes via <see cref="_writeMutex"/>. Returns
+    /// <c>false</c> when the writer should stop draining (stream
+    /// gone or socket failure). Errors during the actual socket
+    /// write close the stream and return <c>false</c>; the read loop
+    /// observes the broken stream and runs the deregister/release
+    /// path.
+    ///
+    /// <para>Intentionally does NOT short-circuit on
+    /// <see cref="_closed"/>: shutdown drain (RFC §5.3.2) runs while
+    /// <c>_closed</c> may already be set, and we must still flush
+    /// queued frames before the stream is torn down. The stream's
+    /// own state (closed / faulted) is the authoritative signal —
+    /// surfaced as an exception from
+    /// <see cref="System.IO.Stream.WriteAsync(System.ReadOnlyMemory{byte}, System.Threading.CancellationToken)"/>.</para>
+    /// </summary>
+    private async ValueTask<bool> WriteOutboundFromDrainLoopAsync(
+        ReadOnlyMemory<byte> bytes, CancellationToken ct)
+    {
         var stream = _stream;
         if (stream is null) return false;
 
-        // Copy out of the borrowed (potentially pooled) memory before
-        // the Task.Run captures it — see the §5.5 transitional note
-        // above. Cheap relative to the SBE encode + socket write.
-        var owned = framedBytes.ToArray();
-
-        // Fire-and-forget. Errors land in the catch and quietly close
-        // the connection; the read loop will observe the broken stream
-        // on its next iteration and run the deregister/release path.
-        _ = Task.Run(async () =>
+        await _writeMutex.WaitAsync(ct).ConfigureAwait(false);
+        try
         {
-            await _writeMutex.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                if (_closed) return;
-                await stream.WriteAsync(owned, CancellationToken.None).ConfigureAwait(false);
-                TouchOutbound();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "fixp.outbound.write.error connectionId={ConnectionId}", _connectionId);
-                _closed = true;
-                try { stream.Close(); } catch { /* ignore */ }
-            }
-            finally
-            {
-                _writeMutex.Release();
-            }
-        });
-        return true;
+            await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            TouchOutbound();
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown / write-mutex wait was cancelled. Surface to
+            // the drain loop, which treats cancellation as "shutdown
+            // drain timeout fired" and returns without disposing.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "fixp.outbound.write.error connectionId={ConnectionId}", _connectionId);
+            _closed = true;
+            try { stream.Close(); } catch { /* ignore */ }
+            return false;
+        }
+        finally
+        {
+            // Defensive: WaitAsync may have thrown ObjectDisposedException
+            // if Dispose() raced with us. Guard the release.
+            try { _writeMutex.Release(); }
+            catch (ObjectDisposedException) { }
+            catch (SemaphoreFullException) { }
+        }
     }
 
     public void Dispose()
@@ -1338,6 +1420,23 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         // Used by the multiplexer's overflow path to force-close.
         _closed = true;
         StopHeartbeatLoop();
+
+        // RFC §5.3.2 shutdown drain: best-effort flush of in-flight
+        // outbound frames, bounded by OutboundDrainShutdownTimeout.
+        // Frames not drained remain owned by the per-credential
+        // BotOutboundBuffer and ride retransmit on next reconnect —
+        // never silently dropped. Drain loop never disposes (RFC §5.5).
+        var writer = _outboundWriter;
+        if (writer is not null)
+        {
+            try
+            {
+                writer.CompleteAsync(_options.Buffers.OutboundDrainShutdownTimeout)
+                    .GetAwaiter().GetResult();
+            }
+            catch { /* best-effort on shutdown */ }
+        }
+
         try { _stream?.Close(); } catch { /* ignore */ }
         try { _tcpClient.Close(); } catch { /* ignore */ }
         _writeMutex.Dispose();

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/IBotSessionConnectionDirectory.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/IBotSessionConnectionDirectory.cs
@@ -1,3 +1,5 @@
+using B3.Trading.Application.UserBots;
+
 namespace B3.Trading.EntryPointListener.Hosting;
 
 /// <summary>
@@ -36,23 +38,42 @@ public interface IBotSessionConnectionDirectory
 
 /// <summary>
 /// Outbound side of a live FIXP connection. The multiplexer pushes
-/// pre-framed SOFH bytes here; the implementation is responsible for
-/// serialising writes against any concurrent handshake/order-ack
-/// writes coming from the connection's own request loop.
+/// pre-framed SOFH SBE messages here; the implementation owns a
+/// per-connection bounded channel + dedicated drain loop (RFC §5.3 /
+/// P8 / F3) that serialises writes against any concurrent
+/// handshake/order-ack writes coming from the connection's own request
+/// loop. <c>TryEnqueue</c> never blocks on socket I/O.
+///
+/// <para><b>Single-disposer of pooled outbound memory (RFC §5.5).</b>
+/// The <see cref="OutboundFrame"/> handed in here is owned by the
+/// per-credential <see cref="BotOutboundBuffer"/> (the caller appended
+/// it before reaching us). Implementations only borrow
+/// <see cref="OutboundFrame.Bytes"/> for the socket write — neither
+/// the channel writer nor the drain loop ever calls
+/// <c>DisposeOwner</c>. The buffer releases the pooled owner on
+/// <c>EvictUpTo</c> / overflow / <c>Reset</c>.</para>
+///
+/// <para><b>Lifetime safety.</b> A bot can only ack a watermark for
+/// sequences it has actually received, so an unsent (still-queued)
+/// frame's seq cannot be evicted under us. Overflow / version-bump
+/// force-closes the connection BEFORE the buffer's Reset clears
+/// pooled owners, which terminates the drain loop. Both invariants
+/// together let the drain loop hold the OutboundFrame across an
+/// awaited <c>WriteAsync</c> without a defensive heap copy.</para>
 /// </summary>
 public interface IBotSessionOutboundSender
 {
     /// <summary>
-    /// Synchronously enqueues <paramref name="framedBytes"/> for send.
-    /// Implementations buffer + flush on a background task; this method
-    /// must NOT block on socket I/O so the caller (the ER multiplexer
-    /// drain loop) is not coupled to network latency.
+    /// Synchronously enqueues <paramref name="frame"/> for send onto
+    /// the per-connection bounded outbound channel. Non-blocking.
+    /// Returns <c>false</c> when (a) the sender is closed (the
+    /// connection went away between the directory lookup and this
+    /// call) or (b) the channel is full — the documented backpressure
+    /// surface for a slow consumer (RFC §5.3.1). In both refused
+    /// branches the frame remains owned by the per-credential
+    /// <see cref="BotOutboundBuffer"/> and is replayed via
+    /// retransmit (sub-issue G) on the next reconnect; this method
+    /// itself never disposes pooled memory.
     /// </summary>
-    /// <returns>
-    /// <c>true</c> when the bytes were accepted; <c>false</c> when the
-    /// sender is closed (the connection went away between the directory
-    /// lookup and the enqueue — the multiplexer falls back to buffering
-    /// for retransmit).
-    /// </returns>
-    bool TryEnqueue(ReadOnlyMemory<byte> framedBytes);
+    bool TryEnqueue(OutboundFrame frame);
 }

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
@@ -163,7 +163,7 @@ public class BotErMultiplexerTests
     {
         public int SentCount;
         public bool Disposed;
-        public bool TryEnqueue(ReadOnlyMemory<byte> framedBytes)
+        public bool TryEnqueue(OutboundFrame frame)
         {
             if (Disposed) return false;
             Interlocked.Increment(ref SentCount);

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
@@ -1,0 +1,260 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.UserBots;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// RFC §5.3 / P8 / F3 — behavioural tests for the per-FIXP-connection
+/// outbound writer. Verifies (a) per-connection FIFO ordering, (b)
+/// bounded-channel backpressure surfaces as <c>TryEnqueue == false</c>
+/// (never silent drop), (c) shutdown drain flushes already-queued
+/// frames, (d) the drain loop NEVER disposes an
+/// <see cref="OutboundFrame"/> (single-disposer rule, RFC §5.5).
+/// </summary>
+public sealed class FixpOutboundChannelWriterTests
+{
+    private static OutboundFrame Frame(byte tag)
+    {
+        // Use a unique payload byte so the receive log can assert
+        // ordering without depending on payload format.
+        return OutboundFrame.Unowned(new byte[] { tag });
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task TryEnqueue_PreservesPerConnectionFifoOrder()
+    {
+        // Many enqueues from a single producer must reach the socket
+        // in arrival order — single-reader drain over a FIFO channel.
+        var received = new List<byte>();
+        var allDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        const int total = 1000;
+
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 4096,
+            writeAsync: (bytes, ct) =>
+            {
+                received.Add(bytes.Span[0]);
+                if (received.Count == total) allDelivered.TrySetResult();
+                return ValueTask.FromResult(true);
+            },
+            connectionId: "conn-fifo",
+            logger: NullLogger.Instance);
+
+        for (var i = 0; i < total; i++)
+        {
+            Assert.True(writer.TryEnqueue(Frame((byte)(i % 251))));
+        }
+
+        await allDelivered.Task.WaitAsync(TimeSpan.FromSeconds(3));
+        await writer.CompleteAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(total, received.Count);
+        for (var i = 0; i < total; i++)
+            Assert.Equal((byte)(i % 251), received[i]);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task TryEnqueue_WhenChannelFull_ReturnsFalseAndDoesNotDispose()
+    {
+        // Block the drain so the bounded channel can fill, then assert
+        // that the next TryEnqueue returns false (RFC §5.3.1: surface
+        // backpressure, never silent drop / DropOldest).
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var written = 0;
+
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 2,
+            writeAsync: async (bytes, ct) =>
+            {
+                if (Interlocked.Increment(ref written) == 1)
+                {
+                    firstEntered.TrySetResult();
+                    await release.Task.WaitAsync(ct).ConfigureAwait(false);
+                }
+                return true;
+            },
+            connectionId: "conn-bp",
+            logger: NullLogger.Instance);
+
+        // Use a pooled-tracking frame to assert no double-dispose.
+        var pool = new TrackingPool();
+        var rejected = pool.RentFrame(payload: 0xFF);
+
+        // Saturate: 1 in-flight + 2 queued = 3. The 4th must be rejected.
+        Assert.True(writer.TryEnqueue(Frame(0x01)));
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(writer.TryEnqueue(Frame(0x02)));
+        Assert.True(writer.TryEnqueue(Frame(0x03)));
+
+        // Spin a few iterations to allow the previous TryWrite to land.
+        // Bounded TryWrite returns false deterministically once full.
+        var didReject = false;
+        for (var i = 0; i < 200; i++)
+        {
+            if (!writer.TryEnqueue(rejected)) { didReject = true; break; }
+            await Task.Delay(5);
+        }
+
+        Assert.True(didReject, "expected channel-full TryEnqueue to return false");
+        // Drain loop NEVER disposes (RFC §5.5). The rejected frame is
+        // still owned by the caller (in production: the per-credential
+        // BotOutboundBuffer); the writer must NOT have touched its
+        // pooled owner.
+        Assert.Equal(0, pool.DisposedCount);
+
+        release.TrySetResult();
+        await writer.CompleteAsync(TimeSpan.FromSeconds(2));
+        // Still no dispose by the writer, even after drain completes.
+        Assert.Equal(0, pool.DisposedCount);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task CompleteAsync_FlushesAlreadyQueuedFrames()
+    {
+        // RFC §5.3.2 shutdown drain: frames enqueued before Complete
+        // must be observed by the drain loop before it returns.
+        var received = new ConcurrentQueue<byte>();
+
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 16,
+            writeAsync: (bytes, ct) =>
+            {
+                received.Enqueue(bytes.Span[0]);
+                return ValueTask.FromResult(true);
+            },
+            connectionId: "conn-drain",
+            logger: NullLogger.Instance);
+
+        for (byte i = 1; i <= 8; i++) Assert.True(writer.TryEnqueue(Frame(i)));
+
+        await writer.CompleteAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(8, received.Count);
+        for (byte i = 1; i <= 8; i++)
+        {
+            Assert.True(received.TryDequeue(out var b));
+            Assert.Equal(i, b);
+        }
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task CompleteAsync_AfterTimeout_LeavesQueuedFramesUntouched()
+    {
+        // A pathologically slow socket-write must not block shutdown
+        // forever; the writer cancels its drain and remaining queued
+        // frames stay owned by the caller (single-disposer rule).
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pool = new TrackingPool();
+
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 16,
+            writeAsync: async (bytes, ct) =>
+            {
+                await release.Task.WaitAsync(ct).ConfigureAwait(false);
+                return true;
+            },
+            connectionId: "conn-timeout",
+            logger: NullLogger.Instance);
+
+        // First TryEnqueue lands in the in-flight WriteAsync; the rest
+        // sit in the channel.
+        Assert.True(writer.TryEnqueue(pool.RentFrame(0x10)));
+        Assert.True(writer.TryEnqueue(pool.RentFrame(0x20)));
+        Assert.True(writer.TryEnqueue(pool.RentFrame(0x30)));
+
+        await writer.CompleteAsync(TimeSpan.FromMilliseconds(150));
+        // None of the frames may have been disposed by the writer.
+        Assert.Equal(0, pool.DisposedCount);
+        // Unblock so the test does not leak the producer task.
+        release.TrySetResult();
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task TryEnqueue_AfterCompleteAsync_ReturnsFalse()
+    {
+        // No double-dispose under shutdown race: TryEnqueue arriving
+        // after CompleteAsync must return false WITHOUT touching the
+        // frame's pooled owner.
+        var pool = new TrackingPool();
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 4,
+            writeAsync: (_, _) => ValueTask.FromResult(true),
+            connectionId: "conn-race",
+            logger: NullLogger.Instance);
+
+        await writer.CompleteAsync(TimeSpan.FromSeconds(1));
+
+        var late = pool.RentFrame(0xAA);
+        Assert.False(writer.TryEnqueue(late));
+        // Writer NEVER disposes — even on the rejected branch
+        // (RFC §5.5: only BotOutboundBuffer may dispose).
+        Assert.Equal(0, pool.DisposedCount);
+    }
+
+    [Fact(Timeout = 5_000)]
+    public async Task DrainLoop_WhenWriteCallbackThrows_EndsLoopWithoutDisposing()
+    {
+        // Socket failure mid-drain ends the loop. The frame in flight
+        // and any successors stay owned by the caller.
+        var pool = new TrackingPool();
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 4,
+            writeAsync: (_, _) => throw new IOException("simulated socket failure"),
+            connectionId: "conn-fail",
+            logger: NullLogger.Instance);
+
+        Assert.True(writer.TryEnqueue(pool.RentFrame(0xCA)));
+        // Wait for the drain loop to terminate after observing the throw.
+        await writer.DrainCompletion.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, pool.DisposedCount);
+
+        // Subsequent enqueues just sit in the channel until Complete;
+        // still no dispose.
+        Assert.True(writer.TryEnqueue(pool.RentFrame(0xCB)) || true);
+        await writer.CompleteAsync(TimeSpan.FromMilliseconds(100));
+        Assert.Equal(0, pool.DisposedCount);
+    }
+
+    /// <summary>
+    /// Test-only owner that flips a flag on Dispose so the test can
+    /// assert the writer never invoked <c>DisposeOwner</c>.
+    /// </summary>
+    private sealed class TrackingPool
+    {
+        private int _disposed;
+        public int DisposedCount => Volatile.Read(ref _disposed);
+
+        public OutboundFrame RentFrame(byte payload)
+        {
+            var owner = new TrackingOwner(this, payload);
+            return OutboundFrame.Pooled(owner, length: 1);
+        }
+
+        internal void NotifyDisposed() => Interlocked.Increment(ref _disposed);
+
+        private sealed class TrackingOwner : System.Buffers.IMemoryOwner<byte>
+        {
+            private readonly TrackingPool _pool;
+            private readonly byte[] _buf;
+            private bool _disposed;
+
+            public TrackingOwner(TrackingPool pool, byte payload)
+            {
+                _pool = pool;
+                _buf = new byte[1] { payload };
+            }
+
+            public Memory<byte> Memory => _buf;
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _pool.NotifyDisposed();
+            }
+        }
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpRetransmitIntegrationTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Integration/FixpRetransmitIntegrationTests.cs
@@ -199,8 +199,13 @@ public class FixpRetransmitIntegrationTests
         BotOutboundCoordinator coord, IBotSessionOutboundSender sender, Guid credId, byte[] framed)
     {
         var seq = coord.AllocateNext(credId);
-        coord.GetOrCreateBuffer(credId).Append(seq, framed);
-        sender.TryEnqueue(framed);
+        // Wrap once and pass the same instance to both Append and
+        // TryEnqueue: Append takes ownership (single-disposer rule)
+        // and TryEnqueue only borrows frame.Bytes via the per-conn
+        // drain loop (RFC §5.3 / §5.5).
+        var frame = OutboundFrame.Unowned(framed);
+        coord.GetOrCreateBuffer(credId).Append(seq, frame);
+        sender.TryEnqueue(frame);
     }
 
     // ─── Tests ───────────────────────────────────────────────────────────


### PR DESCRIPTION
RFC §5.3 / F3. Replaces the fire-and-forget `Task.Run`-per-outbound-send in `FixpSessionConnection.IBotSessionOutboundSender.TryEnqueue` with a per-connection bounded `Channel<OutboundFrame>` + a single dedicated drain loop. **One Task per connection, not per outbound message** — the entire point of P8.

Closes #202.

## What changed

- **New `FixpOutboundChannelWriter`** (`backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs`) — encapsulates the bounded channel + drain loop with explicit shutdown drain semantics (RFC §5.3.2). Drain loop is single-reader, FIFO; producers go through `TryWrite` (never blocks).
- **Interface update**: `IBotSessionOutboundSender.TryEnqueue(OutboundFrame frame)` — was `(ReadOnlyMemory<byte>)`. The drain loop borrows `frame.Bytes` directly across the awaited socket write; no transitional heap copy. Lifetime safety per RFC §5.5: a bot can only ack a watermark for sequences it has actually received, and overflow force-closes the connection BEFORE the buffer's `Reset` clears pooled owners.
- **Bounded channel** — capacity `OutboundChannelCapacity` (default 4096), `FullMode = Wait` declared, but producers use non-blocking `TryWrite`. When full, `TryEnqueue` returns `false` and the per-credential `BotOutboundBuffer` (sole owner) replays via retransmit on next reconnect (RFC §5.3.1: surface, never silent drop). `DropOldest` intentionally rejected.
- **Drain loop NEVER disposes** `OutboundFrame.Owner` (RFC §5.5 single-disposer rule). The buffer remains the sole disposer on `EvictUpTo` / overflow / `Reset`.
- **Shutdown drain** (RFC §5.3.2) — `CompleteAsync` flushes queued frames bounded by `OutboundDrainShutdownTimeout` (default 1s). Drain runs **before** `_closed` flips / stream tears down so the in-flight callback writes to a live socket. After timeout, drain is cancelled with a bounded grace period (250 ms) — a callback that ignores cancellation cannot indefinitely block connection cleanup. Frames not drained at the deadline stay owned by the buffer and ride retransmit on next reconnect — never silently dropped from the bot's perspective.
- **Mutex serialisation** — drain callback takes the existing `_writeMutex` so it interleaves safely with handshake / order-ack / heartbeat writes from the request loop. **Post-Establish `HandleTerminate` now also takes the mutex**, closing a pre-existing byte-interleave window between the Terminate response and the drain loop (called out by code review).
- **Multiplexer update** — `RouteOne` now calls `sender.TryEnqueue(frame)` instead of `TryEnqueue(frame.Bytes)`. Same `OutboundFrame` instance the line above accepted into `BotOutboundBuffer`.

## Drain policy chosen

1. `Writer.Complete()` — no further enqueues accepted.
2. `await foreach` continues until the channel is empty AND complete.
3. Bounded by `OutboundDrainShutdownTimeout` (default 1s, configurable).
4. On timeout: cancel the drain CTS; bounded 250 ms grace; if still hung, log `fixp.outbound.drain.shutdown.abandoned` and proceed with cleanup.
5. **Frames not drained are NEVER lost from the bot's perspective** — they remain owned by `BotOutboundBuffer` and ride sub-issue G's retransmit path on the next reconnect.

This honours RFC §4.5 (single-active-session): the drain gate runs before directory deregister, so the credential is not handed to a successor session mid-flush.

## Tests

+6 (total **1013**, up from 1007). New file `FixpOutboundChannelWriterTests.cs`:

| Test | Verifies |
|---|---|
| `TryEnqueue_PreservesPerConnectionFifoOrder` | (a) ordering — 1000 enqueues delivered in arrival order |
| `TryEnqueue_WhenChannelFull_ReturnsFalseAndDoesNotDispose` | (b) bounded backpressure + drain never disposes (tracking pool) |
| `CompleteAsync_FlushesAlreadyQueuedFrames` | (c) shutdown drain happy-path |
| `CompleteAsync_AfterTimeout_LeavesQueuedFramesUntouched` | (c) shutdown drain timeout — stuck peer doesn't block |
| `TryEnqueue_AfterCompleteAsync_ReturnsFalse` | (d) no double-dispose under shutdown race |
| `DrainLoop_WhenWriteCallbackThrows_EndsLoopWithoutDisposing` | drain loop terminates cleanly on socket failure; in-flight + queued frames stay owned by the buffer |

All three High issues from the gpt-5.5 code review pass were fixed before merge:
1. Post-Establish `HandleTerminate` now takes `_writeMutex` (closes byte-interleave window with drain).
2. `RunAsync` finally block reordered: drain BEFORE `_closed = true`, and the drain callback no longer short-circuits on `_closed` — RFC §5.3.2 actually flushes queued frames now.
3. `WaitForDrainAsync` post-cancel wait is bounded (250 ms grace) — drain timeout is a hard ceiling, not a soft hint.

## Bench numbers

`BotErRouter_RouteOne_Bench` uses an in-process `CountingSender` that stubs `IBotSessionOutboundSender`, so it does **not** exercise the per-connection writer this PR changes. The hot-path GC win this PR delivers — **1 Task allocation per connection** vs. **1 Task allocation per outbound message** — surfaces under live socket load (load-test PR #216), not in this micro-bench. Numbers from the existing bench are unchanged ±noise as expected.

The relevant runtime change: at 100k ER/s × N bots, the per-message Task.Run + closure allocation is gone — replaced by a single drain-loop Task per connection that lives for the connection's lifetime.

## Invariants

- **§4.4 ClOrdId monotonicity** — untouched (allocator is upstream of the writer).
- **§4.5 single-active session** — preserved by draining before deregister.
- **§5.3.1 backpressure** — bounded channel, `TryWrite` never blocks, surfaces overflow via existing retransmit path; no silent drop.
- **§5.5 single-disposer** — drain loop and `TryEnqueue` never call `DisposeOwner` on any path; verified by tracking-pool tests.
- **P10 zero-copy inbound (`DispatchFrameAsync`)** — outbound-only change; inbound path unaffected.
