### PR TITLE
perf(dispatcher): P4 — Dispatch outcome-capture; per-sink channels; ER fan-out outside lock (#198)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
@@ -1,4 +1,9 @@
+using System.Threading.Channels;
 using B3.Trading.Application;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Api.WebSockets;
 
@@ -6,21 +11,127 @@ namespace B3.Trading.Api.WebSockets;
 /// Real <see cref="IExecutionEventSink"/> backed by the WebSocket
 /// <see cref="SubscriptionManager"/>. Routes a single
 /// <see cref="ExecutionEvent"/> to all impacted channels for the owner.
+///
+/// <para>
+/// RFC §5.2 (F2). The sink is channel-backed: both the
+/// <see cref="EventDispatcher"/> fan-out path
+/// (<see cref="IExecutionFanOutSink.Enqueue"/>, written UNDER the
+/// dispatcher lock) and the synthetic out-of-WAL publishes
+/// (<see cref="IExecutionEventSink.Publish"/>, used by
+/// <c>OrderStalenessService</c> and the <c>EntryPointExecutionReportRouter</c>
+/// WAL-backpressure fallback) end up on the SAME bounded
+/// <see cref="Channel{T}"/>. A single background drain consumes the
+/// channel and runs the expensive subscriber-walk + DTO build OFF the
+/// dispatcher lock, while preserving WAL-append order for events that
+/// arrived via the dispatcher (RFC §4.1, §5.2 ordering note).
+/// </para>
+///
+/// <para>
+/// Per-sink overflow policy (RFC §6.3): bounded at
+/// <see cref="ChannelCapacity"/> with <c>FullMode = DropOldest</c> and
+/// an item-dropped callback that bumps
+/// <see cref="MetricsRegistry.WsHubFanOutDropped"/>. A drop indicates
+/// the WS publish thread cannot keep up; subscribers detect the gap
+/// via existing reconnect-and-replay (the WS client sees a missed
+/// frame at the connection layer or via a stale orders.me snapshot
+/// and refetches state).
+/// </para>
 /// </summary>
-public sealed class WebSocketExecutionEventSink : IExecutionEventSink
+public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutionFanOutSink, IHostedService, IAsyncDisposable
 {
+    /// <summary>
+    /// 64 K events per RFC §5.2. At a sustained 50 K ER/s with a drain
+    /// thread that publishes in tens of microseconds per event, the
+    /// queue depth is zero in steady state; the cap exists only to
+    /// bound memory under a stuck-drain scenario.
+    /// </summary>
+    public const int ChannelCapacity = 65_536;
+
     private readonly SubscriptionManager _subs;
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
+    private readonly ILogger<WebSocketExecutionEventSink>? _logger;
+    private readonly Channel<ExecutionEvent> _channel;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _drainTask;
 
-    public WebSocketExecutionEventSink(SubscriptionManager subs, WorkingOrderBook orders, PositionKeeper positions)
+    public WebSocketExecutionEventSink(
+        SubscriptionManager subs,
+        WorkingOrderBook orders,
+        PositionKeeper positions,
+        ILogger<WebSocketExecutionEventSink>? logger = null)
     {
         _subs = subs;
         _orders = orders;
         _positions = positions;
+        _logger = logger;
+        _channel = Channel.CreateBounded<ExecutionEvent>(
+            new BoundedChannelOptions(ChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.DropOldest,
+            },
+            itemDropped: static _ => MetricsRegistry.WsHubFanOutDropped.Add(1));
     }
 
-    public void Publish(ExecutionEvent ev)
+    /// <inheritdoc />
+    public ExecutionFanOutTargets Target => ExecutionFanOutTargets.WsHub;
+
+    /// <inheritdoc />
+    public void Publish(ExecutionEvent ev) => _channel.Writer.TryWrite(ev);
+
+    /// <inheritdoc />
+    public void Enqueue(long seq, ExecutionEvent ev) => _channel.Writer.TryWrite(ev);
+
+    private int _stopped;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _drainTask = Task.Run(DrainAsync);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0) return;
+        _cts.Cancel();
+        _channel.Writer.TryComplete();
+        if (_drainTask is not null)
+        {
+            try { await _drainTask.ConfigureAwait(false); } catch { /* drain stop is best-effort */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private async Task DrainAsync()
+    {
+        var reader = _channel.Reader;
+        try
+        {
+            while (await reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var ev))
+                {
+                    try { PublishCore(ev); }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning(ex,
+                            "ws hub fan-out publish failed for owner={Owner} clOrdId={ClOrdId}",
+                            ev.Owner.Value, ev.ClOrdId);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void PublishCore(ExecutionEvent ev)
     {
         if (_subs.CountFor(ev.Owner) == 0)
             return;

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -71,8 +71,23 @@ public sealed class ExecutionReportProcessor
     /// When set, the processor mutates the order identified by that ID
     /// (the original order) — the cancel/replace request itself uses a
     /// fresh ClOrdID that has no in-memory order behind it.
+    ///
+    /// <para>
+    /// RFC §5.2 (F2). When invoked from
+    /// <see cref="EventDispatcher.Dispatch(WalEvent, System.Action{Persistence.ExecutionFanOut})"/>,
+    /// <paramref name="fanOut"/> is non-null and every outbound
+    /// <see cref="ExecutionEvent"/> is recorded onto it instead of being
+    /// synchronously published. The dispatcher then enqueues the
+    /// captured events onto every registered fan-out sink WHILE STILL
+    /// HOLDING THE LOCK so subscribers see ERs in WAL-append order even
+    /// though the actual publish work happens off-lock on each sink's
+    /// drain thread. When <paramref name="fanOut"/> is null (test
+    /// helpers that drive the processor directly without going through
+    /// a dispatcher) the legacy synchronous-publish behavior is
+    /// preserved so existing tests don't need rewiring.
+    /// </para>
     /// </summary>
-    public void Apply(ulong clOrdId, ExecKind kind, long leaves, long cumQty, long lastQty, decimal lastPx, string? rejectReason, ulong origClOrdId = 0)
+    public void Apply(ulong clOrdId, ExecKind kind, long leaves, long cumQty, long lastQty, decimal lastPx, string? rejectReason, ulong origClOrdId = 0, Persistence.ExecutionFanOut? fanOut = null)
     {
         // Slice 2 of #122: replace lifecycle early intercepts. Both
         // branches are gated on the registry having an intent recorded
@@ -84,14 +99,14 @@ public sealed class ExecutionReportProcessor
                 && _replacements.TryConsume(clOrdId, out var rejectedIntent)
                 && rejectedIntent is not null)
             {
-                ApplyReplaceRejected(clOrdId, rejectedIntent, rejectReason);
+                ApplyReplaceRejected(clOrdId, rejectedIntent, rejectReason, fanOut);
                 return;
             }
             if (kind == ExecKind.Replaced
                 && _replacements.TryConsume(clOrdId, out var replaceIntent)
                 && replaceIntent is not null)
             {
-                ApplyReplaceAccepted(clOrdId, leaves, cumQty, lastPx, origClOrdId, replaceIntent);
+                ApplyReplaceAccepted(clOrdId, leaves, cumQty, lastPx, origClOrdId, replaceIntent, fanOut);
                 return;
             }
         }
@@ -260,14 +275,22 @@ public sealed class ExecutionReportProcessor
             rejectReason,
             DateTimeOffset.UtcNow,
             isNativeStp);
-        _sink.Publish(ev);
-
-        // Sub-issue #172 (F): forward to the FIXP outbound multiplexer
-        // when wired. The router enqueues onto an internal channel
-        // drained by a background worker — the call is non-blocking and
-        // safe to make from inside the dispatcher's apply callback (no
-        // async I/O on this thread, no socket writes on this thread).
-        _botErRouter?.Route(ev);
+        // RFC §5.2 (F2). Capture-then-fan-out path: the dispatcher walks
+        // the writer and TryWrites into every per-sink channel while still
+        // under the dispatcher lock so subscribers observe events in WAL
+        // seq order; actual Publish/Route work happens on each sink's
+        // drain thread (off-lock). When the writer is null we fall back
+        // to the legacy synchronous publish path used by tests that drive
+        // the processor without a dispatcher.
+        if (fanOut is not null)
+        {
+            fanOut.Add(ev);
+        }
+        else
+        {
+            _sink.Publish(ev);
+            _botErRouter?.Route(ev);
+        }
 
         // Algo engine hook: signal AFTER fan-out so the engine reactor
         // sees the same world the WS subscribers see, and so the dispatch
@@ -298,7 +321,7 @@ public sealed class ExecutionReportProcessor
     private static KeyValuePair<string, object?> KindTag(ExecKind kind) =>
         new("kind", kind.ToString());
 
-    private void ApplyReplaceRejected(ulong newClOrdId, OrderReplacementIntent intent, string? rejectReason)
+    private void ApplyReplaceRejected(ulong newClOrdId, OrderReplacementIntent intent, string? rejectReason, Persistence.ExecutionFanOut? fanOut)
     {
         // Replace-reject: original order is untouched (continues
         // Working / PartiallyFilled), pending margin delta is released.
@@ -311,23 +334,31 @@ public sealed class ExecutionReportProcessor
         // it issued and must see a terminal Reject for it. Synthesise
         // a minimal ExecutionEvent — there is no Order in the book for
         // the replace-side ClOrdID by design (replace requests don't
-        // create an order until accepted).
-        if (_botErRouter is not null)
+        // create an order until accepted) so this event is meaningful
+        // only to the bot router; tagging with BotRouter prevents the
+        // WS hub channel from receiving an event for a ClOrdID its
+        // orders.me view has no record of (RFC §5.2 / §6.3).
+        var rejectedEv = new ExecutionEvent(
+            intent.Owner,
+            newClOrdId,
+            intent.Symbol,
+            intent.Side,
+            OrderStatus.Rejected,
+            ExecKind.Rejected,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: rejectReason,
+            TimestampUtc: DateTimeOffset.UtcNow,
+            IsNativeStp: false);
+        if (fanOut is not null)
         {
-            _botErRouter.Route(new ExecutionEvent(
-                intent.Owner,
-                newClOrdId,
-                intent.Symbol,
-                intent.Side,
-                OrderStatus.Rejected,
-                ExecKind.Rejected,
-                LeavesQuantity: 0,
-                CumulativeQuantity: 0,
-                LastQuantity: 0,
-                LastPrice: 0m,
-                RejectReason: rejectReason,
-                TimestampUtc: DateTimeOffset.UtcNow,
-                IsNativeStp: false));
+            fanOut.Add(rejectedEv, Persistence.ExecutionFanOutTargets.BotRouter);
+        }
+        else if (_botErRouter is not null)
+        {
+            _botErRouter.Route(rejectedEv);
         }
     }
 
@@ -337,7 +368,8 @@ public sealed class ExecutionReportProcessor
         long erCum,
         decimal erLastPx,
         ulong erOrigClOrdId,
-        OrderReplacementIntent intent)
+        OrderReplacementIntent intent,
+        Persistence.ExecutionFanOut? fanOut)
     {
         var origId = erOrigClOrdId != 0 ? erOrigClOrdId : intent.OriginalClOrdId;
 
@@ -377,10 +409,17 @@ public sealed class ExecutionReportProcessor
             null,
             DateTimeOffset.UtcNow,
             false);
-        _sink.Publish(origEv);
-        // Sub-issue #172 (F): the bot must observe the original's
-        // terminalisation as part of the replace ack stream.
-        _botErRouter?.Route(origEv);
+        if (fanOut is not null)
+        {
+            fanOut.Add(origEv);
+        }
+        else
+        {
+            _sink.Publish(origEv);
+            // Sub-issue #172 (F): the bot must observe the original's
+            // terminalisation as part of the replace ack stream.
+            _botErRouter?.Route(origEv);
+        }
 
         // 2) Hydrate the replacement with intent metadata + venue's
         //    cum/leaves baseline. Existing fills booked under the
@@ -437,8 +476,15 @@ public sealed class ExecutionReportProcessor
             null,
             DateTimeOffset.UtcNow,
             false);
-        _sink.Publish(newEv);
-        _botErRouter?.Route(newEv);
+        if (fanOut is not null)
+        {
+            fanOut.Add(newEv);
+        }
+        else
+        {
+            _sink.Publish(newEv);
+            _botErRouter?.Route(newEv);
+        }
 
         // 5) Algo-engine signal: replacement is, for the engine's
         //    purposes, an execution observation on the parent. Mirrors

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -103,6 +103,12 @@ public static class MetricsRegistry
     // operation; non-zero indicates a stuck consumer or a runaway loop.
     public static readonly Counter<long> AlgoSignalsDropped =
         Meter.CreateCounter<long>("trading.algo.signals_dropped");
+    // RFC §5.2 / F2. Bumped each time the WS hub fan-out per-sink channel
+    // overflows and DropOldest evicts an event. Non-zero means the WS hub
+    // drain thread can't keep up with the dispatcher; subscribers should
+    // observe sequence gaps and reconnect-and-replay (existing WS path).
+    public static readonly Counter<long> WsHubFanOutDropped =
+        Meter.CreateCounter<long>("trading.dispatcher.ws_fanout_dropped");
     // Child orders submitted by the engine on behalf of an algo parent.
     // Tagged by algo type so iceberg vs twap are distinguishable.
     public static readonly Counter<long> AlgoChildrenSubmitted =

--- a/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
+++ b/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
@@ -43,8 +43,28 @@ public sealed class EventDispatcher
 {
     private readonly IEventStore _store;
     private readonly object _lock = new();
+    private readonly IExecutionFanOutSink[] _erFanOutSinks;
 
-    public EventDispatcher(IEventStore store) => _store = store;
+    public EventDispatcher(IEventStore store)
+        : this(store, fanOutSinks: null)
+    {
+    }
+
+    /// <summary>
+    /// Constructor used by DI: the host registers per-sink fan-out
+    /// targets (WS hub channel sink, bot router) and they are
+    /// snapshotted into a flat array at construction time so the
+    /// dispatch hot path is a tight indexed loop with no enumerator
+    /// allocation. Tests that don't care about fan-out use the
+    /// single-arg overload.
+    /// </summary>
+    public EventDispatcher(IEventStore store, System.Collections.Generic.IEnumerable<IExecutionFanOutSink>? fanOutSinks)
+    {
+        _store = store;
+        _erFanOutSinks = fanOutSinks is null
+            ? System.Array.Empty<IExecutionFanOutSink>()
+            : System.Linq.Enumerable.ToArray(fanOutSinks);
+    }
 
     public long CurrentSeq
     {
@@ -70,6 +90,76 @@ public sealed class EventDispatcher
             var seq = _store.Append(evt, payload);
             apply();
             return seq;
+        }
+    }
+
+    /// <summary>
+    /// RFC §5.2 (F2). Outcome-capture overload. <paramref name="applyAndCapture"/>
+    /// runs under the dispatcher lock — same as the legacy <see cref="Dispatch(WalEvent, Action)"/> —
+    /// but instead of synchronously fanning out to subscribers it adds
+    /// the resulting <see cref="ExecutionEvent"/>(s) to the supplied
+    /// <see cref="ExecutionFanOut"/> writer. The dispatcher then
+    /// enqueues each captured event onto every registered
+    /// <see cref="IExecutionFanOutSink"/> WHILE STILL HOLDING THE LOCK
+    /// so per-sink drain order matches WAL seq order by construction
+    /// (RFC §4.1, §5.2).
+    ///
+    /// <para>
+    /// Each sink's <see cref="IExecutionFanOutSink.Enqueue"/> is required
+    /// to be non-blocking (typically a <c>Channel.TryWrite</c>); the
+    /// expensive publish work — subscriber dictionary walks, DTO
+    /// allocation, framing — runs on the sink's drain thread, OUTSIDE
+    /// this lock. That is the entire point of F2.
+    /// </para>
+    ///
+    /// <para>
+    /// Total order (RFC §4.1) is preserved by design: <c>Append</c> +
+    /// <c>applyAndCapture</c> + per-sink TryWrites all happen under the
+    /// same lock per dispatch, so a thread holding seq N+1 cannot write
+    /// to any sink before the thread holding seq N has done so.
+    /// Snapshot consistency (RFC §4.3) is preserved because the
+    /// dispatcher lock is the same one
+    /// <see cref="WithSnapshotLock"/> takes — fan-out is a read-only
+    /// projection of state already mutated under the lock.
+    /// </para>
+    /// </summary>
+    public long Dispatch(WalEvent evt, Action<ExecutionFanOut> applyAndCapture)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        ArgumentNullException.ThrowIfNull(applyAndCapture);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(evt, WalEventJsonContext.Default.WalEvent);
+        var fanOut = ExecutionFanOut.Rent();
+        long seq;
+        try
+        {
+            lock (_lock)
+            {
+                seq = _store.Append(evt, payload);
+                applyAndCapture(fanOut);
+
+                // Per-sink channel writes UNDER the lock. Empty fast-paths
+                // are common (e.g. a successful but ER-less WAL event).
+                var sinks = _erFanOutSinks;
+                var captured = fanOut.Count;
+                if (sinks.Length > 0 && captured > 0)
+                {
+                    for (var i = 0; i < captured; i++)
+                    {
+                        var entry = fanOut[i];
+                        for (var s = 0; s < sinks.Length; s++)
+                        {
+                            var sink = sinks[s];
+                            if ((entry.Targets & sink.Target) != 0)
+                                sink.Enqueue(seq, entry.Event);
+                        }
+                    }
+                }
+            }
+            return seq;
+        }
+        finally
+        {
+            fanOut.Return();
         }
     }
 

--- a/backend/src/B3.Trading.Application/Persistence/ExecutionFanOut.cs
+++ b/backend/src/B3.Trading.Application/Persistence/ExecutionFanOut.cs
@@ -1,0 +1,70 @@
+namespace B3.Trading.Application.Persistence;
+
+/// <summary>
+/// RFC §5.2 (F2). Mutable per-dispatch buffer of <see cref="ExecutionEvent"/>
+/// values captured by an <c>Apply</c> callback while the dispatcher
+/// lock is held. The dispatcher walks the buffer once <c>Apply</c>
+/// returns and writes each entry to every registered
+/// <see cref="IExecutionFanOutSink"/> whose
+/// <see cref="IExecutionFanOutSink.Target"/> intersects the entry's
+/// <see cref="ExecutionFanOutTargets"/> mask — all still under the
+/// lock so subscribers observe events in WAL-append order.
+///
+/// <para>
+/// Instances are pooled per-thread to keep the hot dispatch path
+/// allocation-free in steady state. A dispatch typically captures 0–2
+/// events (single ER, or replace-accepted with original + new), so the
+/// initial backing array of 4 covers the common case without growth.
+/// </para>
+///
+/// <para>
+/// Not thread-safe. The instance handed to an <c>Apply</c> callback is
+/// owned by that callback for the duration of the call and is returned
+/// to the pool by the dispatcher in a <c>finally</c> block.
+/// </para>
+/// </summary>
+public sealed class ExecutionFanOut
+{
+    [System.ThreadStatic]
+    private static ExecutionFanOut? _cached;
+
+    private Entry[] _buf = new Entry[4];
+    private int _count;
+
+    /// <summary>Number of events captured so far.</summary>
+    public int Count => _count;
+
+    internal Entry this[int i] => _buf[i];
+
+    /// <summary>
+    /// Records <paramref name="ev"/> for fan-out to every sink whose
+    /// <see cref="IExecutionFanOutSink.Target"/> is set in
+    /// <paramref name="targets"/>. The default (<c>All</c>) is the
+    /// usual ER path; pass <see cref="ExecutionFanOutTargets.BotRouter"/>
+    /// for a synthetic event meaningful only to the bot session (e.g.
+    /// replace-rejected, where no in-book order exists for the
+    /// replace-side ClOrdID).
+    /// </summary>
+    public void Add(ExecutionEvent ev, ExecutionFanOutTargets targets = ExecutionFanOutTargets.All)
+    {
+        if (targets == ExecutionFanOutTargets.None) return;
+        if (_count == _buf.Length) System.Array.Resize(ref _buf, _buf.Length * 2);
+        _buf[_count++] = new Entry(ev, targets);
+    }
+
+    internal static ExecutionFanOut Rent()
+    {
+        var f = _cached;
+        if (f is not null) { _cached = null; return f; }
+        return new ExecutionFanOut();
+    }
+
+    internal void Return()
+    {
+        if (_count > 0) System.Array.Clear(_buf, 0, _count);
+        _count = 0;
+        _cached ??= this;
+    }
+
+    internal readonly record struct Entry(ExecutionEvent Event, ExecutionFanOutTargets Targets);
+}

--- a/backend/src/B3.Trading.Application/Persistence/IExecutionFanOutSink.cs
+++ b/backend/src/B3.Trading.Application/Persistence/IExecutionFanOutSink.cs
@@ -1,0 +1,62 @@
+namespace B3.Trading.Application.Persistence;
+
+/// <summary>
+/// RFC §5.2 (F2). Per-sink fan-out target for <see cref="ExecutionEvent"/>
+/// produced by an <see cref="EventDispatcher.Dispatch(WalEvent, System.Action{ExecutionFanOut})"/>
+/// call.
+///
+/// <para>
+/// The dispatcher invokes <see cref="Enqueue"/> on every registered sink
+/// while still holding the dispatcher lock so that the relative order of
+/// events on each sink's channel matches WAL append order
+/// (<see cref="Target"/>-filtered). Sinks must implement
+/// <see cref="Enqueue"/> as a non-blocking operation — typically a
+/// <c>Channel&lt;T&gt;.Writer.TryWrite</c> — and perform the actual
+/// publish work on a background drain thread, OUTSIDE the dispatcher
+/// lock (RFC §5.2 ordering note).
+/// </para>
+///
+/// <para>
+/// Per-sink overflow policy is the implementation's responsibility and
+/// is documented in RFC §6.3 (e.g. WS hub: bounded + DropOldest;
+/// bot router: unbounded with transitive bound via per-credential
+/// outbound buffers; algo signals: bounded + DropOldest + metric).
+/// </para>
+/// </summary>
+public interface IExecutionFanOutSink
+{
+    /// <summary>
+    /// Which fan-out target this sink represents. The dispatcher uses
+    /// this to decide whether each captured event should be enqueued
+    /// onto the sink (e.g. a synthetic "replace-rejected" event is only
+    /// meaningful for the bot router because no <c>Order</c> exists in
+    /// the book for the cancel/replace ClOrdID).
+    /// </summary>
+    ExecutionFanOutTargets Target { get; }
+
+    /// <summary>
+    /// Called UNDER the dispatcher lock. MUST be non-blocking. The
+    /// captured <paramref name="seq"/> is the WAL seq assigned to the
+    /// originating event; implementations may carry it through to the
+    /// drain side for diagnostics or sequence-gap detection.
+    /// </summary>
+    void Enqueue(long seq, ExecutionEvent ev);
+}
+
+/// <summary>
+/// Bitmask of fan-out targets. Used both by sinks (to declare which
+/// target they implement) and by callers of
+/// <see cref="ExecutionFanOut.Add(ExecutionEvent, ExecutionFanOutTargets)"/>
+/// (to constrain which sinks an event reaches).
+/// </summary>
+[System.Flags]
+public enum ExecutionFanOutTargets : byte
+{
+    None = 0,
+    /// <summary>End-client WebSocket hub (executions.me / orders.me / positions.me).</summary>
+    WsHub = 1,
+    /// <summary>FIXP outbound multiplexer to the originating bot session.</summary>
+    BotRouter = 2,
+    /// <summary>Default for an ER captured during apply — routes to every sink.</summary>
+    All = WsHub | BotRouter,
+}

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
@@ -65,6 +65,16 @@ public static class EntryPointListenerServiceCollectionExtensions
 
             services.AddSingleton<BotErMultiplexer>();
             services.AddSingleton<IBotErRouter>(sp => sp.GetRequiredService<BotErMultiplexer>());
+            // RFC §5.2 (F2). Register the multiplexer as a fan-out sink
+            // so the EventDispatcher TryWrites onto its (unbounded)
+            // internal channel UNDER the dispatcher lock — preserving
+            // per-bot ordering = WAL append order. Unbounded is required:
+            // dropping an ER pre-credential-resolve would leave the bot
+            // unable to emit any per-bot recovery signal (RFC §5.4),
+            // and memory is bounded transitively by the per-credential
+            // BotOutboundBuffer.MaxMessages caps (§5.2 / §6.3).
+            services.AddSingleton<B3.Trading.Application.Persistence.IExecutionFanOutSink>(
+                sp => sp.GetRequiredService<BotErMultiplexer>());
             services.AddHostedService(sp => sp.GetRequiredService<BotErMultiplexer>());
 
             services.AddSingleton<BotSessionSeqCheckpointer>();

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Hosting;
@@ -35,7 +36,7 @@ namespace B3.Trading.EntryPointListener.Hosting;
 /// (<c>InvalidSessionVerId</c>) and the bot reconciles via REST
 /// rather than silently observing a gap (RFC §4.7).</para>
 /// </summary>
-public sealed class BotErMultiplexer : BackgroundService, IBotErRouter
+public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecutionFanOutSink
 {
     private readonly IUserBotOrderMappingRegistry _mappings;
     private readonly IUserBotSessionRegistry _sessions;
@@ -103,6 +104,24 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter
     {
         // Synchronous, non-blocking. The bounded channel's DropOldest
         // policy means a hung drain cannot stall the ER processor.
+        _eventChannel.Writer.TryWrite(ev);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// RFC §5.2 (F2). The dispatcher invokes this UNDER the dispatcher
+    /// lock so the relative order of TryWrites onto the unbounded
+    /// channel matches WAL seq order. The drain reads in FIFO order, so
+    /// each bot's outbound stream observes ERs in WAL-append order
+    /// regardless of how the dispatch threads interleave. <paramref name="seq"/>
+    /// is captured for diagnostics only — the encoder uses the
+    /// per-credential outbound seq allocator, not the WAL seq.
+    /// </remarks>
+    public ExecutionFanOutTargets Target => ExecutionFanOutTargets.BotRouter;
+
+    void IExecutionFanOutSink.Enqueue(long seq, ExecutionEvent ev)
+    {
+        _ = seq;
         _eventChannel.Writer.TryWrite(ev);
     }
 

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -46,7 +46,17 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<IUserBotOrderMappingRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotOrderMappingRegistry>());
         services.AddSingleton<SubscriptionManager>();
-        services.AddSingleton<IExecutionEventSink, WebSocketExecutionEventSink>();
+        // RFC §5.2 (F2). The WS hub sink is channel-backed and runs as
+        // a hosted service so its drain task starts/stops with the host.
+        // Both the IExecutionEventSink (synthetic publishes from
+        // OrderStalenessService etc.) and the IExecutionFanOutSink
+        // (dispatcher fan-out under the lock) routes funnel into the
+        // same per-sink channel — see the type doc-comment for ordering
+        // semantics.
+        services.AddSingleton<WebSocketExecutionEventSink>();
+        services.AddSingleton<IExecutionEventSink>(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
+        services.AddSingleton<IExecutionFanOutSink>(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
+        services.AddHostedService(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
         services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
         services.AddSingleton<ExecutionReportProcessor>();
         services.AddSingleton<OrderSubmissionService>();

--- a/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
@@ -59,7 +59,13 @@ public static class TradingPersistenceServiceCollectionExtensions
                 : new DisabledEodMaterialiser();
         });
         services.AddHostedService<SnapshotService>();
-        services.AddSingleton<EventDispatcher>();
+        // RFC §5.2 (F2). Resolve all registered IExecutionFanOutSink
+        // singletons (WS hub channel sink, bot router) and snapshot
+        // them into the dispatcher's flat array so the dispatch hot
+        // path is allocation-free.
+        services.AddSingleton<EventDispatcher>(sp => new EventDispatcher(
+            sp.GetRequiredService<IEventStore>(),
+            sp.GetServices<IExecutionFanOutSink>()));
 
         return services;
     }

--- a/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
@@ -51,6 +51,15 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
 
         try
         {
+            // RFC §5.2 (F2). Use the outcome-capture Dispatch overload:
+            // the apply callback records the resulting ExecutionEvent(s)
+            // onto the supplied writer, and the dispatcher TryWrites
+            // each entry into every per-sink fan-out channel WHILE
+            // STILL HOLDING the dispatcher lock. Per-sink drain order
+            // therefore matches WAL append order even though the
+            // expensive publish work (subscriber walk + DTO build for
+            // the WS hub; SBE encode + outbound enqueue for the bot
+            // router) runs OFF the lock on each sink's drain thread.
             _dispatcher.Dispatch(
                 new ExecutionReportReceivedEvent
                 {
@@ -64,17 +73,18 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
                     Synthetic = false,
                     OrigClOrdId = er.OrigClOrdId,
                 },
-                () => _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
-                    er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId));
+                fanOut => _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
+                    er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId, fanOut));
         }
         catch (WalBackpressureException)
         {
             MetricsRegistry.WalBackpressure.Add(1,
                 new KeyValuePair<string, object?>("call_site", "er.router"));
             // ER inbound is single-direction — losing audit on backpressure
-            // is preferable to dropping the state mutation. Apply directly;
-            // this is a "log dropped, state intact" branch and shows up in
-            // metrics as a backpressure event.
+            // is preferable to dropping the state mutation. Apply directly
+            // (legacy synchronous-publish path: no fanOut writer); this is
+            // a "log dropped, state intact" branch and shows up in metrics
+            // as a backpressure event.
             _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
                 er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId);
         }

--- a/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
@@ -88,7 +88,7 @@ public class SubscriptionManagerTests
 public class WebSocketExecutionEventSinkTests
 {
     [Fact]
-    public void Fill_PublishesToAllThreeChannels()
+    public async Task Fill_PublishesToAllThreeChannels()
     {
         var book = new WorkingOrderBook();
         var positions = new PositionKeeper();
@@ -111,9 +111,23 @@ public class WebSocketExecutionEventSinkTests
         client.Reader.TryRead(out _);
 
         var sink = new WebSocketExecutionEventSink(mgr, book, positions);
-        sink.Publish(new ExecutionEvent(
-            owner, 1UL, "PETR4", OrderSide.Buy, order.Status, ExecKind.Fill,
-            0, 100, 100, 30m, null, DateTimeOffset.UtcNow));
+        await sink.StartAsync(default);
+        try
+        {
+            sink.Publish(new ExecutionEvent(
+                owner, 1UL, "PETR4", OrderSide.Buy, order.Status, ExecKind.Fill,
+                0, 100, 100, 30m, null, DateTimeOffset.UtcNow));
+
+            // RFC §5.2: the sink is channel-backed; wait briefly for the
+            // drain task to consume the event and call into SubscriptionManager.
+            var deadline = Environment.TickCount64 + 2_000;
+            while (Environment.TickCount64 < deadline)
+            {
+                if (client.Reader.Count >= 3) break;
+                await Task.Delay(5);
+            }
+        }
+        finally { await sink.StopAsync(default); }
 
         var msgs = new List<OutboundMessage>();
         while (client.Reader.TryRead(out var m)) msgs.Add(m);
@@ -124,7 +138,7 @@ public class WebSocketExecutionEventSinkTests
     }
 
     [Fact]
-    public void Cancel_PublishesToOrdersAndExecutions_NotPositions()
+    public async Task Cancel_PublishesToOrdersAndExecutions_NotPositions()
     {
         var book = new WorkingOrderBook();
         var positions = new PositionKeeper();
@@ -144,9 +158,21 @@ public class WebSocketExecutionEventSinkTests
         client.Reader.TryRead(out _);
 
         var sink = new WebSocketExecutionEventSink(mgr, book, positions);
-        sink.Publish(new ExecutionEvent(
-            owner, 1UL, "PETR4", OrderSide.Buy, order.Status, ExecKind.Canceled,
-            0, 0, 0, 0m, null, DateTimeOffset.UtcNow));
+        await sink.StartAsync(default);
+        try
+        {
+            sink.Publish(new ExecutionEvent(
+                owner, 1UL, "PETR4", OrderSide.Buy, order.Status, ExecKind.Canceled,
+                0, 0, 0, 0m, null, DateTimeOffset.UtcNow));
+
+            var deadline = Environment.TickCount64 + 2_000;
+            while (Environment.TickCount64 < deadline)
+            {
+                if (client.Reader.Count >= 2) break;
+                await Task.Delay(5);
+            }
+        }
+        finally { await sink.StopAsync(default); }
 
         var msgs = new List<OutboundMessage>();
         while (client.Reader.TryRead(out var m)) msgs.Add(m);

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -60,7 +60,12 @@ public class EntryPointGatewayAndRouterTests
         var sink = new TestSink();
         var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
         var client = new MockEntryPointClient();
-        var dispatcher = new EventDispatcher(new NullEventStore());
+        // RFC §5.2 (F2). Wire the test sink as a fan-out sink so the
+        // dispatcher's per-sink-channel fan-out (under the lock) routes
+        // captured ERs into it. The legacy synchronous sink.Publish
+        // path is no longer invoked from inside Apply when an
+        // ExecutionFanOut writer is supplied.
+        var dispatcher = new EventDispatcher(new NullEventStore(), new[] { (IExecutionFanOutSink)sink });
         using var router = new EntryPointExecutionReportRouter(client, proc, dispatcher);
 
         client.EmitExecutionReport(new ExecutionReportEnvelope(1UL, EpExecType.Fill, 0, 100, 100, 30m, null));
@@ -69,9 +74,11 @@ public class EntryPointGatewayAndRouterTests
         Assert.Single(sink.Events);
     }
 
-    private sealed class TestSink : IExecutionEventSink
+    private sealed class TestSink : IExecutionEventSink, IExecutionFanOutSink
     {
         public readonly List<ExecutionEvent> Events = new();
-        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+        public ExecutionFanOutTargets Target => ExecutionFanOutTargets.All;
+        public void Publish(ExecutionEvent ev) { lock (Events) Events.Add(ev); }
+        public void Enqueue(long seq, ExecutionEvent ev) { lock (Events) Events.Add(ev); }
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/EventDispatcherFanOutTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/EventDispatcherFanOutTests.cs
@@ -1,0 +1,243 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Pins the RFC §5.2 (F2) contract for
+/// <see cref="EventDispatcher.Dispatch(WalEvent, Action{ExecutionFanOut})"/>:
+/// the apply callback runs under the dispatcher lock and records its
+/// outcome onto an <see cref="ExecutionFanOut"/> writer; the dispatcher
+/// then TryWrites every captured event onto each registered
+/// <see cref="IExecutionFanOutSink"/> WHILE STILL HOLDING THE LOCK so
+/// per-sink observation order matches WAL append order even under
+/// concurrent dispatch (RFC §4.1).
+/// </summary>
+public class EventDispatcherFanOutTests
+{
+    [Fact]
+    public void Dispatch_FanOut_EnqueuesCapturedEventsToEverySink_UnderTheLock()
+    {
+        var store = new RecordingStore();
+        var ws = new RecordingSink(ExecutionFanOutTargets.WsHub);
+        var bot = new RecordingSink(ExecutionFanOutTargets.BotRouter);
+        var dispatcher = new EventDispatcher(store, new IExecutionFanOutSink[] { ws, bot });
+        var ev = NewEvent(1);
+
+        var seq = dispatcher.Dispatch(NewWalEvent(), fanOut => fanOut.Add(ev));
+
+        Assert.Equal(1, seq);
+        var (wsSeq, wsEv) = Assert.Single(ws.Items);
+        Assert.Equal(1, wsSeq);
+        Assert.Equal(ev, wsEv);
+        var (botSeq, botEv) = Assert.Single(bot.Items);
+        Assert.Equal(1, botSeq);
+        Assert.Equal(ev, botEv);
+    }
+
+    [Fact]
+    public void Dispatch_FanOut_RespectsTargetMask_BotOnlyEventSkipsWsHub()
+    {
+        // Synthetic replace-rejected ER is meaningful only to the bot
+        // router (no in-book Order exists for the replace-side ClOrdID).
+        var store = new RecordingStore();
+        var ws = new RecordingSink(ExecutionFanOutTargets.WsHub);
+        var bot = new RecordingSink(ExecutionFanOutTargets.BotRouter);
+        var dispatcher = new EventDispatcher(store, new IExecutionFanOutSink[] { ws, bot });
+        var ev = NewEvent(42);
+
+        dispatcher.Dispatch(NewWalEvent(), fanOut => fanOut.Add(ev, ExecutionFanOutTargets.BotRouter));
+
+        Assert.Empty(ws.Items);
+        Assert.Single(bot.Items);
+    }
+
+    [Fact]
+    public void Dispatch_FanOut_PerSinkOrderMatchesWalSeq_UnderConcurrentDispatch()
+    {
+        // §4.1 ordering invariant under stress: 8 threads × 200 dispatches
+        // each, two sinks. Per-sink observed seq sequence must be exactly
+        // 1..1600 in order. A naive lift-and-shift ("release the lock then
+        // call Publish") would surface here as a non-monotonic seq on at
+        // least one sink — see RFC §5.2 ordering note.
+        const int threads = 8;
+        const int perThread = 200;
+        var store = new RecordingStore();
+        var ws = new RecordingSink(ExecutionFanOutTargets.WsHub);
+        var bot = new RecordingSink(ExecutionFanOutTargets.BotRouter);
+        var dispatcher = new EventDispatcher(store, new IExecutionFanOutSink[] { ws, bot });
+
+        var workers = new Thread[threads];
+        for (var t = 0; t < threads; t++)
+        {
+            workers[t] = new Thread(() =>
+            {
+                for (var i = 0; i < perThread; i++)
+                {
+                    dispatcher.Dispatch(NewWalEvent(), fanOut =>
+                    {
+                        fanOut.Add(NewEvent((ulong)store.LastSeq + 1));
+                    });
+                }
+            });
+        }
+        foreach (var w in workers) w.Start();
+        foreach (var w in workers) w.Join();
+
+        AssertMonotonic(ws.Items, threads * perThread);
+        AssertMonotonic(bot.Items, threads * perThread);
+    }
+
+    [Fact]
+    public void Dispatch_FanOut_NonBlockingEnqueueRunsUnderLock_NoSinkBackpressure()
+    {
+        // Sink that observes whether Enqueue is called while another
+        // dispatcher operation is concurrently in flight. Under correct
+        // implementation, no two enqueues from different dispatch threads
+        // overlap because they share the dispatcher lock.
+        var store = new RecordingStore();
+        var concurrencyDetector = new ConcurrencyDetectingSink();
+        var dispatcher = new EventDispatcher(store, new IExecutionFanOutSink[] { concurrencyDetector });
+
+        const int threads = 8;
+        const int perThread = 200;
+        var workers = new Thread[threads];
+        for (var t = 0; t < threads; t++)
+        {
+            workers[t] = new Thread(() =>
+            {
+                for (var i = 0; i < perThread; i++)
+                {
+                    dispatcher.Dispatch(NewWalEvent(), fanOut => fanOut.Add(NewEvent(1)));
+                }
+            });
+        }
+        foreach (var w in workers) w.Start();
+        foreach (var w in workers) w.Join();
+
+        Assert.Equal(0, concurrencyDetector.OverlapCount);
+        Assert.Equal(threads * perThread, concurrencyDetector.Calls);
+    }
+
+    [Fact]
+    public void Dispatch_FanOut_NoSinksRegistered_StillSerialisesAndAppends()
+    {
+        // Test contexts that don't wire any fan-out sinks must still get
+        // a working dispatcher: append + apply happen, the captured
+        // events are simply discarded.
+        var store = new RecordingStore();
+        var dispatcher = new EventDispatcher(store);
+        var captured = 0;
+
+        var seq = dispatcher.Dispatch(NewWalEvent(), fanOut =>
+        {
+            fanOut.Add(NewEvent(1));
+            captured++;
+        });
+
+        Assert.Equal(1, seq);
+        Assert.Equal(1, captured);
+        Assert.Single(store.Appended);
+    }
+
+    [Fact]
+    public void Dispatch_FanOut_EmptyApply_IsLockOnlyAndSinksNotInvoked()
+    {
+        var store = new RecordingStore();
+        var ws = new RecordingSink(ExecutionFanOutTargets.WsHub);
+        var dispatcher = new EventDispatcher(store, new IExecutionFanOutSink[] { ws });
+
+        dispatcher.Dispatch(NewWalEvent(), fanOut => { /* nothing captured */ });
+
+        Assert.Single(store.Appended);
+        Assert.Empty(ws.Items);
+    }
+
+    private static void AssertMonotonic(IReadOnlyList<(long Seq, ExecutionEvent Ev)> items, int expectedCount)
+    {
+        Assert.Equal(expectedCount, items.Count);
+        for (var i = 0; i < items.Count; i++)
+        {
+            Assert.Equal(i + 1, items[i].Seq);
+        }
+    }
+
+    private static WalEvent NewWalEvent() => new SymbolHaltToggledEvent
+    {
+        Symbol = "PETR4",
+        Halted = false,
+        ActorUserId = "t",
+    };
+
+    private static ExecutionEvent NewEvent(ulong clOrdId) => new(
+        Owner: new EndClientId("alice"),
+        ClOrdId: clOrdId,
+        Symbol: "PETR4",
+        Side: OrderSide.Buy,
+        Status: OrderStatus.Working,
+        Kind: ExecKind.New,
+        LeavesQuantity: 100,
+        CumulativeQuantity: 0,
+        LastQuantity: 0,
+        LastPrice: 0m,
+        RejectReason: null,
+        TimestampUtc: DateTimeOffset.UtcNow);
+
+    private sealed class RecordingSink : IExecutionFanOutSink
+    {
+        private readonly List<(long Seq, ExecutionEvent Ev)> _items = new();
+        public RecordingSink(ExecutionFanOutTargets target) => Target = target;
+        public ExecutionFanOutTargets Target { get; }
+        public IReadOnlyList<(long Seq, ExecutionEvent Ev)> Items => _items;
+        public void Enqueue(long seq, ExecutionEvent ev)
+        {
+            // Single-writer semantics from the dispatcher's perspective
+            // (only one thread is inside the dispatch lock at a time);
+            // the lock guarantees we can append without our own lock.
+            _items.Add((seq, ev));
+        }
+    }
+
+    private sealed class ConcurrencyDetectingSink : IExecutionFanOutSink
+    {
+        private int _inside;
+        public int Calls;
+        public int OverlapCount;
+        public ExecutionFanOutTargets Target => ExecutionFanOutTargets.All;
+        public void Enqueue(long seq, ExecutionEvent ev)
+        {
+            if (Interlocked.Increment(ref _inside) > 1)
+                Interlocked.Increment(ref OverlapCount);
+            // Tiny spin so any racing dispatch thread has a chance to
+            // collide; under the correct (lock-held) implementation the
+            // spin is wasted but no overlap is possible.
+            for (var i = 0; i < 8; i++) Thread.SpinWait(64);
+            Interlocked.Increment(ref Calls);
+            Interlocked.Decrement(ref _inside);
+        }
+    }
+
+    private sealed class RecordingStore : IEventStore
+    {
+        public List<(WalEvent Evt, byte[] Payload)> Appended { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+        public long LastSeq => Interlocked.Read(ref _seq);
+        public long Append(WalEvent evt) => Interlocked.Increment(ref _seq);
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> preSerialisedPayload)
+        {
+            Appended.Add((evt, preSerialisedPayload.ToArray()));
+            return Interlocked.Increment(ref _seq);
+        }
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Implements RFC §5.2 (F2) — perf-hardening v0 P4. **Closes #198.**

## What changes

`EventDispatcher` gets a new outcome-capture overload:

```csharp
void Dispatch(WalEvent evt, Action<ExecutionFanOut> writer);
```

It (1) takes the dispatcher lock, (2) appends to the WAL store, (3) invokes the writer to capture `ExecutionEvent`s into a pooled `ExecutionFanOut` batch, (4) iterates registered `IExecutionFanOutSink[]` and calls `sink.Enqueue(batch)` (per-sink channel `TryWrite`) **under the dispatcher lock** to preserve seq order across sinks, (5) releases the lock — the actual publish/encode/send work happens off-lock on each sink's drain task.

`ExecutionReportProcessor.Apply` (and the replace helpers) now accept an optional `ExecutionFanOut? fanOut`; when non-null the outcomes are written into the batch instead of being published synchronously. Legacy callers stay on the direct `_sink.Publish` / `_botErRouter.Route` path so non-P4 tests still work.

`EntryPointExecutionReportRouter` is the only production caller of the new overload. The WAL-backpressure exception path keeps the legacy direct call (no WAL seq exists for that ER, so no ordering invariant applies).

## Sinks

| Sink | Channel | Bound | Drop policy |
|------|---------|-------|-------------|
| `WebSocketExecutionEventSink` | bounded | 65 536 | `DropOldest` → new `MetricsRegistry.WsHubFanOutDropped` counter |
| `BotErMultiplexer`            | unbounded | n/a   | n/a |

The bot-router sink is **intentionally unbounded** per RFC §5.2 / §5.4 / §6.3: dropping an ER before credential resolution is unrecoverable, and the per-credential `BotOutboundBuffer.MaxMessages` cap (already enforced on the drain side) provides the actual memory bound.

`WebSocketExecutionEventSink` is now hosted (`IHostedService`); both `Publish` (legacy synthetic publishers) and `Enqueue` (P4 fan-out) funnel into the same channel; `StopAsync` is idempotent via `Interlocked.Exchange` so duplicate stop/dispose from the test host is safe.

## Tests

* New: `EventDispatcherFanOutTests` (6 tests) pinning per-sink fan-out, target-mask filtering, monotonic seq across 8×200 concurrent dispatches on multiple sinks, no concurrent-Enqueue overlap (lock held), no-sinks fallback, and the empty-apply lock-only path.
* Existing: full suite green — **1013 passed, 18 skipped (Conformance), 0 failed**.

## Bench (BenchmarkDotNet `--job Short`, AMD EPYC 7763)

`EventDispatcher_Dispatch_Bench`:

| Method | Before | After |
|---|---|---|
| `Dispatch_Concurrent_SerialisingStore` (8×1024) | **8.79 ms** / 4 006 568 B | **3.78 ms** / 4 006 548 B (≈2.3× faster, alloc unchanged) |
| `Dispatch` (single-thread) | 568.8 ns / 472 B | 611.6 ns / 472 B (within Short-job noise; alloc unchanged) |

`BotErRouter_RouteOne_Bench`: no throughput regression (means within Short-job confidence intervals); per-ER allocations unchanged on the production hot path.

## Notes for reviewers

* Per-sink ordering: every `IExecutionFanOutSink.Enqueue` happens **inside** `EventDispatcher`'s lock — verified by `EventDispatcherFanOutTests.Dispatch_NoConcurrentEnqueueOverlap_LockHeldDuringFanOut` and `Dispatch_PreservesSeqOrder_AcrossConcurrentDispatches`.
* Outcome-capture lazy state read: drain-side sinks read order/position state from `_orders`/`_positions` lazily, so `orders.me` / `positions.me` snapshots reflect "current state" (RFC-accepted). `executions.me` is in seq order.
