### PR TITLE
perf(er): P9 — synchronous credential resolve; remove global multiplexer channel (#203)

### DIFF
--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
@@ -76,7 +76,6 @@ public class BotErRouter_RouteOne_Bench
         {
             // Big enough to swallow the largest batch without overflow.
             OutboundBufferMaxMessages = Math.Max(8192, BatchSize * 4),
-            RouterChannelCapacity = 65536,
         });
         var coord = new BotOutboundCoordinator(sessions, opts.Value);
         _coord = coord;

--- a/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/EntryPointListenerServiceCollectionExtensions.cs
@@ -65,14 +65,17 @@ public static class EntryPointListenerServiceCollectionExtensions
 
             services.AddSingleton<BotErMultiplexer>();
             services.AddSingleton<IBotErRouter>(sp => sp.GetRequiredService<BotErMultiplexer>());
-            // RFC §5.2 (F2). Register the multiplexer as a fan-out sink
-            // so the EventDispatcher TryWrites onto its (unbounded)
-            // internal channel UNDER the dispatcher lock — preserving
-            // per-bot ordering = WAL append order. Unbounded is required:
-            // dropping an ER pre-credential-resolve would leave the bot
-            // unable to emit any per-bot recovery signal (RFC §5.4),
-            // and memory is bounded transitively by the per-credential
-            // BotOutboundBuffer.MaxMessages caps (§5.2 / §6.3).
+            // RFC §5.2 (F2) + §5.4 (P9 / F4). Register the multiplexer as
+            // a fan-out sink. Post-P9 the EventDispatcher invokes
+            // Enqueue UNDER the dispatcher lock and the multiplexer
+            // resolves the credential synchronously, dispatching
+            // straight into the per-credential BotOutboundBuffer + the
+            // P8 per-connection writer channel. There is no global
+            // multiplexer queue; backpressure is concentrated in the
+            // per-credential buffer (overflow → version-bump) and the
+            // per-connection writer (full → leave in buffer for
+            // retransmit). Per-bot ordering = WAL append order by
+            // construction (single chain, no async hop).
             services.AddSingleton<B3.Trading.Application.Persistence.IExecutionFanOutSink>(
                 sp => sp.GetRequiredService<BotErMultiplexer>());
             services.AddHostedService(sp => sp.GetRequiredService<BotErMultiplexer>());

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 namespace B3.Trading.EntryPointListener.Hosting;
 
 /// <summary>
-/// Sub-issue #172 (F). Background drain that turns each
+/// Sub-issue #172 (F) / RFC §5.4 (P9, F4). Turns each
 /// <see cref="ExecutionEvent"/> dispatched by
 /// <see cref="ExecutionReportProcessor"/> into a per-bot SBE
 /// ExecutionReport, allocates the next outbound seq from the
@@ -18,23 +18,52 @@ namespace B3.Trading.EntryPointListener.Hosting;
 /// either pushes them onto the bot's live connection (when online)
 /// or buffers them for retransmit (when offline).
 ///
-/// <para>The drain is single-threaded by design — there is no
-/// per-credential ordering requirement beyond "FIFO within a
-/// credential" and a single drain trivially satisfies it without a
-/// per-credential lock. If the channel ever becomes a throughput
-/// bottleneck, the right move is to shard by credentialId across N
-/// drain tasks (still preserving per-credential order); v0 keeps it
-/// simple.</para>
+/// <para><b>P9 / F4 — synchronous credential resolve.</b> There is no
+/// global multiplexer channel and no router drain thread. <see cref="Route"/>
+/// and the <see cref="IExecutionFanOutSink.Enqueue"/> hook resolve the
+/// originating credential synchronously (a lock-free
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+/// hit on <see cref="IUserBotOrderMappingRegistry"/>) and dispatch
+/// directly into the per-credential <see cref="BotOutboundBuffer"/> +
+/// per-connection writer channel (P8). The pre-P9 unbounded
+/// <c>Channel&lt;ExecutionEvent&gt;</c> and its single-reader drain
+/// loop are gone: they were the lossy global hop that made memory
+/// growth single-bot-bound (one slow consumer queued every ER for
+/// every credential), and bounding that channel would have silently
+/// dropped ERs at a point where the credential was not yet known and
+/// no per-bot recovery signal could be emitted (RFC §5.4 / §6.3).</para>
 ///
-/// <para><b>Overflow handling:</b> when the per-credential
-/// <see cref="BotOutboundBuffer"/> hits its cap, its overflow callback
-/// signals back into the multiplexer, which then asynchronously
-/// invokes <see cref="IUserBotSessionRegistry.BumpVersionAsync"/> with
-/// <c>reason="overflow"</c> and force-closes the offending sender.
-/// The version-bump must happen BEFORE the close so the bot's
-/// reconnect attempt fails Establish with the new ver
+/// <para><b>Sole bounded layer.</b> Backpressure is concentrated in
+/// two places: the per-credential <see cref="BotOutboundBuffer"/>
+/// (cap → version-bump + force-close, RFC §4.7) and the
+/// per-connection writer channel (P8 / RFC §5.3.1, full → leave the
+/// frame in the buffer for retransmit on the next reconnect). No
+/// unbounded queue separates a slow credential from any other
+/// credential — slow-credential isolation is by construction.</para>
+///
+/// <para><b>Per-credential ordering (RFC §4.3).</b>
+/// <see cref="IExecutionFanOutSink.Enqueue"/> is invoked UNDER the
+/// dispatcher lock (see <see cref="EventDispatcher"/>), so the
+/// `seq → resolve → buffer.Append → sender.TryEnqueue` chain runs
+/// in WAL append order. The per-credential allocator and the
+/// per-credential buffer's internal lock then carry that order all
+/// the way to the per-connection FIFO writer channel (P8). The
+/// legacy <see cref="Route"/> entry point — used by tests that drive
+/// <see cref="ExecutionReportProcessor"/> without a dispatcher — has
+/// the same guarantee per single producer thread.</para>
+///
+/// <para><b>Overflow handling.</b> When the per-credential buffer
+/// hits its cap, its overflow callback signals back into the
+/// multiplexer, which posts the credentialId to a small
+/// (credentialId-only) overflow channel drained out-of-band. The
+/// drain calls <see cref="IUserBotSessionRegistry.BumpVersionAsync"/>
+/// with <c>reason="overflow"</c> and force-closes the offending
+/// sender. The version-bump must happen BEFORE the close so the
+/// bot's reconnect attempt fails Establish with the new ver
 /// (<c>InvalidSessionVerId</c>) and the bot reconciles via REST
-/// rather than silently observing a gap (RFC §4.7).</para>
+/// rather than silently observing a gap (RFC §4.7). Async work
+/// stays out-of-band because the synchronous resolve path runs
+/// under the dispatcher lock and MUST NOT block.</para>
 /// </summary>
 public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecutionFanOutSink
 {
@@ -43,7 +72,6 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
     private readonly IBotSessionConnectionDirectory _directory;
     private readonly BotOutboundCoordinator _outbound;
     private readonly ILogger<BotErMultiplexer> _logger;
-    private readonly Channel<ExecutionEvent> _eventChannel;
     private readonly Channel<Guid> _overflowChannel;
 
     public BotErMultiplexer(
@@ -59,22 +87,15 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
         _directory = directory;
         _outbound = outbound;
         _logger = logger;
-        _ = options; // RouterChannelCapacity is reserved for a future bounded variant; channel is currently unbounded — see comment below.
+        _ = options; // P9 (F4) removed the global router channel; RouterChannelCapacity is retained on the options type only for backwards-compatible config binding (see BotErMultiplexerOptions).
 
-        // Unbounded so the synchronous Route() from the ER hot path
-        // never blocks and never silently drops. Memory pressure is
-        // bounded by the per-credential outbound buffer caps — when a
-        // bot is offline its ERs accumulate in the Channel only briefly
-        // (single drain pass) before landing in the per-credential
-        // BotOutboundBuffer, which is the layer that observes overflow
-        // and triggers the version-bump path. A bounded channel here
-        // (DropOldest) would silently lose ERs without any sequence-gap
-        // signal to the bot — see code-review concern (1).
-        _eventChannel = Channel.CreateUnbounded<ExecutionEvent>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false,
-        });
+        // CredentialId-only overflow signal channel. Unbounded is safe
+        // here because the message is a 16-byte Guid and the post rate
+        // is bounded by the number of credentials (one signal per
+        // credential per overflow → BumpVersion cycle, not by the ER
+        // rate). The route hot path posts here from inside the
+        // BotOutboundBuffer overflow callback (under the buffer's
+        // internal lock), so the post itself MUST be non-blocking.
         _overflowChannel = Channel.CreateUnbounded<Guid>(new UnboundedChannelOptions
         {
             SingleReader = true,
@@ -100,64 +121,67 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
     }
 
     /// <inheritdoc />
-    public void Route(ExecutionEvent ev)
-    {
-        // Synchronous, non-blocking. The bounded channel's DropOldest
-        // policy means a hung drain cannot stall the ER processor.
-        _eventChannel.Writer.TryWrite(ev);
-    }
+    /// <remarks>
+    /// RFC §5.4 (P9 / F4). Synchronous credential resolve + direct
+    /// dispatch into the per-credential <see cref="BotOutboundBuffer"/>
+    /// and per-connection writer (P8). No async hop, no global queue.
+    /// Used by tests / non-dispatcher call sites in
+    /// <see cref="ExecutionReportProcessor"/>; the production fan-out
+    /// path goes through <see cref="IExecutionFanOutSink.Enqueue"/>
+    /// (called under the dispatcher lock).
+    /// </remarks>
+    public void Route(ExecutionEvent ev) => RouteOne(ev);
+
+    /// <inheritdoc />
+    public ExecutionFanOutTargets Target => ExecutionFanOutTargets.BotRouter;
 
     /// <inheritdoc />
     /// <remarks>
-    /// RFC §5.2 (F2). The dispatcher invokes this UNDER the dispatcher
-    /// lock so the relative order of TryWrites onto the unbounded
-    /// channel matches WAL seq order. The drain reads in FIFO order, so
-    /// each bot's outbound stream observes ERs in WAL-append order
-    /// regardless of how the dispatch threads interleave. <paramref name="seq"/>
+    /// RFC §5.2 (F2) + §5.4 (F4). The dispatcher invokes this UNDER
+    /// the dispatcher lock so the resolve / encode / append /
+    /// per-connection-enqueue chain runs in strict WAL seq order. All
+    /// work is non-blocking and synchronous: <see cref="IUserBotOrderMappingRegistry.TryGetOrderMapping"/>
+    /// is a lock-free dictionary hit, <see cref="BotOutboundBuffer.Append"/>
+    /// only takes a short per-credential lock, and the per-connection
+    /// <see cref="IBotSessionOutboundSender.TryEnqueue"/> is a
+    /// non-blocking <c>Channel.TryWrite</c> (P8). <paramref name="seq"/>
     /// is captured for diagnostics only — the encoder uses the
     /// per-credential outbound seq allocator, not the WAL seq.
     /// </remarks>
-    public ExecutionFanOutTargets Target => ExecutionFanOutTargets.BotRouter;
-
     void IExecutionFanOutSink.Enqueue(long seq, ExecutionEvent ev)
     {
         _ = seq;
-        _eventChannel.Writer.TryWrite(ev);
+        RouteOne(ev);
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Two cooperating loops: one drains the event channel and
-        // performs the routing/encode work synchronously; the other
-        // handles overflow events out-of-band so the version-bump
-        // FlushAsync does not stall the ER pipeline.
-        var routeLoop = Task.Run(() => RunRouteLoopAsync(stoppingToken), stoppingToken);
-        var overflowLoop = Task.Run(() => RunOverflowLoopAsync(stoppingToken), stoppingToken);
-        await Task.WhenAll(routeLoop, overflowLoop).ConfigureAwait(false);
-    }
-
-    private async Task RunRouteLoopAsync(CancellationToken ct)
-    {
-        try
-        {
-            await foreach (var ev in _eventChannel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-            {
-                try
-                {
-                    RouteOne(ev);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex,
-                        "fixp.outbound.route.error clOrdId={ClOrdId} kind={Kind}",
-                        ev.ClOrdId, ev.Kind);
-                }
-            }
-        }
-        catch (OperationCanceledException) { /* shutdown */ }
+        // Post-P9 there is no router drain — only the out-of-band
+        // overflow handler, whose async BumpVersion+close work cannot
+        // run inline under the dispatcher lock.
+        return Task.Run(() => RunOverflowLoopAsync(stoppingToken), stoppingToken);
     }
 
     private void RouteOne(ExecutionEvent ev)
+    {
+        try
+        {
+            RouteOneCore(ev);
+        }
+        catch (Exception ex)
+        {
+            // The route path runs under the dispatcher lock; an
+            // unhandled throw would tear down the entire ER pipeline
+            // and (worse) block any other dispatch waiting on the
+            // lock. Swallow and log — a single bot's encode failure
+            // must not stall every other bot.
+            _logger.LogError(ex,
+                "fixp.outbound.route.error clOrdId={ClOrdId} kind={Kind}",
+                ev.ClOrdId, ev.Kind);
+        }
+    }
+
+    private void RouteOneCore(ExecutionEvent ev)
     {
         if (!_mappings.TryGetOrderMapping(ev.ClOrdId, out var mapping))
         {

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -249,14 +249,37 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
             // the drain loop (RFC §5.3 / §5.5).
             if (!sender.TryEnqueue(frame))
             {
-                // Race or backpressure (RFC §5.3.1): the connection
-                // went away between TryGet and TryEnqueue, OR the
-                // per-connection bounded outbound channel is full.
-                // Either way, the buffer already holds the message,
-                // so retransmit (G) will pick it up on reconnect.
-                _logger.LogDebug(
-                    "fixp.outbound.send.race-or-backpressure credentialId={CredentialId} seq={Seq}",
+                // RFC §5.3.1 / §5.4: per-session writer-channel
+                // backpressure (P8 channel full) MUST trigger the
+                // version-bump path. The frame is already in the
+                // per-credential buffer so retransmit can replay it,
+                // but every subsequent successfully-enqueued ER would
+                // carry a higher per-credential outbound seq — the bot
+                // would observe an N+1 on the wire without ever seeing
+                // N. Without a forced reconnect (with bumped ver), the
+                // gap is silent. Signal the same out-of-band overflow
+                // handler the buffer-cap path uses: BumpVersion +
+                // force-close + Reset. The signal is a Guid only and
+                // the channel is unbounded; the credential-rate cap
+                // (one signal per credential per overflow→bump cycle)
+                // is enforced by the buffer's own _overflowed gate
+                // once the cleared buffer goes back into Append-reject
+                // mode after this frame.
+                //
+                // We also trigger this on a TryGet/TryEnqueue race
+                // (sender removed between calls, or sender already
+                // disposed): the cost is one redundant version bump
+                // for a bot that will reconnect anyway, which is
+                // strictly safer than a silent gap.
+                _logger.LogWarning(
+                    "fixp.outbound.send.backpressure-or-race credentialId={CredentialId} seq={Seq}",
                     mapping.CredentialId, seq);
+                if (!_overflowChannel.Writer.TryWrite(mapping.CredentialId))
+                {
+                    _logger.LogWarning(
+                        "fixp.outbound.overflow.signal-dropped credentialId={CredentialId}",
+                        mapping.CredentialId);
+                }
             }
         }
         // else: bot offline, message is buffered for G's retransmit.

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
@@ -18,10 +18,18 @@ public sealed class BotErMultiplexerOptions
     public int OutboundBufferMaxMessages { get; set; } = BotOutboundBuffer.DefaultMaxMessages;
 
     /// <summary>
-    /// Capacity of the in-process channel between
-    /// <see cref="ExecutionReportProcessor"/> and the routing loop.
-    /// DropOldest on full so the ER processor is never stalled.
+    /// <b>Deprecated (P9 / RFC §5.4).</b> Pre-P9, this sized the global
+    /// <c>Channel&lt;ExecutionEvent&gt;</c> between the dispatcher and
+    /// the multiplexer drain thread. P9 / F4 removed that channel —
+    /// credential resolve is now synchronous in the fan-out path and
+    /// the per-credential <see cref="BotOutboundBuffer"/> is the sole
+    /// bounded layer (with <see cref="OutboundBufferMaxMessages"/> the
+    /// only knob for ER-rate backpressure). The property is retained
+    /// solely for backwards-compatible binding of existing
+    /// <c>appsettings.json</c> sections so deployment configs do not
+    /// fail to load; the value is ignored.
     /// </summary>
+    [Obsolete("Removed in P9 / RFC §5.4 — synchronous credential resolve eliminated the global router channel. Tune OutboundBufferMaxMessages instead.")]
     public int RouterChannelCapacity { get; set; } = 16_384;
 
     /// <summary>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
@@ -106,7 +106,6 @@ public class BotErMultiplexerTests
         var opts = Options.Create(new BotErMultiplexerOptions
         {
             OutboundBufferMaxMessages = bufferCap,
-            RouterChannelCapacity = 1024,
         });
         var coord = new BotOutboundCoordinator(sessions, opts.Value);
         var mux = new BotErMultiplexer(mappings, sessions, directory, coord,

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
@@ -1,0 +1,314 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Issue #203 / RFC §5.4 (P9, F4). Behavioural tests for the post-P9
+/// synchronous credential resolve in <see cref="BotErMultiplexer"/>.
+/// Pin the three invariants the global-multiplexer-channel removal
+/// must NOT regress:
+/// <list type="number">
+///   <item>Per-credential ordering under concurrent dispatch — the
+///   per-bot ER stream observes ERs in the producer's submit order
+///   even when ≥8 producer threads fan ERs across multiple
+///   credentials. (RFC §4.3 + §5.4 invariant table.)</item>
+///   <item>Slow-credential isolation — a bot whose per-connection
+///   writer channel is full (P8 backpressure) cannot stall any other
+///   credential. The pre-P9 single-reader global drain coupled them.</item>
+///   <item>Backpressure when one credential's <see cref="BotOutboundBuffer"/>
+///   is full — the buffer is the sole bounded layer (RFC §6.3) and
+///   trips the version-bump path; no unbounded queue absorbs the
+///   surplus elsewhere.</item>
+/// </list>
+/// </summary>
+public class BotErRouterSyncResolveTests
+{
+    [Fact]
+    public async Task PerCredentialOrdering_PreservedUnderConcurrentDispatch()
+    {
+        // 8 credentials × 8 producer threads × 500 ERs each = 32k
+        // routes, fanned across credentials by hashing the producer's
+        // monotonically increasing seq onto a credential id. The
+        // synchronous Route() chain runs entirely under a per-thread
+        // simulated dispatcher lock (a single shared object) — same
+        // contract EventDispatcher gives the IExecutionFanOutSink hook.
+        const int credentials = 8;
+        const int producers = 8;
+        const int perProducer = 500;
+
+        var (mux, ctx) = await NewMuxAsync(bufferCap: 100_000);
+        var credIds = new Guid[credentials];
+        var senders = new RecordingSender[credentials];
+        for (var c = 0; c < credentials; c++)
+        {
+            credIds[c] = Guid.NewGuid();
+            await ctx.Sessions.GetOrCreateAsync(credIds[c], default);
+            senders[c] = new RecordingSender();
+            ctx.Directory.Register(credIds[c], senders[c]);
+        }
+
+        // Every internalId carries (producerIdx, perProducerSeq) packed
+        // into the high/low halves so the assert can recover the
+        // producer's submit order from the recorded clOrdId stream.
+        // Mapping table is fully populated up front so the resolve hot
+        // path is a pure dictionary hit (P9 contract).
+        for (var p = 0; p < producers; p++)
+        {
+            for (var i = 0; i < perProducer; i++)
+            {
+                var internalId = PackId(p, i);
+                var credIdx = (int)(internalId % credentials);
+                ctx.Mappings.Add(internalId, credIds[credIdx], externalId: 1_000_000UL + internalId);
+            }
+        }
+
+        // Single shared lock simulates the dispatcher lock: P9's
+        // contract is "synchronous resolve under the dispatcher lock",
+        // and the ordering guarantee depends on that serialisation.
+        var dispatcherLock = new object();
+        var threads = new Thread[producers];
+        for (var p = 0; p < producers; p++)
+        {
+            var producerIdx = p;
+            threads[p] = new Thread(() =>
+            {
+                for (var i = 0; i < perProducer; i++)
+                {
+                    var ev = NewEvent(PackId(producerIdx, i));
+                    lock (dispatcherLock)
+                    {
+                        mux.Route(ev);
+                    }
+                }
+            });
+        }
+        foreach (var t in threads) t.Start();
+        foreach (var t in threads) t.Join();
+
+        // Per-credential, the recorded ExternalClOrdId stream must be
+        // strictly ascending in the per-producer subsequence — i.e.
+        // for any two ERs from the same producer, the one with the
+        // lower perProducer index must appear first on its
+        // credential's wire.
+        for (var c = 0; c < credentials; c++)
+        {
+            var lastSeenPerProducer = new int[producers];
+            Array.Fill(lastSeenPerProducer, -1);
+            var observed = senders[c].SnapshotExternalIds();
+            foreach (var ext in observed)
+            {
+                var internalId = ext - 1_000_000UL;
+                var (pIdx, seq) = UnpackId(internalId);
+                Assert.True(seq > lastSeenPerProducer[pIdx],
+                    $"credential={c} producer={pIdx}: out-of-order seq={seq} after {lastSeenPerProducer[pIdx]}");
+                lastSeenPerProducer[pIdx] = seq;
+            }
+        }
+
+        // Total accounting: every routed ER reached exactly its
+        // credential's sender (no cross-credential leakage, no drops).
+        var total = 0;
+        for (var c = 0; c < credentials; c++) total += senders[c].SentCount;
+        Assert.Equal(producers * perProducer, total);
+    }
+
+    [Fact]
+    public async Task SlowCredential_DoesNotStall_OtherCredentials()
+    {
+        // Pre-P9: the global multiplexer Channel<ExecutionEvent> was
+        // single-reader, so the slow bot's RouteOne would have held
+        // up the drain for all credentials. Post-P9 the resolve runs
+        // on the producer thread itself; only the slow credential's
+        // per-connection writer (P8) can backpressure, and TryEnqueue
+        // returns false instantly. Other credentials are unaffected.
+        var (mux, ctx) = await NewMuxAsync(bufferCap: 10_000);
+
+        var slow = Guid.NewGuid();
+        var fast = Guid.NewGuid();
+        await ctx.Sessions.GetOrCreateAsync(slow, default);
+        await ctx.Sessions.GetOrCreateAsync(fast, default);
+
+        var slowSender = new BlockingSender(); // TryEnqueue returns false (full)
+        var fastSender = new RecordingSender();
+        ctx.Directory.Register(slow, slowSender);
+        ctx.Directory.Register(fast, fastSender);
+
+        ctx.Mappings.Add(internalId: 1, credId: slow, externalId: 100);
+        ctx.Mappings.Add(internalId: 2, credId: fast, externalId: 200);
+
+        // Hammer the slow credential first — would stall the pre-P9
+        // drain. Time the subsequent fast-credential burst.
+        for (var i = 0; i < 5_000; i++) mux.Route(NewEvent(1));
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (var i = 0; i < 5_000; i++) mux.Route(NewEvent(2));
+        sw.Stop();
+
+        Assert.Equal(5_000, fastSender.SentCount);
+        // Fast credential's burst must be unaffected by the slow one;
+        // budget is generous (the path is encode + buffer + TryEnqueue).
+        // Exceeding it would indicate cross-credential coupling, the
+        // exact regression P9 is meant to prevent.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"fast burst took {sw.ElapsedMilliseconds} ms — slow credential leaked backpressure");
+        // The slow sender's TryEnqueue returned false every time, but
+        // the per-credential buffer absorbed the frames (sole bounded
+        // layer). Nothing was lost; retransmit replays them.
+        Assert.Equal(5_000, ctx.Coordinator.GetOrCreateBuffer(slow).Count);
+    }
+
+    [Fact]
+    public async Task BufferFull_TripsOverflow_NoUnboundedQueueElsewhere()
+    {
+        // Per RFC §6.3, the per-credential BotOutboundBuffer is the
+        // sole bounded layer for ER backpressure. When it fills, the
+        // overflow callback fires immediately (synchronously, inside
+        // Append) and the message is rejected — there is no upstream
+        // queue silently absorbing the surplus. We verify by checking
+        // (a) the buffer signals overflow on cap+1, (b) the sender
+        // gets the version-bump force-close, and (c) there is no
+        // hidden queue: the multiplexer holds no per-event state
+        // beyond the credentialId-only overflow channel.
+        var (mux, ctx) = await NewMuxAsync(bufferCap: 4);
+        var cred = Guid.NewGuid();
+        await ctx.Sessions.GetOrCreateAsync(cred, default);
+        var sender = new RecordingSender();
+        ctx.Directory.Register(cred, sender);
+        ctx.Mappings.Add(internalId: 7, credId: cred, externalId: 70);
+        var startVer = (await ctx.Sessions.GetOrCreateAsync(cred, default)).CurrentVer;
+
+        // 8 routes against a cap-4 buffer: the first 4 land, the 5th
+        // trips overflow (and bulk-clears the buffer). The remaining
+        // 3 are rejected because the buffer stays in overflowed-state
+        // until Reset (called by HandleOverflowAsync).
+        for (var i = 0; i < 8; i++) mux.Route(NewEvent(7));
+
+        // Wait for the out-of-band overflow handler (BumpVersion is
+        // async and runs off-lock by design). Bounded retries — the
+        // handler is a single Task.Delay-free path and finishes fast.
+        for (var i = 0; i < 50 && !sender.Disposed; i++)
+            await Task.Delay(20);
+
+        Assert.True(sender.Disposed, "overflow handler must force-close the offending sender");
+        var newState = await ctx.Sessions.GetOrCreateAsync(cred, default);
+        Assert.True(newState.CurrentVer > startVer, "version must be bumped");
+        // After Reset, buffer is clean — the overflow path is the sole
+        // signal for downstream catch-up. No silent in-flight queue.
+        Assert.False(ctx.Coordinator.GetOrCreateBuffer(cred).IsOverflowed);
+    }
+
+    private static ulong PackId(int producer, int seq) => ((ulong)producer << 32) | (uint)seq;
+    private static (int producer, int seq) UnpackId(ulong id) => ((int)(id >> 32), (int)(id & 0xFFFFFFFFu));
+
+    private static ExecutionEvent NewEvent(ulong clOrdId) =>
+        new(
+            Owner: new EndClientId("u1"),
+            ClOrdId: clOrdId,
+            Symbol: "PETR4",
+            Side: OrderSide.Buy,
+            Status: OrderStatus.Working,
+            Kind: ExecKind.New,
+            LeavesQuantity: 100,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            TimestampUtc: DateTimeOffset.UtcNow);
+
+    private static async Task<(BotErMultiplexer, MuxCtx)> NewMuxAsync(int bufferCap)
+    {
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var mappings = new FakeMappingRegistry();
+        var directory = new BotSessionConnectionDirectory();
+        var opts = Options.Create(new BotErMultiplexerOptions
+        {
+            OutboundBufferMaxMessages = bufferCap,
+        });
+        var coord = new BotOutboundCoordinator(sessions, opts.Value);
+        var mux = new BotErMultiplexer(mappings, sessions, directory, coord,
+            NullLogger<BotErMultiplexer>.Instance, opts);
+        var cts = new CancellationTokenSource();
+        await mux.StartAsync(cts.Token);
+        return (mux, new MuxCtx(sessions, mappings, directory, coord));
+    }
+
+    private sealed class MuxCtx
+    {
+        public InMemoryUserBotSessionRegistry Sessions { get; }
+        public FakeMappingRegistry Mappings { get; }
+        public BotSessionConnectionDirectory Directory { get; }
+        public BotOutboundCoordinator Coordinator { get; }
+        public MuxCtx(
+            InMemoryUserBotSessionRegistry sessions,
+            FakeMappingRegistry mappings,
+            BotSessionConnectionDirectory directory,
+            BotOutboundCoordinator coordinator)
+        {
+            Sessions = sessions;
+            Mappings = mappings;
+            Directory = directory;
+            Coordinator = coordinator;
+        }
+    }
+
+    private sealed class RecordingSender : IBotSessionOutboundSender, IDisposable
+    {
+        // Offset of ExternalClOrdId in the OutboundExecutionReportEncoder
+        // ExecutionReport_New frame: [SOFH 4][SBE header 8][body offset 20].
+        private const int ExternalClOrdIdFrameOffset = 4 + 8 + 20;
+
+        private readonly ConcurrentQueue<ulong> _externalIds = new();
+        private int _sent;
+        public int SentCount => Volatile.Read(ref _sent);
+        public bool Disposed { get; private set; }
+        public bool TryEnqueue(OutboundFrame frame)
+        {
+            if (Disposed) return false;
+            // Recover the bot-visible ExternalClOrdId from the SBE
+            // body so the per-credential ordering assert can recover
+            // each producer's submit subsequence (PackId / UnpackId).
+            var bytes = frame.Bytes.Span;
+            var externalId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(
+                bytes.Slice(ExternalClOrdIdFrameOffset, 8));
+            _externalIds.Enqueue(externalId);
+            Interlocked.Increment(ref _sent);
+            return true;
+        }
+        public IReadOnlyList<ulong> SnapshotExternalIds() => _externalIds.ToArray();
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class BlockingSender : IBotSessionOutboundSender
+    {
+        // Models the P8 per-connection writer channel being full —
+        // TryEnqueue returns false instantly without touching the
+        // frame. This is the slow-credential signature.
+        public bool TryEnqueue(OutboundFrame frame) => false;
+    }
+
+    private sealed class FakeMappingRegistry : IUserBotOrderMappingRegistry
+    {
+        private readonly ConcurrentDictionary<ulong, OrderMapping> _orders = new();
+        public void Add(ulong internalId, Guid credId, ulong externalId)
+            => _orders[internalId] = new OrderMapping(credId, externalId);
+        public bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping)
+            => _orders.TryGetValue(internalClOrdId, out mapping);
+        public bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId)
+        { internalClOrdId = 0; return false; }
+        public bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping)
+        { mapping = default; return false; }
+        public void Reap(ulong internalClOrdId) { }
+        public void ReapCancel(ulong cancelInternalClOrdId) { }
+        public void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId) { }
+        public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
+        public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
+        public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
@@ -127,7 +127,9 @@ public class BotErRouterSyncResolveTests
         // up the drain for all credentials. Post-P9 the resolve runs
         // on the producer thread itself; only the slow credential's
         // per-connection writer (P8) can backpressure, and TryEnqueue
-        // returns false instantly. Other credentials are unaffected.
+        // returns false instantly. The false return triggers the
+        // out-of-band version-bump + force-close (RFC §5.3.1 / §5.4).
+        // The fast credential is unaffected throughout.
         var (mux, ctx) = await NewMuxAsync(bufferCap: 10_000);
 
         var slow = Guid.NewGuid();
@@ -135,13 +137,15 @@ public class BotErRouterSyncResolveTests
         await ctx.Sessions.GetOrCreateAsync(slow, default);
         await ctx.Sessions.GetOrCreateAsync(fast, default);
 
-        var slowSender = new BlockingSender(); // TryEnqueue returns false (full)
+        var slowSender = new BlockingSender(); // TryEnqueue always returns false
         var fastSender = new RecordingSender();
         ctx.Directory.Register(slow, slowSender);
         ctx.Directory.Register(fast, fastSender);
 
         ctx.Mappings.Add(internalId: 1, credId: slow, externalId: 100);
         ctx.Mappings.Add(internalId: 2, credId: fast, externalId: 200);
+
+        var slowStartVer = (await ctx.Sessions.GetOrCreateAsync(slow, default)).CurrentVer;
 
         // Hammer the slow credential first — would stall the pre-P9
         // drain. Time the subsequent fast-credential burst.
@@ -157,10 +161,19 @@ public class BotErRouterSyncResolveTests
         // exact regression P9 is meant to prevent.
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
             $"fast burst took {sw.ElapsedMilliseconds} ms — slow credential leaked backpressure");
-        // The slow sender's TryEnqueue returned false every time, but
-        // the per-credential buffer absorbed the frames (sole bounded
-        // layer). Nothing was lost; retransmit replays them.
-        Assert.Equal(5_000, ctx.Coordinator.GetOrCreateBuffer(slow).Count);
+
+        // The slow credential triggers the version-bump + force-close
+        // recovery path (RFC §5.3.1). Bounded retries — the overflow
+        // loop is async and runs out-of-band.
+        for (var i = 0; i < 50 && !slowSender.Disposed; i++)
+            await Task.Delay(20);
+        Assert.True(slowSender.Disposed,
+            "slow credential's writer-channel backpressure must trigger force-close");
+        var slowNewVer = (await ctx.Sessions.GetOrCreateAsync(slow, default)).CurrentVer;
+        Assert.True(slowNewVer > slowStartVer,
+            "slow credential's session version must be bumped on writer-channel backpressure");
+        // Fast credential is untouched by the slow's recovery path.
+        Assert.False(fastSender.Disposed);
     }
 
     [Fact]
@@ -284,12 +297,15 @@ public class BotErRouterSyncResolveTests
         public void Dispose() => Disposed = true;
     }
 
-    private sealed class BlockingSender : IBotSessionOutboundSender
+    private sealed class BlockingSender : IBotSessionOutboundSender, IDisposable
     {
         // Models the P8 per-connection writer channel being full —
         // TryEnqueue returns false instantly without touching the
-        // frame. This is the slow-credential signature.
+        // frame. This is the slow-credential signature. IDisposable
+        // so the overflow handler can force-close us.
+        public bool Disposed { get; private set; }
         public bool TryEnqueue(OutboundFrame frame) => false;
+        public void Dispose() => Disposed = true;
     }
 
     private sealed class FakeMappingRegistry : IUserBotOrderMappingRegistry


### PR DESCRIPTION
Implements **P9 / F4** of the perf hardening v0 RFC (§5.4).

## What

Removes the unbounded global `Channel<ExecutionEvent>` in `BotErMultiplexer` and its single-reader drain loop. `BotErRouter.Route` and the `IExecutionFanOutSink.Enqueue` hook (post-P4 #220, called UNDER the dispatcher lock) now resolve the originating credential synchronously via a lock-free `IUserBotOrderMappingRegistry` lookup and dispatch directly into the per-credential `BotOutboundBuffer` (P7) and the per-connection writer channel (P8).

Backpressure is now concentrated in two layers, both already bounded:

| Layer | Cap | Full-policy |
|---|---|---|
| `BotOutboundBuffer` (per credential) | `OutboundBufferMaxMessages` (default 50,000) | overflow → BumpVersion + force-close + Reset (RFC §4.7) |
| `FixpOutboundChannelWriter` (per connection, P8) | per-connection bounded | full → leave frame in buffer + signal same overflow path (RFC §5.3.1) |

The credentialId-only `_overflowChannel` + `RunOverflowLoopAsync` remain, because `BumpVersionAsync` is genuinely async and cannot run inline under the dispatcher lock. Its post rate is bounded by credential count, not ER rate.

`RouterChannelCapacity` on `BotErMultiplexerOptions` is marked `[Obsolete]` — kept solely for backwards-compatible `appsettings.json` binding; the value is ignored.

## Invariant table (§5.4)

| Invariant | Pre-P9 | Post-P9 | How it's preserved |
|---|---|---|---|
| §4.3 per-credential ER order = WAL append order | single-reader drain → trivial FIFO | synchronous chain under dispatcher lock → trivial FIFO | new test `PerCredentialOrdering_PreservedUnderConcurrentDispatch` (8 producers × 8 credentials × 500 events) |
| §4.5 single active session | overflow handler bumps version then closes | unchanged | existing `Overflow_BumpsVersion_DisposesSender_AndResetsBuffer` |
| §6.3 backpressure (sole bounded layer) | global unbounded channel + per-credential buffer | per-credential buffer + per-connection writer channel | new test `BufferFull_TripsOverflow_NoUnboundedQueueElsewhere` |
| Slow-credential isolation | broken — slow bot stalled the global drain for all credentials | synchronous resolve has no shared queue; slow sender's TryEnqueue=false triggers per-credential recovery | new test `SlowCredential_DoesNotStall_OtherCredentials` |
| §5.5 single-disposer | unchanged | unchanged | existing buffer ownership tests |

## Bench (`BotErRouter_RouteOne_Bench`, `--job Short`)

`AMD EPYC 7763 2.45 GHz, .NET 10.0.5`

| BatchSize | MappedCredentials | Before (Mean) | After (Mean) | Speedup | Allocated (before/after) |
|---|---|---|---|---|---|
| 64 | 1 | 2.262 ms | **78.40 µs** | **28.9×** | 28.59 KB / 28.5 KB |
| 64 | 16 | 2.013 ms | **90.49 µs** | **22.2×** | 28.59 KB / 28.5 KB |
| 1024 | 1 | 2.842 ms | **1.379 ms** | **2.06×** | 596.09 KB / 595.73 KB |
| 1024 | 16 | 2.040 ms | **1.687 ms** | **1.21×** | 596.09 KB / 595.73 KB |

Small-batch wins are dominated by the eliminated channel-write + drain-thread wakeup overhead per route. Allocations are unchanged (encode allocs dominate; F5 already eliminated the double-copy). Acceptance gate (≥3× ops/s) cleared for the small-batch hot path.

## Mandatory `gpt-5.5` code-review pass

Run focused on (a) no async hop in resolve path, (b) per-credential ordering, (c) slow-credential isolation, (d) no unbounded queue introduced. One **High** surfaced and fixed in `59b7702`: per-connection writer-channel backpressure was only logged, not signaled to the version-bump path → silent gap risk. Now signals via the same overflow channel; test updated to assert the recovery path fires.

## Tests

`dotnet test B3TradingPlatform.slnx --no-build -c Release` → 1022 passed, 18 skipped (Conformance suite, environment-gated). New tests under `BotErRouterSyncResolveTests`.

`dotnet format --verify-no-changes` clean.

Closes #203
RFC: `docs/rfcs/perf-hardening-v0.md` §5.4
