### PR TITLE
fix(tests): unblock main — add Raw* methods to BotErRouterSyncResolveTests fake

### DIFF
--- a/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
@@ -82,9 +82,15 @@ public class TwoPhaseSnapshotCaptureTests
             dispatcher.Dispatch(
                 new OrderSubmittedEvent
                 {
-                    ClOrdId = clOrdId, EndClientId = "alice", FirmId = "TEST",
-                    Symbol = "PETR4", SecurityId = 4321UL,
-                    Side = "Buy", Type = "Limit", Quantity = quantity, Price = 30m,
+                    ClOrdId = clOrdId,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Limit",
+                    Quantity = quantity,
+                    Price = 30m,
                 },
                 () =>
                 {

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
@@ -325,6 +325,8 @@ public class BotErRouterSyncResolveTests
         public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
         public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
         public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public BotOrderMappingRaw[] RawSnapshotOrders() => Array.Empty<BotOrderMappingRaw>();
+        public BotCancelMappingRaw[] RawSnapshotCancels() => Array.Empty<BotCancelMappingRaw>();
         public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
     }
 }


### PR DESCRIPTION
Hot-fix for main: auto-merge of #222 (P6) landed after #221 (P9). P9 introduced `BotErRouterSyncResolveTests.FakeMappingRegistry` which does not implement the two new `IUserBotOrderMappingRegistry` members added in P6 (`RawSnapshotOrders` / `RawSnapshotCancels`). Build & Test failed on the merge commit b3bb81a with two CS0535 errors. Adds no-op implementations returning empty arrays. Also fixes whitespace flagged by dotnet format in the new `TwoPhaseSnapshotCaptureTests`.

Verified: `dotnet build` 0/0, full suite 1026 pass / 18 skipped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>