### PR TITLE
fix(test): bump WAL channel capacity in two-phase snapshot stress test

### DIFF
--- a/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
@@ -55,7 +55,7 @@ public class TwoPhaseSnapshotCaptureTests
             {
                 DataDirectory = root,
                 FirmId = "test",
-                ChannelCapacity = 4096,
+                ChannelCapacity = 32_768,
                 GroupCommitMaxRecords = 32,
                 GroupCommitWindow = TimeSpan.FromMilliseconds(5),
                 FsyncOnFlush = false,

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/TwoPhaseSnapshotCaptureTests.cs
@@ -82,9 +82,15 @@ public class TwoPhaseSnapshotCaptureTests
             dispatcher.Dispatch(
                 new OrderSubmittedEvent
                 {
-                    ClOrdId = clOrdId, EndClientId = "alice", FirmId = "TEST",
-                    Symbol = "PETR4", SecurityId = 4321UL,
-                    Side = "Buy", Type = "Limit", Quantity = quantity, Price = 30m,
+                    ClOrdId = clOrdId,
+                    EndClientId = "alice",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Limit",
+                    Quantity = quantity,
+                    Price = 30m,
                 },
                 () =>
                 {

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
@@ -325,6 +325,8 @@ public class BotErRouterSyncResolveTests
         public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
         public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
         public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public BotOrderMappingRaw[] RawSnapshotOrders() => Array.Empty<BotOrderMappingRaw>();
+        public BotCancelMappingRaw[] RawSnapshotCancels() => Array.Empty<BotCancelMappingRaw>();
         public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
     }
 }


### PR DESCRIPTION
Hot-fix for main: `TwoPhaseSnapshotCaptureTests.SnapshotConsistency_HoldsUnderConcurrentDispatchAndConcurrentReads` failed on CI runner 25672051562 with `WalBackpressureException` (WAL channel was full at 4096). The test dispatches 4 writers × 4000 events = 16k WAL appends; on the slower CI runner the WAL drain couldn't keep up before backpressure tripped. Bump `ChannelCapacity` from 4096 → 32768 so the snapshot stress test isn't bounded by an unrelated WAL setting.

Verified: 4/4 two-phase tests pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>