### PR TITLE
docs(ops): observability + RUNBOOK for perf hardening v0 (#231)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,12 @@ Start here. This is the map for everything under `docs/` in
 
 ## Operations / Runbooks
 
+- [RUNBOOK.md](RUNBOOK.md) — top-level operations runbook;
+  cross-cutting "what to watch in prod" items including the
+  perf-hardening v0 metric / log / config surface.
+- [ops/perf-v0-alerts.md](ops/perf-v0-alerts.md) — concrete
+  Prometheus + log-derived alert rules for the perf-hardening v0
+  observability surface (companion to the RUNBOOK §1).
 - [operations/fixp-listener.md](operations/fixp-listener.md) —
   enabling, sizing, credentials, retransmit, drain & shutdown for the
   FIXP listener.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,218 @@
+# Operations Runbook
+
+Top-level operational runbook for the B3 trading-host. Per-subsystem
+guides live alongside this file (e.g.
+[`operations/fixp-listener.md`](operations/fixp-listener.md));
+this document covers cross-cutting "what to watch in prod" items
+and shutdown / drain semantics that don't belong to a single
+subsystem.
+
+For the OTel metric surface itself see [`METRICS.md`](METRICS.md).
+For alert rules in Prometheus / AlertManager YAML form see
+[`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md).
+
+---
+
+## 1. Perf hardening v0 — what to watch
+
+The perf-hardening v0 RFC ([`rfcs/perf-hardening-v0.md`](rfcs/perf-hardening-v0.md))
+introduced a small set of new metrics, log signals, and tunables
+that operators must monitor in production. Each item below lists
+its source PR, what the signal means, an alert threshold, and the
+mitigation path.
+
+> **Composite load-test results that motivated these knobs are in
+> [`perf-hardening-v0-results.md`](perf-hardening-v0-results.md).**
+
+### 1.1 `trading.dispatcher.ws_fanout_dropped` (counter)
+
+| Field | Value |
+|---|---|
+| OTel name | `trading.dispatcher.ws_fanout_dropped` |
+| Prom name | `trading_dispatcher_ws_fanout_dropped_total` |
+| C# symbol | `MetricsRegistry.WsHubFanOutDropped` ([`Observability/MetricsRegistry.cs`](../backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs)) |
+| Origin    | P4 / F2 — PR [#220](https://github.com/pedrosakuma/B3TradingPlatform/pull/220), RFC §5.2 |
+| Type      | OTel `Counter<long>`, no tags |
+
+**What it signals.** The WS hub sink (`WebSocketExecutionEventSink`,
+`B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs`) owns a
+**single** bounded channel of 64 K events between the dispatcher
+and its drain thread, with `BoundedChannelFullMode.DropOldest` and
+an item-dropped callback that bumps this counter. A bump means
+**the WS-hub publish→drain queue overflowed** — i.e. the drain
+thread can't keep up with the dispatcher's publish rate (the
+drain does the per-subscriber walk + DTO build). It is **not** a
+per-subscriber slow-consumer signal; individual slow WS clients
+are detected on their own per-client channel and disconnected
+out-of-band (see `SubscribedClient.Enqueue`'s
+`slow_consumer_resync_required` path), without bumping this
+counter. This counter is **lossy by design** and should be
+**flat at zero** in healthy operation.
+
+**Alert.** `rate(trading_dispatcher_ws_fanout_dropped_total[1m]) > 0`
+sustained for **1 minute** → **page**. Any non-zero rate means
+the WS hub drain is behind and *all* subscribed WS clients will
+observe a gap and have to reconnect-and-replay through the
+existing WS recovery path.
+
+**Mitigation, in order:**
+
+1. Check `trading.er.received` rate against recent baseline — a
+   producer-side spike (replay storm, ER burst from B3) is the
+   most common cause and self-resolves once the burst clears.
+2. Look at the host-level signals (CPU, GC pauses, scheduler
+   latency) on the trading-host pod — the drain runs on a single
+   `Task.Run` thread and is sensitive to runtime stalls.
+3. Persistent saturation under known-good load → the 64 K cap is
+   genuinely undersized for current participant volume; raise
+   `WebSocketExecutionEventSink.ChannelCapacity` (compile-time
+   constant, see PR #220) and ship a patch. **Do not** silently
+   increase it without an issue tracking the new value — the
+   cap is also the worst-case in-memory queue bound.
+
+### 1.2 `fixp.outbound.drain.shutdown.abandoned` (warning log)
+
+| Field | Value |
+|---|---|
+| Source | Structured log line in [`Hosting/FixpOutboundChannelWriter.cs`](../backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs) at `LogWarning` (the `_drainLoop.WaitAsync` 250 ms catch) |
+| Origin | P8 / F3 — PR [#219](https://github.com/pedrosakuma/B3TradingPlatform/pull/219), RFC §5.3.2 |
+| Type   | **Warning log** — *not* an OTel counter today (see follow-up note below) |
+
+**Message shape.**
+
+```
+fixp.outbound.drain.shutdown.abandoned connectionId={ConnectionId} timeoutMs={TimeoutMs}
+```
+
+The same file emits a sibling line `fixp.outbound.drain.shutdown.timeout`
+when `CompleteAsync` returns past its configured deadline; that
+is the **expected** "deadline elapsed" path. The `.abandoned`
+line is the harder failure: the drain loop **ignored cancellation**
+for >250 ms after `_cts.Cancel()` and the connection cleanup gave
+up waiting. The orphaned drain task will exit when its in-flight
+`WriteAsync` eventually unblocks; in the meantime no per-frame data
+is lost from the bot's perspective — the per-credential
+`BotOutboundBuffer` still owns the queued frames and replays them
+on the next reconnect (RFC §5.3.2).
+
+**What it signals.** Either (a) the kernel socket buffer is
+permanently full because the peer is dead but TCP RST hasn't
+fired yet, or (b) a callback in the write path is genuinely
+ignoring the cancellation token. Either case means a connection
+slot was closed without a clean drain; the credential is freed
+for a successor session per §4.5 only after the orphaned task
+finally exits.
+
+**Alert.** Any occurrence is operator-visible. Recommended:
+`count_over_time({msg=~"fixp.outbound.drain.shutdown.abandoned.*"}[5m]) > 0`
+→ **page**. (Translate the LogQL above to your stack — Loki
+example shown.) Contrast with the sibling `.timeout` line, which
+should be alerted at info-level only — that one is the documented
+"slow peer, deadline elapsed" path and is bounded by
+`OutboundDrainShutdownTimeout` (§1.3 below).
+
+**Mitigation:**
+
+1. Pull the `connectionId` from the log line and grep recent
+   FIXP listener logs for matching `Negotiate`, `Establish`,
+   `Terminate` to identify the credential / firm.
+2. If isolated to one peer, the peer is misbehaving — coordinate a
+   forced session cleanup via `/admin/fixp` (see fixp-listener
+   ops doc).
+3. If broad — multiple `connectionId`s in a short window — the
+   write path itself has regressed in cancellation behaviour. Roll
+   back the most recent listener change and open a P0.
+
+> **Follow-up.** Today this is a log line only. Issue
+> [#231](https://github.com/pedrosakuma/B3TradingPlatform/issues/231)'s
+> table named `fixp.outbound.drain.shutdown.abandoned` as a
+> *metric*; it is currently emitted **only** as a structured log.
+> A counter equivalent is tracked as a separate follow-up
+> (TBD — to be filed). Until then alerting must be log-derived.
+
+### 1.3 `OutboundDrainShutdownTimeout` (config, default `00:00:01`)
+
+| Field | Value |
+|---|---|
+| Path  | `Trading:EntryPointListener:Buffers:OutboundDrainShutdownTimeout` |
+| Env   | `Trading__EntryPointListener__Buffers__OutboundDrainShutdownTimeout=00:00:01` |
+| Code  | [`EntryPointListenerOptions.BuffersOptions`](../backend/src/B3.Trading.EntryPointListener/EntryPointListenerOptions.cs) |
+| Origin | P8 / F3 — PR [#219](https://github.com/pedrosakuma/B3TradingPlatform/pull/219), RFC §5.3.2 |
+
+**What it controls.** Maximum wall-clock the per-connection drain
+loop will spend flushing already-queued outbound frames on
+connection close before giving up and emitting
+`fixp.outbound.drain.shutdown.timeout`. Frames still queued at
+the deadline remain owned by the per-credential
+`BotOutboundBuffer` and are replayed via retransmit on the next
+reconnect — they are never silently dropped from the bot's
+perspective.
+
+**When to tune.** Default `1s` is sized for the v0 buffer
+(`OutboundChannelCapacity=4096`) and a healthy peer. Raise it
+only if you observe `.timeout` log lines correlated with **slow
+but live** peers (e.g. high-latency transit links) where the
+extra time would let drains complete cleanly instead of
+deferring frames into the post-reconnect replay path. Do **not**
+raise it as a workaround for `.abandoned` — that path is not
+deadline-bounded and a longer timeout cannot help.
+
+**Drift detection.** Today the trading-host does **not** emit a
+gauge for the running value, so a Prometheus `expr: <gauge> != 1`
+rule would silently never fire. Until a `build-info`-style gauge
+lands (tracked as a follow-up to #231), enforce drift at deploy
+time by diffing the rendered config against the documented
+default in CI; see [`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md)
+§1.1 for the skeleton runtime rule to enable later.
+
+### 1.4 `Trading:Persistence:GroupCommitMaxRecords` (config, default `512`)
+
+| Field | Value |
+|---|---|
+| Path  | `Trading:Persistence:GroupCommitMaxRecords` |
+| Env   | `Trading__Persistence__GroupCommitMaxRecords=512` |
+| Code  | [`PersistenceOptions`](../backend/src/B3.Trading.Infrastructure/Persistence/PersistenceOptions.cs) |
+| Origin | P5 / F7 — PR [#214](https://github.com/pedrosakuma/B3TradingPlatform/pull/214), RFC §4.2 / §5.7 |
+
+**What it controls.** Maximum records per WAL group-commit batch.
+Raised from `64 → 512` in P5 to amortise `fsync` over more records
+at participant-volume throughput without breaching the
+`GroupCommitWindow` (10 ms) latency cap.
+
+**Worst-case crash exposure.** `ChannelCapacity + GroupCommitMaxRecords`
+acked-but-unfsynced records (i.e. with defaults: `4096 + 512 =
+4608` records). The platform's invariant is **ack-before-fsync**
+on the dispatcher path (RFC §4.2): an order is acknowledged once
+its WAL append is enqueued, not once it is durable. This is a
+**deliberate** design choice; do not "fix" it by reverting the
+batch size.
+
+**When to tune.**
+
+- **Lower** (e.g. back to `256`) only if a regulator requires a
+  tighter recoverable-state bound and you have measured the fsync
+  amplification cost. Coordinate with the §4.2 owners — this
+  changes a documented invariant boundary.
+- **Higher** is **not** recommended without a fresh re-run of the
+  perf-hardening composite suite ([`perf-hardening-v0-results.md`](perf-hardening-v0-results.md)).
+  Larger batches risk exceeding `GroupCommitWindow` under load,
+  pushing latency past the §7.3 gate.
+
+**Drift detection.** Same constraint as §1.3: no runtime gauge
+exists today, so enforce drift at deploy time. Skeleton
+Prometheus rule for when the gauge lands is in
+[`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md) §1.1.
+
+---
+
+## 2. Cross-references
+
+- **Alert rules.** [`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md)
+- **Metric inventory.** [`METRICS.md`](METRICS.md)
+- **Observability wiring (host / k8s).** [`OBSERVABILITY.md`](OBSERVABILITY.md)
+- **FIXP listener ops** (drain, sessions, admin endpoints).
+  [`operations/fixp-listener.md`](operations/fixp-listener.md)
+- **RFC.** [`rfcs/perf-hardening-v0.md`](rfcs/perf-hardening-v0.md) §4.2
+  (durability), §5.3 (per-connection writer / drain), §6.3
+  (backpressure policy).
+- **Composite results.** [`perf-hardening-v0-results.md`](perf-hardening-v0-results.md)

--- a/docs/ops/perf-v0-alerts.md
+++ b/docs/ops/perf-v0-alerts.md
@@ -1,0 +1,130 @@
+# Perf hardening v0 — alert rules
+
+Concrete Prometheus alert rules for the metrics, log signals and
+config knobs catalogued in [`../RUNBOOK.md`](../RUNBOOK.md) §1.
+Drop the `groups:` block below into your existing
+`alerting_rules.yml` (or the equivalent file your AlertManager
+deploy loads).
+
+The trading-host scrape pipeline is documented in
+[`../METRICS.md`](../METRICS.md): app-meter signals reach
+Prometheus via the OTel collector's `prometheusexporter` on
+`otel-collector:8889`. OTel meter names are translated to
+Prometheus convention (dots → underscores; counters get a
+`_total` suffix); the rules below already use the
+post-translation names.
+
+> **Translation notes.**
+>
+> - The repo currently has **no** committed alert rules — only the
+>   scrape config in [`docker/observability/prometheus.yml`](../../docker/observability/prometheus.yml).
+>   These rules are intentionally portable: drop them into any
+>   Prometheus + AlertManager stack, or translate them to the
+>   recording / alerting equivalent in your ops platform
+>   (Datadog monitor, Grafana Cloud alert, etc.) — the
+>   `expr:` / `for:` / labels are the contract.
+> - The `.abandoned` rule is **log-derived** (Loki / equivalent),
+>   not Prometheus — see §1.2 of the runbook for why. The example
+>   below is LogQL; translate the selector to whatever log query
+>   language your aggregator uses.
+
+---
+
+## 1. Prometheus alerting rules
+
+```yaml
+groups:
+  - name: perf-hardening-v0
+    interval: 30s
+    rules:
+      # 1.1 WS hub fan-out drops — see RUNBOOK §1.1 / PR #220.
+      # Any sustained non-zero rate means real subscribers are
+      # losing events and forced into reconnect-and-replay.
+      - alert: WsHubFanOutDropping
+        expr: rate(trading_dispatcher_ws_fanout_dropped_total[1m]) > 0
+        for: 1m
+        labels:
+          severity: page
+          subsystem: ws-hub
+          rfc: perf-hardening-v0
+          rfc_section: "5.2"
+        annotations:
+          summary: "WS hub publish→drain queue overflowed (DropOldest, 64K)"
+          description: |
+            trading.dispatcher.ws_fanout_dropped has been > 0/s for
+            1 minute on {{ $labels.instance }}. The
+            WebSocketExecutionEventSink's single drain thread is
+            behind the dispatcher's publish rate, so all subscribed
+            WS clients will see a gap and must reconnect-and-replay.
+            See docs/RUNBOOK.md §1.1 for the triage sequence.
+          runbook_url: "https://github.com/pedrosakuma/B3TradingPlatform/blob/main/docs/RUNBOOK.md#11-tradingdispatcherws_fanout_dropped-counter"
+
+```
+
+### 1.1 Config-drift detection (deferred)
+
+Issue #231 also asks for info-level drift detection on
+`OutboundDrainShutdownTimeout` (default `1s`) and
+`GroupCommitMaxRecords` (default `512`). Implementing those as
+**Prometheus alerts requires a `build-info`-style config gauge that
+the trading-host does not emit today** — there is no
+`trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds`
+or `trading_persistence_group_commit_max_records` series in the
+current scrape, so any rule of the form `expr: <metric> != <default>`
+would silently never fire (no series → no samples → no alert).
+
+Until those gauges are added (tracked as a follow-up to #231), the
+recommended path is a **deploy-time** check rather than a runtime
+alert: diff the rendered `appsettings.Production.json` (or the
+equivalent K8s `ConfigMap` / Helm values) against the documented
+defaults in CI, and fail the deploy on unexplained drift. Skeleton
+rule for when the gauges land:
+
+```yaml
+# To be enabled once the trading-host emits build-info gauges
+# for the perf-v0 config knobs (follow-up to #231).
+#
+# - alert: PerfV0OutboundDrainTimeoutDrift
+#   expr: trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds != 1
+#   for: 5m
+#   labels:  { severity: info, subsystem: fixp-listener,  rfc_section: "5.3" }
+# - alert: PerfV0GroupCommitMaxRecordsDrift
+#   expr: trading_persistence_group_commit_max_records != 512
+#   for: 5m
+#   labels:  { severity: info, subsystem: persistence,    rfc_section: "4.2" }
+```
+
+## 2. Log-derived alert (`.abandoned`)
+
+The drain-loop **abandoned** signal is a structured warning log,
+not an OTel counter (see RUNBOOK §1.2). LogQL example for a
+Loki-backed stack:
+
+```logql
+sum(count_over_time({app="b3-trading-host"}
+    |= "fixp.outbound.drain.shutdown.abandoned" [5m])) > 0
+```
+
+Translate the selector to your aggregator. Recommended
+AlertManager wiring:
+
+| Field | Value |
+|---|---|
+| Severity | `page` |
+| Subsystem | `fixp-listener` |
+| For | immediate (any occurrence) |
+| Runbook | [`../RUNBOOK.md#12-fixpoutbounddrainshutdownabandoned-warning-log`](../RUNBOOK.md#12-fixpoutbounddrainshutdownabandoned-warning-log) |
+
+Do **not** alert on the sibling `fixp.outbound.drain.shutdown.timeout`
+log line at page severity — that is the documented "deadline
+elapsed" path bounded by `OutboundDrainShutdownTimeout` (§1.3) and
+is recoverable by design.
+
+## 3. Summary table
+
+| Rule | Type | Severity | Source |
+|---|---|---|---|
+| `WsHubFanOutDropping` | Prometheus | page | PR #220 |
+| Drain `.abandoned` | log-derived | page | PR #219 |
+| `OutboundDrainShutdownTimeout` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #219 |
+| `GroupCommitMaxRecords` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #214 |

--- a/docs/perf-hardening-v0-results.md
+++ b/docs/perf-hardening-v0-results.md
@@ -261,6 +261,17 @@ that can carry it.
   pure measurement-and-documentation pass. All ~1 050 backend
   tests still pass on the underlying merge (`6c72880`).
 
+### What to watch in prod
+
+The metric / log / config surface introduced by the v0 fixes
+(WS hub fan-out drops, FIXP outbound drain shutdown,
+`GroupCommitMaxRecords`, `OutboundDrainShutdownTimeout`) is
+documented in [`RUNBOOK.md`](RUNBOOK.md) §1, with concrete
+Prometheus + log-derived alert rules in
+[`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md). Operators
+deploying a build that includes the perf-hardening v0 wave
+(P1–P14) should wire those alerts before promoting to prod.
+
 ### Recommended next step before declaring v0 fully signed off
 
 Re-run the full §7.3 composite scenario on a host that can carry


### PR DESCRIPTION
Closes #231.

Doc-heavy ship of the observability surface for the perf-hardening v0 wave (P1–P14). No production code changes — metric/log/option names cross-checked against `MetricsRegistry.cs`, `FixpOutboundChannelWriter.cs`, `EntryPointListenerOptions.cs`, and `PersistenceOptions.cs`.

## New / modified docs

| File | Change |
|---|---|
| `docs/RUNBOOK.md` | **new** — top-level runbook; §1 "Perf hardening v0 — what to watch" |
| `docs/ops/perf-v0-alerts.md` | **new** — Prometheus rule group + LogQL alert |
| `docs/README.md` | linked both new docs under "Operations / Runbooks" |
| `docs/perf-hardening-v0-results.md` | added "What to watch in prod" subsection pointing at RUNBOOK §1 |

## Coverage of issue #231 table

| Item | Source PR | RFC | Documented in |
|---|---|---|---|
| `trading.dispatcher.ws_fanout_dropped` (`MetricsRegistry.WsHubFanOutDropped`) | #220 | §5.2 | RUNBOOK §1.1 + alert `WsHubFanOutDropping` (page) |
| `fixp.outbound.drain.shutdown.abandoned` | #219 | §5.3.2 | RUNBOOK §1.2 + log-derived alert (page) |
| `OutboundDrainShutdownTimeout` (default 1s) | #219 | §5.3.2 | RUNBOOK §1.3 + drift-detection note |
| `Trading:Persistence:GroupCommitMaxRecords` (default 512) | #214 | §4.2 | RUNBOOK §1.4 + drift-detection note |

## Notable findings during the pass

- `fixp.outbound.drain.shutdown.abandoned` is currently emitted as a structured **warning log**, not an OTel counter. The issue body listed it as a metric; the runbook documents the actual surface (log) and flags the counter as a follow-up.
- `trading.dispatcher.ws_fanout_dropped` fires when the **single** `WebSocketExecutionEventSink` dispatcher→drain channel overflows, not per-subscriber. Individual slow WS clients are detected on their own per-client channel (`SubscribedClient.Enqueue`'s `slow_consumer_resync_required` path) without bumping this metric. Triage steps in §1.1 reflect that.
- Config-drift alerts for `OutboundDrainShutdownTimeout` and `GroupCommitMaxRecords` would require `build-info`-style gauges that the trading-host does **not** emit today. Inline runtime rules would silently never fire; instead the doc points operators at deploy-time CI checks and ships a commented-out skeleton for when the gauges land.

## Code-review pass

Mandatory `gpt-5.5` `agent_type: code-review` pass run on the diff. Two Medium findings, both addressed in this branch:

- **WS fan-out triage pointed at the wrong bottleneck** → §1.1 rewritten to describe the single-drain semantics; mitigation now starts from producer-rate / runtime stalls rather than per-client triage.
- **Inert drift rules would never fire** → drift rules removed from the active rule group, replaced with a "deferred" subsection that explains the missing gauge and shows a commented-out skeleton.

## Follow-ups (to file as separate issues)

1. Add an OTel `Counter<long>` mirror for `fixp.outbound.drain.shutdown.abandoned` so the page-severity alert can be Prometheus-native.
2. Emit `build-info`-style gauges for `OutboundDrainShutdownTimeout` and `GroupCommitMaxRecords` so the drift alerts can be enabled.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>