### PR TITLE
perf(bench): harness v2 — real-disk fsync mode + live-socket router bench (#228)

### DIFF
--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_LiveSocket_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_LiveSocket_Bench.cs
@@ -1,0 +1,339 @@
+using System.Net;
+using System.Net.Sockets;
+
+using BenchmarkDotNet.Attributes;
+
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Benchmarks.Benches;
+
+/// <summary>
+/// Harness v2 (#228) live-socket variant of <see cref="BotErRouter_RouteOne_Bench"/>.
+/// The original bench used an in-process <c>CountingSender</c> stub, which means
+/// PRs that touched the per-connection writer Task (P8 / #202) and the
+/// <see cref="Socket.NoDelay"/> flag (P11) could not measure the change
+/// against a baseline that actually went through the production wire path.
+///
+/// <para>This bench keeps everything from the in-process variant (router,
+/// coordinator, per-credential <see cref="BotOutboundBuffer"/>, ownership
+/// rules from P7 / PR #218) and only swaps the sender: each
+/// <see cref="MappedCredentials"/> credential gets its own ephemeral TCP
+/// loopback connection (<see cref="TcpListener"/> bound to
+/// <c>IPAddress.Loopback:0</c>) and a real
+/// <see cref="FixpOutboundChannelWriter"/> drain loop (one Task per
+/// connection — the P8 invariant) writing into the connected socket with
+/// <see cref="Socket.NoDelay"/> enabled (P11).</para>
+///
+/// <para><b>Receive side.</b> Each accepted server-side socket is drained
+/// into a discard buffer by a per-connection background read loop so the
+/// kernel send buffer never back-pressures the writer (which would turn
+/// the bench into a measure of TCP buffer sizing rather than the writer
+/// loop). Bytes received are not parsed — the bench just needs to ensure
+/// the writer's <c>WriteAsync</c> consistently completes.</para>
+///
+/// <para><b>Completion signal.</b> Each iteration counts frames the drain
+/// callback has actually completed writing to the wire, NOT
+/// <c>TryEnqueue</c> returns. <see cref="RouteBatch"/> spin-waits until
+/// that counter reaches <see cref="BatchSize"/>, with a 30 s deadline so a
+/// regression that stalls the writer surfaces as a loud
+/// <see cref="TimeoutException"/> instead of a hung benchmark process.
+/// BenchmarkDotNet handles statistics — the writer's iteration count and
+/// warmup are kept on BDN defaults so the spin-wait never gates the
+/// statistical confidence intervals.</para>
+///
+/// <para><b>Lifecycle.</b> <see cref="GlobalSetup"/> binds the listener,
+/// connects every client, sets <see cref="Socket.NoDelay"/>, starts each
+/// per-connection drain loop and the receive-side discard loop.
+/// <see cref="GlobalCleanup"/> disposes every writer (which drains then
+/// closes the socket), tears down the receive loops, and disposes the
+/// listener. No port is held past <see cref="GlobalCleanup"/> — the OS
+/// reclaims the ephemeral port as soon as the listener and the
+/// connected sockets are closed.</para>
+///
+/// <para><b>Single-machine loopback caveat.</b> This is still a single-host
+/// loopback — kernel TCP fast-path, no NIC / wire latency. Cross-host
+/// numbers are #207 / load-test territory; see the bench README "Known
+/// limitations" section.</para>
+/// </summary>
+[MemoryDiagnoser]
+public class BotErRouter_RouteOne_LiveSocket_Bench
+{
+    [Params(64, 1024)]
+    public int BatchSize { get; set; }
+
+    [Params(1, 16)]
+    public int MappedCredentials { get; set; }
+
+    private BotErMultiplexer _mux = null!;
+    private CancellationTokenSource _cts = null!;
+    private FakeMappingRegistry _mappings = null!;
+    private BotOutboundCoordinator _coord = null!;
+
+    private TcpListener _listener = null!;
+    private CancellationTokenSource _acceptCts = null!;
+    private LiveSocketSender[] _senders = null!;
+    private TcpClient[] _serverSides = null!;
+    private Task[] _serverDrainTasks = null!;
+    private Guid[] _credIds = null!;
+    private ulong[] _internalIds = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+
+        var sessions = new InMemoryUserBotSessionRegistry();
+        var directory = new BotSessionConnectionDirectory();
+        _mappings = new FakeMappingRegistry();
+
+        _credIds = new Guid[MappedCredentials];
+        _senders = new LiveSocketSender[MappedCredentials];
+        _serverSides = new TcpClient[MappedCredentials];
+        _serverDrainTasks = new Task[MappedCredentials];
+        _internalIds = new ulong[BatchSize];
+        _acceptCts = new CancellationTokenSource();
+
+        for (var i = 0; i < MappedCredentials; i++)
+        {
+            _credIds[i] = Guid.NewGuid();
+            await sessions.GetOrCreateAsync(_credIds[i], default).ConfigureAwait(false);
+
+            // Connect client + accept server in parallel; await both.
+            var client = new TcpClient();
+            var connectTask = client.ConnectAsync(endpoint.Address, endpoint.Port);
+            var acceptTask = _listener.AcceptTcpClientAsync(_acceptCts.Token).AsTask();
+            await Task.WhenAll(connectTask, acceptTask).ConfigureAwait(false);
+
+            client.NoDelay = true;            // P11
+            var server = acceptTask.Result;
+            server.NoDelay = true;            // symmetric, mirrors prod tuning
+            _serverSides[i] = server;
+
+            // Per-connection server-side discard loop. Without this the
+            // writer would block once kernel send buffer fills.
+            _serverDrainTasks[i] = Task.Run(() => DiscardLoopAsync(server, _acceptCts.Token));
+
+            var sender = new LiveSocketSender(
+                client,
+                channelCapacity: Math.Max(8192, BatchSize * 4),
+                connectionId: $"bench-{i}");
+            _senders[i] = sender;
+            directory.Register(_credIds[i], sender);
+        }
+
+        for (var i = 0; i < BatchSize; i++)
+        {
+            var internalId = (ulong)(i + 1);
+            _internalIds[i] = internalId;
+            var cred = _credIds[i % MappedCredentials];
+            _mappings.Add(internalId, cred, externalId: 1_000_000UL + internalId);
+        }
+
+        var opts = Options.Create(new BotErMultiplexerOptions
+        {
+            OutboundBufferMaxMessages = Math.Max(8192, BatchSize * 4),
+        });
+        _coord = new BotOutboundCoordinator(sessions, opts.Value);
+        _mux = new BotErMultiplexer(_mappings, sessions, directory, _coord,
+            NullLogger<BotErMultiplexer>.Instance, opts);
+
+        _cts = new CancellationTokenSource();
+        await _mux.StartAsync(_cts.Token).ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        try { await _mux.StopAsync(CancellationToken.None).ConfigureAwait(false); }
+        catch { /* best-effort */ }
+
+        // Stop accepting new connections + cancel discard loops.
+        try { _acceptCts.Cancel(); } catch { /* ignore */ }
+
+        if (_senders is not null)
+        {
+            foreach (var s in _senders)
+            {
+                try { await s.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort */ }
+            }
+        }
+
+        if (_serverSides is not null)
+        {
+            foreach (var s in _serverSides)
+            {
+                try { s.Close(); } catch { /* ignore */ }
+            }
+        }
+
+        if (_serverDrainTasks is not null)
+        {
+            try { await Task.WhenAll(_serverDrainTasks).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false); }
+            catch { /* best-effort — discard loops exit on socket close */ }
+        }
+
+        try { _listener.Stop(); } catch { /* ignore */ }
+        _acceptCts.Dispose();
+        _cts.Dispose();
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Mirror the in-process bench: reset per-iteration counters AND
+        // the per-credential outbound buffers. Without the buffer reset
+        // BotOutboundBuffer would permanently mark itself overflowed
+        // mid-run and silently make Route skip TryEnqueue, hanging the
+        // spin-wait in RouteBatch.
+        foreach (var s in _senders) s.ResetCounter();
+        foreach (var credId in _credIds) _coord.GetOrCreateBuffer(credId).Reset();
+    }
+
+    [Benchmark]
+    public void RouteBatch()
+    {
+        for (var i = 0; i < BatchSize; i++)
+        {
+            _mux.Route(NewEvent(_internalIds[i]));
+        }
+
+        var deadline = Environment.TickCount64 + 30_000;
+        var spin = new SpinWait();
+        while (TotalDrained() < BatchSize)
+        {
+            if (Environment.TickCount64 > deadline)
+            {
+                throw new TimeoutException(
+                    $"RouteBatch live-socket drain stalled at {TotalDrained()}/{BatchSize} after 30s");
+            }
+            spin.SpinOnce();
+        }
+    }
+
+    private int TotalDrained()
+    {
+        var sum = 0;
+        foreach (var s in _senders) sum += s.DrainedCount;
+        return sum;
+    }
+
+    private static ExecutionEvent NewEvent(ulong clOrdId) =>
+        new(
+            Owner: new EndClientId("u1"),
+            ClOrdId: clOrdId,
+            Symbol: "PETR4",
+            Side: OrderSide.Buy,
+            Status: OrderStatus.Working,
+            Kind: ExecKind.New,
+            LeavesQuantity: 100,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            TimestampUtc: DateTimeOffset.UtcNow);
+
+    private static async Task DiscardLoopAsync(TcpClient server, CancellationToken ct)
+    {
+        var buf = new byte[8 * 1024];
+        try
+        {
+            var stream = server.GetStream();
+            while (!ct.IsCancellationRequested)
+            {
+                var n = await stream.ReadAsync(buf, ct).ConfigureAwait(false);
+                if (n == 0) return; // peer closed
+            }
+        }
+        catch { /* socket closed / cancelled — exit */ }
+    }
+
+    /// <summary>
+    /// Thin <see cref="IBotSessionOutboundSender"/> that owns one TCP
+    /// connection and one <see cref="FixpOutboundChannelWriter"/> drain
+    /// loop, mirroring the production
+    /// <c>FixpSessionConnection.IBotSessionOutboundSender.TryEnqueue</c>
+    /// path. Counts frames the drain loop has actually written to the
+    /// wire so the bench can wait on real throughput, not enqueue
+    /// success.
+    /// </summary>
+    private sealed class LiveSocketSender : IBotSessionOutboundSender, IAsyncDisposable
+    {
+        private readonly TcpClient _client;
+        private readonly NetworkStream _stream;
+        private readonly FixpOutboundChannelWriter _writer;
+        private int _drained;
+
+        public LiveSocketSender(TcpClient client, int channelCapacity, string connectionId)
+        {
+            _client = client;
+            _stream = client.GetStream();
+            _writer = new FixpOutboundChannelWriter(
+                capacity: channelCapacity,
+                writeAsync: WriteAsync,
+                connectionId: connectionId,
+                logger: null);
+        }
+
+        public int DrainedCount => Volatile.Read(ref _drained);
+        public void ResetCounter() => Volatile.Write(ref _drained, 0);
+
+        public bool TryEnqueue(OutboundFrame frame) => _writer.TryEnqueue(frame);
+
+        private async ValueTask<bool> WriteAsync(ReadOnlyMemory<byte> bytes, CancellationToken ct)
+        {
+            try
+            {
+                await _stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+                Interlocked.Increment(ref _drained);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { await _writer.CompleteAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false); }
+            catch { /* best-effort */ }
+            try { _stream.Close(); } catch { /* ignore */ }
+            try { _client.Close(); } catch { /* ignore */ }
+        }
+    }
+
+    private sealed class FakeMappingRegistry : IUserBotOrderMappingRegistry
+    {
+        private readonly Dictionary<ulong, OrderMapping> _orders = new();
+
+        public void Add(ulong internalId, Guid credId, ulong externalId)
+            => _orders[internalId] = new OrderMapping(credId, externalId);
+
+        public bool TryGetOrderMapping(ulong internalClOrdId, out OrderMapping mapping)
+            => _orders.TryGetValue(internalClOrdId, out mapping);
+
+        public bool TryGetByExternal(Guid credentialId, ulong externalClOrdId, out ulong internalClOrdId)
+        { internalClOrdId = 0; return false; }
+        public bool TryGetCancelMapping(ulong cancelInternalClOrdId, out CancelMapping mapping)
+        { mapping = default; return false; }
+        public void Reap(ulong internalClOrdId) { }
+        public void ReapCancel(ulong cancelInternalClOrdId) { }
+        public void RegisterOrderInternal(ulong internalClOrdId, Guid credentialId, ulong externalClOrdId) { }
+        public void RegisterCancelInternal(ulong c, ulong o, Guid g, ulong e) { }
+        public IReadOnlyList<BotOrderMappingSnapshot> SnapshotOrders() => Array.Empty<BotOrderMappingSnapshot>();
+        public IReadOnlyList<BotCancelMappingSnapshot> SnapshotCancels() => Array.Empty<BotCancelMappingSnapshot>();
+        public BotOrderMappingRaw[] RawSnapshotOrders() => Array.Empty<BotOrderMappingRaw>();
+        public BotCancelMappingRaw[] RawSnapshotCancels() => Array.Empty<BotCancelMappingRaw>();
+        public void Restore(IEnumerable<BotOrderMappingSnapshot> orders, IEnumerable<BotCancelMappingSnapshot> cancels) { }
+    }
+}

--- a/backend/bench/B3.Trading.Benchmarks/Benches/WAL_Append_Flush_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/WAL_Append_Flush_Bench.cs
@@ -9,15 +9,30 @@ namespace B3.Trading.Benchmarks.Benches;
 
 /// <summary>
 /// RFC §7.1 — baseline for the WAL append + group-commit path that
-/// F1/F7 target. Runs against tmpfs (<c>/dev/shm</c>) when available so
-/// disk seek latency does not dominate; falls back to
-/// <see cref="Path.GetTempPath"/> on platforms without a RAM-disk
-/// (Windows CI). The bench data dir is created per-iteration in
-/// <see cref="GlobalSetup"/> and torn down in <see cref="GlobalCleanup"/>.
+/// F1/F7 target. Harness v2 (#228) parametrises the WAL data root so
+/// the same bench gates both the no-fsync ceiling (tmpfs) and the
+/// real-disk fsync path (P5 #199).
+///
+/// <para><b>DataRoot semantics.</b>
+/// <list type="bullet">
+///   <item><c>/dev/shm</c> — Linux tmpfs. <c>fsync</c> is effectively a
+///     no-op here, so this measures the in-process append + group-commit
+///     ceiling, NOT the fsync cost. Numbers from this row are <i>not</i>
+///     comparable with disk-backed rows.</item>
+///   <item><c>/tmp</c> (or any disk-backed path) — exercises the real
+///     <c>fsync</c> path. This is the row P5 (#199) gates against; PR #214
+///     could not see a delta because only the tmpfs row was measured.</item>
+/// </list>
+/// The defaults are <c>/dev/shm</c> + <c>/tmp</c>; CI/operators can override
+/// the matrix with <c>B3_BENCH_WAL_PATHS=/dev/shm,/tmp,/var/lib/b3</c>
+/// (comma-separated, evaluated at process start by
+/// <see cref="DataRootValuesProvider"/>). Paths whose parent directory
+/// does not exist are skipped silently to keep the matrix portable.
+/// </para>
 ///
 /// <para>Acceptance gate (RFC §7.3 / F7): post-fix saturated Append rate
-/// must be ≥4× baseline. P5/P8 PRs record before/after numbers in their
-/// bodies referencing this bench by name.</para>
+/// must be ≥4× baseline on the real-disk row. P5/P8 PRs record before/after
+/// numbers in their bodies referencing this bench by name.</para>
 /// </summary>
 [MemoryDiagnoser]
 public class WAL_Append_Flush_Bench
@@ -30,6 +45,56 @@ public class WAL_Append_Flush_Bench
     [Params(1, 64)]
     public int BatchSize { get; set; }
 
+    /// <summary>
+    /// WAL data root. See class doc for semantics. Populated by
+    /// <see cref="DataRootValuesProvider"/> from
+    /// <c>B3_BENCH_WAL_PATHS</c> or, when unset, from
+    /// <see cref="DefaultDataRoots"/>.
+    /// </summary>
+    [ParamsSource(nameof(DataRootValues))]
+    public string DataRoot { get; set; } = null!;
+
+    /// <summary>
+    /// Defaults when <c>B3_BENCH_WAL_PATHS</c> is not set: tmpfs (no-fsync
+    /// ceiling) + a disk-backed path (real fsync). Filtered to existing
+    /// roots at enumeration time so Windows CI silently degrades to
+    /// <see cref="Path.GetTempPath"/>.
+    /// </summary>
+    private static readonly string[] DefaultDataRoots =
+        new[] { "/dev/shm", "/tmp" };
+
+    /// <summary>
+    /// BenchmarkDotNet picks up <c>[ParamsSource]</c> values from a
+    /// public property/field; this exposes the resolved list (env-var
+    /// overridable) to the runtime.
+    /// </summary>
+    public static IEnumerable<string> DataRootValues => DataRootValuesProvider();
+
+    private static IEnumerable<string> DataRootValuesProvider()
+    {
+        var env = Environment.GetEnvironmentVariable("B3_BENCH_WAL_PATHS");
+        IEnumerable<string> candidates = !string.IsNullOrWhiteSpace(env)
+            ? env.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : DefaultDataRoots;
+
+        var any = false;
+        foreach (var c in candidates)
+        {
+            if (Directory.Exists(c))
+            {
+                any = true;
+                yield return c;
+            }
+        }
+
+        // Last-resort fallback so the bench class is always runnable
+        // (e.g. Windows CI where neither /dev/shm nor /tmp exist).
+        if (!any)
+        {
+            yield return Path.GetTempPath();
+        }
+    }
+
     private FileEventStore _store = null!;
     private string _dataDir = null!;
     private WalEvent _evt = null!;
@@ -37,8 +102,7 @@ public class WAL_Append_Flush_Bench
     [GlobalSetup]
     public void Setup()
     {
-        var root = Directory.Exists("/dev/shm") ? "/dev/shm" : Path.GetTempPath();
-        _dataDir = Path.Combine(root, "b3-bench-wal-" + Guid.NewGuid().ToString("N"));
+        _dataDir = Path.Combine(DataRoot, "b3-bench-wal-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_dataDir);
 
         var opts = new PersistenceOptions

--- a/backend/bench/B3.Trading.Benchmarks/README.md
+++ b/backend/bench/B3.Trading.Benchmarks/README.md
@@ -13,16 +13,74 @@ run on developer hardware (or in a future labelled-dispatch job).
 
 ## Registered benchmarks
 
-| Class                                  | Hot path                                                       | Acceptance gate (RFC §7.3) |
-| -------------------------------------- | -------------------------------------------------------------- | -------------------------- |
-| `EventDispatcher_Dispatch_Bench`       | `EventDispatcher.Dispatch` against `NullEventStore`            | F1 — ≥3× ops/s, alloc −50% |
-| `WAL_Append_Flush_Bench`               | `FileEventStore.Append` + group-commit `FlushAsync` (tmpfs)    | F7 — Append rate ≥4×       |
-| `OutboundExecutionReportEncoder_Bench` | `OutboundExecutionReportEncoder.Encode` per `ExecKind`         | F5 — Gen0 −80%             |
-| `BotErRouter_RouteOne_Bench`           | `BotErMultiplexer.Route` end-to-end (drain + encode + send)    | F4/F5 — alloc −95%, no throughput regression |
+| Class                                       | Hot path                                                                  | Optimisation gated                | Issues / PRs |
+| ------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------- | ------------ |
+| `EventDispatcher_Dispatch_Bench`            | `EventDispatcher.Dispatch` against `NullEventStore`                       | F1 — ≥3× ops/s, alloc −50%        | #194, PR #213 |
+| `WAL_Append_Flush_Bench`                    | `FileEventStore.Append` + group-commit `FlushAsync`, parametrised by data root (tmpfs **and** real-disk; harness v2) | F7 Append rate ≥4×; **P5 fsync tuning** | #199, PR #214, #228 |
+| `OutboundExecutionReportEncoder_Bench`      | `OutboundExecutionReportEncoder.Encode` per `ExecKind`                    | F5 — Gen0 −80%                    | #194, PR #213 |
+| `BotErRouter_RouteOne_Bench`                | `BotErMultiplexer.Route` end-to-end with in-process `CountingSender` stub | F4/F5 — alloc −95%, no throughput regression | #194, PR #213, PR #218 |
+| `BotErRouter_RouteOne_LiveSocket_Bench`     | Same as above, but every credential gets a real TCP loopback connection + `FixpOutboundChannelWriter` drain loop with `Socket.NoDelay` (harness v2) | **P8 per-conn writer Task.Run removal** (#202, PR #219) and **P11 Socket.NoDelay** | #228 |
 
-`OutboundExecutionReportEncoder.Encode` is `internal`; this project is
-granted access via `InternalsVisibleTo` on
-`backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj`.
+`OutboundExecutionReportEncoder.Encode` and `FixpOutboundChannelWriter`
+are `internal`; this project is granted access via
+`InternalsVisibleTo` on
+`backend/src/B3.Trading.EntryPointListener/B3.Trading.EntryPointListener.csproj`
+and `backend/src/B3.Trading.Application/B3.Trading.Application.csproj`.
+
+### Harness v2 (#228) — what changed
+
+PRs #214 (P5, fsync tuning) and #219 (P8, per-conn writer
+`Task.Run` removal) hit the same wall: the v1 harness measured the
+optimisation on a path that bypassed the change.
+
+- `WAL_Append_Flush_Bench` ran exclusively against `/dev/shm`,
+  where `fsync` is effectively a no-op, so #199's tuning came out
+  inside the noise floor.
+- `BotErRouter_RouteOne_Bench` used an in-process `CountingSender`,
+  so #202's removal of the per-message `Task.Run` and #211's
+  `Socket.NoDelay` flag were never actually exercised.
+
+Harness v2 fixes both:
+
+1. `WAL_Append_Flush_Bench` now has a `[ParamsSource]` over data
+   roots. Defaults are `/dev/shm` (no-fsync ceiling) **and**
+   `/tmp` (real fsync). `/dev/shm` rows are explicitly the
+   no-fsync ceiling and are NOT comparable with disk-backed rows.
+2. `BotErRouter_RouteOne_LiveSocket_Bench` is the new live-socket
+   variant (one ephemeral TCP loopback connection per credential,
+   real `FixpOutboundChannelWriter` drain loop, `Socket.NoDelay`
+   set on both ends). Iterations count frames the drain callback
+   has actually written to the wire, not enqueue success.
+
+### Overriding the WAL data-root matrix
+
+Operators / CI can extend the matrix without code change:
+
+```sh
+# Add a real SSD path alongside the defaults
+B3_BENCH_WAL_PATHS=/dev/shm,/tmp,/var/lib/b3 \
+  dotnet run -c Release --project backend/bench/B3.Trading.Benchmarks -- \
+  --filter '*WAL_Append_Flush_Bench*'
+```
+
+Comma-separated, trimmed, evaluated at process start. Paths whose
+parent directory does not exist are silently skipped so the bench
+class stays portable (Windows CI degrades to
+`Path.GetTempPath()`).
+
+### Known limitations
+
+- The live-socket bench is **single-machine loopback** — kernel TCP
+  fast path, no NIC / wire latency. Cross-host behaviour (jumbo
+  frames, MTU, real switch latency) is out of scope here and
+  belongs to the load-test harness (#207) and the §7.3 composite
+  scenario in `docs/perf-hardening-v0-results.md`.
+- Bench harness is excluded from CI: `IsPackable=false`, no test
+  runner integration, no `.github/workflows/` job. It runs on
+  developer hardware (or a future labelled-dispatch job).
+- `/dev/shm` rows of the WAL bench are the no-fsync ceiling; do
+  not compare them with disk-backed rows when sizing fsync
+  budgets.
 
 ## Running
 
@@ -52,9 +110,12 @@ with these settings:
 - **Build:** `dotnet build -c Release` against the bench project.
 - **Process isolation:** close other CPU-heavy work; pin to performance
   governor on Linux (`cpupower frequency-set -g performance`).
-- **WAL bench:** uses `/dev/shm` when present (Linux). On platforms
-  without a RAM-disk it falls back to `Path.GetTempPath()`; numbers from
-  those runs are NOT comparable with tmpfs runs and must be flagged.
+- **WAL bench:** the data-root matrix is parametrised. Defaults
+  to `/dev/shm` + `/tmp`; override with
+  `B3_BENCH_WAL_PATHS=...` (see "Overriding the WAL data-root
+  matrix" above). Compare like with like — `/dev/shm` rows are
+  the no-fsync ceiling and must not be benchmarked against
+  disk-backed rows.
 - **Process count:** the default `Job` already runs benchmarks in a
   child process per benchmark for isolation — leave it alone unless you
   have a specific reason.

--- a/docs/perf-hardening-v0-results.md
+++ b/docs/perf-hardening-v0-results.md
@@ -284,3 +284,18 @@ to this document under a "§6 production-host re-run" section and
 flip the §4 verdict accordingly. Until that happens the v0
 composite-gate sign-off remains **provisional**: capacity demonstrated,
 strict driven-rate gate pending production-host evaluation.
+
+## Appendix — re-bench with harness v2 (#228)
+
+Bench-harness v2 closes the v1 gaps that PR #214 (P5 fsync) and PR #219 (P8 per-conn writer) flagged. Runner: AMD EPYC 7763, .NET 10.0.5 Server GC, `--job Short` (3 warmup / 3 iterations).
+
+**P5 — `WAL_Append_Flush_Bench`, real-disk row (`/tmp`)**
+- `BatchSize=1   /dev/shm` 12.52 ms · `/tmp` 14.42 ms (+15 %)
+- `BatchSize=64  /dev/shm` 12.13 ms · `/tmp` 15.86 ms (+31 %)
+- The disk-backed row is the one P5 (#199) is allowed to gate against; tmpfs remains the no-fsync ceiling.
+
+**P8 — `BotErRouter_RouteOne_LiveSocket_Bench` (real TCP loopback, `Socket.NoDelay`)**
+- `BatchSize=64  Creds=1`  2.40 ms · `Creds=16` 2.09 ms
+- `BatchSize=1024 Creds=1` 11.61 ms · `Creds=16` 2.91 ms
+
+ShortRun confidence intervals are wide (BDN warns) — these numbers exist to validate the harness, not to re-open the §4 verdict. Full-Default-job comparisons against `main` belong in per-fix PRs that touch the relevant hot path.


### PR DESCRIPTION
Closes #228.

## Why

Two gaps in harness v1 made the relevant optimisations un-measurable:

- `WAL_Append_Flush_Bench` ran exclusively on `/dev/shm` (tmpfs → `fsync` is a no-op), so PR #214 (P5 / #199 fsync tuning) saw its delta inside the noise floor.
- `BotErRouter_RouteOne_Bench` used an in-process `CountingSender` stub, so PR #219 (P8 / #202 per-conn writer `Task.Run` removal) and #211's `Socket.NoDelay` were never actually exercised.

## What

1. **`WAL_Append_Flush_Bench`** now has `[ParamsSource(nameof(DataRootValues))]` over the data root. Defaults to `/dev/shm` (no-fsync ceiling) + `/tmp` (real fsync). Operators/CI can override with `B3_BENCH_WAL_PATHS=/dev/shm,/tmp,/var/lib/b3`. Non-existing paths are silently skipped; Windows degrades to `Path.GetTempPath()`. `/dev/shm` rows remain the no-fsync ceiling and must not be compared with disk-backed rows.
2. **`BotErRouter_RouteOne_LiveSocket_Bench`** (new) — one ephemeral TCP loopback connection per mapped credential, `TcpListener(IPAddress.Loopback, 0)`. Both client + server sockets get `Socket.NoDelay = true` (P11). Each sender wraps the production `FixpOutboundChannelWriter` so the P8 per-conn drain loop is the real hot path. A per-connection server-side discard loop drains kernel buffers so the writer never back-pressures. Iterations count frames the drain callback has actually written to the wire, not enqueue success. 30 s spin-wait deadline turns a regression into a loud `TimeoutException` instead of a hung benchmark process. Ownership rules from P7/PR #218 preserved (drain callback only borrows `frame.Bytes`).
3. **README v2** — matrix of bench classes → optimisation gated → issue/PR links; env-var override docs; known limitations (single-machine loopback; cross-host is #207 / load-test territory).
4. **`docs/perf-hardening-v0-results.md`** — appendix with the re-bench numbers below.

No production code changes. `FixpOutboundChannelWriter` is `internal`; access via the existing `InternalsVisibleTo "B3.Trading.Benchmarks"` (pattern from PR #213).

## Bench harness — dry runs (smoke)

`WAL_Append_Flush_Bench --job Dry`:

| Method | BatchSize | DataRoot | Mean | Allocated |
| --- | --- | --- | --- | --- |
| AppendBatchThenFlush | 1   | /dev/shm | 120.8 ms |  2.01 KB |
| AppendBatchThenFlush | 1   | /tmp     | 127.2 ms |  2.01 KB |
| AppendBatchThenFlush | 64  | /dev/shm | 127.8 ms | 34.16 KB |
| AppendBatchThenFlush | 64  | /tmp     | 135.1 ms |    34 KB |

`BotErRouter_RouteOne_LiveSocket_Bench --job Dry`:

| Method | BatchSize | MappedCredentials | Mean | Allocated |
| --- | --- | --- | --- | --- |
| RouteBatch |  64  |  1 |  9.57 ms |  29.48 KB |
| RouteBatch |  64  | 16 | 10.97 ms |  31.75 KB |
| RouteBatch | 1024 |  1 | 19.25 ms | 595.82 KB |
| RouteBatch | 1024 | 16 | 11.33 ms | 638.35 KB |

## Re-bench (`--job Short`, AMD EPYC 7763, .NET 10.0.5 Server GC) — validates harness produces meaningful numbers

`WAL_Append_Flush_Bench` (P5):

| Method | BatchSize | DataRoot | Mean |
| --- | --- | --- | --- |
| AppendBatchThenFlush | 1  | /dev/shm | 12.52 ms |
| AppendBatchThenFlush | 1  | /tmp     | 14.42 ms (+15 %) |
| AppendBatchThenFlush | 64 | /dev/shm | 12.13 ms |
| AppendBatchThenFlush | 64 | /tmp     | 15.86 ms (+31 %) |

`BotErRouter_RouteOne_LiveSocket_Bench` (P8):

| Method | BatchSize | MappedCredentials | Mean |
| --- | --- | --- | --- |
| RouteBatch |  64  |  1 |  2.40 ms |
| RouteBatch |  64  | 16 |  2.09 ms |
| RouteBatch | 1024 |  1 | 11.61 ms |
| RouteBatch | 1024 | 16 |  2.91 ms |

ShortRun CIs are wide (BDN warns); these numbers exist to validate the harness, not to re-open the §4 verdict. Full-Default-job head-to-head against `main` belongs to per-fix PRs touching the relevant hot path.

## New bench classes

- `BotErRouter_RouteOne_LiveSocket_Bench` (live TCP loopback + `FixpOutboundChannelWriter` + `Socket.NoDelay`)

## Bench-matrix table

(see `backend/bench/B3.Trading.Benchmarks/README.md` for the canonical version, including links to per-optimisation issues/PRs)

## Constraints honoured

- Bench harness still excluded from CI (`IsPackable=false`, no test-runner integration).
- No production code changes; no new `InternalsVisibleTo` needed (existing pattern from PR #213 already covers `FixpOutboundChannelWriter`).
- Central package management — no `Version=` in csproj.
- All ~1030 backend tests pass (53 + 23 + 207 + 119 + 628 = 1030 across Domain / SimulatorBot / Api / EntryPointListener / Application; Conformance suite 18 skipped as usual).
- `dotnet format --verify-no-changes` clean.

## Review

gpt-5.5 code-review pass — no High issues. Reviewer specifically verified (a) socket lifecycle (no port leak, no leaked discard task, listener stopped, server-side closed, `FixpOutboundChannelWriter.CompleteAsync` bounded by 2 s timeout) and (b) no timing-dependent assertions in the hot path; BDN defaults govern iteration/warmup.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
