### PR TITLE
perf(er): eliminate OutboundFrame wrapper allocation (#230)

### DIFF
--- a/backend/src/B3.Trading.Application/UserBots/BotOutboundBuffer.cs
+++ b/backend/src/B3.Trading.Application/UserBots/BotOutboundBuffer.cs
@@ -101,7 +101,6 @@ public sealed class BotOutboundBuffer
     /// </summary>
     public bool Append(ulong seq, OutboundFrame frame)
     {
-        ArgumentNullException.ThrowIfNull(frame);
         lock (_gate)
         {
             if (_overflowed)

--- a/backend/src/B3.Trading.Application/UserBots/OutboundFrame.cs
+++ b/backend/src/B3.Trading.Application/UserBots/OutboundFrame.cs
@@ -3,96 +3,139 @@ using System.Buffers;
 namespace B3.Trading.Application.UserBots;
 
 /// <summary>
-/// RFC §5.5 (P7 / F5). Wraps a SOFH-framed outbound application
-/// message together with optional ownership of the pooled memory it
-/// lives in. Encoders rent from a <see cref="MemoryPool{T}"/>, write
-/// the frame in-place, and hand the resulting <see cref="OutboundFrame"/>
-/// to <see cref="BotOutboundBuffer.Append"/>. From that point on, the
-/// per-credential buffer is the <b>sole</b> owner of the pooled memory
-/// and is responsible for its eventual disposal.
+/// RFC §5.5 / issue #230. Stack-only carrier for a SOFH-framed outbound
+/// application message together with optional ownership of a pooled
+/// <c>byte[]</c>. Encoders rent from
+/// <see cref="ArrayPool{T}.Shared"/>, write the frame in-place, and
+/// hand the resulting <see cref="OutboundFrame"/> to
+/// <see cref="BotOutboundBuffer.Append(ulong, OutboundFrame)"/>. From
+/// that point on, the per-credential buffer is the <b>sole</b> owner of
+/// the pooled array and is responsible for its eventual return to the
+/// pool.
+///
+/// <para><b>Wrapper allocation elimination (issue #230, post P7).</b>
+/// In P7 (#218) <c>OutboundFrame</c> was introduced as a <c>sealed
+/// class</c> wrapping <c>(IMemoryOwner&lt;byte&gt;?, ReadOnlyMemory&lt;byte&gt;)</c>.
+/// The combined per-encode overhead (the class + the
+/// <c>ArrayMemoryPoolBuffer</c> the <see cref="MemoryPool{T}.Shared"/>
+/// returns on every <c>Rent</c>) was ~64B. Issue #230 collapses both:
+/// (a) turns the wrapper into a <c>readonly struct</c>, passed by
+/// value through encoder → multiplexer → buffer / channel, stored
+/// inline in container slots; (b) replaces the <c>MemoryPool</c> hop
+/// with <see cref="ArrayPool{T}.Shared"/> directly, which returns the
+/// <c>byte[]</c> without an owner wrapper. Net: 0B managed per encode
+/// (the rented array itself comes from the pool's already-allocated
+/// inventory and does not register as a per-call allocation).</para>
 ///
 /// <para><b>Single-disposer rule (RFC §5.5 — non-negotiable).</b>
 /// <list type="bullet">
-///   <item>The buffer disposes the <see cref="Owner"/> exactly once,
-///         either when the frame's seq is evicted by an acked
+///   <item>The buffer returns the <see cref="PooledArray"/> exactly
+///         once, either when the frame's seq is evicted by an acked
 ///         watermark (<see cref="BotOutboundBuffer.EvictUpTo"/>) or
 ///         when an overflow / reset triggers a bulk clear.</item>
-///   <item><c>TryEnqueue</c> to the live socket NEVER disposes — it
+///   <item><c>TryEnqueue</c> to the live socket NEVER returns — it
 ///         only borrows <see cref="Bytes"/>.</item>
-///   <item>The drain loop NEVER disposes — same rule.</item>
+///   <item>The drain loop NEVER returns — same rule.</item>
 ///   <item>If <c>Append</c> rejects the frame (overflow / closed),
-///         <c>Append</c> itself disposes before returning.</item>
+///         <c>Append</c> itself returns the pooled array before
+///         returning <c>false</c>.</item>
 ///   <item>If a caller encodes but decides not to call <c>Append</c>,
-///         it must dispose the owner via <see cref="DisposeOwner"/>
-///         (test-only; no production code path needs this today
+///         it must release via <see cref="DisposeOwner"/> (test /
+///         bench only; no production code path needs this today
 ///         because <c>Route</c> always reaches <c>Append</c>).</item>
-/// </list></para>
+/// </list>
+/// Because the struct is passed by value, multiple copies of an
+/// <see cref="OutboundFrame"/> may exist in flight (one on the
+/// multiplexer's stack, one held by the buffer's <c>Entry</c>, one in
+/// the channel writer's array). Single-disposer is preserved by
+/// <b>policy</b>: only the per-credential buffer's stored copy is ever
+/// returned, and the return is serialised under the buffer's internal
+/// lock together with the entry's removal from the linked list, so no
+/// returned-copy is reachable afterwards. Channel-side and drain-loop
+/// copies never call <see cref="DisposeOwner"/>.</para>
 ///
 /// <para>By design <c>OutboundFrame</c> is <b>not</b>
 /// <see cref="IDisposable"/> — that prevents accidental
-/// <c>using</c>-blocking the frame mid-pipeline and double-freeing the
-/// pooled buffer. The <see cref="Owner"/> getter is <c>internal</c> to
-/// the <c>B3.Trading.Application</c> assembly so only the buffer can
-/// touch it; outside callers can only read <see cref="Bytes"/>.</para>
+/// <c>using</c>-blocking the frame mid-pipeline. <see cref="PooledArray"/>
+/// and <see cref="Pool"/> are <c>internal</c> to the
+/// <c>B3.Trading.Application</c> assembly so only the buffer can touch
+/// them; outside callers can only read <see cref="Bytes"/>.</para>
 ///
 /// <para>An <see cref="Unowned"/> variant exists for tests and legacy
 /// call sites whose bytes are not pooled (typically a heap-allocated
 /// <c>byte[]</c>). The buffer treats unowned frames identically except
-/// that there is nothing to dispose.</para>
+/// that there is nothing to return.</para>
 /// </summary>
-public sealed class OutboundFrame
+public readonly struct OutboundFrame
 {
-    private IMemoryOwner<byte>? _owner;
-
     /// <summary>The framed bytes ready for the socket.</summary>
     public ReadOnlyMemory<byte> Bytes { get; }
 
     /// <summary>
-    /// Pooled-memory owner, or <c>null</c> when the frame is unowned
-    /// (heap-backed). Internal so only the buffer assembly can hold it
-    /// — see the single-disposer rule above.
+    /// Pooled <c>byte[]</c> backing <see cref="Bytes"/>, or <c>null</c>
+    /// for unowned (heap-backed) frames. Internal so only the buffer
+    /// assembly can hold it — see the single-disposer rule above.
     /// </summary>
-    internal IMemoryOwner<byte>? Owner => _owner;
+    internal byte[]? PooledArray { get; }
 
-    private OutboundFrame(IMemoryOwner<byte>? owner, ReadOnlyMemory<byte> bytes)
+    /// <summary>
+    /// Array pool the <see cref="PooledArray"/> must be returned to,
+    /// or <c>null</c> for unowned frames. Carried alongside the array
+    /// so tests can swap in a tracking pool without static state.
+    /// </summary>
+    internal ArrayPool<byte>? Pool { get; }
+
+    private OutboundFrame(byte[]? array, ArrayPool<byte>? pool, ReadOnlyMemory<byte> bytes)
     {
-        _owner = owner;
+        PooledArray = array;
+        Pool = pool;
         Bytes = bytes;
     }
 
     /// <summary>
-    /// Wraps a freshly-rented <paramref name="owner"/> together with the
-    /// <paramref name="length"/>-byte slice the encoder filled in. The
-    /// returned frame transfers ownership to whoever ultimately calls
-    /// <see cref="BotOutboundBuffer.Append"/>.
+    /// Wraps a freshly-rented <paramref name="array"/> together with
+    /// the <paramref name="length"/>-byte slice the encoder filled in
+    /// and the <paramref name="pool"/> it came from. The returned
+    /// frame transfers ownership to whoever ultimately calls
+    /// <see cref="BotOutboundBuffer.Append(ulong, OutboundFrame)"/>.
     /// </summary>
-    public static OutboundFrame Pooled(IMemoryOwner<byte> owner, int length)
+    public static OutboundFrame Pooled(byte[] array, int length, ArrayPool<byte> pool)
     {
-        ArgumentNullException.ThrowIfNull(owner);
-        if ((uint)length > (uint)owner.Memory.Length)
+        ArgumentNullException.ThrowIfNull(array);
+        ArgumentNullException.ThrowIfNull(pool);
+        if ((uint)length > (uint)array.Length)
             throw new ArgumentOutOfRangeException(nameof(length));
-        return new OutboundFrame(owner, owner.Memory[..length]);
+        return new OutboundFrame(array, pool, new ReadOnlyMemory<byte>(array, 0, length));
     }
 
     /// <summary>
     /// Builds an unowned frame around an existing in-memory buffer
     /// (typically a heap-allocated <c>byte[]</c> from a test or a
-    /// legacy non-pooled encode path). The buffer never disposes
+    /// legacy non-pooled encode path). The buffer never returns
     /// anything for unowned frames; the caller guarantees the bytes
     /// remain valid for as long as the frame is buffered.
     /// </summary>
     public static OutboundFrame Unowned(ReadOnlyMemory<byte> bytes)
-        => new(owner: null, bytes);
+        => new(array: null, pool: null, bytes);
 
     /// <summary>
-    /// Releases the pooled <see cref="Owner"/>, if any. Invoked
-    /// exclusively by <see cref="BotOutboundBuffer"/> when its hold
-    /// on the frame ends (eviction / overflow / reset / rejected
-    /// append). Idempotent.
+    /// Returns the pooled <see cref="PooledArray"/> to its
+    /// <see cref="Pool"/>, if any. Invoked exclusively by
+    /// <see cref="BotOutboundBuffer"/> when its hold on the frame ends
+    /// (eviction / overflow / reset / rejected append), under the
+    /// buffer's internal lock and immediately followed (in the
+    /// eviction / reset paths) by removing the owning entry from the
+    /// linked list. The buffer is the only code that ever calls this;
+    /// channel-writer / drain-loop copies of the struct must not.
     /// </summary>
     internal void DisposeOwner()
     {
-        var owner = Interlocked.Exchange(ref _owner, null);
-        owner?.Dispose();
+        if (PooledArray is { } array && Pool is { } pool)
+        {
+            // clearArray:false — outbound frames hold only public ER
+            // wire bytes; no credentials or shared secrets that would
+            // justify the per-return memset cost.
+            pool.Return(array, clearArray: false);
+        }
     }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
@@ -33,8 +33,8 @@ namespace B3.Trading.EntryPointListener.Hosting;
 /// diagnosable cause (RFC §5.3.1, code-review concern (1)).</para>
 ///
 /// <para><b>Single-disposer rule (RFC §5.5).</b> The drain loop NEVER
-/// disposes <see cref="OutboundFrame.Owner"/>. The frame remains
-/// owned by the per-credential <see cref="BotOutboundBuffer"/> from
+/// returns the pooled array backing
+/// <see cref="OutboundFrame.PooledArray"/>. The frame remains owned by the per-credential <see cref="BotOutboundBuffer"/> from
 /// the moment <c>buffer.Append</c> succeeded upstream; the buffer is
 /// the sole disposer (on <c>EvictUpTo</c> / overflow / <c>Reset</c>).
 /// This writer only borrows <see cref="OutboundFrame.Bytes"/> for
@@ -131,7 +131,6 @@ internal sealed class FixpOutboundChannelWriter
     /// </summary>
     public bool TryEnqueue(OutboundFrame frame)
     {
-        ArgumentNullException.ThrowIfNull(frame);
         if (_completed) return false;
         // TryWrite is non-blocking and returns false when the bounded
         // channel is full — exactly the surface §5.3.1 wants. We also

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
@@ -29,14 +29,14 @@ namespace B3.Trading.EntryPointListener.Hosting;
 /// optionals expose only <c>Nullable&lt;T&gt;</c> getters and require
 /// raw memory writes to set the wire layout).</para>
 ///
-/// <para>P7 / F5 (issue #201): the framed bytes live in a buffer
-/// rented from <see cref="MemoryPool{T}.Shared"/>. The encoder writes
-/// the SOFH header + body in-place into that buffer and returns an
-/// <see cref="OutboundFrame"/> whose
-/// <see cref="OutboundFrame.Owner"/> the per-credential
+/// <para>P7 / F5 (issue #201) + #230: the framed bytes live in a
+/// buffer rented from <see cref="ArrayPool{T}.Shared"/>. The encoder
+/// writes the SOFH header + body in-place into that array and returns
+/// an <see cref="OutboundFrame"/> whose <see cref="OutboundFrame.PooledArray"/>
+/// + <see cref="OutboundFrame.Pool"/> the per-credential
 /// <see cref="BotOutboundBuffer"/> takes over via
 /// <see cref="BotOutboundBuffer.Append(ulong, OutboundFrame)"/>. The
-/// encoder NEVER disposes the rented owner after constructing the
+/// encoder NEVER returns the rented array after constructing the
 /// frame — single-disposer rule (RFC §5.5).</para>
 /// </summary>
 internal static class OutboundExecutionReportEncoder
@@ -179,15 +179,17 @@ internal static class OutboundExecutionReportEncoder
     private static OutboundFrame Frame(ushort blockLength, ushort templateId, ReadOnlySpan<byte> body)
     {
         var frameSize = SofhFrameWriter.FrameSize(body.Length);
-        // Rent from the shared pool. The pool returns a buffer at LEAST
-        // frameSize bytes; we tell OutboundFrame the exact framed length
-        // so downstream code (TryEnqueue, retransmit) sees the right
-        // slice. The owner travels with the frame and is disposed
-        // exactly once by BotOutboundBuffer (RFC §5.5 single-disposer).
-        var owner = MemoryPool<byte>.Shared.Rent(frameSize);
+        // Issue #230: rent the raw byte[] directly from
+        // ArrayPool<byte>.Shared (rather than MemoryPool<byte>.Shared,
+        // whose Rent allocates an ArrayMemoryPoolBuffer wrapper per
+        // call) so the encoder produces zero managed allocations
+        // beyond the pool's already-resident inventory. The frame
+        // travels with its (array, pool) pair and is returned exactly
+        // once by BotOutboundBuffer (RFC §5.5 single-disposer).
+        var array = ArrayPool<byte>.Shared.Rent(frameSize);
         SofhFrameWriter.WriteFrame(
-            owner.Memory.Span[..frameSize], blockLength, templateId, SchemaIdV6, VersionApp, body);
-        return OutboundFrame.Pooled(owner, frameSize);
+            array.AsSpan(0, frameSize), blockLength, templateId, SchemaIdV6, VersionApp, body);
+        return OutboundFrame.Pooled(array, frameSize, ArrayPool<byte>.Shared);
     }
 
     private static Side ToSbeSide(OrderSide side) => side switch

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferOwnershipTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferOwnershipTests.cs
@@ -15,10 +15,10 @@ public class BotOutboundBufferOwnershipTests
 {
     private static OutboundFrame Pooled(TrackingMemoryPool pool, int length, byte tag)
     {
-        var owner = pool.Rent(length);
-        owner.Memory.Span[..length].Clear();
-        owner.Memory.Span[0] = tag;
-        return OutboundFrame.Pooled(owner, length);
+        var arr = pool.Rent(length);
+        arr.AsSpan(0, length).Clear();
+        arr[0] = tag;
+        return OutboundFrame.Pooled(arr, length, pool);
     }
 
     [Fact]
@@ -49,18 +49,20 @@ public class BotOutboundBufferOwnershipTests
     public void Encoder_HandsOff_NeverDisposes()
     {
         // Encoder hands off to Append; once Append accepts, only the
-        // buffer disposes — *never* the caller. We model the encoder
-        // by renting via the tracking pool and confirm that even after
-        // we drop our reference to the frame, the pool sees a dispose
-        // exactly once when the buffer evicts.
+        // buffer disposes — *never* the caller. Post issue #230 the
+        // frame is a readonly struct (no finalizer, no heap), so the
+        // pre-#230 "drop reference + GC.Collect" rehearsal no longer
+        // applies. The substantive invariant remains: dispose is
+        // observed only after the buffer evicts.
         using var pool = new TrackingMemoryPool();
         var buf = new BotOutboundBuffer(Guid.NewGuid(), maxMessages: 4);
 
-        var frame = Pooled(pool, 32, tag: 0xAB);
-        Assert.True(buf.Append(1, frame));
+        Assert.True(buf.Append(1, Pooled(pool, 32, tag: 0xAB)));
+        Assert.Equal(0, pool.DisposeCount);
 
-        // Caller drops the reference; nothing must dispose yet.
-        frame = null!;
+        // Force a GC to confirm that even with the struct's
+        // copy-by-value flying around the stack, no finalizer-based
+        // path disposes the owner — only the buffer's eviction does.
         GC.Collect();
         GC.WaitForPendingFinalizers();
         Assert.Equal(0, pool.DisposeCount);

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/BotOutboundBufferTests.cs
@@ -26,13 +26,14 @@ public class BotOutboundBufferTests
         // Successor to the old "DefensivelyCopiesPayload" test. After
         // RFC §5.5 / issue #201, Append no longer copies — the buffer
         // takes ownership of the pooled memory and disposes it on
-        // EvictUpTo. We verify the lifecycle through a tracking pool.
+        // EvictUpTo. Issue #230 moved the rent from MemoryPool to
+        // ArrayPool; the lifecycle through a tracking pool is the same.
         using var pool = new TrackingMemoryPool();
         var buf = new BotOutboundBuffer(Guid.NewGuid(), maxMessages: 10);
-        var owner = pool.Rent(8);
-        owner.Memory.Span[..3].Clear();
-        owner.Memory.Span[0] = 1; owner.Memory.Span[1] = 2; owner.Memory.Span[2] = 3;
-        var frame = OutboundFrame.Pooled(owner, 3);
+        var arr = pool.Rent(8);
+        arr.AsSpan(0, 3).Clear();
+        arr[0] = 1; arr[1] = 2; arr[2] = 3;
+        var frame = OutboundFrame.Pooled(arr, 3, pool);
 
         Assert.True(buf.Append(1, frame));
         Assert.Equal(1, pool.RentCount);

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/TrackingMemoryPool.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/TrackingMemoryPool.cs
@@ -4,61 +4,63 @@ using System.Collections.Concurrent;
 namespace B3.Trading.Application.Tests.UserBots;
 
 /// <summary>
-/// RFC §5.5 / issue #201 test double. Wraps
-/// <see cref="MemoryPool{T}.Shared"/> and tracks rent / dispose counts
-/// per outstanding owner so tests can assert the
+/// RFC §5.5 / issue #230 test double. Wraps
+/// <see cref="ArrayPool{T}.Shared"/> and tracks rent / return counts per
+/// outstanding array so tests can assert the
 /// <see cref="B3.Trading.Application.UserBots.BotOutboundBuffer"/>
-/// single-disposer invariant: every rented owner is disposed exactly
-/// once and never disposed twice.
+/// single-disposer invariant: every rented array is returned exactly
+/// once and never returned twice.
+///
+/// <para>Successor to the pre-#230 <c>TrackingMemoryPool</c>: that
+/// double wrapped <see cref="MemoryPool{T}.Shared"/> and produced an
+/// <see cref="IMemoryOwner{T}"/> wrapper per rent. After #230 the
+/// production encoder rents raw arrays directly from
+/// <see cref="ArrayPool{T}.Shared"/>; this double mirrors that path
+/// so the dispose-count invariant translates exactly.</para>
 /// </summary>
-internal sealed class TrackingMemoryPool : MemoryPool<byte>
+internal sealed class TrackingMemoryPool : ArrayPool<byte>, IDisposable
 {
     private int _rentCount;
     private int _disposeCount;
-    // We track each rented owner individually so a double-dispose
+    // We track each rented array by identity so a double-return
     // surfaces as a deterministic test failure instead of a silent
     // double-decrement on a shared counter.
-    private readonly ConcurrentDictionary<TrackingOwner, byte> _outstanding = new();
+    private readonly ConcurrentDictionary<byte[], byte> _outstanding =
+        new(ReferenceEqualityComparer<byte[]>.Instance);
 
     public int RentCount => Volatile.Read(ref _rentCount);
     public int DisposeCount => Volatile.Read(ref _disposeCount);
     public int OutstandingCount => _outstanding.Count;
-    public override int MaxBufferSize => Shared.MaxBufferSize;
 
-    public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
+    public override byte[] Rent(int minimumLength)
     {
-        var inner = Shared.Rent(minBufferSize);
+        var arr = Shared.Rent(minimumLength);
         Interlocked.Increment(ref _rentCount);
-        var wrapper = new TrackingOwner(this, inner);
-        _outstanding[wrapper] = 0;
-        return wrapper;
+        if (!_outstanding.TryAdd(arr, 0))
+        {
+            // The shared pool handed us back an array we already
+            // believe is outstanding — that would mean we missed a
+            // Return upstream. Fail loudly so the test surfaces it.
+            throw new InvalidOperationException(
+                "TrackingMemoryPool received a rent for an array that is still tracked as outstanding.");
+        }
+        return arr;
     }
 
-    internal void OnOwnerDisposed(TrackingOwner owner)
+    public override void Return(byte[] array, bool clearArray = false)
     {
-        if (!_outstanding.TryRemove(owner, out _))
-            throw new InvalidOperationException("OutboundFrame double-dispose detected by TrackingMemoryPool.");
+        if (!_outstanding.TryRemove(array, out _))
+            throw new InvalidOperationException("OutboundFrame double-return detected by TrackingMemoryPool.");
         Interlocked.Increment(ref _disposeCount);
+        Shared.Return(array, clearArray);
     }
 
-    protected override void Dispose(bool disposing) { /* nothing — Shared owns the underlying */ }
+    public void Dispose() { /* nothing — Shared owns the underlying inventory */ }
 
-    internal sealed class TrackingOwner : IMemoryOwner<byte>
+    private sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
     {
-        private readonly TrackingMemoryPool _pool;
-        private IMemoryOwner<byte>? _inner;
-        public TrackingOwner(TrackingMemoryPool pool, IMemoryOwner<byte> inner)
-        {
-            _pool = pool;
-            _inner = inner;
-        }
-        public Memory<byte> Memory => (_inner ?? throw new ObjectDisposedException(nameof(TrackingOwner))).Memory;
-        public void Dispose()
-        {
-            var inner = Interlocked.Exchange(ref _inner, null)
-                ?? throw new InvalidOperationException("TrackingOwner double-dispose.");
-            inner.Dispose();
-            _pool.OnOwnerDisposed(this);
-        }
+        public static readonly ReferenceEqualityComparer<T> Instance = new();
+        public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+        public int GetHashCode(T obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
@@ -219,42 +219,29 @@ public sealed class FixpOutboundChannelWriterTests
     }
 
     /// <summary>
-    /// Test-only owner that flips a flag on Dispose so the test can
-    /// assert the writer never invoked <c>DisposeOwner</c>.
+    /// Test-only pool that tracks how many of its rented arrays got
+    /// returned, so the test can assert the writer never invoked
+    /// <c>DisposeOwner</c> (RFC §5.5 single-disposer rule). Issue #230:
+    /// switched from <c>IMemoryOwner&lt;byte&gt;</c> to a raw
+    /// <see cref="System.Buffers.ArrayPool{T}"/>-based path; this
+    /// double subclasses <see cref="System.Buffers.ArrayPool{T}"/> to
+    /// observe the return.
     /// </summary>
-    private sealed class TrackingPool
+    private sealed class TrackingPool : System.Buffers.ArrayPool<byte>
     {
         private int _disposed;
         public int DisposedCount => Volatile.Read(ref _disposed);
 
         public OutboundFrame RentFrame(byte payload)
         {
-            var owner = new TrackingOwner(this, payload);
-            return OutboundFrame.Pooled(owner, length: 1);
+            var arr = Rent(1);
+            arr[0] = payload;
+            return OutboundFrame.Pooled(arr, length: 1, pool: this);
         }
 
-        internal void NotifyDisposed() => Interlocked.Increment(ref _disposed);
+        public override byte[] Rent(int minimumLength) => new byte[Math.Max(minimumLength, 1)];
 
-        private sealed class TrackingOwner : System.Buffers.IMemoryOwner<byte>
-        {
-            private readonly TrackingPool _pool;
-            private readonly byte[] _buf;
-            private bool _disposed;
-
-            public TrackingOwner(TrackingPool pool, byte payload)
-            {
-                _pool = pool;
-                _buf = new byte[1] { payload };
-            }
-
-            public Memory<byte> Memory => _buf;
-
-            public void Dispose()
-            {
-                if (_disposed) return;
-                _disposed = true;
-                _pool.NotifyDisposed();
-            }
-        }
+        public override void Return(byte[] array, bool clearArray = false)
+            => Interlocked.Increment(ref _disposed);
     }
 }


### PR DESCRIPTION
Closes #230.

## Option chosen

Issue #230 listed two options. After a brief design spike, **option 1** (`readonly … struct OutboundFrame` + POCO storage in the buffer) was selected and shipped — but landed as a plain **`readonly struct`** rather than the issue's literal `readonly ref struct`. A true ref struct is incompatible with two pre-existing pipeline invariants that #230 explicitly leaves untouched:

1. `FixpOutboundChannelWriter` stores frames in `Channel<OutboundFrame>` — `Channel<T>` requires `T` to be heap-storable; ref structs can't be the channel item type.
2. `FixpOutboundChannelWriter.DrainAsync` holds the frame across `await stream.WriteAsync(frame.Bytes, ct)` — ref structs can't survive an await.

A plain `readonly struct` delivers the same observable outcome the issue is after — no wrapper class on the GC heap per encode — without rewriting the channel + drain pipeline (which would have cascaded into >5 files exactly the way the issue's fallback clause warns about). The ObjectPool<OutboundFrame> fallback was therefore unnecessary.

## Before / after

`OutboundExecutionReportEncoder_Bench` (`--job Short`, all four covered ExecKinds):

| Kind | Mean before (P7) | Allocated before | Mean after | Allocated after |
|---|---|---|---|---|
| New | ~108 ns | 64 B | ~93 ns | **0 B** |
| PartialFill | ~108 ns | 64 B | ~122 ns | **0 B** |
| Canceled | ~108 ns | 64 B | ~100 ns | **0 B** |
| Rejected | ~108 ns | 64 B | ~95 ns | **0 B** |

Acceptance gate (64 B → ≤16 B, target 0 B): **met at 0 B**.

The two changes that compound to 0 B:
1. `OutboundFrame` is now `readonly struct` (no class instance per encode).
2. `OutboundExecutionReportEncoder.Frame` rents directly from `ArrayPool<byte>.Shared` instead of `MemoryPool<byte>.Shared`, eliminating the per-`Rent` `ArrayMemoryPoolBuffer` wrapper that the latter allocates.

## Invariant justification

### Single-disposer rule (RFC §5.5) — preserved

Pre-#230 `OutboundFrame` used `Interlocked.Exchange(ref _owner, null)` so `DisposeOwner` was idempotent at the value level. Post-#230 the struct calls `Pool.Return(array, clearArray: false)` directly with no guard. Single-disposer is preserved by **policy**:

- All buffer mutations (`Append`, `EvictUpTo`, `Reset`, overflow bulk clear) are serialised under `BotOutboundBuffer._gate`.
- `EvictUpTo` / `Reset` / overflow remove the `Entry` from the `LinkedList` in the same critical section that calls `DisposeOwner`, so no second call on the same logical entry is reachable.
- `IBotSessionOutboundSender.TryEnqueue` / `FixpOutboundChannelWriter.DrainAsync` / `BotOutboundBuffer.GetRange` only borrow `Bytes` and never call `DisposeOwner`.
- `Append`'s refused branches (closed buffer, cap trip) dispose the *incoming* frame before returning `false`; the caller never disposes (and now syntactically cannot leak a `null` since `frame` is a struct).

### Lifetime across the awaited socket write — preserved

A bot can only ack a watermark for sequences it has actually received, so an unsent (still-queued) frame's seq cannot be evicted under the drain loop. Overflow / version-bump force-closes the connection (terminating the drain loop) BEFORE the buffer's `Reset` clears pooled arrays. Both invariants — already documented on `FixpOutboundChannelWriter` pre-#230 — are properties of the protocol surface, not of the wrapper type, so they carry over verbatim.

### Race coverage

`BotOutboundBufferOwnershipTests.Concurrent_RetransmitWalk_AndEvict_DoesNotDoubleDispose` (1000 entries × 4 reader threads × 1 evictor) still passes against the new `TrackingMemoryPool` (rewritten as an `ArrayPool<byte>` subclass that throws on double-return).

## Ownership diagram

```
encoder ──Pooled(array, len, pool)──► multiplexer
                                          │
                                          ▼
                                 buffer.Append (under _gate)
                                          │
                      ┌───────────────────┼──────────────────┐
                      ▼                                      ▼
             LinkedList<Entry>                       sender.TryEnqueue
             (sole owner; disposes                    (borrows Bytes;
              in EvictUpTo /                            never disposes)
              Reset / overflow)                              │
                                                             ▼
                                                    Channel<OutboundFrame>
                                                             │
                                                             ▼
                                                    DrainAsync.WriteAsync
                                                    (borrows Bytes;
                                                     never disposes)
```

## Validation

- ✅ Build: 0 warnings / 0 errors (Release).
- ✅ Tests: **1030 / 1030** pass (53 Domain + 207 Api + 23 SimulatorBot + 119 EntryPointListener + 628 Application; 18 skipped Conformance specs unchanged).
- ✅ Format: `dotnet format` clean.
- ✅ Bench: 64 B → 0 B (table above).
- ✅ Code-review pass (gpt-5.5, focus: single-disposer across all paths, struct lifetime correctness across the awaited drain, ArrayPool semantics): no Critical/High issues.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>