### PR TITLE
obs(fixp): OTel counter for outbound drain shutdown abandoned (#233)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -94,6 +94,16 @@ public static class MetricsRegistry
     // Drain
     public static readonly Counter<long> DrainRejections =
         Meter.CreateCounter<long>("trading.drain.rejections");
+    // RFC §5.3.2 / P8 / F3. Bumped each time the per-FIXP-connection
+    // outbound drain loop ignored cancellation for >250 ms past the
+    // configured shutdown timeout and the writer abandoned it
+    // (FixpOutboundChannelWriter.WaitForDrainAsync). Sibling of the
+    // existing structured warning log of the same name; the log
+    // remains the source of truth for the `connectionId` field, the
+    // counter is intentionally untagged to keep cardinality bounded
+    // (one series per process, no per-connection labels). Issue #233.
+    public static readonly Counter<long> FixpOutboundDrainShutdownAbandoned =
+        Meter.CreateCounter<long>("trading.fixp.outbound.drain.shutdown.abandoned");
 
     // Algo engine (RFC algo-orders-v0 §7 C1)
     public static readonly Counter<long> AlgoSignalsConsumed =

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using B3.Trading.Application.Observability;
 using B3.Trading.Application.UserBots;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -190,6 +191,7 @@ internal sealed class FixpOutboundChannelWriter
                 // Drain still hung — log and abandon. Connection
                 // cleanup proceeds; the (orphaned) drain task will
                 // exit when its WriteAsync eventually unblocks.
+                MetricsRegistry.FixpOutboundDrainShutdownAbandoned.Add(1);
                 _logger.LogWarning(
                     "fixp.outbound.drain.shutdown.abandoned connectionId={ConnectionId} timeoutMs={TimeoutMs}",
                     _connectionId, (int)timeout.TotalMilliseconds);

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using B3.Trading.Application.Observability;
 using B3.Trading.Application.UserBots;
 using B3.Trading.EntryPointListener.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -227,6 +229,58 @@ public sealed class FixpOutboundChannelWriterTests
     /// double subclasses <see cref="System.Buffers.ArrayPool{T}"/> to
     /// observe the return.
     /// </summary>
+    [Fact(Timeout = 10_000)]
+    public async Task CompleteAsync_AbandonedPath_IncrementsOtelCounter()
+    {
+        // Issue #233. The abandoned path must increment the
+        // `trading.fixp.outbound.drain.shutdown.abandoned` OTel
+        // counter exactly once, at the same call site as the
+        // existing structured warning log. We force the abandoned
+        // branch by handing the writer a write callback that
+        // ignores the cancellation token entirely — after the
+        // configured timeout the writer cancels its CTS, waits
+        // 250 ms, observes the drain loop still has not returned,
+        // logs `.abandoned` and bumps the counter.
+        long captured = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Name == "trading.fixp.outbound.drain.shutdown.abandoned")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+        {
+            Interlocked.Add(ref captured, measurement);
+        });
+        listener.Start();
+
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writer = new FixpOutboundChannelWriter(
+            capacity: 4,
+            // Intentionally ignores ct — this is the "drain loop
+            // ignored cancellation" pathology the abandoned path
+            // exists to detect.
+            writeAsync: async (_, _) =>
+            {
+                await release.Task.ConfigureAwait(false);
+                return true;
+            },
+            connectionId: "conn-abandoned",
+            logger: NullLogger.Instance);
+
+        Assert.True(writer.TryEnqueue(OutboundFrame.Unowned(new byte[] { 0x01 })));
+
+        // Short timeout → quick to the abandoned branch
+        // (timeout + 250 ms cancel grace ≈ 300 ms).
+        await writer.CompleteAsync(TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(1, Interlocked.Read(ref captured));
+
+        // Unblock so the orphaned drain task can exit cleanly and
+        // the test does not leak it.
+        release.TrySetResult();
+    }
+
     private sealed class TrackingPool : System.Buffers.ArrayPool<byte>
     {
         private int _disposed;

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -70,13 +70,16 @@ existing WS recovery path.
    increase it without an issue tracking the new value — the
    cap is also the worst-case in-memory queue bound.
 
-### 1.2 `fixp.outbound.drain.shutdown.abandoned` (warning log)
+### 1.2 `trading.fixp.outbound.drain.shutdown.abandoned` (counter + warning log)
 
 | Field | Value |
 |---|---|
-| Source | Structured log line in [`Hosting/FixpOutboundChannelWriter.cs`](../backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs) at `LogWarning` (the `_drainLoop.WaitAsync` 250 ms catch) |
-| Origin | P8 / F3 — PR [#219](https://github.com/pedrosakuma/B3TradingPlatform/pull/219), RFC §5.3.2 |
-| Type   | **Warning log** — *not* an OTel counter today (see follow-up note below) |
+| Source | OTel `Counter<long>` on the `B3.Trading` meter + structured log line in [`Hosting/FixpOutboundChannelWriter.cs`](../backend/src/B3.Trading.EntryPointListener/Hosting/FixpOutboundChannelWriter.cs) at `LogWarning` (the `_drainLoop.WaitAsync` 250 ms catch) |
+| OTel name | `trading.fixp.outbound.drain.shutdown.abandoned` |
+| Prom name | `trading_fixp_outbound_drain_shutdown_abandoned_total` |
+| Labels | none — untagged on purpose, see "follow-up" below |
+| Origin | P8 / F3 — PR [#219](https://github.com/pedrosakuma/B3TradingPlatform/pull/219) (log), issue [#233](https://github.com/pedrosakuma/B3TradingPlatform/issues/233) (counter), RFC §5.3.2 |
+| Type   | Counter (Prometheus-native, page-severity) + structured warning log (operator-readable `connectionId`) |
 
 **Message shape.**
 
@@ -103,11 +106,14 @@ slot was closed without a clean drain; the credential is freed
 for a successor session per §4.5 only after the orphaned task
 finally exits.
 
-**Alert.** Any occurrence is operator-visible. Recommended:
-`count_over_time({msg=~"fixp.outbound.drain.shutdown.abandoned.*"}[5m]) > 0`
-→ **page**. (Translate the LogQL above to your stack — Loki
-example shown.) Contrast with the sibling `.timeout` line, which
-should be alerted at info-level only — that one is the documented
+**Alert.** Any occurrence is operator-visible. Prometheus-native
+rule (preferred): `increase(trading_fixp_outbound_drain_shutdown_abandoned_total[5m]) > 0`
+→ **page**. The legacy LogQL fallback
+(`count_over_time({msg=~"fixp.outbound.drain.shutdown.abandoned.*"}[5m]) > 0`)
+remains valid for stacks without the OTel scrape but is
+demoted to `info` in [`perf-v0-alerts.md`](ops/perf-v0-alerts.md) §2.
+Contrast with the sibling `.timeout` line, which should be
+alerted at info-level only — that one is the documented
 "slow peer, deadline elapsed" path and is bounded by
 `OutboundDrainShutdownTimeout` (§1.3 below).
 
@@ -115,7 +121,9 @@ should be alerted at info-level only — that one is the documented
 
 1. Pull the `connectionId` from the log line and grep recent
    FIXP listener logs for matching `Negotiate`, `Establish`,
-   `Terminate` to identify the credential / firm.
+   `Terminate` to identify the credential / firm. (The counter
+   itself is intentionally untagged; the `connectionId` lives
+   on the sibling log line.)
 2. If isolated to one peer, the peer is misbehaving — coordinate a
    forced session cleanup via `/admin/fixp` (see fixp-listener
    ops doc).
@@ -123,12 +131,12 @@ should be alerted at info-level only — that one is the documented
    write path itself has regressed in cancellation behaviour. Roll
    back the most recent listener change and open a P0.
 
-> **Follow-up.** Today this is a log line only. Issue
-> [#231](https://github.com/pedrosakuma/B3TradingPlatform/issues/231)'s
-> table named `fixp.outbound.drain.shutdown.abandoned` as a
-> *metric*; it is currently emitted **only** as a structured log.
-> A counter equivalent is tracked as a separate follow-up
-> (TBD — to be filed). Until then alerting must be log-derived.
+> **Cardinality note.** The counter is emitted **untagged** so
+> that the Prometheus series is bounded to one per process. The
+> `connectionId` is preserved on the sibling structured log line
+> for operator triage; do not promote it to a metric label
+> without a follow-up issue weighing the cardinality cost
+> (FIXP connection IDs are not bounded over time).
 
 ### 1.3 `OutboundDrainShutdownTimeout` (config, default `00:00:01`)
 

--- a/docs/ops/perf-v0-alerts.md
+++ b/docs/ops/perf-v0-alerts.md
@@ -23,10 +23,11 @@ post-translation names.
 >   recording / alerting equivalent in your ops platform
 >   (Datadog monitor, Grafana Cloud alert, etc.) — the
 >   `expr:` / `for:` / labels are the contract.
-> - The `.abandoned` rule is **log-derived** (Loki / equivalent),
->   not Prometheus — see §1.2 of the runbook for why. The example
->   below is LogQL; translate the selector to whatever log query
->   language your aggregator uses.
+> - The `.abandoned` rule is **Prometheus-native** as of issue #233
+>   (the OTel counter `trading.fixp.outbound.drain.shutdown.abandoned`
+>   is now emitted on the same code path as the structured warning
+>   log). The legacy LogQL form is retained below as `info` for
+>   stacks without the OTel scrape.
 
 ---
 
@@ -58,6 +59,34 @@ groups:
             WS clients will see a gap and must reconnect-and-replay.
             See docs/RUNBOOK.md §1.1 for the triage sequence.
           runbook_url: "https://github.com/pedrosakuma/B3TradingPlatform/blob/main/docs/RUNBOOK.md#11-tradingdispatcherws_fanout_dropped-counter"
+
+      # 1.2 FIXP outbound drain shutdown abandoned — see RUNBOOK §1.2
+      # / PR #219 (log) + issue #233 (counter). Any increase means
+      # the per-FIXP-connection drain loop ignored cancellation for
+      # >250 ms past the configured shutdown timeout. Counter is
+      # untagged on purpose (one series per process); the
+      # connectionId is on the sibling structured warning log.
+      - alert: FixpOutboundDrainShutdownAbandoned
+        expr: increase(trading_fixp_outbound_drain_shutdown_abandoned_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: page
+          subsystem: fixp-listener
+          rfc: perf-hardening-v0
+          rfc_section: "5.3.2"
+        annotations:
+          summary: "FIXP outbound drain abandoned (cancellation ignored on shutdown)"
+          description: |
+            trading.fixp.outbound.drain.shutdown.abandoned incremented
+            on {{ $labels.instance }}. A per-connection outbound drain
+            loop ignored cancellation for >250 ms past its configured
+            shutdown timeout and the writer abandoned it; the orphaned
+            task will exit when its in-flight WriteAsync unblocks.
+            No per-frame data is lost (BotOutboundBuffer replays on
+            reconnect) but the connection slot was closed without a
+            clean drain. See docs/RUNBOOK.md §1.2 for the triage
+            sequence (grep the sibling log line for the connectionId).
+          runbook_url: "https://github.com/pedrosakuma/B3TradingPlatform/blob/main/docs/RUNBOOK.md#12-tradingfixpoutbounddrainshutdownabandoned-counter--warning-log"
 
 ```
 
@@ -94,11 +123,15 @@ rule for when the gauges land:
 #   labels:  { severity: info, subsystem: persistence,    rfc_section: "4.2" }
 ```
 
-## 2. Log-derived alert (`.abandoned`)
+## 2. Log-derived fallback (`.abandoned`, `info`)
 
-The drain-loop **abandoned** signal is a structured warning log,
-not an OTel counter (see RUNBOOK §1.2). LogQL example for a
-Loki-backed stack:
+As of issue #233 the `.abandoned` signal is emitted as a
+Prometheus-native counter (see §1.2 above —
+`trading_fixp_outbound_drain_shutdown_abandoned_total`). The
+LogQL rule below is retained as an **info-severity fallback**
+for stacks that do not yet scrape the OTel collector (or for
+correlating the counter increment with the `connectionId` /
+`timeoutMs` structured fields on the sibling warning log).
 
 ```logql
 sum(count_over_time({app="b3-trading-host"}
@@ -110,10 +143,10 @@ AlertManager wiring:
 
 | Field | Value |
 |---|---|
-| Severity | `page` |
+| Severity | `info` (page severity is owned by the Prom rule in §1.2) |
 | Subsystem | `fixp-listener` |
 | For | immediate (any occurrence) |
-| Runbook | [`../RUNBOOK.md#12-fixpoutbounddrainshutdownabandoned-warning-log`](../RUNBOOK.md#12-fixpoutbounddrainshutdownabandoned-warning-log) |
+| Runbook | [`../RUNBOOK.md#12-tradingfixpoutbounddrainshutdownabandoned-counter--warning-log`](../RUNBOOK.md#12-tradingfixpoutbounddrainshutdownabandoned-counter--warning-log) |
 
 Do **not** alert on the sibling `fixp.outbound.drain.shutdown.timeout`
 log line at page severity — that is the documented "deadline
@@ -125,6 +158,7 @@ is recoverable by design.
 | Rule | Type | Severity | Source |
 |---|---|---|---|
 | `WsHubFanOutDropping` | Prometheus | page | PR #220 |
-| Drain `.abandoned` | log-derived | page | PR #219 |
+| `FixpOutboundDrainShutdownAbandoned` | Prometheus | page | PR #219 (log) + #233 (counter) |
+| Drain `.abandoned` (log fallback) | log-derived | info | PR #219 |
 | `OutboundDrainShutdownTimeout` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #219 |
 | `GroupCommitMaxRecords` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #214 |


### PR DESCRIPTION
Adds an OTel `Counter<long>` mirror of the existing
`fixp.outbound.drain.shutdown.abandoned` structured warning log so
the page-severity alert in `docs/ops/perf-v0-alerts.md` can be a
first-class Prometheus rule alongside
`trading.dispatcher.ws_fanout_dropped` instead of LogQL-derived.

## Counter

| Field | Value |
|---|---|
| OTel name | `trading.fixp.outbound.drain.shutdown.abandoned` |
| Prom name | `trading_fixp_outbound_drain_shutdown_abandoned_total` |
| Meter | `B3.Trading` (existing `MetricsRegistry.Meter`) |
| Labels | **none** — untagged on purpose; `connectionId` is unbounded over time and stays on the sibling warning log for triage |
| Call site | `FixpOutboundChannelWriter.WaitForDrainAsync` — same `if`-branch as the existing `LogWarning("fixp.outbound.drain.shutdown.abandoned …")`. The sibling `.timeout` path is **not** touched. |

## Docs updated

- `docs/RUNBOOK.md` §1.2 — replaced the "deferred to follow-up"
  note with the actual OTel + Prom names, swapped the alert
  recommendation to the Prom-native rule, and added an explicit
  cardinality note explaining why the counter is untagged.
- `docs/ops/perf-v0-alerts.md` — added the
  `FixpOutboundDrainShutdownAbandoned` Prometheus alert under §1
  and demoted the LogQL form to an **info**-severity fallback
  under §2 (still useful when correlating with `connectionId` on
  the structured log line).

## Test

`FixpOutboundChannelWriterTests.CompleteAsync_AbandonedPath_IncrementsOtelCounter`
forces the abandoned branch with a write callback that
intentionally ignores its cancellation token, then asserts the
counter increments via a `MeterListener` (same pattern as
`B3.Trading.EntryPointListener.Tests/Hardening/MetricsTests.cs`).

## Validation

- `dotnet build B3TradingPlatform.slnx` — 0 warnings, 0 errors.
- `dotnet test B3TradingPlatform.slnx` — **1038 passed**, 18 skipped (was 1037 + 18 on `main` pre-change).
- `dotnet format B3TradingPlatform.slnx --verify-no-changes` — clean.
- Mandatory `gpt-5.5` code-review pass — no High issues (cardinality, increment site, doc/name alignment all verified).

Closes #233

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>