### PR TITLE
obs(host): build-info gauges for perf-v0 tunables (#234)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -450,4 +450,47 @@ public static class MetricsRegistry
         _orderRateActiveBucketsEc = endClient;
         _orderRateActiveBucketsFirm = firm;
     }
+
+    // Issue #234 — build-info gauges for perf-v0 tunables.
+    //
+    // Both gauges report the *runtime configured value* of the
+    // associated <c>IOptionsMonitor&lt;T&gt;</c> binding, so a config
+    // reload (file-watcher or IConfigurationRoot.Reload()) is
+    // reflected on the next scrape without a host restart. The source
+    // callbacks are intentionally untagged: one series per process,
+    // no high-cardinality labels — these are config drift signals,
+    // not per-tenant operational metrics. See
+    // <c>docs/ops/perf-v0-alerts.md</c> §1.1 for the matching
+    // PromQL drift rules.
+    private static volatile Func<double>? _outboundDrainShutdownTimeoutSecondsSource;
+    public static readonly ObservableGauge<double> FixpOutboundDrainShutdownTimeoutSeconds =
+        Meter.CreateObservableGauge<double>(
+            "trading.entrypoint_listener.outbound_drain_shutdown_timeout",
+            () =>
+            {
+                var src = _outboundDrainShutdownTimeoutSecondsSource;
+                return src is null
+                    ? Array.Empty<Measurement<double>>()
+                    : new[] { new Measurement<double>(src()) };
+            },
+            unit: "s",
+            description: "Configured EntryPointListener:Buffers:OutboundDrainShutdownTimeout (seconds). Build-info-style gauge sourced from IOptionsMonitor; reflects config reloads.");
+    public static void RegisterOutboundDrainShutdownTimeoutSource(Func<double> sourceSeconds) =>
+        _outboundDrainShutdownTimeoutSecondsSource = sourceSeconds;
+
+    private static volatile Func<int>? _groupCommitMaxRecordsSource;
+    public static readonly ObservableGauge<int> PersistenceGroupCommitMaxRecords =
+        Meter.CreateObservableGauge<int>(
+            "trading.persistence.group_commit_max_records",
+            () =>
+            {
+                var src = _groupCommitMaxRecordsSource;
+                return src is null
+                    ? Array.Empty<Measurement<int>>()
+                    : new[] { new Measurement<int>(src()) };
+            },
+            unit: "records",
+            description: "Configured Trading:Persistence:GroupCommitMaxRecords. Build-info-style gauge sourced from IOptionsMonitor; reflects config reloads.");
+    public static void RegisterGroupCommitMaxRecordsSource(Func<int> source) =>
+        _groupCommitMaxRecordsSource = source;
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
@@ -47,6 +47,17 @@ internal static class TradingHostStartup
             B3.Trading.Application.Observability.MetricsRegistry.RegisterMarginReservationCountsSource(
                 () => marginProvider.GetReservationCounts());
         }
+
+        // Issue #234 — build-info gauges for the perf-v0 tunables
+        // (RUNBOOK §1.3 / §1.4). Sourced from IOptionsMonitor so
+        // a config reload (file-watcher or IConfigurationRoot.Reload())
+        // is reflected on the next scrape without a host restart.
+        var entryPointOpts = app.Services.GetRequiredService<IOptionsMonitor<EntryPointListenerOptions>>();
+        B3.Trading.Application.Observability.MetricsRegistry.RegisterOutboundDrainShutdownTimeoutSource(
+            () => entryPointOpts.CurrentValue.Buffers.OutboundDrainShutdownTimeout.TotalSeconds);
+        var persistenceOpts = app.Services.GetRequiredService<IOptionsMonitor<PersistenceOptions>>();
+        B3.Trading.Application.Observability.MetricsRegistry.RegisterGroupCommitMaxRecordsSource(
+            () => persistenceOpts.CurrentValue.GroupCommitMaxRecords);
     }
 
     /// <summary>

--- a/backend/tests/B3.Trading.Application.Tests/BuildInfoGaugesTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/BuildInfoGaugesTests.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application.Observability;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Issue #234 — verifies the build-info gauges report the
+/// runtime-configured values of <c>OutboundDrainShutdownTimeout</c>
+/// and <c>GroupCommitMaxRecords</c>, and that the source callback is
+/// re-read on each observation (so an <c>IOptionsMonitor</c> swap is
+/// reflected without re-registration).
+/// </summary>
+public sealed class BuildInfoGaugesTests
+{
+    private static (List<Measurement<double>> Timeouts, List<Measurement<int>> GroupCommit) Collect()
+    {
+        var timeouts = new List<Measurement<double>>();
+        var groupCommit = new List<Measurement<int>>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (inst.Meter.Name != "B3.Trading") return;
+                if (inst.Name == "trading.entrypoint_listener.outbound_drain_shutdown_timeout" ||
+                    inst.Name == "trading.persistence.group_commit_max_records")
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((inst, v, tags, _) =>
+        {
+            if (inst.Name == "trading.entrypoint_listener.outbound_drain_shutdown_timeout")
+                lock (timeouts) timeouts.Add(new Measurement<double>(v, tags.ToArray()));
+        });
+        listener.SetMeasurementEventCallback<int>((inst, v, tags, _) =>
+        {
+            if (inst.Name == "trading.persistence.group_commit_max_records")
+                lock (groupCommit) groupCommit.Add(new Measurement<int>(v, tags.ToArray()));
+        });
+        listener.Start();
+        listener.RecordObservableInstruments();
+        return (timeouts, groupCommit);
+    }
+
+    [Fact]
+    public void Gauges_Report_Configured_Values_And_Reflect_Live_Source_Changes()
+    {
+        // Snapshot a configured value through a swappable source — mimics
+        // IOptionsMonitor.CurrentValue resolution on each callback.
+        var timeoutSeconds = 1.0;
+        var maxRecords = 512;
+        MetricsRegistry.RegisterOutboundDrainShutdownTimeoutSource(() => timeoutSeconds);
+        MetricsRegistry.RegisterGroupCommitMaxRecordsSource(() => maxRecords);
+
+        var (t1, g1) = Collect();
+        Assert.Contains(t1, m => m.Value == 1.0);
+        Assert.Contains(g1, m => m.Value == 512);
+        // Build-info contract: no high-cardinality tags. The gauge is
+        // one series per process; verify the emitted measurements carry
+        // no tag keys at all.
+        Assert.All(t1, m => Assert.Empty(m.Tags.ToArray()));
+        Assert.All(g1, m => Assert.Empty(m.Tags.ToArray()));
+
+        // Simulate a hot config reload: closure observes the new value
+        // on the next scrape without re-registering the source.
+        timeoutSeconds = 2.5;
+        maxRecords = 1024;
+        var (t2, g2) = Collect();
+        Assert.Contains(t2, m => m.Value == 2.5);
+        Assert.Contains(g2, m => m.Value == 1024);
+    }
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -165,13 +165,16 @@ deferring frames into the post-reconnect replay path. Do **not**
 raise it as a workaround for `.abandoned` — that path is not
 deadline-bounded and a longer timeout cannot help.
 
-**Drift detection.** Today the trading-host does **not** emit a
-gauge for the running value, so a Prometheus `expr: <gauge> != 1`
-rule would silently never fire. Until a `build-info`-style gauge
-lands (tracked as a follow-up to #231), enforce drift at deploy
-time by diffing the rendered config against the documented
-default in CI; see [`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md)
-§1.1 for the skeleton runtime rule to enable later.
+**Drift detection.** Since #234 the trading-host emits the
+build-info gauge
+`trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds`
+(OTel meter:
+`trading.entrypoint_listener.outbound_drain_shutdown_timeout`,
+unit `s`), sourced from
+`IOptionsMonitor<EntryPointListenerOptions>.CurrentValue.Buffers.OutboundDrainShutdownTimeout`
+so config reloads are reflected on the next scrape without a host
+restart. The matching `PerfV0OutboundDrainTimeoutDrift` Prometheus
+rule lives in [`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md) §1.1.
 
 ### 1.4 `Trading:Persistence:GroupCommitMaxRecords` (config, default `512`)
 
@@ -206,10 +209,14 @@ batch size.
   Larger batches risk exceeding `GroupCommitWindow` under load,
   pushing latency past the §7.3 gate.
 
-**Drift detection.** Same constraint as §1.3: no runtime gauge
-exists today, so enforce drift at deploy time. Skeleton
-Prometheus rule for when the gauge lands is in
-[`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md) §1.1.
+**Drift detection.** Since #234 the trading-host emits the
+build-info gauge `trading_persistence_group_commit_max_records`
+(OTel meter: `trading.persistence.group_commit_max_records`),
+sourced from
+`IOptionsMonitor<PersistenceOptions>.CurrentValue.GroupCommitMaxRecords`
+so config reloads are reflected on the next scrape without a host
+restart. The matching `PerfV0GroupCommitMaxRecordsDrift` Prometheus
+rule lives in [`ops/perf-v0-alerts.md`](ops/perf-v0-alerts.md) §1.1.
 
 ---
 

--- a/docs/ops/perf-v0-alerts.md
+++ b/docs/ops/perf-v0-alerts.md
@@ -90,38 +90,71 @@ groups:
 
 ```
 
-### 1.1 Config-drift detection (deferred)
+### 1.1 Config-drift detection
 
 Issue #231 also asks for info-level drift detection on
 `OutboundDrainShutdownTimeout` (default `1s`) and
-`GroupCommitMaxRecords` (default `512`). Implementing those as
-**Prometheus alerts requires a `build-info`-style config gauge that
-the trading-host does not emit today** — there is no
-`trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds`
-or `trading_persistence_group_commit_max_records` series in the
-current scrape, so any rule of the form `expr: <metric> != <default>`
-would silently never fire (no series → no samples → no alert).
+`GroupCommitMaxRecords` (default `512`). Since #234 the trading-host
+emits **build-info-style** gauges for both:
 
-Until those gauges are added (tracked as a follow-up to #231), the
-recommended path is a **deploy-time** check rather than a runtime
-alert: diff the rendered `appsettings.Production.json` (or the
-equivalent K8s `ConfigMap` / Helm values) against the documented
-defaults in CI, and fail the deploy on unexplained drift. Skeleton
-rule for when the gauges land:
+| OTel meter instrument | Prometheus series (post-translation) | Source of truth |
+|---|---|---|
+| `trading.entrypoint_listener.outbound_drain_shutdown_timeout` (unit `s`) | `trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds` | `IOptionsMonitor<EntryPointListenerOptions>.CurrentValue.Buffers.OutboundDrainShutdownTimeout` |
+| `trading.persistence.group_commit_max_records` (unit `records`) | `trading_persistence_group_commit_max_records` | `IOptionsMonitor<PersistenceOptions>.CurrentValue.GroupCommitMaxRecords` |
+
+Both source callbacks read the live `IOptionsMonitor.CurrentValue`
+on every scrape, so a config reload (file-watcher or
+`IConfigurationRoot.Reload()`) is reflected on the next scrape
+without a host restart. The gauges carry **no labels** — one
+series per process; cardinality is bounded by construction.
+
+The matching alerting rules — append them to the
+`perf-hardening-v0` group above:
 
 ```yaml
-# To be enabled once the trading-host emits build-info gauges
-# for the perf-v0 config knobs (follow-up to #231).
-#
-# - alert: PerfV0OutboundDrainTimeoutDrift
-#   expr: trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds != 1
-#   for: 5m
-#   labels:  { severity: info, subsystem: fixp-listener,  rfc_section: "5.3" }
-# - alert: PerfV0GroupCommitMaxRecordsDrift
-#   expr: trading_persistence_group_commit_max_records != 512
-#   for: 5m
-#   labels:  { severity: info, subsystem: persistence,    rfc_section: "4.2" }
+      # 1.1.1 OutboundDrainShutdownTimeout drift — RUNBOOK §1.3 / PR #219.
+      - alert: PerfV0OutboundDrainTimeoutDrift
+        expr: trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds != 1
+        for: 5m
+        labels:
+          severity: info
+          subsystem: fixp-listener
+          rfc: perf-hardening-v0
+          rfc_section: "5.3"
+        annotations:
+          summary: "OutboundDrainShutdownTimeout drifted from documented default (1s)"
+          description: |
+            trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds
+            on {{ $labels.instance }} reports {{ $value }}s, which differs
+            from the documented v0 default of 1s. Confirm the deploy
+            intended this and update docs/RUNBOOK.md §1.3 if so.
+          runbook_url: "https://github.com/pedrosakuma/B3TradingPlatform/blob/main/docs/RUNBOOK.md#13-outbounddrainshutdowntimeout-config-default-000001"
+
+      # 1.1.2 GroupCommitMaxRecords drift — RUNBOOK §1.4 / PR #214.
+      - alert: PerfV0GroupCommitMaxRecordsDrift
+        expr: trading_persistence_group_commit_max_records != 512
+        for: 5m
+        labels:
+          severity: info
+          subsystem: persistence
+          rfc: perf-hardening-v0
+          rfc_section: "4.2"
+        annotations:
+          summary: "GroupCommitMaxRecords drifted from documented default (512)"
+          description: |
+            trading_persistence_group_commit_max_records on
+            {{ $labels.instance }} reports {{ $value }}, which differs
+            from the documented v0 default of 512. Confirm the deploy
+            intended this and update docs/RUNBOOK.md §1.4 if so.
+          runbook_url: "https://github.com/pedrosakuma/B3TradingPlatform/blob/main/docs/RUNBOOK.md#14-tradingpersistencegroupcommitmaxrecords-config-default-512"
 ```
+
+> **Why `info` severity.** A drift from the documented default is
+> not necessarily a bug — the v0 numbers are tuned for participant
+> volumes (RFC §4.2 / §5.3.2) and may legitimately be re-tuned in a
+> deploy. The alert exists to surface unintended drift (typo in a
+> Helm values file, stale ConfigMap not re-rendered) for a human to
+> confirm, not to wake an on-call.
 
 ## 2. Log-derived fallback (`.abandoned`, `info`)
 
@@ -160,5 +193,5 @@ is recoverable by design.
 | `WsHubFanOutDropping` | Prometheus | page | PR #220 |
 | `FixpOutboundDrainShutdownAbandoned` | Prometheus | page | PR #219 (log) + #233 (counter) |
 | Drain `.abandoned` (log fallback) | log-derived | info | PR #219 |
-| `OutboundDrainShutdownTimeout` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #219 |
-| `GroupCommitMaxRecords` drift | deploy-time check (gauge TBD, follow-up to #231) | info | PR #214 |
+| `PerfV0OutboundDrainTimeoutDrift` | Prometheus (build-info gauge) | info | PR #219 / #234 |
+| `PerfV0GroupCommitMaxRecordsDrift` | Prometheus (build-info gauge) | info | PR #214 / #234 |


### PR DESCRIPTION
Closes #234.

## Summary

Activates the previously commented-out config-drift alerts from
`docs/ops/perf-v0-alerts.md` §1.1 by emitting OTel build-info-style
observable gauges for the two perf-v0 tunables called out in
`docs/RUNBOOK.md` §1.3 / §1.4. Before this PR no Prometheus series
existed for either knob, so a `expr: <metric> != <default>` rule would
silently never fire.

## New gauges

| OTel meter instrument | Prom (post-translation) | Source of truth |
|---|---|---|
| `trading.entrypoint_listener.outbound_drain_shutdown_timeout` (unit `s`) | `trading_entrypoint_listener_outbound_drain_shutdown_timeout_seconds` | `IOptionsMonitor<EntryPointListenerOptions>.CurrentValue.Buffers.OutboundDrainShutdownTimeout` |
| `trading.persistence.group_commit_max_records` (unit `records`) | `trading_persistence_group_commit_max_records` | `IOptionsMonitor<PersistenceOptions>.CurrentValue.GroupCommitMaxRecords` |

Both follow the existing `MetricsRegistry` pattern (static
`ObservableGauge<T>` + host-side `RegisterXxxSource()` setter invoked
once from `TradingHostStartup.RegisterMetricsSources`).

## Reload behavior

Both source callbacks resolve `IOptionsMonitor.CurrentValue` **on
every scrape**, so a config push via file-watcher or
`IConfigurationRoot.Reload()` is reflected on the next scrape without
a host restart. The unit test exercises this by mutating a closure
captured by the source delegate and re-collecting measurements — the
gauge reports the new value without re-registration.

## Cardinality

The gauges are intentionally **untagged** — one series per process.
Build-info gauges should not carry per-tenant or per-connection
labels; the test asserts the emitted measurements have an empty tag
set.

## Docs updated

- `docs/ops/perf-v0-alerts.md` §1.1 — replaced the "deferred" skeleton
  with active `PerfV0OutboundDrainTimeoutDrift` and
  `PerfV0GroupCommitMaxRecordsDrift` rules at `info` severity,
  appended to the `perf-hardening-v0` rule group.
- `docs/RUNBOOK.md` §1.3 / §1.4 — Drift-detection paragraphs now
  reference the new gauges instead of the deploy-time stopgap.
- `docs/ops/perf-v0-alerts.md` §3 summary table — updated.

## Verification

- `dotnet build B3TradingPlatform.slnx` — clean.
- `dotnet test B3TradingPlatform.slnx --no-build` — **1038 passed, 18 skipped, 0 failed** (1037 baseline + 1 new `BuildInfoGaugesTests`).
- `dotnet format B3TradingPlatform.slnx --verify-no-changes` — clean.
- Mandatory `gpt-5.5` code-review pass: no High-severity findings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>