### PR TITLE
chore(deps): bump backend + frontend pinned versions (May 2026)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -12,28 +12,28 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.3" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
-    <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
@@ -16,6 +16,18 @@ public class InMemoryUserBotCredentialRegistryTests
     private static InMemoryUserBotCredentialRegistry Reg() => new();
 
     [Fact]
+    public void BCrypt_LegacyHashFromV4_0_3_StillVerifiesUnderCurrentVersion()
+    {
+        // Hash produced by BCrypt.Net-Next 4.0.3 (the previous pinned version)
+        // for the plaintext "hunter2-legacy" with workFactor=11. Embedded as a
+        // literal so the test fails loud if a future BCrypt bump ever breaks
+        // the on-disk hash format used by stored bot credentials.
+        const string legacyHash = "$2a$11$uSDHF7qiiPXH6ieX8MD8SOzSdu00/4PBrjkJcy/UulOLvvFPt1sj2";
+        Assert.True(BCrypt.Net.BCrypt.Verify("hunter2-legacy", legacyHash));
+        Assert.False(BCrypt.Net.BCrypt.Verify("wrong-password", legacyHash));
+    }
+
+    [Fact]
     public async Task Create_ReturnsPlainTokenInExpectedShape()
     {
         var r = Reg();

--- a/frontend/e2e/package.json
+++ b/frontend/e2e/package.json
@@ -7,6 +7,6 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.1"
+    "@playwright/test": "1.60.0"
   }
 }


### PR DESCRIPTION
Bumps backend (central package management in `backend/Directory.Packages.props`) and the opt-in frontend e2e harness to current versions.

## Bumps

| Package | Before | After | Type |
|---|---|---|---|
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.7 | 10.0.8 | patch |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.0 | 10.0.8 | patch |
| Microsoft.Extensions.Configuration.Binder | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Configuration.EnvironmentVariables | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Configuration.Json | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.DependencyInjection | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Hosting | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Http | 10.0.0 | 10.0.8 | patch |
| Microsoft.Extensions.Logging.Abstractions | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Logging.Console | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Options | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Options.ConfigurationExtensions | 10.0.7 | 10.0.8 | patch |
| Microsoft.Extensions.Options.DataAnnotations | 10.0.0 | 10.0.8 | patch |
| System.IO.Hashing | 10.0.7 | 10.0.8 | patch |
| BenchmarkDotNet | 0.15.4 | 0.15.8 | minor |
| BCrypt.Net-Next | 4.0.3 | 4.2.0 | minor |
| coverlet.collector | 6.0.4 | 10.0.0 | major |
| @playwright/test (frontend/e2e) | 1.49.1 | 1.60.0 | minor |

## BCrypt back-compat

A new regression test, `InMemoryUserBotCredentialRegistryTests.BCrypt_LegacyHashFromV4_0_3_StillVerifiesUnderCurrentVersion`, embeds a literal `$2a$11$…` hash that was produced offline by BCrypt.Net-Next **4.0.3** for the plaintext `"hunter2-legacy"`, and asserts it still verifies under **4.2.0** (and that a wrong password does not). This covers the only on-disk hash format we persist for user-bot credentials, so any future BCrypt bump that breaks compatibility will fail loudly.

Confirmed locally: pre-existing 4.0.3 hashes still verify under 4.2.0. ✅

## coverlet 10.0.0

Verified locally that `dotnet test --collect:"XPlat Code Coverage"` still emits `coverage.cobertura.xml` with the same `<coverage line-rate=… version="1.9" …>` schema. CI only uploads the artifact (no further processing), so no consumer is affected.

## Skipped / follow-ups

None — all packages from the planned scope were bumped.

## Validation

- `dotnet build B3TradingPlatform.slnx -c Release` → 0 warnings, 0 errors.
- `dotnet test B3TradingPlatform.slnx -c Release` → **1040 passed**, 0 failed, 18 skipped (pre-existing conformance specs).
- `dotnet format --verify-no-changes --severity warn` → clean.
- gpt-5.5 review pass: no high-severity issues (security advisories / BCrypt hash compat / coverlet output format all clear).
