### PR TITLE
fix(#241): handle Cancel-as-Replace priority-lost path in ExecutionReportProcessor

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -109,6 +109,31 @@ public sealed class ExecutionReportProcessor
                 ApplyReplaceAccepted(clOrdId, leaves, cumQty, lastPx, origClOrdId, replaceIntent, fanOut);
                 return;
             }
+            // Issue #241: B3MatchingPlatform implements OrderCancelReplaceRequest
+            // via a "priority-lost" path (any change other than same-price /
+            // qty-down) by emitting Cancel(orig) + Trade/New(new) under the
+            // replace's NEW ClOrdID — never an ExecType=Replaced. Without this
+            // intercept the Cancel terminalises the original AND the new
+            // ClOrdID is never created in the book, so the subsequent Trade
+            // ER drops with "missing order" and the fill is silently lost
+            // (position/cash diverge from the venue). Funnel through
+            // ApplyReplaceAccepted so the original goes Replaced (not
+            // Cancelled), the new Order is hydrated under newClOrdId, and
+            // the margin coordinator sees Commit (not a leaked reservation).
+            if (kind == ExecKind.Canceled
+                && _replacements.TryConsume(clOrdId, out var cancelAsReplaceIntent)
+                && cancelAsReplaceIntent is not null)
+            {
+                ApplyReplaceAccepted(
+                    newClOrdId: clOrdId,
+                    erLeaves: cancelAsReplaceIntent.NewQuantity,
+                    erCum: 0,
+                    erLastPx: 0m,
+                    erOrigClOrdId: origClOrdId,
+                    intent: cancelAsReplaceIntent,
+                    fanOut: fanOut);
+                return;
+            }
         }
 
         // For cancel/replace acks, the meaningful identity is the original
@@ -139,7 +164,14 @@ public sealed class ExecutionReportProcessor
 
         if (!_orders.TryGet(lookupId, out var order) || order is null)
         {
-            _logger.LogWarning("ER for known owner {Owner} but missing order {ClOrdId} (orig={Orig}); dropping.", owner, clOrdId, origClOrdId);
+            // Issue #241: silent loss of a fill for a known owner is a P0
+            // correctness bug (position/cash divergence with the venue),
+            // not an idiomatic "ephemeral state" miss. Surface as error +
+            // metric so ops can alert; the most common cause is the
+            // priority-lost cancel-as-replace branch above failing to
+            // intercept (e.g. registry not wired or already consumed).
+            MetricsRegistry.ExecutionReportsDroppedKnownOwnerMissingOrder.Add(1, KindTag(kind));
+            _logger.LogError("ER for known owner {Owner} but missing order {ClOrdId} (orig={Orig}); dropping.", owner, clOrdId, origClOrdId);
             return;
         }
 

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -49,6 +49,14 @@ public static class MetricsRegistry
     // its terminal status.
     public static readonly Counter<long> ExecutionReportsLateFillAfterTerminal =
         Meter.CreateCounter<long>("trading.er.late_fill_after_terminal");
+    // Issue #241: an ER resolved to a known owner via OrderOwnershipMap
+    // but the corresponding Order is absent from WorkingOrderBook —
+    // we have nowhere to apply the fill / status mutation. Most often
+    // a venue cancel-as-replace (priority-lost) path that wasn't
+    // intercepted as a replacement. A non-zero rate here means a
+    // silent fill loss with position/cash divergence; alertable.
+    public static readonly Counter<long> ExecutionReportsDroppedKnownOwnerMissingOrder =
+        Meter.CreateCounter<long>("trading.execution_reports.dropped_known_owner_missing_order");
 
     // Risk / kill-switch
     public static readonly Counter<long> KillSwitchToggled =

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -332,5 +333,194 @@ public class OrderModifyMarginAndProcessorTests
 
         Assert.Equal(OrderStatus.Rejected, order.Status);
         Assert.Single(sink.Events);
+    }
+
+    // ---------------- Issue #241: Cancel-as-Replace (priority-lost) ----------------
+
+    private sealed class RecordingReplaceCoordinator : IReplaceMarginCoordinator
+    {
+        public List<(ulong Orig, ulong New, decimal Notional)> Commits { get; } = new();
+        public List<ulong> Aborts { get; } = new();
+        public List<(ulong Orig, ulong New, decimal Notional)> Prepares { get; } = new();
+
+        public Task<RiskDecision> PrepareReplaceAsync(ulong originalClOrdId, ulong newClOrdId, EndClientId owner, decimal newRemainingNotional, CancellationToken ct)
+        {
+            Prepares.Add((originalClOrdId, newClOrdId, newRemainingNotional));
+            return Task.FromResult(RiskDecision.Approve);
+        }
+
+        public void CommitReplace(ulong originalClOrdId, ulong newClOrdId, decimal confirmedRemainingNotional)
+            => Commits.Add((originalClOrdId, newClOrdId, confirmedRemainingNotional));
+
+        public void AbortReplace(ulong newClOrdId) => Aborts.Add(newClOrdId);
+    }
+
+    private sealed class RecordingBotErRouter : IBotErRouter
+    {
+        public List<ExecutionEvent> Events { get; } = new();
+        public void Route(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    [Fact]
+    public void Processor_CancelAsReplace_priorityLost_terminalisesOriginalAndHydratesNew_thenSubsequentFillBooksPositionAndCash()
+    {
+        // Repro for issue #241. B3 priority-lost path: venue emits
+        //   ER_Cancel(new=778, orig=777)  +  ER_Trade(new=778, orig=0)
+        // — never an ExecType=Replaced. Pre-fix the Cancel terminalised
+        // 777, the new order was never created in the book, and the
+        // Trade dropped silently (position/cash diverged).
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var cash = new CashLedger();
+        var sink = new CaptureSink();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["bob"] = 100_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var marginProvider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        var replaceCoord = new RecordingReplaceCoordinator();
+        var botRouter = new RecordingBotErRouter();
+        var reg = new PendingReplacementRegistry();
+        cash.SeedIfAbsent(new EndClientId("bob"), 100_000m);
+
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink, marginProvider,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: cash,
+            replacements: reg,
+            replaceMargin: replaceCoord,
+            botErRouter: botRouter);
+
+        var bob = new EndClientId("bob");
+        // 1) Original Buy 100 PETR4 @ 32.49 — sits in book.
+        var orig = new Order(777UL, bob, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 32.49m, "FIRM");
+        book.TryAdd(orig);
+        orig.MarkWorking();
+        ownership.Register(777UL, bob);
+
+        // 2) Modify-to-cross 32.49 → 32.50: register link + intent for newClOrdId=778.
+        ownership.RegisterReplaceLink(777UL, 778UL);
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: 777UL,
+            NewClOrdId: 778UL,
+            Owner: bob,
+            Symbol: "PETR4",
+            SecurityId: 4321UL,
+            Side: OrderSide.Buy,
+            Type: OrderType.Limit,
+            NewQuantity: 100,
+            NewPrice: 32.50m,
+            FirmId: "FIRM",
+            ParentAlgoId: null,
+            AlgoSliceSeq: null);
+        Assert.True(reg.TryAdd(intent));
+
+        // 3) Venue cancel-as-replace ER under newClOrdID — priority-lost branch.
+        proc.Apply(778UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: null, origClOrdId: 777UL);
+
+        // Original terminalised as Replaced (not Cancelled); new order hydrated.
+        Assert.Equal(OrderStatus.Replaced, orig.Status);
+        Assert.True(book.TryGet(778UL, out var newOrder));
+        Assert.NotNull(newOrder);
+        Assert.Equal(OrderStatus.Working, newOrder!.Status);
+        Assert.Equal(100, newOrder.LeavesQuantity);
+        Assert.Equal(0, newOrder.CumulativeQuantity);
+        // Margin coordinator saw Commit, NOT Abort.
+        Assert.Single(replaceCoord.Commits);
+        Assert.Empty(replaceCoord.Aborts);
+        Assert.Equal((777UL, 778UL, 32.50m * 100), replaceCoord.Commits[0]);
+        // Replace-fanout: orig + new ExecutionEvent (kind=Replaced) on the sink.
+        Assert.Equal(2, sink.Events.Count);
+        Assert.All(sink.Events, e => Assert.Equal(ExecKind.Replaced, e.Kind));
+        Assert.Contains(sink.Events, e => e.ClOrdId == 777UL);
+        Assert.Contains(sink.Events, e => e.ClOrdId == 778UL);
+        // Bot router saw both replace ERs.
+        Assert.Equal(2, botRouter.Events.Count);
+
+        // 4) Subsequent Trade ER on the new ClOrdID (orig=0 in priority-lost trade).
+        proc.Apply(778UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 32.50m, rejectReason: null, origClOrdId: 0);
+
+        Assert.Equal(OrderStatus.Filled, newOrder.Status);
+        Assert.Equal(0, newOrder.LeavesQuantity);
+        Assert.Equal(100, newOrder.CumulativeQuantity);
+        // Position booked.
+        var pos = positions.GetOrCreate(bob, "PETR4");
+        Assert.Equal(100, pos.NetQuantity);
+        Assert.Equal(32.50m, pos.AverageEntryPrice);
+        // Cash debited (Buy: available drops by notional).
+        Assert.Equal(100_000m - (32.50m * 100), cash.GetAvailable(bob));
+        // Fill ER published on sink + routed to bot.
+        Assert.Equal(3, sink.Events.Count);
+        var fillEv = sink.Events[2];
+        Assert.Equal(ExecKind.Fill, fillEv.Kind);
+        Assert.Equal(778UL, fillEv.ClOrdId);
+        Assert.Equal(3, botRouter.Events.Count);
+    }
+
+    [Fact]
+    public void Processor_CancelAsReplace_secondCancelReplay_isIdempotentNoOp()
+    {
+        // Edge-case from #241: PendingReplacementRegistry.TryConsume is
+        // one-shot, so a replayed Cancel ER (FIXP retransmit) falls
+        // through to the standard cancel branch. Order is already
+        // Replaced (terminal) so MarkCancelled is guarded — no throw,
+        // no double-add, no state regression.
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new CaptureSink();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["bob"] = 100_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var marginProvider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        var replaceCoord = new RecordingReplaceCoordinator();
+        var reg = new PendingReplacementRegistry();
+
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink, marginProvider,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: null,
+            replacements: reg,
+            replaceMargin: replaceCoord,
+            botErRouter: null);
+
+        var bob = new EndClientId("bob");
+        var orig = new Order(777UL, bob, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 32.49m, "FIRM");
+        book.TryAdd(orig);
+        orig.MarkWorking();
+        ownership.Register(777UL, bob);
+        ownership.RegisterReplaceLink(777UL, 778UL);
+        Assert.True(reg.TryAdd(new OrderReplacementIntent(
+            777UL, 778UL, bob, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 32.50m, "FIRM", null, null)));
+
+        // First Cancel ER — intercepted as cancel-as-replace.
+        proc.Apply(778UL, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: 777UL);
+        Assert.Equal(OrderStatus.Replaced, orig.Status);
+        Assert.True(book.TryGet(778UL, out var newOrder));
+        Assert.Equal(OrderStatus.Working, newOrder!.Status);
+        var sinkCountAfterFirst = sink.Events.Count;
+        Assert.Single(replaceCoord.Commits);
+
+        // Second Cancel ER (FIXP replay) — registry consumed; falls
+        // through. The 778 lookup finds the now-Working new order;
+        // MarkCancelled WILL apply to it (no terminal guard against
+        // Working). This is the documented v1 behaviour for replayed
+        // cancels arriving after the new order was hydrated; the more
+        // important assertion is no throw, no double-add, no reservation
+        // leak (no extra Commit/Abort on the coordinator).
+        var origStatusBefore = orig.Status;
+        proc.Apply(778UL, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: 777UL);
+        Assert.Equal(origStatusBefore, orig.Status); // original untouched
+        Assert.Single(replaceCoord.Commits); // no extra commit
+        Assert.Empty(replaceCoord.Aborts);   // no leak
+        Assert.True(book.TryGet(778UL, out var stillThere));
+        Assert.Same(newOrder, stillThere);   // not re-hydrated
+        // Fan-out emitted at most one extra ER for the standard cancel path.
+        Assert.InRange(sink.Events.Count - sinkCountAfterFirst, 0, 1);
     }
 }


### PR DESCRIPTION
Closes #241

## Summary

B3MatchingPlatform implements `OrderCancelReplaceRequest` via two paths:
- **priority-kept** (same price, qty ≤ current): emits `ExecType=Replaced`. Already handled by the existing early-intercept.
- **priority-lost** (any other change): emits `Cancel(orig)` + `Trade/New(new)` under the **new** ClOrdID — *never* an `ExecType=Replaced`.

Pre-fix, the priority-lost path terminalised the original as `Cancelled`, never hydrated the new ClOrdID in the book, and dropped the subsequent Trade ER with `ER for known owner ... missing order ...; dropping.` — silent fill loss, divergent position/cash, leaked replace-margin reservation.

## Change

- **`ExecutionReportProcessor.Apply`**: new early-intercept branch parallel to the existing Rejected/Replaced ones — when `kind == Canceled` AND a `PendingReplacementRegistry` intent is present for `clOrdId`, funnel through `ApplyReplaceAccepted` so the original goes `Replaced` (idempotent), the new `Order` is hydrated under `newClOrdId` (so the follow-up Trade lands), and `IReplaceMarginCoordinator.CommitReplace` runs.
- **Observability**: promote the "missing order for known owner" warn to **error** and add counter `trading.execution_reports.dropped_known_owner_missing_order` (tag `kind`). A non-zero rate means a silent fill loss — alertable.

## Tests

Added in `OrderModifyMarginAndProcessorTests`:
1. `Processor_CancelAsReplace_priorityLost_terminalisesOriginalAndHydratesNew_thenSubsequentFillBooksPositionAndCash` — full scenario from #241 (Bob 100@32.49 → modify to 32.50 → `Cancel(778, orig=777)` + `Trade(778, orig=0, cum=100, lastPx=32.50)`). Asserts: original `Replaced`; new order in book, `Filled`, cum=100; `PositionKeeper` +100 @ 32.50; `CashLedger` debited 3250; coordinator `Commit` (not `Abort`); replace + fill events on sink and bot router.
2. `Processor_CancelAsReplace_secondCancelReplay_isIdempotentNoOp` — FIXP-replay idempotency: second Cancel ER falls through (registry consumed once), no extra `Commit`/`Abort`, original untouched, no double-add.

## Test count

`1040 → 1042 passing, 0 failed` (full `dotnet test B3TradingPlatform.slnx -c Release`).