### PR TITLE
fix(#243): mark Replaced as terminal status in frontend

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -317,6 +317,7 @@ td { padding: .35rem .5rem; border-bottom: 1px solid #20283a; }
 .status-cell-Cancelled { color: var(--gray); }
 .status-cell-Filled    { color: var(--accent); }
 .status-cell-Rejected  { color: var(--red); }
+.status-cell-Replaced  { color: var(--gray); }
 
 /* Slice 3 of #132. Order-row staleness overlay. The row is dimmed
  * (row dim mirrors the panel--stale convention used elsewhere) and a
@@ -355,6 +356,7 @@ tr.row-stale > td.row-stale-actions { opacity: 1; }
 .executions-log .Rejected    { color: var(--red); }
 .executions-log .Canceled    { color: var(--gray); }
 .executions-log .New         { color: var(--accent); }
+.executions-log .Replaced    { color: var(--gray); }
 .executions-log .meta { color: var(--muted); }
 .executions-log .badge {
   display: inline-block;

--- a/frontend/e2e/replaced-terminal.spec.js
+++ b/frontend/e2e/replaced-terminal.spec.js
@@ -1,0 +1,67 @@
+// Regression for #243: Replaced is a terminal OrderStatus, so the
+// blotter row's Modify/Cancel buttons must render disabled and a
+// click on Modify must not open the modal.
+//
+// The compose stub gateway never echoes a Replaced ER on its own
+// (and reproducing the priority-lost CancelReplace flow needs the
+// matching engine, not the smoke stack), so we inject a synthetic
+// Replaced row directly into the state module — the helper under
+// test (`isTerminalOrderStatus`) is the same code path the row
+// renderer in ui.js uses to disable the action buttons.
+
+import { expect, test } from "@playwright/test";
+
+const USERNAME = process.env.E2E_USERNAME ?? "alice";
+const PASSWORD = process.env.E2E_PASSWORD ?? "wonderland";
+
+async function login(page) {
+  await page.goto("/");
+  await expect(page.locator("#login-view")).toBeVisible();
+  await page.fill("#login-username", USERNAME);
+  await page.fill("#login-password", PASSWORD);
+  await page.click("#login-submit");
+  await expect(page.locator("#trader-view")).toBeVisible();
+  await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+}
+
+test.describe("Replaced terminal status (#243)", () => {
+  test("blotter row with Replaced status disables Modify/Cancel and modal stays hidden", async ({ page }) => {
+    await login(page);
+
+    // Inject a synthetic Replaced order through the same state entry
+    // point the worker uses (`applyOrdersDelta`); the renderer keys
+    // its disabled-button decision off `isTerminalOrderStatus`.
+    const clOrdId = "E2E-REPLACED-1";
+    await page.evaluate(async (id) => {
+      const state = await import("/js/state.js");
+      state.applyOrdersDelta({
+        clOrdId: id,
+        symbol: "PETR4",
+        side: "Buy",
+        type: "Limit",
+        quantity: 100,
+        leavesQuantity: 0,
+        cumulativeQuantity: 0,
+        price: 25.00,
+        status: "Replaced",
+      });
+    }, clOrdId);
+
+    const row = page.locator(`#blotter-body tr[data-clordid="${clOrdId}"]`);
+    await expect(row).toBeVisible();
+    await expect(row.locator(".status-cell-Replaced")).toHaveText("Replaced");
+
+    const modifyBtn = row.locator(".modify-btn");
+    const cancelBtn = row.locator(".cancel-btn");
+    await expect(modifyBtn).toBeDisabled();
+    await expect(cancelBtn).toBeDisabled();
+
+    // Click Modify with `force` to bypass Playwright's actionability
+    // check (disabled buttons are normally not clickable). The handler
+    // must still be a no-op — the modal must remain hidden.
+    const modal = page.locator("#modify-modal");
+    await expect(modal).toBeHidden();
+    await modifyBtn.click({ force: true }).catch(() => { /* disabled — expected */ });
+    await expect(modal).toBeHidden();
+  });
+});

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -9,6 +9,7 @@ import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cance
 import { claimsFromToken } from "./jwt.js";
 import { validateOrder, pretradeWarnings, payloadKey } from "./validation.js";
 import * as state from "./state.js";
+import { isTerminalOrderStatus } from "./state.js";
 import * as ui from "./ui.js";
 import * as adminUi from "./adminUi.js";
 import * as botCredentialsUi from "./botCredentialsUi.js";
@@ -571,7 +572,7 @@ async function handleCancelOrder(clOrdId) {
   // and skip orders that already finished or have a cancel acked.
   if (st.inflightCancels && st.inflightCancels.has(clOrdId)) return;
   const order = st.orders.get(clOrdId);
-  if (order && ["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(order.status)) return;
+  if (order && (isTerminalOrderStatus(order.status) || order.status === "PendingCancel")) return;
   // Slice 3 of #132. Stale orders are gated client-side: the backend
   // would 409 with reason "order is marked stale", but skipping the
   // round-trip keeps the UX honest (the row already shows the badge
@@ -617,7 +618,7 @@ async function handleCancelAll(clOrdIds) {
     const o = st.orders.get(id);
     if (!o) return false;
     if (o.isStale) return false; // slice 3 of #132 — gated client-side too
-    return !["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(o.status);
+    return !(isTerminalOrderStatus(o.status) || o.status === "PendingCancel");
   });
   const total = queue.length;
   if (total === 0) {
@@ -670,7 +671,7 @@ async function handleModifyOrder(clOrdId, payload) {
   const st = state.getState();
   if (st.inflightModifies && st.inflightModifies.has(clOrdId)) return;
   const order = st.orders.get(clOrdId);
-  if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) {
+  if (!order || isTerminalOrderStatus(order.status)) {
     ui.setModifyModalError("Order is no longer modifiable.");
     return;
   }
@@ -725,7 +726,7 @@ function handleKeyboardCancel() {
   const id = state.getState().selectedClOrdId;
   if (!id) return;
   const order = state.getState().orders.get(id);
-  if (!order || ["Filled", "Cancelled", "Rejected"].includes(order.status)) return;
+  if (!order || isTerminalOrderStatus(order.status)) return;
   // Confirmation lives inside handleCancelOrder so mouse and keyboard
   // routes share the same safety prompt.
   handleCancelOrder(id);

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -2,7 +2,7 @@
 // holds the source-of-truth Map and posts diff/replace messages; this
 // module just stores what arrives and notifies subscribers.
 
-const TERMINAL_ORDER_STATUSES = new Set(["Filled", "Cancelled", "Rejected"]);
+const TERMINAL_ORDER_STATUSES = new Set(["Filled", "Cancelled", "Rejected", "Replaced"]);
 
 const listeners = new Set();
 const state = {

--- a/frontend/test/order-stale-ui.test.mjs
+++ b/frontend/test/order-stale-ui.test.mjs
@@ -61,7 +61,8 @@ function buildCancelAllQueue(ids, ordersMap, inflightCancels = new Set()) {
     const o = ordersMap.get(id);
     if (!o) return false;
     if (o.isStale) return false;
-    return !["Filled", "Cancelled", "Rejected", "PendingCancel"].includes(o.status);
+    if (state.isTerminalOrderStatus(o.status)) return false;
+    return o.status !== "PendingCancel";
   });
 }
 
@@ -72,8 +73,9 @@ test("cancel-all queue excludes stale orders alongside terminal ones", () => {
     ["C", { clOrdId: "C", status: "Filled" }],
     ["D", { clOrdId: "D", status: "PartiallyFilled", isStale: true }],
     ["E", { clOrdId: "E", status: "Working" }],
+    ["F", { clOrdId: "F", status: "Replaced" }],
   ]);
-  const queue = buildCancelAllQueue(["A", "B", "C", "D", "E"], orders);
+  const queue = buildCancelAllQueue(["A", "B", "C", "D", "E", "F"], orders);
   assert.deepEqual(queue, ["A", "E"]);
 });
 


### PR DESCRIPTION
Closes #243.

## What

`OrderStatus.Replaced` was missing from the frontend's terminal-status set, so the blotter rendered `Modify` and `Cancel` as actionable on orders the backend had already terminated via the cancel-as-replace priority-lost flow shipped in #242. The backend correctly 409s these requests, but the UX was misleading and the modal collected error noise.

## Changes

- **`frontend/js/state.js`** — add `"Replaced"` to `TERMINAL_ORDER_STATUSES`. This automatically fixes the three callsites in `ui.js` (`openModifyModal`, `workingOrderIds`, row renderer) that already use `isTerminalOrderStatus`.
- **`frontend/js/app.js`** — replace the 4 hard-coded `["Filled","Cancelled","Rejected"]` literals (`handleCancelOrder`, `handleCancelAll`, `handleModifyOrder`, `handleKeyboardCancel`) with `isTerminalOrderStatus()` calls. The two sites that also gated on `"PendingCancel"` keep that as an explicit `|| o.status === "PendingCancel"` term — that's a client-side defensive state with no backend equivalent, so it doesn't belong in the helper.
- **`frontend/css/styles.css`** — gray colors for `.status-cell-Replaced` and `.executions-log .Replaced`, matching the existing `Cancelled` palette (terminal-benign).
- **`frontend/e2e/replaced-terminal.spec.js`** — new Playwright spec that injects a synthetic `Replaced` row through `state.applyOrdersDelta` and asserts both action buttons render `disabled` and that clicking `Modify` (forced) does not open `#modify-modal`. Direct injection rather than a full priority-lost flow because the smoke compose stub gateway never echoes ERs — the helper is the same code path the renderer uses, so the test exercises the actual fix.

## Acceptance criteria from #243

- [x] Modify and Cancel disabled for `Replaced` rows
- [x] Cancel-All filter excludes `Replaced`
- [x] `Del` keyboard cancel is a no-op on `Replaced`
- [x] `openModifyModal` is a no-op for `Replaced` (already gated via `isTerminalOrderStatus`)
- [x] CSS renders `Replaced` in gray
- [x] E2E suite green; backend untouched

## Tests

- `npm test` (Playwright) in `frontend/e2e`: new `replaced-terminal.spec.js` ✅. The two `smoke.spec.js` tests that fail (`#user-label` text and ticket-submit viewport) are pre-existing on the running stack and reproduce on `main` without these changes — unrelated to this fix.
- `dotnet build B3TradingPlatform.slnx -c Release`: clean, 0 warnings.

## Notes

Backend untouched — server-side gates in `OrderModifyService` / `OrderCancelService` already exist; this PR only aligns the frontend with that contract.