### PR TITLE
feat(#245): order detail modal — drill-down de execuções por ClOrdID

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -578,3 +578,65 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 .bot-credentials-secret-card .modal-actions button[type="button"]:hover {
   background: rgba(255,255,255,.05);
 }
+
+/* ---------- Order detail modal (#245) ---------- */
+.order-detail-backdrop { align-items: start; padding-top: 4vh; }
+.order-detail-card {
+  width: min(880px, 94vw);
+  max-height: 90vh;
+  padding: 1rem 1.25rem 1.25rem;
+  gap: .75rem;
+}
+.order-detail-header { display: flex; flex-direction: column; gap: .5rem; }
+.order-detail-title-row {
+  display: flex; align-items: center; justify-content: space-between; gap: .75rem;
+}
+.order-detail-title-row h2 { font-size: 1rem; margin: 0; }
+.order-detail-close {
+  background: transparent; border: 0; color: var(--muted); font-size: 1.4rem;
+  line-height: 1; padding: .1rem .4rem; cursor: pointer; border-radius: 4px;
+}
+.order-detail-close:hover { color: var(--text); background: rgba(255,255,255,.05); }
+.order-detail-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.order-detail-body {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: .5rem .85rem; font-size: .8rem;
+}
+.order-detail-body .field { display: flex; flex-direction: column; gap: .15rem; }
+.order-detail-body .field .label {
+  color: var(--muted); font-size: .65rem; letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.order-detail-body .field .value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .85rem; color: var(--text);
+}
+.order-detail-body .field.field-wide { grid-column: 1 / -1; }
+.modal-progress {
+  position: relative;
+  height: 6px; border-radius: 3px; background: var(--panel-2);
+  overflow: hidden; margin-top: .25rem;
+}
+.modal-progress > .modal-progress-fill {
+  position: absolute; top: 0; left: 0; bottom: 0;
+  background: var(--accent);
+}
+.order-detail-exec-scroll { max-height: 50vh; overflow: auto; }
+.order-detail-table {
+  width: 100%; border-collapse: collapse;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .75rem;
+}
+.order-detail-table th, .order-detail-table td {
+  padding: .3rem .5rem; border-bottom: 1px solid #20283a; text-align: left;
+}
+.order-detail-table th {
+  position: sticky; top: 0; background: var(--panel);
+  color: var(--muted); font-weight: 600; font-size: .7rem;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.order-detail-table td.num, .order-detail-table th.num {
+  text-align: right; font-variant-numeric: tabular-nums;
+}
+.order-detail-table tr.empty td { color: var(--muted); text-align: center; padding: .8rem; }
+#blotter-body tr[data-clordid] { cursor: pointer; }
+#blotter-body tr[data-clordid] td.row-stale-actions { cursor: default; }

--- a/frontend/e2e/order-detail.spec.js
+++ b/frontend/e2e/order-detail.spec.js
@@ -179,5 +179,13 @@ test.describe("Order detail modal (#245)", () => {
 
     await expect(modal.locator("#order-detail-exec-body tr")).toHaveCount(3);
     await expect(modal.locator(".status-cell-Filled").first()).toBeVisible();
+
+    // P2 — after a live `orders.delta` the originating row reference
+    // we cached on open is detached (renderBlotter() replaces
+    // #blotter-body.innerHTML). Closing must still return focus to the
+    // row matching the same ClOrdID, re-resolved from the new DOM.
+    await page.locator("#order-detail-close").click();
+    await expect(modal).toBeHidden();
+    await expect(row).toBeFocused();
   });
 });

--- a/frontend/e2e/order-detail.spec.js
+++ b/frontend/e2e/order-detail.spec.js
@@ -1,0 +1,183 @@
+// E2E for the Order Detail modal (#245). The full flow is:
+//   1. login → blotter visible
+//   2. inject a synthetic Working order + a couple of executions for it
+//      via the same state entry points used by the worker (mirrors the
+//      pattern in replaced-terminal.spec.js — the smoke stack doesn't
+//      actually fill orders end-to-end)
+//   3. click any non-button cell of the row → modal opens with header +
+//      executions table
+//   4. dismiss with backdrop, then re-open and dismiss with Esc
+//   5. ensure clicking the Modify button does NOT open the detail modal
+
+import { expect, test } from "@playwright/test";
+
+const USERNAME = process.env.E2E_USERNAME ?? "alice";
+const PASSWORD = process.env.E2E_PASSWORD ?? "wonderland";
+
+async function login(page) {
+  await page.goto("/");
+  await expect(page.locator("#login-view")).toBeVisible();
+  await page.fill("#login-username", USERNAME);
+  await page.fill("#login-password", PASSWORD);
+  await page.click("#login-submit");
+  await expect(page.locator("#trader-view")).toBeVisible();
+  await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+}
+
+async function injectOrderAndExecutions(page, clOrdId) {
+  await page.evaluate(async (id) => {
+    const state = await import("/js/state.js");
+    state.applyOrdersDelta({
+      clOrdId: id,
+      symbol: "PETR4",
+      securityId: 4,
+      side: "Buy",
+      type: "Limit",
+      quantity: 200,
+      leavesQuantity: 100,
+      cumulativeQuantity: 100,
+      price: 32.50,
+      status: "PartiallyFilled",
+    });
+    state.applyExecutionsDelta({
+      clOrdId: id,
+      symbol: "PETR4",
+      side: "Buy",
+      status: "Working",
+      kind: "New",
+      leavesQuantity: 200,
+      cumulativeQuantity: 0,
+      lastQuantity: 0,
+      lastPrice: 0,
+      rejectReason: null,
+      timestampUtc: "2026-05-07T20:00:00.000Z",
+      isNativeStp: false,
+    });
+    state.applyExecutionsDelta({
+      clOrdId: id,
+      symbol: "PETR4",
+      side: "Buy",
+      status: "PartiallyFilled",
+      kind: "PartialFill",
+      leavesQuantity: 100,
+      cumulativeQuantity: 100,
+      lastQuantity: 100,
+      lastPrice: 32.50,
+      rejectReason: null,
+      timestampUtc: "2026-05-07T20:00:01.000Z",
+      isNativeStp: false,
+    });
+  }, clOrdId);
+}
+
+test.describe("Order detail modal (#245)", () => {
+  test("clicking a working-order row opens the detail modal with header + executions, then closes via backdrop, Esc, and × button", async ({ page }) => {
+    await login(page);
+
+    const clOrdId = "E2E-ORDER-DETAIL-1";
+    await injectOrderAndExecutions(page, clOrdId);
+
+    const row = page.locator(`#blotter-body tr[data-clordid="${clOrdId}"]`);
+    await expect(row).toBeVisible();
+
+    const modal = page.locator("#order-detail-modal");
+    await expect(modal).toBeHidden();
+
+    // Click on the Symbol cell (a non-button area of the row).
+    await row.locator("td").nth(1).click();
+    await expect(modal).toBeVisible();
+    await expect(page.locator("#order-detail-title")).toContainText(clOrdId);
+    // Status badge reuses .status-cell-* class.
+    await expect(modal.locator(".status-cell-PartiallyFilled").first()).toBeVisible();
+    // Executions table should have at least one fill row + one transition row.
+    const execRows = modal.locator("#order-detail-exec-body tr");
+    await expect(execRows).toHaveCount(2);
+
+    // Backdrop click closes.
+    await modal.click({ position: { x: 5, y: 5 } });
+    await expect(modal).toBeHidden();
+
+    // Re-open, then close via Esc.
+    await row.locator("td").nth(1).click();
+    await expect(modal).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(modal).toBeHidden();
+
+    // Re-open, then close via × button.
+    await row.locator("td").nth(1).click();
+    await expect(modal).toBeVisible();
+    await page.locator("#order-detail-close").click();
+    await expect(modal).toBeHidden();
+  });
+
+  test("clicking the Modify button on a working-order row does NOT open the order-detail modal", async ({ page }) => {
+    await login(page);
+
+    const clOrdId = "E2E-ORDER-DETAIL-2";
+    await injectOrderAndExecutions(page, clOrdId);
+
+    const row = page.locator(`#blotter-body tr[data-clordid="${clOrdId}"]`);
+    await expect(row).toBeVisible();
+
+    const detailModal = page.locator("#order-detail-modal");
+    const modifyModal = page.locator("#modify-modal");
+    await expect(detailModal).toBeHidden();
+    await expect(modifyModal).toBeHidden();
+
+    await row.locator(".modify-btn").click();
+    // Detail modal must remain hidden; Modify modal opens (its own flow).
+    await expect(detailModal).toBeHidden();
+    await expect(modifyModal).toBeVisible();
+    // Cleanup: dismiss modify modal so it doesn't bleed into other tests.
+    await page.keyboard.press("Escape");
+    await expect(modifyModal).toBeHidden();
+  });
+
+  test("a new ER for the open ClOrdID is appended live and refreshes the header", async ({ page }) => {
+    await login(page);
+
+    const clOrdId = "E2E-ORDER-DETAIL-3";
+    await injectOrderAndExecutions(page, clOrdId);
+
+    const row = page.locator(`#blotter-body tr[data-clordid="${clOrdId}"]`);
+    await expect(row).toBeVisible();
+    await row.locator("td").nth(1).click();
+    const modal = page.locator("#order-detail-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal.locator("#order-detail-exec-body tr")).toHaveCount(2);
+
+    // Push a second fill that completes the order.
+    await page.evaluate(async (id) => {
+      const state = await import("/js/state.js");
+      state.applyOrdersDelta({
+        clOrdId: id,
+        symbol: "PETR4",
+        securityId: 4,
+        side: "Buy",
+        type: "Limit",
+        quantity: 200,
+        leavesQuantity: 0,
+        cumulativeQuantity: 200,
+        price: 32.50,
+        status: "Filled",
+      });
+      state.applyExecutionsDelta({
+        clOrdId: id,
+        symbol: "PETR4",
+        side: "Buy",
+        status: "Filled",
+        kind: "Fill",
+        leavesQuantity: 0,
+        cumulativeQuantity: 200,
+        lastQuantity: 100,
+        lastPrice: 32.60,
+        rejectReason: null,
+        timestampUtc: "2026-05-07T20:00:02.000Z",
+        isNativeStp: false,
+      });
+    }, clOrdId);
+
+    await expect(modal.locator("#order-detail-exec-body tr")).toHaveCount(3);
+    await expect(modal.locator(".status-cell-Filled").first()).toBeVisible();
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -410,6 +410,37 @@
     </form>
   </div>
 
+  <!-- ORDER DETAIL MODAL (#245) ------------------------------------- -->
+  <!-- Drill-down per ClOrdID: header (order summary + VWAP + progress)
+       and an executions table filtered by the same ClOrdID. Opened by
+       clicking any non-button cell on a Working Orders row. -->
+  <div id="order-detail-modal" class="modal-backdrop order-detail-backdrop" hidden
+       role="dialog" aria-modal="true" aria-labelledby="order-detail-title">
+    <div class="modal-card order-detail-card">
+      <header class="order-detail-header">
+        <div class="order-detail-title-row">
+          <h2 id="order-detail-title">Order detail</h2>
+          <button type="button" id="order-detail-close" class="order-detail-close"
+                  aria-label="Close order detail">×</button>
+        </div>
+        <div id="order-detail-body" class="order-detail-body"></div>
+      </header>
+      <div class="table-scroll order-detail-exec-scroll">
+        <table id="order-detail-exec-table" class="order-detail-table">
+          <thead>
+            <tr>
+              <th>Time</th><th>Kind</th>
+              <th class="num">LastQty</th><th class="num">LastPx</th>
+              <th class="num">CumQty</th><th class="num">Leaves</th>
+              <th>Status</th><th>Notes</th>
+            </tr>
+          </thead>
+          <tbody id="order-detail-exec-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
   <!-- Cancel-all modal (T3). Two-stage: trader must type CANCEL to
        arm submit, then the burst kicks off with progress. Only the
        Close button is enabled once the burst is running. -->

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -244,6 +244,232 @@ export function setModifyModalSubmitting(busy) {
   submit.textContent = busy ? "Sending…" : "Send modify";
 }
 
+// ── Order detail modal (#245) ──────────────────────────────────────
+//
+// Read-only drill-down per ClOrdID. Surfaces the executions that
+// belong to a single client order (no Replace-chain following, no
+// algo slice expansion — those are deliberately out of scope per the
+// issue). Re-renders idempotently when new ERs arrive while open.
+
+let openClOrdId = null;
+let originatingRow = null;
+let orderDetailKeyHandler = null;
+
+/**
+ * Volume-Weighted Average Price across the executions array, restricted
+ * to ones that actually moved size (lastQuantity > 0). Returns `null`
+ * when no qualifying fills exist so callers can render `—` instead of
+ * a misleading `0.00`.
+ */
+export function vwapOf(executions) {
+  if (!Array.isArray(executions) || executions.length === 0) return null;
+  let notional = 0;
+  let qty = 0;
+  for (const e of executions) {
+    const lq = Number(e?.lastQuantity);
+    const lp = Number(e?.lastPrice);
+    if (!Number.isFinite(lq) || lq <= 0) continue;
+    if (!Number.isFinite(lp)) continue;
+    notional += lq * lp;
+    qty += lq;
+  }
+  if (qty === 0) return null;
+  return notional / qty;
+}
+
+/**
+ * Filters the executions ring to only those whose ClOrdID matches.
+ * Comparison is string-based (DtoMappings already `.toString()`s the
+ * server-side ClOrdId so equality on numbers is unsafe).
+ */
+export function executionsForClOrdId(executions, clOrdId) {
+  if (!Array.isArray(executions) || clOrdId == null) return [];
+  const key = String(clOrdId);
+  return executions.filter(e => e != null && String(e.clOrdId) === key);
+}
+
+function fmtExecTime(ts) {
+  if (ts == null) return "—";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(11, 23);
+}
+
+function focusableInDialog(dialog) {
+  const sel = [
+    "a[href]", "button:not([disabled])", "input:not([disabled])",
+    "select:not([disabled])", "textarea:not([disabled])",
+    "[tabindex]:not([tabindex='-1'])",
+  ].join(",");
+  return Array.from(dialog.querySelectorAll(sel))
+    .filter(el => !el.hidden && el.offsetParent !== null);
+}
+
+function openOrderDetail(clOrdId, row) {
+  if (clOrdId == null) return;
+  const modal = $("order-detail-modal");
+  if (!modal) return;
+  openClOrdId = String(clOrdId);
+  originatingRow = row ?? null;
+  modal.hidden = false;
+  renderOrderDetail();
+  if (!orderDetailKeyHandler) {
+    orderDetailKeyHandler = (e) => onOrderDetailKeydown(e);
+    document.addEventListener("keydown", orderDetailKeyHandler, true);
+  }
+  // Focus the close button so keyboard-only users land inside the
+  // dialog immediately; focus trap takes care of the rest.
+  setTimeout(() => $("order-detail-close")?.focus(), 0);
+}
+
+export function closeOrderDetail() {
+  const modal = $("order-detail-modal");
+  if (!modal) return;
+  modal.hidden = true;
+  $("order-detail-body").innerHTML = "";
+  $("order-detail-exec-body").innerHTML = "";
+  if (orderDetailKeyHandler) {
+    document.removeEventListener("keydown", orderDetailKeyHandler, true);
+    orderDetailKeyHandler = null;
+  }
+  const row = originatingRow;
+  openClOrdId = null;
+  originatingRow = null;
+  // Return focus to the originating row when it's still in the DOM;
+  // pagination / re-renders may have detached it, in which case we
+  // intentionally let the browser fall back to <body>.
+  if (row && document.contains(row)) {
+    row.setAttribute("tabindex", "-1");
+    try { row.focus({ preventScroll: true }); } catch { /* ignore */ }
+  }
+}
+
+function refreshOpenOrderDetail() {
+  if (openClOrdId == null) return;
+  renderOrderDetail();
+}
+
+function renderOrderDetail() {
+  if (openClOrdId == null) return;
+  const st = getState();
+  const order = st.orders?.get(openClOrdId);
+  const execs = executionsForClOrdId(st.executions, openClOrdId);
+  renderOrderDetailHeader(order, execs);
+  renderOrderDetailExecutions(execs);
+}
+
+function renderOrderDetailHeader(order, execs) {
+  const body = $("order-detail-body");
+  const title = $("order-detail-title");
+  if (!body) return;
+  if (!order) {
+    if (title) title.textContent = `Order ${openClOrdId}`;
+    body.innerHTML = `<div class="field field-wide"><span class="value">Order not found in current cache.</span></div>`;
+    return;
+  }
+  if (title) title.textContent = `Order ${order.clOrdId}`;
+  const vwap = vwapOf(execs);
+  const qty = Number(order.quantity) || 0;
+  const cum = Number(order.cumulativeQuantity) || 0;
+  const leaves = Number(order.leavesQuantity) || 0;
+  const pct = qty > 0 ? Math.max(0, Math.min(100, (cum / qty) * 100)) : 0;
+  const price = order.price == null ? "MKT" : fmtPx(order.price);
+  const staleBadge = order.isStale
+    ? ` <span class="order-stale-badge" title="${escapeHtml(order.staleReason || "stale")}">stale</span>`
+    : "";
+  const algoBlock = order.parentAlgoId
+    ? `<div class="field"><span class="label">Parent algo</span><span class="value"><code>${escapeHtml(order.parentAlgoId)}</code>${order.algoSliceSeq != null ? ` · slice ${escapeHtml(order.algoSliceSeq)}` : ""}</span></div>`
+    : "";
+  body.innerHTML = `
+    <div class="field"><span class="label">ClOrdID</span><span class="value"><code>${escapeHtml(order.clOrdId)}</code></span></div>
+    <div class="field"><span class="label">Symbol</span><span class="value">${escapeHtml(order.symbol)}${order.securityId != null ? ` <span class="muted-line">· ${escapeHtml(order.securityId)}</span>` : ""}</span></div>
+    <div class="field"><span class="label">Side</span><span class="value">${escapeHtml(order.side)}</span></div>
+    <div class="field"><span class="label">Type</span><span class="value">${escapeHtml(order.type)}</span></div>
+    <div class="field"><span class="label">Status</span><span class="value status-cell-${escapeHtml(order.status)}">${escapeHtml(order.status)}${staleBadge}</span></div>
+    <div class="field"><span class="label">Price</span><span class="value">${price}</span></div>
+    <div class="field"><span class="label">VWAP fills</span><span class="value">${vwap == null ? "—" : fmtPx(vwap)}</span></div>
+    <div class="field field-wide">
+      <span class="label">Qty / Cum / Leaves</span>
+      <span class="value">${fmtQty(qty)} · ${fmtQty(cum)} · ${fmtQty(leaves)}</span>
+      <div class="modal-progress" role="progressbar" aria-valuenow="${cum}" aria-valuemin="0" aria-valuemax="${qty}">
+        <div class="modal-progress-fill" style="width: ${pct}%"></div>
+      </div>
+    </div>
+    ${algoBlock}
+  `;
+}
+
+function renderOrderDetailExecutions(execs) {
+  const tbody = $("order-detail-exec-body");
+  if (!tbody) return;
+  if (execs.length === 0) {
+    tbody.innerHTML = `<tr class="empty"><td colspan="8">No executions for this ClOrdID yet.</td></tr>`;
+    return;
+  }
+  // Newest first.
+  const sorted = execs.slice().sort((a, b) => {
+    const ta = Date.parse(a.timestampUtc) || 0;
+    const tb = Date.parse(b.timestampUtc) || 0;
+    return tb - ta;
+  });
+  tbody.innerHTML = sorted.map(execDetailRow).join("");
+}
+
+function execDetailRow(e) {
+  const ts = fmtExecTime(e.timestampUtc);
+  const hasFill = Number(e.lastQuantity) > 0;
+  const lastQty = hasFill ? fmtQty(e.lastQuantity) : "";
+  const lastPx = hasFill ? fmtPx(e.lastPrice) : "";
+  const stp = stpBadgeFor(e);
+  const reason = e.rejectReason ? escapeHtml(e.rejectReason) : "";
+  const notes = [reason, stp].filter(Boolean).join(" ");
+  return `<tr>
+    <td>${ts}</td>
+    <td class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</td>
+    <td class="num">${lastQty}</td>
+    <td class="num">${lastPx}</td>
+    <td class="num">${fmtQty(e.cumulativeQuantity)}</td>
+    <td class="num">${fmtQty(e.leavesQuantity)}</td>
+    <td class="status-cell-${escapeHtml(e.status)}">${escapeHtml(e.status)}</td>
+    <td>${notes}</td>
+  </tr>`;
+}
+
+function onOrderDetailKeydown(e) {
+  const modal = $("order-detail-modal");
+  if (!modal || modal.hidden) return;
+  if (e.key === "Escape") {
+    e.stopPropagation();
+    e.preventDefault();
+    closeOrderDetail();
+    return;
+  }
+  if (e.key !== "Tab") return;
+  // Focus trap. Loop the focusable set inside the dialog.
+  const dialog = modal.querySelector(".order-detail-card");
+  if (!dialog) return;
+  const focusables = focusableInDialog(dialog);
+  if (focusables.length === 0) {
+    e.preventDefault();
+    return;
+  }
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+  if (!dialog.contains(active)) {
+    e.preventDefault();
+    first.focus();
+    return;
+  }
+  if (e.shiftKey && active === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && active === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
 function submitModifyForm() {
   const form  = $("modify-modal-form");
   const qtyEl = $("modify-modal-qty");
@@ -457,7 +683,7 @@ export function bindUi() {
 
   // Event delegation for per-row Cancel + Modify buttons in the
   // blotter, plus row selection (clicking anywhere outside the
-  // action buttons).
+  // action buttons) and the order-detail drill-down (#245).
   $("blotter-body").addEventListener("click", (e) => {
     const cancelBtn = e.target.closest(".cancel-btn");
     if (cancelBtn) {
@@ -472,8 +698,27 @@ export function bindUi() {
       return;
     }
     const row = e.target.closest("tr[data-clordid]");
-    if (row) onSelectOrder(row.dataset.clordid);
+    if (!row) return;
+    onSelectOrder(row.dataset.clordid);
+    // Order-detail modal opens for any non-button cell click. Skip
+    // links / form controls just in case future renders embed any.
+    if (e.target.closest("button, a, input, select, textarea")) return;
+    openOrderDetail(row.dataset.clordid, row);
   });
+
+  // Order-detail modal wiring (#245). Backdrop click and × button both
+  // dismiss; Esc + focus trap handled by the keydown listener installed
+  // when the modal opens.
+  const orderDetailModal = $("order-detail-modal");
+  if (orderDetailModal) {
+    orderDetailModal.addEventListener("click", (e) => {
+      if (e.target === orderDetailModal) closeOrderDetail();
+    });
+  }
+  const orderDetailCloseBtn = $("order-detail-close");
+  if (orderDetailCloseBtn) {
+    orderDetailCloseBtn.addEventListener("click", () => closeOrderDetail());
+  }
 
   // Modify modal wiring (slice 5 of #122).
   const modifyForm = $("modify-modal-form");
@@ -944,6 +1189,7 @@ function renderForSlice(slice) {
   if (slice === "orders" || slice === "all") renderCancelAllButton();
   if (slice === "positions" || slice === "all") renderPositions();
   if (slice === "executions" || slice === "all") renderExecutions();
+  if (slice === "executions" || slice === "orders" || slice === "all") refreshOpenOrderDetail();
   if (slice === "status") {
     setStatusPill(getState().status);
     renderReconnect(); // pill change usually correlates with countdown reset

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -305,7 +305,7 @@ function focusableInDialog(dialog) {
     .filter(el => !el.hidden && el.offsetParent !== null);
 }
 
-function openOrderDetail(clOrdId, row) {
+export function openOrderDetail(clOrdId, row) {
   if (clOrdId == null) return;
   const modal = $("order-detail-modal");
   if (!modal) return;
@@ -325,22 +325,43 @@ function openOrderDetail(clOrdId, row) {
 export function closeOrderDetail() {
   const modal = $("order-detail-modal");
   if (!modal) return;
+  // Idempotent: nothing to do when the modal isn't currently open.
+  // This matters because state.clearAll() fan-outs to "all" and we
+  // call closeOrderDetail() unconditionally from renderForSlice — it
+  // must be safe regardless of whether the user actually had it open.
+  if (openClOrdId == null && modal.hidden && !orderDetailKeyHandler) return;
   modal.hidden = true;
-  $("order-detail-body").innerHTML = "";
-  $("order-detail-exec-body").innerHTML = "";
+  const body = $("order-detail-body");
+  if (body) body.innerHTML = "";
+  const execBody = $("order-detail-exec-body");
+  if (execBody) execBody.innerHTML = "";
   if (orderDetailKeyHandler) {
     document.removeEventListener("keydown", orderDetailKeyHandler, true);
     orderDetailKeyHandler = null;
   }
   const row = originatingRow;
+  const clOrdIdToRestore = openClOrdId;
   openClOrdId = null;
   originatingRow = null;
-  // Return focus to the originating row when it's still in the DOM;
-  // pagination / re-renders may have detached it, in which case we
-  // intentionally let the browser fall back to <body>.
-  if (row && document.contains(row)) {
-    row.setAttribute("tabindex", "-1");
-    try { row.focus({ preventScroll: true }); } catch { /* ignore */ }
+  // Return focus to the originating row. Live `orders.delta` updates
+  // re-render #blotter-body and detach the stored node, so when the
+  // original reference is gone we re-resolve the row by ClOrdID. If
+  // even that is missing (terminalized + paginated off), fall back to
+  // the blotter body so focus stays in the trader pane instead of
+  // silently landing on <body>.
+  let target = (row && document.contains(row)) ? row : null;
+  if (!target && clOrdIdToRestore != null && document.querySelector) {
+    const escaped = (typeof CSS !== "undefined" && CSS.escape)
+      ? CSS.escape(clOrdIdToRestore)
+      : String(clOrdIdToRestore).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    try {
+      target = document.querySelector(`#blotter-body tr[data-clordid="${escaped}"]`);
+    } catch { target = null; }
+  }
+  if (!target) target = $("blotter-body") || null;
+  if (target) {
+    try { target.setAttribute("tabindex", "-1"); } catch { /* ignore */ }
+    try { target.focus({ preventScroll: true }); } catch { /* ignore */ }
   }
 }
 
@@ -1185,6 +1206,13 @@ function renderGatewayPill() {
 }
 
 function renderForSlice(slice) {
+  // state.clearAll() (logout / session expiry / WS "clear" frame)
+  // notifies "all". The Order Detail modal is owned by ui and would
+  // otherwise survive the state wipe — leaving the previous user's
+  // ClOrdID rendered on top of the login screen with the capture-
+  // phase Esc/Tab listener still live. Close it before any panel
+  // re-render so subsequent renders run against a clean slate.
+  if (slice === "all") closeOrderDetail();
   if (slice === "orders" || slice === "all" || slice === "blotterFilter" || slice === "blotterPage" || slice === "selectedOrder") renderBlotter();
   if (slice === "orders" || slice === "all") renderCancelAllButton();
   if (slice === "positions" || slice === "all") renderPositions();

--- a/frontend/test/order-detail-lifecycle.test.mjs
+++ b/frontend/test/order-detail-lifecycle.test.mjs
@@ -1,0 +1,200 @@
+// Lifecycle tests for the Order Detail modal (#245 follow-up).
+//
+// These cover two regressions surfaced in the PR #246 review:
+//   * P1 — modal must close when state.clearAll() runs (logout / session
+//     expiry / WS "clear" frame), so the previous user's ClOrdID doesn't
+//     stay rendered on top of the login screen with the capture-phase
+//     keydown listener still live.
+//   * P2 — closeOrderDetail() must restore focus to the originating row
+//     even after orders.delta re-renders #blotter-body and detaches the
+//     stored node reference; it re-resolves the row by ClOrdID.
+//
+// The rest of frontend/test/ runs without jsdom, so we hand-roll the
+// minimum DOM surface ui.js touches (modal element, body containers,
+// document.contains, document.querySelector for the row fallback,
+// addEventListener/removeEventListener with capture).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+class FakeEl {
+  constructor(tag) {
+    this.tagName = String(tag || "div").toUpperCase();
+    this.hidden = false;
+    this.innerHTML = "";
+    this.textContent = "";
+    this._attrs = new Map();
+    this.dataset = {};
+    this._parent = null;
+    this._children = [];
+    this._focused = 0;
+  }
+  setAttribute(k, v) { this._attrs.set(k, String(v)); }
+  removeAttribute(k) { this._attrs.delete(k); }
+  getAttribute(k) { return this._attrs.has(k) ? this._attrs.get(k) : null; }
+  focus() { this._focused++; }
+  appendChild(c) { c._parent = this; this._children.push(c); return c; }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+}
+
+function makeDocument() {
+  const elements = new Map();
+  const doc = {
+    _root: new FakeEl("html"),
+    body: new FakeEl("body"),
+    getElementById: (id) => elements.get(id) ?? null,
+    addEventListener: (type, fn /* , opts */) => {
+      const key = `${type}`;
+      const list = doc._listeners.get(key) ?? [];
+      list.push(fn);
+      doc._listeners.set(key, list);
+    },
+    removeEventListener: (type, fn /* , opts */) => {
+      const list = doc._listeners.get(type);
+      if (!list) return;
+      const i = list.indexOf(fn);
+      if (i >= 0) list.splice(i, 1);
+    },
+    contains: (node) => {
+      // True if the node is one of the tracked elements OR was attached
+      // to the synthetic blotter body (used to simulate detachment by
+      // a re-render in the P2 test).
+      if (!node) return false;
+      if (node === doc.body) return true;
+      for (const el of elements.values()) {
+        if (el === node) return true;
+      }
+      const blotter = elements.get("blotter-body");
+      if (blotter && blotter._children.includes(node)) return true;
+      return false;
+    },
+    querySelector: (sel) => {
+      const m = sel.match(/^#blotter-body tr\[data-clordid="([^"]+)"\]$/);
+      if (!m) return null;
+      const blotter = elements.get("blotter-body");
+      if (!blotter) return null;
+      return blotter._children.find(c => c.dataset?.clordid === m[1]) ?? null;
+    },
+    _listeners: new Map(),
+    _elements: elements,
+  };
+  return doc;
+}
+
+function installFakeDom() {
+  const doc = makeDocument();
+  for (const id of [
+    "order-detail-modal",
+    "order-detail-body",
+    "order-detail-exec-body",
+    "order-detail-close",
+    "order-detail-title",
+    "blotter-body",
+  ]) {
+    const el = new FakeEl(id === "blotter-body" ? "tbody" : "div");
+    if (id === "order-detail-modal") el.hidden = true;
+    doc._elements.set(id, el);
+  }
+  globalThis.document = doc;
+  globalThis.window = globalThis.window ?? {};
+  globalThis.CSS = { escape: (s) => String(s).replace(/(["\\])/g, "\\$1") };
+  // ui.js renderOrderDetail uses setTimeout to focus the close button;
+  // we run it sync so we don't have pending timers when tests finish.
+  globalThis.setTimeout = (fn) => { try { fn(); } catch { /* ignore */ } return 0; };
+  return doc;
+}
+
+const doc = installFakeDom();
+const ui = await import("../js/ui.js");
+const state = await import("../js/state.js");
+
+function makeRow(clOrdId) {
+  const row = new FakeEl("tr");
+  row.dataset.clordid = clOrdId;
+  doc._elements.get("blotter-body").appendChild(row);
+  return row;
+}
+
+function detachAllRows() {
+  // Simulate orders.delta re-rendering #blotter-body — the stored
+  // originatingRow reference is still alive but no longer in the DOM.
+  doc._elements.get("blotter-body")._children = [];
+}
+
+test("closeOrderDetail is idempotent when nothing is open", () => {
+  // Should be a no-op even before openOrderDetail has ever been called.
+  ui.closeOrderDetail();
+  ui.closeOrderDetail();
+  const modal = doc.getElementById("order-detail-modal");
+  assert.equal(modal.hidden, true);
+});
+
+test("clearAll fan-out closes an open order-detail modal (P1)", () => {
+  // Wire the production fan-out: state.subscribe is the same hook
+  // bindUi() uses; we drive renderForSlice's "all" branch by calling
+  // closeOrderDetail directly on the "all" notification, which is
+  // exactly what renderForSlice does.
+  const unsub = state.subscribe((slice) => {
+    if (slice === "all") ui.closeOrderDetail();
+  });
+
+  const row = makeRow("CLORD-LOGOUT-1");
+  ui.openOrderDetail("CLORD-LOGOUT-1", row);
+  const modal = doc.getElementById("order-detail-modal");
+  assert.equal(modal.hidden, false, "precondition: modal opened");
+  assert.ok(
+    (doc._listeners.get("keydown") ?? []).length === 1,
+    "precondition: capture-phase keydown listener installed",
+  );
+
+  state.clearAll();
+
+  assert.equal(modal.hidden, true, "modal hidden after clearAll");
+  assert.equal(
+    (doc._listeners.get("keydown") ?? []).length, 0,
+    "capture-phase keydown listener removed",
+  );
+
+  // Re-open / re-close cycle proves the listener wasn't leaked nor
+  // double-registered (else listener count would creep above 1).
+  ui.openOrderDetail("CLORD-LOGOUT-2", makeRow("CLORD-LOGOUT-2"));
+  assert.equal((doc._listeners.get("keydown") ?? []).length, 1);
+  ui.closeOrderDetail();
+  assert.equal((doc._listeners.get("keydown") ?? []).length, 0);
+
+  unsub();
+});
+
+test("closeOrderDetail re-resolves the originating row by ClOrdID after a re-render (P2)", () => {
+  const clOrdId = "CLORD-REFOCUS-1";
+  const originalRow = makeRow(clOrdId);
+  ui.openOrderDetail(clOrdId, originalRow);
+
+  // Simulate `orders.delta` replacing #blotter-body's children — the
+  // node we cached in originatingRow is now detached.
+  detachAllRows();
+  assert.equal(doc.contains(originalRow), false);
+
+  // The new row representing the same ClOrdID after the re-render.
+  const replacementRow = makeRow(clOrdId);
+
+  ui.closeOrderDetail();
+
+  assert.ok(replacementRow._focused >= 1, "replacement row received focus");
+  assert.equal(replacementRow.getAttribute("tabindex"), "-1");
+});
+
+test("closeOrderDetail falls back to #blotter-body when the row is gone entirely", () => {
+  const clOrdId = "CLORD-REFOCUS-2";
+  const row = makeRow(clOrdId);
+  ui.openOrderDetail(clOrdId, row);
+
+  // Drop the row and don't replace it (terminal + paginated off).
+  detachAllRows();
+
+  const blotter = doc.getElementById("blotter-body");
+  const focusBefore = blotter._focused;
+  ui.closeOrderDetail();
+  assert.ok(blotter._focused > focusBefore, "blotter-body received focus as fallback");
+});

--- a/frontend/test/order-detail.test.mjs
+++ b/frontend/test/order-detail.test.mjs
@@ -1,0 +1,120 @@
+// Unit tests for the Order Detail modal helpers (#245).
+//
+// We don't exercise the DOM rendering (the rest of frontend/test/
+// follows the same convention — pure function tests via node:test);
+// the helpers covered here are the ones that can produce a wrong
+// number that the trader will visibly read off the screen, so they
+// must be locked down independently of the layout.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { vwapOf, executionsForClOrdId } from "../js/ui.js";
+
+function ex(over = {}) {
+  return {
+    clOrdId: "X1",
+    symbol: "PETR4",
+    side: "Buy",
+    status: "PartiallyFilled",
+    kind: "PartialFill",
+    leavesQuantity: 0,
+    cumulativeQuantity: 0,
+    lastQuantity: 0,
+    lastPrice: 0,
+    rejectReason: null,
+    timestampUtc: "2026-05-07T20:00:00Z",
+    isNativeStp: false,
+    ...over,
+  };
+}
+
+test("vwapOf returns null for empty input", () => {
+  assert.equal(vwapOf([]), null);
+  assert.equal(vwapOf(null), null);
+  assert.equal(vwapOf(undefined), null);
+});
+
+test("vwapOf returns the price when there is exactly one fill", () => {
+  const v = vwapOf([ex({ lastQuantity: 100, lastPrice: 32.5 })]);
+  assert.equal(v, 32.5);
+});
+
+test("vwapOf computes the weighted average across mixed fills", () => {
+  // 60 @ 32.50 + 40 @ 32.60 → (1950 + 1304) / 100 = 32.54
+  const v = vwapOf([
+    ex({ lastQuantity: 60, lastPrice: 32.5 }),
+    ex({ lastQuantity: 40, lastPrice: 32.6 }),
+  ]);
+  assert.ok(Math.abs(v - 32.54) < 1e-9, `expected 32.54, got ${v}`);
+});
+
+test("vwapOf preserves the average when fills are equal qty", () => {
+  // 2 fills of 100 @ 32.50 → VWAP 32.50
+  const v = vwapOf([
+    ex({ lastQuantity: 100, lastPrice: 32.5 }),
+    ex({ lastQuantity: 100, lastPrice: 32.5 }),
+  ]);
+  assert.equal(v, 32.5);
+});
+
+test("vwapOf ignores transition ERs (lastQuantity == 0)", () => {
+  const v = vwapOf([
+    ex({ kind: "New", status: "Working", lastQuantity: 0, lastPrice: 0 }),
+    ex({ lastQuantity: 100, lastPrice: 32.5 }),
+    ex({ kind: "Replaced", status: "Replaced", lastQuantity: 0, lastPrice: 0 }),
+  ]);
+  assert.equal(v, 32.5);
+});
+
+test("vwapOf returns null when only zero-qty rows exist", () => {
+  const v = vwapOf([
+    ex({ kind: "New", lastQuantity: 0 }),
+    ex({ kind: "Cancelled", lastQuantity: 0 }),
+  ]);
+  assert.equal(v, null);
+});
+
+test("vwapOf handles non-equal quantities correctly", () => {
+  // 30 @ 10.00 + 70 @ 20.00 → (300 + 1400) / 100 = 17.00
+  const v = vwapOf([
+    ex({ lastQuantity: 30, lastPrice: 10 }),
+    ex({ lastQuantity: 70, lastPrice: 20 }),
+  ]);
+  assert.equal(v, 17);
+});
+
+test("executionsForClOrdId filters by ClOrdID and preserves order", () => {
+  const all = [
+    ex({ clOrdId: "A", lastQuantity: 1, lastPrice: 10, timestampUtc: "2026-05-07T20:00:00Z" }),
+    ex({ clOrdId: "B", lastQuantity: 1, lastPrice: 11, timestampUtc: "2026-05-07T20:00:01Z" }),
+    ex({ clOrdId: "A", lastQuantity: 1, lastPrice: 12, timestampUtc: "2026-05-07T20:00:02Z" }),
+    ex({ clOrdId: "C", lastQuantity: 1, lastPrice: 13, timestampUtc: "2026-05-07T20:00:03Z" }),
+    ex({ clOrdId: "A", lastQuantity: 0, lastPrice: 0, kind: "New", timestampUtc: "2026-05-07T20:00:04Z" }),
+  ];
+  const onlyA = executionsForClOrdId(all, "A");
+  assert.equal(onlyA.length, 3);
+  assert.deepEqual(onlyA.map(e => e.timestampUtc), [
+    "2026-05-07T20:00:00Z",
+    "2026-05-07T20:00:02Z",
+    "2026-05-07T20:00:04Z",
+  ]);
+});
+
+test("executionsForClOrdId compares as strings (numeric ClOrdId from server)", () => {
+  const all = [
+    ex({ clOrdId: "12345" }),
+    ex({ clOrdId: "12346" }),
+  ];
+  // Even if a caller passed a number (it shouldn't, but DTO surface
+  // is loose), the filter must still match without coercion bugs.
+  assert.equal(executionsForClOrdId(all, 12345).length, 1);
+  assert.equal(executionsForClOrdId(all, "12345").length, 1);
+  assert.equal(executionsForClOrdId(all, "missing").length, 0);
+});
+
+test("executionsForClOrdId returns empty for invalid input", () => {
+  assert.deepEqual(executionsForClOrdId(null, "A"), []);
+  assert.deepEqual(executionsForClOrdId([ex({ clOrdId: "A" })], null), []);
+  assert.deepEqual(executionsForClOrdId([], "A"), []);
+});


### PR DESCRIPTION
Closes #245.

## Summary

FE-only feature. Adds a read-only **Order Detail** modal opened by clicking any non-button cell of a Working Orders row. The modal shows an order header (ClOrdID, Symbol+SecurityId, Side, Type, Status badge, Qty/CumQty/LeavesQty progress bar, Price, computed VWAP of fills, parent algo info if present, stale badge) and an executions table filtered by ClOrdID (newest first). Transition ERs (`lastQuantity == 0`: New / Cancelled / Replaced / PendingNew) appear with empty qty/px cells.

## Files

- `frontend/index.html` — modal skeleton (`#order-detail-modal`).
- `frontend/css/styles.css` — modal styles + table; reuses `.status-cell-*` and `.order-stale-badge`.
- `frontend/js/ui.js` — `vwapOf`, `executionsForClOrdId`, `openOrderDetail`, `closeOrderDetail`, `refreshOpenOrderDetail`, focus trap, Esc/backdrop/× wiring; row-click delegation extended on `#blotter-body` (skips `button, a, input, select, textarea`).
- `frontend/test/order-detail.test.mjs` — unit tests (vwap + filter).
- `frontend/e2e/order-detail.spec.js` — Playwright e2e (open / close / live append / Modify-button does NOT open).

## Conformance to acceptance criteria

- [x] Click on row opens modal with header + executions filtered by ClOrdID.
- [x] VWAP correct: `60@32.50 + 40@32.60 → 32.54`; equal-qty preserves price; ignores `lastQuantity == 0` rows; `null → —` when no fills.
- [x] New ER for open ClOrdID appends row + refreshes header (subscribed to `executions` and `orders` slices).
- [x] Esc / backdrop / × all close.
- [x] Focus returns to originating row on close.
- [x] Modify/Cancel button clicks do NOT open the detail modal.
- [x] Terminal status (Filled/Cancelled/Rejected/Replaced) does not block opening.
- [x] Unit + e2e coverage.

## Out of scope (per issue)

No Replace-chain following, no algo slice expansion, no backend / DTO / WS changes.

## Test results

- Frontend unit: **130/130 pass** (`node --test frontend/test/`, +10 new).
- New e2e (`order-detail.spec.js`): **3/3 pass** against the live compose stack.
- Full e2e: 5/5 unrelated tests pass; the 2 pre-existing `smoke.spec.js` failures (`#ticket-submit` viewport ratio + `#user-label` text) reproduce on `origin/main` without these changes — collateral, not fixed here.
- Backend: `dotnet test B3TradingPlatform.slnx` → **1042/1042 pass** (no backend touched).
