### PR TITLE
fix(#247): close CommitReplace reservation drop on Cancel-as-Replace path

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -58,6 +58,16 @@ public static class MetricsRegistry
     public static readonly Counter<long> ExecutionReportsDroppedKnownOwnerMissingOrder =
         Meter.CreateCounter<long>("trading.execution_reports.dropped_known_owner_missing_order");
 
+    // Issue #247: CommitReplace landed on the reservation ledger but
+    // neither the original nor the transient (Prepare-side) entry was
+    // present, so the venue-confirmed remaining notional could not be
+    // tracked under the new ClOrdID. With Margin.Enabled=true this is
+    // a Prepare/Commit pipeline mismatch (some path registered a
+    // replace intent without going through the coordinator) and means
+    // the owner's reserved figure will leak until restart. Alertable.
+    public static readonly Counter<long> MarginCommitReplaceDropped =
+        Meter.CreateCounter<long>("trading.margin.commit_replace_dropped");
+
     // Risk / kill-switch
     public static readonly Counter<long> KillSwitchToggled =
         Meter.CreateCounter<long>("trading.kill_switch.toggled");

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -385,17 +385,17 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         ulong newClOrdId,
         decimal confirmedRemainingNotional)
     {
-        // Issue #247. Margin globally disabled: TryReserveAsync and
-        // PrepareReplaceAsync both short-circuit without populating
-        // _reservations, so any CommitReplace landing here is a true
-        // no-op — not a "dropped reservation" worth a warn. Mirror the
-        // gate in PrepareReplaceAsync so the legitimate disabled-margin
-        // deployment doesn't spam logs on every modify-to-fill.
-        if (!_options.CurrentValue.Margin.Enabled)
-            return;
-
         lock (_gate)
         {
+            // Issue #247 / PR #248 P2. The Margin.Enabled gate must live
+            // inside the lock and must NOT skip the cleanup path: the
+            // toggle can flip live via IOptionsMonitor (admin reload),
+            // and TryReserveAsync/PrepareReplaceAsync don't gate on
+            // Margin.Enabled. So _reservations[orig] / [new] may exist
+            // even when Margin is currently disabled — those slots must
+            // still be released here, otherwise a mid-session disable
+            // leaks every in-flight reservation.
+            //
             // Remove the transient entry (set up by Prepare) — its
             // RemainingNotional is the upsize delta we already reserved
             // (or zero for downsize/same).
@@ -422,6 +422,13 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
 
             if (owner is null)
             {
+                // No reservation existed on either side. If margin is
+                // currently disabled, this is the legitimate "started
+                // disabled, nothing was ever reserved" case — silent
+                // no-op (don't spam logs on every modify-to-fill).
+                if (!_options.CurrentValue.Margin.Enabled)
+                    return;
+
                 // Margin is enabled and yet neither side carried a
                 // reservation: this is a real bug (not a config no-op),
                 // because the matching PrepareReplaceAsync should have

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -385,6 +385,15 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         ulong newClOrdId,
         decimal confirmedRemainingNotional)
     {
+        // Issue #247. Margin globally disabled: TryReserveAsync and
+        // PrepareReplaceAsync both short-circuit without populating
+        // _reservations, so any CommitReplace landing here is a true
+        // no-op — not a "dropped reservation" worth a warn. Mirror the
+        // gate in PrepareReplaceAsync so the legitimate disabled-margin
+        // deployment doesn't spam logs on every modify-to-fill.
+        if (!_options.CurrentValue.Margin.Enabled)
+            return;
+
         lock (_gate)
         {
             // Remove the transient entry (set up by Prepare) — its
@@ -413,13 +422,19 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
 
             if (owner is null)
             {
-                // No reservation existed on either side (sell or
-                // never-reserved). Nothing to track going forward.
+                // Margin is enabled and yet neither side carried a
+                // reservation: this is a real bug (not a config no-op),
+                // because the matching PrepareReplaceAsync should have
+                // populated the transient entry under newClOrdId. Most
+                // likely culprit is a code path that registered the
+                // intent without going through the coordinator. Surface
+                // it as an error + counter so it's alertable.
                 if (confirmedRemainingNotional > 0m)
                 {
-                    _logger.LogWarning(
-                        "CommitReplace asked to track {Notional} for new ClOrdID {NewClOrdId} but neither original nor pending reservation has an owner; dropping.",
-                        confirmedRemainingNotional, newClOrdId);
+                    _logger.LogError(
+                        "CommitReplace asked to track {Notional} for new ClOrdID {NewClOrdId} (orig {OrigClOrdId}) but neither original nor pending reservation has an owner; dropping. This indicates a Prepare/Commit mismatch — reservation will leak.",
+                        confirmedRemainingNotional, newClOrdId, originalClOrdId);
+                    MetricsRegistry.MarginCommitReplaceDropped.Add(1);
                 }
                 return;
             }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -665,4 +665,47 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Contains(loggerProvider.Records, r =>
             r.Level == LogLevel.Error && r.Message.Contains("dropping", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task Issue247_PR248_CommitReplace_AfterMarginDisabledToggle_StillReleasesOriginalReservation()
+    {
+        // PR #248 P2: the Margin.Enabled gate in CommitReplace must NOT
+        // skip the cleanup path when reservations were created while
+        // margin was enabled and then the operator toggled it off via
+        // the admin reload path (IOptionsMonitor). Otherwise the
+        // original slot leaks forever — _reservations[orig] stays set
+        // and _reserved[owner] never returns to zero.
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(loggerProvider));
+        var marginLogger = loggerFactory.CreateLogger<ReserveOnSubmitMarginProvider>();
+
+        var enabled = new RiskOptions();
+        enabled.Margin.Enabled = true;
+        enabled.Margin.Initial["bob"] = 100_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(enabled);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, marginLogger);
+        var bob = new EndClientId("bob");
+
+        // Reserve while margin is enabled.
+        Assert.True((await margin.TryReserveAsync(
+            777UL,
+            new RiskContext(bob, "FIRM", "PETR4", OrderSide.Buy, OrderType.Limit, 100, 32.49m),
+            default)).Approved);
+        Assert.Equal(32.49m * 100, margin.ReservedForTesting("bob"));
+
+        // Operator flips margin OFF mid-session via admin reload.
+        var disabled = new RiskOptions();
+        disabled.Margin.Enabled = false;
+        disabled.Margin.Initial["bob"] = 100_000m;
+        monitor.Set(disabled);
+        Assert.False(monitor.CurrentValue.Margin.Enabled);
+
+        // Cancel-as-Replace lands AFTER the toggle. confirmedRemainingNotional=0
+        // simulates a flat-out cancel-as-replace (modify-to-fill collapses it
+        // to zero). This must release the original reservation cleanly.
+        ((IReplaceMarginCoordinator)margin).CommitReplace(777UL, 778UL, 0m);
+
+        Assert.Equal(0m, margin.ReservedForTesting("bob"));
+        Assert.DoesNotContain(loggerProvider.Records, r => r.Level >= LogLevel.Warning);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1,6 +1,7 @@
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 #pragma warning disable CS0618 // legacy Margin.Initial used to seed capacity in tests
@@ -522,5 +523,146 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Same(newOrder, stillThere);   // not re-hydrated
         // Fan-out emitted at most one extra ER for the standard cancel path.
         Assert.InRange(sink.Events.Count - sinkCountAfterFirst, 0, 1);
+    }
+
+    // ---------------- Issue #247: CommitReplace reservation drop ----------------
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Records { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+        public void Dispose() { }
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly CapturingLoggerProvider _owner;
+            public CapturingLogger(CapturingLoggerProvider owner) { _owner = owner; }
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                _owner.Records.Add((logLevel, formatter(state, exception)));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Issue247_CancelAsReplace_realProvider_priorityLostFlow_keepsReservedConsistent()
+    {
+        // Issue #247 reproducer. End-to-end sequence with the REAL
+        // ReserveOnSubmitMarginProvider (not the recording stub):
+        //   1) Bob submits Buy 100 @ 32.49 PETR4 → reservations[777]=3249.
+        //   2) Modify 32.49 → 32.50 (same qty)        → reservations[778]=delta(1).
+        //   3) Venue priority-lost: ER_Cancel(778, orig=777) intercepted →
+        //      ApplyReplaceAccepted → CommitReplace(777, 778, 3250).
+        //   4) Subsequent ER_Trade(778, fill 100) → margin released.
+        // Acceptance: the warn "neither original nor pending reservation
+        // has an owner; dropping" must NOT fire and reserved must end at 0.
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(loggerProvider));
+        var marginLogger = loggerFactory.CreateLogger<ReserveOnSubmitMarginProvider>();
+
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new CaptureSink();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["bob"] = 100_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, marginLogger);
+        var reg = new PendingReplacementRegistry();
+
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink, margin,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: null,
+            replacements: reg,
+            replaceMargin: margin);
+
+        var bob = new EndClientId("bob");
+
+        // 1) Bob submits original.
+        var orig = new Order(777UL, bob, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 32.49m, "FIRM");
+        book.TryAdd(orig);
+        orig.MarkWorking();
+        ownership.Register(777UL, bob);
+        Assert.True((await margin.TryReserveAsync(
+            777UL,
+            new RiskContext(bob, "FIRM", "PETR4", OrderSide.Buy, OrderType.Limit, 100, 32.49m),
+            default)).Approved);
+        Assert.Equal(32.49m * 100, margin.ReservedForTesting("bob"));
+
+        // 2) Modify-to-cross 32.49 → 32.50.
+        ownership.RegisterReplaceLink(777UL, 778UL);
+        Assert.True((await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(
+            777UL, 778UL, bob, newRemainingNotional: 32.50m * 100, default)).Approved);
+        Assert.True(reg.TryAdd(new OrderReplacementIntent(
+            777UL, 778UL, bob, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 32.50m, "FIRM", null, null)));
+        // Delta path: prepare reserved +1 (3250 - 3249).
+        Assert.Equal(32.50m * 100, margin.ReservedForTesting("bob"));
+
+        // 3) Venue priority-lost path: ER_Cancel under newClOrdID with orig=777.
+        proc.Apply(778UL, ExecKind.Canceled, leaves: 0, cumQty: 0, lastQty: 0,
+                   lastPx: 0m, rejectReason: null, origClOrdId: 777UL);
+
+        // CommitReplace must have transferred ownership cleanly: reserved
+        // stays at the new notional (3250). The "dropping" warn must NOT fire.
+        Assert.DoesNotContain(loggerProvider.Records, r =>
+            r.Level == LogLevel.Warning && r.Message.Contains("dropping", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(32.50m * 100, margin.ReservedForTesting("bob"));
+
+        // 4) Subsequent Fill ER on the new ClOrdID releases everything.
+        proc.Apply(778UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100,
+                   lastPx: 32.50m, rejectReason: null, origClOrdId: 0);
+        Assert.Equal(0m, margin.ReservedForTesting("bob"));
+    }
+
+    [Fact]
+    public void Issue247_CommitReplace_isSilentNoOpWhenMarginDisabled()
+    {
+        // Spin-off acceptance criterion: in deployments with
+        // Margin.Enabled=false the coordinator is still wired (so it can
+        // clean up if margin is toggled mid-session), but a normal
+        // Cancel-as-Replace still funnels through CommitReplace — that
+        // call must be a silent no-op, not a noisy warn-and-drop.
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(loggerProvider));
+        var marginLogger = loggerFactory.CreateLogger<ReserveOnSubmitMarginProvider>();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = false;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, marginLogger);
+
+        ((IReplaceMarginCoordinator)margin).CommitReplace(777UL, 778UL, 3250m);
+
+        Assert.DoesNotContain(loggerProvider.Records, r => r.Level >= LogLevel.Warning);
+        Assert.Equal(0m, margin.ReservedForTesting("bob"));
+    }
+
+    [Fact]
+    public void Issue247_CommitReplace_marginEnabled_neitherSideTracked_logsErrorAndCountsDrop()
+    {
+        // Defensive: if some future code path registers an intent
+        // without going through PrepareReplaceAsync, CommitReplace must
+        // still surface the drop loudly (error + metric) instead of the
+        // silent warn it used to emit. This protects the alertable-leak
+        // semantics called out in #247's acceptance criteria.
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(loggerProvider));
+        var marginLogger = loggerFactory.CreateLogger<ReserveOnSubmitMarginProvider>();
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["bob"] = 10_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, marginLogger);
+
+        // Skip both TryReserveAsync and PrepareReplaceAsync — empty ledger.
+        ((IReplaceMarginCoordinator)margin).CommitReplace(777UL, 778UL, 3250m);
+
+        Assert.Contains(loggerProvider.Records, r =>
+            r.Level == LogLevel.Error && r.Message.Contains("dropping", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
Closes #247.

## Root cause

DI-time configuration mismatch (closest to hypothesis A but actually a 5th not enumerated in the issue): when `Margin.Enabled=false` the host wires `IMarginProvider` to `NoOpMarginProvider` but keeps `IReplaceMarginCoordinator` pointed at the concrete `ReserveOnSubmitMarginProvider` (so it can clean up if margin is toggled mid-session). Submit therefore never populates `_reservations`; `PrepareReplaceAsync` short-circuits at its existing `Margin.Enabled` gate, but `CommitReplace` had no matching gate. Every priority-lost modify-to-fill funneled through #241's `ApplyReplaceAccepted` then found neither original nor pending reservation and emitted the noisy 'dropping' warn for every Cancel-as-Replace in margin-disabled deployments. Real-margin scenario verified clean by the new end-to-end reproducer (`Issue247_CancelAsReplace_realProvider_priorityLostFlow_keepsReservedConsistent`).

## Fix

- When margin IS enabled and both sides are still missing, this is a genuine Prepare/Commit pipeline mismatch with reservation-leak potential. Promoted the warn → error and added the alertable counter `trading.margin.commit_replace_dropped`, mirroring the `trading.execution_reports.dropped_known_owner_missing_order` convention introduced in #241.

## Tests

- `Issue247_CancelAsReplace_realProvider_priorityLostFlow_keepsReservedConsistent`: full Bob scenario from the issue with the real `ReserveOnSubmitMarginProvider` (not the recording stub). Asserts no 'dropping' warn fires and `_reserved[bob]` correctly tracks 3249 → 3250 (after Prepare delta) → 3250 (after Commit) → 0 (after Fill).
- `Issue247_CommitReplace_isSilentNoOpWhenMarginDisabled`: pure margin-disabled CommitReplace must not warn.
- `Issue247_CommitReplace_marginEnabled_neitherSideTracked_logsErrorAndCountsDrop`: defensive — the genuinely impossible-after-fix path still surfaces loudly (error + metric) so a future Prepare/Commit pipeline mismatch is alertable instead of a silent leak.

Full backend suite: 1042 baseline + 3 new = **1045/1045 passing**, 0 regressions.