### PR TITLE
feat(#253): expand OrderType + TimeInForce + StopPrice/GoodTillDate

### DIFF
--- a/backend/bench/B3.Trading.LoadTest/LoopbackFillGateway.cs
+++ b/backend/bench/B3.Trading.LoadTest/LoopbackFillGateway.cs
@@ -49,7 +49,10 @@ public sealed class LoopbackFillGateway : IExchangeGateway
 
     public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken) => Task.CompletedTask;
 
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task CancelReplaceAsync(
+        Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+        TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 
     private void DispatchFill(Order order)
     {

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -101,7 +101,10 @@ public static class OrdersEndpoints
 
             var owner = ResolveOwner(ctx, registry);
             var result = await modifier.ModifyAsync(
-                new OrderModifyRequest(owner, clOrdIdU, req.Quantity, req.Price), ct);
+                new OrderModifyRequest(
+                    owner, clOrdIdU, req.Quantity, req.Price,
+                    req.TimeInForce, req.StopPrice, req.GoodTillDate),
+                ct);
 
             return result.Kind switch
             {
@@ -198,5 +201,11 @@ public sealed record SubmitOrderRequest(
 
 public sealed record ModifyOrderRequest(
     long Quantity,
-    decimal? Price);
+    decimal? Price,
+    /// <summary>Q1.1 (#253). Optional override; null = keep original.</summary>
+    TimeInForce? TimeInForce = null,
+    /// <summary>Q1.1 (#253). Optional override; null = keep original. Required when modifying into <c>StopLoss</c>/<c>StopLimit</c> — but OrderType is not modifiable, so in practice only meaningful for orders that already are stop orders.</summary>
+    decimal? StopPrice = null,
+    /// <summary>Q1.1 (#253). Optional override; null = keep original (or auto-cleared when TIF is moved away from <c>GTD</c>). Required when changing TIF to <c>GTD</c>.</summary>
+    DateTimeOffset? GoodTillDate = null);
 

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -34,6 +34,13 @@ public static class OrdersEndpoints
                 return Results.BadRequest(new { error = $"invalid side '{req.Side}'" });
             if (!Enum.TryParse<OrderType>(req.Type, ignoreCase: true, out var type))
                 return Results.BadRequest(new { error = $"invalid type '{req.Type}'" });
+            // Q1.1 (#253). Optional TIF (default Day); reject malformed
+            // before allocating a ClOrdID so the bad request never enters
+            // the WAL pipeline.
+            var tif = TimeInForce.Day;
+            if (!string.IsNullOrWhiteSpace(req.TimeInForce)
+                && !Enum.TryParse<TimeInForce>(req.TimeInForce, ignoreCase: true, out tif))
+                return Results.BadRequest(new { error = $"invalid timeInForce '{req.TimeInForce}'" });
 
             // SecurityId resolution: explicit non-zero in the payload
             // wins (preserves the conformance contract). Otherwise look
@@ -49,7 +56,10 @@ public static class OrdersEndpoints
 
             var result = await submitter.SubmitAsync(new OrderSubmissionRequest(
                 owner, firm, req.Symbol, securityId, side, type,
-                req.Quantity, req.Price, OrderSubmissionSource.Manual), ct);
+                req.Quantity, req.Price, OrderSubmissionSource.Manual,
+                TimeInForce: tif,
+                StopPrice: req.StopPrice,
+                GoodTillDate: req.GoodTillDate), ct);
 
             return result.Kind switch
             {
@@ -178,7 +188,13 @@ public sealed record SubmitOrderRequest(
     string Side,
     string Type,
     long Quantity,
-    decimal? Price);
+    decimal? Price,
+    /// <summary>Q1.1 (#253). Optional; defaults to <c>"Day"</c>.</summary>
+    string? TimeInForce = null,
+    /// <summary>Q1.1 (#253). Required for <c>StopLoss</c>/<c>StopLimit</c>.</summary>
+    decimal? StopPrice = null,
+    /// <summary>Q1.1 (#253). Required when <c>TimeInForce == "GTD"</c>.</summary>
+    DateTimeOffset? GoodTillDate = null);
 
 public sealed record ModifyOrderRequest(
     long Quantity,

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -99,11 +99,24 @@ public static class OrdersEndpoints
             if (!ulong.TryParse(clOrdId, out var clOrdIdU))
                 return Results.NotFound();
 
+            // Q1.1 (#253). Optional TIF (null = no change) — parse as
+            // string + case-insensitive enum to mirror POST exactly,
+            // since the host does not register JsonStringEnumConverter
+            // and would otherwise force REST callers to send the
+            // numeric enum value over JSON.
+            TimeInForce? tif = null;
+            if (!string.IsNullOrWhiteSpace(req.TimeInForce))
+            {
+                if (!Enum.TryParse<TimeInForce>(req.TimeInForce, ignoreCase: true, out var parsed))
+                    return Results.BadRequest(new { error = $"invalid timeInForce '{req.TimeInForce}'" });
+                tif = parsed;
+            }
+
             var owner = ResolveOwner(ctx, registry);
             var result = await modifier.ModifyAsync(
                 new OrderModifyRequest(
                     owner, clOrdIdU, req.Quantity, req.Price,
-                    req.TimeInForce, req.StopPrice, req.GoodTillDate),
+                    tif, req.StopPrice, req.GoodTillDate),
                 ct);
 
             return result.Kind switch
@@ -202,8 +215,11 @@ public sealed record SubmitOrderRequest(
 public sealed record ModifyOrderRequest(
     long Quantity,
     decimal? Price,
-    /// <summary>Q1.1 (#253). Optional override; null = keep original.</summary>
-    TimeInForce? TimeInForce = null,
+    /// <summary>Q1.1 (#253). Optional override; null = keep original. Accepts
+    /// the case-insensitive <see cref="TimeInForce"/> name (e.g. <c>"GTD"</c>)
+    /// — mirrors the POST submit contract since the host does not register
+    /// <c>JsonStringEnumConverter</c>.</summary>
+    string? TimeInForce = null,
     /// <summary>Q1.1 (#253). Optional override; null = keep original. Required when modifying into <c>StopLoss</c>/<c>StopLimit</c> — but OrderType is not modifiable, so in practice only meaningful for orders that already are stop orders.</summary>
     decimal? StopPrice = null,
     /// <summary>Q1.1 (#253). Optional override; null = keep original (or auto-cleared when TIF is moved away from <c>GTD</c>). Required when changing TIF to <c>GTD</c>.</summary>

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -36,7 +36,13 @@ public sealed record OrderDto(
     int? AlgoSliceSeq = null,
     bool IsStale = false,
     string? StaleReason = null,
-    DateTimeOffset? StaledAtUtc = null);
+    DateTimeOffset? StaledAtUtc = null,
+    /// <summary>Q1.1 (#253). Time-in-force; defaults to <c>"Day"</c>.</summary>
+    string TimeInForce = "Day",
+    /// <summary>Q1.1 (#253). Trigger price for StopLoss/StopLimit; null otherwise.</summary>
+    decimal? StopPrice = null,
+    /// <summary>Q1.1 (#253). Expiry timestamp for GTD; null otherwise.</summary>
+    DateTimeOffset? GoodTillDate = null);
 
 public sealed record PositionDto(
     string Symbol,
@@ -102,7 +108,8 @@ public static class DtoMappings
         o.ClOrdId.ToString(), o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
         o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
         o.ParentAlgoId?.ToString(), o.AlgoSliceSeq,
-        o.IsStale, o.StaleReason, o.StaledAtUtc);
+        o.IsStale, o.StaleReason, o.StaledAtUtc,
+        o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate);
 
     public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
 

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -483,10 +483,11 @@ public sealed class ExecutionReportProcessor
         }
 
         // 3) Margin commit: rebalance to venue-confirmed remaining.
-        //    For Buy + Limit + cash, that's intent.NewPrice * leaves;
+        //    For Buy + margin-bearing type (Limit / StopLimit /
+        //    MarketWithLeftover) + cash, that's intent.NewPrice * leaves;
         //    everything else is zero (the coordinator no-ops on 0).
         var confirmedRemaining = (intent.Side == OrderSide.Buy
-                                  && intent.Type == OrderType.Limit
+                                  && intent.Type.IsMarginBearing()
                                   && intent.NewPrice is { } px
                                   && erLeaves > 0)
             ? px * erLeaves

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -463,7 +463,8 @@ public sealed class ExecutionReportProcessor
         try
         {
             newOrder = Order.HydrateReplacement(
-                origOrder, newClOrdId, intent.NewQuantity, intent.NewPrice, erLeaves, erCum);
+                origOrder, newClOrdId, intent.NewQuantity, intent.NewPrice, erLeaves, erCum,
+                intent.RequestedTimeInForce, intent.RequestedStopPrice, intent.RequestedGoodTillDate);
         }
         catch (Exception ex)
         {

--- a/backend/src/B3.Trading.Application/Gateway/IExchangeGateway.cs
+++ b/backend/src/B3.Trading.Application/Gateway/IExchangeGateway.cs
@@ -28,6 +28,23 @@ public interface IExchangeGateway
     /// <summary>
     /// Cancel-replace a working order. <paramref name="newClOrdId"/> must
     /// already be allocated; the original ClOrdID is the one being replaced.
+    ///
+    /// <para>
+    /// Q1.1 (#253). The trailing optionals carry the modify pipeline's
+    /// new-value overrides for TIF / StopPrice / GoodTillDate. Null on
+    /// any one of them means "inherit from <paramref name="original"/>";
+    /// non-null means "use the requested value on the outbound
+    /// ReplaceOrderRequest". OrderType is intentionally NOT modifiable
+    /// at this layer (FIX 35=G semantics on B3).
+    /// </para>
     /// </summary>
-    Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken);
+    Task CancelReplaceAsync(
+        Order original,
+        ulong newClOrdId,
+        long newQuantity,
+        decimal? newPrice,
+        TimeInForce? requestedTimeInForce,
+        decimal? requestedStopPrice,
+        DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken);
 }

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -205,7 +205,7 @@ public sealed class OrderModifyService
         // Margin Prepare: reserve only the upsize delta. The
         // coordinator no-ops on sells / markets / non-positive notionals.
         var newRemainingNotional = (orig.Side == OrderSide.Buy
-                                    && orig.Type == OrderType.Limit
+                                    && orig.Type.IsMarginBearing()
                                     && req.NewPrice is { } px)
             ? px * effectiveLeaves
             : 0m;

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -116,6 +116,24 @@ public sealed class OrderModifyService
             return OrderModifyResult.Conflict("order is terminal");
         }
 
+        // Q1.1 (#253) — pre-validate the optional TIF/StopPrice/
+        // GoodTillDate overrides against the original's invariants so a
+        // bad request fails BEFORE we burn a ClOrdID, run risk/margin,
+        // append to the WAL or hit the gateway. Mirror of the merge that
+        // Order.HydrateReplacement runs when the venue acks; throwing
+        // there would surface as an opaque replace-rejected ER, here it
+        // surfaces as a clean 400 with the invariant message.
+        try
+        {
+            _ = Order.MergeReplacementOptionals(
+                orig.Type, orig.TimeInForce, orig.StopPrice, orig.GoodTillDate,
+                req.NewTimeInForce, req.NewStopPrice, req.NewGoodTillDate);
+        }
+        catch (ArgumentException ex)
+        {
+            return OrderModifyResult.BadRequest(ex.Message);
+        }
+
         // Slice 1 of #132: refuse Modify against a stale-flagged order.
         // Same rationale as the cancel gate: the venue most likely
         // doesn't know the original ClOrdID, so a CancelReplace would
@@ -213,7 +231,10 @@ public sealed class OrderModifyService
             NewPrice: req.NewPrice,
             FirmId: orig.FirmId,
             ParentAlgoId: orig.ParentAlgoId,
-            AlgoSliceSeq: orig.AlgoSliceSeq);
+            AlgoSliceSeq: orig.AlgoSliceSeq,
+            RequestedTimeInForce: req.NewTimeInForce,
+            RequestedStopPrice: req.NewStopPrice,
+            RequestedGoodTillDate: req.NewGoodTillDate);
 
         try
         {
@@ -232,6 +253,9 @@ public sealed class OrderModifyService
                     NewPrice = req.NewPrice,
                     ParentAlgoId = orig.ParentAlgoId,
                     AlgoSliceSeq = orig.AlgoSliceSeq,
+                    RequestedTimeInForce = req.NewTimeInForce?.ToString(),
+                    RequestedStopPrice = req.NewStopPrice,
+                    RequestedGoodTillDate = req.NewGoodTillDate,
                 },
                 () =>
                 {
@@ -251,7 +275,9 @@ public sealed class OrderModifyService
 
         try
         {
-            await _gateway.CancelReplaceAsync(orig, newClOrdId, req.NewQuantity, req.NewPrice, ct);
+            await _gateway.CancelReplaceAsync(
+                orig, newClOrdId, req.NewQuantity, req.NewPrice,
+                req.NewTimeInForce, req.NewStopPrice, req.NewGoodTillDate, ct);
         }
         catch (Exception ex)
         {
@@ -285,11 +311,30 @@ public sealed class OrderModifyService
     }
 }
 
+/// <summary>
+/// Inputs for <see cref="OrderModifyService.ModifyAsync"/>.
+///
+/// <para>
+/// Q1.1 (#253). The trailing optionals — <see cref="NewTimeInForce"/>,
+/// <see cref="NewStopPrice"/>, <see cref="NewGoodTillDate"/> — follow
+/// the modify-pipeline override convention: <b>null = inherit the
+/// original order's value</b> across the cancel-replace boundary;
+/// <b>non-null = replace it with the supplied value</b>. Domain
+/// invariants (StopPrice required iff Stop*; GoodTillDate required
+/// iff TIF==GTD; auto-cleared when TIF moves away from GTD) are
+/// re-evaluated on the merged result and a violation surfaces as
+/// <see cref="OrderModifyResultKind.BadRequest"/> before any WAL
+/// append or gateway dispatch.
+/// </para>
+/// </summary>
 public sealed record OrderModifyRequest(
     EndClientId Owner,
     ulong OriginalClOrdId,
     long NewQuantity,
-    decimal? NewPrice);
+    decimal? NewPrice,
+    TimeInForce? NewTimeInForce = null,
+    decimal? NewStopPrice = null,
+    DateTimeOffset? NewGoodTillDate = null);
 
 /// <summary>
 /// Outcome of <see cref="OrderModifyService.ModifyAsync"/>. The

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -112,10 +112,25 @@ public sealed class OrderSubmissionService
                 clOrdId, req.Owner.Value, req.FirmId);
             return OrderSubmissionResult.DuplicateClOrdId(clOrdId);
         }
-        var order = new Order(
-            clOrdId, req.Owner, req.Symbol, req.SecurityId, req.Side, req.Type,
-            req.Quantity, req.Price, req.FirmId,
-            parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq);
+        Order order;
+        try
+        {
+            order = new Order(
+                clOrdId, req.Owner, req.Symbol, req.SecurityId, req.Side, req.Type,
+                req.Quantity, req.Price, req.FirmId,
+                parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq,
+                timeInForce: req.TimeInForce, stopPrice: req.StopPrice, goodTillDate: req.GoodTillDate);
+        }
+        catch (ArgumentException ex)
+        {
+            // Q1.1 (#253). Cross-field invariants (StopPrice required iff
+            // Stop*; GoodTillDate required iff GTD) are enforced inside
+            // the Order ctor so WAL replay can't reconstitute illegal
+            // combinations. At the live submit boundary we surface them
+            // as BadRequest so REST callers get a clear 400 rather than
+            // a 500 from an uncaught exception.
+            return OrderSubmissionResult.BadRequest(ex.Message);
+        }
 
         try
         {
@@ -144,6 +159,9 @@ public sealed class OrderSubmissionService
                     ParentAlgoId = req.ParentAlgoId,
                     AlgoSliceSeq = req.AlgoSliceSeq,
                     BotMapping = botMapping,
+                    TimeInForce = req.TimeInForce.ToString(),
+                    StopPrice = req.StopPrice,
+                    GoodTillDate = req.GoodTillDate,
                 },
                 () =>
                 {
@@ -275,7 +293,10 @@ public sealed record OrderSubmissionRequest(
     decimal? Price,
     OrderSubmissionSource Source = OrderSubmissionSource.Manual,
     ulong? ParentAlgoId = null,
-    int? AlgoSliceSeq = null)
+    int? AlgoSliceSeq = null,
+    TimeInForce TimeInForce = TimeInForce.Day,
+    decimal? StopPrice = null,
+    DateTimeOffset? GoodTillDate = null)
 {
     /// <summary>
     /// Sub-issue #171 (E). When non-null, the request originates from

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -121,4 +121,12 @@ public sealed record OrderReplacementIntent(
     decimal? NewPrice,
     string FirmId,
     ulong? ParentAlgoId,
-    int? AlgoSliceSeq);
+    int? AlgoSliceSeq,
+    // Q1.1 (#253). Optional modify-pipeline overrides. Null = inherit
+    // the original Order's value at HydrateReplacement time; non-null
+    // = override. CommitReplace passes these through Order.HydrateReplacement
+    // so the replacement Order carries either the new requested value
+    // or the original, as decided by the modify request.
+    TimeInForce? RequestedTimeInForce = null,
+    decimal? RequestedStopPrice = null,
+    DateTimeOffset? RequestedGoodTillDate = null);

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -161,6 +161,25 @@ public sealed record OrderSnapshot(
     public string? StaleReason { get; init; }
 
     public DateTimeOffset? StaledAtUtc { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). Time-in-force at submit time. Defaults to
+    /// <c>"Day"</c> so older snapshots without the field hydrate with
+    /// the implicit "Day" semantics they actually carried.
+    /// </summary>
+    public string TimeInForce { get; init; } = nameof(B3.Trading.Domain.TimeInForce.Day);
+
+    /// <summary>
+    /// Q1.1 (#253). Trigger price for StopLoss/StopLimit; <c>null</c>
+    /// otherwise. Older snapshots default to <c>null</c>.
+    /// </summary>
+    public decimal? StopPrice { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). Expiry timestamp for GTD; <c>null</c> otherwise.
+    /// Older snapshots default to <c>null</c>.
+    /// </summary>
+    public DateTimeOffset? GoodTillDate { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using B3.Trading.Domain;
 
 namespace B3.Trading.Application.Persistence;
 
@@ -170,6 +171,19 @@ public sealed record OrderReplaceRequestedEvent : WalEvent
     public decimal? NewPrice { get; init; }
     public ulong? ParentAlgoId { get; init; }
     public int? AlgoSliceSeq { get; init; }
+
+    // Q1.1 (#253) — optional modify-pipeline overrides for the three
+    // Q1.1 fields. Null defaults so deserializing pre-Q1.1 WAL payloads
+    // (which never carried these properties) hydrates as "no override
+    // requested" → HydrateReplacement inherits everything from the
+    // original Order. Distinct names (Requested*) avoid ambiguity with
+    // the hydrated Order's TimeInForce/StopPrice/GoodTillDate fields.
+    // TIF is stored as the enum name (string) to mirror
+    // <see cref="OrderSubmittedEvent.TimeInForce"/> and stay stable
+    // across enum renumberings.
+    public string? RequestedTimeInForce { get; init; }
+    public decimal? RequestedStopPrice { get; init; }
+    public DateTimeOffset? RequestedGoodTillDate { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -78,6 +78,32 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// matching the manual-order semantics they actually carried.
     /// </summary>
     public BotOrderMapping? BotMapping { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). Time-in-force at submit time. Defaults to
+    /// <c>"Day"</c> so older WAL segments without the field deserialise
+    /// with the implicit "Day" semantics they actually carried (the
+    /// gateway hardcoded TIF=Day before this slice). Stored as the
+    /// enum name to keep the wire format stable across future
+    /// renumberings of <see cref="Domain.TimeInForce"/>.
+    /// </summary>
+    public string TimeInForce { get; init; } = nameof(B3.Trading.Domain.TimeInForce.Day);
+
+    /// <summary>
+    /// Q1.1 (#253). Trigger price for <see cref="Domain.OrderType.StopLoss"/> /
+    /// <see cref="Domain.OrderType.StopLimit"/>. <c>null</c> for every other
+    /// type. Older WAL segments without the field deserialise as
+    /// <c>null</c>, matching the no-stop-orders semantics they carried.
+    /// </summary>
+    public decimal? StopPrice { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). Expiry timestamp for <see cref="Domain.TimeInForce.GTD"/>.
+    /// <c>null</c> for every other TIF. Older WAL segments without the
+    /// field deserialise as <c>null</c>, matching the no-GTD semantics
+    /// they carried.
+    /// </summary>
+    public DateTimeOffset? GoodTillDate { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -85,6 +85,15 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         if (!ctx.Price.HasValue)
             return Task.FromResult(RiskDecision.Approve);
 
+        // Pass-3 alignment (#253): the cancel-replace pipeline gates
+        // its re-baseline on OrderType.IsMarginBearing(); the submit
+        // path must use the IDENTICAL predicate. Otherwise a buy
+        // Market or buy StopLoss carrying a stray Price would reserve
+        // here at submit but commit 0 on replace, silently freeing the
+        // hold while the order is still working.
+        if (!ctx.Type.IsMarginBearing())
+            return Task.FromResult(RiskDecision.Approve);
+
         var notional = ctx.Price.Value * ctx.Quantity;
         if (notional <= 0m)
             return Task.FromResult(RiskDecision.Approve);

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -207,6 +207,9 @@ public sealed class WorkingOrderBook
                 IsStale = o.IsStale,
                 StaleReason = o.StaleReason,
                 StaledAtUtc = o.StaledAtUtc,
+                TimeInForce = o.TimeInForce.ToString(),
+                StopPrice = o.StopPrice,
+                GoodTillDate = o.GoodTillDate,
             };
         }
     }
@@ -250,10 +253,15 @@ public sealed class WorkingOrderBook
             var side = Enum.Parse<OrderSide>(s.Side);
             var type = Enum.Parse<OrderType>(s.Type);
             var status = Enum.Parse<OrderStatus>(s.Status);
+            // Q1.1 (#253): older snapshots default to "Day" via the
+            // OrderSnapshot record's init default, so a missing field
+            // round-trips through Enum.Parse cleanly.
+            var tif = Enum.Parse<TimeInForce>(s.TimeInForce);
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId,
                 s.ParentAlgoId, s.AlgoSliceSeq,
-                isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc);
+                isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc,
+                timeInForce: tif, stopPrice: s.StopPrice, goodTillDate: s.GoodTillDate);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -10,6 +10,46 @@ public enum OrderType
 {
     Limit,
     Market,
+    /// <summary>
+    /// Stop order: triggers a Market order when last trade price reaches
+    /// <see cref="Order.StopPrice"/>. Wire byte = SBE <c>STOP_LOSS</c>.
+    /// </summary>
+    StopLoss,
+    /// <summary>
+    /// Stop-limit order: triggers a Limit order at <see cref="Order.Price"/>
+    /// when last trade price reaches <see cref="Order.StopPrice"/>. Wire
+    /// byte = SBE <c>STOP_LIMIT</c>.
+    /// </summary>
+    StopLimit,
+    /// <summary>
+    /// Market-with-leftover-as-Limit: marketable up to <see cref="Order.Price"/>;
+    /// any unfilled remainder rests on the book as a Limit at that price.
+    /// Wire byte = SBE <c>MARKET_WITH_LEFTOVER_AS_LIMIT</c>.
+    /// </summary>
+    MarketWithLeftover,
+}
+
+/// <summary>
+/// Time-In-Force for a working order. The default value is <see cref="Day"/>
+/// so older WAL/snapshot payloads that pre-date this enum hydrate with
+/// the implicit "Day" semantics they actually carried.
+/// </summary>
+public enum TimeInForce
+{
+    /// <summary>Resting until the end of the trading day; cancelled at session close.</summary>
+    Day,
+    /// <summary>Match what is immediately marketable; cancel any remainder.</summary>
+    IOC,
+    /// <summary>All-or-nothing on the immediately marketable book; otherwise cancel.</summary>
+    FOK,
+    /// <summary>Resting until cancelled.</summary>
+    GTC,
+    /// <summary>Resting until <see cref="Order.GoodTillDate"/>; cancelled at end of that day.</summary>
+    GTD,
+    /// <summary>Submitted to (only) the closing auction.</summary>
+    AtClose,
+    /// <summary>Submitted to (only) the next opening / re-opening call auction.</summary>
+    GoodForAuction,
 }
 
 /// <summary>
@@ -86,7 +126,10 @@ public sealed class Order
         decimal? price,
         string firmId = "DEFAULT",
         ulong? parentAlgoId = null,
-        int? algoSliceSeq = null)
+        int? algoSliceSeq = null,
+        TimeInForce timeInForce = TimeInForce.Day,
+        decimal? stopPrice = null,
+        DateTimeOffset? goodTillDate = null)
     {
         if (clOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(clOrdId), "ClOrdID cannot be zero (reserved as null sentinel by EntryPoint).");
@@ -98,6 +141,30 @@ public sealed class Order
             throw new ArgumentException("ParentAlgoId and AlgoSliceSeq must be set together (both null = manual order; both set = algo child).");
         if (algoSliceSeq is < 0)
             throw new ArgumentOutOfRangeException(nameof(algoSliceSeq));
+
+        // Q1.1 (#253) — StopPrice/GoodTillDate cross-field invariants.
+        // Always-true invariants checked here (so WAL replay and snapshot
+        // hydrate cannot reconstitute illegal combinations). The wallclock
+        // "GoodTillDate must be in the future" check belongs at submit
+        // time and lives in the API surface, not in the ctor.
+        var requiresStop = type is OrderType.StopLoss or OrderType.StopLimit;
+        if (requiresStop && (!stopPrice.HasValue || stopPrice.Value <= 0m))
+            throw new ArgumentException(
+                $"StopPrice is required and must be positive for OrderType.{type}.",
+                nameof(stopPrice));
+        if (!requiresStop && stopPrice.HasValue)
+            throw new ArgumentException(
+                $"StopPrice must be null for OrderType.{type} (only StopLoss/StopLimit accept a stop trigger).",
+                nameof(stopPrice));
+        if (timeInForce == TimeInForce.GTD && !goodTillDate.HasValue)
+            throw new ArgumentException(
+                "GoodTillDate is required when TimeInForce == GTD.",
+                nameof(goodTillDate));
+        if (timeInForce != TimeInForce.GTD && goodTillDate.HasValue)
+            throw new ArgumentException(
+                $"GoodTillDate must be null when TimeInForce == {timeInForce} (only GTD carries an expiry).",
+                nameof(goodTillDate));
+
         ClOrdId = clOrdId;
         Owner = owner;
         Symbol = symbol;
@@ -109,6 +176,9 @@ public sealed class Order
         FirmId = firmId;
         ParentAlgoId = parentAlgoId;
         AlgoSliceSeq = algoSliceSeq;
+        TimeInForce = timeInForce;
+        StopPrice = stopPrice;
+        GoodTillDate = goodTillDate;
         LeavesQuantity = quantity;
         Status = OrderStatus.PendingNew;
     }
@@ -132,6 +202,32 @@ public sealed class Order
     /// </summary>
     public ulong? ParentAlgoId { get; }
     public int? AlgoSliceSeq { get; }
+
+    /// <summary>
+    /// Q1.1 (#253). Time-in-force for the order. Defaults to <see cref="TimeInForce.Day"/>
+    /// for legacy code paths that pre-date the field; persisted on
+    /// <c>OrderSubmittedEvent</c> and the snapshot.
+    /// </summary>
+    public TimeInForce TimeInForce { get; }
+
+    /// <summary>
+    /// Q1.1 (#253). Trigger price for <see cref="OrderType.StopLoss"/> /
+    /// <see cref="OrderType.StopLimit"/>. <c>null</c> for every other
+    /// <see cref="OrderType"/>; the constructor enforces that invariant
+    /// in both directions.
+    /// </summary>
+    public decimal? StopPrice { get; }
+
+    /// <summary>
+    /// Q1.1 (#253). Expiry timestamp for <see cref="TimeInForce.GTD"/>.
+    /// <c>null</c> for every other <see cref="TimeInForce"/>; the
+    /// constructor enforces that invariant in both directions. The
+    /// "must be in the future" check is the submit pipeline's job (see
+    /// <c>OrderSubmissionService</c>) — replay/hydration must accept
+    /// an already-elapsed timestamp so recovery is total.
+    /// </summary>
+    public DateTimeOffset? GoodTillDate { get; }
+
     public long LeavesQuantity { get; private set; }
     public long CumulativeQuantity { get; private set; }
     public OrderStatus Status { get; private set; }
@@ -304,9 +400,13 @@ public sealed class Order
         ulong clOrdId, EndClientId owner, string symbol, ulong securityId, OrderSide side, OrderType type,
         long quantity, decimal? price, long leaves, long cumQty, OrderStatus status, string firmId = "DEFAULT",
         ulong? parentAlgoId = null, int? algoSliceSeq = null,
-        bool isStale = false, string? staleReason = null, DateTimeOffset? staledAtUtc = null)
+        bool isStale = false, string? staleReason = null, DateTimeOffset? staledAtUtc = null,
+        TimeInForce timeInForce = TimeInForce.Day,
+        decimal? stopPrice = null,
+        DateTimeOffset? goodTillDate = null)
     {
-        var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq);
+        var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq,
+            timeInForce, stopPrice, goodTillDate);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;
@@ -383,6 +483,12 @@ public sealed class Order
             status: status,
             firmId: original.FirmId,
             parentAlgoId: original.ParentAlgoId,
-            algoSliceSeq: original.AlgoSliceSeq);
+            algoSliceSeq: original.AlgoSliceSeq,
+            // Q1.1 (#253) — modify pipeline only mutates qty+price; TIF,
+            // StopPrice and GoodTillDate are inherited from the original
+            // so the replacement order keeps the same surface semantics.
+            timeInForce: original.TimeInForce,
+            stopPrice: original.StopPrice,
+            goodTillDate: original.GoodTillDate);
     }
 }

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -453,7 +453,10 @@ public sealed class Order
         long newQuantity,
         decimal? newPrice,
         long erLeaves,
-        long erCumulative)
+        long erCumulative,
+        TimeInForce? requestedTimeInForce = null,
+        decimal? requestedStopPrice = null,
+        DateTimeOffset? requestedGoodTillDate = null)
     {
         ArgumentNullException.ThrowIfNull(original);
         if (newClOrdId == 0)
@@ -464,6 +467,10 @@ public sealed class Order
             throw new ArgumentOutOfRangeException(nameof(erCumulative));
         if (erLeaves < 0)
             throw new ArgumentOutOfRangeException(nameof(erLeaves));
+
+        var (effTif, effStop, effGtd) = MergeReplacementOptionals(
+            original.Type, original.TimeInForce, original.StopPrice, original.GoodTillDate,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
 
         var status = erCumulative >= newQuantity
             ? OrderStatus.Filled
@@ -484,11 +491,95 @@ public sealed class Order
             firmId: original.FirmId,
             parentAlgoId: original.ParentAlgoId,
             algoSliceSeq: original.AlgoSliceSeq,
-            // Q1.1 (#253) — modify pipeline only mutates qty+price; TIF,
-            // StopPrice and GoodTillDate are inherited from the original
-            // so the replacement order keeps the same surface semantics.
-            timeInForce: original.TimeInForce,
-            stopPrice: original.StopPrice,
-            goodTillDate: original.GoodTillDate);
+            // Q1.1 (#253) — TIF / StopPrice / GoodTillDate are mergeable
+            // through the modify pipeline. Null on the requested side =
+            // inherit the original; non-null = override. OrderType is NOT
+            // modifiable in B3 cancel-replace (FIX standard) so it is
+            // always inherited from the original.
+            timeInForce: effTif,
+            stopPrice: effStop,
+            goodTillDate: effGtd);
+    }
+
+    /// <summary>
+    /// Q1.1 (#253). Pure merge function for the modify pipeline's
+    /// optional Q1.1 fields. The rule, mirrored at every site that
+    /// computes a replacement (early validation in
+    /// <c>OrderModifyService</c>, hydration in
+    /// <see cref="HydrateReplacement"/>, gateway dispatch in
+    /// <c>B3EntryPointClientGateway.CancelReplaceAsync</c>):
+    ///
+    /// <list type="bullet">
+    ///   <item><c>effTif</c> = requested ?? original.</item>
+    ///   <item>If <c>effType</c> ∈ {StopLoss, StopLimit}:
+    ///     <c>effStop</c> = requested ?? original (must be &gt; 0).
+    ///     Otherwise: <c>requestedStop</c> must be null and
+    ///     <c>effStop</c> is null.</item>
+    ///   <item>If <c>effTif == GTD</c>: <c>effGtd</c> = requested ??
+    ///     original (must be non-null). Otherwise: <c>requestedGtd</c>
+    ///     must be null AND <c>effGtd</c> is auto-cleared to null —
+    ///     this is how callers move TIF away from GTD without having
+    ///     to redundantly null-out an inherited expiry.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Throws <see cref="ArgumentException"/> on any violation; the
+    /// caller is expected to translate it into a modify rejection
+    /// (<c>OrderModifyResultKind.BadRequest</c>) before WAL append.
+    /// </para>
+    /// </summary>
+    public static (TimeInForce EffectiveTimeInForce, decimal? EffectiveStopPrice, DateTimeOffset? EffectiveGoodTillDate)
+        MergeReplacementOptionals(
+            OrderType originalType,
+            TimeInForce originalTimeInForce,
+            decimal? originalStopPrice,
+            DateTimeOffset? originalGoodTillDate,
+            TimeInForce? requestedTimeInForce,
+            decimal? requestedStopPrice,
+            DateTimeOffset? requestedGoodTillDate)
+    {
+        var effTif = requestedTimeInForce ?? originalTimeInForce;
+
+        var requiresStop = originalType is OrderType.StopLoss or OrderType.StopLimit;
+        decimal? effStop;
+        if (requiresStop)
+        {
+            effStop = requestedStopPrice ?? originalStopPrice;
+            if (!effStop.HasValue || effStop.Value <= 0m)
+                throw new ArgumentException(
+                    $"StopPrice is required and must be positive for OrderType.{originalType}.",
+                    nameof(requestedStopPrice));
+        }
+        else
+        {
+            if (requestedStopPrice.HasValue)
+                throw new ArgumentException(
+                    $"StopPrice must be null for OrderType.{originalType} (only StopLoss/StopLimit accept a stop trigger).",
+                    nameof(requestedStopPrice));
+            effStop = null;
+        }
+
+        DateTimeOffset? effGtd;
+        if (effTif == TimeInForce.GTD)
+        {
+            effGtd = requestedGoodTillDate ?? originalGoodTillDate;
+            if (!effGtd.HasValue)
+                throw new ArgumentException(
+                    "GoodTillDate is required when TimeInForce == GTD.",
+                    nameof(requestedGoodTillDate));
+        }
+        else
+        {
+            if (requestedGoodTillDate.HasValue)
+                throw new ArgumentException(
+                    $"GoodTillDate must be null when TimeInForce == {effTif} (only GTD carries an expiry).",
+                    nameof(requestedGoodTillDate));
+            // TIF moving away from GTD: auto-clear inherited expiry so
+            // the merged Order satisfies the GTD-iff-GoodTillDate
+            // invariant without forcing callers to null it explicitly.
+            effGtd = null;
+        }
+
+        return (effTif, effStop, effGtd);
     }
 }

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -30,6 +30,30 @@ public enum OrderType
 }
 
 /// <summary>
+/// Helpers over <see cref="OrderType"/> that capture cross-cutting
+/// classifications used by the risk / margin pipeline.
+/// </summary>
+public static class OrderTypeExtensions
+{
+    /// <summary>
+    /// True iff this order type carries a limit price that the
+    /// reserve-on-submit margin provider will use to up-front reserve
+    /// cash on a buy submit. Must stay in lock-step with that
+    /// provider's reserve criterion (Buy +
+    /// <see cref="Order.Price"/> non-null + positive notional): every
+    /// listed type below is one that *can* be priced and therefore can
+    /// have a reservation that the cancel-replace pipeline must
+    /// re-baseline. <see cref="OrderType.Market"/> and
+    /// <see cref="OrderType.StopLoss"/> are excluded — they trigger
+    /// into a Market and have no upfront price to reserve against.
+    /// </summary>
+    public static bool IsMarginBearing(this OrderType type) =>
+        type is OrderType.Limit
+             or OrderType.StopLimit
+             or OrderType.MarketWithLeftover;
+}
+
+/// <summary>
 /// Time-In-Force for a working order. The default value is <see cref="Day"/>
 /// so older WAL/snapshot payloads that pre-date this enum hydrate with
 /// the implicit "Day" semantics they actually carried.

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
@@ -8,6 +8,11 @@ using B3.Trading.Domain;
 using B3.Trading.EntryPointListener.Framing;
 using Microsoft.Extensions.Logging;
 
+// Q1.1 (#253). Both SBE V6 and Domain expose a `TimeInForce` type;
+// alias them to disambiguate references inside this file.
+using DomainTif = B3.Trading.Domain.TimeInForce;
+using SbeTif = B3.Entrypoint.Fixp.Sbe.V6.TimeInForce;
+
 namespace B3.Trading.EntryPointListener.Hosting;
 
 /// <summary>
@@ -129,11 +134,16 @@ internal sealed class FixpOrderAdapter
             return;
         }
 
-        // 2. Validate side/ordType up-front so a malformed wire byte is
-        //    a clean BMR rather than a generic BadRequest from the
-        //    pipeline. Only the LIMIT/MARKET subset is supported by the
-        //    domain model in v0; everything else is rejected.
-        if (!TryMapSide(decoded.Side, out var side) || !TryMapOrdType(decoded.OrdType, out var type))
+        // 2. Validate side/ordType + TIF up-front so a malformed wire
+        //    byte is a clean BMR rather than a generic BadRequest from
+        //    the pipeline. Stop variants and the full TIF set are
+        //    accepted at the wire (Q1.1 / #253) — domain-side cross-
+        //    field invariants (StopPrice required for Stop*; ExpireDate
+        //    required for GTD) are checked inside the Order ctor and
+        //    bubble back up as BadRequest below.
+        if (!TryMapSide(decoded.Side, out var side)
+            || !TryMapOrdType(decoded.OrdType, out var type)
+            || !TryMapTimeInForce(decoded.TimeInForce, out var tif))
         {
             await WriteBusinessMessageRejectAsync(stream,
                 MessageType.NewOrderSingle, refSeqNum, externalClOrdId,
@@ -159,6 +169,15 @@ internal sealed class FixpOrderAdapter
         decimal? price = decoded.PriceMantissa is { } m
             ? m / (decimal)PriceOptional.Multiplier
             : null;
+        // Q1.1 (#253) — StopPx and ExpireDate are optional on the wire.
+        // SBE encodes ExpireDate as ushort days since 1970-01-01 with 0
+        // as the null sentinel.
+        decimal? stopPrice = decoded.StopPxMantissa is { } sm
+            ? sm / (decimal)PriceOptional.Multiplier
+            : null;
+        DateTimeOffset? goodTillDate = decoded.ExpireDateRaw == 0
+            ? null
+            : DateTimeOffset.FromUnixTimeSeconds(decoded.ExpireDateRaw * 86400L);
 
         var req = new OrderSubmissionRequest(
             Owner: owner,
@@ -168,7 +187,10 @@ internal sealed class FixpOrderAdapter
             Side: side,
             Type: type,
             Quantity: qty,
-            Price: price)
+            Price: price,
+            TimeInForce: tif,
+            StopPrice: stopPrice,
+            GoodTillDate: goodTillDate)
         {
             BotOrigin = new BotOrigin(scope.Principal.CredentialId, externalClOrdId),
         };
@@ -313,13 +335,40 @@ internal sealed class FixpOrderAdapter
         }
     }
 
-    private static bool TryMapOrdType(OrdType raw, out OrderType type)
+    internal static bool TryMapOrdType(OrdType raw, out OrderType type)
     {
         switch (raw)
         {
             case OrdType.LIMIT: type = OrderType.Limit; return true;
             case OrdType.MARKET: type = OrderType.Market; return true;
+            // Q1.1 (#253). Stop variants and MWL added with the order
+            // surface expansion. RLP / PEGGED_MIDPOINT remain unsupported
+            // in v0 — the domain has no representation for them yet.
+            case OrdType.STOP_LOSS: type = OrderType.StopLoss; return true;
+            case OrdType.STOP_LIMIT: type = OrderType.StopLimit; return true;
+            case OrdType.MARKET_WITH_LEFTOVER_AS_LIMIT: type = OrderType.MarketWithLeftover; return true;
             default: type = default; return false;
+        }
+    }
+
+    /// <summary>
+    /// Q1.1 (#253). Inbound SBE <c>TimeInForce</c> → Domain mapping.
+    /// Rejects unknown wire bytes so a malformed inbound order is a
+    /// clean BMR rather than an opaque BadRequest deeper in the
+    /// pipeline.
+    /// </summary>
+    internal static bool TryMapTimeInForce(SbeTif raw, out DomainTif tif)
+    {
+        switch (raw)
+        {
+            case SbeTif.DAY: tif = DomainTif.Day; return true;
+            case SbeTif.GOOD_TILL_CANCEL: tif = DomainTif.GTC; return true;
+            case SbeTif.IMMEDIATE_OR_CANCEL: tif = DomainTif.IOC; return true;
+            case SbeTif.FILL_OR_KILL: tif = DomainTif.FOK; return true;
+            case SbeTif.GOOD_TILL_DATE: tif = DomainTif.GTD; return true;
+            case SbeTif.AT_THE_CLOSE: tif = DomainTif.AtClose; return true;
+            case SbeTif.GOOD_FOR_AUCTION: tif = DomainTif.GoodForAuction; return true;
+            default: tif = default; return false;
         }
     }
 

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/InboundDecoders.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/InboundDecoders.cs
@@ -43,6 +43,11 @@ internal static class InboundDecoders
             OrdType = msg.OrdType,
             OrderQty = (ulong)msg.OrderQty,
             PriceMantissa = msg.Price.Mantissa,
+            // Q1.1 (#253) — additional surface fields plumbed for
+            // Stop/StopLimit + GTD + non-Day TIF support.
+            TimeInForce = msg.TimeInForce,
+            StopPxMantissa = msg.StopPx.Mantissa,
+            ExpireDateRaw = msg.ExpireDate ?? 0,
         };
         return true;
     }
@@ -99,6 +104,23 @@ internal readonly struct DecodedNewOrderSingle
     public OrdType OrdType { get; init; }
     public ulong OrderQty { get; init; }
     public long? PriceMantissa { get; init; }
+
+    /// <summary>Q1.1 (#253). SBE wire byte for time-in-force.</summary>
+    public TimeInForce TimeInForce { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). PriceOptional mantissa for the stop trigger; null
+    /// when the wire field was the SBE null sentinel. Same scaling as
+    /// <see cref="PriceMantissa"/>.
+    /// </summary>
+    public long? StopPxMantissa { get; init; }
+
+    /// <summary>
+    /// Q1.1 (#253). Raw SBE <c>ExpireDate</c> (<c>ushort</c>, 0 = null).
+    /// Encoded as days since 1970-01-01 by B3 convention. Decoded into a
+    /// <see cref="DateTimeOffset"/> at the dispatch boundary.
+    /// </summary>
+    public ushort ExpireDateRaw { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -167,10 +167,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             ClOrdID = new UpModels.ClOrdID(order.ClOrdId),
             SecurityId = order.SecurityId,
             Side = order.Side == OrderSide.Buy ? UpModels.Side.Buy : UpModels.Side.Sell,
-            OrderType = order.Type == OrderType.Limit ? UpModels.OrderType.Limit : UpModels.OrderType.Market,
+            OrderType = MapOrderType(order.Type),
             Price = order.Price,
+            StopPrice = order.StopPrice,
             OrderQty = (ulong)order.Quantity,
-            TimeInForce = UpModels.TimeInForce.Day,
+            TimeInForce = MapTimeInForce(order.TimeInForce),
+            ExpireDate = order.GoodTillDate,
         };
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
@@ -209,10 +211,16 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             OrigClOrdID = new UpModels.ClOrdID(original.ClOrdId),
             SecurityId = original.SecurityId,
             Side = original.Side == OrderSide.Buy ? UpModels.Side.Buy : UpModels.Side.Sell,
-            OrderType = original.Type == OrderType.Limit ? UpModels.OrderType.Limit : UpModels.OrderType.Market,
+            OrderType = MapOrderType(original.Type),
             Price = newPrice,
+            // Q1.1 (#253). The modify pipeline only mutates qty+price;
+            // type/TIF/StopPrice/GoodTillDate are inherited from the
+            // original order so the venue sees a consistent surface
+            // across the cancel-replace boundary.
+            StopPrice = original.StopPrice,
             OrderQty = (ulong)newQuantity,
-            TimeInForce = UpModels.TimeInForce.Day,
+            TimeInForce = MapTimeInForce(original.TimeInForce),
+            ExpireDate = original.GoodTillDate,
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -248,6 +256,38 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             new KeyValuePair<string, object?>("firm", _firmId),
             new KeyValuePair<string, object?>("op", op));
     }
+
+    /// <summary>
+    /// Q1.1 (#253). Domain → SDK <see cref="UpModels.OrderType"/> mapping
+    /// covering the full B3 order surface exposed at v0. Internal so the
+    /// gateway tests can pin the table without going through reflection
+    /// on the SDK's private encoder.
+    /// </summary>
+    internal static UpModels.OrderType MapOrderType(OrderType type) => type switch
+    {
+        OrderType.Limit => UpModels.OrderType.Limit,
+        OrderType.Market => UpModels.OrderType.Market,
+        OrderType.StopLoss => UpModels.OrderType.StopLoss,
+        OrderType.StopLimit => UpModels.OrderType.StopLimit,
+        OrderType.MarketWithLeftover => UpModels.OrderType.MarketWithLeftoverAsLimit,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unmapped Domain.OrderType."),
+    };
+
+    /// <summary>
+    /// Q1.1 (#253). Domain → SDK <see cref="UpModels.TimeInForce"/> mapping
+    /// covering all 7 v0 values.
+    /// </summary>
+    internal static UpModels.TimeInForce MapTimeInForce(TimeInForce tif) => tif switch
+    {
+        TimeInForce.Day => UpModels.TimeInForce.Day,
+        TimeInForce.IOC => UpModels.TimeInForce.ImmediateOrCancel,
+        TimeInForce.FOK => UpModels.TimeInForce.FillOrKill,
+        TimeInForce.GTC => UpModels.TimeInForce.GoodTillCancel,
+        TimeInForce.GTD => UpModels.TimeInForce.GoodTillDate,
+        TimeInForce.AtClose => UpModels.TimeInForce.AtTheClose,
+        TimeInForce.GoodForAuction => UpModels.TimeInForce.GoodForAuction,
+        _ => throw new ArgumentOutOfRangeException(nameof(tif), tif, "Unmapped Domain.TimeInForce."),
+    };
 
     // The IEntryPointClient submit-side surface is unused on the real adapter
     // (OrdersEndpoints calls IExchangeGateway directly). We implement it to

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -197,13 +197,33 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             ct => _client.CancelAsync(req, ct), cancellationToken);
     }
 
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
+    public Task CancelReplaceAsync(
+        Order original,
+        ulong newClOrdId,
+        long newQuantity,
+        decimal? newPrice,
+        TimeInForce? requestedTimeInForce,
+        decimal? requestedStopPrice,
+        DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(original);
         if (newClOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(newClOrdId), "Replace ClOrdID must be non-zero.");
         if (newQuantity < 0)
             throw new ArgumentOutOfRangeException(nameof(newQuantity));
+
+        // Q1.1 (#253). Merge requested overrides with the original's
+        // values so the venue sees a coherent ReplaceOrderRequest. The
+        // domain helper enforces the invariants (StopPrice required iff
+        // Stop*; GoodTillDate required iff TIF==GTD; auto-clear when
+        // TIF moves away from GTD). Any violation throws ArgumentException,
+        // which the caller (OrderModifyService) treats as a gateway-side
+        // failure and rolls back the same way it does any other replace
+        // dispatch failure.
+        var (effTif, effStop, effGtd) = Order.MergeReplacementOptionals(
+            original.Type, original.TimeInForce, original.StopPrice, original.GoodTillDate,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
 
         var req = new UpModels.ReplaceOrderRequest
         {
@@ -213,14 +233,10 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             Side = original.Side == OrderSide.Buy ? UpModels.Side.Buy : UpModels.Side.Sell,
             OrderType = MapOrderType(original.Type),
             Price = newPrice,
-            // Q1.1 (#253). The modify pipeline only mutates qty+price;
-            // type/TIF/StopPrice/GoodTillDate are inherited from the
-            // original order so the venue sees a consistent surface
-            // across the cancel-replace boundary.
-            StopPrice = original.StopPrice,
+            StopPrice = effStop,
             OrderQty = (ulong)newQuantity,
-            TimeInForce = MapTimeInForce(original.TimeInForce),
-            ExpireDate = original.GoodTillDate,
+            TimeInForce = MapTimeInForce(effTif),
+            ExpireDate = effGtd,
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,

--- a/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
@@ -55,9 +55,17 @@ public sealed class EntryPointClientGateway : IExchangeGateway
             cancellationToken);
     }
 
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
+    public Task CancelReplaceAsync(
+        Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+        TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(original);
+        // Legacy adapter: OrderCancelReplaceRequest predates Q1.1 and
+        // does not carry TIF / StopPrice / GoodTillDate over the wire.
+        // The Q1.1 modify pipeline targets the B3EntryPointClientGateway
+        // (real adapter); this path is retained for the older
+        // IEntryPointClient seam used by tests and the demo driver.
         return _client.SubmitCancelReplaceAsync(
             new OrderCancelReplaceRequest(
                 original.ClOrdId, newClOrdId, original.SecurityId,

--- a/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
+++ b/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
@@ -113,9 +113,14 @@ public sealed class MultiFirmExchangeGateway : IExchangeGateway
         return _registry.For(order.FirmId).CancelAsync(order, newClOrdId, cancellationToken);
     }
 
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
+    public Task CancelReplaceAsync(
+        Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+        TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(original);
-        return _registry.For(original.FirmId).CancelReplaceAsync(original, newClOrdId, newQuantity, newPrice, cancellationToken);
+        return _registry.For(original.FirmId).CancelReplaceAsync(
+            original, newClOrdId, newQuantity, newPrice,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate, cancellationToken);
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -139,6 +139,9 @@ public sealed class StateSnapshotter
                 IsStale = r.IsStale,
                 StaleReason = r.StaleReason,
                 StaledAtUtc = r.StaledAtUtc,
+                TimeInForce = o.TimeInForce.ToString(),
+                StopPrice = o.StopPrice,
+                GoodTillDate = o.GoodTillDate,
             });
         }
 
@@ -333,8 +336,13 @@ public sealed class EventReplayer
                 var owner = new EndClientId(o.EndClientId);
                 var side = Enum.Parse<OrderSide>(o.Side, ignoreCase: true);
                 var type = Enum.Parse<OrderType>(o.Type, ignoreCase: true);
+                // Q1.1 (#253) — older WAL segments default to "Day" via
+                // the OrderSubmittedEvent record's init default, so a
+                // missing field round-trips through Enum.Parse cleanly.
+                var tif = Enum.Parse<TimeInForce>(o.TimeInForce, ignoreCase: true);
                 _orders.TryAdd(new Order(o.ClOrdId, owner, o.Symbol, o.SecurityId, side, type,
-                    o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq));
+                    o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq,
+                    timeInForce: tif, stopPrice: o.StopPrice, goodTillDate: o.GoodTillDate));
                 _ownership.Register(o.ClOrdId, owner);
                 // #157: advance the ClOrdID registry watermark so the next
                 // live Generate(owner) cannot re-allocate this ID.

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -401,7 +401,12 @@ public sealed class EventReplayer
                         NewPrice: rr.NewPrice,
                         FirmId: rr.FirmId,
                         ParentAlgoId: rr.ParentAlgoId,
-                        AlgoSliceSeq: rr.AlgoSliceSeq);
+                        AlgoSliceSeq: rr.AlgoSliceSeq,
+                        RequestedTimeInForce: rr.RequestedTimeInForce is { } rrTif
+                            ? Enum.Parse<TimeInForce>(rrTif, ignoreCase: true)
+                            : (TimeInForce?)null,
+                        RequestedStopPrice: rr.RequestedStopPrice,
+                        RequestedGoodTillDate: rr.RequestedGoodTillDate);
                     _replacements.TryAdd(intent);
                     _ownership.RegisterReplaceLink(rr.OriginalClOrdId, rr.NewClOrdId);
                 }

--- a/backend/src/B3.Trading.Infrastructure/StubExchangeGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/StubExchangeGateway.cs
@@ -13,5 +13,8 @@ public sealed class StubExchangeGateway : IExchangeGateway
 {
     public Task SubmitAsync(Order order, CancellationToken cancellationToken) => Task.CompletedTask;
     public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken) => Task.CompletedTask;
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task CancelReplaceAsync(
+        Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+        TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/backend/src/B3.Trading.Infrastructure/UnavailableExchangeGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/UnavailableExchangeGateway.cs
@@ -27,6 +27,9 @@ public sealed class UnavailableExchangeGateway : IExchangeGateway
     public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken) =>
         throw new InvalidOperationException(Reason);
 
-    public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken) =>
+    public Task CancelReplaceAsync(
+        Order order, ulong newClOrdId, long newQuantity, decimal? newPrice,
+        TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+        CancellationToken cancellationToken) =>
         throw new InvalidOperationException(Reason);
 }

--- a/backend/tests/B3.Trading.Api.Tests/ExchangeModeTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/ExchangeModeTests.cs
@@ -71,7 +71,7 @@ public class UnavailableExchangeGatewayTests
     {
         var gw = new UnavailableExchangeGateway();
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            gw.CancelReplaceAsync(MakeOrder(), 2UL, 200, 31m, default));
+            gw.CancelReplaceAsync(MakeOrder(), 2UL, 200, 31m, null, null, null, default));
     }
 }
 

--- a/backend/tests/B3.Trading.Api.Tests/OrdersModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersModifyEndpointTests.cs
@@ -107,6 +107,75 @@ public class OrdersModifyEndpointTests
         Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
     }
 
+    [Fact]
+    public async Task PUT_orders_TimeInForceAsString_AcceptsCaseInsensitive()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        var future = DateTimeOffset.UtcNow.AddDays(7);
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origAck!.ClOrdId}")
+        {
+            Content = JsonContent.Create(new
+            {
+                Quantity = 200,
+                Price = 30m,
+                TimeInForce = "gtd", // lowercase string — must parse to TimeInForce.GTD
+                GoodTillDate = future,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var put = await http.SendAsync(req);
+        var body = await put.Content.ReadAsStringAsync();
+
+        Assert.True(put.StatusCode == HttpStatusCode.Accepted, $"Expected 202, got {put.StatusCode}: {body}");
+    }
+
+    [Fact]
+    public async Task PUT_orders_InvalidTimeInForceString_Returns400_WithReason()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origAck!.ClOrdId}")
+        {
+            Content = JsonContent.Create(new { Quantity = 200, Price = 30m, TimeInForce = "Garbage" }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var put = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, put.StatusCode);
+        var body = await put.Content.ReadAsStringAsync();
+        Assert.Contains("timeInForce", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Garbage", body);
+    }
+
+    [Fact]
+    public async Task PUT_orders_OmittedTimeInForce_TreatedAsNoChange()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var posted = await PostOrder(http, token, qty: 100, price: 30m);
+        var origAck = await posted.Content.ReadFromJsonAsync<OrderAck>();
+
+        // Body literally omits TimeInForce — must accept and not blow up.
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origAck!.ClOrdId}")
+        {
+            Content = JsonContent.Create(new { Quantity = 200, Price = 30m }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var put = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Accepted, put.StatusCode);
+    }
+
     private static async Task<HttpResponseMessage> PostOrder(
         HttpClient http, string token, int qty, decimal price, string side = "Buy")
     {

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -1,0 +1,52 @@
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure;
+using Up = B3.EntryPoint.Client.Models;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Q1.1 (#253). Pins the Domain → SDK enum tables exposed by
+/// <see cref="B3EntryPointClientGateway"/>. The mapping is the entire
+/// outbound contract for the new order surface — a regression here
+/// would silently mis-route Stop / GTD / IOC orders to the venue.
+/// </summary>
+public class B3EntryPointClientGatewayMapTests
+{
+    [Theory]
+    [InlineData(OrderType.Limit, Up.OrderType.Limit)]
+    [InlineData(OrderType.Market, Up.OrderType.Market)]
+    [InlineData(OrderType.StopLoss, Up.OrderType.StopLoss)]
+    [InlineData(OrderType.StopLimit, Up.OrderType.StopLimit)]
+    [InlineData(OrderType.MarketWithLeftover, Up.OrderType.MarketWithLeftoverAsLimit)]
+    public void MapOrderType_CoversAllDomainValues(OrderType domain, Up.OrderType sdk)
+    {
+        Assert.Equal(sdk, B3EntryPointClientGateway.MapOrderType(domain));
+    }
+
+    [Theory]
+    [InlineData(TimeInForce.Day, Up.TimeInForce.Day)]
+    [InlineData(TimeInForce.IOC, Up.TimeInForce.ImmediateOrCancel)]
+    [InlineData(TimeInForce.FOK, Up.TimeInForce.FillOrKill)]
+    [InlineData(TimeInForce.GTC, Up.TimeInForce.GoodTillCancel)]
+    [InlineData(TimeInForce.GTD, Up.TimeInForce.GoodTillDate)]
+    [InlineData(TimeInForce.AtClose, Up.TimeInForce.AtTheClose)]
+    [InlineData(TimeInForce.GoodForAuction, Up.TimeInForce.GoodForAuction)]
+    public void MapTimeInForce_CoversAllDomainValues(TimeInForce domain, Up.TimeInForce sdk)
+    {
+        Assert.Equal(sdk, B3EntryPointClientGateway.MapTimeInForce(domain));
+    }
+
+    [Fact]
+    public void MapOrderType_UnmappedValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => B3EntryPointClientGateway.MapOrderType((OrderType)999));
+    }
+
+    [Fact]
+    public void MapTimeInForce_UnmappedValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => B3EntryPointClientGateway.MapTimeInForce((TimeInForce)999));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -36,7 +36,7 @@ public class EntryPointGatewayAndRouterTests
         var gateway = new EntryPointClientGateway(client, "FIRM-A");
         var original = new Order(100UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
 
-        await gateway.CancelReplaceAsync(original, 101UL, 200, 30m, CancellationToken.None);
+        await gateway.CancelReplaceAsync(original, 101UL, 200, 30m, null, null, null, CancellationToken.None);
 
         var sent = Assert.Single(client.SubmittedReplaces);
         Assert.Equal(100UL, sent.OriginalClOrdId);

--- a/backend/tests/B3.Trading.Application.Tests/OrderCancelServiceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderCancelServiceTests.cs
@@ -44,7 +44,10 @@ public class OrderCancelServiceTests
             if (CancelGate is { } g) await g.Task.ConfigureAwait(false);
         }
 
-        public Task CancelReplaceAsync(Order original, ulong newClOrdId, long newQuantity, decimal? newPrice, CancellationToken cancellationToken)
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+            CancellationToken cancellationToken)
             => Task.CompletedTask;
     }
 

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1038,4 +1038,148 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Equal(0m, margin.ReservedForTesting("bob"));
         Assert.DoesNotContain(loggerProvider.Records, r => r.Level >= LogLevel.Warning);
     }
+
+    // ---------------- PR #260 P2: IsMarginBearing predicate covers StopLimit / MarketWithLeftover ----------------
+
+    private static (OrderModifyService svc, CapturingGateway gw, RecordingReplaceCoordinator coord)
+        BuildModifyServiceWithCoordinator(Order seedOrder)
+    {
+        var owner = seedOrder.Owner;
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        Assert.True(book.TryAdd(seedOrder));
+        ownership.Register(seedOrder.ClOrdId, owner);
+        var gateway = new CapturingGateway();
+        var sink = new CapturingSink();
+        var risk = new Risk.RiskPipeline(Array.Empty<Risk.IRiskCheck>());
+        var coord = new RecordingReplaceCoordinator();
+        var replacements = new PendingReplacementRegistry();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderModifyService(
+            clOrdIds, ownership, book, gateway, sink, risk, coord, replacements, dispatcher,
+            new NeverDrain(), NullLogger<OrderModifyService>.Instance);
+        return (svc, gateway, coord);
+    }
+
+    [Fact]
+    public async Task Modify_StopLimit_downsize_passesNewNotionalToCoordinator_notZero()
+    {
+        // Pre-fix the gate was `orig.Type == OrderType.Limit`, so a
+        // buy StopLimit replace silently passed 0 to PrepareReplaceAsync
+        // (and later 0 to CommitReplace), freeing the cash-reservation
+        // even though the new working order still consumed margin.
+        var owner = new EndClientId("alice");
+        var stopLimit = new Order(
+            500_001UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 30m, "FIRM", timeInForce: TimeInForce.Day, stopPrice: 29m);
+        var (svc, _, coord) = BuildModifyServiceWithCoordinator(stopLimit);
+
+        // Downsize 100 → 60 at the same limit price.
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, stopLimit.ClOrdId, NewQuantity: 60, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.Accepted, result.Kind);
+        var prep = Assert.Single(coord.Prepares);
+        Assert.Equal(30m * 60, prep.Notional);
+    }
+
+    [Fact]
+    public async Task Modify_StopLimit_upsize_deltaCheckEnforced_rejectsWhenInsufficient()
+    {
+        // Real provider so the upsize delta check actually fires. Pre-fix
+        // a buy StopLimit upsize sent 0 to PrepareReplaceAsync, so the
+        // capacity check was bypassed and an over-margin upsize would
+        // sneak through.
+        var owner = new EndClientId("alice");
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var stopLimit = new Order(
+            500_002UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 30m, "FIRM", timeInForce: TimeInForce.Day, stopPrice: 29m);
+        Assert.True(book.TryAdd(stopLimit));
+        ownership.Register(stopLimit.ClOrdId, owner);
+
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["alice"] = 3_500m; // room for 100*30=3000 + only 500 headroom
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var margin = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        Assert.True((await margin.TryReserveAsync(
+            stopLimit.ClOrdId,
+            new RiskContext(owner, "FIRM", "PETR4", OrderSide.Buy, OrderType.StopLimit, 100, 30m),
+            default)).Approved);
+        Assert.Equal(3000m, margin.ReservedForTesting("alice"));
+
+        var svc = new OrderModifyService(
+            clOrdIds, ownership, book, new CapturingGateway(), new CapturingSink(),
+            new Risk.RiskPipeline(Array.Empty<Risk.IRiskCheck>()),
+            margin, new PendingReplacementRegistry(), new EventDispatcher(new NullEventStore()),
+            new NeverDrain(), NullLogger<OrderModifyService>.Instance);
+
+        // Upsize 100 → 200 @ 30 = 6000, delta = +3000 against 500 headroom → reject.
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, stopLimit.ClOrdId, NewQuantity: 200, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.RiskRejected, result.Kind);
+        Assert.Contains("insufficient margin", result.Reason);
+        // Original reservation untouched.
+        Assert.Equal(3000m, margin.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Modify_MarketWithLeftover_downsize_passesNewNotionalToCoordinator_notZero()
+    {
+        // MarketWithLeftover carries a Price (the leftover-as-limit
+        // price) and is therefore reserved on submit by the
+        // ReserveOnSubmitMarginProvider — so the same gate fix applies
+        // here, otherwise replace silently frees the cash.
+        var owner = new EndClientId("alice");
+        var mwl = new Order(
+            500_003UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.MarketWithLeftover,
+            100, 30m, "FIRM");
+        var (svc, _, coord) = BuildModifyServiceWithCoordinator(mwl);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, mwl.ClOrdId, NewQuantity: 50, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.Accepted, result.Kind);
+        var prep = Assert.Single(coord.Prepares);
+        Assert.Equal(30m * 50, prep.Notional);
+    }
+
+    [Fact]
+    public async Task Processor_Replaced_StopLimit_commitsAtNewNotional_notZero()
+    {
+        // Processor-side mirror of the same predicate fix: confirmedRemaining
+        // for StopLimit must reflect price * leaves so CommitReplace
+        // rebalances the ledger. Pre-fix it was 0, releasing the original
+        // reservation while the new order was still alive in the book.
+        var (proc, ownership, book, reg, margin, _) = BuildProcessor();
+        var owner = new EndClientId("alice");
+        var orig = new Order(
+            10UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 10m, "FIRM", timeInForce: TimeInForce.Day, stopPrice: 9m);
+        book.TryAdd(orig);
+        ownership.Register(10UL, owner);
+        Assert.True((await margin.TryReserveAsync(
+            10UL,
+            new RiskContext(owner, "FIRM", "PETR4", OrderSide.Buy, OrderType.StopLimit, 100, 10m),
+            default)).Approved);
+
+        // Downsize 100 → 60 @ 10 → new reservation should be 600.
+        Assert.True(reg.TryAdd(new OrderReplacementIntent(
+            10UL, 11UL, owner, "PETR4", 4321UL,
+            OrderSide.Buy, OrderType.StopLimit, 60, 10m, "FIRM", null, null)));
+        await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(10UL, 11UL, owner, 600m, default);
+
+        proc.Apply(11UL, ExecKind.Replaced, leaves: 60, cumQty: 0, lastQty: 0,
+                   lastPx: 0m, rejectReason: null, origClOrdId: 10UL);
+
+        Assert.Equal(600m, margin.ReservedForTesting("alice"));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1,6 +1,8 @@
+using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -132,6 +134,334 @@ public class OrderModifyMarginAndProcessorTests
         var orig = new Order(1UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             Order.HydrateReplacement(orig, 0UL, 200, 31m, 200, 0));
+    }
+
+    // ---------------- Q1.1 (#253) optionals through replace pipeline ----------------
+
+    [Fact]
+    public void HydrateReplacement_inheritsTifStopGtdWhenAllNull()
+    {
+        // Default behaviour: caller passed no Q1.1 overrides → the
+        // replacement Order carries the original's TIF/StopPrice/GTD.
+        var owner = new EndClientId("alice");
+        var orig = new Order(
+            1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 30m, "FIRM",
+            timeInForce: TimeInForce.GTD,
+            stopPrice: 29m,
+            goodTillDate: new DateTimeOffset(2030, 1, 2, 18, 0, 0, TimeSpan.Zero));
+        var replacement = Order.HydrateReplacement(orig, 2UL, 200, 31m, erLeaves: 200, erCumulative: 0);
+        Assert.Equal(TimeInForce.GTD, replacement.TimeInForce);
+        Assert.Equal(29m, replacement.StopPrice);
+        Assert.Equal(orig.GoodTillDate, replacement.GoodTillDate);
+    }
+
+    [Fact]
+    public void HydrateReplacement_overridesStopPriceOnExistingStopLimit()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(
+            1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 30m, "FIRM",
+            timeInForce: TimeInForce.Day, stopPrice: 29m);
+        var replacement = Order.HydrateReplacement(
+            orig, 2UL, 100, 30m, erLeaves: 100, erCumulative: 0,
+            requestedStopPrice: 28.5m);
+        Assert.Equal(28.5m, replacement.StopPrice);
+        Assert.Equal(TimeInForce.Day, replacement.TimeInForce);
+    }
+
+    [Fact]
+    public void Merge_changesTifDayToGtc()
+    {
+        var (tif, stop, gtd) = Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.Day, originalStopPrice: null, originalGoodTillDate: null,
+            requestedTimeInForce: TimeInForce.GTC, requestedStopPrice: null, requestedGoodTillDate: null);
+        Assert.Equal(TimeInForce.GTC, tif);
+        Assert.Null(stop);
+        Assert.Null(gtd);
+    }
+
+    [Fact]
+    public void Merge_changesTifDayToGtdRequiresGoodTillDate()
+    {
+        var future = DateTimeOffset.UtcNow.AddDays(1);
+        var (tif, _, gtd) = Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.Day, null, null,
+            TimeInForce.GTD, null, future);
+        Assert.Equal(TimeInForce.GTD, tif);
+        Assert.Equal(future, gtd);
+
+        // Without supplying GoodTillDate the merge rejects (caller must
+        // explicitly carry the expiry when transitioning into GTD).
+        Assert.Throws<ArgumentException>(() => Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.Day, null, null,
+            TimeInForce.GTD, null, null));
+    }
+
+    [Fact]
+    public void Merge_tifAwayFromGtdAutoClearsGoodTillDate()
+    {
+        // Documented semantic: changing TIF away from GTD without
+        // explicitly nulling GoodTillDate auto-clears the inherited
+        // expiry rather than forcing a redundant null in the request.
+        var origGtd = new DateTimeOffset(2030, 6, 1, 18, 0, 0, TimeSpan.Zero);
+        var (tif, _, gtd) = Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.GTD, null, origGtd,
+            TimeInForce.Day, null, null);
+        Assert.Equal(TimeInForce.Day, tif);
+        Assert.Null(gtd);
+    }
+
+    [Fact]
+    public void Merge_rejectsGoodTillDateWhenEffectiveTifIsNotGtd()
+    {
+        // Caller asked TIF=Day but supplied a GoodTillDate. Auto-clearing
+        // would silently discard the value; reject loudly instead so the
+        // caller fixes their request.
+        var fut = DateTimeOffset.UtcNow.AddDays(1);
+        Assert.Throws<ArgumentException>(() => Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.GTD, null, fut,
+            TimeInForce.Day, null, fut));
+    }
+
+    [Fact]
+    public void Merge_rejectsStopPriceForNonStopOrder()
+    {
+        Assert.Throws<ArgumentException>(() => Order.MergeReplacementOptionals(
+            OrderType.Limit, TimeInForce.Day, null, null,
+            null, requestedStopPrice: 10m, null));
+    }
+
+    [Fact]
+    public void Merge_rejectsNonPositiveStopPriceForStopOrder()
+    {
+        // Original StopLimit has StopPrice=29; caller "overrides" with 0.
+        Assert.Throws<ArgumentException>(() => Order.MergeReplacementOptionals(
+            OrderType.StopLimit, TimeInForce.Day, originalStopPrice: 29m, null,
+            null, requestedStopPrice: 0m, null));
+    }
+
+    [Fact]
+    public void HydrateReplacement_changesTifDayToGtdWithExpiry()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var future = new DateTimeOffset(2030, 12, 31, 18, 0, 0, TimeSpan.Zero);
+        var replacement = Order.HydrateReplacement(
+            orig, 2UL, 100, 30m, erLeaves: 100, erCumulative: 0,
+            requestedTimeInForce: TimeInForce.GTD,
+            requestedGoodTillDate: future);
+        Assert.Equal(TimeInForce.GTD, replacement.TimeInForce);
+        Assert.Equal(future, replacement.GoodTillDate);
+    }
+
+    [Fact]
+    public void HydrateReplacement_changesTifGtdToDayClearsGoodTillDate()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(
+            1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM",
+            timeInForce: TimeInForce.GTD,
+            goodTillDate: new DateTimeOffset(2030, 6, 1, 18, 0, 0, TimeSpan.Zero));
+        var replacement = Order.HydrateReplacement(
+            orig, 2UL, 100, 30m, erLeaves: 100, erCumulative: 0,
+            requestedTimeInForce: TimeInForce.Day);
+        Assert.Equal(TimeInForce.Day, replacement.TimeInForce);
+        Assert.Null(replacement.GoodTillDate);
+    }
+
+    [Fact]
+    public void OrderReplaceRequestedEvent_OldPayloadDeserializesWithNullOptionals()
+    {
+        // Backward-compat: WAL segments written before the Q1.1
+        // overrides existed lack the three Requested* fields. The
+        // source-generated context must hydrate them as null so the
+        // ER-replay path inherits everything from the original Order
+        // (preserving exact pre-Q1.1 behaviour).
+        const string oldJson = """
+        {
+            "OriginalClOrdId": 1,
+            "NewClOrdId": 2,
+            "EndClientId": "alice",
+            "FirmId": "FIRM",
+            "Symbol": "PETR4",
+            "SecurityId": 4321,
+            "Side": "Buy",
+            "Type": "Limit",
+            "NewQuantity": 200,
+            "NewPrice": 30.5
+        }
+        """;
+        var ev = System.Text.Json.JsonSerializer.Deserialize(
+            oldJson,
+            B3.Trading.Application.Persistence.WalEventJsonContext.Default.OrderReplaceRequestedEvent);
+        Assert.NotNull(ev);
+        Assert.Equal(1UL, ev!.OriginalClOrdId);
+        Assert.Equal(2UL, ev.NewClOrdId);
+        Assert.Null(ev.RequestedTimeInForce);
+        Assert.Null(ev.RequestedStopPrice);
+        Assert.Null(ev.RequestedGoodTillDate);
+    }
+
+    [Fact]
+    public void OrderReplaceRequestedEvent_RoundTripsOptionalsWhenSet()
+    {
+        var future = new DateTimeOffset(2030, 6, 1, 18, 0, 0, TimeSpan.Zero);
+        var ev = new OrderReplaceRequestedEvent
+        {
+            OriginalClOrdId = 1UL,
+            NewClOrdId = 2UL,
+            EndClientId = "alice",
+            FirmId = "FIRM",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            NewQuantity = 100,
+            NewPrice = 30m,
+            RequestedTimeInForce = nameof(TimeInForce.GTD),
+            RequestedStopPrice = null,
+            RequestedGoodTillDate = future,
+        };
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            ev, B3.Trading.Application.Persistence.WalEventJsonContext.Default.OrderReplaceRequestedEvent);
+        var roundtrip = System.Text.Json.JsonSerializer.Deserialize(
+            json, B3.Trading.Application.Persistence.WalEventJsonContext.Default.OrderReplaceRequestedEvent);
+        Assert.Equal(nameof(TimeInForce.GTD), roundtrip!.RequestedTimeInForce);
+        Assert.Equal(future, roundtrip.RequestedGoodTillDate);
+    }
+
+    // ---------------- OrderModifyService end-to-end (Q1.1 dispatch) ----------------
+
+    private sealed class CapturingGateway : IExchangeGateway
+    {
+        public List<(Order Original, ulong NewClOrdId, long NewQty, decimal? NewPrice,
+                     TimeInForce? Tif, decimal? Stop, DateTimeOffset? Gtd)> Replaces { get; } = new();
+
+        public Task SubmitAsync(Order order, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQty, decimal? newPrice,
+            TimeInForce? tif, decimal? stop, DateTimeOffset? gtd, CancellationToken ct)
+        {
+            Replaces.Add((original, newClOrdId, newQty, newPrice, tif, stop, gtd));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpReplaceMargin : IReplaceMarginCoordinator
+    {
+        public Task<RiskDecision> PrepareReplaceAsync(ulong _, ulong __, EndClientId ___, decimal ____, CancellationToken _____)
+            => Task.FromResult(RiskDecision.Approve);
+        public void CommitReplace(ulong _, ulong __, decimal ___) { }
+        public void AbortReplace(ulong _) { }
+    }
+
+    private sealed class CapturingSink : IExecutionEventSink
+    {
+        public readonly List<ExecutionEvent> Events = new();
+        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    private sealed class NeverDrain : Lifecycle.IDrainGate { public bool IsDraining => false; }
+
+    private static (OrderModifyService svc, CapturingGateway gw, WorkingOrderBook book, PendingReplacementRegistry reg)
+        BuildModifyService(Order seedOrder)
+    {
+        var owner = seedOrder.Owner;
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        Assert.True(book.TryAdd(seedOrder));
+        ownership.Register(seedOrder.ClOrdId, owner);
+        var gateway = new CapturingGateway();
+        var sink = new CapturingSink();
+        var risk = new Risk.RiskPipeline(Array.Empty<Risk.IRiskCheck>());
+        var margin = new NoOpReplaceMargin();
+        var replacements = new PendingReplacementRegistry();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderModifyService(
+            clOrdIds, ownership, book, gateway, sink, risk, margin, replacements, dispatcher,
+            new NeverDrain(), NullLogger<OrderModifyService>.Instance);
+        return (svc, gateway, book, replacements);
+    }
+
+    [Fact]
+    public async Task Modify_changesStopPriceOnExistingStopLimit_outboundCarriesNewStopPrice()
+    {
+        var owner = new EndClientId("alice");
+        var stopLimit = new Order(
+            1_000_001UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit,
+            100, 30m, "FIRM", timeInForce: TimeInForce.Day, stopPrice: 29m);
+        var (svc, gw, _, _) = BuildModifyService(stopLimit);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, stopLimit.ClOrdId, NewQuantity: 100, NewPrice: 30m,
+                NewTimeInForce: null, NewStopPrice: 28.25m, NewGoodTillDate: null),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.Accepted, result.Kind);
+        var call = Assert.Single(gw.Replaces);
+        Assert.Equal(28.25m, call.Stop);
+        Assert.Null(call.Tif);
+        Assert.Null(call.Gtd);
+    }
+
+    [Fact]
+    public async Task Modify_changesTifDayToGtc_outboundCarriesGtc()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(1_000_002UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var (svc, gw, _, _) = BuildModifyService(orig);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, orig.ClOrdId, 100, 30m, NewTimeInForce: TimeInForce.GTC),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.Accepted, result.Kind);
+        Assert.Equal(TimeInForce.GTC, gw.Replaces.Single().Tif);
+    }
+
+    [Fact]
+    public async Task Modify_changesTifDayToGtdWithExpiry_outboundCarriesBoth()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(1_000_003UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var (svc, gw, _, _) = BuildModifyService(orig);
+        var future = new DateTimeOffset(2030, 12, 31, 18, 0, 0, TimeSpan.Zero);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, orig.ClOrdId, 100, 30m,
+                NewTimeInForce: TimeInForce.GTD, NewGoodTillDate: future),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.Accepted, result.Kind);
+        var call = gw.Replaces.Single();
+        Assert.Equal(TimeInForce.GTD, call.Tif);
+        Assert.Equal(future, call.Gtd);
+    }
+
+    [Fact]
+    public async Task Modify_invariantViolation_isRejectedBeforeWalAndGateway()
+    {
+        var owner = new EndClientId("alice");
+        var orig = new Order(1_000_004UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        var (svc, gw, book, reg) = BuildModifyService(orig);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, orig.ClOrdId, 100, 30m, NewTimeInForce: TimeInForce.GTD),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.BadRequest, result.Kind);
+        Assert.NotNull(result.Reason);
+        Assert.Contains("GoodTillDate", result.Reason);
+        Assert.Empty(gw.Replaces);
+        Assert.False(reg.IsOriginalInFlight(orig.ClOrdId));
+        Assert.True(book.TryGet(orig.ClOrdId, out var still));
+        Assert.NotNull(still);
+        Assert.NotEqual(OrderStatus.Replaced, still!.Status);
     }
 
     // ---------------- IReplaceMarginCoordinator ----------------

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/OrderQ1BackCompatTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/OrderQ1BackCompatTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Q1.1 (#253). Pins additive evolution of <see cref="OrderSubmittedEvent"/>
+/// and <see cref="OrderSnapshot"/>. WAL segments and snapshot files written
+/// before the Q1.1 slice (no <c>TimeInForce</c>, <c>StopPrice</c>, or
+/// <c>GoodTillDate</c>) must hydrate cleanly with the implicit-Day /
+/// no-stop / no-expiry semantics they actually carried.
+/// </summary>
+public class OrderQ1BackCompatTests
+{
+    private static readonly JsonSerializerOptions Opts = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void OrderSubmittedEvent_OldPayload_DeserialisesWithDefaults()
+    {
+        const string oldJson = """
+        {
+          "TimestampUtc": "2024-06-15T12:34:56.789+00:00",
+          "ClOrdId": 42,
+          "EndClientId": "alice",
+          "FirmId": "default",
+          "Symbol": "PETR4",
+          "SecurityId": 4321,
+          "Side": "Buy",
+          "Type": "Limit",
+          "Quantity": 100,
+          "Price": 30.5
+        }
+        """;
+
+        var ev = JsonSerializer.Deserialize<OrderSubmittedEvent>(oldJson, Opts);
+
+        Assert.NotNull(ev);
+        Assert.Equal("Day", ev!.TimeInForce);
+        Assert.Null(ev.StopPrice);
+        Assert.Null(ev.GoodTillDate);
+        Assert.Equal(42UL, ev.ClOrdId);
+        Assert.Equal(100, ev.Quantity);
+    }
+
+    [Fact]
+    public void OrderSnapshot_OldPayload_DeserialisesWithDefaults()
+    {
+        const string oldJson = """
+        {
+          "ClOrdId": 7,
+          "EndClientId": "alice",
+          "Symbol": "PETR4",
+          "SecurityId": 4321,
+          "Side": "Buy",
+          "Type": "Limit",
+          "Quantity": 100,
+          "Price": 30.5,
+          "LeavesQuantity": 100,
+          "CumulativeQuantity": 0,
+          "Status": "New"
+        }
+        """;
+
+        var snap = JsonSerializer.Deserialize<OrderSnapshot>(oldJson, Opts);
+
+        Assert.NotNull(snap);
+        Assert.Equal("Day", snap!.TimeInForce);
+        Assert.Null(snap.StopPrice);
+        Assert.Null(snap.GoodTillDate);
+        Assert.False(snap.IsStale);
+    }
+
+    [Fact]
+    public void OrderSubmittedEvent_NewPayload_RoundTrips()
+    {
+        var ts = new DateTimeOffset(2024, 6, 15, 12, 34, 56, 789, TimeSpan.Zero);
+        var expiry = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var ev = new OrderSubmittedEvent
+        {
+            TimestampUtc = ts,
+            ClOrdId = 1UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "StopLimit",
+            Quantity = 100,
+            Price = 30.5m,
+            TimeInForce = "GTD",
+            StopPrice = 29m,
+            GoodTillDate = expiry,
+        };
+
+        var json = JsonSerializer.Serialize(ev, Opts);
+        var rt = JsonSerializer.Deserialize<OrderSubmittedEvent>(json, Opts)!;
+
+        Assert.Equal("GTD", rt.TimeInForce);
+        Assert.Equal(29m, rt.StopPrice);
+        Assert.Equal(expiry, rt.GoodTillDate);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ReserveOnSubmitMarginProviderTests.cs
@@ -98,6 +98,68 @@ public class ReserveOnSubmitMarginProviderTests
     }
 
     [Fact]
+    public async Task BuyMarket_withStrayPrice_skipsReservation()
+    {
+        // Pass-3 alignment (#253): the OrderType gate must apply even
+        // when a buy Market carries a non-null Price (e.g. caller
+        // populated it for telemetry). The replace pipeline gates on
+        // IsMarginBearing() — submit must agree, otherwise we'd reserve
+        // here and silently release on the next cancel-replace.
+        var (p, _) = Build(initial: 100_000m);
+        var ctx = new RiskContext(
+            new EndClientId("alice"), "FIRM", "PETR4",
+            OrderSide.Buy, OrderType.Market, 100, 50m);
+        var d = await p.TryReserveAsync(1, ctx, CancellationToken.None);
+        Assert.True(d.Approved);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task BuyStopLoss_withStrayPrice_skipsReservation()
+    {
+        // Same alignment as BuyMarket: StopLoss is a stop-into-Market;
+        // it has no resting limit price to reserve against, regardless
+        // of any Price set on the context.
+        var (p, _) = Build(initial: 100_000m);
+        var ctx = new RiskContext(
+            new EndClientId("alice"), "FIRM", "PETR4",
+            OrderSide.Buy, OrderType.StopLoss, 100, 50m);
+        var d = await p.TryReserveAsync(1, ctx, CancellationToken.None);
+        Assert.True(d.Approved);
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task BuyMarginBearingTypes_reserveAsBefore()
+    {
+        // Regression guard: the three OrderType.IsMarginBearing() types
+        // (Limit / StopLimit / MarketWithLeftover) must continue to
+        // reserve cash on a Buy with a positive notional.
+        var (p, _) = Build(initial: 10_000m);
+        Assert.True((await p.TryReserveAsync(1, Buy("alice", 10m, 100, OrderType.Limit), CancellationToken.None)).Approved);
+        Assert.True((await p.TryReserveAsync(2, Buy("alice", 10m, 100, OrderType.StopLimit), CancellationToken.None)).Approved);
+        Assert.True((await p.TryReserveAsync(3, Buy("alice", 10m, 100, OrderType.MarketWithLeftover), CancellationToken.None)).Approved);
+        Assert.Equal(3_000m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
+    public async Task Sell_ofAnyType_skipsReservation()
+    {
+        // Regression guard: the Side gate runs first, so even
+        // margin-bearing types with a price never reserve on Sell.
+        var (p, _) = Build(initial: 10_000m);
+        foreach (var t in new[] { OrderType.Limit, OrderType.StopLimit, OrderType.MarketWithLeftover, OrderType.Market, OrderType.StopLoss })
+        {
+            var ctx = new RiskContext(
+                new EndClientId("alice"), "FIRM", "PETR4",
+                OrderSide.Sell, t, 100, 50m);
+            var d = await p.TryReserveAsync((ulong)t + 100, ctx, CancellationToken.None);
+            Assert.True(d.Approved);
+        }
+        Assert.Equal(0m, p.ReservedForTesting("alice"));
+    }
+
+    [Fact]
     public async Task Unknown_owner_has_zero_balance_and_is_rejected()
     {
         var (p, _) = Build(initial: 1_000m, owner: "alice");

--- a/backend/tests/B3.Trading.Domain.Tests/OrderQ1ValidationTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderQ1ValidationTests.cs
@@ -1,0 +1,84 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+/// <summary>
+/// Q1.1 (#253). Domain-level invariants for the expanded
+/// <see cref="OrderType"/> / <see cref="TimeInForce"/> surface.
+///
+/// The constructor enforces cross-field rules so a malformed order cannot
+/// reach the matching pipeline regardless of which adapter built it
+/// (REST, FIXP listener, replay).
+/// </summary>
+public class OrderQ1ValidationTests
+{
+    private static readonly EndClientId Owner = new("alice");
+
+    [Fact]
+    public void Limit_DefaultsToDay_WithNoStopOrExpiry()
+    {
+        var o = new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+
+        Assert.Equal(TimeInForce.Day, o.TimeInForce);
+        Assert.Null(o.StopPrice);
+        Assert.Null(o.GoodTillDate);
+    }
+
+    [Theory]
+    [InlineData(OrderType.StopLoss)]
+    [InlineData(OrderType.StopLimit)]
+    public void StopVariant_RequiresStopPrice(OrderType type)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, type, 100, 30m, timeInForce: TimeInForce.Day, stopPrice: null));
+    }
+
+    [Theory]
+    [InlineData(OrderType.Limit)]
+    [InlineData(OrderType.Market)]
+    [InlineData(OrderType.MarketWithLeftover)]
+    public void NonStopVariant_RejectsStopPrice(OrderType type)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, type, 100, 30m, timeInForce: TimeInForce.Day, stopPrice: 29m));
+    }
+
+    [Fact]
+    public void Gtd_RequiresGoodTillDate()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, timeInForce: TimeInForce.GTD, goodTillDate: null));
+    }
+
+    [Theory]
+    [InlineData(TimeInForce.Day)]
+    [InlineData(TimeInForce.IOC)]
+    [InlineData(TimeInForce.FOK)]
+    [InlineData(TimeInForce.GTC)]
+    [InlineData(TimeInForce.AtClose)]
+    [InlineData(TimeInForce.GoodForAuction)]
+    public void NonGtd_RejectsGoodTillDate(TimeInForce tif)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, timeInForce: tif, goodTillDate: DateTimeOffset.UtcNow.AddDays(1)));
+    }
+
+    [Fact]
+    public void StopLimit_WithStopAndPrice_Constructs()
+    {
+        var o = new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.StopLimit, 100, 30m, timeInForce: TimeInForce.Day, stopPrice: 29m);
+
+        Assert.Equal(OrderType.StopLimit, o.Type);
+        Assert.Equal(29m, o.StopPrice);
+    }
+
+    [Fact]
+    public void Gtd_WithDate_Constructs()
+    {
+        var when = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var o = new Order(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, timeInForce: TimeInForce.GTD, goodTillDate: when);
+
+        Assert.Equal(TimeInForce.GTD, o.TimeInForce);
+        Assert.Equal(when, o.GoodTillDate);
+    }
+}

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOrderAdapterMappingTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOrderAdapterMappingTests.cs
@@ -1,0 +1,54 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.Trading.Domain;
+using B3.Trading.EntryPointListener.Hosting;
+using DomainTif = B3.Trading.Domain.TimeInForce;
+using SbeTif = B3.Entrypoint.Fixp.Sbe.V6.TimeInForce;
+
+namespace B3.Trading.EntryPointListener.Tests.Hosting;
+
+/// <summary>
+/// Q1.1 (#253). Pins the SBE → Domain mapping tables consumed by
+/// the FIXP listener. A regression here means the matching pipeline
+/// would silently mis-classify Stop / GTD / IOC orders coming from
+/// real B3 EntryPoint sessions.
+/// </summary>
+public class FixpOrderAdapterMappingTests
+{
+    [Theory]
+    [InlineData(OrdType.LIMIT, OrderType.Limit)]
+    [InlineData(OrdType.MARKET, OrderType.Market)]
+    [InlineData(OrdType.STOP_LOSS, OrderType.StopLoss)]
+    [InlineData(OrdType.STOP_LIMIT, OrderType.StopLimit)]
+    [InlineData(OrdType.MARKET_WITH_LEFTOVER_AS_LIMIT, OrderType.MarketWithLeftover)]
+    public void TryMapOrdType_KnownValues(OrdType raw, OrderType expected)
+    {
+        Assert.True(FixpOrderAdapter.TryMapOrdType(raw, out var got));
+        Assert.Equal(expected, got);
+    }
+
+    [Fact]
+    public void TryMapOrdType_UnknownValue_Rejected()
+    {
+        Assert.False(FixpOrderAdapter.TryMapOrdType((OrdType)200, out _));
+    }
+
+    [Theory]
+    [InlineData(SbeTif.DAY, DomainTif.Day)]
+    [InlineData(SbeTif.GOOD_TILL_CANCEL, DomainTif.GTC)]
+    [InlineData(SbeTif.IMMEDIATE_OR_CANCEL, DomainTif.IOC)]
+    [InlineData(SbeTif.FILL_OR_KILL, DomainTif.FOK)]
+    [InlineData(SbeTif.GOOD_TILL_DATE, DomainTif.GTD)]
+    [InlineData(SbeTif.AT_THE_CLOSE, DomainTif.AtClose)]
+    [InlineData(SbeTif.GOOD_FOR_AUCTION, DomainTif.GoodForAuction)]
+    public void TryMapTimeInForce_KnownValues(SbeTif raw, DomainTif expected)
+    {
+        Assert.True(FixpOrderAdapter.TryMapTimeInForce(raw, out var got));
+        Assert.Equal(expected, got);
+    }
+
+    [Fact]
+    public void TryMapTimeInForce_UnknownValue_Rejected()
+    {
+        Assert.False(FixpOrderAdapter.TryMapTimeInForce((SbeTif)200, out _));
+    }
+}


### PR DESCRIPTION
Closes #253.

## Q1.1 — Order surface expansion

Threads the order types and TIFs that real B3 equity sessions emit through every layer of the platform:

| Layer | Change |
|---|---|
| **Domain** | `OrderType` += `StopLoss`, `StopLimit`, `MarketWithLeftover`. New `TimeInForce` enum (Day/IOC/FOK/GTC/GTD/AtClose/GoodForAuction). Order ctor enforces cross-field invariants (StopPrice required iff Stop\\*; GoodTillDate required iff GTD). |
| **Persistence** | `OrderSubmittedEvent` + `OrderSnapshot` get additive `TimeInForce` / `StopPrice` / `GoodTillDate` fields. Defaults preserve old payload semantics — verified by back-compat tests. |
| **API** | `POST /orders` accepts the new fields; bad TIF or invariant violation → `400 BadRequest`. `OrderDto` exposes them to WS. |
| **Outbound (B3 SDK)** | `B3EntryPointClientGateway` maps Domain → SDK enums for both NewOrder + Replace, populating `StopPrice` + `ExpireDate`. |
| **Inbound (FIXP listener)** | `InboundDecoders` surfaces TIF/StopPx/ExpireDate; `FixpOrderAdapter` maps SBE → Domain. Unknown wire values produce a clean BMR. |

## Out of scope (per spec)
- Risk validation for new types (future Q1 sub-issue).
- GTD scheduler / expiry sweep.
- UI changes.
- Conformance goldens.

## Tests added
- `OrderQ1ValidationTests` — ctor invariant matrix (15 cases).
- `OrderQ1BackCompatTests` — old WAL/snapshot JSON hydrates with Day/null/null defaults; new payload round-trips.
- `B3EntryPointClientGatewayMapTests` — Domain→SDK enum tables (12 cases + reject unmapped).
- `FixpOrderAdapterMappingTests` — SBE→Domain enum tables (12 cases + reject unknown).

## Test results
```
Domain:             68 passed (was 53, +15)
Application:       660 passed (was 643, +17)
EntryPointListener: 134 passed (was 120, +14)
Api:               207 passed
SimulatorBot:       23 passed
Conformance:        18 skipped
Total:            1092 passed / 18 skipped / 0 failed
```
