### PR TITLE
feat(#254): risk checks for stop trigger, IOC/FOK leftover, GFA phase, GTD bounds

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -398,6 +398,14 @@ public static class MetricsRegistry
     public static readonly Counter<long> CollarBypassedNoReference =
         Meter.CreateCounter<long>("trading.risk.collar.bypassed_no_reference");
 
+    // Q1.2 (#254). Counts the cases where StopTriggerCheck approved a
+    // Stop* order purely because it could not obtain a reference price
+    // for the symbol — the StopPrice > 0 invariant still ran, but the
+    // Buy>=ref / Sell<=ref relation was skipped. Tagged by symbol so
+    // ops can spot the coverage gap before it hides a fat-finger stop.
+    public static readonly Counter<long> StopCheckSkippedNoRef =
+        Meter.CreateCounter<long>("trading.risk.stop_check_skipped_no_ref");
+
     // Per-symbol age (seconds) of the last live MD update held in the
     // MarketDataReferencePrice cache. Sourced from a callback registered
     // by the provider on construction (singleton). Symbols that have

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -187,11 +187,34 @@ public sealed class OrderModifyService
             return OrderModifyResult.DuplicateClOrdId(newClOrdId);
         }
         var effectiveLeaves = req.NewQuantity - orig.CumulativeQuantity;
+        // Q1.2 (#254). Resolve the effective TIF/StopPrice/GoodTillDate
+        // through the same merge the domain ctor will use (null on the
+        // request = inherit the original) so the pipeline's stop-trigger,
+        // IOC/FOK leftover, GFA-phase and GTD-bounds checks see the same
+        // post-replace values that would land on the new Order.
+        TimeInForce effTif;
+        decimal? effStop;
+        DateTimeOffset? effGtd;
+        try
+        {
+            (effTif, effStop, effGtd) = Order.MergeReplacementOptionals(
+                orig.Type, orig.TimeInForce, orig.StopPrice, orig.GoodTillDate,
+                req.NewTimeInForce, req.NewStopPrice, req.NewGoodTillDate);
+        }
+        catch (ArgumentException ex)
+        {
+            // Same posture as submit: domain cross-field invariants
+            // surface as BadRequest (400) before any WAL append.
+            return OrderModifyResult.BadRequest(ex.Message);
+        }
         var riskCtx = new RiskContext(
             req.Owner, orig.FirmId, orig.Symbol, orig.Side, orig.Type,
             req.NewQuantity, req.NewPrice,
             ReplaceOriginalClOrdId: req.OriginalClOrdId,
-            EffectiveLeavesQuantity: effectiveLeaves);
+            EffectiveLeavesQuantity: effectiveLeaves,
+            TimeInForce: effTif,
+            StopPrice: effStop,
+            GoodTillDate: effGtd);
 
         var decision = _risk.Evaluate(riskCtx);
         if (!decision.Approved)

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -205,7 +205,11 @@ public sealed class OrderSubmissionService
             new KeyValuePair<string, object?>("source",
                 req.Source == OrderSubmissionSource.Algo ? "algo" : "manual"));
 
-        var riskCtx = new RiskContext(req.Owner, req.FirmId, req.Symbol, req.Side, req.Type, req.Quantity, req.Price);
+        var riskCtx = new RiskContext(
+            req.Owner, req.FirmId, req.Symbol, req.Side, req.Type, req.Quantity, req.Price,
+            TimeInForce: req.TimeInForce,
+            StopPrice: req.StopPrice,
+            GoodTillDate: req.GoodTillDate);
         var decision = _risk.Evaluate(riskCtx);
         var marginReserved = false;
         if (decision.Approved)

--- a/backend/src/B3.Trading.Application/Risk/Checks/Q12RiskChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/Q12RiskChecks.cs
@@ -1,0 +1,205 @@
+using System.Globalization;
+using B3.Trading.Application.Observability;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Q1.2 (#254). Stop-trigger sanity for <see cref="OrderType.StopLoss"/>
+/// and <see cref="OrderType.StopLimit"/>.
+///
+/// <para><b>Rules (layered on top of the domain invariant that
+/// <c>StopPrice</c> is required + positive for Stop* orders):</b></para>
+/// <list type="bullet">
+///   <item><description>Buy stop ⇒ <c>StopPrice &gt;= ref</c> (you "stop" once price rises into the trigger).</description></item>
+///   <item><description>Sell stop ⇒ <c>StopPrice &lt;= ref</c>.</description></item>
+///   <item><description><c>StopLimit</c> additionally requires <c>Price</c> to be present and to honour <c>Buy: Price &gt;= StopPrice</c> / <c>Sell: Price &lt;= StopPrice</c> — a sell-stop-limit with a limit ABOVE the trigger would never fill once triggered.</description></item>
+/// </list>
+///
+/// <para><b>Lenient skip on missing reference:</b> if the platform has
+/// no reference price for the symbol the relation check is skipped
+/// (only the <c>StopPrice &gt; 0</c> invariant — already enforced by
+/// the domain — applies). The
+/// <see cref="MetricsRegistry.StopCheckSkippedNoRef"/> counter is bumped
+/// with a <c>symbol</c> tag so ops can spot coverage gaps. Same
+/// fail-open posture as <see cref="PriceCollarCheck"/>: a configured
+/// guard with no anchor cannot be enforced, and a hard reject would
+/// silently halt Stop* trading on every symbol the MD feed hasn't
+/// covered yet.</para>
+///
+/// <para>Pipeline order=305 — runs right after <see cref="PriceCollarCheck"/>
+/// (300) so the cheaper price-band gate short-circuits first.</para>
+/// </summary>
+public sealed class StopTriggerCheck : IRiskCheck
+{
+    private readonly IReferencePrice _refPrice;
+
+    public StopTriggerCheck(IReferencePrice refPrice) => _refPrice = refPrice;
+
+    public int Order => 305;
+    public string Name => "stop_trigger";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.Type is not (OrderType.StopLoss or OrderType.StopLimit))
+            return RiskDecision.Approve;
+
+        // Domain guarantees StopPrice is present and > 0 for Stop*; we
+        // re-verify defensively because the risk pipeline runs on the
+        // RiskContext, not on a constructed Order.
+        if (!ctx.StopPrice.HasValue || ctx.StopPrice.Value <= 0m)
+            return RiskDecision.Reject(
+                $"stop_trigger_invalid stopPrice={Format(ctx.StopPrice)} side={ctx.Side.ToString().ToLowerInvariant()}");
+
+        var stop = ctx.StopPrice.Value;
+
+        if (ctx.Type == OrderType.StopLimit)
+        {
+            if (!ctx.Price.HasValue)
+                return RiskDecision.Reject(
+                    $"stop_limit_price_invalid stopPrice={Format(stop)} side={ctx.Side.ToString().ToLowerInvariant()} price=null");
+            var limit = ctx.Price.Value;
+            var limitOk = ctx.Side == OrderSide.Buy ? limit >= stop : limit <= stop;
+            if (!limitOk)
+                return RiskDecision.Reject(
+                    $"stop_limit_price_invalid stopPrice={Format(stop)} price={Format(limit)} side={ctx.Side.ToString().ToLowerInvariant()}");
+        }
+
+        var lookup = _refPrice.Lookup(ctx.Symbol);
+        if (!lookup.Found || lookup.Price <= 0m)
+        {
+            // Lenient skip: emit observability and approve. See class
+            // doc — fail-open consistent with PriceCollarCheck.
+            MetricsRegistry.StopCheckSkippedNoRef.Add(1,
+                new KeyValuePair<string, object?>("symbol", ctx.Symbol));
+            return RiskDecision.Approve;
+        }
+
+        var refPx = lookup.Price;
+        var stopOk = ctx.Side == OrderSide.Buy ? stop >= refPx : stop <= refPx;
+        if (!stopOk)
+            return RiskDecision.Reject(
+                $"stop_trigger_invalid stopPrice={Format(stop)} ref={Format(refPx)} side={ctx.Side.ToString().ToLowerInvariant()}");
+        return RiskDecision.Approve;
+    }
+
+    private static string Format(decimal? v) =>
+        v.HasValue ? v.Value.ToString(CultureInfo.InvariantCulture) : "null";
+    private static string Format(decimal v) => v.ToString(CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// Q1.2 (#254). <see cref="TimeInForce.IOC"/> and
+/// <see cref="TimeInForce.FOK"/> are immediate-match TIFs;
+/// <see cref="OrderType.MarketWithLeftover"/> explicitly intends to
+/// rest the un-filled remainder on the book. The combination is
+/// nonsensical (the venue would either reject it or silently downgrade
+/// one of the two), so we reject up-front rather than route an
+/// ambiguous order to the gateway.
+///
+/// <para>Pipeline order=20 — early and cheap (no allocations / no IO).</para>
+/// </summary>
+public sealed class IocFokMarketWithLeftoverCheck : IRiskCheck
+{
+    public int Order => 20;
+    public string Name => "tif_incompatible_with_market_with_leftover";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.Type != OrderType.MarketWithLeftover) return RiskDecision.Approve;
+        if (ctx.TimeInForce is TimeInForce.IOC or TimeInForce.FOK)
+            return RiskDecision.Reject(
+                $"tif_incompatible_with_market_with_leftover tif={ctx.TimeInForce}");
+        return RiskDecision.Approve;
+    }
+}
+
+/// <summary>
+/// Q1.2 (#254). <see cref="TimeInForce.GoodForAuction"/> is only
+/// meaningful inside a call auction. Reject when the current
+/// <see cref="TradingPhase"/> for the symbol is not
+/// <see cref="TradingPhase.OpeningCall"/> or
+/// <see cref="TradingPhase.FinalClosingCall"/>.
+///
+/// <para><b>Default provider stub:</b> in the absence of #257
+/// (auction-MD ingest) the registered <see cref="IPhaseProvider"/> is
+/// <see cref="NoPhaseProvider"/> which always reports
+/// <see cref="TradingPhase.Open"/>. Under the stub every GFA submission
+/// is rejected — the intended fail-closed posture, since accepting a
+/// GFA into continuous matching has no meaning. Tests that need to
+/// exercise the accept path inject a fake provider preset to
+/// <see cref="TradingPhase.OpeningCall"/> / <see cref="TradingPhase.FinalClosingCall"/>.</para>
+///
+/// <para>Pipeline order=14 — right after <see cref="SessionPhaseCheck"/>
+/// (12) and before any IO-bearing gate.</para>
+/// </summary>
+public sealed class GoodForAuctionPhaseCheck : IRiskCheck
+{
+    private readonly IPhaseProvider _phases;
+    public GoodForAuctionPhaseCheck(IPhaseProvider phases) => _phases = phases;
+
+    public int Order => 14;
+    public string Name => "gfa_outside_auction_phase";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.TimeInForce != TimeInForce.GoodForAuction) return RiskDecision.Approve;
+        var phase = _phases.GetPhase(ctx.Symbol);
+        if (phase is TradingPhase.OpeningCall or TradingPhase.FinalClosingCall)
+            return RiskDecision.Approve;
+        return RiskDecision.Reject($"gfa_outside_auction_phase phase={phase}");
+    }
+}
+
+/// <summary>
+/// Q1.2 (#254). <see cref="TimeInForce.GTD"/> bounds:
+/// <c>GoodTillDate</c> must be present (domain-enforced), strictly in
+/// the future, and within
+/// <see cref="RiskOptions.MaxGtdHorizon"/> (default 30 days).
+///
+/// <para>Time source is <see cref="TimeProvider"/> from DI so tests
+/// can pin "now" with a <c>FakeTimeProvider</c>; production resolves
+/// to <see cref="TimeProvider.System"/> via the existing host
+/// registration.</para>
+///
+/// <para>Pipeline order=22 — early and cheap.</para>
+/// </summary>
+public sealed class GtdBoundsCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+    private readonly TimeProvider _clock;
+
+    public GtdBoundsCheck(IOptionsMonitor<RiskOptions> options, TimeProvider? clock = null)
+    {
+        _options = options;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public int Order => 22;
+    public string Name => "gtd_bounds";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.TimeInForce != TimeInForce.GTD) return RiskDecision.Approve;
+        if (!ctx.GoodTillDate.HasValue)
+            return RiskDecision.Reject("gtd_invalid expiry=null");
+
+        var now = _clock.GetUtcNow();
+        var maxHorizon = _options.CurrentValue.MaxGtdHorizon;
+        if (maxHorizon <= TimeSpan.Zero) maxHorizon = TimeSpan.FromDays(30);
+
+        var expiry = ctx.GoodTillDate.Value;
+        var horizonDays = (int)Math.Round(maxHorizon.TotalDays);
+        if (expiry <= now)
+            return RiskDecision.Reject(
+                $"gtd_invalid expiry={Iso(expiry)} now={Iso(now)} maxHorizonDays={horizonDays}");
+        if (expiry - now > maxHorizon)
+            return RiskDecision.Reject(
+                $"gtd_invalid expiry={Iso(expiry)} now={Iso(now)} maxHorizonDays={horizonDays}");
+        return RiskDecision.Approve;
+    }
+
+    private static string Iso(DateTimeOffset t) =>
+        t.ToString("O", CultureInfo.InvariantCulture);
+}

--- a/backend/src/B3.Trading.Application/Risk/IPhaseProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/IPhaseProvider.cs
@@ -1,3 +1,9 @@
+// LOCKED LOCATION: this interface is consumed by GoodForAuctionPhaseCheck and
+// will be implemented by issue #257 (auction MD ingest + AuctionStateStore).
+// Do NOT move to another namespace without coordinating both PRs - DI binding
+// is by exact type identity. The temporary NoPhaseProvider registration in
+// TradingRiskServiceCollectionExtensions is replaced by #257's
+// AuctionStateStore-backed provider for the same interface type.
 namespace B3.Trading.Application.Risk;
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Risk/IPhaseProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/IPhaseProvider.cs
@@ -1,0 +1,74 @@
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// B3 trading-phase ladder for an instrument as observed by the
+/// market-data side (auction lifecycle). Distinct from
+/// <see cref="B3.Trading.Domain.SessionPhase"/> which is the broader
+/// venue-level surface that <see cref="Checks.SessionPhaseCheck"/>
+/// gates on. The two will eventually consolidate (#257 wires the real
+/// <see cref="IPhaseProvider"/> from the auction-MD ingest); for now
+/// they coexist because Q1.2 (#254) needs the finer-grained call /
+/// closing-call distinction to gate <c>GoodForAuction</c> while the
+/// session-phase axis still describes "is the venue continuous,
+/// after-hours, closed".
+/// </summary>
+public enum TradingPhase
+{
+    /// <summary>Pre-trade reservation window — orders accepted but no matching.</summary>
+    Reserved,
+    /// <summary>Opening call auction — accepts <c>GoodForAuction</c>.</summary>
+    OpeningCall,
+    /// <summary>Continuous matching.</summary>
+    Open,
+    /// <summary>Closing call auction (a.k.a. "leilão de fechamento") — accepts <c>GoodForAuction</c>.</summary>
+    FinalClosingCall,
+    /// <summary>After-hours / venue closed for matching.</summary>
+    Close,
+    /// <summary>Phase information not available for the symbol (e.g. no MD subscription).</summary>
+    Unknown,
+}
+
+/// <summary>
+/// Per-symbol view of the current B3 <see cref="TradingPhase"/>.
+/// Backs <see cref="Checks.GoodForAuctionPhaseCheck"/> (#254) and will
+/// be the seam through which #257 publishes auction-MD-driven phase
+/// transitions.
+///
+/// <para><b>Why a new interface (and not an extension of
+/// <see cref="SessionPhaseService"/>):</b> session phase is a venue-
+/// wide control surface owned by the operator (kill-switch-adjacent);
+/// trading phase is a market-data fact reported by the venue per
+/// instrument. They have different write paths, different durabilities,
+/// and overlap only loosely on the "is matching active" question.
+/// Forcing one to model the other makes both worse.</para>
+/// </summary>
+public interface IPhaseProvider
+{
+    /// <summary>
+    /// Returns the current <see cref="TradingPhase"/> for the symbol,
+    /// or <see cref="TradingPhase.Unknown"/> when no phase information
+    /// is available. Implementations must be cheap and side-effect-free
+    /// — the pipeline calls this on the hot path.
+    /// </summary>
+    TradingPhase GetPhase(string symbol);
+}
+
+/// <summary>
+/// <b>TEMPORARY default until #257 wires the auction-MD-driven provider.</b>
+/// Always reports <see cref="TradingPhase.Open"/> so the rest of the
+/// risk pipeline can run without forcing #257 to land first. The
+/// consequence is that <see cref="Checks.GoodForAuctionPhaseCheck"/>
+/// will <i>always reject</i> a <c>GoodForAuction</c> TIF under this
+/// stub (Open ∉ {OpeningCall, FinalClosingCall}) — which is the
+/// intended fail-closed posture: GFA is a low-volume specialty TIF
+/// and a silent accept here would route those orders into continuous
+/// matching, where <c>GoodForAuction</c> is meaningless.
+///
+/// <para>When the real provider is registered (#257) it must replace
+/// this singleton in DI, not coexist — the pipeline resolves a single
+/// <see cref="IPhaseProvider"/>.</para>
+/// </summary>
+public sealed class NoPhaseProvider : IPhaseProvider
+{
+    public TradingPhase GetPhase(string symbol) => TradingPhase.Open;
+}

--- a/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
@@ -28,7 +28,16 @@ public sealed record RiskContext(
     long Quantity,
     decimal? Price,
     ulong? ReplaceOriginalClOrdId = null,
-    long? EffectiveLeavesQuantity = null);
+    long? EffectiveLeavesQuantity = null,
+    // Q1.2 (#254). TIF / StopPrice / GoodTillDate are forwarded to the
+    // pipeline so the new gates (stop-trigger, IOC/FOK + MarketWithLeftover,
+    // GoodForAuction phase, GTD bounds) can run without re-reading the
+    // request. Default values keep the legacy plain-Limit/Day call sites
+    // ergonomic — every existing test still constructs `new RiskContext(...)`
+    // with the original positional arguments.
+    TimeInForce TimeInForce = TimeInForce.Day,
+    decimal? StopPrice = null,
+    DateTimeOffset? GoodTillDate = null);
 
 public sealed record RiskDecision(bool Approved, string? Reason)
 {

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -21,6 +21,18 @@ public sealed class RiskOptions
     public MarginOptions Margin { get; set; } = new();
 
     /// <summary>
+    /// Q1.2 (#254). Maximum allowed horizon between "now" and a
+    /// <see cref="B3.Trading.Domain.TimeInForce.GTD"/> order's
+    /// <c>GoodTillDate</c>. Defaults to 30 days — picked to match
+    /// the regulatory / clearing window most B3 brokers honor for
+    /// good-till-date instructions. Bound at the global level only
+    /// (not per-firm / per-symbol): a tenant-scoped override would
+    /// just be a way to push expiries further out, which is the
+    /// thing the cap exists to prevent.
+    /// </summary>
+    public TimeSpan MaxGtdHorizon { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
     /// Rolling-window notional cap (slice 7). Modeled as its own
     /// section instead of a field on <see cref="RiskLimits"/> because
     /// the underlying ledger is keyed per-end-client (and per-firm)

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -96,6 +96,15 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
         services.AddSingleton<IRiskCheck, PriceCollarCheck>();
         services.AddSingleton<IRiskCheck, StaleReferencePriceCheck>();
+        // Q1.2 (#254). Stop-trigger / IOC-FOK-leftover / GFA-phase /
+        // GTD-bounds gates for the new Q1.1 order surface.
+        // IPhaseProvider defaults to NoPhaseProvider until #257 wires
+        // the auction-MD-driven implementation — see IPhaseProvider.cs.
+        services.TryAddSingleton<IPhaseProvider, NoPhaseProvider>();
+        services.AddSingleton<IRiskCheck, StopTriggerCheck>();
+        services.AddSingleton<IRiskCheck, IocFokMarketWithLeftoverCheck>();
+        services.AddSingleton<IRiskCheck, GoodForAuctionPhaseCheck>();
+        services.AddSingleton<IRiskCheck, GtdBoundsCheck>();
         services.AddSingleton<RiskPipeline>();
 
         // Throttle accountants (slice 7). TimeProvider is fetched from DI so

--- a/backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs
@@ -1,0 +1,241 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q1.2 (#254) end-to-end coverage for the new risk gates over the
+/// Q1.1 order surface. Reuses the deterministic <see cref="TestAppFactory"/>
+/// (PETR4 reference price seeded at 30.0; Risk pipeline up).
+///
+/// <para>Submit risk rejections come back as <c>202 Accepted</c> with
+/// <c>Status="Rejected"</c> — the existing contract on <c>POST /orders</c>;
+/// modify risk rejections come back as <c>422 UnprocessableEntity</c>.
+/// We assert the reason string carries the machine-readable prefix so
+/// downstream consumers (UI / FIXP bot) can branch on it.</para>
+/// </summary>
+public class Q12RiskEndpointTests
+{
+    [Fact]
+    public async Task POST_StopLoss_BuyBelowRef_RejectsWithStopTriggerReason()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        // PETR4 ref = 30. Buy stop below ref is invalid.
+        var resp = await PostStop(http, token, "Buy", "StopLoss", stop: 25m, price: null);
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.Equal("Rejected", ack.Status);
+        Assert.StartsWith("stop_trigger_invalid", ack.Reason);
+    }
+
+    [Fact]
+    public async Task POST_StopLimit_BuyLimitBelowStop_RejectsWithStopLimitPriceReason()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        // Buy stop above ref OK (32 > 30), but limit below stop is invalid for buy.
+        var resp = await PostStop(http, token, "Buy", "StopLimit", stop: 32m, price: 31m);
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.StartsWith("stop_limit_price_invalid", ack.Reason);
+    }
+
+    [Fact]
+    public async Task POST_MarketWithLeftover_IOC_RejectsWithTifIncompatReason()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var resp = await PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "MarketWithLeftover",
+            Quantity = 100,
+            Price = (decimal?)null,
+            TimeInForce = "IOC",
+        });
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.StartsWith("tif_incompatible_with_market_with_leftover", ack.Reason);
+    }
+
+    [Fact]
+    public async Task POST_GoodForAuction_OutsideAuction_Rejects()
+    {
+        // Default IPhaseProvider (NoPhaseProvider) reports Open ⇒ rejects every GFA.
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var resp = await PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+            TimeInForce = "GoodForAuction",
+        });
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.StartsWith("gfa_outside_auction_phase", ack.Reason);
+    }
+
+    [Fact]
+    public async Task POST_GTD_BeyondHorizon_Rejects()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var beyond = DateTimeOffset.UtcNow.AddDays(60); // default horizon = 30
+        var resp = await PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+            TimeInForce = "GTD",
+            GoodTillDate = beyond,
+        });
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.StartsWith("gtd_invalid", ack.Reason);
+    }
+
+    [Fact]
+    public async Task POST_GTD_WithinHorizon_Accepted()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var ok = DateTimeOffset.UtcNow.AddDays(7);
+        var resp = await PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+            TimeInForce = "GTD",
+            GoodTillDate = ok,
+        });
+        var ack = await ReadAck(resp);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        Assert.True(ack.Status is null or "" or not "Rejected", $"unexpected reject: {ack.Reason}");
+    }
+
+    [Fact]
+    public async Task PUT_Modify_StopTrigger_ViolatedOnReplace_Rejects422()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Submit a valid Buy StopLimit (ref 30, stop 31 ≥ ref, limit 32 ≥ stop).
+        var posted = await PostStop(http, token, "Buy", "StopLimit", stop: 31m, price: 32m);
+        var origAck = await ReadAck(posted);
+        Assert.True(origAck.Status != "Rejected", $"unexpected submit reject: {origAck.Reason}");
+
+        // Modify pulls the stop below ref ⇒ stop_trigger_invalid.
+        var put = await PutModify(http, token, origAck.ClOrdId, new
+        {
+            Quantity = 100L,
+            Price = (decimal?)32m,
+            StopPrice = (decimal?)25m,
+        });
+        var bodyText = await put.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, put.StatusCode);
+        Assert.Contains("stop_trigger_invalid", bodyText);
+    }
+
+    [Fact]
+    public async Task PUT_Modify_GTD_BeyondHorizon_Rejects422()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Plain Day order first — TIF/GTD upgraded on the modify.
+        var posted = await PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30m,
+        });
+        var origAck = await ReadAck(posted);
+        Assert.True(string.IsNullOrEmpty(origAck.Reason));
+
+        var beyond = DateTimeOffset.UtcNow.AddDays(60);
+        var put = await PutModify(http, token, origAck.ClOrdId, new
+        {
+            Quantity = 100L,
+            Price = (decimal?)30m,
+            TimeInForce = "GTD",
+            GoodTillDate = beyond,
+        });
+        var bodyText = await put.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, put.StatusCode);
+        Assert.Contains("gtd_invalid", bodyText);
+    }
+
+    // ---- helpers ----
+
+    private static async Task<HttpResponseMessage> PostBase(HttpClient http, string token, object payload)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private static Task<HttpResponseMessage> PostStop(
+        HttpClient http, string token, string side, string type,
+        decimal stop, decimal? price) =>
+        PostBase(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = side,
+            Type = type,
+            Quantity = 100,
+            Price = price,
+            StopPrice = (decimal?)stop,
+        });
+
+    private static async Task<HttpResponseMessage> PutModify(
+        HttpClient http, string token, string clOrdId, object payload)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/orders/{clOrdId}")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<OrderAck> ReadAck(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        var ack = JsonSerializer.Deserialize<OrderAck>(body,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.NotNull(ack);
+        return ack!;
+    }
+
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason);
+}

--- a/backend/tests/B3.Trading.Application.Tests/Risk/Q12RiskChecksTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Risk/Q12RiskChecksTests.cs
@@ -1,0 +1,277 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests.RiskQ12;
+
+public class Q12RiskChecksTests
+{
+    private const string Owner = "alice";
+    private const string Firm = "FIRM";
+    private const string Symbol = "PETR4";
+
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) =>
+        new StaticOptionsMonitor<RiskOptions>(o);
+
+    // ---- StopTriggerCheck ----
+
+    private sealed class StubRefPrice : IReferencePrice
+    {
+        private readonly Dictionary<string, decimal> _table;
+        public StubRefPrice(params (string Symbol, decimal Price)[] entries) =>
+            _table = entries.ToDictionary(e => e.Symbol, e => e.Price, StringComparer.OrdinalIgnoreCase);
+        public bool TryGet(string symbol, out decimal price) => _table.TryGetValue(symbol, out price);
+    }
+
+    private static RiskContext StopCtx(OrderSide side, OrderType type,
+        decimal? stopPrice, decimal? price = null, string symbol = Symbol) =>
+        new(new EndClientId(Owner), Firm, symbol, side, type, 100, price,
+            StopPrice: stopPrice);
+
+    [Fact]
+    public void StopTrigger_Skips_NonStop_Orders()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice());
+        var ctx = new RiskContext(new EndClientId(Owner), Firm, Symbol,
+            OrderSide.Buy, OrderType.Limit, 100, 10m);
+        Assert.True(check.Check(ctx).Approved);
+    }
+
+    [Fact]
+    public void StopTrigger_BuyStopLoss_Above_Ref_Approves()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Buy, OrderType.StopLoss, stopPrice: 22m);
+        Assert.True(check.Check(ctx).Approved);
+    }
+
+    [Fact]
+    public void StopTrigger_BuyStopLoss_Below_Ref_Rejects()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Buy, OrderType.StopLoss, stopPrice: 18m);
+        var d = check.Check(ctx);
+        Assert.False(d.Approved);
+        Assert.StartsWith("stop_trigger_invalid", d.Reason);
+        Assert.Contains("side=buy", d.Reason);
+    }
+
+    [Fact]
+    public void StopTrigger_SellStopLoss_Below_Ref_Approves()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Sell, OrderType.StopLoss, stopPrice: 18m);
+        Assert.True(check.Check(ctx).Approved);
+    }
+
+    [Fact]
+    public void StopTrigger_SellStopLoss_Above_Ref_Rejects()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Sell, OrderType.StopLoss, stopPrice: 22m);
+        var d = check.Check(ctx);
+        Assert.False(d.Approved);
+        Assert.StartsWith("stop_trigger_invalid", d.Reason);
+        Assert.Contains("side=sell", d.Reason);
+    }
+
+    [Fact]
+    public void StopTrigger_Lenient_Skip_When_No_Reference()
+    {
+        // No entries — Lookup returns Missing. Relation skipped, approve.
+        var check = new StopTriggerCheck(new StubRefPrice());
+        var ctx = StopCtx(OrderSide.Buy, OrderType.StopLoss, stopPrice: 5m);
+        Assert.True(check.Check(ctx).Approved);
+    }
+
+    [Fact]
+    public void StopTrigger_BuyStopLimit_Limit_Below_Stop_Rejects()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        // Buy stop above ref OK, but limit below stop fails StopLimit relation.
+        var ctx = StopCtx(OrderSide.Buy, OrderType.StopLimit, stopPrice: 25m, price: 24m);
+        var d = check.Check(ctx);
+        Assert.False(d.Approved);
+        Assert.StartsWith("stop_limit_price_invalid", d.Reason);
+    }
+
+    [Fact]
+    public void StopTrigger_SellStopLimit_Limit_Above_Stop_Rejects()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Sell, OrderType.StopLimit, stopPrice: 18m, price: 19m);
+        var d = check.Check(ctx);
+        Assert.False(d.Approved);
+        Assert.StartsWith("stop_limit_price_invalid", d.Reason);
+    }
+
+    [Fact]
+    public void StopTrigger_StopLimit_Happy_Path()
+    {
+        var check = new StopTriggerCheck(new StubRefPrice((Symbol, 20m)));
+        var ctx = StopCtx(OrderSide.Buy, OrderType.StopLimit, stopPrice: 22m, price: 23m);
+        Assert.True(check.Check(ctx).Approved);
+    }
+
+    // ---- IocFokMarketWithLeftoverCheck ----
+
+    private static RiskContext TifCtx(OrderType type, TimeInForce tif) =>
+        new(new EndClientId(Owner), Firm, Symbol,
+            OrderSide.Buy, type, 100, type == OrderType.Limit ? 10m : (decimal?)null,
+            TimeInForce: tif);
+
+    [Fact]
+    public void IocFokLeftover_Limit_Day_Approves()
+    {
+        var check = new IocFokMarketWithLeftoverCheck();
+        Assert.True(check.Check(TifCtx(OrderType.Limit, TimeInForce.Day)).Approved);
+    }
+
+    [Fact]
+    public void IocFokLeftover_MarketWithLeftover_Day_Approves()
+    {
+        var check = new IocFokMarketWithLeftoverCheck();
+        Assert.True(check.Check(TifCtx(OrderType.MarketWithLeftover, TimeInForce.Day)).Approved);
+    }
+
+    [Fact]
+    public void IocFokLeftover_MarketWithLeftover_IOC_Rejects()
+    {
+        var check = new IocFokMarketWithLeftoverCheck();
+        var d = check.Check(TifCtx(OrderType.MarketWithLeftover, TimeInForce.IOC));
+        Assert.False(d.Approved);
+        Assert.StartsWith("tif_incompatible_with_market_with_leftover", d.Reason);
+    }
+
+    [Fact]
+    public void IocFokLeftover_MarketWithLeftover_FOK_Rejects()
+    {
+        var check = new IocFokMarketWithLeftoverCheck();
+        var d = check.Check(TifCtx(OrderType.MarketWithLeftover, TimeInForce.FOK));
+        Assert.False(d.Approved);
+        Assert.StartsWith("tif_incompatible_with_market_with_leftover", d.Reason);
+    }
+
+    // ---- GoodForAuctionPhaseCheck ----
+
+    private sealed class FakePhaseProvider : IPhaseProvider
+    {
+        public TradingPhase Phase { get; set; } = TradingPhase.Open;
+        public TradingPhase GetPhase(string symbol) => Phase;
+    }
+
+    private static RiskContext GfaCtx(TimeInForce tif = TimeInForce.GoodForAuction) =>
+        new(new EndClientId(Owner), Firm, Symbol,
+            OrderSide.Buy, OrderType.Limit, 100, 10m, TimeInForce: tif);
+
+    [Theory]
+    [InlineData(TradingPhase.OpeningCall)]
+    [InlineData(TradingPhase.FinalClosingCall)]
+    public void Gfa_AuctionPhases_Approve(TradingPhase phase)
+    {
+        var phases = new FakePhaseProvider { Phase = phase };
+        Assert.True(new GoodForAuctionPhaseCheck(phases).Check(GfaCtx()).Approved);
+    }
+
+    [Theory]
+    [InlineData(TradingPhase.Reserved)]
+    [InlineData(TradingPhase.Open)]
+    [InlineData(TradingPhase.Close)]
+    [InlineData(TradingPhase.Unknown)]
+    public void Gfa_NonAuctionPhases_Reject(TradingPhase phase)
+    {
+        var phases = new FakePhaseProvider { Phase = phase };
+        var d = new GoodForAuctionPhaseCheck(phases).Check(GfaCtx());
+        Assert.False(d.Approved);
+        Assert.StartsWith("gfa_outside_auction_phase", d.Reason);
+        Assert.Contains($"phase={phase}", d.Reason);
+    }
+
+    [Fact]
+    public void Gfa_NonGfaTif_Skipped_Even_In_Open()
+    {
+        var phases = new FakePhaseProvider { Phase = TradingPhase.Open };
+        Assert.True(new GoodForAuctionPhaseCheck(phases).Check(GfaCtx(TimeInForce.Day)).Approved);
+    }
+
+    [Fact]
+    public void NoPhaseProvider_Default_Stub_Returns_Open()
+    {
+        // Documents the stub posture: GFA always rejects until #257 wires the real provider.
+        var stub = new NoPhaseProvider();
+        Assert.Equal(TradingPhase.Open, stub.GetPhase("ANY"));
+        var d = new GoodForAuctionPhaseCheck(stub).Check(GfaCtx());
+        Assert.False(d.Approved);
+    }
+
+    // ---- GtdBoundsCheck ----
+
+    private sealed class FixedClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FixedClock(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private static RiskContext GtdCtx(DateTimeOffset? gtd, TimeInForce tif = TimeInForce.GTD) =>
+        new(new EndClientId(Owner), Firm, Symbol,
+            OrderSide.Buy, OrderType.Limit, 100, 10m,
+            TimeInForce: tif, GoodTillDate: gtd);
+
+    [Fact]
+    public void Gtd_NonGtd_Skipped()
+    {
+        var clock = new FixedClock(DateTimeOffset.UnixEpoch);
+        var check = new GtdBoundsCheck(Wrap(new RiskOptions()), clock);
+        Assert.True(check.Check(GtdCtx(null, TimeInForce.Day)).Approved);
+    }
+
+    [Fact]
+    public void Gtd_NowMinus1s_Rejects()
+    {
+        var now = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var check = new GtdBoundsCheck(Wrap(new RiskOptions()), new FixedClock(now));
+        var d = check.Check(GtdCtx(now.AddSeconds(-1)));
+        Assert.False(d.Approved);
+        Assert.StartsWith("gtd_invalid", d.Reason);
+        Assert.Contains("maxHorizonDays=30", d.Reason);
+    }
+
+    [Fact]
+    public void Gtd_NowPlus1s_Approves()
+    {
+        var now = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var check = new GtdBoundsCheck(Wrap(new RiskOptions()), new FixedClock(now));
+        Assert.True(check.Check(GtdCtx(now.AddSeconds(1))).Approved);
+    }
+
+    [Fact]
+    public void Gtd_AtHorizon_Approves()
+    {
+        var now = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var opts = new RiskOptions { MaxGtdHorizon = TimeSpan.FromDays(30) };
+        var check = new GtdBoundsCheck(Wrap(opts), new FixedClock(now));
+        Assert.True(check.Check(GtdCtx(now.AddDays(30))).Approved);
+    }
+
+    [Fact]
+    public void Gtd_BeyondHorizon_Rejects()
+    {
+        var now = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var opts = new RiskOptions { MaxGtdHorizon = TimeSpan.FromDays(30) };
+        var check = new GtdBoundsCheck(Wrap(opts), new FixedClock(now));
+        var d = check.Check(GtdCtx(now.AddDays(30).AddSeconds(1)));
+        Assert.False(d.Approved);
+        Assert.StartsWith("gtd_invalid", d.Reason);
+    }
+
+    [Fact]
+    public void Gtd_Now_Equal_Expiry_Rejects()
+    {
+        // Boundary: expiry == now is "not strictly in the future" — reject.
+        var now = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var check = new GtdBoundsCheck(Wrap(new RiskOptions()), new FixedClock(now));
+        Assert.False(check.Check(GtdCtx(now)).Approved);
+    }
+}


### PR DESCRIPTION
Closes #254.

## Summary

Q1.2 risk-pipeline gates over the Q1.1 (#253) order surface. Four new
`IRiskCheck` implementations, one new `IPhaseProvider` seam, one new
config knob, one new metric — wired through DI, exercised on both the
submit and modify paths.

## Checks

| Check | Order | Reject reason prefix | Notes |
|---|---|---|---|
| `IocFokMarketWithLeftoverCheck` | 20 | `tif_incompatible_with_market_with_leftover` | `MarketWithLeftover` + IOC/FOK is contradictory |
| `GoodForAuctionPhaseCheck` | 14 | `gfa_outside_auction_phase` | accepts only `OpeningCall` / `FinalClosingCall` |
| `GtdBoundsCheck` | 22 | `gtd_invalid` | `now < expiry ≤ now + RiskOptions.MaxGtdHorizon` (default 30d) |
| `StopTriggerCheck` | 305 | `stop_trigger_invalid` / `stop_limit_price_invalid` | Buy stop ≥ ref / Sell stop ≤ ref; StopLimit also: Buy limit ≥ stop / Sell limit ≤ stop |

## Decisions

- **Lenient skip on missing reference price (StopTriggerCheck).** When
  `IReferencePrice.Lookup` returns `Missing`, the Buy/Sell-vs-ref
  relation is **skipped** (the `StopPrice > 0` invariant — already in
  the domain — still holds). The new `trading.risk.stop_check_skipped_no_ref{symbol}`
  counter records every skip so ops can spot coverage gaps. Same
  fail-open posture as `PriceCollarCheck`: a configured guard with no
  anchor cannot be enforced, and a hard reject would silently halt
  Stop\* trading on every symbol the MD feed hasn't covered yet.

- **`NoPhaseProvider` stub.** `IPhaseProvider` defaults to a singleton
  that always returns `TradingPhase.Open`. Documented as **TEMPORARY
  until #257** wires the auction-MD-driven implementation. Under the
  stub every `GoodForAuction` submission rejects (`Open ∉ {OpeningCall,
  FinalClosingCall}`), which is the intended fail-closed posture — a
  silent accept would route GFA into continuous matching where the TIF
  is meaningless. When #257 lands it must replace the singleton in DI,
  not coexist; the pipeline resolves a single `IPhaseProvider`.

- **`RiskContext` extended additively.** `TimeInForce` / `StopPrice` /
  `GoodTillDate` were added as defaulted positional fields so every
  existing call site (tests included) keeps compiling without changes.
  `OrderSubmissionService` forwards the request fields straight through;
  `OrderModifyService` runs `Order.MergeReplacementOptionals` first so
  risk evaluates the post-replace effective TIF/Stop/GTD.

- **Reason format matches existing checks.** Plain string of the form
  ``reason_key key1=val1 key2=val2`` (cf. existing
  ``phase_not_allowed:closed (...)``). Machine-readable prefix +
  human-readable payload — no new types introduced.

## Constraints honored

- Did not touch `OrderModifyService` / `ExecutionReportProcessor` past
  the existing risk-pipeline call sites. #255 will run on the same files
  in parallel.
- No GTD scheduler — only validate at submit/modify.
- No auction-MD ingest — only the `NoPhaseProvider` stub + clearly
  documented seam for #257.

## Tests

Baseline post-Q1.1 merge: **1119**. After this PR: **1154** (+35).

| Project | Before | After |
|---|---|---|
| `B3.Trading.Application.Tests` | 684 | 711 |
| `B3.Trading.Api.Tests` | 210 | 218 |
| (others, unchanged) | 225 | 225 |

- Unit (`backend/tests/B3.Trading.Application.Tests/Risk/Q12RiskChecksTests.cs`):
  per check ≥2 happy + ≥2 reject; stop-trigger covers each side,
  with-ref / without-ref / lenient-skip; GFA exercises every
  `TradingPhase` value; GTD covers now-1s / now+1s / now+horizon /
  horizon+1s plus the boundary `expiry == now`.
- Integration (`backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs`):
  POST /orders for each invalid combo asserting reject reason in body;
  PUT /orders/{id} for stop-trigger and GTD violations on the replace
  path (422 `UnprocessableEntity` per existing modify contract).

## Files

```
backend/src/B3.Trading.Application/Risk/IPhaseProvider.cs            (new)
backend/src/B3.Trading.Application/Risk/Checks/Q12RiskChecks.cs      (new)
backend/src/B3.Trading.Application/Risk/IRiskCheck.cs                (RiskContext +3 fields)
backend/src/B3.Trading.Application/Risk/RiskOptions.cs               (+MaxGtdHorizon)
backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs  (+StopCheckSkippedNoRef)
backend/src/B3.Trading.Application/OrderSubmissionService.cs         (forward TIF/Stop/GTD)
backend/src/B3.Trading.Application/OrderModifyService.cs             (merge + forward)
backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs  (DI)
backend/tests/B3.Trading.Application.Tests/Risk/Q12RiskChecksTests.cs (new)
backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs            (new)
```