### PR TITLE
feat(#258): phase badge + auction panel + ticket coupling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
         run: node --test frontend/test/decoder.test.mjs
 
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs frontend/test/bot-credentials-ui.test.mjs
+        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs frontend/test/bot-credentials-ui.test.mjs frontend/test/phase-badge.test.mjs frontend/test/auction-panel.test.mjs frontend/test/ticket-phase-coupling.test.mjs

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -640,3 +640,73 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 .order-detail-table tr.empty td { color: var(--muted); text-align: center; padding: .8rem; }
 #blotter-body tr[data-clordid] { cursor: pointer; }
 #blotter-body tr[data-clordid] td.row-stale-actions { cursor: default; }
+
+/* ---------- Phase badges + auction panel (Q1.6 / #258) ---------- */
+
+/* Compact pill rendered next to the symbol cell in the market-data
+   table. Color tokens reuse the global --green / --warn / --red /
+   --gray surface so the palette stays consistent with status-cell-*. */
+.phase-badge {
+  display: inline-block;
+  margin-left: .35rem;
+  padding: .05rem .35rem;
+  font-size: .65rem; font-weight: 600;
+  letter-spacing: .03em; text-transform: uppercase;
+  border-radius: 999px; border: 1px solid currentColor;
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+.phase-badge.PRE-OPEN { color: var(--warn);   background: rgba(245,166,35,.12); }
+.phase-badge.OPEN     { color: var(--green);  background: rgba(54,196,111,.12); }
+.phase-badge.CLOSING  { color: #f08c2e;       background: rgba(240,140,46,.14); }
+.phase-badge.CLOSED   { color: var(--gray);   background: rgba(107,114,128,.16); }
+.phase-badge.RESERVED { color: var(--red);    background: rgba(239,83,80,.14); }
+
+/* Auction panel — collapsible, wedged into the trader grid. Default
+   collapsed visual is just the toggle line; expanded state surfaces a
+   2-column metric grid + a recent-prints list. */
+.auction-panel { padding: .55rem .75rem; }
+.auction-panel.collapsed { padding-bottom: .45rem; }
+.auction-toggle {
+  display: inline-flex; align-items: center; gap: .35rem;
+  background: transparent; border: 0; color: var(--text);
+  font: inherit; font-weight: 600; cursor: pointer; padding: 0;
+}
+.auction-toggle:hover { color: var(--accent); }
+.auction-caret { display: inline-block; width: .9em; color: var(--muted); }
+.auction-body { margin-top: .5rem; }
+.auction-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: .35rem .8rem;
+  margin-bottom: .55rem;
+}
+.auction-cell { display: flex; flex-direction: column; gap: .1rem; }
+.auction-label {
+  font-size: .68rem; color: var(--muted); text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.auction-value {
+  font-size: .95rem; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.auction-arrow { display: inline-block; margin-right: .15rem; }
+.auction-arrow.up   { color: var(--green); }
+.auction-arrow.down { color: var(--red); }
+.auction-value.imb-buy  { color: var(--green); }
+.auction-value.imb-sell { color: var(--red); }
+.auction-prints-title {
+  margin: .35rem 0 .25rem 0; font-size: .72rem; font-weight: 600;
+  color: var(--muted); text-transform: uppercase; letter-spacing: .04em;
+}
+.auction-prints {
+  list-style: none; padding: 0; margin: 0;
+  font-size: .8rem; max-height: 7rem; overflow-y: auto;
+}
+.auction-prints li { padding: .15rem 0; border-bottom: 1px solid var(--border); }
+.auction-prints li:last-child { border-bottom: 0; }
+.auction-print-kind { color: var(--muted); margin-right: .25rem; }
+.auction-print-px,
+.auction-print-qty { font-variant-numeric: tabular-nums; }
+
+/* Ticket coupling: TIF hint colors (info vs. soft warning). */
+.field-hint.hint-info { color: var(--accent); }
+.field-hint.hint-warn { color: var(--warn); }

--- a/frontend/e2e/auction-phase.spec.js
+++ b/frontend/e2e/auction-phase.spec.js
@@ -1,0 +1,93 @@
+// Q1.6 (#258) — auction phase / panel / ticket coupling E2E.
+//
+// We don't drive a real venue here; we inject phase + auction frames
+// straight into state via the same setters the WS worker uses (mirrors
+// the pattern in order-detail.spec.js — the smoke stack doesn't run a
+// real opening auction). The DOM should react:
+//   1. Watchlist row badge updates as the phase transitions.
+//   2. Auction panel auto-expands when the selected symbol enters
+//      OpeningCall and renders TOP / match-qty / imbalance.
+//   3. Ticket TIF default flips to GoodForAuction; Submit disables in
+//      Reserved.
+
+import { expect, test } from "@playwright/test";
+
+const USERNAME = process.env.E2E_USERNAME ?? "alice";
+const PASSWORD = process.env.E2E_PASSWORD ?? "wonderland";
+
+async function login(page) {
+  await page.goto("/");
+  await expect(page.locator("#login-view")).toBeVisible();
+  await page.fill("#login-username", USERNAME);
+  await page.fill("#login-password", PASSWORD);
+  await page.click("#login-submit");
+  await expect(page.locator("#trader-view")).toBeVisible();
+  await expect(page.locator("#ws-status")).toHaveText("connected", { timeout: 30_000 });
+}
+
+async function injectPhase(page, symbol, phase) {
+  await page.evaluate(async ({ symbol, phase }) => {
+    const state = await import("/js/state.js");
+    state.applyPhaseFrame({ symbol, phase, at: new Date().toISOString() });
+  }, { symbol, phase });
+}
+
+async function injectAuctionTop(page, symbol, top, imbalance, side) {
+  await page.evaluate(async ({ symbol, top, imbalance, side }) => {
+    const state = await import("/js/state.js");
+    state.applyAuctionFrame({
+      symbol, top, indicativeMatchQty: 5000,
+      imbalance, imbalanceSide: side,
+      at: new Date().toISOString(),
+    });
+  }, { symbol, top, imbalance, side });
+}
+
+async function selectSymbol(page, symbol) {
+  await page.evaluate(async (sym) => {
+    const state = await import("/js/state.js");
+    // Make sure the symbol is in the watchlist so the renderer shows it.
+    const cur = state.getState().watchlist;
+    if (!cur.includes(sym)) state.setWatchlist([...cur, sym]);
+    state.setSelectedSymbol(sym);
+  }, symbol);
+}
+
+test.describe("Auction phase + panel + ticket coupling (#258)", () => {
+  test("phase transitions update badge, auto-open auction panel and adapt ticket", async ({ page }) => {
+    await login(page);
+
+    const SYM = "PETR4";
+    await selectSymbol(page, SYM);
+
+    // 1. Inject Open → badge shows OPEN, panel stays hidden.
+    await injectPhase(page, SYM, "Open");
+    await expect(page.locator(`.phase-badge[data-symbol="${SYM}"]`)).toHaveText("OPEN");
+    await expect(page.locator("#auction-panel")).toBeHidden();
+
+    // 2. Type the symbol into the ticket and inject OpeningCall — TIF
+    //    flips to GoodForAuction, hint visible, panel auto-opens.
+    await page.fill("#ticket-symbol", SYM);
+    await injectPhase(page, SYM, "OpeningCall");
+    await expect(page.locator(`.phase-badge[data-symbol="${SYM}"]`)).toHaveText("PRE-OPEN");
+    await expect(page.locator("#auction-panel")).toBeVisible();
+    await expect(page.locator("#ticket-tif")).toHaveValue("GoodForAuction");
+    await expect(page.locator("#ticket-tif-hint")).toBeVisible();
+
+    // 3. Inject auction top + imbalance — panel renders the values.
+    await injectAuctionTop(page, SYM, 32.50, 1500, "Buy");
+    await expect(page.locator("#auction-top-price")).toHaveText("32,50");
+    await expect(page.locator("#auction-imbalance")).toContainText("Buy");
+
+    // 4. Inject Reserved (halt) — Submit disabled with tooltip.
+    await injectPhase(page, SYM, "Reserved");
+    await expect(page.locator(`.phase-badge[data-symbol="${SYM}"]`)).toHaveText("RESERVED");
+    await expect(page.locator("#ticket-submit")).toBeDisabled();
+    await expect(page.locator("#ticket-submit")).toHaveAttribute("title", "Instrumento halted");
+
+    // 5. Back to Open — Submit re-enabled, panel collapses.
+    await injectPhase(page, SYM, "Open");
+    await expect(page.locator("#ticket-submit")).toBeEnabled();
+    await expect(page.locator("#auction-panel")).toBeHidden();
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,6 +133,18 @@
               <input id="ticket-price" type="number" min="0" step="0.01" />
             </label>
           </div>
+          <label>
+            <span>Time in force</span>
+            <select id="ticket-tif" aria-describedby="ticket-tif-hint">
+              <option value="Day">Day</option>
+              <option value="IOC">IOC</option>
+              <option value="FOK">FOK</option>
+              <option value="GTC">GTC</option>
+              <option value="GoodForAuction">GoodForAuction</option>
+              <option value="AtClose">AtClose</option>
+            </select>
+          </label>
+          <p id="ticket-tif-hint" class="field-hint" role="status" aria-live="polite" hidden></p>
           <p id="ticket-rules-hint" class="field-hint" aria-live="polite">lot 100 · tick 0.01</p>
           <button type="submit" id="ticket-submit">Submit</button>
           <p id="ticket-inflight" class="inflight" hidden></p>
@@ -220,6 +232,48 @@
             </thead>
             <tbody id="md-body"></tbody>
           </table>
+        </div>
+      </section>
+
+      <!-- AUCTION PANEL (Q1.6 / #258) ------------------------------- -->
+      <!-- Collapsed by default; auto-expands when the selected symbol -->
+      <!-- enters an auction phase (OpeningCall / FinalClosingCall).   -->
+      <section id="auction-panel" class="panel auction-panel collapsed"
+               role="region" aria-label="Auction state" hidden>
+        <h2>
+          <button type="button" id="auction-toggle" class="auction-toggle"
+                  aria-expanded="false" aria-controls="auction-body">
+            <span class="auction-caret" aria-hidden="true">▸</span>
+            Auction
+            <span id="auction-symbol-tag" class="symbol-tag" aria-live="polite">—</span>
+          </button>
+        </h2>
+        <div id="auction-body" class="auction-body" hidden>
+          <div class="auction-grid">
+            <div class="auction-cell">
+              <span class="auction-label">TOP</span>
+              <span id="auction-top" class="auction-value">
+                <span id="auction-top-arrow" class="auction-arrow" aria-hidden="true"></span>
+                <span id="auction-top-price">—</span>
+              </span>
+            </div>
+            <div class="auction-cell">
+              <span class="auction-label">Match qty</span>
+              <span id="auction-match-qty" class="auction-value">—</span>
+            </div>
+            <div class="auction-cell">
+              <span class="auction-label">Imbalance</span>
+              <span id="auction-imbalance" class="auction-value">—</span>
+            </div>
+            <div class="auction-cell">
+              <span class="auction-label" title="Time to uncross — not yet emitted upstream">TTU</span>
+              <span id="auction-ttu" class="auction-value">—</span>
+            </div>
+          </div>
+          <h3 class="auction-prints-title">Recent prints</h3>
+          <ol id="auction-prints" class="auction-prints">
+            <li class="muted-line">No prints yet</li>
+          </ol>
         </div>
       </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -97,6 +97,16 @@ function init() {
     onRevoke:   handleRevokeBotCredential,
   });
 
+  // Q1.6 (#258). Whenever the watchlist or auctionPanelSymbol slice
+  // changes, re-diff the public WS subscription set so phase badges
+  // stay in sync with the watchlist and auction.${symbol} is only
+  // subscribed while the panel is open.
+  state.subscribe((slice) => {
+    if (slice === "watchlist" || slice === "auctionPanelSymbol" || slice === "all") {
+      syncPublicChannels();
+    }
+  });
+
   const stored = readSession();
   if (stored) {
     // Boot guard: if the stored session is already inside the warning
@@ -310,6 +320,24 @@ function startWorker() {
   worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
   worker.onmessage = (ev) => onWorkerMessage(ev.data);
   worker.postMessage({ type: "start", backend: session.backend, token: session.token });
+  // Q1.6 (#258). Push the current public-channel set immediately so the
+  // worker has it queued by the time the WS opens. Idempotent — same
+  // hook fires on watchlist / auctionPanelSymbol slice changes below.
+  syncPublicChannels();
+}
+
+// Q1.6 (#258). Build the public-channel set the worker should be
+// subscribed to right now: phases.${symbol} for every watchlist
+// symbol (so badges populate immediately), plus auction.${symbol}
+// only while the panel is open (cost control on WS fan-out).
+function syncPublicChannels() {
+  if (!worker) return;
+  const st = state.getState();
+  const channels = [];
+  for (const sym of st.watchlist) channels.push("phases." + sym);
+  if (st.auctionPanelSymbol) channels.push("auction." + st.auctionPanelSymbol);
+  try { worker.postMessage({ type: "setPublicChannels", channels }); }
+  catch { /* worker not ready yet — replayed by next slice notify */ }
 }
 
 function restartWorker() {
@@ -488,6 +516,8 @@ function onWorkerMessage(msg) {
     case "positions.delta":     state.applyPositionsDelta(msg.data); break;
     case "executions.snapshot": state.applyExecutionsSnapshot(msg.data); break;
     case "executions.delta":    state.applyExecutionsDelta(msg.data); break;
+    case "phases.frame":        state.applyPhaseFrame(msg.data); break;
+    case "auction.frame":       state.applyAuctionFrame(msg.data); break;
     case "error":
       // A frame-level error from the server (e.g., unknown_channel).
       // Surface in the executions log to keep it visible without a toast.

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -94,6 +94,25 @@ const state = {
   // placeholder to a louder "no book — check MD settings ⚙" warning
   // (after ~10s without a snapshot).
   selectedSymbolSetAt: 0,
+  // Q1.6 (#258). Per-symbol auction-phase state from the public
+  // `phases.${symbol}` WS channel. Populated for every watchlist
+  // symbol via auto-subscribe; absent until the first snapshot lands
+  // (treated as "Unknown" by readers).
+  phaseBySymbol: new Map(),     // Symbol -> phase string ("OpeningCall" | "Open" | ...)
+  phaseAtBySymbol: new Map(),   // Symbol -> ISO timestamp of last transition (or null)
+  // Q1.6 (#258). Per-symbol auction-state cache from the public
+  // `auction.${symbol}` channel. Only populated while the auction
+  // panel is open (cost control on WS fan-out). Shape:
+  //   { top, indicativeMatchQty, imbalance, imbalanceSide, at,
+  //     prevTop, lastPrints: [{kind, price, qty, at}, ...] }
+  // `prevTop` retains the previous top so the renderer can draw the
+  // up/down trend arrow without a separate per-renderer cache.
+  // `lastPrints` is bounded — see AUCTION_PRINT_HISTORY.
+  auctionBySymbol: new Map(),
+  // Q1.6 (#258). Symbol the auction panel is currently rendering, or
+  // null when the panel is collapsed. Used by the WS subscription
+  // manager to decide whether to (un)subscribe `auction.${symbol}`.
+  auctionPanelSymbol: null,
 };
 
 const EXECUTIONS_CAPACITY = 500;
@@ -192,6 +211,12 @@ export function clearAll() {
   state.inflightModifies.clear();
   state.lastWsActivity = null;
   state.lastMdActivity = null;
+  // Q1.6 (#258). Phase + auction caches survive market-data restarts
+  // but die with the trader-WS reconnect (which is what triggers
+  // clearAll) — the server replays snapshots after the (re)subscribe.
+  state.phaseBySymbol.clear();
+  state.phaseAtBySymbol.clear();
+  state.auctionBySymbol.clear();
   notify("all");
 }
 
@@ -649,4 +674,96 @@ export function markModifyInflight(clOrdId, inflight) {
   if (inflight) state.inflightModifies.add(clOrdId);
   else state.inflightModifies.delete(clOrdId);
   if (before !== inflight) notify("orders");
+}
+
+// ── Q1.6 (#258): Auction phase + auction state slices ──────────────
+//
+// Two public WS channels per symbol:
+//   • phases.${symbol}  → { symbol, phase, at }   (snapshot + deltas)
+//   • auction.${symbol} → either { symbol, top, indicativeMatchQty,
+//                                 imbalance, imbalanceSide, at, kind:null }
+//                         (top frame; nullable fields after a print)
+//                       or { symbol, kind:"Opening"|"Closing", price,
+//                            qty, at }            (cross print delta)
+// The two frames are discriminated on the wire by `price` presence:
+// only AuctionPrintDto carries `price`. Snapshot vs delta distinction
+// is irrelevant on the auction channel — both shapes are merged.
+
+// Phases the order ticket should treat as auction (see #258 §Ticket
+// coupling: TIF default → GoodForAuction, Day → soft warning).
+const AUCTION_PHASES = new Set(["OpeningCall", "FinalClosingCall"]);
+
+// Cap on the per-symbol AuctionPrint history rendered in the panel.
+// Five matches the visible scrollless rows in the panel layout.
+const AUCTION_PRINT_HISTORY = 5;
+
+export function applyPhaseFrame(payload) {
+  if (!payload || typeof payload.symbol !== "string") return;
+  const symbol = payload.symbol;
+  const phase = typeof payload.phase === "string" ? payload.phase : "Unknown";
+  state.phaseBySymbol.set(symbol, phase);
+  state.phaseAtBySymbol.set(symbol, payload.at ?? null);
+  notify("phases");
+}
+
+export function applyAuctionFrame(payload) {
+  if (!payload || typeof payload.symbol !== "string") return;
+  const symbol = payload.symbol;
+  let entry = state.auctionBySymbol.get(symbol);
+  if (!entry) {
+    entry = {
+      top: null, indicativeMatchQty: null,
+      imbalance: null, imbalanceSide: null,
+      at: null, prevTop: null, lastPrints: [],
+    };
+    state.auctionBySymbol.set(symbol, entry);
+  }
+  // Discriminator: AuctionPrintDto has `price`; AuctionSnapshotDto has
+  // `top` (possibly null) and no `price` field.
+  if (payload.price !== undefined) {
+    entry.lastPrints.unshift({
+      kind:  payload.kind ?? null,
+      price: payload.price,
+      qty:   payload.qty,
+      at:    payload.at ?? null,
+    });
+    if (entry.lastPrints.length > AUCTION_PRINT_HISTORY) {
+      entry.lastPrints.length = AUCTION_PRINT_HISTORY;
+    }
+  } else {
+    // Top / imbalance frame. Track previous top BEFORE overwriting so
+    // the renderer can draw the up/down trend arrow. Skip the bookkeep
+    // when both are null (an "empty" snapshot served on cold subscribe
+    // — no trend yet).
+    if (entry.top != null && payload.top != null && entry.top !== payload.top) {
+      entry.prevTop = entry.top;
+    }
+    entry.top                = payload.top ?? null;
+    entry.indicativeMatchQty = payload.indicativeMatchQty ?? null;
+    entry.imbalance          = payload.imbalance ?? null;
+    entry.imbalanceSide      = payload.imbalanceSide ?? null;
+    entry.at                 = payload.at ?? null;
+  }
+  notify("auction");
+}
+
+export function setAuctionPanelSymbol(symbol) {
+  const next = symbol == null || symbol === "" ? null : symbol;
+  if (state.auctionPanelSymbol === next) return;
+  state.auctionPanelSymbol = next;
+  notify("auctionPanelSymbol");
+}
+
+export function getPhase(symbol) {
+  if (!symbol) return "Unknown";
+  return state.phaseBySymbol.get(symbol) ?? "Unknown";
+}
+
+export function getAuctionState(symbol) {
+  if (!symbol) return null;
+  return state.auctionBySymbol.get(symbol) ?? null;
+}
+
+export function isAuctionPhase(phase) {
+  return AUCTION_PHASES.has(phase);
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -3,6 +3,7 @@
 
 import {
   getState, subscribe, isTerminalOrderStatus,
+  getPhase, getAuctionState, isAuctionPhase, setAuctionPanelSymbol,
 } from "./state.js";
 import { rulesFor } from "./validation.js";
 
@@ -665,15 +666,31 @@ export function bindUi() {
 
   $("ticket-form").addEventListener("submit", (e) => {
     e.preventDefault();
+    const tifEl = $("ticket-tif");
     const payload = {
       symbol: $("ticket-symbol").value.trim().toUpperCase(),
       side:   $("ticket-side").value,
       type:   $("ticket-type").value,
       quantity: Number($("ticket-qty").value),
       price: priceEl.disabled || priceEl.value === "" ? null : Number(priceEl.value),
+      // Q1.6 (#258). Backend defaults to Day when omitted, but we
+      // always pass the visible value so what the trader sees on the
+      // ticket is exactly what hits the venue.
+      timeInForce: tifEl ? tifEl.value : "Day",
     };
     onSubmitOrder(payload);
   });
+
+  // Q1.6 (#258). Track the trader's manual TIF picks so the auction
+  // auto-pick (renderTicketPhaseCoupling) doesn't trample them.
+  const tifEl = $("ticket-tif");
+  if (tifEl) {
+    tifEl.addEventListener("change", () => {
+      tifEl.dataset.userPicked = "1";
+      delete tifEl.dataset.autoPicked;
+      renderTicketPhaseCoupling();
+    });
+  }
 
   // Auto-uppercase the symbol field as the trader types so the visual
   // matches what we actually submit (we already toUpperCase on submit).
@@ -688,14 +705,21 @@ export function bindUi() {
         e.target.value = upper;
         try { e.target.setSelectionRange(pos, pos); } catch {}
       }
+      // Q1.6 (#258). Symbol changes reset the user's TIF affinity so a
+      // new ticket starts from defaults — otherwise a manual pick on
+      // ticket A locks the auto-pick on ticket B for a different symbol.
+      const tifEl2 = $("ticket-tif");
+      if (tifEl2) { delete tifEl2.dataset.userPicked; delete tifEl2.dataset.autoPicked; }
       syncTicketRules();
+      renderTicketPhaseCoupling();
     });
     symEl.addEventListener("compositionend", (e) => {
       const upper = e.target.value.toUpperCase();
       if (e.target.value !== upper) e.target.value = upper;
       syncTicketRules();
+      renderTicketPhaseCoupling();
     });
-    symEl.addEventListener("change", syncTicketRules);
+    symEl.addEventListener("change", () => { syncTicketRules(); renderTicketPhaseCoupling(); });
     // Initial paint so the hint reflects defaults before any input.
     syncTicketRules();
   }
@@ -899,6 +923,23 @@ export function bindUi() {
   // text input to avoid stealing keystrokes. Backspace is intentionally
   // NOT a cancel shortcut — too easy to fire accidentally.
   document.addEventListener("keydown", onGlobalKeydown);
+
+  // Q1.6 (#258). Auction-panel manual toggle. The panel auto-opens
+  // when the selected symbol enters an auction phase, but the trader
+  // can also collapse it manually — clicking the header collapses to
+  // the symbol-only state without unsubscribing (re-open replays the
+  // current state).
+  const auctionToggle = $("auction-toggle");
+  if (auctionToggle) {
+    auctionToggle.addEventListener("click", () => {
+      const st = getState();
+      if (st.auctionPanelSymbol) {
+        setAuctionPanelSymbol(null);
+      } else if (st.selectedSymbol) {
+        setAuctionPanelSymbol(st.selectedSymbol);
+      }
+    });
+  }
 
   subscribe(renderForSlice);
   renderAll();
@@ -1239,6 +1280,13 @@ function renderForSlice(slice) {
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "book" || slice === "all") renderDob();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "tapeShowAll" || slice === "tape" || slice === "all") scheduleTapeRender();
+  // Q1.6 (#258). Phase + auction wiring.
+  if (slice === "phases" || slice === "marketData" || slice === "watchlist" || slice === "all") renderMarketData();
+  if (slice === "phases" || slice === "selectedSymbol" || slice === "all") {
+    reconcileAuctionPanel();
+    renderTicketPhaseCoupling();
+  }
+  if (slice === "auction" || slice === "auctionPanelSymbol" || slice === "all") renderAuctionPanel();
 }
 
 // ── Stale-data overlay (T2) ────────────────────────────────────────
@@ -1303,6 +1351,9 @@ function renderAll() {
   renderInflight();
   renderReconnect();
   renderFirmsHealth();
+  reconcileAuctionPanel();
+  renderAuctionPanel();
+  renderTicketPhaseCoupling();
   ensureTicker();
 }
 
@@ -1332,19 +1383,223 @@ function renderMarketData() {
   body.innerHTML = rows.map(symbol => {
     const e = md.get(symbol);
     if (!e || e.lastPrice == null) {
-      return `<tr><td>${escapeHtml(symbol)}</td><td colspan="4" class="muted-cell">awaiting data…</td></tr>`;
+      return `<tr><td>${escapeHtml(symbol)}${phaseBadgeHtml(symbol)}</td><td colspan="4" class="muted-cell">awaiting data…</td></tr>`;
     }
     const ts = e.updatedAt ? new Date(e.updatedAt).toISOString().slice(11, 19) : "—";
     const stale = e.updatedAt && (now - e.updatedAt) > MD_STALE_MS;
     const tsCls = stale ? ' class="md-cell-stale"' : "";
     return `<tr>
-      <td>${escapeHtml(symbol)}</td>
+      <td>${escapeHtml(symbol)}${phaseBadgeHtml(symbol)}</td>
       <td class="num">${fmtPx(e.lastPrice)}</td>
       <td class="num">${fmtQty(e.lastQty)}</td>
       <td class="num">${e.lastTradeId ?? "—"}</td>
       <td${tsCls}>${ts}</td>
     </tr>`;
   }).join("");
+}
+
+// ── Q1.6 (#258): Phase badge + auction panel + ticket coupling ────
+
+// Maps the wire-side TradingPhase enum names to the trader-facing
+// labels + CSS class fragments. Unknown is intentionally not in the
+// map: we render no badge at all when the phase is Unknown so a
+// not-yet-loaded snapshot doesn't show a misleading "OPEN" default.
+const PHASE_LABELS = {
+  Reserved:         { label: "RESERVED",  cls: "RESERVED"  },
+  OpeningCall:      { label: "PRE-OPEN",  cls: "PRE-OPEN"  },
+  Open:             { label: "OPEN",      cls: "OPEN"      },
+  FinalClosingCall: { label: "CLOSING",   cls: "CLOSING"   },
+  Close:            { label: "CLOSED",    cls: "CLOSED"    },
+};
+
+export function phaseBadgeHtml(symbol) {
+  const phase = getPhase(symbol);
+  const meta = PHASE_LABELS[phase];
+  if (!meta) return "";
+  const aria = `${symbol} phase: ${meta.label}`;
+  return ` <span class="phase-badge ${meta.cls}" data-symbol="${escapeHtml(symbol)}" aria-label="${escapeHtml(aria)}">${meta.label}</span>`;
+}
+
+// Auto-open / refresh the auction panel based on the selected symbol's
+// phase. Called whenever phases or selectedSymbol changes. The "open"
+// state is owned by state.auctionPanelSymbol so the WS layer can key
+// off it for subscribe/unsubscribe.
+function reconcileAuctionPanel() {
+  const st = getState();
+  const sym = st.selectedSymbol;
+  if (!sym) {
+    if (st.auctionPanelSymbol !== null) setAuctionPanelSymbol(null);
+    return;
+  }
+  const phase = getPhase(sym);
+  if (isAuctionPhase(phase)) {
+    if (st.auctionPanelSymbol !== sym) setAuctionPanelSymbol(sym);
+  } else {
+    // Leaving the auction phase — collapse the panel automatically so
+    // the trader doesn't see a stale Top after the cross prints. Manual
+    // toggle still works (renderAuctionPanel respects the current sym).
+    if (st.auctionPanelSymbol !== null && st.auctionPanelSymbol === sym) {
+      setAuctionPanelSymbol(null);
+    }
+  }
+}
+
+export function renderAuctionPanel() {
+  const panel = $("auction-panel");
+  if (!panel) return;
+  const st = getState();
+  const sym = st.auctionPanelSymbol;
+  if (!sym) {
+    panel.hidden = true;
+    panel.classList.add("collapsed");
+    const body = $("auction-body");
+    if (body) body.hidden = true;
+    const toggle = $("auction-toggle");
+    if (toggle) toggle.setAttribute("aria-expanded", "false");
+    const caret = panel.querySelector(".auction-caret");
+    if (caret) caret.textContent = "▸";
+    return;
+  }
+
+  panel.hidden = false;
+  panel.classList.remove("collapsed");
+  panel.setAttribute("aria-label", `Auction state for ${sym}`);
+  const body = $("auction-body");
+  if (body) body.hidden = false;
+  const toggle = $("auction-toggle");
+  if (toggle) toggle.setAttribute("aria-expanded", "true");
+  const caret = panel.querySelector(".auction-caret");
+  if (caret) caret.textContent = "▾";
+
+  const tag = $("auction-symbol-tag");
+  if (tag) tag.textContent = sym;
+
+  const aux = getAuctionState(sym);
+  const top = aux?.top ?? null;
+  const prev = aux?.prevTop ?? null;
+  const matchQty = aux?.indicativeMatchQty ?? null;
+  const imb = aux?.imbalance ?? null;
+  const imbSide = aux?.imbalanceSide ?? null;
+
+  const topPriceEl = $("auction-top-price");
+  if (topPriceEl) topPriceEl.textContent = top == null ? "—" : fmtPx(top);
+  const arrowEl = $("auction-top-arrow");
+  if (arrowEl) {
+    if (top != null && prev != null && top !== prev) {
+      arrowEl.textContent = top > prev ? "▲" : "▼";
+      arrowEl.className = "auction-arrow " + (top > prev ? "up" : "down");
+    } else {
+      arrowEl.textContent = "";
+      arrowEl.className = "auction-arrow";
+    }
+  }
+
+  const matchEl = $("auction-match-qty");
+  if (matchEl) matchEl.textContent = matchQty == null ? "—" : fmtQty(matchQty);
+
+  const imbEl = $("auction-imbalance");
+  if (imbEl) {
+    if (imb == null || imb === 0) {
+      imbEl.textContent = imb == null ? "—" : "0";
+      imbEl.className = "auction-value";
+    } else {
+      const sideLabel = imbSide && imbSide !== "None" ? imbSide : "";
+      imbEl.textContent = `${fmtQty(imb)}${sideLabel ? ` ${sideLabel}` : ""}`;
+      imbEl.className = "auction-value " + (imbSide === "Buy"  ? "imb-buy"
+                                          : imbSide === "Sell" ? "imb-sell"
+                                          : "");
+    }
+  }
+
+  // Time-to-uncross: upstream B3MatchingPlatform doesn't expose this
+  // today (#321 in the upstream tracker — when it lands, the auction
+  // frame will gain a field we can render here without further UI
+  // work). For now ship the placeholder.
+  const ttuEl = $("auction-ttu");
+  if (ttuEl) ttuEl.textContent = "—";
+
+  const printsEl = $("auction-prints");
+  if (printsEl) {
+    const prints = aux?.lastPrints ?? [];
+    if (prints.length === 0) {
+      printsEl.innerHTML = `<li class="muted-line">No prints yet</li>`;
+    } else {
+      printsEl.innerHTML = prints.map(p => {
+        const ts = p.at ? new Date(p.at).toISOString().slice(11, 19) : "—";
+        const kind = escapeHtml(p.kind ?? "");
+        return `<li><span class="auction-print-kind">${kind}</span> <span class="auction-print-px">${fmtPx(p.price)}</span> × <span class="auction-print-qty">${fmtQty(p.qty)}</span> <span class="muted-line">${escapeHtml(ts)}</span></li>`;
+      }).join("");
+    }
+  }
+}
+
+// Order-ticket coupling. Reacts to phase transitions on the symbol the
+// trader is currently typing into. Three things happen:
+//   1. TIF default flips to GoodForAuction in OpeningCall /
+//      FinalClosingCall (the trader gets a hint explaining why).
+//   2. TIF=Day in an auction phase shows a soft warning that the order
+//      will sit pending until the cross — non-blocking.
+//   3. Reserved (halt) disables Submit with an explanatory tooltip.
+export function renderTicketPhaseCoupling() {
+  const symEl = $("ticket-symbol");
+  const tifEl = $("ticket-tif");
+  const submitEl = $("ticket-submit");
+  const hintEl = $("ticket-tif-hint");
+  if (!symEl || !tifEl || !submitEl) return;
+
+  const sym = (symEl.value || "").trim().toUpperCase();
+  const phase = sym ? getPhase(sym) : "Unknown";
+
+  // (1) Auto-pick GoodForAuction the first time we see an auction
+  // phase for this symbol — but don't trample a value the trader has
+  // explicitly chosen for this ticket. We mark the auto-pick on the
+  // dataset so a manual change clears it.
+  const inAuction = isAuctionPhase(phase);
+  if (inAuction) {
+    if (tifEl.value === "Day" && tifEl.dataset.userPicked !== "1") {
+      tifEl.value = "GoodForAuction";
+      tifEl.dataset.autoPicked = "1";
+    }
+  } else if (tifEl.dataset.autoPicked === "1") {
+    // Phase left auction territory — revert the auto-pick to Day so
+    // the trader doesn't accidentally submit a GoodForAuction on the
+    // wrong phase.
+    tifEl.value = "Day";
+    delete tifEl.dataset.autoPicked;
+  }
+
+  // (2) Hint / soft warning under the TIF select.
+  if (hintEl) {
+    if (inAuction && tifEl.value === "GoodForAuction") {
+      hintEl.hidden = false;
+      hintEl.className = "field-hint hint-info";
+      hintEl.textContent = "Auction phase — GoodForAuction recommended";
+    } else if (inAuction && tifEl.value === "Day") {
+      hintEl.hidden = false;
+      hintEl.className = "field-hint hint-warn";
+      hintEl.textContent = "Esta ordem ficará pending até a abertura.";
+    } else {
+      hintEl.hidden = true;
+      hintEl.textContent = "";
+      hintEl.className = "field-hint";
+    }
+  }
+
+  // (3) Reserved (halt) disables Submit. We track the halt-disable
+  // independently of the inflight-disable so toggling phases doesn't
+  // re-enable a submitting button.
+  const halted = phase === "Reserved";
+  if (halted) {
+    submitEl.disabled = true;
+    submitEl.setAttribute("aria-disabled", "true");
+    submitEl.setAttribute("title", "Instrumento halted");
+    submitEl.dataset.haltDisabled = "1";
+  } else if (submitEl.dataset.haltDisabled === "1") {
+    submitEl.disabled = false;
+    submitEl.removeAttribute("aria-disabled");
+    submitEl.removeAttribute("title");
+    delete submitEl.dataset.haltDisabled;
+  }
 }
 
 const DOB_TOP_N = 10;

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -1019,9 +1019,34 @@ export function setTicketFeedbackIfMatches(expected, replacement) {
   setTicketFeedback(replacement, null);
 }
 
+// Submit button disabled-state is the OR of two independent conditions
+// tracked on dataset flags so two writers (the in-flight submit path and
+// the phase-coupling halt path) don't clobber each other's intent.
+// Always go through applySubmitDisabled() — never write submit.disabled
+// directly.
+function applySubmitDisabled() {
+  const el = $("ticket-submit");
+  if (!el) return;
+  const inflight = el.dataset.submitInflight === "1";
+  const halted   = el.dataset.haltDisabled   === "1";
+  const disabled = inflight || halted;
+  el.disabled = disabled;
+  if (disabled) {
+    el.setAttribute("aria-disabled", "true");
+  } else {
+    el.removeAttribute("aria-disabled");
+  }
+}
+
 export function setTicketSubmitting(submitting) {
-  $("ticket-submit").disabled = !!submitting;
-  $("ticket-submit").textContent = submitting ? "Submitting…" : "Submit";
+  const el = $("ticket-submit");
+  if (submitting) {
+    el.dataset.submitInflight = "1";
+  } else {
+    delete el.dataset.submitInflight;
+  }
+  el.textContent = submitting ? "Submitting…" : "Submit";
+  applySubmitDisabled();
 }
 
 export function clearTicket() {
@@ -1424,7 +1449,7 @@ export function phaseBadgeHtml(symbol) {
 // phase. Called whenever phases or selectedSymbol changes. The "open"
 // state is owned by state.auctionPanelSymbol so the WS layer can key
 // off it for subscribe/unsubscribe.
-function reconcileAuctionPanel() {
+export function reconcileAuctionPanel() {
   const st = getState();
   const sym = st.selectedSymbol;
   if (!sym) {
@@ -1433,12 +1458,21 @@ function reconcileAuctionPanel() {
   }
   const phase = getPhase(sym);
   if (isAuctionPhase(phase)) {
+    // Auto-open / switch to the selected symbol. Assigning a new symbol
+    // implicitly drops any previous panel-symbol subscription so symbol
+    // switches in-flight don't leak an orphaned auction.${prev} sub.
     if (st.auctionPanelSymbol !== sym) setAuctionPanelSymbol(sym);
   } else {
-    // Leaving the auction phase — collapse the panel automatically so
-    // the trader doesn't see a stale Top after the cross prints. Manual
-    // toggle still works (renderAuctionPanel respects the current sym).
-    if (st.auctionPanelSymbol !== null && st.auctionPanelSymbol === sym) {
+    // Selected symbol is NOT in an auction phase. Drop the panel +
+    // subscription whenever it's open — covers both cases:
+    //   (a) the same symbol left auction (cross printed),
+    //   (b) the trader switched to a non-auction symbol while a panel
+    //       for a different symbol was still pinned (the previous
+    //       implementation only closed when symbols matched, leaking
+    //       the auction.${prev} subscription).
+    // The trader can manually re-open via the toggle button for any
+    // selected symbol if they want to keep watching.
+    if (st.auctionPanelSymbol !== null) {
       setAuctionPanelSymbol(null);
     }
   }
@@ -1586,20 +1620,18 @@ export function renderTicketPhaseCoupling() {
   }
 
   // (3) Reserved (halt) disables Submit. We track the halt-disable
-  // independently of the inflight-disable so toggling phases doesn't
-  // re-enable a submitting button.
+  // independently of the inflight-disable via dataset flags so toggling
+  // phases doesn't re-enable a submitting button (and vice-versa).
+  // applySubmitDisabled() ORs both conditions together.
   const halted = phase === "Reserved";
   if (halted) {
-    submitEl.disabled = true;
-    submitEl.setAttribute("aria-disabled", "true");
-    submitEl.setAttribute("title", "Instrumento halted");
     submitEl.dataset.haltDisabled = "1";
+    submitEl.setAttribute("title", "Instrumento halted");
   } else if (submitEl.dataset.haltDisabled === "1") {
-    submitEl.disabled = false;
-    submitEl.removeAttribute("aria-disabled");
-    submitEl.removeAttribute("title");
     delete submitEl.dataset.haltDisabled;
+    submitEl.removeAttribute("title");
   }
+  applySubmitDisabled();
 }
 
 const DOB_TOP_N = 10;

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -23,6 +23,13 @@ let stopped = false;
 
 const CHANNELS = ["orders.me", "executions.me", "positions.me"];
 
+// Q1.6 (#258). Wanted set of public per-symbol channels that should be
+// subscribed any time the WS is connected. Drives diff (un)subscribes
+// when the main thread calls setPublicChannels, and is replayed on
+// (re)connect after the static CHANNELS go out. Held across reconnects
+// so a flap doesn't lose the watchlist subscriptions.
+const wantedPublic = new Set();
+
 function send(obj) {
   if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
 }
@@ -70,6 +77,12 @@ function connect() {
     post({ type: "status", value: "connected" });
     post({ type: "reconnect.scheduled", nextAt: null });
     send({ type: "subscribe", channels: CHANNELS });
+    // Q1.6 (#258). Replay the public-channel set the main thread had
+    // configured so the watchlist phase badges + auction panel keep
+    // working across reconnects without a re-set from app.js.
+    if (wantedPublic.size > 0) {
+      send({ type: "subscribe", channels: [...wantedPublic] });
+    }
   };
 
   socket.onmessage = (ev) => {
@@ -107,7 +120,39 @@ function handleFrame(frame) {
     case "executions.me":
       post({ type: frame.type === "snapshot" ? "executions.snapshot" : "executions.delta", data: frame.data });
       break;
+    default:
+      // Q1.6 (#258). Public per-symbol channels — phases.${symbol} and
+      // auction.${symbol}. Snapshot and delta share the same payload
+      // shape (the state setters merge both); collapse to a single
+      // event type per channel kind to keep the main-thread router
+      // simple. Anything else is an unknown channel — drop silently.
+      if (typeof frame.channel !== "string") return;
+      if (frame.channel.startsWith("phases.")) {
+        post({ type: "phases.frame", data: frame.data });
+      } else if (frame.channel.startsWith("auction.")) {
+        post({ type: "auction.frame", data: frame.data });
+      }
+      break;
   }
+}
+
+// Q1.6 (#258). Diff the wanted public-channel set against the new one
+// and send subscribe/unsubscribe deltas. Idempotent — repeated calls
+// with the same set are no-ops. Gracefully handles the disconnected
+// state: the wanted set is recorded and replayed on next onopen.
+function setPublicChannels(channels) {
+  const next = new Set();
+  for (const c of channels || []) {
+    if (typeof c === "string" && c.length > 0) next.add(c);
+  }
+  const toAdd = [];
+  const toRemove = [];
+  for (const c of next)         if (!wantedPublic.has(c)) toAdd.push(c);
+  for (const c of wantedPublic) if (!next.has(c))         toRemove.push(c);
+  wantedPublic.clear();
+  for (const c of next) wantedPublic.add(c);
+  if (toAdd.length    > 0) send({ type: "subscribe",   channels: toAdd });
+  if (toRemove.length > 0) send({ type: "unsubscribe", channels: toRemove });
 }
 
 self.onmessage = (ev) => {
@@ -128,6 +173,10 @@ self.onmessage = (ev) => {
         try { ws.close(1000, "client logout"); } catch { /* swallow */ }
       }
       ws = null;
+      wantedPublic.clear();
+      break;
+    case "setPublicChannels":
+      setPublicChannels(msg.channels);
       break;
   }
 };

--- a/frontend/test/auction-panel.test.mjs
+++ b/frontend/test/auction-panel.test.mjs
@@ -1,0 +1,158 @@
+// Q1.6 (#258) — auction reducer + render tests.
+//
+// Covers the state-side reducer (snapshot apply, top trend tracking,
+// print-history append + cap, panel open/close) and the DOM render
+// path that turns the cached state into the panel UI.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+
+installDomStub({
+  ids: {
+    "auction-panel":       { tag: "section", hidden: true },
+    "auction-toggle":      { tag: "button" },
+    "auction-body":        { tag: "div", hidden: true },
+    "auction-symbol-tag":  { tag: "span" },
+    "auction-top":         { tag: "span" },
+    "auction-top-arrow":   { tag: "span" },
+    "auction-top-price":   { tag: "span" },
+    "auction-match-qty":   { tag: "span" },
+    "auction-imbalance":   { tag: "span" },
+    "auction-ttu":         { tag: "span" },
+    "auction-prints":      { tag: "ol" },
+  },
+});
+
+const state = await import("../js/state.js");
+const ui    = await import("../js/ui.js");
+
+const SYM = "AUCT1";
+
+function clearAuction() {
+  // Reset by zeroing the per-symbol entry — clearAll touches too much.
+  state.getState().auctionBySymbol.delete(SYM);
+  state.setAuctionPanelSymbol(null);
+}
+
+test("setAuctionPanelSymbol toggles the open state", () => {
+  clearAuction();
+  assert.equal(state.getState().auctionPanelSymbol, null);
+  state.setAuctionPanelSymbol(SYM);
+  assert.equal(state.getState().auctionPanelSymbol, SYM);
+  state.setAuctionPanelSymbol(null);
+  assert.equal(state.getState().auctionPanelSymbol, null);
+});
+
+test("applyAuctionFrame top frame populates the cache", () => {
+  clearAuction();
+  state.applyAuctionFrame({
+    symbol: SYM, top: 32.50, indicativeMatchQty: 1000,
+    imbalance: 200, imbalanceSide: "Buy", at: "2026-01-01T13:00:00Z",
+  });
+  const aux = state.getAuctionState(SYM);
+  assert.equal(aux.top, 32.50);
+  assert.equal(aux.indicativeMatchQty, 1000);
+  assert.equal(aux.imbalance, 200);
+  assert.equal(aux.imbalanceSide, "Buy");
+  assert.equal(aux.prevTop, null);
+  assert.deepEqual(aux.lastPrints, []);
+});
+
+test("applyAuctionFrame tracks prevTop across top changes", () => {
+  clearAuction();
+  state.applyAuctionFrame({ symbol: SYM, top: 32.50, imbalanceSide: "Buy" });
+  state.applyAuctionFrame({ symbol: SYM, top: 32.60, imbalanceSide: "Buy" });
+  let aux = state.getAuctionState(SYM);
+  assert.equal(aux.top,     32.60);
+  assert.equal(aux.prevTop, 32.50);
+  state.applyAuctionFrame({ symbol: SYM, top: 32.55, imbalanceSide: "Buy" });
+  aux = state.getAuctionState(SYM);
+  assert.equal(aux.top,     32.55);
+  assert.equal(aux.prevTop, 32.60);
+});
+
+test("applyAuctionFrame ignores prevTop when current top is null (cold snapshot)", () => {
+  clearAuction();
+  // Cold snapshot — server sends nulls when nothing observed yet.
+  state.applyAuctionFrame({ symbol: SYM, top: null });
+  state.applyAuctionFrame({ symbol: SYM, top: 30.00 });
+  // First non-null top should NOT have a prevTop (no prior real value).
+  assert.equal(state.getAuctionState(SYM).prevTop, null);
+});
+
+test("applyAuctionFrame appends prints newest-first and caps at 5", () => {
+  clearAuction();
+  for (let i = 0; i < 8; i++) {
+    state.applyAuctionFrame({
+      symbol: SYM, kind: "Opening",
+      price: 30 + i, qty: 100 + i, at: `2026-01-01T13:00:0${i}Z`,
+    });
+  }
+  const prints = state.getAuctionState(SYM).lastPrints;
+  assert.equal(prints.length, 5);
+  // Newest first → last-pushed (i=7) is at index 0.
+  assert.equal(prints[0].price, 37);
+  assert.equal(prints[4].price, 33);
+});
+
+test("renderAuctionPanel hides the panel when closed", () => {
+  clearAuction();
+  ui.renderAuctionPanel();
+  const panel = document.getElementById("auction-panel");
+  assert.equal(panel.hidden, true);
+  assert.ok(panel.classList.contains("collapsed"));
+});
+
+test("renderAuctionPanel shows TOP, match qty, imbalance and arrow direction", () => {
+  clearAuction();
+  state.applyAuctionFrame({ symbol: SYM, top: 30.00, imbalanceSide: "Buy" });
+  state.applyAuctionFrame({
+    symbol: SYM, top: 30.50, indicativeMatchQty: 5000,
+    imbalance: 800, imbalanceSide: "Buy",
+  });
+  state.setAuctionPanelSymbol(SYM);
+  ui.renderAuctionPanel();
+
+  const panel = document.getElementById("auction-panel");
+  assert.equal(panel.hidden, false);
+  assert.equal(document.getElementById("auction-symbol-tag").textContent, SYM);
+  // Top price formatted via fmtPx (pt-BR comma decimal).
+  assert.equal(document.getElementById("auction-top-price").textContent, "30,50");
+  // Up arrow because 30.50 > 30.00.
+  const arrow = document.getElementById("auction-top-arrow");
+  assert.equal(arrow.textContent, "▲");
+  assert.match(arrow.className, /\bup\b/);
+  // Imbalance side colors the cell green for Buy.
+  const imb = document.getElementById("auction-imbalance");
+  assert.match(imb.textContent, /Buy/);
+  assert.match(imb.className,  /imb-buy/);
+  // TTU placeholder remains an em-dash until upstream emits it.
+  assert.equal(document.getElementById("auction-ttu").textContent, "—");
+});
+
+test("renderAuctionPanel renders Sell-side imbalance with the sell color class", () => {
+  clearAuction();
+  state.applyAuctionFrame({
+    symbol: SYM, top: 30.00, imbalance: 1500, imbalanceSide: "Sell",
+  });
+  state.setAuctionPanelSymbol(SYM);
+  ui.renderAuctionPanel();
+  const imb = document.getElementById("auction-imbalance");
+  assert.match(imb.className, /imb-sell/);
+  assert.match(imb.textContent, /Sell/);
+});
+
+test("renderAuctionPanel renders the print history newest-first", () => {
+  clearAuction();
+  state.applyAuctionFrame({ symbol: SYM, kind: "Opening", price: 30, qty: 100, at: "2026-01-01T13:00:00Z" });
+  state.applyAuctionFrame({ symbol: SYM, kind: "Opening", price: 31, qty: 200, at: "2026-01-01T13:00:01Z" });
+  state.setAuctionPanelSymbol(SYM);
+  ui.renderAuctionPanel();
+  const html = document.getElementById("auction-prints").innerHTML;
+  // Most recent (price=31) should appear before the older one in the
+  // rendered list.
+  assert.ok(html.indexOf("31,00") < html.indexOf("30,00"),
+    "newest print must appear first in the list");
+});

--- a/frontend/test/auction-panel.test.mjs
+++ b/frontend/test/auction-panel.test.mjs
@@ -156,3 +156,93 @@ test("renderAuctionPanel renders the print history newest-first", () => {
   assert.ok(html.indexOf("31,00") < html.indexOf("30,00"),
     "newest print must appear first in the list");
 });
+
+// ── reconcileAuctionPanel symbol-switch contract (Pass-1 review fix) ──
+//
+// Bug being fixed: reconcileAuctionPanel previously only closed the
+// panel when auctionPanelSymbol === selectedSymbol, so switching to a
+// non-auction symbol left the panel pinned to the previous symbol and
+// leaked the auction.${prev} subscription. The contract is now:
+//   * Newly selected symbol IS in auction → panel switches to it (auto-
+//     open / drop previous).
+//   * Newly selected symbol is NOT in auction → panel closes whenever
+//     it's open (regardless of which symbol it was pinned to). The
+//     trader can manually re-open via the toggle for any symbol.
+
+const SYM_A = "PETR4";
+const SYM_B = "VALE3";
+
+function resetReconcile() {
+  state.getState().auctionBySymbol.delete(SYM_A);
+  state.getState().auctionBySymbol.delete(SYM_B);
+  state.getState().phaseBySymbol.delete(SYM_A);
+  state.getState().phaseBySymbol.delete(SYM_B);
+  state.setAuctionPanelSymbol(null);
+  state.setSelectedSymbol(null);
+}
+
+test("reconcile auto-opens panel when selected symbol is in OpeningCall", () => {
+  resetReconcile();
+  state.applyPhaseFrame({ symbol: SYM_A, phase: "OpeningCall" });
+  state.setSelectedSymbol(SYM_A);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, SYM_A);
+});
+
+test("reconcile closes panel + drops sub when switching to a non-auction symbol", () => {
+  resetReconcile();
+  state.applyPhaseFrame({ symbol: SYM_A, phase: "OpeningCall" });
+  state.setSelectedSymbol(SYM_A);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, SYM_A);
+  // Switch to a symbol in the regular Open phase — panel must close so
+  // the auction.${SYM_A} subscription doesn't leak.
+  state.applyPhaseFrame({ symbol: SYM_B, phase: "Open" });
+  state.setSelectedSymbol(SYM_B);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, null,
+    "panel must close on switch to non-auction symbol (no leak)");
+});
+
+test("reconcile switches panel symbol when moving between two auction phases", () => {
+  resetReconcile();
+  state.applyPhaseFrame({ symbol: SYM_A, phase: "OpeningCall" });
+  state.setSelectedSymbol(SYM_A);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, SYM_A);
+  state.applyPhaseFrame({ symbol: SYM_B, phase: "FinalClosingCall" });
+  state.setSelectedSymbol(SYM_B);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, SYM_B,
+    "panel switches to new auction symbol; previous sub dropped implicitly");
+});
+
+test("reconcile closes a manually-opened panel when selected symbol is non-auction", () => {
+  // Documented behavior: there is no manual-open marker, so we close on
+  // any selected-symbol change to a non-auction symbol. Trader can
+  // re-open via toggle if they want to keep watching.
+  resetReconcile();
+  state.applyPhaseFrame({ symbol: SYM_A, phase: "Open" });
+  state.setSelectedSymbol(SYM_A);
+  // Trader manually toggles open for SYM_A while it's in Open.
+  state.setAuctionPanelSymbol(SYM_A);
+  // Switch to another symbol also in Open.
+  state.applyPhaseFrame({ symbol: SYM_B, phase: "Open" });
+  state.setSelectedSymbol(SYM_B);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, null,
+    "manual-open does not survive a non-auction symbol switch");
+});
+
+test("clearAll clears phase cache so reconcile closes the panel", () => {
+  resetReconcile();
+  state.applyPhaseFrame({ symbol: SYM_A, phase: "OpeningCall" });
+  state.setSelectedSymbol(SYM_A);
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, SYM_A);
+  // clearAll wipes phaseBySymbol; reconcile then sees Unknown phase
+  // (not an auction phase) and closes the panel.
+  state.clearAll();
+  ui.reconcileAuctionPanel();
+  assert.equal(state.getState().auctionPanelSymbol, null);
+});

--- a/frontend/test/dom-stub.mjs
+++ b/frontend/test/dom-stub.mjs
@@ -25,6 +25,7 @@ class FakeElement {
     this.tagName = String(tag || "div").toUpperCase();
     this._listeners = new Map();
     this._dataset = {};
+    this._attributes = new Map();
     this.classList = new FakeClassList();
     this.hidden = false;
     this.disabled = false;
@@ -45,11 +46,14 @@ class FakeElement {
     const i = l.indexOf(fn);
     if (i >= 0) l.splice(i, 1);
   }
-  setAttribute() {}
-  removeAttribute() {}
+  setAttribute(name, value) { this._attributes.set(String(name), String(value)); }
+  removeAttribute(name)     { this._attributes.delete(String(name)); }
+  getAttribute(name)        { return this._attributes.has(String(name)) ? this._attributes.get(String(name)) : null; }
+  hasAttribute(name)        { return this._attributes.has(String(name)); }
   focus() {}
   select() {}
   closest() { return null; }
+  querySelector() { return null; }
   querySelectorAll() { return []; }
   appendChild(c) { this.children.push(c); return c; }
 }

--- a/frontend/test/phase-badge.test.mjs
+++ b/frontend/test/phase-badge.test.mjs
@@ -1,0 +1,57 @@
+// Q1.6 (#258) — phase-badge HTML rendering. Locks the per-phase label,
+// CSS class, aria-label and the "no badge" rule for unknown phases so
+// a refactor of PHASE_LABELS or the wire-side enum can't silently
+// change what the trader sees on the watchlist.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+
+installDomStub({ ids: {} });
+
+const ui    = await import("../js/ui.js");
+const state = await import("../js/state.js");
+
+test("phase badge renders nothing for Unknown / no snapshot", () => {
+  const html = ui.phaseBadgeHtml("UNK4");
+  assert.equal(html, "");
+});
+
+const cases = [
+  ["Reserved",         "RESERVED"],
+  ["OpeningCall",      "PRE-OPEN"],
+  ["Open",             "OPEN"],
+  ["FinalClosingCall", "CLOSING"],
+  ["Close",            "CLOSED"],
+];
+
+for (const [phase, label] of cases) {
+  test(`phase badge renders ${label} for ${phase}`, () => {
+    state.applyPhaseFrame({ symbol: "PETR4", phase, at: "2026-01-01T00:00:00Z" });
+    const html = ui.phaseBadgeHtml("PETR4");
+    assert.match(html, new RegExp(`class="phase-badge ${label}"`),
+      `expected class fragment for ${phase}`);
+    assert.match(html, new RegExp(`>${label}</span>$`),
+      `expected label text ${label}`);
+    assert.match(html, /aria-label="PETR4 phase: /,
+      "aria-label must mention symbol and phase");
+    assert.match(html, new RegExp(`aria-label="PETR4 phase: ${label}"`),
+      "aria-label must include the trader-facing phase label");
+    assert.match(html, /data-symbol="PETR4"/, "data-symbol attr present");
+  });
+}
+
+test("getPhase returns Unknown when no snapshot is loaded", () => {
+  // Use a unique symbol so previous tests don't pollute.
+  assert.equal(state.getPhase("NEVERSEEN"), "Unknown");
+});
+
+test("isAuctionPhase is true only for OpeningCall and FinalClosingCall", () => {
+  assert.equal(state.isAuctionPhase("OpeningCall"),      true);
+  assert.equal(state.isAuctionPhase("FinalClosingCall"), true);
+  assert.equal(state.isAuctionPhase("Open"),             false);
+  assert.equal(state.isAuctionPhase("Reserved"),         false);
+  assert.equal(state.isAuctionPhase("Close"),            false);
+  assert.equal(state.isAuctionPhase("Unknown"),          false);
+});

--- a/frontend/test/ticket-phase-coupling.test.mjs
+++ b/frontend/test/ticket-phase-coupling.test.mjs
@@ -1,0 +1,130 @@
+// Q1.6 (#258) — order-ticket coupling to auction phase.
+//
+// What we lock down:
+//   * Phase ∈ {OpeningCall, FinalClosingCall} → TIF default flips to
+//     GoodForAuction unless the trader manually picked something.
+//   * Manual user pick is preserved across phase changes (no trample).
+//   * TIF=Day in an auction phase shows the soft "pending until open"
+//     warning text.
+//   * Phase=Reserved disables the Submit button and exposes
+//     aria-disabled + the "Instrumento halted" tooltip.
+//   * Leaving the auction phase reverts the auto-pick back to Day.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+
+installDomStub({
+  ids: {
+    "ticket-symbol":   { tag: "input"  },
+    "ticket-tif":      { tag: "select" },
+    "ticket-submit":   { tag: "button" },
+    "ticket-tif-hint": { tag: "p", hidden: true },
+  },
+});
+
+const state = await import("../js/state.js");
+const ui    = await import("../js/ui.js");
+
+const SYM = "PETR4";
+
+function setupTicket() {
+  const symEl = document.getElementById("ticket-symbol");
+  const tifEl = document.getElementById("ticket-tif");
+  const submitEl = document.getElementById("ticket-submit");
+  const hintEl = document.getElementById("ticket-tif-hint");
+  symEl.value = SYM;
+  tifEl.value = "Day";
+  // Reset coupling-affecting dataset between tests.
+  delete tifEl.dataset.userPicked;
+  delete tifEl.dataset.autoPicked;
+  delete submitEl.dataset.haltDisabled;
+  submitEl.disabled = false;
+  submitEl.removeAttribute("aria-disabled");
+  submitEl.removeAttribute("title");
+  hintEl.hidden = true;
+  hintEl.textContent = "";
+  hintEl.className = "field-hint";
+  return { symEl, tifEl, submitEl, hintEl };
+}
+
+test("OpeningCall flips TIF default to GoodForAuction", () => {
+  const { tifEl, hintEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "OpeningCall" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "GoodForAuction");
+  assert.equal(tifEl.dataset.autoPicked, "1");
+  assert.equal(hintEl.hidden, false);
+  assert.match(hintEl.textContent, /GoodForAuction recommended/);
+  assert.match(hintEl.className, /hint-info/);
+});
+
+test("FinalClosingCall flips TIF default to GoodForAuction", () => {
+  const { tifEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "FinalClosingCall" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "GoodForAuction");
+});
+
+test("manual user pick is preserved through phase changes", () => {
+  const { tifEl } = setupTicket();
+  // Trader picks Day explicitly (mark via dataset like the change handler does).
+  tifEl.dataset.userPicked = "1";
+  state.applyPhaseFrame({ symbol: SYM, phase: "OpeningCall" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "Day", "user pick must not be overwritten");
+});
+
+test("Day in auction phase surfaces the soft pending warning", () => {
+  const { tifEl, hintEl } = setupTicket();
+  // Trader explicitly picks Day, so the renderer keeps it but warns.
+  tifEl.dataset.userPicked = "1";
+  state.applyPhaseFrame({ symbol: SYM, phase: "OpeningCall" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "Day");
+  assert.equal(hintEl.hidden, false);
+  assert.match(hintEl.textContent, /pending até a abertura/);
+  assert.match(hintEl.className, /hint-warn/);
+});
+
+test("Reserved phase disables Submit with aria-disabled + tooltip", () => {
+  const { submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Reserved" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(submitEl.disabled, true);
+  assert.equal(submitEl.getAttribute("aria-disabled"), "true");
+  assert.equal(submitEl.getAttribute("title"), "Instrumento halted");
+  assert.equal(submitEl.dataset.haltDisabled, "1");
+});
+
+test("leaving Reserved re-enables Submit and clears the tooltip", () => {
+  const { submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Reserved" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(submitEl.disabled, true);
+  state.applyPhaseFrame({ symbol: SYM, phase: "Open" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(submitEl.disabled, false);
+  assert.equal(submitEl.getAttribute("aria-disabled"), null);
+  assert.equal(submitEl.getAttribute("title"), null);
+});
+
+test("leaving the auction phase reverts the auto-picked TIF back to Day", () => {
+  const { tifEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "OpeningCall" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "GoodForAuction");
+  state.applyPhaseFrame({ symbol: SYM, phase: "Open" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "Day", "auto-pick must revert when phase leaves auction");
+});
+
+test("non-auction, non-Reserved phase shows no hint and leaves submit enabled", () => {
+  const { tifEl, hintEl, submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Open" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(tifEl.value, "Day");
+  assert.equal(hintEl.hidden, true);
+  assert.equal(submitEl.disabled, false);
+});

--- a/frontend/test/ticket-phase-coupling.test.mjs
+++ b/frontend/test/ticket-phase-coupling.test.mjs
@@ -128,3 +128,55 @@ test("non-auction, non-Reserved phase shows no hint and leaves submit enabled", 
   assert.equal(hintEl.hidden, true);
   assert.equal(submitEl.disabled, false);
 });
+
+// ── Submit disabled-state OR semantics (Pass-1 review fix) ─────────
+//
+// The Submit button has two independent disable conditions tracked on
+// dataset flags: dataset.submitInflight (set by setTicketSubmitting) and
+// dataset.haltDisabled (set by renderTicketPhaseCoupling for Reserved).
+// The disabled bit must be the OR of both — neither writer is allowed
+// to clear the other's intent.
+
+test("Reserved + setTicketSubmitting(false) keeps Submit disabled (halt wins)", () => {
+  const { submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Reserved" });
+  ui.renderTicketPhaseCoupling();
+  ui.setTicketSubmitting(true);
+  assert.equal(submitEl.disabled, true, "in-flight + halted both disable");
+  ui.setTicketSubmitting(false);
+  assert.equal(submitEl.disabled, true,
+    "clearing in-flight must NOT re-enable while halted");
+  assert.equal(submitEl.dataset.haltDisabled, "1");
+  assert.equal(submitEl.getAttribute("aria-disabled"), "true");
+});
+
+test("In-flight + phase Reserved→Open keeps Submit disabled (in-flight wins)", () => {
+  const { submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Reserved" });
+  ui.renderTicketPhaseCoupling();
+  ui.setTicketSubmitting(true);
+  assert.equal(submitEl.disabled, true);
+  // Phase exits Reserved while submit is still in flight.
+  state.applyPhaseFrame({ symbol: SYM, phase: "Open" });
+  ui.renderTicketPhaseCoupling();
+  assert.equal(submitEl.disabled, true,
+    "leaving Reserved must NOT re-enable while a submit is in flight");
+  assert.equal(submitEl.dataset.submitInflight, "1");
+  assert.equal(submitEl.getAttribute("aria-disabled"), "true");
+  // Now clear in-flight: both conditions gone → enabled.
+  ui.setTicketSubmitting(false);
+  assert.equal(submitEl.disabled, false);
+  assert.equal(submitEl.getAttribute("aria-disabled"), null);
+});
+
+test("Both flags clear → Submit enabled, aria-disabled removed", () => {
+  const { submitEl } = setupTicket();
+  state.applyPhaseFrame({ symbol: SYM, phase: "Open" });
+  ui.renderTicketPhaseCoupling();
+  ui.setTicketSubmitting(true);
+  ui.setTicketSubmitting(false);
+  assert.equal(submitEl.disabled, false);
+  assert.equal(submitEl.dataset.submitInflight, undefined);
+  assert.equal(submitEl.dataset.haltDisabled,   undefined);
+  assert.equal(submitEl.getAttribute("aria-disabled"), null);
+});


### PR DESCRIPTION
Closes #258. Q1.6 of the Phase 2 trader-UI cycle: react in the frontend to the public `phases.${symbol}` / `auction.${symbol}` WS channels landed in #257.

## Summary

- **Watchlist phase badges** — Each market-data row now renders a colored phase pill next to the symbol. PRE-OPEN (yellow) / OPEN (green) / CLOSING (orange) / CLOSED (gray) / RESERVED (red). No badge is rendered for `Unknown` so a not-yet-loaded snapshot doesn't show a misleading default.
- **Auction panel** — New collapsible section above DOB. Auto-expands when the selected symbol enters `OpeningCall` / `FinalClosingCall` and collapses on exit. Renders TOP (with up/down trend arrow comparing to previous), indicative match qty, imbalance qty + side colored, and the last 5 `AuctionPrint` frames newest-first.
- **Ticket coupling** — New TIF select on the order ticket (Day / IOC / FOK / GTC / GoodForAuction / AtClose). In auction phases the default flips to GoodForAuction with an info hint; manual user picks are preserved. TIF=Day in an auction phase shows a soft warning ("Esta ordem ficará pending até a abertura."). `Reserved` disables Submit with `aria-disabled` + `"Instrumento halted"` tooltip.

## WS subscription discipline

- `worker.js` gains a `setPublicChannels` message + a `wantedPublic` set that is diff-subscribed on slice changes and replayed on reconnect.
- `phases.${symbol}` is subscribed permanently per watchlist symbol (badges always need it).
- `auction.${symbol}` is subscribed **only while the panel is open** (cost control on WS fan-out). State.auctionPanelSymbol is the source of truth.

## Accessibility

- Each badge: `aria-label="<symbol> phase: <phase-label>"`.
- Auction panel: `role="region" aria-label="Auction state for <sym>"`, with `aria-expanded` on the toggle button.
- Ticket TIF hint: `role="status" aria-live="polite"`.
- Submit halt-disable: `aria-disabled="true"` + native `title` tooltip.

## Tests

- **+25 unit tests** via `node:test`. Total now **158** (was 133).
  - `phase-badge.test.mjs` — badge HTML for each phase (label, class, aria-label, no-badge for Unknown).
  - `auction-panel.test.mjs` — reducer (snapshot apply, prevTop trend tracking, print history newest-first + cap of 5) + DOM render (panel show/hide, top/qty/imbalance/arrow, Buy/Sell color classes, prints order).
  - `ticket-phase-coupling.test.mjs` — TIF auto-pick, manual-pick preservation, Day soft warning, Reserved disable, auto-revert on phase exit.
- `frontend/test/dom-stub.mjs` — added `setAttribute` / `getAttribute` / `hasAttribute` (backward-compatible).
- New Playwright spec `frontend/e2e/auction-phase.spec.js` drives the full flow via direct state injection (mirrors `order-detail.spec.js`).
- CI (`.github/workflows/ci.yml`) — added the three new test files to the existing `node:test` job.

## Decisions worth flagging

- **TTU placeholder**: rendered as `—`. Upstream wire shape from #257 doesn't carry a time-to-uncross today. When B3MatchingPlatform exposes it, only `renderAuctionPanel` needs an edit.
- **Auto-open trigger**: the panel opens when the **selected** symbol (DOB / chart pane) is in an auction phase — not every watched symbol. Auto-popping multiple panels for a 5-symbol watchlist would be noisy.
- **clearAll**: phase + auction caches are dropped on `state.clearAll()` (which fires on trader-WS reconnect / logout). The server replays snapshots after re-subscribe.

## Files touched

```
.github/workflows/ci.yml         |   2 +-
frontend/css/styles.css          |  70 +++
frontend/e2e/auction-phase.spec.js | (new)
frontend/index.html              |  54 ++
frontend/js/app.js               |  30 +
frontend/js/state.js             | 117 +++
frontend/js/ui.js                | 261 ++++++
frontend/js/worker.js            |  49 ++
frontend/test/auction-panel.test.mjs | (new)
frontend/test/dom-stub.mjs       |   8 +-
frontend/test/phase-badge.test.mjs | (new)
frontend/test/ticket-phase-coupling.test.mjs | (new)
```

## Backend

Untouched (#258 is frontend-only; #255 is in flight elsewhere).

## Screenshot expectations

- Watchlist row: `PETR4 [PRE-OPEN]` (yellow pill) / `[RESERVED]` (red pill).
- Auction panel header: `▾ Auction PETR4` with TOP / Match qty / Imbalance / TTU grid + Recent prints list.
- Ticket: TIF select reads `GoodForAuction` during call auctions, with the "Auction phase — GoodForAuction recommended" info line below.