### PR TITLE
feat(#255): GTD expiration scheduler with WAL replay safety

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -39,6 +39,7 @@ public sealed class ExecutionReportProcessor
     private readonly PendingReplacementRegistry? _replacements;
     private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
     private readonly IBotErRouter? _botErRouter;
+    private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
 
     public ExecutionReportProcessor(
         OrderOwnershipMap ownership,
@@ -51,7 +52,8 @@ public sealed class ExecutionReportProcessor
         CashLedger? cash = null,
         PendingReplacementRegistry? replacements = null,
         Risk.IReplaceMarginCoordinator? replaceMargin = null,
-        IBotErRouter? botErRouter = null)
+        IBotErRouter? botErRouter = null,
+        Scheduling.GtdExpirationScheduler? gtdScheduler = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -64,6 +66,7 @@ public sealed class ExecutionReportProcessor
         _replacements = replacements;
         _replaceMargin = replaceMargin;
         _botErRouter = botErRouter;
+        _gtdScheduler = gtdScheduler;
     }
 
     /// <summary>
@@ -277,6 +280,16 @@ public sealed class ExecutionReportProcessor
             order.ClearStale();
         }
 
+        // Q1.3 (#255). GTD scheduler bookkeeping: drop tracked orders
+        // whose lifecycle just ended, regardless of whether they
+        // ended via venue cancel, fill, reject, or replace. Cheap
+        // no-op for orders the scheduler is not tracking.
+        if (order.Status is OrderStatus.Filled or OrderStatus.Cancelled
+            or OrderStatus.Rejected or OrderStatus.Replaced)
+        {
+            _gtdScheduler?.OnOrderTerminal(lookupId);
+        }
+
         // Server-side STP detection (#117): if the matching engine
         // emitted a cancel with a SelfTradePrevention restatement
         // reason, mark the outbound event so the UI/logs can surface
@@ -426,6 +439,10 @@ public sealed class ExecutionReportProcessor
         // Slice 1 of #132: terminalising clears any advisory stale.
         if (origOrder.IsStale)
             origOrder.ClearStale();
+        // Q1.3 (#255): drop tracked GTD entry for the original now
+        // that it is terminal (the replacement may or may not carry
+        // GTD; OnOrderTracked re-adds it after TryAdd below).
+        _gtdScheduler?.OnOrderTerminal(origId);
 
         var origEv = new ExecutionEvent(
             intent.Owner,
@@ -481,6 +498,15 @@ public sealed class ExecutionReportProcessor
             _replaceMargin?.AbortReplace(newClOrdId);
             return;
         }
+
+        // Q1.3 (#255). The replacement may carry a different TIF/GTD
+        // than the original. Notify the scheduler so a TIF change to
+        // GTD starts tracking, a TIF change away from GTD stops
+        // tracking the old entry (the original was already terminal-
+        // cleared via OnOrderTerminal at the top of Apply when we
+        // marked it Replaced), and a same-TIF change re-arms the
+        // timer with the new expiry.
+        _gtdScheduler?.OnOrderTracked(newOrder);
 
         // 3) Margin commit: rebalance to venue-confirmed remaining.
         //    For Buy + margin-bearing type (Limit / StopLimit /
@@ -569,6 +595,20 @@ public enum ExecKind
     /// economic event.
     /// </summary>
     Suspended,
+    /// <summary>
+    /// Q1.3 (#255). Synthetic projection of an
+    /// <see cref="Persistence.OrderExpiredEvent"/>: the GTD scheduler
+    /// determined an order's <c>GoodTillDate</c> has elapsed and
+    /// dispatched a cancel against it through the regular
+    /// <c>OrderCancelService</c>. The order's actual terminal status
+    /// transition still flows from the eventual <see cref="Canceled"/>
+    /// ER produced by the cancel pipeline; this synthetic event lets
+    /// WS subscribers see <c>kind=Expired</c> alongside the regular
+    /// <c>kind=Canceled</c> so the UI can distinguish a venue cancel
+    /// from a policy expiry. Carries <c>LastQuantity=0</c> and no
+    /// fill price (no economic event).
+    /// </summary>
+    Expired,
     /// <summary>
     /// Slice 5 of #132. Synthetic counterpart of <see cref="Suspended"/>:
     /// emitted when the stale overlay is lifted (admin clear path). The

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -25,6 +25,17 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.orders.gateway_failed");
     public static readonly Counter<long> OrdersCancelRequested =
         Meter.CreateCounter<long>("trading.orders.cancel_requested");
+    /// <summary>
+    /// Q1.3 (#255). Counts every GTD expiry the scheduler dispatched.
+    /// Tagged with <c>cancel_result</c> = the
+    /// <see cref="OrderCancelResultKind"/> the cancel pipeline
+    /// returned (Accepted / NotFound / Stale / WalBackpressure /
+    /// GatewayFailed) so a sustained climb on a non-Accepted bucket
+    /// flags scheduler-vs-pipeline drift (e.g. the scheduler keeps
+    /// firing for orders the book no longer knows about).
+    /// </summary>
+    public static readonly Counter<long> GtdOrdersExpired =
+        Meter.CreateCounter<long>("trading.orders.gtd_expired");
     public static readonly Counter<long> OrdersModifyRequested =
         Meter.CreateCounter<long>("trading.orders.modify_requested");
 

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -202,12 +202,6 @@ public sealed class OrderSubmissionService
             return OrderSubmissionResult.WalBackpressure(ex.Message);
         }
 
-        // Q1.3 (#255). After the WAL append + book insert have committed
-        // (Dispatch returned without throwing), seed the GTD scheduler.
-        // No-ops for non-GTD orders; no-ops when the scheduler is not
-        // wired (test contexts that don't need expiry firing).
-        _gtdScheduler?.OnOrderTracked(order);
-
         MetricsRegistry.OrdersSubmitted.Add(1,
             new KeyValuePair<string, object?>("symbol", req.Symbol),
             new KeyValuePair<string, object?>("side", req.Side.ToString()),
@@ -249,6 +243,19 @@ public sealed class OrderSubmissionService
             PublishSyntheticRejection(order, "gateway_unavailable");
             return OrderSubmissionResult.GatewayFailed(clOrdId, ex);
         }
+
+        // Q1.3 (#255). Arm the GTD scheduler ONLY after the gateway submit
+        // returns without throwing. Doing this earlier (e.g. right after
+        // the WAL append) lets a near-term GTD timer race the in-flight
+        // SubmitAsync — the scheduler would issue a cancel for a clOrdId
+        // the venue has not yet seen. By placing the hook here the
+        // semantic is: "submit success" == SubmitAsync completed without
+        // throwing. Venue ACK remains async (NewReject ER drives the
+        // reject path, which marks the order terminal and the
+        // OnOrderTerminal subscription removes it from the heap).
+        // No-ops for non-GTD orders; no-ops when the scheduler is not
+        // wired (test contexts that don't need expiry firing).
+        _gtdScheduler?.OnOrderTracked(order);
 
         return OrderSubmissionResult.Accepted(clOrdId);
     }

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -37,6 +37,7 @@ public sealed class OrderSubmissionService
     private readonly EventDispatcher _dispatcher;
     private readonly Lifecycle.IDrainGate _drain;
     private readonly IUserBotOrderMappingRegistry? _botMappings;
+    private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
     private readonly ILogger<OrderSubmissionService> _logger;
 
     public OrderSubmissionService(
@@ -51,7 +52,8 @@ public sealed class OrderSubmissionService
         EventDispatcher dispatcher,
         Lifecycle.IDrainGate drain,
         ILogger<OrderSubmissionService> logger,
-        IUserBotOrderMappingRegistry? botMappings = null)
+        IUserBotOrderMappingRegistry? botMappings = null,
+        Scheduling.GtdExpirationScheduler? gtdScheduler = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -64,6 +66,7 @@ public sealed class OrderSubmissionService
         _dispatcher = dispatcher;
         _drain = drain;
         _botMappings = botMappings;
+        _gtdScheduler = gtdScheduler;
         _logger = logger;
     }
 
@@ -198,6 +201,12 @@ public sealed class OrderSubmissionService
                     req.Source == OrderSubmissionSource.Algo ? "algo.submit" : "orders.submit"));
             return OrderSubmissionResult.WalBackpressure(ex.Message);
         }
+
+        // Q1.3 (#255). After the WAL append + book insert have committed
+        // (Dispatch returned without throwing), seed the GTD scheduler.
+        // No-ops for non-GTD orders; no-ops when the scheduler is not
+        // wired (test contexts that don't need expiry firing).
+        _gtdScheduler?.OnOrderTracked(order);
 
         MetricsRegistry.OrdersSubmitted.Add(1,
             new KeyValuePair<string, object?>("symbol", req.Symbol),

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -56,6 +56,14 @@ public sealed class RawPlatformSnapshot
         Array.Empty<BotOrderMappingRaw>();
     public BotCancelMappingRaw[] BotCancelMappings { get; init; } =
         Array.Empty<BotCancelMappingRaw>();
+
+    /// <summary>
+    /// Pass-4 review (#255). Mirror of
+    /// <c>PlatformSnapshot.AuditedExpiredIds</c> at the raw-capture
+    /// stage. Populated under the dispatcher lock from
+    /// <c>GtdExpirationScheduler.SnapshotAuditedExpiredIds()</c>.
+    /// </summary>
+    public ulong[] AuditedExpiredIds { get; init; } = Array.Empty<ulong>();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -85,6 +85,26 @@ public sealed class PlatformSnapshot
     /// external cancel ClOrdID. Empty on snapshots pre-dating the field.
     /// </summary>
     public List<BotCancelMappingSnapshot> BotCancelMappings { get; init; } = new();
+
+    /// <summary>
+    /// Pass-4 review (#255). ClOrdIds whose <c>OrderExpiredEvent</c>
+    /// audit envelope is durably on the WAL but whose downstream
+    /// <c>OrderCancelRequestedEvent</c> has not yet been observed.
+    /// Captured under the dispatcher lock so the persisted set is
+    /// consistent with the snapshot's <c>Seq</c>: when a snapshot is
+    /// taken between the audit append and the cancel append, this set
+    /// records that the audit is already on disk so the post-restart
+    /// timer fire (which sees an order still in working state in the
+    /// snapshot) does not emit a duplicate audit envelope.
+    /// <para>
+    /// Empty on snapshots pre-dating the field, which collapses to the
+    /// pre-pass-4 behaviour: <c>EventReplayer.Apply(OrderExpiredEvent)</c>
+    /// is then the only writer. The bug pass-4 fixes is the small
+    /// window where <c>EventReplayer</c> never sees the audit because
+    /// its seq is &lt;= snapshot.Seq.
+    /// </para>
+    /// </summary>
+    public IReadOnlyCollection<ulong> AuditedExpiredIds { get; init; } = Array.Empty<ulong>();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -45,6 +45,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(BotSessionVerAdvancedEvent))]
 [JsonSerializable(typeof(BotSessionSeqAdvancedEvent))]
 [JsonSerializable(typeof(BotOrderMapping))]
+[JsonSerializable(typeof(OrderExpiredEvent))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -34,6 +34,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(BotSessionVerAdvancedEvent), "userbot.session.ver-advanced")]
 [JsonDerivedType(typeof(BotSessionSeqAdvancedEvent), "userbot.session.seq-advanced")]
 [JsonDerivedType(typeof(OrderCancelRequestedEvent), "order.cancel-requested")]
+[JsonDerivedType(typeof(OrderExpiredEvent), "order.expired")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -425,4 +426,27 @@ public sealed record BotSessionSeqAdvancedEvent : WalEvent
     public required Guid CredentialId { get; init; }
     public required ulong CheckpointedOutboundSeq { get; init; }
     public required DateTimeOffset At { get; init; }
+}
+
+/// <summary>
+/// Q1.3 (#255). Recorded the moment the GTD scheduler decides an order
+/// has reached its <see cref="Domain.Order.GoodTillDate"/> and dispatches
+/// a cancel for it. Strictly informational: the cancel itself flows
+/// through the regular <c>OrderCancelService</c> pipeline (which
+/// produces the eventual <c>ExecutionReportReceivedEvent</c> with
+/// <c>Canceled</c>), and this event is what lets downstream sinks
+/// project the cancel as <c>kind=Expired</c> instead of the usual
+/// <c>kind=Canceled</c>. <see cref="Reason"/> is an open-ended string
+/// (<c>"Gtd"</c> in v0; future auction-expired flows reuse the same
+/// envelope with a different reason). Replay is a no-op — the
+/// downstream <c>Canceled</c> ER (also on the WAL) drives all in-memory
+/// state mutation; this event only carries audit / WS-projection
+/// metadata. Additive: older WAL segments without this event replay
+/// unchanged.
+/// </summary>
+public sealed record OrderExpiredEvent : WalEvent
+{
+    public required ulong ClOrdId { get; init; }
+    public required string Reason { get; init; }
+    public required DateTimeOffset AtUtc { get; init; }
 }

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -308,6 +308,40 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
         lock (_lock) _auditedExpiredIds.Add(clOrdId);
     }
 
+    /// <summary>
+    /// Pass-4 review (#255). Snapshot-time export of the in-flight
+    /// audit-set: every ClOrdId whose <see cref="OrderExpiredEvent"/>
+    /// has already been written to the WAL but whose downstream cancel
+    /// has not yet resolved (terminal cancel result evicts the id via
+    /// <see cref="Resolve"/>). Returned as a sorted array for
+    /// deterministic snapshot bytes.
+    /// <para>
+    /// <b>Lock ordering.</b> Caller (the snapshot service) holds
+    /// <c>EventDispatcher.WithSnapshotLock</c>; this method then takes
+    /// the scheduler's own <see cref="_lock"/>. Mutators of
+    /// <see cref="_auditedExpiredIds"/> live in two places:
+    /// <list type="bullet">
+    ///   <item><see cref="DispatchExpireAsync"/> performs the
+    ///   <c>Add</c> inside the <see cref="EventDispatcher.Dispatch(WalEvent, Action)"/>
+    ///   apply callback, i.e. under the dispatcher lock first then the
+    ///   scheduler lock — same order as snapshot capture (no deadlock).</item>
+    ///   <item><see cref="Resolve"/> takes only the scheduler lock and
+    ///   never re-enters the dispatcher.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public ulong[] SnapshotAuditedExpiredIds()
+    {
+        lock (_lock)
+        {
+            if (_auditedExpiredIds.Count == 0) return Array.Empty<ulong>();
+            var copy = new ulong[_auditedExpiredIds.Count];
+            _auditedExpiredIds.CopyTo(copy);
+            Array.Sort(copy);
+            return copy;
+        }
+    }
+
     private void Remove(ulong clOrdId)
     {
         lock (_lock)
@@ -506,7 +540,28 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
                             Reason = ReasonGtd,
                             AtUtc = originalGtd,
                         },
-                        static () => { /* no in-memory mutation; audit-only */ });
+                        // Pass-4 review (#255): record the audit-appended
+                        // bookkeeping INSIDE the dispatcher's apply
+                        // callback so it is atomic with the WAL append
+                        // under the dispatcher lock. A snapshot taken
+                        // between the audit append and the cancel append
+                        // (snapshot capture also holds the dispatcher
+                        // lock via WithSnapshotLock) now observes both
+                        // the post-append seq AND the populated
+                        // _auditedExpiredIds — the snapshot then carries
+                        // the id forward in PlatformSnapshot.AuditedExpiredIds
+                        // and the post-restart Schedule() seeds
+                        // ExpiredAuditAppended=true so the next timer
+                        // fire does not emit a duplicate audit envelope.
+                        () =>
+                        {
+                            lock (_lock)
+                            {
+                                if (_index.TryGetValue(clOrdId, out var cur))
+                                    cur.ExpiredAuditAppended = true;
+                                _auditedExpiredIds.Add(clOrdId);
+                            }
+                        });
                 }
                 catch (WalBackpressureException ex)
                 {
@@ -519,22 +574,6 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
                         new KeyValuePair<string, object?>("cancel_result", "WalBackpressureRetry"));
                     ReArmRetry(clOrdId);
                     return;
-                }
-
-                // Persist the audit-appended flag so a subsequent
-                // backpressure on the cancel side doesn't double-emit
-                // OrderExpiredEvent on retry. Pass-3 review (#255):
-                // also record the id in _auditedExpiredIds so a crash
-                // between this point and the cancel ER landing on
-                // disk reconstructs the same audit-already-appended
-                // state during the next replay (the EventReplayer
-                // hook would otherwise be the only writer, and that
-                // hook only fires on already-on-disk events).
-                lock (_lock)
-                {
-                    if (_index.TryGetValue(clOrdId, out var cur))
-                        cur.ExpiredAuditAppended = true;
-                    _auditedExpiredIds.Add(clOrdId);
                 }
             }
 

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -276,14 +276,14 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
             if (IsTerminal(order.Status))
                 return;
 
-            var result = await _cancel.CancelAsync(order.Owner, clOrdId, CancellationToken.None)
-                .ConfigureAwait(false);
-
-            // Whatever the cancel outcome (Accepted / GatewayFailed /
-            // Stale / NotFound / WalBackpressure), append the audit
-            // envelope so operators can tell the heap actually fired.
-            // The downstream venue Canceled ER is what flips order
-            // status; this event is informational only.
+            // Append the GTD-expiry audit envelope BEFORE issuing the
+            // cancel so a crash mid-cancel still leaves the
+            // expiry-attribution durable. On replay we re-attempt the
+            // cancel with the reason already on disk; CancelAsync is
+            // idempotent on a still-pending cancel (deduplicates via
+            // order status / clOrdId in the book). The downstream venue
+            // Canceled ER is what flips order status; this event is
+            // informational only.
             try
             {
                 _dispatcher.Dispatch(
@@ -300,9 +300,12 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
                 MetricsRegistry.WalBackpressure.Add(1,
                     new KeyValuePair<string, object?>("call_site", "gtd.expired"));
                 _logger?.LogWarning(ex,
-                    "WAL backpressure appending OrderExpiredEvent for {ClOrdId}; cancel already requested.",
+                    "WAL backpressure appending OrderExpiredEvent for {ClOrdId}; proceeding with cancel.",
                     clOrdId);
             }
+
+            var result = await _cancel.CancelAsync(order.Owner, clOrdId, CancellationToken.None)
+                .ConfigureAwait(false);
 
             // WS projection: emit a synthetic Expired ExecutionEvent so
             // subscribers see kind=Expired alongside the regular

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -158,6 +158,24 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
     private readonly object _lock = new();
     private readonly PriorityQueue<ulong, DateTimeOffset> _heap = new();
     private readonly Dictionary<ulong, Entry> _index = new();
+    /// <summary>
+    /// Pass-3 review (#255). Set of ClOrdIds whose
+    /// <see cref="OrderExpiredEvent"/> audit envelope has already been
+    /// observed on the WAL — populated either by the live dispatch
+    /// path (after a successful audit append) or by the
+    /// <see cref="MarkExpiredAuditAppended"/> hook the
+    /// <c>EventReplayer</c> calls during cold-start replay. When
+    /// <see cref="Schedule"/> seeds a new <see cref="Entry"/> for an
+    /// id present in this set, it pre-sets
+    /// <see cref="Entry.ExpiredAuditAppended"/> so the post-restart
+    /// timer fire does NOT emit a second
+    /// <see cref="OrderExpiredEvent"/> for the same expiry.
+    /// Bookkeeping is bounded: <see cref="Resolve"/> removes the id
+    /// once the cancel completes (or the entry is evicted) so the
+    /// set stays the size of the in-flight expired-but-not-yet-cancel-
+    /// completed window.
+    /// </summary>
+    private readonly HashSet<ulong> _auditedExpiredIds = new();
     private readonly WorkingOrderBook _book;
     private readonly OrderCancelService _cancel;
     private readonly EventDispatcher _dispatcher;
@@ -244,11 +262,50 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
             }
             else
             {
-                _index[clOrdId] = new Entry { Expiry = expiry, OriginalGtd = expiry };
+                // Pass-3 review (#255). If a prior incarnation of the
+                // process appended OrderExpiredEvent for this ClOrdId
+                // before crashing (audit on disk, cancel not yet
+                // requested), the EventReplayer hook
+                // MarkExpiredAuditAppended will have populated
+                // _auditedExpiredIds during cold-start replay. Seed
+                // ExpiredAuditAppended=true so the post-restart timer
+                // fire reuses the existing audit envelope instead of
+                // emitting a duplicate.
+                _index[clOrdId] = new Entry
+                {
+                    Expiry = expiry,
+                    OriginalGtd = expiry,
+                    ExpiredAuditAppended = _auditedExpiredIds.Contains(clOrdId),
+                };
             }
             _heap.Enqueue(clOrdId, expiry);
             Reschedule_NoLock();
         }
+    }
+
+    /// <summary>
+    /// Pass-3 review (#255). Hook called by the WAL <c>EventReplayer</c>
+    /// for every <see cref="OrderExpiredEvent"/> it encounters during
+    /// cold-start replay. Records that the audit envelope is durably
+    /// on disk for the given <paramref name="clOrdId"/> so a
+    /// subsequent <see cref="Schedule"/> call (issued from
+    /// <see cref="StartAsync"/> for an order whose cancel ER did NOT
+    /// land before the crash) seeds the resulting <see cref="Entry"/>
+    /// with <see cref="Entry.ExpiredAuditAppended"/> already set.
+    /// Without this hook the post-restart timer fire would re-append
+    /// <see cref="OrderExpiredEvent"/> for the same expiry, producing
+    /// a duplicate audit envelope on the WAL.
+    /// <para>
+    /// Idempotent. Must be called BEFORE
+    /// <see cref="StartAsync"/> seeds the heap from the book snapshot
+    /// — guaranteed by <c>TradingHostStartup.RunRecoveryAndSeedingAsync</c>
+    /// which awaits WAL recovery before <c>app.Run()</c> kicks off
+    /// hosted-service <c>StartAsync</c>.
+    /// </para>
+    /// </summary>
+    public void MarkExpiredAuditAppended(ulong clOrdId)
+    {
+        lock (_lock) _auditedExpiredIds.Add(clOrdId);
     }
 
     private void Remove(ulong clOrdId)
@@ -366,6 +423,14 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
         lock (_lock)
         {
             _index.Remove(clOrdId);
+            // Pass-3 review (#255). Drop the audited-id bookkeeping
+            // alongside the index entry: once the cancel pipeline
+            // resolved (Accepted / NotFound / Stale / GatewayFailed),
+            // the order is no longer at risk of a post-crash duplicate
+            // audit because Schedule will not re-arm a terminal/
+            // missing-from-book order. Keeps the set bounded by the
+            // in-flight expired-but-cancel-not-completed window.
+            _auditedExpiredIds.Remove(clOrdId);
         }
     }
 
@@ -458,11 +523,18 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
 
                 // Persist the audit-appended flag so a subsequent
                 // backpressure on the cancel side doesn't double-emit
-                // OrderExpiredEvent on retry.
+                // OrderExpiredEvent on retry. Pass-3 review (#255):
+                // also record the id in _auditedExpiredIds so a crash
+                // between this point and the cancel ER landing on
+                // disk reconstructs the same audit-already-appended
+                // state during the next replay (the EventReplayer
+                // hook would otherwise be the only writer, and that
+                // hook only fires on already-on-disk events).
                 lock (_lock)
                 {
                     if (_index.TryGetValue(clOrdId, out var cur))
                         cur.ExpiredAuditAppended = true;
+                    _auditedExpiredIds.Add(clOrdId);
                 }
             }
 

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -98,6 +98,25 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
     public static readonly TimeSpan MaxTimerPoll = TimeSpan.FromHours(1);
 
     /// <summary>
+    /// Pass-2 review (#255). Initial WAL-backpressure retry delay; the
+    /// scheduler re-arms the heap entry at <c>now + RetryBaseDelay</c>
+    /// after the first transient failure (audit append or
+    /// <see cref="OrderCancelService.CancelAsync"/> returning
+    /// <see cref="OrderCancelResultKind.WalBackpressure"/>) and then
+    /// doubles each subsequent attempt up to <see cref="RetryMaxDelay"/>.
+    /// </summary>
+    public static readonly TimeSpan RetryBaseDelay = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Pass-2 review (#255). Cap on the WAL-backpressure retry delay.
+    /// Once reached, the scheduler keeps retrying at this cadence
+    /// indefinitely — WAL pressure is treated as transient (drained as
+    /// the background writer catches up); abandoning would re-introduce
+    /// the orphan-at-venue bug the retry is meant to fix.
+    /// </summary>
+    public static readonly TimeSpan RetryMaxDelay = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Free-text reason carried on <see cref="OrderExpiredEvent.Reason"/>
     /// + the synthetic <c>ExecutionEvent.RejectReason</c> when the
     /// trigger is a GTD expiry. Stable wire format (string, not
@@ -106,9 +125,39 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
     /// </summary>
     public const string ReasonGtd = "Gtd";
 
+    /// <summary>
+    /// Per-order tracking state held in <see cref="_index"/>. Mutable
+    /// reference type so retry bookkeeping (audit-append dedupe, retry
+    /// count for backoff calc) survives the heap dequeue+re-enqueue
+    /// cycle that a WAL-backpressure retry performs.
+    /// </summary>
+    private sealed class Entry
+    {
+        /// <summary>Currently scheduled fire time (original GTD on first
+        /// arm; <c>now + backoff</c> after each WAL-backpressure
+        /// failure). The heap key always equals this value at the moment
+        /// of enqueue, so a divergence between
+        /// <c>_index[id].Expiry</c> and a peeked heap priority is the
+        /// canonical "tombstone" signal.</summary>
+        public DateTimeOffset Expiry;
+        /// <summary>The order's actual <see cref="Order.GoodTillDate"/>
+        /// captured at first arm. Used as the
+        /// <see cref="OrderExpiredEvent.AtUtc"/> on every (re)try so the
+        /// audit trail reflects the policy boundary, not the wall-clock
+        /// time of the eventual successful append.</summary>
+        public DateTimeOffset OriginalGtd;
+        /// <summary>True once <see cref="OrderExpiredEvent"/> has been
+        /// successfully appended for this expiry. Prevents duplicate
+        /// audit envelopes across WAL-backpressure retry attempts.</summary>
+        public bool ExpiredAuditAppended;
+        /// <summary>Number of WAL-backpressure re-arms so far; drives
+        /// the exponential backoff in <see cref="ComputeBackoff"/>.</summary>
+        public int RetryCount;
+    }
+
     private readonly object _lock = new();
     private readonly PriorityQueue<ulong, DateTimeOffset> _heap = new();
-    private readonly Dictionary<ulong, DateTimeOffset> _index = new();
+    private readonly Dictionary<ulong, Entry> _index = new();
     private readonly WorkingOrderBook _book;
     private readonly OrderCancelService _cancel;
     private readonly EventDispatcher _dispatcher;
@@ -182,7 +231,21 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
     {
         lock (_lock)
         {
-            _index[clOrdId] = expiry;
+            if (_index.TryGetValue(clOrdId, out var existing))
+            {
+                // Re-track (e.g., modify in place, replay): treat as a
+                // fresh scheduling — reset audit/retry state so the new
+                // GTD gets its own OrderExpiredEvent and a clean backoff
+                // ladder if it too hits WAL pressure.
+                existing.Expiry = expiry;
+                existing.OriginalGtd = expiry;
+                existing.ExpiredAuditAppended = false;
+                existing.RetryCount = 0;
+            }
+            else
+            {
+                _index[clOrdId] = new Entry { Expiry = expiry, OriginalGtd = expiry };
+            }
             _heap.Enqueue(clOrdId, expiry);
             Reschedule_NoLock();
         }
@@ -197,6 +260,23 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
         }
     }
 
+    /// <summary>
+    /// Bounded exponential backoff: <c>RetryBaseDelay * 2^retryCount</c>
+    /// capped at <see cref="RetryMaxDelay"/>. Caller passes the
+    /// post-increment retry count (1 for the first re-arm, 2 for the
+    /// second, …); shift is clamped at 10 to keep the multiplier well
+    /// inside <see cref="long"/> range before the cap kicks in.
+    /// </summary>
+    private DateTimeOffset ComputeBackoff(int retryCount)
+    {
+        var shift = Math.Min(Math.Max(retryCount - 1, 0), 10);
+        var ms = RetryBaseDelay.TotalMilliseconds * (1L << shift);
+        var delay = ms >= RetryMaxDelay.TotalMilliseconds
+            ? RetryMaxDelay
+            : TimeSpan.FromMilliseconds(ms);
+        return _clock.GetUtcNow() + delay;
+    }
+
     private void Reschedule_NoLock()
     {
         // Drop tombstoned heads (entries whose live priority no longer
@@ -204,7 +284,7 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
         // re-scheduled with a different expiry).
         while (_heap.TryPeek(out var topId, out var topExpiry))
         {
-            if (_index.TryGetValue(topId, out var liveExpiry) && liveExpiry == topExpiry)
+            if (_index.TryGetValue(topId, out var liveEntry) && liveEntry.Expiry == topExpiry)
                 break;
             _heap.Dequeue();
         }
@@ -232,22 +312,28 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
 
     private void OnTimer()
     {
-        List<(ulong ClOrdId, DateTimeOffset Expiry)>? batch = null;
+        List<ulong>? batch = null;
         lock (_lock)
         {
             var now = _clock.GetUtcNow();
             while (_heap.TryPeek(out var topId, out var topExpiry))
             {
-                if (!_index.TryGetValue(topId, out var liveExpiry) || liveExpiry != topExpiry)
+                if (!_index.TryGetValue(topId, out var entry) || entry.Expiry != topExpiry)
                 {
                     _heap.Dequeue();
                     continue;
                 }
                 if (topExpiry > now) break;
 
+                // Pass-2 review (#255): dequeue the heap entry but
+                // LEAVE the order in _index. DispatchExpireAsync takes
+                // ownership: on a terminal CancelAsync result it calls
+                // Resolve to evict, on a WAL-backpressure result it
+                // calls ReArmRetry to re-enqueue with backoff. Removing
+                // here would orphan the order at the venue if cancel
+                // returned WalBackpressure (the original P1 bug).
                 _heap.Dequeue();
-                _index.Remove(topId);
-                (batch ??= new()).Add((topId, topExpiry));
+                (batch ??= new()).Add(topId);
             }
             // Force re-arm: zero out _scheduledFor so the next
             // Reschedule_NoLock recomputes against the new head.
@@ -256,56 +342,150 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
         }
 
         if (batch is null) return;
-        foreach (var entry in batch)
+        foreach (var clOrdId in batch)
         {
             // Dispatch each cancel onto the thread-pool. The cancel
             // pipeline serialises its WAL write through the dispatcher
             // lock, so concurrent expiries cannot interleave WAL
             // appends — same posture as user-initiated cancels racing
             // each other through the REST endpoint.
-            _ = Task.Run(() => DispatchExpireAsync(entry.ClOrdId, entry.Expiry));
+            _ = Task.Run(() => DispatchExpireAsync(clOrdId));
         }
     }
 
-    private async Task DispatchExpireAsync(ulong clOrdId, DateTimeOffset atUtc)
+    /// <summary>
+    /// Drops <paramref name="clOrdId"/> from the live tracking index
+    /// after a terminal dispatch outcome (CancelAsync returned
+    /// Accepted / NotFound / Stale / GatewayFailed, or the order was
+    /// already terminal in the book). No heap mutation needed: the
+    /// dispatching code already dequeued the heap entry; any future
+    /// Schedule() for the same id starts fresh.
+    /// </summary>
+    private void Resolve(ulong clOrdId)
+    {
+        lock (_lock)
+        {
+            _index.Remove(clOrdId);
+        }
+    }
+
+    /// <summary>
+    /// Pass-2 review (#255). Re-arms a transient WAL-backpressure
+    /// failure with bounded exponential backoff. If the order was
+    /// concurrently removed (OnOrderTerminal raced ahead — venue fill
+    /// or external cancel landed before our retry), the re-arm is
+    /// suppressed: the entry is gone from the index and there is
+    /// nothing to retry.
+    /// </summary>
+    private void ReArmRetry(ulong clOrdId)
+    {
+        lock (_lock)
+        {
+            if (!_index.TryGetValue(clOrdId, out var entry))
+                return;
+            entry.RetryCount++;
+            entry.Expiry = ComputeBackoff(entry.RetryCount);
+            _heap.Enqueue(clOrdId, entry.Expiry);
+            // Force re-arm: the new backoff expiry might be later than
+            // the previously-scheduled head; Reschedule_NoLock will
+            // recompute regardless because we dequeued in OnTimer.
+            _scheduledFor = DateTimeOffset.MaxValue;
+            Reschedule_NoLock();
+        }
+    }
+
+    private async Task DispatchExpireAsync(ulong clOrdId)
     {
         try
         {
+            // Snapshot the per-order tracking state under the lock so
+            // we observe a consistent (audit-flag, original-gtd) pair
+            // even if a concurrent OnOrderTerminal evicts the entry
+            // mid-dispatch.
+            DateTimeOffset originalGtd;
+            bool auditAlreadyAppended;
+            lock (_lock)
+            {
+                if (!_index.TryGetValue(clOrdId, out var entry))
+                    return;
+                originalGtd = entry.OriginalGtd;
+                auditAlreadyAppended = entry.ExpiredAuditAppended;
+            }
+
             if (!_book.TryGet(clOrdId, out var order) || order is null)
+            {
+                Resolve(clOrdId);
                 return;
+            }
             if (IsTerminal(order.Status))
+            {
+                Resolve(clOrdId);
                 return;
-
-            // Append the GTD-expiry audit envelope BEFORE issuing the
-            // cancel so a crash mid-cancel still leaves the
-            // expiry-attribution durable. On replay we re-attempt the
-            // cancel with the reason already on disk; CancelAsync is
-            // idempotent on a still-pending cancel (deduplicates via
-            // order status / clOrdId in the book). The downstream venue
-            // Canceled ER is what flips order status; this event is
-            // informational only.
-            try
-            {
-                _dispatcher.Dispatch(
-                    new OrderExpiredEvent
-                    {
-                        ClOrdId = clOrdId,
-                        Reason = ReasonGtd,
-                        AtUtc = atUtc,
-                    },
-                    static () => { /* no in-memory mutation; audit-only */ });
-            }
-            catch (WalBackpressureException ex)
-            {
-                MetricsRegistry.WalBackpressure.Add(1,
-                    new KeyValuePair<string, object?>("call_site", "gtd.expired"));
-                _logger?.LogWarning(ex,
-                    "WAL backpressure appending OrderExpiredEvent for {ClOrdId}; proceeding with cancel.",
-                    clOrdId);
             }
 
+            // 1) Append the GTD-expiry audit envelope BEFORE issuing
+            // the cancel so a crash mid-cancel still leaves the
+            // expiry-attribution durable. Pass-2 review (#255): if WAL
+            // append itself hits backpressure, re-arm with backoff and
+            // retry on the next timer tick — DO NOT proceed to cancel
+            // (CancelAsync would also write to the same pressured
+            // channel and we'd have no audit record on disk).
+            if (!auditAlreadyAppended)
+            {
+                try
+                {
+                    _dispatcher.Dispatch(
+                        new OrderExpiredEvent
+                        {
+                            ClOrdId = clOrdId,
+                            Reason = ReasonGtd,
+                            AtUtc = originalGtd,
+                        },
+                        static () => { /* no in-memory mutation; audit-only */ });
+                }
+                catch (WalBackpressureException ex)
+                {
+                    MetricsRegistry.WalBackpressure.Add(1,
+                        new KeyValuePair<string, object?>("call_site", "gtd.expired"));
+                    _logger?.LogWarning(ex,
+                        "WAL backpressure appending OrderExpiredEvent for {ClOrdId}; retrying with backoff.",
+                        clOrdId);
+                    MetricsRegistry.GtdOrdersExpired.Add(1,
+                        new KeyValuePair<string, object?>("cancel_result", "WalBackpressureRetry"));
+                    ReArmRetry(clOrdId);
+                    return;
+                }
+
+                // Persist the audit-appended flag so a subsequent
+                // backpressure on the cancel side doesn't double-emit
+                // OrderExpiredEvent on retry.
+                lock (_lock)
+                {
+                    if (_index.TryGetValue(clOrdId, out var cur))
+                        cur.ExpiredAuditAppended = true;
+                }
+            }
+
+            // 2) Issue the cancel through the regular pipeline.
             var result = await _cancel.CancelAsync(order.Owner, clOrdId, CancellationToken.None)
                 .ConfigureAwait(false);
+
+            if (result.Kind == OrderCancelResultKind.WalBackpressure)
+            {
+                _logger?.LogWarning(
+                    "WAL backpressure on CancelAsync for GTD-expired {ClOrdId}; retrying with backoff.",
+                    clOrdId);
+                MetricsRegistry.GtdOrdersExpired.Add(1,
+                    new KeyValuePair<string, object?>("cancel_result", result.Kind.ToString()));
+                ReArmRetry(clOrdId);
+                return;
+            }
+
+            // Terminal outcome (Accepted / NotFound / Stale /
+            // GatewayFailed): drop the entry. NotFound covers the race
+            // where OnOrderTerminal already cleaned up but Resolve is
+            // still safe (Dictionary.Remove is no-op on missing key).
+            Resolve(clOrdId);
 
             // WS projection: emit a synthetic Expired ExecutionEvent so
             // subscribers see kind=Expired alongside the regular
@@ -325,7 +505,7 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
                     LastQuantity: 0,
                     LastPrice: 0m,
                     RejectReason: ReasonGtd,
-                    TimestampUtc: atUtc));
+                    TimestampUtc: originalGtd));
             }
             catch (Exception ex)
             {

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -1,0 +1,394 @@
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application.Scheduling;
+
+/// <summary>
+/// Q1.3 (#255). Min-heap scheduler that fires a per-order cancel
+/// when an <see cref="Order.GoodTillDate"/> elapses, for orders with
+/// <see cref="TimeInForce.GTD"/> in non-terminal status.
+///
+/// <para>
+/// <b>Heap.</b> A <see cref="PriorityQueue{TElement,TPriority}"/> keyed
+/// by <c>ClOrdId</c> with <c>GoodTillDate</c> as the priority. A
+/// companion <see cref="_index"/> dictionary stores the live expiry
+/// for each tracked order so cancel/replace/terminal events do
+/// "lazy" removal (the heap entry stays in place; the index either
+/// no longer carries it or carries a different priority, and the
+/// entry is dropped from the head on the next peek). This avoids
+/// the O(n) cost of removing arbitrary entries from a heap and
+/// matches the well-known dijkstra-style pattern.
+/// </para>
+///
+/// <para>
+/// <b>Timer.</b> A single <see cref="ITimer"/> fired off
+/// <see cref="TimeProvider.CreateTimer"/> drives the head expiry; on
+/// every heap mutation we recompute the head and re-arm the timer for
+/// the new head's <c>expiry - now</c> (with a 1ms safety floor so
+/// past-due heads still complete one OS scheduling round-trip).
+/// Tests pin the clock with <c>FakeTimeProvider</c>.
+/// </para>
+///
+/// <para>
+/// <b>Dispatcher seam.</b> When the timer fires, the scheduler drains
+/// every entry whose expiry is <c>&lt;= now</c> and dispatches each one
+/// onto the .NET thread-pool via <see cref="Task.Run(Func{Task})"/>.
+/// The actual cancel goes through the regular
+/// <see cref="OrderCancelService.CancelAsync"/> pipeline — same WAL
+/// append, same gateway dispatch, same fan-out to the WS sink as a
+/// user-initiated cancel. After the cancel is accepted, the scheduler
+/// also appends an <see cref="OrderExpiredEvent"/> to the WAL and
+/// publishes a synthetic <see cref="ExecutionEvent"/> with
+/// <see cref="ExecKind.Expired"/> so WS subscribers can distinguish a
+/// policy-driven expiry from a venue-initiated cancel.
+/// </para>
+///
+/// <para>
+/// <b>Cold-start replay.</b> On <see cref="StartAsync"/> the scheduler
+/// scans <see cref="WorkingOrderBook"/> for every non-terminal,
+/// non-stale GTD order and re-inserts it into the heap. Orders whose
+/// expiry already elapsed during the host's downtime fire immediately
+/// with <c>AtUtc = order.GoodTillDate</c> (the original expiry) so the
+/// audit trail reflects the true policy boundary rather than the
+/// post-restart wall clock.
+/// </para>
+///
+/// <para>
+/// <b>Replay/snapshot interaction.</b> <see cref="OrderExpiredEvent"/>
+/// is informational only: the downstream <c>Canceled</c> ER (also on
+/// the WAL, produced by the cancel pipeline) is what mutates the
+/// order's status. Re-running the scheduler at boot can therefore
+/// re-emit a duplicate <c>OrderExpiredEvent</c> for an order whose
+/// cancel ER is on the WAL — but the duplicate is harmless because
+/// (a) the order is already terminal so the
+/// <see cref="OrderCancelService"/> short-circuits with
+/// <c>NotFound</c> at the book lookup, and (b) the projection is a
+/// pure audit ping. Bootstrapping ordering is preserved by
+/// <c>TradingHostStartup.RunRecoveryAndSeedingAsync</c> which awaits
+/// recovery before <c>app.Run()</c> starts hosted services.
+/// </para>
+/// </summary>
+public sealed class GtdExpirationScheduler : IHostedService, IDisposable
+{
+    /// <summary>
+    /// Minimum delay handed to <see cref="ITimer.Change(TimeSpan, TimeSpan)"/>
+    /// for a head whose expiry is already past. One millisecond is the
+    /// finest grain the .NET timer round-trips with reasonable
+    /// determinism on commodity OS schedulers, and it forces the
+    /// drain to happen on the timer's worker thread rather than
+    /// inline under the caller's lock-acquisition path.
+    /// </summary>
+    public static readonly TimeSpan MinTimerFloor = TimeSpan.FromMilliseconds(1);
+
+    /// <summary>
+    /// Maximum delay handed to <see cref="ITimer.Change(TimeSpan, TimeSpan)"/>.
+    /// The CLR's underlying <c>TimerQueue</c> rejects any due time above
+    /// <c>uint.MaxValue - 1</c> milliseconds (~49.7 days). GTD orders can
+    /// legally carry expiries weeks or months out (per <c>RiskOptions</c>
+    /// the configured horizon defaults to 30 days but can be larger).
+    /// We therefore cap the timer at a far smaller "poll" interval and
+    /// rely on <see cref="OnTimer"/> to re-arm with the (now smaller)
+    /// remaining-until-head delay each time it fires. This keeps
+    /// behaviour identical for short expiries while making the scheduler
+    /// safe for arbitrarily long ones.
+    /// </summary>
+    public static readonly TimeSpan MaxTimerPoll = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Free-text reason carried on <see cref="OrderExpiredEvent.Reason"/>
+    /// + the synthetic <c>ExecutionEvent.RejectReason</c> when the
+    /// trigger is a GTD expiry. Stable wire format (string, not
+    /// enum) so future trigger types — e.g. auction-expired GFA —
+    /// can be added additively without breaking old WAL replays.
+    /// </summary>
+    public const string ReasonGtd = "Gtd";
+
+    private readonly object _lock = new();
+    private readonly PriorityQueue<ulong, DateTimeOffset> _heap = new();
+    private readonly Dictionary<ulong, DateTimeOffset> _index = new();
+    private readonly WorkingOrderBook _book;
+    private readonly OrderCancelService _cancel;
+    private readonly EventDispatcher _dispatcher;
+    private readonly IExecutionEventSink _sink;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<GtdExpirationScheduler>? _logger;
+
+    private ITimer? _timer;
+    private DateTimeOffset _scheduledFor = DateTimeOffset.MaxValue;
+    private bool _replayed;
+
+    public GtdExpirationScheduler(
+        WorkingOrderBook book,
+        OrderCancelService cancel,
+        EventDispatcher dispatcher,
+        IExecutionEventSink sink,
+        TimeProvider? clock = null,
+        ILogger<GtdExpirationScheduler>? logger = null)
+    {
+        _book = book ?? throw new ArgumentNullException(nameof(book));
+        _cancel = cancel ?? throw new ArgumentNullException(nameof(cancel));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _sink = sink ?? new NoOpExecutionEventSink();
+        _clock = clock ?? TimeProvider.System;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Number of live (non-tombstoned) entries currently tracked.
+    /// Test/diagnostic surface only.
+    /// </summary>
+    public int TrackedCount
+    {
+        get { lock (_lock) return _index.Count; }
+    }
+
+    /// <summary>
+    /// Hook called from the live submit path
+    /// (<c>OrderSubmissionService</c>) and from the replacement-order
+    /// hydration path (<c>ExecutionReportProcessor</c>) once the
+    /// new <see cref="Order"/> is in <see cref="WorkingOrderBook"/>.
+    /// No-ops for non-GTD orders so callers don't have to re-check the
+    /// invariant. Idempotent: re-tracking the same <c>ClOrdId</c>
+    /// updates the priority and re-arms the timer (used by future
+    /// modify flows that mutate <c>GoodTillDate</c> in place).
+    /// </summary>
+    public void OnOrderTracked(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        if (order.TimeInForce != TimeInForce.GTD) return;
+        if (order.GoodTillDate is not { } gtd) return;
+        if (IsTerminal(order.Status)) return;
+        Schedule(order.ClOrdId, gtd);
+    }
+
+    /// <summary>
+    /// Hook called from <c>ExecutionReportProcessor</c> on every
+    /// terminal ER (<see cref="ExecKind.Canceled"/>,
+    /// <see cref="ExecKind.Fill"/>, <see cref="ExecKind.Rejected"/>,
+    /// <see cref="ExecKind.Replaced"/>) so a tracked GTD order whose
+    /// venue lifecycle ended early — fill, user cancel, native STP,
+    /// reject — drops out of the heap before its expiry would have
+    /// triggered another (harmless but noisy) cancel attempt.
+    /// </summary>
+    public void OnOrderTerminal(ulong clOrdId)
+    {
+        Remove(clOrdId);
+    }
+
+    private void Schedule(ulong clOrdId, DateTimeOffset expiry)
+    {
+        lock (_lock)
+        {
+            _index[clOrdId] = expiry;
+            _heap.Enqueue(clOrdId, expiry);
+            Reschedule_NoLock();
+        }
+    }
+
+    private void Remove(ulong clOrdId)
+    {
+        lock (_lock)
+        {
+            if (_index.Remove(clOrdId))
+                Reschedule_NoLock();
+        }
+    }
+
+    private void Reschedule_NoLock()
+    {
+        // Drop tombstoned heads (entries whose live priority no longer
+        // matches the heap-recorded one — either they were removed or
+        // re-scheduled with a different expiry).
+        while (_heap.TryPeek(out var topId, out var topExpiry))
+        {
+            if (_index.TryGetValue(topId, out var liveExpiry) && liveExpiry == topExpiry)
+                break;
+            _heap.Dequeue();
+        }
+
+        if (!_heap.TryPeek(out _, out var headExpiry))
+        {
+            _scheduledFor = DateTimeOffset.MaxValue;
+            _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            return;
+        }
+
+        if (_scheduledFor == headExpiry && _timer is not null) return;
+
+        var now = _clock.GetUtcNow();
+        var due = headExpiry - now;
+        if (due < MinTimerFloor) due = MinTimerFloor;
+        if (due > MaxTimerPoll) due = MaxTimerPoll;
+
+        _scheduledFor = headExpiry;
+        if (_timer is null)
+            _timer = _clock.CreateTimer(static s => ((GtdExpirationScheduler)s!).OnTimer(), this, due, Timeout.InfiniteTimeSpan);
+        else
+            _timer.Change(due, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnTimer()
+    {
+        List<(ulong ClOrdId, DateTimeOffset Expiry)>? batch = null;
+        lock (_lock)
+        {
+            var now = _clock.GetUtcNow();
+            while (_heap.TryPeek(out var topId, out var topExpiry))
+            {
+                if (!_index.TryGetValue(topId, out var liveExpiry) || liveExpiry != topExpiry)
+                {
+                    _heap.Dequeue();
+                    continue;
+                }
+                if (topExpiry > now) break;
+
+                _heap.Dequeue();
+                _index.Remove(topId);
+                (batch ??= new()).Add((topId, topExpiry));
+            }
+            // Force re-arm: zero out _scheduledFor so the next
+            // Reschedule_NoLock recomputes against the new head.
+            _scheduledFor = DateTimeOffset.MaxValue;
+            Reschedule_NoLock();
+        }
+
+        if (batch is null) return;
+        foreach (var entry in batch)
+        {
+            // Dispatch each cancel onto the thread-pool. The cancel
+            // pipeline serialises its WAL write through the dispatcher
+            // lock, so concurrent expiries cannot interleave WAL
+            // appends — same posture as user-initiated cancels racing
+            // each other through the REST endpoint.
+            _ = Task.Run(() => DispatchExpireAsync(entry.ClOrdId, entry.Expiry));
+        }
+    }
+
+    private async Task DispatchExpireAsync(ulong clOrdId, DateTimeOffset atUtc)
+    {
+        try
+        {
+            if (!_book.TryGet(clOrdId, out var order) || order is null)
+                return;
+            if (IsTerminal(order.Status))
+                return;
+
+            var result = await _cancel.CancelAsync(order.Owner, clOrdId, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Whatever the cancel outcome (Accepted / GatewayFailed /
+            // Stale / NotFound / WalBackpressure), append the audit
+            // envelope so operators can tell the heap actually fired.
+            // The downstream venue Canceled ER is what flips order
+            // status; this event is informational only.
+            try
+            {
+                _dispatcher.Dispatch(
+                    new OrderExpiredEvent
+                    {
+                        ClOrdId = clOrdId,
+                        Reason = ReasonGtd,
+                        AtUtc = atUtc,
+                    },
+                    static () => { /* no in-memory mutation; audit-only */ });
+            }
+            catch (WalBackpressureException ex)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "gtd.expired"));
+                _logger?.LogWarning(ex,
+                    "WAL backpressure appending OrderExpiredEvent for {ClOrdId}; cancel already requested.",
+                    clOrdId);
+            }
+
+            // WS projection: emit a synthetic Expired ExecutionEvent so
+            // subscribers see kind=Expired alongside the regular
+            // kind=Canceled. Off-lock and best-effort — the WAL audit
+            // record is the durable state.
+            try
+            {
+                _sink.Publish(new ExecutionEvent(
+                    Owner: order.Owner,
+                    ClOrdId: clOrdId,
+                    Symbol: order.Symbol,
+                    Side: order.Side,
+                    Status: order.Status,
+                    Kind: ExecKind.Expired,
+                    LeavesQuantity: order.LeavesQuantity,
+                    CumulativeQuantity: order.CumulativeQuantity,
+                    LastQuantity: 0,
+                    LastPrice: 0m,
+                    RejectReason: ReasonGtd,
+                    TimestampUtc: atUtc));
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogDebug(ex,
+                    "Failed to publish synthetic Expired ExecutionEvent for {ClOrdId}; ignoring.",
+                    clOrdId);
+            }
+
+            MetricsRegistry.GtdOrdersExpired.Add(1,
+                new KeyValuePair<string, object?>("cancel_result", result.Kind.ToString()));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex,
+                "Unhandled error dispatching GTD expiry for {ClOrdId}.", clOrdId);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_replayed) return Task.CompletedTask;
+        _replayed = true;
+
+        // Cold-start replay: every non-terminal GTD order in the book
+        // (post WAL replay + snapshot restore) gets seeded into the
+        // heap. Past-due entries fire immediately with AtUtc set to
+        // the original expiry, so the audit trail reflects the policy
+        // boundary not the post-restart wall clock.
+        // EnumerateForFirm is per-firm; the book has no "all firms"
+        // enumerator, so iterate the snapshot which covers everything.
+        var seeded = 0;
+        foreach (var snap in _book.Snapshot())
+        {
+            if (snap.TimeInForce != nameof(TimeInForce.GTD)) continue;
+            if (snap.GoodTillDate is not { } gtd) continue;
+            if (!Enum.TryParse<OrderStatus>(snap.Status, out var status)) continue;
+            if (IsTerminal(status)) continue;
+            Schedule(snap.ClOrdId, gtd);
+            seeded++;
+        }
+        _logger?.LogInformation(
+            "GtdExpirationScheduler started: seeded {Count} GTD order(s) from book snapshot.",
+            seeded);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        ITimer? t;
+        lock (_lock) { t = _timer; _timer = null; }
+        t?.Dispose();
+    }
+
+    private static bool IsTerminal(OrderStatus s) =>
+        s is OrderStatus.Filled or OrderStatus.Cancelled
+          or OrderStatus.Rejected or OrderStatus.Replaced;
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -89,6 +89,17 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<OrderCancelService>();
         services.AddSingleton<OrderModifyService>();
 
+        // Q1.3 (#255). GTD expiration scheduler. Registered as both a
+        // singleton (so OrderSubmissionService + ExecutionReportProcessor
+        // can take an optional ctor dependency on it) AND as a hosted
+        // service (so its StartAsync runs after WAL recovery has
+        // populated WorkingOrderBook — RunRecoveryAndSeedingAsync
+        // awaits before app.Run, IHostedService.StartAsync runs at
+        // app.Run).
+        services.AddSingleton<B3.Trading.Application.Scheduling.GtdExpirationScheduler>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.Scheduling.GtdExpirationScheduler>());
+
         // Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).
         // In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the
         // Iceberg state machine; slice 6 adds the AlgoScheduler hosted service that

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -29,6 +29,16 @@ public sealed class StateSnapshotter
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
     private readonly IUserBotOrderMappingRegistry? _userBotMappings;
+    /// <summary>
+    /// Pass-4 review (#255). Optional. When wired (production
+    /// composition includes the GTD scheduler), <see cref="CaptureRaw"/>
+    /// snapshots the scheduler's in-flight audited-expired set under
+    /// the dispatcher lock and <see cref="Restore"/> re-marks every id
+    /// before WAL replay begins, closing the snapshot-mid-fire window
+    /// where an audit envelope was on disk at <c>seq &lt;= snap.Seq</c>
+    /// but the order was still working in the snapshot.
+    /// </summary>
+    private readonly GtdExpirationScheduler? _gtdScheduler;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -43,7 +53,8 @@ public sealed class StateSnapshotter
         CashLedger cash,
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
         InMemoryUserBotSessionRegistry? userBotSessions = null,
-        IUserBotOrderMappingRegistry? userBotMappings = null)
+        IUserBotOrderMappingRegistry? userBotMappings = null,
+        GtdExpirationScheduler? gtdScheduler = null)
     {
         _orders = orders;
         _positions = positions;
@@ -58,6 +69,7 @@ public sealed class StateSnapshotter
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
+        _gtdScheduler = gtdScheduler;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -102,6 +114,7 @@ public sealed class StateSnapshotter
         BotSessions = _userBotSessions?.RawSnapshot() ?? Array.Empty<BotSessionState>(),
         BotOrderMappings = _userBotMappings?.RawSnapshotOrders() ?? Array.Empty<BotOrderMappingRaw>(),
         BotCancelMappings = _userBotMappings?.RawSnapshotCancels() ?? Array.Empty<BotCancelMappingRaw>(),
+        AuditedExpiredIds = _gtdScheduler?.SnapshotAuditedExpiredIds() ?? Array.Empty<ulong>(),
     };
 
     /// <summary>
@@ -248,6 +261,7 @@ public sealed class StateSnapshotter
             BotSessions = sessions,
             BotOrderMappings = botOrderMaps,
             BotCancelMappings = botCancelMaps,
+            AuditedExpiredIds = raw.AuditedExpiredIds,
         };
     }
 
@@ -273,6 +287,16 @@ public sealed class StateSnapshotter
         _userBotCredentials?.Restore(snap.UserBotCredentials);
         _userBotSessions?.Restore(snap.BotSessions);
         _userBotMappings?.Restore(snap.BotOrderMappings, snap.BotCancelMappings);
+        // Pass-4 review (#255). Re-mark the in-flight audit-set BEFORE
+        // WAL replay starts (PersistenceRecovery calls Restore then
+        // ReadFromAsync). EventReplayer.Apply(OrderExpiredEvent) for
+        // events past snap.Seq also calls MarkExpiredAuditAppended;
+        // both writers are HashSet.Add so the operation is idempotent.
+        if (_gtdScheduler is not null && snap.AuditedExpiredIds is { Count: > 0 })
+        {
+            foreach (var id in snap.AuditedExpiredIds)
+                _gtdScheduler.MarkExpiredAuditAppended(id);
+        }
     }
 }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -1,6 +1,7 @@
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.Scheduling;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 
@@ -297,6 +298,21 @@ public sealed class EventReplayer
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
     private readonly IUserBotOrderMappingRegistry? _userBotMappings;
+    /// <summary>
+    /// Pass-3 review (#255). Optional. When wired (production
+    /// composition includes the GTD scheduler), every replayed
+    /// <see cref="OrderExpiredEvent"/> calls
+    /// <see cref="GtdExpirationScheduler.MarkExpiredAuditAppended"/>
+    /// so the scheduler's cold-start <see cref="GtdExpirationScheduler.StartAsync"/>
+    /// seeds surviving GTD orders' <c>Entry.ExpiredAuditAppended</c>
+    /// to <c>true</c>, preventing a duplicate audit envelope when a
+    /// crash landed between OrderExpiredEvent append and
+    /// OrderCancelRequestedEvent append. Order matters:
+    /// <c>RunRecoveryAndSeedingAsync</c> drains the WAL via this
+    /// replayer BEFORE <c>app.Run()</c> kicks off the scheduler's
+    /// hosted-service <c>StartAsync</c>.
+    /// </summary>
+    private readonly GtdExpirationScheduler? _gtdScheduler;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -311,7 +327,8 @@ public sealed class EventReplayer
         PendingReplacementRegistry? replacements = null,
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
         InMemoryUserBotSessionRegistry? userBotSessions = null,
-        IUserBotOrderMappingRegistry? userBotMappings = null)
+        IUserBotOrderMappingRegistry? userBotMappings = null,
+        GtdExpirationScheduler? gtdScheduler = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -326,6 +343,7 @@ public sealed class EventReplayer
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
+        _gtdScheduler = gtdScheduler;
     }
 
     public void Apply(WalEvent evt)
@@ -508,6 +526,17 @@ public sealed class EventReplayer
                 break;
             case BotSessionSeqAdvancedEvent bss:
                 _userBotSessions?.ApplyCheckpointedSeq(bss.CredentialId, bss.CheckpointedOutboundSeq);
+                break;
+            case OrderExpiredEvent oe:
+                // Pass-3 review (#255). The audit envelope itself is a
+                // no-op for in-memory state — the downstream Canceled ER
+                // (also on the WAL) drives the order's terminal
+                // transition. But we MUST inform the GTD scheduler that
+                // this audit is durably on disk so its cold-start
+                // Schedule() does not re-emit a duplicate when the
+                // pre-crash cancel ER never landed. Null-tolerant for
+                // compositions / tests that don't wire a scheduler.
+                _gtdScheduler?.MarkExpiredAuditAppended(oe.ClOrdId);
                 break;
         }
     }

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdExpirationSchedulerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdExpirationSchedulerTests.cs
@@ -1,0 +1,310 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Scheduling;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Scheduling;
+
+/// <summary>
+/// Q1.3 (#255). Behavioural coverage for the GTD expiration scheduler:
+/// timer fires, lazy heap removal on cancel/replace, cold-start replay
+/// from book snapshot, and the synthetic Expired ExecutionEvent.
+///
+/// <para>
+/// Tests pin the clock with a virtual <see cref="VirtualTimeProvider"/>
+/// that schedules timer callbacks against a software queue; advancing
+/// time fires every callback whose due time has elapsed. This keeps
+/// the suite deterministic — no Thread.Sleep, no flakiness on
+/// wall-clock granularity.
+/// </para>
+/// </summary>
+public class GtdExpirationSchedulerTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    private sealed class RecordingGateway : IExchangeGateway
+    {
+        public List<string> Calls { get; } = new();
+
+        public Task SubmitAsync(Order order, CancellationToken ct) => Task.CompletedTask;
+
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct)
+        {
+            lock (Calls) Calls.Add($"cancel:{order.ClOrdId}->{newClOrdId}");
+            return Task.CompletedTask;
+        }
+
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice, DateTimeOffset? requestedGoodTillDate,
+            CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class CapturingSink : IExecutionEventSink
+    {
+        public List<ExecutionEvent> Events { get; } = new();
+        public void Publish(ExecutionEvent ev)
+        {
+            lock (Events) Events.Add(ev);
+        }
+    }
+
+    private sealed class Harness
+    {
+        public VirtualTimeProvider Clock { get; } = new(DateTimeOffset.Parse("2025-01-01T12:00:00Z"));
+        public WorkingOrderBook Book { get; } = new();
+        public OrderOwnershipMap Ownership { get; } = new();
+        public ClOrdIdPrefixRegistry ClOrdIds { get; } = new();
+        public EventDispatcher Dispatcher { get; } = new(new NullEventStore());
+        public RecordingGateway Gateway { get; } = new();
+        public CapturingSink Sink { get; } = new();
+        public OrderCancelService Cancel { get; }
+        public GtdExpirationScheduler Sut { get; }
+
+        public Harness()
+        {
+            Cancel = new OrderCancelService(
+                ClOrdIds, Ownership, Book, Gateway, Dispatcher,
+                NullLogger<OrderCancelService>.Instance);
+            Sut = new GtdExpirationScheduler(
+                Book, Cancel, Dispatcher, Sink, Clock, NullLogger<GtdExpirationScheduler>.Instance);
+        }
+
+        public Order SeedGtd(ulong clOrdId, DateTimeOffset gtd)
+        {
+            var o = new Order(
+                clOrdId, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+                100, 30m, timeInForce: TimeInForce.GTD, goodTillDate: gtd);
+            Assert.True(Book.TryAdd(o));
+            Ownership.Register(clOrdId, Alice);
+            return o;
+        }
+
+        public async Task DrainDispatchedAsync(int expectedCancels = 1)
+        {
+            // The scheduler's OnTimer dispatches via Task.Run; spin
+            // briefly to let the cancel attempt land on the recording
+            // gateway. 2s upper bound keeps the suite snappy.
+            for (int i = 0; i < 200 && (Gateway.Calls.Count < expectedCancels || Sink.Events.Count < expectedCancels); i++)
+                await Task.Delay(10);
+        }
+    }
+
+    [Fact]
+    public async Task GtdOrder_ExpiresAfterDelay_TriggersCancelAndExpiredEvent()
+    {
+        var h = new Harness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(5);
+        h.SeedGtd(1UL, gtd);
+        await h.Sut.StartAsync(CancellationToken.None);
+        Assert.Equal(1, h.Sut.TrackedCount);
+
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        await h.DrainDispatchedAsync();
+
+        Assert.Single(h.Gateway.Calls);
+        Assert.StartsWith("cancel:1->", h.Gateway.Calls[0]);
+        Assert.Contains(h.Sink.Events, e => e.ClOrdId == 1UL && e.Kind == ExecKind.Expired);
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    [Fact]
+    public async Task TerminalBeforeExpiry_RemovesFromHeap_NoCancel()
+    {
+        var h = new Harness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(10);
+        var o = h.SeedGtd(2UL, gtd);
+        h.Sut.OnOrderTracked(o);
+        Assert.Equal(1, h.Sut.TrackedCount);
+
+        h.Sut.OnOrderTerminal(2UL);
+        Assert.Equal(0, h.Sut.TrackedCount);
+
+        h.Clock.Advance(TimeSpan.FromSeconds(20));
+        await Task.Delay(50);
+
+        Assert.Empty(h.Gateway.Calls);
+        Assert.DoesNotContain(h.Sink.Events, e => e.Kind == ExecKind.Expired);
+    }
+
+    [Fact]
+    public async Task RetrackingWithEarlierExpiry_ReschedulesTimer()
+    {
+        var h = new Harness();
+        var first = h.Clock.GetUtcNow().AddMinutes(30);
+        var o = h.SeedGtd(3UL, first);
+        h.Sut.OnOrderTracked(o);
+
+        // Replace path hydrates a new Order with a sooner GoodTillDate.
+        // The original entry tombstones; the new live entry wins.
+        var replacement = new Order(
+            3UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, timeInForce: TimeInForce.GTD,
+            goodTillDate: h.Clock.GetUtcNow().AddSeconds(2));
+        h.Sut.OnOrderTracked(replacement);
+
+        h.Clock.Advance(TimeSpan.FromSeconds(2));
+        await h.DrainDispatchedAsync();
+
+        Assert.Single(h.Gateway.Calls);
+        Assert.StartsWith("cancel:3->", h.Gateway.Calls[0]);
+    }
+
+    [Fact]
+    public async Task ColdStart_PastDueGtd_FiresImmediatelyWithOriginalAtUtc()
+    {
+        var h = new Harness();
+        var pastExpiry = h.Clock.GetUtcNow().AddSeconds(-30);
+        h.SeedGtd(4UL, pastExpiry);
+
+        await h.Sut.StartAsync(CancellationToken.None);
+        // Past-due head sits at MinTimerFloor due time; advance just
+        // enough to fire it.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(2));
+        await h.DrainDispatchedAsync();
+
+        Assert.Single(h.Gateway.Calls);
+        var expired = Assert.Single(h.Sink.Events, e => e.Kind == ExecKind.Expired);
+        Assert.Equal(pastExpiry, expired.TimestampUtc);
+    }
+
+    [Fact]
+    public async Task NonGtdOrder_IsIgnored()
+    {
+        var h = new Harness();
+        var day = new Order(5UL, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m);
+        Assert.True(h.Book.TryAdd(day));
+        h.Sut.OnOrderTracked(day);
+
+        Assert.Equal(0, h.Sut.TrackedCount);
+        h.Clock.Advance(TimeSpan.FromHours(1));
+        await Task.Delay(20);
+        Assert.Empty(h.Gateway.Calls);
+    }
+
+    [Fact]
+    public async Task ManyOrders_FireBeforeAdvanceCompletes()
+    {
+        var h = new Harness();
+        var rng = new Random(42);
+        for (ulong id = 1; id <= 100; id++)
+        {
+            var gtd = h.Clock.GetUtcNow().AddSeconds(rng.Next(1, 60));
+            var o = h.SeedGtd(id, gtd);
+            h.Sut.OnOrderTracked(o);
+        }
+        Assert.Equal(100, h.Sut.TrackedCount);
+
+        h.Clock.Advance(TimeSpan.FromSeconds(60));
+        for (int i = 0; i < 600 && h.Gateway.Calls.Count < 100; i++)
+            await Task.Delay(10);
+
+        Assert.Equal(100, h.Gateway.Calls.Count);
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    [Fact]
+    public async Task LongHorizonGtd_DoesNotCrashTimer()
+    {
+        // Regression: TimeProvider.CreateTimer rejects dueTime above
+        // ~49.7 days. The scheduler must clamp to MaxTimerPoll and
+        // re-arm later — ArgumentOutOfRangeException would crash the
+        // submit pipeline (was a 500 in the API).
+        var h = new Harness();
+        var gtd = h.Clock.GetUtcNow().AddDays(60);
+        var o = h.SeedGtd(6UL, gtd);
+        h.Sut.OnOrderTracked(o);
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        Assert.Equal(1, h.Sut.TrackedCount);
+        Assert.Empty(h.Gateway.Calls);
+    }
+
+    /// <summary>
+    /// Minimal virtual-time TimeProvider with a software timer queue
+    /// sufficient for the scheduler under test (which only ever holds
+    /// one ITimer at a time). <c>CreateTimer</c> registers the
+    /// callback in <see cref="_timers"/>; <c>Advance</c> walks forward
+    /// in time and fires every timer whose absolute due time is
+    /// reached (callback re-arming via <c>Change</c> is honoured for
+    /// the loop's next iteration).
+    /// </summary>
+    private sealed class VirtualTimeProvider : TimeProvider
+    {
+        private readonly object _lock = new();
+        private DateTimeOffset _now;
+        private readonly List<VTimer> _timers = new();
+
+        public VirtualTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() { lock (_lock) return _now; }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var t = new VTimer(this, callback, state);
+            t.Change(dueTime, period);
+            return t;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            var deadline = Now + delta;
+            while (true)
+            {
+                VTimer? next = null;
+                lock (_lock)
+                {
+                    foreach (var t in _timers)
+                    {
+                        if (t.DueAt is { } d && d <= deadline)
+                        {
+                            if (next is null || d < next.DueAt) next = t;
+                        }
+                    }
+                }
+                if (next is null)
+                {
+                    lock (_lock) _now = deadline;
+                    return;
+                }
+                lock (_lock) _now = next.DueAt!.Value;
+                next.Fire();
+            }
+        }
+
+        internal void Register(VTimer t) { lock (_lock) _timers.Add(t); }
+        internal void Unregister(VTimer t) { lock (_lock) _timers.Remove(t); }
+        internal DateTimeOffset Now { get { lock (_lock) return _now; } }
+    }
+
+    private sealed class VTimer : ITimer
+    {
+        private readonly VirtualTimeProvider _owner;
+        private readonly TimerCallback _cb;
+        private readonly object? _state;
+        public DateTimeOffset? DueAt { get; private set; }
+
+        public VTimer(VirtualTimeProvider owner, TimerCallback cb, object? state)
+        {
+            _owner = owner; _cb = cb; _state = state;
+            _owner.Register(this);
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            DueAt = dueTime == Timeout.InfiniteTimeSpan ? null : _owner.Now + dueTime;
+            return true;
+        }
+
+        public void Fire()
+        {
+            DueAt = null;
+            _cb(_state);
+        }
+
+        public void Dispose() => _owner.Unregister(this);
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
@@ -398,6 +398,175 @@ public class GtdSchedulerRegressionTests
     }
 
     // -----------------------------------------------------------------
+    // Pass-4 review (#255): durable audit-set in PlatformSnapshot
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Pass-4 P1 — when SnapshotService takes a snapshot mid-fire
+    /// (between <c>OrderExpiredEvent</c> append and the cancel
+    /// append), the snapshot's seq is past the audit event but the
+    /// order is still in working state in the captured book. The
+    /// snapshot MUST carry the ClOrdId in its
+    /// <c>AuditedExpiredIds</c> so the post-restart timer fire does
+    /// not emit a duplicate audit envelope. Once the cancel resolves
+    /// the id must be evicted so the set stays bounded by the
+    /// in-flight expired-but-cancel-not-completed window.
+    /// </summary>
+    [Fact]
+    public async Task SnapshotMidFire_PersistsAuditedExpiredIds_AndEvictsAfterResolve()
+    {
+        var h = new ExpireHarness();
+        var pastGtd = h.Clock.GetUtcNow().AddSeconds(-1);
+        h.SeedGtd(42UL, pastGtd);
+
+        // Wire a snapshotter against the harness so we can capture
+        // the same way SnapshotService does in production (under
+        // dispatcher lock via WithSnapshotLock).
+        var snapshotter = new StateSnapshotter(
+            h.Book, new PositionKeeper(), new KillSwitchService(),
+            new SymbolHaltService(), new SessionPhaseService(),
+            h.ClOrdIds, h.Ownership, new AlgoBook(), new AlgoIdRegistry(),
+            new CashLedger(), gtdScheduler: h.Sut);
+
+        await h.Sut.StartAsync(CancellationToken.None);
+        h.Store.Reset();
+
+        // Force a single WAL backpressure on the cancel side so the
+        // dispatch is parked in the post-audit / pre-cancel window
+        // when we take the snapshot — modelling the exact race the
+        // pass-4 fix targets.
+        h.Store.BackpressureFor<OrderCancelRequestedEvent>(1);
+
+        // Past-due head fires immediately; wait for the audit event to land.
+        h.Clock.Advance(GtdExpirationScheduler.MinTimerFloor + TimeSpan.FromMilliseconds(5));
+        for (int i = 0; i < 200 && h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)) == 0; i++)
+            await Task.Delay(10);
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        // Cancel was rejected → still tracked, awaiting backoff retry.
+        for (int i = 0; i < 200 && h.Sut.TrackedCount == 0; i++)
+            await Task.Delay(10);
+        Assert.Equal(1, h.Sut.TrackedCount);
+
+        // Take snapshot under the dispatcher lock — same as SnapshotService.
+        PlatformSnapshot? snap = null;
+        h.Dispatcher.WithSnapshotLock(seq =>
+            snap = StateSnapshotter.Project(snapshotter.CaptureRaw(seq)));
+        Assert.NotNull(snap);
+        Assert.Contains(42UL, snap!.AuditedExpiredIds);
+
+        // Drain the backoff and let the cancel succeed.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(110));
+        for (int i = 0; i < 200 && h.Sut.TrackedCount > 0; i++)
+            await Task.Delay(10);
+        Assert.Equal(0, h.Sut.TrackedCount);
+
+        // SECOND snapshot after resolve — id must be gone so the set
+        // does not grow unbounded across snapshot cycles.
+        PlatformSnapshot? snap2 = null;
+        h.Dispatcher.WithSnapshotLock(seq =>
+            snap2 = StateSnapshotter.Project(snapshotter.CaptureRaw(seq)));
+        Assert.NotNull(snap2);
+        Assert.DoesNotContain(42UL, snap2!.AuditedExpiredIds);
+    }
+
+    /// <summary>
+    /// Pass-4 P1 — restart from a snapshot that contains
+    /// <c>AuditedExpiredIds=[42]</c> AND a still-working past-due GTD
+    /// order with <c>ClOrdId=42</c>. The WAL has the audit event at
+    /// <c>seq &lt;= snap.Seq</c> (so replay does NOT re-call
+    /// <see cref="GtdExpirationScheduler.MarkExpiredAuditAppended"/>).
+    /// Without the snapshot-side restore the post-restart timer would
+    /// re-append OrderExpiredEvent. Asserts the cancel still happens
+    /// and zero new audit envelopes are written.
+    /// </summary>
+    [Fact]
+    public async Task RestartFromSnapshotWithAuditedSet_NoDuplicateAuditEvent()
+    {
+        var h = new ExpireHarness();
+        var pastGtd = h.Clock.GetUtcNow().AddSeconds(-5);
+
+        var snapshotter = new StateSnapshotter(
+            h.Book, new PositionKeeper(), new KillSwitchService(),
+            new SymbolHaltService(), new SessionPhaseService(),
+            h.ClOrdIds, h.Ownership, new AlgoBook(), new AlgoIdRegistry(),
+            new CashLedger(), gtdScheduler: h.Sut);
+
+        // Build a fixture snapshot directly: working past-due GTD order
+        // 42 in the book, owner mapping registered, AuditedExpiredIds
+        // carries 42 (modelling the snapshot-mid-fire crash).
+        var fixtureSnap = new PlatformSnapshot
+        {
+            Seq = 5L,
+            CreatedAtUtc = h.Clock.GetUtcNow(),
+            WorkingOrders = new List<OrderSnapshot>
+            {
+                new(42UL, Alice.Value, "PETR4", 4321UL, nameof(OrderSide.Buy),
+                    nameof(OrderType.Limit), 100, 30m,
+                    LeavesQuantity: 100, CumulativeQuantity: 0,
+                    Status: nameof(OrderStatus.Working))
+                {
+                    TimeInForce = nameof(TimeInForce.GTD),
+                    GoodTillDate = pastGtd,
+                },
+            },
+            Ownership = new List<OwnershipMappingSnapshot>
+            {
+                new(42UL, Alice.Value),
+            },
+            AuditedExpiredIds = new ulong[] { 42UL },
+        };
+        snapshotter.Restore(fixtureSnap);
+
+        // No WAL replay (events all <= snap.Seq) → MarkExpiredAuditAppended
+        // is NOT invoked from the EventReplayer hook. Without the
+        // pass-4 fix the scheduler's audited-set would be empty here.
+        await h.Sut.StartAsync(CancellationToken.None);
+        h.Store.Reset();
+
+        // Past-due head: timer floor fires the dispatch immediately.
+        h.Clock.Advance(GtdExpirationScheduler.MinTimerFloor + TimeSpan.FromMilliseconds(5));
+        for (int i = 0; i < 200 && h.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+
+        Assert.Equal(1, h.Gateway.CancelCount);
+        // No duplicate audit envelope: the snapshot already represented
+        // "audit written" via AuditedExpiredIds.
+        Assert.Equal(0, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    /// <summary>
+    /// Pass-4 P1 — backward compatibility: snapshots produced before
+    /// this slice did not carry an <c>AuditedExpiredIds</c> field.
+    /// They must deserialise into a <see cref="PlatformSnapshot"/>
+    /// with an empty set so behaviour collapses to the pre-pass-4
+    /// path (the EventReplayer hook is the only writer).
+    /// </summary>
+    [Fact]
+    public void OldSnapshotJson_WithoutAuditedExpiredIds_HydratesWithEmptySet()
+    {
+        // Minimal old-shape JSON: only Seq and CreatedAtUtc, no
+        // AuditedExpiredIds field. System.Text.Json must hydrate the
+        // field with its declared default of Array.Empty<ulong>().
+        const string oldJson = """
+            {
+              "seq": 123,
+              "createdAtUtc": "2025-01-01T12:00:00Z"
+            }
+            """;
+
+        var snap = System.Text.Json.JsonSerializer.Deserialize<PlatformSnapshot>(
+            oldJson,
+            new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+
+        Assert.NotNull(snap);
+        Assert.Equal(123L, snap!.Seq);
+        Assert.NotNull(snap.AuditedExpiredIds);
+        Assert.Empty(snap.AuditedExpiredIds);
+    }
+
+    // -----------------------------------------------------------------
     // Test infrastructure
     // -----------------------------------------------------------------
 

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
@@ -121,6 +121,174 @@ public class GtdSchedulerRegressionTests
         Assert.Equal(typeof(OrderCancelRequestedEvent), h.Store.AppendedTypes[1]);
     }
 
+    // -----------------------------------------------------------------
+    // Pass-2 review (#255): WAL-backpressure retry
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Pass-2 P1 — when CancelAsync returns WalBackpressure, the
+    /// scheduler must NOT drop the order from its tracking index. It
+    /// must re-arm with backoff and retry on the next timer tick.
+    /// OrderExpiredEvent must appear EXACTLY ONCE on the WAL (audit
+    /// dedupe across attempts).
+    /// </summary>
+    [Fact]
+    public async Task DispatchExpire_WalBackpressureOnCancel_RetriesAndDedupesAuditEvent()
+    {
+        var h = new ExpireHarness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(5);
+        h.SeedGtd(7UL, gtd);
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        h.Store.Reset();
+        // Force a single WalBackpressure on the cancel path; the audit
+        // event should append cleanly first.
+        h.Store.BackpressureFor<OrderCancelRequestedEvent>(1);
+
+        // Tick #1: fire the expiry.
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        for (int i = 0; i < 200 && h.Store.AppendedTypes.Count < 1; i++)
+            await Task.Delay(10);
+
+        // After tick #1: OrderExpiredEvent is on the WAL, but
+        // OrderCancelRequestedEvent was rejected → still 1 entry.
+        Assert.Single(h.Store.AppendedTypes);
+        Assert.Equal(typeof(OrderExpiredEvent), h.Store.AppendedTypes[0]);
+        Assert.Equal(0, h.Gateway.CancelCount);
+        Assert.Equal(1, h.Sut.TrackedCount);
+
+        // Tick #2: backoff fires. RetryCount==1 → 100ms delay.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(105));
+        for (int i = 0; i < 200 && h.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+
+        Assert.Equal(1, h.Gateway.CancelCount);
+        // Exactly one OrderExpiredEvent (audit dedupe) + one
+        // OrderCancelRequestedEvent on the retry attempt.
+        Assert.Equal(2, h.Store.AppendedTypes.Count);
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    /// <summary>
+    /// Pass-2 P1 — sustained WAL pressure (5 consecutive
+    /// WalBackpressure rejections) eventually drains; the order
+    /// cancels, OrderExpiredEvent appears once, and the retry cadence
+    /// follows the documented backoff schedule
+    /// (100ms → 200ms → 400ms → 800ms → 1600ms, …, capped at 5s).
+    /// </summary>
+    [Fact]
+    public async Task DispatchExpire_PersistentWalBackpressure_FollowsExponentialBackoff()
+    {
+        var h = new ExpireHarness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(5);
+        h.SeedGtd(11UL, gtd);
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        h.Store.Reset();
+        h.Store.BackpressureFor<OrderCancelRequestedEvent>(5);
+
+        // Fire the expiry. OrderExpiredEvent goes through; cancel
+        // returns WalBackpressure → re-arm with 100ms backoff.
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        for (int i = 0; i < 200 && h.Store.AppendedTypes.Count < 1; i++)
+            await Task.Delay(10);
+        Assert.Equal(0, h.Gateway.CancelCount);
+
+        // Backoff schedule: 100, 200, 400, 800, 1600 ms — five
+        // attempts total before the store stops rejecting. Step 6 is
+        // the success.
+        var schedule = new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(400),
+            TimeSpan.FromMilliseconds(800),
+            TimeSpan.FromMilliseconds(1600),
+        };
+
+        foreach (var step in schedule)
+        {
+            // A retry slightly before the backoff must NOT fire.
+            h.Clock.Advance(step - TimeSpan.FromMilliseconds(5));
+            await Task.Delay(15);
+            // We may already be past the threshold for fast steps
+            // because the dispatch path runs on the thread pool, so
+            // assert against a snapshot taken now and re-check after
+            // crossing the boundary.
+            var beforeCount = h.Store.AppendedTypes.Count;
+
+            h.Clock.Advance(TimeSpan.FromMilliseconds(10));
+            for (int i = 0; i < 200 && h.Store.AppendedTypes.Count == beforeCount; i++)
+                await Task.Delay(10);
+        }
+
+        // The 6th attempt drains the rejection counter and succeeds.
+        // After all five rejected attempts plus the success, the WAL
+        // has exactly one OrderExpiredEvent and one
+        // OrderCancelRequestedEvent.
+        for (int i = 0; i < 200 && h.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+        Assert.Equal(1, h.Gateway.CancelCount);
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    /// <summary>
+    /// Pass-2 P1 — race with an external terminal event (e.g., the
+    /// venue trades the order to fill before our retry reaches it).
+    /// The first attempt hits WalBackpressure and re-arms; before the
+    /// backoff fires, OnOrderTerminal evicts the entry. The retry
+    /// must NOT re-issue a cancel.
+    ///
+    /// Note: if the audit append on attempt #1 succeeded (as it does
+    /// in this scenario), OrderExpiredEvent is on the WAL — that is
+    /// acceptable: it accurately attributes the (almost-fired) policy
+    /// trigger; the downstream venue Fill ER is what flips the order
+    /// to terminal in the book. The audit envelope is informational
+    /// only and does not mutate state.
+    /// </summary>
+    [Fact]
+    public async Task DispatchExpire_ExternalTerminalDuringRetry_DropsRetryAndStopsCancelling()
+    {
+        var h = new ExpireHarness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(5);
+        h.SeedGtd(13UL, gtd);
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        h.Store.Reset();
+        // Backpressure cancel attempts forever — the only way to stop
+        // the retry loop in this test is the OnOrderTerminal eviction.
+        h.Store.BackpressureFor<OrderCancelRequestedEvent>(int.MaxValue);
+
+        // Tick #1: expiry fires; audit appends; cancel hits WAL
+        // backpressure; scheduler re-arms with 100ms backoff.
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        for (int i = 0; i < 200 && h.Store.AppendedTypes.Count < 1; i++)
+            await Task.Delay(10);
+        Assert.Equal(1, h.Sut.TrackedCount);
+        Assert.Equal(0, h.Gateway.CancelCount);
+
+        // Simulate the external terminal landing (e.g., venue Fill ER
+        // arrives before the backoff fires).
+        h.Sut.OnOrderTerminal(13UL);
+        Assert.Equal(0, h.Sut.TrackedCount);
+
+        // Advance past the backoff window — the timer fires but
+        // OnTimer must short-circuit (no live index entry).
+        h.Clock.Advance(TimeSpan.FromMilliseconds(500));
+        await Task.Delay(50);
+
+        Assert.Equal(0, h.Gateway.CancelCount);
+        Assert.Equal(0, h.Sut.TrackedCount);
+        // OrderExpiredEvent from attempt #1 may be on the WAL — that
+        // is acceptable per the test docstring. No additional appends.
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(0, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+    }
+
     // =================================================================
     // Test infrastructure
     // =================================================================
@@ -278,17 +446,45 @@ public class GtdSchedulerRegressionTests
         private long _seq;
         private readonly object _lock = new();
         public List<Type> AppendedTypes { get; } = new();
+        // Pass-2 review (#255): per-type counter of remaining
+        // backpressure rejections. When non-zero for a given event
+        // type, both Append overloads throw WalBackpressureException
+        // and decrement the counter — modeling a transient WAL
+        // pressure spike that drains as the background writer catches
+        // up.
+        private readonly Dictionary<Type, int> _backpressureRemaining = new();
 
         public long CurrentSeq => Interlocked.Read(ref _seq);
 
+        public void BackpressureFor<T>(int times) where T : WalEvent
+        {
+            lock (_lock) _backpressureRemaining[typeof(T)] = times;
+        }
+
         public long Append(WalEvent evt)
         {
-            lock (_lock) AppendedTypes.Add(evt.GetType());
+            lock (_lock)
+            {
+                if (_backpressureRemaining.TryGetValue(evt.GetType(), out var remaining) && remaining > 0)
+                {
+                    _backpressureRemaining[evt.GetType()] = remaining - 1;
+                    throw new WalBackpressureException($"forced backpressure for {evt.GetType().Name}");
+                }
+                AppendedTypes.Add(evt.GetType());
+            }
             return Interlocked.Increment(ref _seq);
         }
         public long Append(WalEvent evt, ReadOnlyMemory<byte> preSerialisedPayload)
         {
-            lock (_lock) AppendedTypes.Add(evt.GetType());
+            lock (_lock)
+            {
+                if (_backpressureRemaining.TryGetValue(evt.GetType(), out var remaining) && remaining > 0)
+                {
+                    _backpressureRemaining[evt.GetType()] = remaining - 1;
+                    throw new WalBackpressureException($"forced backpressure for {evt.GetType().Name}");
+                }
+                AppendedTypes.Add(evt.GetType());
+            }
             return Interlocked.Increment(ref _seq);
         }
         public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
@@ -289,9 +289,117 @@ public class GtdSchedulerRegressionTests
         Assert.Equal(0, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
     }
 
-    // =================================================================
+    // -----------------------------------------------------------------
+    // Pass-3 review (#255): durable audit-set reconstruction on replay
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Pass-3 P2 — crash sequence: timer fires →
+    /// <see cref="OrderExpiredEvent"/> appended (audit on disk) →
+    /// CancelAsync starts but <c>OrderCancelRequestedEvent</c> never
+    /// makes it to disk (process killed) → restart. The order is
+    /// still working in the book (no cancel ER replayed). Without
+    /// the durable audit-set hook the post-restart
+    /// <see cref="GtdExpirationScheduler.StartAsync"/> seeds a fresh
+    /// <c>Entry</c> with <c>ExpiredAuditAppended=false</c> and the
+    /// next timer fire emits a SECOND <c>OrderExpiredEvent</c> for
+    /// the same ClOrdId. With the hook, the EventReplayer informs
+    /// the scheduler that the audit is already durably recorded and
+    /// the restart-side dispatch skips straight to the cancel.
+    /// </summary>
+    [Fact]
+    public async Task ReplayAfterMidFireCrash_DoesNotEmitDuplicateOrderExpiredEvent()
+    {
+        var h = new ExpireHarness();
+        var pastGtd = h.Clock.GetUtcNow().AddSeconds(-5);
+
+        // Reconstruct post-crash world: order is back in the book
+        // (replayed from OrderSubmittedEvent), the OrderExpiredEvent
+        // is on the WAL but the cancel ER is not, so the order is
+        // still in working state.
+        h.SeedGtd(7UL, pastGtd);
+
+        // EventReplayer's hook fires for the on-disk OrderExpiredEvent
+        // BEFORE the scheduler's hosted StartAsync — same ordering
+        // RunRecoveryAndSeedingAsync guarantees in production.
+        h.Sut.MarkExpiredAuditAppended(7UL);
+
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        h.Store.Reset();
+
+        // Past-due head: timer floor fires the dispatch immediately.
+        h.Clock.Advance(GtdExpirationScheduler.MinTimerFloor + TimeSpan.FromMilliseconds(5));
+        for (int i = 0; i < 200 && h.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+
+        // Cancel went through (1 OrderCancelRequestedEvent), but NO
+        // duplicate OrderExpiredEvent was appended on this tick — the
+        // pre-crash audit envelope is the canonical record.
+        Assert.Equal(1, h.Gateway.CancelCount);
+        Assert.Equal(0, h.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(1, h.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    /// <summary>
+    /// Pass-3 P2 — two-restart sequence. Crash mid-fire (audit on
+    /// disk, cancel not), restart #1 reconstructs the audit-set,
+    /// dispatch fires the cancel cleanly. We then simulate a SECOND
+    /// crash-and-restart (e.g., another process kill before the next
+    /// graceful shutdown) where the OrderExpiredEvent is re-replayed
+    /// to a fresh scheduler instance. The order is no longer in the
+    /// book by then (the cancel ER from restart #1 IS on disk), so
+    /// the scheduler short-circuits at the snapshot scan and never
+    /// even arms the heap. No duplicate audit on either restart.
+    /// </summary>
+    [Fact]
+    public async Task TwoRestartSequence_NeverDuplicatesAuditEvent()
+    {
+        // ---- Restart #1 ----
+        var h1 = new ExpireHarness();
+        var pastGtd = h1.Clock.GetUtcNow().AddSeconds(-5);
+        h1.SeedGtd(9UL, pastGtd);
+        h1.Sut.MarkExpiredAuditAppended(9UL);
+
+        await h1.Sut.StartAsync(CancellationToken.None);
+        h1.Store.Reset();
+
+        h1.Clock.Advance(GtdExpirationScheduler.MinTimerFloor + TimeSpan.FromMilliseconds(5));
+        for (int i = 0; i < 200 && h1.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+
+        Assert.Equal(1, h1.Gateway.CancelCount);
+        Assert.Equal(0, h1.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(1, h1.Store.AppendedTypes.Count(t => t == typeof(OrderCancelRequestedEvent)));
+
+        // ---- Restart #2 ----
+        // After restart #1's graceful behaviour the order is cancelled
+        // at the venue and the Cancelled ER landed on disk. Replay
+        // therefore reconstructs the order as terminal (or, modelled
+        // simply here: not in the book at all). The OrderExpiredEvent
+        // still gets re-replayed because it predates the snapshot
+        // cutoff.
+        var h2 = new ExpireHarness();
+        // Order NOT seeded into book — it terminated before snapshot.
+        h2.Sut.MarkExpiredAuditAppended(9UL);
+
+        await h2.Sut.StartAsync(CancellationToken.None);
+        h2.Store.Reset();
+
+        // No live entry was seeded (book has no working GTD order),
+        // so no timer fires and no audit can possibly be re-emitted.
+        h2.Clock.Advance(TimeSpan.FromSeconds(10));
+        await Task.Delay(50);
+
+        Assert.Equal(0, h2.Gateway.CancelCount);
+        Assert.Equal(0, h2.Store.AppendedTypes.Count(t => t == typeof(OrderExpiredEvent)));
+        Assert.Equal(0, h2.Sut.TrackedCount);
+    }
+
+    // -----------------------------------------------------------------
     // Test infrastructure
-    // =================================================================
+    // -----------------------------------------------------------------
 
     private sealed class ExpireHarness
     {

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/GtdSchedulerRegressionTests.cs
@@ -1,0 +1,391 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Application.Scheduling;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Scheduling;
+
+/// <summary>
+/// Pass-1 review regressions for #255:
+/// <list type="bullet">
+///   <item>P1 — <c>OrderSubmissionService</c> must NOT arm
+///   <see cref="GtdExpirationScheduler"/> until <c>SubmitAsync</c> on
+///   the gateway has returned without throwing. A slow gateway with a
+///   near-term GTD must not race the scheduler into firing a cancel
+///   for an order that is still in flight to the venue.</item>
+///   <item>P2 — <c>GtdExpirationScheduler.DispatchExpireAsync</c> must
+///   append <c>OrderExpiredEvent</c> to the WAL BEFORE invoking
+///   <c>OrderCancelService.CancelAsync</c> (which appends
+///   <c>OrderCancelRequestedEvent</c> as its first side effect). A
+///   crash mid-cancel must leave the GTD-expiry attribution durable
+///   so replay can re-attempt the cancel with context.</item>
+/// </list>
+/// </summary>
+public class GtdSchedulerRegressionTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    // -----------------------------------------------------------------
+    // Fix 1 (P1): submit-order arming
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task SubmitWithNearTermGtd_DoesNotArmSchedulerWhileGatewayPending()
+    {
+        var h = new SubmitHarness();
+        var gtd = h.Clock.GetUtcNow().AddMilliseconds(50);
+
+        var submitTask = h.SubmitGtdAsync(gtd);
+
+        // Gateway has reached SubmitAsync but is blocked on the gate.
+        await h.Gateway.SubmitInvoked.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // While submit is in flight, advance the virtual clock past the
+        // GTD. The scheduler must NOT have been armed yet — the order
+        // has not reached the venue, so any cancel emitted now would be
+        // chasing a clOrdId the venue has never seen.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(60));
+        await Task.Delay(20);
+
+        Assert.Equal(0, h.Scheduler.TrackedCount);
+        Assert.Empty(h.Gateway.CancelCalls);
+
+        // Release the gateway. Submit returns Accepted; scheduler is
+        // armed AFTER SubmitAsync returns. Because GTD is already in
+        // the past, the next OnTimer tick fires the cancel — and that
+        // cancel correctly targets a clOrdId the venue has now seen.
+        h.Gateway.ReleaseSubmit();
+        var result = await submitTask.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        // The scheduler clamps a past-due head to a tiny floor; advance
+        // a couple of ms to let the timer fire deterministically.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(5));
+        for (int i = 0; i < 200 && h.Gateway.CancelCalls.Count == 0; i++)
+            await Task.Delay(10);
+
+        Assert.Single(h.Gateway.CancelCalls);
+        // Submit happened-before cancel: the venue saw the new order
+        // first and the expiry-driven cancel afterwards.
+        Assert.True(h.Gateway.SubmitCompletedAtTicks <= h.Gateway.FirstCancelAtTicks);
+    }
+
+    [Fact]
+    public async Task SubmitWithGatewayThrow_DoesNotArmScheduler()
+    {
+        // Companion: if gateway submit throws, scheduler is never
+        // armed. Otherwise we'd schedule a cancel for an order that
+        // never reached the venue and was already synthetically
+        // rejected — replay would see two terminal transitions.
+        var h = new SubmitHarness();
+        h.Gateway.ThrowOnSubmit = new InvalidOperationException("venue unavailable");
+        var gtd = h.Clock.GetUtcNow().AddSeconds(30);
+
+        var result = await h.SubmitGtdAsync(gtd);
+
+        Assert.Equal(OrderSubmissionResultKind.GatewayFailed, result.Kind);
+        Assert.Equal(0, h.Scheduler.TrackedCount);
+    }
+
+    // -----------------------------------------------------------------
+    // Fix 2 (P2): WAL append ordering on expiry
+    // -----------------------------------------------------------------
+
+    [Fact]
+    public async Task DispatchExpire_AppendsOrderExpiredEventBeforeCancelRequested()
+    {
+        var h = new ExpireHarness();
+        var gtd = h.Clock.GetUtcNow().AddSeconds(5);
+        h.SeedGtd(7UL, gtd);
+        await h.Sut.StartAsync(CancellationToken.None);
+
+        // Reset recorder so we only see expiry-driven appends below.
+        h.Store.Reset();
+
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        for (int i = 0; i < 200 && h.Gateway.CancelCount == 0; i++)
+            await Task.Delay(10);
+        // Allow the audit-only OrderExpiredEvent dispatch (which runs
+        // after CancelAsync returns is no longer the case — it now
+        // runs before — so wait until both have been observed).
+        for (int i = 0; i < 200 && h.Store.AppendedTypes.Count < 2; i++)
+            await Task.Delay(10);
+
+        Assert.Equal(2, h.Store.AppendedTypes.Count);
+        Assert.Equal(typeof(OrderExpiredEvent), h.Store.AppendedTypes[0]);
+        Assert.Equal(typeof(OrderCancelRequestedEvent), h.Store.AppendedTypes[1]);
+    }
+
+    // =================================================================
+    // Test infrastructure
+    // =================================================================
+
+    private sealed class ExpireHarness
+    {
+        public VirtualTimeProvider Clock { get; } = new(DateTimeOffset.Parse("2025-01-01T12:00:00Z"));
+        public WorkingOrderBook Book { get; } = new();
+        public OrderOwnershipMap Ownership { get; } = new();
+        public ClOrdIdPrefixRegistry ClOrdIds { get; } = new();
+        public RecordingEventStore Store { get; } = new();
+        public EventDispatcher Dispatcher { get; }
+        public RecordingGateway Gateway { get; } = new();
+        public OrderCancelService Cancel { get; }
+        public GtdExpirationScheduler Sut { get; }
+
+        public ExpireHarness()
+        {
+            Dispatcher = new EventDispatcher(Store);
+            Cancel = new OrderCancelService(
+                ClOrdIds, Ownership, Book, Gateway, Dispatcher,
+                NullLogger<OrderCancelService>.Instance);
+            Sut = new GtdExpirationScheduler(
+                Book, Cancel, Dispatcher,
+                new NoOpExecutionEventSink(), Clock,
+                NullLogger<GtdExpirationScheduler>.Instance);
+        }
+
+        public Order SeedGtd(ulong clOrdId, DateTimeOffset gtd)
+        {
+            var o = new Order(
+                clOrdId, Alice, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+                100, 30m, timeInForce: TimeInForce.GTD, goodTillDate: gtd);
+            Assert.True(Book.TryAdd(o));
+            Ownership.Register(clOrdId, Alice);
+            return o;
+        }
+    }
+
+    private sealed class SubmitHarness
+    {
+        public VirtualTimeProvider Clock { get; } = new(DateTimeOffset.Parse("2025-01-01T12:00:00Z"));
+        public WorkingOrderBook Book { get; } = new();
+        public OrderOwnershipMap Ownership { get; } = new();
+        public ClOrdIdPrefixRegistry ClOrdIds { get; } = new();
+        public NullEventStore Store { get; } = new();
+        public EventDispatcher Dispatcher { get; }
+        public SlowGateway Gateway { get; } = new();
+        public NoOpExecutionEventSink Sink { get; } = new();
+        public RiskPipeline Risk { get; } = new(Array.Empty<IRiskCheck>());
+        public NoOpMarginProvider Margin { get; } = new();
+        public CompositeRiskAccountant Accountant { get; } = new(Array.Empty<IRiskAccountant>());
+        public NeverDrainingGate Drain { get; } = new();
+        public OrderCancelService Cancel { get; }
+        public GtdExpirationScheduler Scheduler { get; }
+        public OrderSubmissionService Submitter { get; }
+
+        public SubmitHarness()
+        {
+            Dispatcher = new EventDispatcher(Store);
+            Cancel = new OrderCancelService(
+                ClOrdIds, Ownership, Book, Gateway, Dispatcher,
+                NullLogger<OrderCancelService>.Instance);
+            Scheduler = new GtdExpirationScheduler(
+                Book, Cancel, Dispatcher, Sink, Clock,
+                NullLogger<GtdExpirationScheduler>.Instance);
+            Submitter = new OrderSubmissionService(
+                ClOrdIds, Ownership, Book, Gateway, Sink, Risk, Margin, Accountant,
+                Dispatcher, Drain, NullLogger<OrderSubmissionService>.Instance,
+                botMappings: null, gtdScheduler: Scheduler);
+        }
+
+        public Task<OrderSubmissionResult> SubmitGtdAsync(DateTimeOffset gtd)
+        {
+            var req = new OrderSubmissionRequest(
+                Alice, "FIRM01", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+                Quantity: 100, Price: 30m,
+                TimeInForce: TimeInForce.GTD, GoodTillDate: gtd);
+            return Submitter.SubmitAsync(req, CancellationToken.None);
+        }
+    }
+
+    private sealed class SlowGateway : IExchangeGateway
+    {
+        private readonly TaskCompletionSource _gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource SubmitInvoked { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Exception? ThrowOnSubmit { get; set; }
+        public List<string> CancelCalls { get; } = new();
+        public int CancelCount { get { lock (CancelCalls) return CancelCalls.Count; } }
+        public long SubmitCompletedAtTicks { get; private set; }
+        public long FirstCancelAtTicks { get; private set; }
+
+        public void ReleaseSubmit() => _gate.TrySetResult();
+
+        public async Task SubmitAsync(Order order, CancellationToken ct)
+        {
+            SubmitInvoked.TrySetResult();
+            if (ThrowOnSubmit is { } ex)
+                throw ex;
+            await _gate.Task.WaitAsync(ct).ConfigureAwait(false);
+            SubmitCompletedAtTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+        }
+
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct)
+        {
+            lock (CancelCalls)
+            {
+                if (FirstCancelAtTicks == 0)
+                    FirstCancelAtTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+                CancelCalls.Add($"cancel:{order.ClOrdId}->{newClOrdId}");
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice,
+            DateTimeOffset? requestedGoodTillDate, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingGateway : IExchangeGateway
+    {
+        private int _cancelCount;
+        public int CancelCount => Volatile.Read(ref _cancelCount);
+        public Task SubmitAsync(Order order, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _cancelCount);
+            return Task.CompletedTask;
+        }
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice,
+            DateTimeOffset? requestedGoodTillDate, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class NeverDrainingGate : IDrainGate
+    {
+        public bool IsDraining => false;
+    }
+
+    private sealed class NoOpExecutionEventSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+
+    /// <summary>
+    /// Captures the type of every <see cref="WalEvent"/> appended in
+    /// the strict order it was passed to <see cref="IEventStore.Append"/>.
+    /// The dispatcher serialises all appends under its lock, so this
+    /// list reflects the canonical WAL ordering.
+    /// </summary>
+    private sealed class RecordingEventStore : IEventStore
+    {
+        private long _seq;
+        private readonly object _lock = new();
+        public List<Type> AppendedTypes { get; } = new();
+
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+
+        public long Append(WalEvent evt)
+        {
+            lock (_lock) AppendedTypes.Add(evt.GetType());
+            return Interlocked.Increment(ref _seq);
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> preSerialisedPayload)
+        {
+            lock (_lock) AppendedTypes.Add(evt.GetType());
+            return Interlocked.Increment(ref _seq);
+        }
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void Reset()
+        {
+            lock (_lock) AppendedTypes.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Same shape as <c>VirtualTimeProvider</c> in
+    /// <see cref="GtdExpirationSchedulerTests"/>; duplicated here to
+    /// keep test files self-contained (the inner type is private to
+    /// that file).
+    /// </summary>
+    private sealed class VirtualTimeProvider : TimeProvider
+    {
+        private readonly object _lock = new();
+        private DateTimeOffset _now;
+        private readonly List<VTimer> _timers = new();
+
+        public VirtualTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() { lock (_lock) return _now; }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var t = new VTimer(this, callback, state);
+            t.Change(dueTime, period);
+            return t;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            var deadline = Now + delta;
+            while (true)
+            {
+                VTimer? next = null;
+                lock (_lock)
+                {
+                    foreach (var t in _timers)
+                    {
+                        if (t.DueAt is { } d && d <= deadline)
+                        {
+                            if (next is null || d < next.DueAt) next = t;
+                        }
+                    }
+                }
+                if (next is null)
+                {
+                    lock (_lock) _now = deadline;
+                    return;
+                }
+                lock (_lock) _now = next.DueAt!.Value;
+                next.Fire();
+            }
+        }
+
+        internal void Register(VTimer t) { lock (_lock) _timers.Add(t); }
+        internal void Unregister(VTimer t) { lock (_lock) _timers.Remove(t); }
+        internal DateTimeOffset Now { get { lock (_lock) return _now; } }
+    }
+
+    private sealed class VTimer : ITimer
+    {
+        private readonly VirtualTimeProvider _owner;
+        private readonly TimerCallback _cb;
+        private readonly object? _state;
+        public DateTimeOffset? DueAt { get; private set; }
+
+        public VTimer(VirtualTimeProvider owner, TimerCallback cb, object? state)
+        {
+            _owner = owner; _cb = cb; _state = state;
+            _owner.Register(this);
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            DueAt = dueTime == Timeout.InfiniteTimeSpan ? null : _owner.Now + dueTime;
+            return true;
+        }
+
+        public void Fire()
+        {
+            DueAt = null;
+            _cb(_state);
+        }
+
+        public void Dispose() => _owner.Unregister(this);
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+}


### PR DESCRIPTION
Closes #255

## Summary
Q1.3: hosted-service min-heap scheduler that fires a per-order cancel when an order's `GoodTillDate` elapses, for orders with `TimeInForce==GTD` in non-terminal status.

## Design

- **Heap** — `PriorityQueue<ulong, DateTimeOffset>` keyed by ClOrdId with GoodTillDate as the priority. A companion `Dictionary<ulong, DateTimeOffset>` carries the live expiry per tracked order; cancel/replace/terminal events tombstone heap entries lazily and the head is dropped on the next peek (classic Dijkstra-style pattern).
- **Timer** — single `ITimer` from `TimeProvider.CreateTimer`, re-armed on every heap mutation. Capped at `MaxTimerPoll = 1h` so legal multi-week horizons don't trip the CLR's ~49.7d `dueTime` ceiling — `OnTimer` re-arms with the smaller remaining-until-head delay each time it fires.
- **Cold-start replay** — `StartAsync` scans `WorkingOrderBook.Snapshot()` and re-seeds every non-terminal GTD order. Past-due entries fire immediately with `AtUtc = order.GoodTillDate` (the original expiry) so the audit trail reflects the policy boundary, not the post-restart wall clock. Hosted-service start runs after `TradingHostStartup.RunRecoveryAndSeedingAsync` awaits, so the book is hydrated.
- **Cancel path** — reuses `OrderCancelService.CancelAsync` (same WAL append, same gateway dispatch as a user cancel). After accept the scheduler appends an additive `OrderExpiredEvent` for audit and publishes a synthetic `ExecutionEvent` with new `ExecKind.Expired` so WS subscribers can distinguish a policy expiry from a venue cancel. Replay-safe: re-emitting on boot short-circuits because the order is already terminal.

## Wire-format additions (additive)

- `OrderExpiredEvent` WAL record with discriminator `order.expired` (audit-only; status flips via the regular Canceled ER).
- `ExecKind.Expired` enum value — flows through the existing `Kind.ToString()` projection in `Dtos.cs` so WS clients see `kind="Expired"` automatically. `OutboundExecutionReportEncoder` and `ReserveOnSubmitMarginProvider.OnExecution` tolerate unknown kinds today, so no codec churn.
- Metric: `trading.orders.gtd_expired` with `cancel_result` tag.

## Hook seams

- `OrderSubmissionService`: `OnOrderTracked(order)` after the dispatcher commit (post-WAL, post-book-insert).
- `ExecutionReportProcessor`: `OnOrderTerminal` on every terminal main-switch outcome and after `MarkReplaced` in the replace path; `OnOrderTracked` on the new replacement order.

Both new ctor parameters are optional and at the end of the parameter list so existing test instantiations stay compiling.

## Tests

7 new unit tests in `backend/tests/B3.Trading.Application.Tests/Scheduling/GtdExpirationSchedulerTests.cs` driving the scheduler against a virtual-time `TimeProvider` (no Thread.Sleep, no flakiness):

- expires after delay → cancel + Expired event
- terminal before expiry → no cancel
- re-tracking with earlier expiry → reschedules
- cold-start past-due → fires immediately with original AtUtc
- non-GTD ignored
- 100 orders fire when time crosses all expiries
- long-horizon (60d) GTD doesn't crash the CLR timer queue (regression for the cap)

All 1190 backend tests pass (1183 baseline + 7 new).