### PR TITLE
feat(#268): history endpoints (orders + executions, cursor pagination)

### DIFF
--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -179,8 +179,8 @@ public static class HistoryEndpoints
         // map (TryResolveOrig) to find the original order. The history
         // projector must mirror that fallback or it silently strands
         // every cancel/replace ack whose OrigClOrdId field was missing.
-        var cancelLinks = new Dictionary<ulong, ulong>();   // cancelClOrdId -> originalClOrdId
-        var replaceLinks = new Dictionary<ulong, ulong>();  // newClOrdId    -> originalClOrdId
+        var cancelLinks = new Dictionary<ulong, ulong>();           // cancelClOrdId -> originalClOrdId
+        var replaceLinks = new Dictionary<ulong, ReplaceIntent>();  // newClOrdId    -> (originalClOrdId, requested NewQuantity)
         // Tracks which projections have at least one event in [from,to].
         // We must apply ALL events with ts <= to to project the correct
         // state-at-`to` (a partial fill at 10:00 followed by a full fill
@@ -220,7 +220,7 @@ public static class HistoryEndpoints
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol);
                     // Mirror OrderOwnershipMap.RegisterReplaceLink — needed
                     // when the venue's Replaced ER omits OrigClOrdId.
-                    replaceLinks[rr.NewClOrdId] = rr.OriginalClOrdId;
+                    replaceLinks[rr.NewClOrdId] = new ReplaceIntent(rr.OriginalClOrdId, rr.NewQuantity);
                     if (!OwnerMatches(rr.EndClientId, owner)) break;
                     if (symbol is not null && !rr.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
                     byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(seq, rr);
@@ -257,8 +257,8 @@ public static class HistoryEndpoints
                         // through PendingReplacementRegistry instead of
                         // the OrigClOrdId fallback). Replaced ERs
                         // resolve only via replaceLinks.
-                        if (kind == ExecKind.Replaced && replaceLinks.TryGetValue(er.ClOrdId, out var rOrig))
-                            resolvedOrig = rOrig;
+                        if (kind == ExecKind.Replaced && replaceLinks.TryGetValue(er.ClOrdId, out var rIntent))
+                            resolvedOrig = rIntent.OriginalClOrdId;
                         else if ((kind is ExecKind.Canceled or ExecKind.Rejected or ExecKind.Expired)
                             && cancelLinks.TryGetValue(er.ClOrdId, out var cOrig))
                             resolvedOrig = cOrig;
@@ -320,13 +320,13 @@ public static class HistoryEndpoints
                     // OrigClOrdId-fallback resolution above wired via cancelLinks
                     // (the new-side ClOrdID is never in cancelLinks).
                     if (kind == ExecKind.Canceled
-                        && replaceLinks.TryGetValue(er.ClOrdId, out var carOrig))
+                        && replaceLinks.TryGetValue(er.ClOrdId, out var carIntent))
                     {
                         // Mirror ApplyReplaceAccepted: prefer the ER's
                         // OrigClOrdId when the venue did supply one,
                         // otherwise fall back to the intent's original
                         // (here: the replaceLinks entry).
-                        var origId = er.OrigClOrdId != 0 ? er.OrigClOrdId : carOrig;
+                        var origId = er.OrigClOrdId != 0 ? er.OrigClOrdId : carIntent.OriginalClOrdId;
                         if (byClOrdId.TryGetValue(origId, out var carOrigProj))
                         {
                             carOrigProj.ApplyReplacedTerminal(seq, er);
@@ -334,7 +334,16 @@ public static class HistoryEndpoints
                         }
                         if (byClOrdId.TryGetValue(er.ClOrdId, out var carNewProj))
                         {
-                            carNewProj.HydrateFromReplaceEr(seq, er);
+                            // Mirror ExecutionReportProcessor.Apply for the
+                            // Canceled cancel-as-replace branch: runtime calls
+                            // ApplyReplaceAccepted(erLeaves: intent.NewQuantity,
+                            // erCum: 0) — the venue's cancel-side ER reports
+                            // LeavesQuantity=0 (it's a cancel ack), so we MUST
+                            // hydrate from the originating
+                            // OrderReplaceRequestedEvent's NewQuantity, not
+                            // from the ER's leaves/cum (which would mark the
+                            // replacement as Filled).
+                            carNewProj.HydrateFromCancelAsReplaceIntent(seq, er, carIntent.NewQuantity);
                             if (inWindow) hadEventInWindow.Add(er.ClOrdId);
                         }
                         // Consume the link — mirrors PendingReplacementRegistry
@@ -411,7 +420,7 @@ public static class HistoryEndpoints
         // owner/firm — without this fallback the executions endpoint
         // silently drops every such ack for the firm-isolation filter.
         var cancelLinks = new Dictionary<ulong, ulong>();
-        var replaceLinks = new Dictionary<ulong, ulong>();
+        var replaceLinks = new Dictionary<ulong, ReplaceIntent>();
         var result = new List<ExecutionProjection>();
 
         await foreach (var (seq, evt) in store.ReadFromAsync(0, ct))
@@ -423,7 +432,7 @@ public static class HistoryEndpoints
                     break;
                 case OrderReplaceRequestedEvent rr:
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
-                    replaceLinks[rr.NewClOrdId] = rr.OriginalClOrdId;
+                    replaceLinks[rr.NewClOrdId] = new ReplaceIntent(rr.OriginalClOrdId, rr.NewQuantity);
                     break;
                 case OrderCancelRequestedEvent cr:
                     cancelLinks[cr.CancelClOrdId] = cr.OriginalClOrdId;
@@ -450,8 +459,8 @@ public static class HistoryEndpoints
                         // not via the OrigClOrdId fallback.
                         Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var execKind);
                         if (execKind == ExecKind.Replaced
-                            && replaceLinks.TryGetValue(er.ClOrdId, out var rOrig)
-                            && ownerByClOrdId.TryGetValue(rOrig, out var m3)) meta = m3;
+                            && replaceLinks.TryGetValue(er.ClOrdId, out var rIntent)
+                            && ownerByClOrdId.TryGetValue(rIntent.OriginalClOrdId, out var m3)) meta = m3;
                         else if (execKind is ExecKind.Canceled or ExecKind.Rejected or ExecKind.Expired
                             && cancelLinks.TryGetValue(er.ClOrdId, out var cOrig)
                             && ownerByClOrdId.TryGetValue(cOrig, out var m4)) meta = m4;
@@ -634,6 +643,18 @@ public static class HistoryEndpoints
     // -----------------------------------------------------------------
     // Internal projection types
     // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Replace-link entry recorded from <see cref="OrderReplaceRequestedEvent"/>:
+    /// the original ClOrdID being replaced and the requested
+    /// <c>NewQuantity</c>. The latter is needed by the cancel-as-replace
+    /// branch to mirror <c>ExecutionReportProcessor.Apply</c>'s
+    /// <c>ApplyReplaceAccepted(erLeaves: intent.NewQuantity, erCum: 0)</c>
+    /// for <c>ExecKind.Canceled</c> — the cancel-side ER's
+    /// <c>LeavesQuantity</c> is 0 and cannot be used to hydrate the
+    /// replacement.
+    /// </summary>
+    private readonly record struct ReplaceIntent(ulong OriginalClOrdId, long NewQuantity);
 
     private sealed class OrderProjection
     {
@@ -874,6 +895,28 @@ public static class HistoryEndpoints
             Status = er.LeavesQuantity == 0
                 ? OrderStatus.Filled
                 : (er.CumulativeQuantity > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Working);
+            LastSeq = seq;
+            LastTs = er.TimestampUtc;
+        }
+
+        /// <summary>
+        /// Applied to the NEW ClOrdID's projection on a cancel-as-replace
+        /// Canceled ER (B3MatchingPlatform "priority-lost" path, issue #241).
+        /// Mirrors <c>ExecutionReportProcessor.Apply</c> for
+        /// <c>ExecKind.Canceled</c>, which calls
+        /// <c>ApplyReplaceAccepted(erLeaves: intent.NewQuantity, erCum: 0)</c>:
+        /// the venue's cancel-side ER reports <c>LeavesQuantity=0</c>
+        /// (it's a cancel ack), so we hydrate from the originating
+        /// <see cref="OrderReplaceRequestedEvent"/>'s
+        /// <c>NewQuantity</c>, not from the ER's leaves/cum. Cumulative is
+        /// reset to 0 — the replacement is a brand-new order in the runtime
+        /// book and does not inherit the predecessor's fills.
+        /// </summary>
+        public void HydrateFromCancelAsReplaceIntent(long seq, ExecutionReportReceivedEvent er, long intentNewQuantity)
+        {
+            LeavesQuantity = intentNewQuantity;
+            CumulativeQuantity = 0;
+            Status = intentNewQuantity == 0 ? OrderStatus.Filled : OrderStatus.Working;
             LastSeq = seq;
             LastTs = er.TimestampUtc;
         }

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -72,11 +72,35 @@ public static class HistoryEndpoints
             var owner = ResolveOwner(ctx, registry);
             var pageSize = ClampLimit(limit);
 
-            var orders = await ProjectOrdersAsync(store, owner.Value, symbol, fromTs, toTs, ct);
+            // Freeze the read view across the entire pagination walk.
+            // Order projections are mutable: an order returned on page 1
+            // can have its LastSeq advance (e.g. a new ER) before page 2
+            // is fetched, sliding it past the cursor anchor and silently
+            // dropping it from the result. Capturing snapshotSeq once on
+            // the first request and threading it through every subsequent
+            // page guarantees a stable, repeatable pagination — any WAL
+            // record with seq > snapshotSeq is invisible to the walk.
+            //
+            // Executions don't need this because their projection rows
+            // are immutable per-seq: a new ER can only land at a higher
+            // seq, and ApplyCursorAndPage already excludes seq >= cursor,
+            // so newcomers naturally fall outside the in-progress walk.
+            long snapshotSeq;
+            if (cursorState is { SnapshotSeq: > 0 })
+            {
+                snapshotSeq = cursorState.SnapshotSeq;
+            }
+            else
+            {
+                await store.FlushAsync(ct);
+                snapshotSeq = store.CurrentSeq;
+            }
+
+            var orders = await ProjectOrdersAsync(store, owner.Value, symbol, fromTs, toTs, snapshotSeq, ct);
             // Sort newest-first by the order's last touching seq (cursor anchor).
             orders.Sort(static (a, b) => b.LastSeq.CompareTo(a.LastSeq));
 
-            var page = ApplyCursorAndPage(orders, cursorState, pageSize, static x => (x.LastSeq, x.LastTs));
+            var page = ApplyCursorAndPage(orders, cursorState, pageSize, snapshotSeq, static x => (x.LastSeq, x.LastTs));
             var items = new List<OrderHistoryItemDto>(page.Items.Count);
             foreach (var p in page.Items) items.Add(p.ToDto());
 
@@ -105,7 +129,7 @@ public static class HistoryEndpoints
             var executions = await ProjectExecutionsAsync(store, owner.Value, symbol, fromTs, toTs, ct);
             executions.Sort(static (a, b) => b.Seq.CompareTo(a.Seq));
 
-            var page = ApplyCursorAndPage(executions, cursorState, pageSize, static x => (x.Seq, x.TimestampUtc));
+            var page = ApplyCursorAndPage(executions, cursorState, pageSize, snapshotSeq: 0, static x => (x.Seq, x.TimestampUtc));
             var items = new List<ExecutionHistoryItemDto>(page.Items.Count);
             foreach (var e in page.Items) items.Add(e.ToDto());
 
@@ -120,12 +144,15 @@ public static class HistoryEndpoints
     // -----------------------------------------------------------------
 
     private static async Task<List<OrderProjection>> ProjectOrdersAsync(
-        IEventStore store, string owner, string? symbol, DateTimeOffset from, DateTimeOffset to, CancellationToken ct)
+        IEventStore store, string owner, string? symbol,
+        DateTimeOffset from, DateTimeOffset to, long snapshotSeq, CancellationToken ct)
     {
-        // Force the WAL writer to drain so freshly-appended events are
-        // visible on disk: ReadFromAsync only reads persisted segments.
-        // Cheap when nothing is pending.
-        await store.FlushAsync(ct);
+        // The endpoint already drained the writer + captured snapshotSeq
+        // for first-page requests so the read view is frozen for the
+        // entire pagination walk. On subsequent pages the snapshotSeq
+        // comes from the cursor; the on-disk WAL is at least as fresh as
+        // when we captured it, but anything appended past snapshotSeq is
+        // explicitly ignored below.
         var byClOrdId = new Dictionary<ulong, OrderProjection>();
         // Side-table: every ClOrdId we have ever seen on the WAL, mapped
         // to its owner + symbol. Needed because ER events do not carry
@@ -133,9 +160,27 @@ public static class HistoryEndpoints
         // time (not submit). Tracking firm-wide is fine — we filter to
         // the requested owner only when materialising the projection.
         var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol)>();
+        // Tracks which projections have at least one event in [from,to].
+        // We must apply ALL events with ts <= to to project the correct
+        // state-at-`to` (a partial fill at 10:00 followed by a full fill
+        // at 12:00 with to=11:00 must surface the partial — ignoring
+        // post-`to` events keeps the result a slice, not a final snapshot).
+        // Pre-`from` events are still applied so the seed state is right;
+        // we just don't flag them as in-window.
+        var hadEventInWindow = new HashSet<ulong>();
 
         await foreach (var (seq, evt) in store.ReadFromAsync(0, ct))
         {
+            // Snapshot fence — see endpoint comment. snapshotSeq==0 means
+            // the caller did not capture one (only the executions path
+            // takes that branch and never calls this method).
+            if (snapshotSeq > 0 && seq > snapshotSeq) break;
+            // Future events relative to the requested window must NOT
+            // mutate state — they would over-advance the projection past
+            // the slice the caller asked for.
+            if (evt.TimestampUtc > to) continue;
+            var inWindow = evt.TimestampUtc >= from;
+
             switch (evt)
             {
                 case OrderSubmittedEvent o:
@@ -143,6 +188,7 @@ public static class HistoryEndpoints
                     if (!OwnerMatches(o.EndClientId, owner)) break;
                     if (symbol is not null && !o.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
                     byClOrdId[o.ClOrdId] = OrderProjection.FromSubmit(seq, o);
+                    if (inWindow) hadEventInWindow.Add(o.ClOrdId);
                     break;
 
                 case OrderReplaceRequestedEvent rr:
@@ -154,40 +200,78 @@ public static class HistoryEndpoints
                     if (!OwnerMatches(rr.EndClientId, owner)) break;
                     if (symbol is not null && !rr.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
                     byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(seq, rr);
+                    if (inWindow) hadEventInWindow.Add(rr.NewClOrdId);
                     break;
 
                 case ExecutionReportReceivedEvent er:
-                    // ER may target either ClOrdId directly (New, Fill, etc.)
-                    // or via OrigClOrdId (cancel-replace ack lands on the
-                    // new ID but mutates the original). Mirror the live
-                    // processor's resolution exactly.
+                    Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind);
+                    if (kind == ExecKind.Replaced && er.OrigClOrdId != 0)
+                    {
+                        // Mirror ExecutionReportProcessor.ApplyReplaceAccepted
+                        // + Order.HydrateReplacement: the original goes
+                        // terminal (Replaced) and the new ClOrdID is
+                        // hydrated from the ER's leaves/cum baseline so
+                        // subsequent fill ERs (which arrive under the
+                        // new ID with OrigClOrdId=0) advance from the
+                        // correct starting point. Without this the new
+                        // row would stay at PendingNew forever — the
+                        // venue never issues a separate New ER for the
+                        // replacement.
+                        if (byClOrdId.TryGetValue(er.OrigClOrdId, out var origProj))
+                        {
+                            origProj.ApplyReplacedTerminal(seq, er);
+                            if (inWindow) hadEventInWindow.Add(er.OrigClOrdId);
+                        }
+                        if (byClOrdId.TryGetValue(er.ClOrdId, out var newProj))
+                        {
+                            newProj.HydrateFromReplaceEr(seq, er);
+                            if (inWindow) hadEventInWindow.Add(er.ClOrdId);
+                        }
+                        break;
+                    }
+
+                    // Non-Replaced ER: may target either ClOrdId directly
+                    // (New, Fill, etc.) or via OrigClOrdId (cancel ack
+                    // lands on the cancel-side ID — never carried by an
+                    // OrderSubmittedEvent — but mutates the original).
                     var targetId = er.ClOrdId;
                     if (er.OrigClOrdId != 0 && byClOrdId.ContainsKey(er.OrigClOrdId))
                         targetId = er.OrigClOrdId;
                     if (byClOrdId.TryGetValue(targetId, out var proj))
+                    {
                         proj.ApplyEr(seq, er);
+                        if (inWindow) hadEventInWindow.Add(targetId);
+                    }
                     break;
 
                 case OrderStaledEvent os:
                     if (byClOrdId.TryGetValue(os.ClOrdId, out var staleProj))
+                    {
                         staleProj.ApplyStaled(seq, os);
+                        if (inWindow) hadEventInWindow.Add(os.ClOrdId);
+                    }
                     break;
 
                 case OrderStaleClearedEvent osc:
                     if (byClOrdId.TryGetValue(osc.ClOrdId, out var clearProj))
+                    {
                         clearProj.ApplyStaleCleared(seq, osc);
+                        if (inWindow) hadEventInWindow.Add(osc.ClOrdId);
+                    }
                     break;
             }
         }
 
-        // Keep only the orders whose last-touching event falls inside
-        // the requested window. Sub-window orders that are still
-        // working would not appear — that matches the spec (history is
-        // a slice of WAL events, not "all currently open").
+        // Include an order iff at least one of its events fell inside
+        // the requested window. State is projected as of `to` (post-`to`
+        // events were skipped above), so the surfaced snapshot is the
+        // order's state at the end of the window — even when the order's
+        // most recent event predates `from`, as long as something inside
+        // [from,to] touched it.
         var result = new List<OrderProjection>(byClOrdId.Count);
         foreach (var p in byClOrdId.Values)
         {
-            if (p.LastTs < from || p.LastTs > to) continue;
+            if (!hadEventInWindow.Contains(p.ClOrdId)) continue;
             result.Add(p);
         }
         return result;
@@ -253,7 +337,7 @@ public static class HistoryEndpoints
     // -----------------------------------------------------------------
 
     private static PageResult<T> ApplyCursorAndPage<T>(
-        List<T> sortedDesc, CursorState? cursor, int pageSize,
+        List<T> sortedDesc, CursorState? cursor, int pageSize, long snapshotSeq,
         Func<T, (long Seq, DateTimeOffset Ts)> anchor)
     {
         // Items are sorted seq-DESC. The cursor anchors the LAST item we
@@ -286,7 +370,10 @@ public static class HistoryEndpoints
         if (hasMore && last is not null)
         {
             var a = anchor(last);
-            next = EncodeCursor(new CursorState(a.Seq, a.Ts));
+            // snapshotSeq travels with the cursor so every page in the
+            // walk reads the same frozen view. Executions pass 0 here
+            // and ProjectExecutionsAsync ignores the field.
+            next = EncodeCursor(new CursorState(a.Seq, a.Ts) { SnapshotSeq = snapshotSeq });
         }
         return new PageResult<T>(taken, next);
     }
@@ -484,6 +571,47 @@ public static class HistoryEndpoints
             LastTs = er.TimestampUtc;
         }
 
+        /// <summary>
+        /// Applied to the ORIGINAL order on a Replaced ER. Mirrors
+        /// <c>ExecutionReportProcessor.ApplyReplaceAccepted</c> +
+        /// <c>Order.MarkReplaced</c>: terminalize the original at
+        /// <see cref="OrderStatus.Replaced"/> without disturbing its
+        /// historical leaves/cum (the ER's leaves/cum belong to the
+        /// new ClOrdID, not the original — they describe the venue's
+        /// post-replacement state, which the original order never owns).
+        /// </summary>
+        public void ApplyReplacedTerminal(long seq, ExecutionReportReceivedEvent er)
+        {
+            Status = OrderStatus.Replaced;
+            // MarkReplaced clears any advisory stale (slice 1 of #132);
+            // mirror that here so the projection matches the runtime.
+            IsStale = false;
+            StaleReason = null;
+            StaledAtUtc = null;
+            LastSeq = seq;
+            LastTs = er.TimestampUtc;
+        }
+
+        /// <summary>
+        /// Applied to the NEW ClOrdID's projection on a Replaced ER.
+        /// Mirrors <c>Order.HydrateReplacement</c>: copy the venue's
+        /// leaves/cum baseline and derive status (Filled when leaves==0,
+        /// PartiallyFilled when cum>0, otherwise Working — never PendingNew
+        /// because the venue has already accepted the replacement).
+        /// Subsequent ERs targeting the new ClOrdID flow through
+        /// <see cref="ApplyEr"/> and accumulate from this baseline.
+        /// </summary>
+        public void HydrateFromReplaceEr(long seq, ExecutionReportReceivedEvent er)
+        {
+            LeavesQuantity = er.LeavesQuantity;
+            CumulativeQuantity = er.CumulativeQuantity;
+            Status = er.LeavesQuantity == 0
+                ? OrderStatus.Filled
+                : (er.CumulativeQuantity > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Working);
+            LastSeq = seq;
+            LastTs = er.TimestampUtc;
+        }
+
         public void ApplyStaled(long seq, OrderStaledEvent os)
         {
             IsStale = true;
@@ -558,6 +686,12 @@ public static class HistoryEndpoints
         // keys via [JsonPropertyName] keeps the wire format compact.
         [System.Text.Json.Serialization.JsonPropertyName("seq")] public long Seq { get; init; } = Seq;
         [System.Text.Json.Serialization.JsonPropertyName("ts")] public DateTimeOffset Ts { get; init; } = Ts;
+        // Q2.1 (#268). Pagination snapshot anchor for /orders/history.
+        // Captured on the first request (no cursor) and threaded through
+        // every subsequent page so the walk reads a frozen WAL view.
+        // Default 0 means "no snapshot" — old cursors (pre-fix) and the
+        // executions endpoint both deserialise/encode that way.
+        [System.Text.Json.Serialization.JsonPropertyName("snap")] public long SnapshotSeq { get; init; }
     }
 
     private sealed record PageResult<T>(IReadOnlyList<T> Items, string? NextCursor);

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -97,10 +97,20 @@ public static class HistoryEndpoints
             }
 
             var orders = await ProjectOrdersAsync(store, owner.Value, symbol, fromTs, toTs, snapshotSeq, ct);
-            // Sort newest-first by the order's last touching seq (cursor anchor).
-            orders.Sort(static (a, b) => b.LastSeq.CompareTo(a.LastSeq));
+            // Sort newest-first by the composite key (LastSeq, ClOrdId).
+            // The ClOrdId tie-breaker is required because a Replaced ER
+            // updates BOTH the original and the replacement projection
+            // with the same LastSeq; pagination by LastSeq alone would
+            // drop one sibling whenever the page boundary fell between
+            // them. See ApplyCursorAndPage for the matching cursor
+            // filter.
+            orders.Sort(static (a, b) =>
+            {
+                var c = b.LastSeq.CompareTo(a.LastSeq);
+                return c != 0 ? c : b.ClOrdId.CompareTo(a.ClOrdId);
+            });
 
-            var page = ApplyCursorAndPage(orders, cursorState, pageSize, snapshotSeq, static x => (x.LastSeq, x.LastTs));
+            var page = ApplyCursorAndPage(orders, cursorState, pageSize, snapshotSeq, static x => (x.LastSeq, x.ClOrdId, x.LastTs));
             var items = new List<OrderHistoryItemDto>(page.Items.Count);
             foreach (var p in page.Items) items.Add(p.ToDto());
 
@@ -129,7 +139,7 @@ public static class HistoryEndpoints
             var executions = await ProjectExecutionsAsync(store, owner.Value, symbol, fromTs, toTs, ct);
             executions.Sort(static (a, b) => b.Seq.CompareTo(a.Seq));
 
-            var page = ApplyCursorAndPage(executions, cursorState, pageSize, snapshotSeq: 0, static x => (x.Seq, x.TimestampUtc));
+            var page = ApplyCursorAndPage(executions, cursorState, pageSize, snapshotSeq: 0, static x => (x.Seq, 0UL, x.TimestampUtc));
             var items = new List<ExecutionHistoryItemDto>(page.Items.Count);
             foreach (var e in page.Items) items.Add(e.ToDto());
 
@@ -160,6 +170,17 @@ public static class HistoryEndpoints
         // time (not submit). Tracking firm-wide is fine — we filter to
         // the requested owner only when materialising the projection.
         var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol)>();
+        // Cancel/replace link maps. Mirror the in-memory
+        // OrderOwnershipMap.RegisterCancelLink / RegisterReplaceLink the
+        // runtime maintains on dispatch (see OrderCancelService and
+        // OrderModifyService). When a venue ER drops OrigClOrdId on a
+        // cancel-ack or Replaced — some EntryPoint SDK versions do —
+        // ExecutionReportProcessor.Apply falls back to that ownership
+        // map (TryResolveOrig) to find the original order. The history
+        // projector must mirror that fallback or it silently strands
+        // every cancel/replace ack whose OrigClOrdId field was missing.
+        var cancelLinks = new Dictionary<ulong, ulong>();   // cancelClOrdId -> originalClOrdId
+        var replaceLinks = new Dictionary<ulong, ulong>();  // newClOrdId    -> originalClOrdId
         // Tracks which projections have at least one event in [from,to].
         // We must apply ALL events with ts <= to to project the correct
         // state-at-`to` (a partial fill at 10:00 followed by a full fill
@@ -197,15 +218,53 @@ public static class HistoryEndpoints
                     // live ExecutionReportProcessor.HandleReplaced semantics
                     // where the new ID is a separate Order).
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol);
+                    // Mirror OrderOwnershipMap.RegisterReplaceLink — needed
+                    // when the venue's Replaced ER omits OrigClOrdId.
+                    replaceLinks[rr.NewClOrdId] = rr.OriginalClOrdId;
                     if (!OwnerMatches(rr.EndClientId, owner)) break;
                     if (symbol is not null && !rr.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
                     byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(seq, rr);
                     if (inWindow) hadEventInWindow.Add(rr.NewClOrdId);
                     break;
 
+                case OrderCancelRequestedEvent cr:
+                    // No projection row for cancel-side ClOrdIDs (they
+                    // never become an Order in the runtime book either).
+                    // We only need the link so a cancel-ack ER without
+                    // OrigClOrdId still resolves to the original order.
+                    // Mirrors OrderOwnershipMap.RegisterCancelLink.
+                    cancelLinks[cr.CancelClOrdId] = cr.OriginalClOrdId;
+                    break;
+
                 case ExecutionReportReceivedEvent er:
                     Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind);
-                    if (kind == ExecKind.Replaced && er.OrigClOrdId != 0)
+                    // Resolve OrigClOrdId from the link maps when the venue
+                    // dropped it on the wire. Mirrors the runtime
+                    // ExecutionReportProcessor.Apply OrigClOrdId fallback
+                    // (TryResolveOrig) — without this, history strands
+                    // cancel-acks and Replaced ERs whose OrigClOrdId was 0.
+                    var resolvedOrig = er.OrigClOrdId;
+                    if (resolvedOrig == 0)
+                    {
+                        // Two distinct link maps mirror the runtime
+                        // OrderOwnershipMap fallback: a cancel-side ack
+                        // resolves only via cancelLinks (so a Cancel ER
+                        // for a ClOrdID that ALSO happens to be the
+                        // "new" side of an in-flight replace is treated
+                        // as a direct cancel of that order, not a cancel
+                        // of its predecessor — matches runtime, which
+                        // routes the priority-lost cancel-as-replace
+                        // through PendingReplacementRegistry instead of
+                        // the OrigClOrdId fallback). Replaced ERs
+                        // resolve only via replaceLinks.
+                        if (kind == ExecKind.Replaced && replaceLinks.TryGetValue(er.ClOrdId, out var rOrig))
+                            resolvedOrig = rOrig;
+                        else if ((kind is ExecKind.Canceled or ExecKind.Rejected or ExecKind.Expired)
+                            && cancelLinks.TryGetValue(er.ClOrdId, out var cOrig))
+                            resolvedOrig = cOrig;
+                    }
+
+                    if (kind == ExecKind.Replaced && resolvedOrig != 0)
                     {
                         // Mirror ExecutionReportProcessor.ApplyReplaceAccepted
                         // + Order.HydrateReplacement: the original goes
@@ -217,10 +276,10 @@ public static class HistoryEndpoints
                         // row would stay at PendingNew forever — the
                         // venue never issues a separate New ER for the
                         // replacement.
-                        if (byClOrdId.TryGetValue(er.OrigClOrdId, out var origProj))
+                        if (byClOrdId.TryGetValue(resolvedOrig, out var origProj))
                         {
                             origProj.ApplyReplacedTerminal(seq, er);
-                            if (inWindow) hadEventInWindow.Add(er.OrigClOrdId);
+                            if (inWindow) hadEventInWindow.Add(resolvedOrig);
                         }
                         if (byClOrdId.TryGetValue(er.ClOrdId, out var newProj))
                         {
@@ -235,8 +294,8 @@ public static class HistoryEndpoints
                     // lands on the cancel-side ID — never carried by an
                     // OrderSubmittedEvent — but mutates the original).
                     var targetId = er.ClOrdId;
-                    if (er.OrigClOrdId != 0 && byClOrdId.ContainsKey(er.OrigClOrdId))
-                        targetId = er.OrigClOrdId;
+                    if (resolvedOrig != 0 && byClOrdId.ContainsKey(resolvedOrig))
+                        targetId = resolvedOrig;
                     if (byClOrdId.TryGetValue(targetId, out var proj))
                     {
                         proj.ApplyEr(seq, er);
@@ -290,6 +349,13 @@ public static class HistoryEndpoints
         // Same side-table rationale as ProjectOrdersAsync: ER carries no
         // owner/symbol so we backfill from the prior submit/replace.
         var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side)>();
+        // Mirrors OrderOwnershipMap.RegisterCancelLink/RegisterReplaceLink
+        // so cancel/replace ack ERs that the venue emitted with
+        // OrigClOrdId=0 still resolve back to the original order's
+        // owner/firm — without this fallback the executions endpoint
+        // silently drops every such ack for the firm-isolation filter.
+        var cancelLinks = new Dictionary<ulong, ulong>();
+        var replaceLinks = new Dictionary<ulong, ulong>();
         var result = new List<ExecutionProjection>();
 
         await foreach (var (seq, evt) in store.ReadFromAsync(0, ct))
@@ -301,15 +367,39 @@ public static class HistoryEndpoints
                     break;
                 case OrderReplaceRequestedEvent rr:
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
+                    replaceLinks[rr.NewClOrdId] = rr.OriginalClOrdId;
+                    break;
+                case OrderCancelRequestedEvent cr:
+                    cancelLinks[cr.CancelClOrdId] = cr.OriginalClOrdId;
                     break;
                 case ExecutionReportReceivedEvent er:
                     if (er.TimestampUtc < from || er.TimestampUtc > to) break;
-                    // Owner resolution falls back to OrigClOrdId for cancel/
-                    // replace acks where the cancel-side ID was never carried
-                    // by an OrderSubmittedEvent.
+                    // Owner resolution: try the ER's own ClOrdId first,
+                    // then OrigClOrdId, then the link maps (mirroring the
+                    // runtime ExecutionReportProcessor.Apply fallback).
                     (string Owner, string Symbol, string Side)? meta = null;
                     if (ownerByClOrdId.TryGetValue(er.ClOrdId, out var m1)) meta = m1;
                     else if (er.OrigClOrdId != 0 && ownerByClOrdId.TryGetValue(er.OrigClOrdId, out var m2)) meta = m2;
+                    else
+                    {
+                        // OrigClOrdId fallback: same separation as
+                        // ProjectOrdersAsync — replaceLinks is consulted
+                        // only for Replaced ERs, cancelLinks only for
+                        // cancel-side acks (Canceled / Rejected /
+                        // Expired). Mirrors runtime
+                        // OrderOwnershipMap.TryResolveOrig + the
+                        // cancel-as-replace intercept that owns the
+                        // "Cancel ER for the new side of an in-flight
+                        // replace" case via PendingReplacementRegistry,
+                        // not via the OrigClOrdId fallback.
+                        Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var execKind);
+                        if (execKind == ExecKind.Replaced
+                            && replaceLinks.TryGetValue(er.ClOrdId, out var rOrig)
+                            && ownerByClOrdId.TryGetValue(rOrig, out var m3)) meta = m3;
+                        else if (execKind is ExecKind.Canceled or ExecKind.Rejected or ExecKind.Expired
+                            && cancelLinks.TryGetValue(er.ClOrdId, out var cOrig)
+                            && ownerByClOrdId.TryGetValue(cOrig, out var m4)) meta = m4;
+                    }
                     if (meta is null) break;
                     if (!OwnerMatches(meta.Value.Owner, owner)) break;
                     if (symbol is not null && !meta.Value.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
@@ -338,17 +428,25 @@ public static class HistoryEndpoints
 
     private static PageResult<T> ApplyCursorAndPage<T>(
         List<T> sortedDesc, CursorState? cursor, int pageSize, long snapshotSeq,
-        Func<T, (long Seq, DateTimeOffset Ts)> anchor)
+        Func<T, (long Seq, ulong TieBreaker, DateTimeOffset Ts)> anchor)
     {
-        // Items are sorted seq-DESC. The cursor anchors the LAST item we
-        // returned previously; the next page strictly precedes it.
+        // Items are sorted (Seq DESC, TieBreaker DESC). The cursor anchors
+        // the LAST item we returned previously; the next page strictly
+        // precedes it under the same composite ordering. The TieBreaker
+        // is the order's ClOrdId for /orders/history (a Replaced ER
+        // updates both the original and the replacement with the same
+        // LastSeq, so paging by Seq alone would drop the sibling at the
+        // boundary). For /executions/history each ER occupies a unique
+        // WAL Seq so the tie-breaker is unused (passed as 0).
         IEnumerable<T> windowed = sortedDesc;
         if (cursor is { } c)
         {
             windowed = sortedDesc.Where(x =>
             {
                 var a = anchor(x);
-                return a.Seq < c.Seq;
+                if (a.Seq < c.Seq) return true;
+                if (a.Seq > c.Seq) return false;
+                return a.TieBreaker < c.ClOrdId;
             });
         }
 
@@ -373,7 +471,7 @@ public static class HistoryEndpoints
             // snapshotSeq travels with the cursor so every page in the
             // walk reads the same frozen view. Executions pass 0 here
             // and ProjectExecutionsAsync ignores the field.
-            next = EncodeCursor(new CursorState(a.Seq, a.Ts) { SnapshotSeq = snapshotSeq });
+            next = EncodeCursor(new CursorState(a.Seq, a.Ts) { ClOrdId = a.TieBreaker, SnapshotSeq = snapshotSeq });
         }
         return new PageResult<T>(taken, next);
     }
@@ -549,23 +647,123 @@ public static class HistoryEndpoints
             LastTs = rr.TimestampUtc,
         };
 
+        /// <summary>
+        /// Applies an ER to this projection. Mirrors the runtime
+        /// state-transition guards in
+        /// <c>ExecutionReportProcessor.Apply</c> and
+        /// <see cref="B3.Trading.Domain.Order.ApplyCumulativeFill"/> /
+        /// <see cref="B3.Trading.Domain.Order.MarkCancelled"/> /
+        /// <see cref="B3.Trading.Domain.Order.MarkRejected"/> /
+        /// <see cref="B3.Trading.Domain.Order.MarkWorking"/>:
+        /// <list type="bullet">
+        ///   <item>Fills only advance forward on cumulative quantity and
+        ///   never regress a terminal status (<c>Cancelled</c> /
+        ///   <c>Rejected</c> / <c>Replaced</c>); a late fill on a
+        ///   cancelled order keeps the order Cancelled.</item>
+        ///   <item>Cancels are dropped if the order is already terminal
+        ///   (<c>Filled</c> / <c>Rejected</c> / <c>Cancelled</c> /
+        ///   <c>Replaced</c>).</item>
+        ///   <item>Rejects are dropped if the order has any fill or is
+        ///   terminal.</item>
+        ///   <item><c>New</c> only transitions from <c>PendingNew</c> and
+        ///   never touches leaves/cum.</item>
+        /// </list>
+        /// Without these guards, the history view diverges from the
+        /// runtime book on ER orderings the runtime de-duplicates
+        /// (e.g. <c>[Canceled(A), Fill(A)]</c> → runtime keeps A
+        /// Cancelled; history previously flipped to Filled).
+        /// </summary>
         public void ApplyEr(long seq, ExecutionReportReceivedEvent er)
         {
-            LeavesQuantity = er.LeavesQuantity;
-            CumulativeQuantity = er.CumulativeQuantity;
             if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))
             {
-                Status = kind switch
+                switch (kind)
                 {
-                    ExecKind.New => OrderStatus.Working,
-                    ExecKind.PartialFill => OrderStatus.PartiallyFilled,
-                    ExecKind.Fill => er.LeavesQuantity == 0 ? OrderStatus.Filled : OrderStatus.PartiallyFilled,
-                    ExecKind.Canceled => OrderStatus.Cancelled,
-                    ExecKind.Expired => OrderStatus.Cancelled,
-                    ExecKind.Rejected => OrderStatus.Rejected,
-                    ExecKind.Replaced => OrderStatus.Replaced,
-                    _ => Status,
-                };
+                    case ExecKind.New:
+                        // Order.MarkWorking: PendingNew → Working only.
+                        // Leaves/cum are NOT touched (the runtime never
+                        // alters them on a New ER either; a re-delivered
+                        // New must not regress a fillable order).
+                        if (Status == OrderStatus.PendingNew)
+                            Status = OrderStatus.Working;
+                        break;
+
+                    case ExecKind.PartialFill:
+                    case ExecKind.Fill:
+                        // Order.ApplyCumulativeFill: only advance when
+                        // cumQty > current; preserve terminal status on
+                        // late fills (Cancelled / Rejected / Replaced
+                        // remain — exchange's truth still books to
+                        // positions in the runtime, but the order
+                        // surface keeps its terminal label).
+                        if (er.CumulativeQuantity > CumulativeQuantity)
+                        {
+                            CumulativeQuantity = er.CumulativeQuantity;
+                            LeavesQuantity = Math.Max(0, Quantity - CumulativeQuantity);
+                            if (Status is not (OrderStatus.Cancelled
+                                or OrderStatus.Rejected
+                                or OrderStatus.Replaced))
+                            {
+                                Status = LeavesQuantity == 0
+                                    ? OrderStatus.Filled
+                                    : OrderStatus.PartiallyFilled;
+                            }
+                        }
+                        break;
+
+                    case ExecKind.Canceled:
+                    case ExecKind.Expired:
+                        // Order.MarkCancelled: dropped if already terminal.
+                        // Note ExecutionReportProcessor.Apply also drops a
+                        // Canceled ER for an already-PartiallyFilled order
+                        // only via the MarkCancelled guard — which DOES
+                        // allow PartiallyFilled→Cancelled (a working order
+                        // with a partial can still be cancelled). Mirror
+                        // exactly: only Filled/Rejected/Cancelled/Replaced
+                        // block.
+                        if (Status is not (OrderStatus.Filled
+                            or OrderStatus.Rejected
+                            or OrderStatus.Cancelled
+                            or OrderStatus.Replaced))
+                        {
+                            Status = OrderStatus.Cancelled;
+                            LeavesQuantity = er.LeavesQuantity;
+                            CumulativeQuantity = Math.Max(CumulativeQuantity, er.CumulativeQuantity);
+                        }
+                        break;
+
+                    case ExecKind.Rejected:
+                        // Order.MarkRejected: dropped after any fill or
+                        // any terminal. Matches the
+                        // ExecutionReportProcessor guard set exactly.
+                        if (Status is not (OrderStatus.Filled
+                            or OrderStatus.PartiallyFilled
+                            or OrderStatus.Rejected
+                            or OrderStatus.Cancelled
+                            or OrderStatus.Replaced))
+                        {
+                            Status = OrderStatus.Rejected;
+                            LeavesQuantity = er.LeavesQuantity;
+                            CumulativeQuantity = Math.Max(CumulativeQuantity, er.CumulativeQuantity);
+                        }
+                        break;
+
+                    case ExecKind.Replaced:
+                        // Defensive only: Replaced ERs flow through
+                        // ApplyReplacedTerminal/HydrateFromReplaceEr in
+                        // ProjectOrdersAsync. If we land here it means
+                        // OrigClOrdId was missing AND no replace link
+                        // was registered — fall back to MarkReplaced
+                        // semantics on the targeted projection.
+                        if (Status is not (OrderStatus.Filled
+                            or OrderStatus.Rejected
+                            or OrderStatus.Cancelled
+                            or OrderStatus.Replaced))
+                        {
+                            Status = OrderStatus.Replaced;
+                        }
+                        break;
+                }
             }
             LastSeq = seq;
             LastTs = er.TimestampUtc;
@@ -704,6 +902,15 @@ public static class HistoryEndpoints
         // Default 0 means "no snapshot" — old cursors (pre-fix) and the
         // executions endpoint both deserialise/encode that way.
         [System.Text.Json.Serialization.JsonPropertyName("snap")] public long SnapshotSeq { get; init; }
+        // Q2.1 (#268) — composite-keyset tie-breaker. Required because
+        // a Replaced ER advances both the original and the replacement
+        // projection to the same LastSeq; sorting/paging by Seq alone
+        // would silently drop one sibling whenever the page boundary
+        // fell between them. ClOrdId is the secondary sort key for the
+        // /orders/history walk; /executions/history sets it to 0
+        // (each ER is one WAL row with a unique Seq). Default 0 keeps
+        // pre-fix encoded cursors decodable.
+        [System.Text.Json.Serialization.JsonPropertyName("cl")] public ulong ClOrdId { get; init; }
     }
 
     private sealed record PageResult<T>(IReadOnlyList<T> Items, string? NextCursor);

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -899,6 +899,20 @@ public static class HistoryEndpoints
                         break;
                 }
             }
+            // Mirror ExecutionReportProcessor.Apply (slice 1 of #132): a real
+            // terminal ER proves the venue still knew the order, so any prior
+            // advisory stale overlay was a false positive. Clear stale on
+            // Filled/Cancelled/Rejected/Replaced — but NOT on PartiallyFilled
+            // (trader's concern about the un-filled remainder is still valid).
+            if (IsStale && Status is OrderStatus.Filled
+                or OrderStatus.Cancelled
+                or OrderStatus.Rejected
+                or OrderStatus.Replaced)
+            {
+                IsStale = false;
+                StaleReason = null;
+                StaledAtUtc = null;
+            }
             LastSeq = seq;
             LastTs = er.TimestampUtc;
         }

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -92,8 +92,17 @@ public static class HistoryEndpoints
             }
             else
             {
-                await store.FlushAsync(ct);
+                // Capture the boundary BEFORE the flush — IEventStore.CurrentSeq
+                // includes appends that have not yet hit disk, so reading it after
+                // FlushAsync allows a concurrent AppendCore (between the flush
+                // returning and CurrentSeq being read) to inflate snapshotSeq with
+                // a record that page 1 cannot see. That record's (LastSeq, ClOrdId)
+                // would sort above page 1's cursor anchor and be filtered out of
+                // every subsequent page forever. Capturing first and flushing after
+                // gives a stable frozen view: late appends get a seq > snapshotSeq
+                // and are intentionally invisible to this walk.
                 snapshotSeq = store.CurrentSeq;
+                await store.FlushAsync(ct);
             }
 
             var orders = await ProjectOrdersAsync(store, owner.Value, symbol, fromTs, toTs, snapshotSeq, ct);

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -1,0 +1,602 @@
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// Q2.1 (#268). Trader-scoped historical queries projected on demand
+/// from the WAL:
+/// <list type="bullet">
+///   <item><c>GET /orders/history</c> — one entry per ClOrdID, materialised
+///   from the order's submit + ER stream; includes terminals.</item>
+///   <item><c>GET /executions/history</c> — one entry per ExecutionReport
+///   the platform routed; covers every <see cref="ExecKind"/>.</item>
+/// </list>
+///
+/// <para>
+/// Pagination is cursor-based. The cursor is an opaque base64 of a
+/// <c>{"seq":...,"ts":...}</c> JSON object; clients must treat it as a
+/// black-box token. Default page size is 100 with a hard cap of 500
+/// (over-cap requests are clamped, not rejected). Date filter
+/// <c>[from,to]</c> is in UTC and applied to the WAL event timestamp;
+/// optional <c>symbol</c> matches the exchange ticker exactly.
+/// </para>
+///
+/// <para>
+/// <b>Implementation note.</b> The current projection walks the WAL
+/// from genesis on every request and materialises in memory before
+/// applying the requested page. That is O(N) in the WAL length and is
+/// acceptable for participant-side volumes (RFC §4.2 — single-firm,
+/// ≤30k events/day) but will need to swap for an indexed read once
+/// retention grows. The cursor envelope is intentionally future-proof:
+/// <c>{seq,ts}</c> is enough to anchor a binary search via the segment
+/// index, so an indexed implementation can ship without a wire-shape
+/// change. TODO(history-index): indexed reader keyed by
+/// <c>(endclient, ts)</c>, tracked alongside the EOD materialiser.
+/// </para>
+/// </summary>
+public static class HistoryEndpoints
+{
+    /// <summary>Default page size when the caller omits <c>limit</c>.</summary>
+    public const int DefaultLimit = 100;
+
+    /// <summary>Hard cap on page size. Larger values are clamped, not rejected.</summary>
+    public const int MaxLimit = 500;
+
+    public static IEndpointRouteBuilder MapHistory(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/orders/history", async (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            IEventStore store,
+            string? from,
+            string? to,
+            string? cursor,
+            int? limit,
+            string? symbol,
+            CancellationToken ct) =>
+        {
+            if (!TryParseRange(from, to, out var fromTs, out var toTs, out var rangeError))
+                return Results.BadRequest(new { error = rangeError });
+            if (!TryParseCursor(cursor, out var cursorState, out var cursorError))
+                return Results.BadRequest(new { error = cursorError });
+
+            var owner = ResolveOwner(ctx, registry);
+            var pageSize = ClampLimit(limit);
+
+            var orders = await ProjectOrdersAsync(store, owner.Value, symbol, fromTs, toTs, ct);
+            // Sort newest-first by the order's last touching seq (cursor anchor).
+            orders.Sort(static (a, b) => b.LastSeq.CompareTo(a.LastSeq));
+
+            var page = ApplyCursorAndPage(orders, cursorState, pageSize, static x => (x.LastSeq, x.LastTs));
+            var items = new List<OrderHistoryItemDto>(page.Items.Count);
+            foreach (var p in page.Items) items.Add(p.ToDto());
+
+            return Results.Ok(new HistoryPageDto<OrderHistoryItemDto>(items, page.NextCursor));
+        }).RequireAuthorization();
+
+        app.MapGet("/executions/history", async (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            IEventStore store,
+            string? from,
+            string? to,
+            string? cursor,
+            int? limit,
+            string? symbol,
+            CancellationToken ct) =>
+        {
+            if (!TryParseRange(from, to, out var fromTs, out var toTs, out var rangeError))
+                return Results.BadRequest(new { error = rangeError });
+            if (!TryParseCursor(cursor, out var cursorState, out var cursorError))
+                return Results.BadRequest(new { error = cursorError });
+
+            var owner = ResolveOwner(ctx, registry);
+            var pageSize = ClampLimit(limit);
+
+            var executions = await ProjectExecutionsAsync(store, owner.Value, symbol, fromTs, toTs, ct);
+            executions.Sort(static (a, b) => b.Seq.CompareTo(a.Seq));
+
+            var page = ApplyCursorAndPage(executions, cursorState, pageSize, static x => (x.Seq, x.TimestampUtc));
+            var items = new List<ExecutionHistoryItemDto>(page.Items.Count);
+            foreach (var e in page.Items) items.Add(e.ToDto());
+
+            return Results.Ok(new HistoryPageDto<ExecutionHistoryItemDto>(items, page.NextCursor));
+        }).RequireAuthorization();
+
+        return app;
+    }
+
+    // -----------------------------------------------------------------
+    // Projection: orders
+    // -----------------------------------------------------------------
+
+    private static async Task<List<OrderProjection>> ProjectOrdersAsync(
+        IEventStore store, string owner, string? symbol, DateTimeOffset from, DateTimeOffset to, CancellationToken ct)
+    {
+        // Force the WAL writer to drain so freshly-appended events are
+        // visible on disk: ReadFromAsync only reads persisted segments.
+        // Cheap when nothing is pending.
+        await store.FlushAsync(ct);
+        var byClOrdId = new Dictionary<ulong, OrderProjection>();
+        // Side-table: every ClOrdId we have ever seen on the WAL, mapped
+        // to its owner + symbol. Needed because ER events do not carry
+        // owner/symbol and the cancel-side ClOrdID is invented at cancel
+        // time (not submit). Tracking firm-wide is fine — we filter to
+        // the requested owner only when materialising the projection.
+        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol)>();
+
+        await foreach (var (seq, evt) in store.ReadFromAsync(0, ct))
+        {
+            switch (evt)
+            {
+                case OrderSubmittedEvent o:
+                    ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol);
+                    if (!OwnerMatches(o.EndClientId, owner)) break;
+                    if (symbol is not null && !o.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
+                    byClOrdId[o.ClOrdId] = OrderProjection.FromSubmit(seq, o);
+                    break;
+
+                case OrderReplaceRequestedEvent rr:
+                    // The replacement is itself a brand-new ClOrdID and
+                    // becomes its own row in the history (matches the
+                    // live ExecutionReportProcessor.HandleReplaced semantics
+                    // where the new ID is a separate Order).
+                    ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol);
+                    if (!OwnerMatches(rr.EndClientId, owner)) break;
+                    if (symbol is not null && !rr.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
+                    byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(seq, rr);
+                    break;
+
+                case ExecutionReportReceivedEvent er:
+                    // ER may target either ClOrdId directly (New, Fill, etc.)
+                    // or via OrigClOrdId (cancel-replace ack lands on the
+                    // new ID but mutates the original). Mirror the live
+                    // processor's resolution exactly.
+                    var targetId = er.ClOrdId;
+                    if (er.OrigClOrdId != 0 && byClOrdId.ContainsKey(er.OrigClOrdId))
+                        targetId = er.OrigClOrdId;
+                    if (byClOrdId.TryGetValue(targetId, out var proj))
+                        proj.ApplyEr(seq, er);
+                    break;
+
+                case OrderStaledEvent os:
+                    if (byClOrdId.TryGetValue(os.ClOrdId, out var staleProj))
+                        staleProj.ApplyStaled(seq, os);
+                    break;
+
+                case OrderStaleClearedEvent osc:
+                    if (byClOrdId.TryGetValue(osc.ClOrdId, out var clearProj))
+                        clearProj.ApplyStaleCleared(seq, osc);
+                    break;
+            }
+        }
+
+        // Keep only the orders whose last-touching event falls inside
+        // the requested window. Sub-window orders that are still
+        // working would not appear — that matches the spec (history is
+        // a slice of WAL events, not "all currently open").
+        var result = new List<OrderProjection>(byClOrdId.Count);
+        foreach (var p in byClOrdId.Values)
+        {
+            if (p.LastTs < from || p.LastTs > to) continue;
+            result.Add(p);
+        }
+        return result;
+    }
+
+    // -----------------------------------------------------------------
+    // Projection: executions
+    // -----------------------------------------------------------------
+
+    private static async Task<List<ExecutionProjection>> ProjectExecutionsAsync(
+        IEventStore store, string owner, string? symbol, DateTimeOffset from, DateTimeOffset to, CancellationToken ct)
+    {
+        // See ProjectOrdersAsync: drain the writer so the read-side picks
+        // up everything appended before the request.
+        await store.FlushAsync(ct);
+        // Same side-table rationale as ProjectOrdersAsync: ER carries no
+        // owner/symbol so we backfill from the prior submit/replace.
+        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side)>();
+        var result = new List<ExecutionProjection>();
+
+        await foreach (var (seq, evt) in store.ReadFromAsync(0, ct))
+        {
+            switch (evt)
+            {
+                case OrderSubmittedEvent o:
+                    ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol, o.Side);
+                    break;
+                case OrderReplaceRequestedEvent rr:
+                    ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
+                    break;
+                case ExecutionReportReceivedEvent er:
+                    if (er.TimestampUtc < from || er.TimestampUtc > to) break;
+                    // Owner resolution falls back to OrigClOrdId for cancel/
+                    // replace acks where the cancel-side ID was never carried
+                    // by an OrderSubmittedEvent.
+                    (string Owner, string Symbol, string Side)? meta = null;
+                    if (ownerByClOrdId.TryGetValue(er.ClOrdId, out var m1)) meta = m1;
+                    else if (er.OrigClOrdId != 0 && ownerByClOrdId.TryGetValue(er.OrigClOrdId, out var m2)) meta = m2;
+                    if (meta is null) break;
+                    if (!OwnerMatches(meta.Value.Owner, owner)) break;
+                    if (symbol is not null && !meta.Value.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
+                    result.Add(new ExecutionProjection(
+                        Seq: seq,
+                        ClOrdId: er.ClOrdId,
+                        Symbol: meta.Value.Symbol,
+                        Side: meta.Value.Side,
+                        Kind: er.ExecKind,
+                        LeavesQuantity: er.LeavesQuantity,
+                        CumulativeQuantity: er.CumulativeQuantity,
+                        LastQuantity: er.LastQuantity,
+                        LastPrice: er.LastPrice,
+                        RejectReason: er.RejectReason,
+                        TimestampUtc: er.TimestampUtc));
+                    break;
+            }
+        }
+
+        return result;
+    }
+
+    // -----------------------------------------------------------------
+    // Cursor + paging helpers
+    // -----------------------------------------------------------------
+
+    private static PageResult<T> ApplyCursorAndPage<T>(
+        List<T> sortedDesc, CursorState? cursor, int pageSize,
+        Func<T, (long Seq, DateTimeOffset Ts)> anchor)
+    {
+        // Items are sorted seq-DESC. The cursor anchors the LAST item we
+        // returned previously; the next page strictly precedes it.
+        IEnumerable<T> windowed = sortedDesc;
+        if (cursor is { } c)
+        {
+            windowed = sortedDesc.Where(x =>
+            {
+                var a = anchor(x);
+                return a.Seq < c.Seq;
+            });
+        }
+
+        var taken = new List<T>(pageSize);
+        T? last = default;
+        var hasMore = false;
+        foreach (var x in windowed)
+        {
+            if (taken.Count == pageSize)
+            {
+                hasMore = true;
+                break;
+            }
+            taken.Add(x);
+            last = x;
+        }
+
+        string? next = null;
+        if (hasMore && last is not null)
+        {
+            var a = anchor(last);
+            next = EncodeCursor(new CursorState(a.Seq, a.Ts));
+        }
+        return new PageResult<T>(taken, next);
+    }
+
+    private static int ClampLimit(int? limit)
+    {
+        if (limit is null || limit <= 0) return DefaultLimit;
+        if (limit > MaxLimit) return MaxLimit;
+        return limit.Value;
+    }
+
+    private static bool TryParseRange(
+        string? from, string? to,
+        out DateTimeOffset fromTs, out DateTimeOffset toTs, out string? error)
+    {
+        var nowUtc = DateTimeOffset.UtcNow;
+        toTs = nowUtc;
+        // Default `from` = today UTC start.
+        fromTs = new DateTimeOffset(nowUtc.UtcDateTime.Date, TimeSpan.Zero);
+        error = null;
+
+        if (!string.IsNullOrWhiteSpace(from))
+        {
+            if (!DateTimeOffset.TryParse(from, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                    out var parsed))
+            {
+                error = $"invalid 'from' timestamp: '{from}' (expected ISO 8601)";
+                return false;
+            }
+            fromTs = parsed;
+        }
+        if (!string.IsNullOrWhiteSpace(to))
+        {
+            if (!DateTimeOffset.TryParse(to, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                    out var parsed))
+            {
+                error = $"invalid 'to' timestamp: '{to}' (expected ISO 8601)";
+                return false;
+            }
+            toTs = parsed;
+        }
+        if (toTs < fromTs)
+        {
+            error = "'to' must be greater than or equal to 'from'";
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryParseCursor(string? cursor, out CursorState? state, out string? error)
+    {
+        state = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(cursor)) return true;
+        try
+        {
+            // The cursor wire-format is intentionally URL-safe-tolerant:
+            // accept '-_' as well as '+/' so callers do not have to
+            // double-encode in query strings.
+            var normalised = cursor.Replace('-', '+').Replace('_', '/');
+            // Pad to a multiple of 4 — Convert.FromBase64String is strict.
+            switch (normalised.Length % 4)
+            {
+                case 2: normalised += "=="; break;
+                case 3: normalised += "="; break;
+            }
+            var bytes = Convert.FromBase64String(normalised);
+            var parsed = JsonSerializer.Deserialize<CursorState>(bytes);
+            if (parsed is null || parsed.Seq < 0)
+            {
+                error = "malformed cursor";
+                return false;
+            }
+            state = parsed;
+            return true;
+        }
+        catch (Exception)
+        {
+            error = "malformed cursor";
+            return false;
+        }
+    }
+
+    private static string EncodeCursor(CursorState state)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(state);
+        return Convert.ToBase64String(bytes);
+    }
+
+    private static bool OwnerMatches(string eventOwner, string requestedOwner) =>
+        // EndClientRegistry stores ids lowercased; WAL events were appended with the
+        // same value, so a case-sensitive ordinal compare is safe and faster.
+        string.Equals(eventOwner, requestedOwner, StringComparison.Ordinal);
+
+    private static EndClientId ResolveOwner(HttpContext ctx, EndClientRegistry registry)
+    {
+        var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                  ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
+        return registry.Register(sub);
+    }
+
+    // -----------------------------------------------------------------
+    // Internal projection types
+    // -----------------------------------------------------------------
+
+    private sealed class OrderProjection
+    {
+        public ulong ClOrdId;
+        public string Symbol = string.Empty;
+        public ulong SecurityId;
+        public string Side = string.Empty;
+        public string Type = string.Empty;
+        public long Quantity;
+        public decimal? Price;
+        public string TimeInForce = nameof(B3.Trading.Domain.TimeInForce.Day);
+        public decimal? StopPrice;
+        public DateTimeOffset? GoodTillDate;
+
+        public long LeavesQuantity;
+        public long CumulativeQuantity;
+        public OrderStatus Status = OrderStatus.PendingNew;
+
+        public bool IsStale;
+        public string? StaleReason;
+        public DateTimeOffset? StaledAtUtc;
+
+        public long FirstSeq;
+        public DateTimeOffset CreatedAtUtc;
+        public long LastSeq;
+        public DateTimeOffset LastTs;
+
+        public static OrderProjection FromSubmit(long seq, OrderSubmittedEvent o) => new()
+        {
+            ClOrdId = o.ClOrdId,
+            Symbol = o.Symbol,
+            SecurityId = o.SecurityId,
+            Side = o.Side,
+            Type = o.Type,
+            Quantity = o.Quantity,
+            Price = o.Price,
+            TimeInForce = o.TimeInForce,
+            StopPrice = o.StopPrice,
+            GoodTillDate = o.GoodTillDate,
+            LeavesQuantity = o.Quantity,
+            CumulativeQuantity = 0,
+            Status = OrderStatus.PendingNew,
+            FirstSeq = seq,
+            CreatedAtUtc = o.TimestampUtc,
+            LastSeq = seq,
+            LastTs = o.TimestampUtc,
+        };
+
+        public static OrderProjection FromReplace(long seq, OrderReplaceRequestedEvent rr) => new()
+        {
+            ClOrdId = rr.NewClOrdId,
+            Symbol = rr.Symbol,
+            SecurityId = rr.SecurityId,
+            Side = rr.Side,
+            Type = rr.Type,
+            Quantity = rr.NewQuantity,
+            Price = rr.NewPrice,
+            TimeInForce = rr.RequestedTimeInForce ?? nameof(B3.Trading.Domain.TimeInForce.Day),
+            StopPrice = rr.RequestedStopPrice,
+            GoodTillDate = rr.RequestedGoodTillDate,
+            LeavesQuantity = rr.NewQuantity,
+            CumulativeQuantity = 0,
+            Status = OrderStatus.PendingNew,
+            FirstSeq = seq,
+            CreatedAtUtc = rr.TimestampUtc,
+            LastSeq = seq,
+            LastTs = rr.TimestampUtc,
+        };
+
+        public void ApplyEr(long seq, ExecutionReportReceivedEvent er)
+        {
+            LeavesQuantity = er.LeavesQuantity;
+            CumulativeQuantity = er.CumulativeQuantity;
+            if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))
+            {
+                Status = kind switch
+                {
+                    ExecKind.New => OrderStatus.Working,
+                    ExecKind.PartialFill => OrderStatus.PartiallyFilled,
+                    ExecKind.Fill => er.LeavesQuantity == 0 ? OrderStatus.Filled : OrderStatus.PartiallyFilled,
+                    ExecKind.Canceled => OrderStatus.Cancelled,
+                    ExecKind.Expired => OrderStatus.Cancelled,
+                    ExecKind.Rejected => OrderStatus.Rejected,
+                    ExecKind.Replaced => OrderStatus.Replaced,
+                    _ => Status,
+                };
+            }
+            LastSeq = seq;
+            LastTs = er.TimestampUtc;
+        }
+
+        public void ApplyStaled(long seq, OrderStaledEvent os)
+        {
+            IsStale = true;
+            StaleReason = os.Reason;
+            StaledAtUtc = os.StaledAtUtc;
+            LastSeq = seq;
+            LastTs = os.TimestampUtc;
+        }
+
+        public void ApplyStaleCleared(long seq, OrderStaleClearedEvent osc)
+        {
+            IsStale = false;
+            StaleReason = null;
+            StaledAtUtc = null;
+            LastSeq = seq;
+            LastTs = osc.TimestampUtc;
+        }
+
+        public OrderHistoryItemDto ToDto() => new(
+            ClOrdId.ToString(),
+            Symbol,
+            SecurityId,
+            Side,
+            Type,
+            Quantity,
+            LeavesQuantity,
+            CumulativeQuantity,
+            Price,
+            Status.ToString(),
+            TimeInForce,
+            StopPrice,
+            GoodTillDate,
+            IsStale,
+            StaleReason,
+            StaledAtUtc,
+            CreatedAtUtc,
+            LastTs);
+    }
+
+    private sealed record ExecutionProjection(
+        long Seq,
+        ulong ClOrdId,
+        string Symbol,
+        string Side,
+        string Kind,
+        long LeavesQuantity,
+        long CumulativeQuantity,
+        long LastQuantity,
+        decimal LastPrice,
+        string? RejectReason,
+        DateTimeOffset TimestampUtc)
+    {
+        public ExecutionHistoryItemDto ToDto() => new(
+            ClOrdId.ToString(),
+            Symbol,
+            Side,
+            Kind,
+            LeavesQuantity,
+            CumulativeQuantity,
+            LastQuantity,
+            LastPrice,
+            RejectReason,
+            TimestampUtc,
+            IsNativeStp: Kind.Equals(nameof(ExecKind.Canceled), StringComparison.OrdinalIgnoreCase)
+                && NativeStpDetector.IsNativeStpReason(RejectReason));
+    }
+
+    private sealed record CursorState(long Seq, DateTimeOffset Ts)
+    {
+        // STJ requires either a parameterless ctor or matching property names
+        // for deserialisation. Using positional record + lowercased JSON
+        // keys via [JsonPropertyName] keeps the wire format compact.
+        [System.Text.Json.Serialization.JsonPropertyName("seq")] public long Seq { get; init; } = Seq;
+        [System.Text.Json.Serialization.JsonPropertyName("ts")] public DateTimeOffset Ts { get; init; } = Ts;
+    }
+
+    private sealed record PageResult<T>(IReadOnlyList<T> Items, string? NextCursor);
+}
+
+/// <summary>Q2.1 (#268). Generic cursor-paginated history page wire shape.</summary>
+public sealed record HistoryPageDto<T>(IReadOnlyList<T> Items, string? NextCursor);
+
+/// <summary>Q2.1 (#268). Wire shape for one row of <c>GET /orders/history</c>.</summary>
+public sealed record OrderHistoryItemDto(
+    string ClOrdId,
+    string Symbol,
+    ulong SecurityId,
+    string Side,
+    string Type,
+    long Quantity,
+    long LeavesQuantity,
+    long CumulativeQuantity,
+    decimal? Price,
+    string Status,
+    string TimeInForce,
+    decimal? StopPrice,
+    DateTimeOffset? GoodTillDate,
+    bool IsStale,
+    string? StaleReason,
+    DateTimeOffset? StaledAtUtc,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset LastUpdatedAtUtc);
+
+/// <summary>Q2.1 (#268). Wire shape for one row of <c>GET /executions/history</c>.</summary>
+public sealed record ExecutionHistoryItemDto(
+    string ClOrdId,
+    string Symbol,
+    string Side,
+    string Kind,
+    long LeavesQuantity,
+    long CumulativeQuantity,
+    long LastQuantity,
+    decimal LastPrice,
+    string? RejectReason,
+    DateTimeOffset TimestampUtc,
+    bool IsNativeStp);

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -223,7 +223,16 @@ public static class HistoryEndpoints
                     replaceLinks[rr.NewClOrdId] = new ReplaceIntent(rr.OriginalClOrdId, rr.NewQuantity);
                     if (!OwnerMatches(rr.EndClientId, owner)) break;
                     if (symbol is not null && !rr.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
-                    byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(seq, rr);
+                    byClOrdId[rr.NewClOrdId] = OrderProjection.FromReplace(
+                        seq,
+                        rr,
+                        // Inherit TIF/StopPrice/GoodTillDate from the
+                        // original projection when the modify request
+                        // omits them — mirrors Order.HydrateReplacement
+                        // / Order.MergeReplacementOptionals so a quantity-
+                        // only replace of a GTD or stop order doesn't
+                        // silently drop those fields in the history view.
+                        byClOrdId.TryGetValue(rr.OriginalClOrdId, out var origReplaceFrom) ? origReplaceFrom : null);
                     if (inWindow) hadEventInWindow.Add(rr.NewClOrdId);
                     break;
 
@@ -703,26 +712,60 @@ public static class HistoryEndpoints
             LastTs = o.TimestampUtc,
         };
 
-        public static OrderProjection FromReplace(long seq, OrderReplaceRequestedEvent rr) => new()
+        public static OrderProjection FromReplace(long seq, OrderReplaceRequestedEvent rr, OrderProjection? original)
         {
-            ClOrdId = rr.NewClOrdId,
-            Symbol = rr.Symbol,
-            SecurityId = rr.SecurityId,
-            Side = rr.Side,
-            Type = rr.Type,
-            Quantity = rr.NewQuantity,
-            Price = rr.NewPrice,
-            TimeInForce = rr.RequestedTimeInForce ?? nameof(B3.Trading.Domain.TimeInForce.Day),
-            StopPrice = rr.RequestedStopPrice,
-            GoodTillDate = rr.RequestedGoodTillDate,
-            LeavesQuantity = rr.NewQuantity,
-            CumulativeQuantity = 0,
-            Status = OrderStatus.PendingNew,
-            FirstSeq = seq,
-            CreatedAtUtc = rr.TimestampUtc,
-            LastSeq = seq,
-            LastTs = rr.TimestampUtc,
-        };
+            // Q1.1 (#253) parity with Order.HydrateReplacement /
+            // Order.MergeReplacementOptionals: when the modify request
+            // omits TIF / StopPrice / GoodTillDate, the runtime
+            // INHERITS them from the original order. Treating the
+            // requested fields as final values would silently demote a
+            // GTD or stop order on a quantity-only replace (history
+            // would show TIF=Day + null stop/gtd while the live book
+            // kept the original semantics).
+            //
+            // Mirror MergeReplacementOptionals exactly so the projection
+            // matches HydrateReplacement's effective fields:
+            //   • effTif  = requested ?? original
+            //   • effStop = requested ?? original
+            //   • effGtd  = requested ?? original IF effTif == GTD;
+            //               otherwise auto-cleared (same trick the
+            //               domain uses to let callers shed an inherited
+            //               expiry just by switching TIF away from GTD).
+            //
+            // If the original projection isn't available (e.g. owner
+            // filter dropped it, or the WAL slice begins after the
+            // original) we fall back to the request as-is — there is
+            // no inheritance source.
+            var effTif = rr.RequestedTimeInForce
+                ?? original?.TimeInForce
+                ?? nameof(B3.Trading.Domain.TimeInForce.Day);
+            var effStop = rr.RequestedStopPrice ?? original?.StopPrice;
+            var isGtd = string.Equals(effTif, nameof(B3.Trading.Domain.TimeInForce.GTD), StringComparison.Ordinal);
+            var effGtd = isGtd
+                ? (rr.RequestedGoodTillDate ?? original?.GoodTillDate)
+                : null;
+
+            return new OrderProjection
+            {
+                ClOrdId = rr.NewClOrdId,
+                Symbol = rr.Symbol,
+                SecurityId = rr.SecurityId,
+                Side = rr.Side,
+                Type = rr.Type,
+                Quantity = rr.NewQuantity,
+                Price = rr.NewPrice,
+                TimeInForce = effTif,
+                StopPrice = effStop,
+                GoodTillDate = effGtd,
+                LeavesQuantity = rr.NewQuantity,
+                CumulativeQuantity = 0,
+                Status = OrderStatus.PendingNew,
+                FirstSeq = seq,
+                CreatedAtUtc = rr.TimestampUtc,
+                LastSeq = seq,
+                LastTs = rr.TimestampUtc,
+            };
+        }
 
         /// <summary>
         /// Applies an ER to this projection. Mirrors the runtime
@@ -797,15 +840,20 @@ public static class HistoryEndpoints
                         // allow PartiallyFilled→Cancelled (a working order
                         // with a partial can still be cancelled). Mirror
                         // exactly: only Filled/Rejected/Cancelled/Replaced
-                        // block.
+                        // block. Crucially, MarkCancelled only flips
+                        // Status — it does NOT touch leaves/cum. Real
+                        // venue cancels typically carry LeavesQuantity=0,
+                        // so copying them into the projection would
+                        // diverge from the runtime book (a 10-lot working
+                        // order cancelled would show leaves=0 in history
+                        // while runtime keeps leaves=10). Quantities only
+                        // advance from fill ERs.
                         if (Status is not (OrderStatus.Filled
                             or OrderStatus.Rejected
                             or OrderStatus.Cancelled
                             or OrderStatus.Replaced))
                         {
                             Status = OrderStatus.Cancelled;
-                            LeavesQuantity = er.LeavesQuantity;
-                            CumulativeQuantity = Math.Max(CumulativeQuantity, er.CumulativeQuantity);
                         }
                         break;
 
@@ -813,6 +861,8 @@ public static class HistoryEndpoints
                         // Order.MarkRejected: dropped after any fill or
                         // any terminal. Matches the
                         // ExecutionReportProcessor guard set exactly.
+                        // Like MarkCancelled, MarkRejected is status-only;
+                        // do not copy leaves/cum from the ER.
                         if (Status is not (OrderStatus.Filled
                             or OrderStatus.PartiallyFilled
                             or OrderStatus.Rejected
@@ -820,8 +870,6 @@ public static class HistoryEndpoints
                             or OrderStatus.Replaced))
                         {
                             Status = OrderStatus.Rejected;
-                            LeavesQuantity = er.LeavesQuantity;
-                            CumulativeQuantity = Math.Max(CumulativeQuantity, er.CumulativeQuantity);
                         }
                         break;
 

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -582,9 +582,21 @@ public static class HistoryEndpoints
         /// </summary>
         public void ApplyReplacedTerminal(long seq, ExecutionReportReceivedEvent er)
         {
-            Status = OrderStatus.Replaced;
+            // Mirror Order.MarkReplaced: a Replaced ack racing a real
+            // terminal (Filled/Rejected/Cancelled) — or a duplicated
+            // Replaced ER — must NOT regress the predecessor's status.
+            // Only flip non-terminal predecessors to Replaced.
+            if (Status is not (OrderStatus.Filled
+                or OrderStatus.Rejected
+                or OrderStatus.Cancelled
+                or OrderStatus.Replaced))
+            {
+                Status = OrderStatus.Replaced;
+            }
             // MarkReplaced clears any advisory stale (slice 1 of #132);
             // mirror that here so the projection matches the runtime.
+            // Applied unconditionally — runtime ClearStale runs after
+            // MarkReplaced regardless of whether status changed.
             IsStale = false;
             StaleReason = null;
             StaledAtUtc = null;

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -286,6 +286,62 @@ public static class HistoryEndpoints
                             newProj.HydrateFromReplaceEr(seq, er);
                             if (inWindow) hadEventInWindow.Add(er.ClOrdId);
                         }
+                        // Consume the replace link — mirrors
+                        // PendingReplacementRegistry.TryConsume's
+                        // remove-on-success contract on the runtime's
+                        // Replaced branch. Without this a later cancel of
+                        // er.ClOrdId (which is now Working in its own
+                        // right and may be modified/cancelled directly)
+                        // would be re-intercepted by the cancel-as-replace
+                        // branch below as if the link were still in
+                        // flight.
+                        replaceLinks.Remove(er.ClOrdId);
+                        break;
+                    }
+
+                    // Issue #241 mirror: B3MatchingPlatform's "priority-lost"
+                    // cancel-as-replace path. The venue implements an effective
+                    // modify by emitting Cancel(orig) + Trade/New(new) under
+                    // the replacement's NEW ClOrdID — never an ExecType=Replaced.
+                    // Runtime intercepts in ExecutionReportProcessor.Apply via
+                    // PendingReplacementRegistry.TryConsume on the Canceled
+                    // branch and funnels through ApplyReplaceAccepted. The
+                    // projector mirrors that contract: a Canceled ER whose
+                    // ClOrdId matches an unresolved replace link (i.e. the new
+                    // side of an in-flight replace where no Replaced ER has
+                    // landed yet) terminalises the original at Replaced
+                    // (subject to terminal-preservation in ApplyReplacedTerminal)
+                    // and hydrates the new ClOrdID from the ER's leaves/cum,
+                    // then CONSUMES the link so a subsequent true cancel ack
+                    // on the same ClOrdID is processed as a normal cancel of
+                    // the new order rather than re-intercepted. The check
+                    // uses er.ClOrdId directly (the registry is keyed by
+                    // newClOrdId, same as replaceLinks) and runs BEFORE any
+                    // OrigClOrdId-fallback resolution above wired via cancelLinks
+                    // (the new-side ClOrdID is never in cancelLinks).
+                    if (kind == ExecKind.Canceled
+                        && replaceLinks.TryGetValue(er.ClOrdId, out var carOrig))
+                    {
+                        // Mirror ApplyReplaceAccepted: prefer the ER's
+                        // OrigClOrdId when the venue did supply one,
+                        // otherwise fall back to the intent's original
+                        // (here: the replaceLinks entry).
+                        var origId = er.OrigClOrdId != 0 ? er.OrigClOrdId : carOrig;
+                        if (byClOrdId.TryGetValue(origId, out var carOrigProj))
+                        {
+                            carOrigProj.ApplyReplacedTerminal(seq, er);
+                            if (inWindow) hadEventInWindow.Add(origId);
+                        }
+                        if (byClOrdId.TryGetValue(er.ClOrdId, out var carNewProj))
+                        {
+                            carNewProj.HydrateFromReplaceEr(seq, er);
+                            if (inWindow) hadEventInWindow.Add(er.ClOrdId);
+                        }
+                        // Consume the link — mirrors PendingReplacementRegistry
+                        // .TryConsume's remove-on-success contract so the next
+                        // Canceled ER on this ClOrdID is treated as a real
+                        // cancel of the new order, not re-intercepted.
+                        replaceLinks.Remove(er.ClOrdId);
                         break;
                     }
 

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -26,6 +26,7 @@ public static class TradingEndpointsExtensions
 
         app.MapAuth();
         app.MapOrders();
+        app.MapHistory();
         app.MapAlgo();
         app.MapPositions();
         app.MapBalance();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
@@ -249,14 +249,24 @@ public sealed class FileEventStore : IEventStore
 
     private void FlushBatch(List<PendingRecord> batch)
     {
-        TaskCompletionSource? lastFence = null;
+        // Collect every fence's TCS in the batch. A previous version
+        // tracked only the LAST fence and dropped earlier ones — two
+        // concurrent FlushAsync calls landing in the same batch would
+        // hang the first caller until cancellation/timeout because its
+        // TCS was overwritten before being completed. Tracking all
+        // fences here completes every waiter promptly.
+        List<TaskCompletionSource>? fences = null;
         foreach (var rec in batch)
         {
             if (rec.FlushTcs is not null)
             {
-                // Sentinel: flush whatever is buffered so far, ack the waiter.
+                // Sentinel: flush whatever is buffered so far so the
+                // ack is honest about what's durable. The TCS itself
+                // is completed below, after the post-batch flush, so
+                // every fence — first, middle, last — sees the full
+                // batch's writes on disk.
                 _activeWriter?.Flush();
-                lastFence = rec.FlushTcs;
+                (fences ??= new List<TaskCompletionSource>()).Add(rec.FlushTcs);
                 continue;
             }
 
@@ -264,8 +274,10 @@ public sealed class FileEventStore : IEventStore
             _activeWriter!.Append(rec.Seq, rec.Payload, rec.TimestampMs);
         }
         _activeWriter?.Flush();
-        lastFence?.TrySetResult();
-        // Sentinels earlier in the batch are also satisfied at this point — they were ack'd inline.
+        if (fences is not null)
+        {
+            foreach (var f in fences) f.TrySetResult();
+        }
     }
 
     private void EnsureActiveSegmentFor(PendingRecord rec)

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -1121,6 +1121,64 @@ public class HistoryEndpointTests : IDisposable
     }
 
     [Fact]
+    public async Task OrdersHistory_TerminalEr_ClearsAdvisoryStaleOverlay()
+    {
+        // P1 regression for #275 pass-7 follow-up: ExecutionReportProcessor
+        // (slice 1 of #132) clears the advisory IsStale overlay after a
+        // real terminal ER (Filled/Cancelled/Rejected/Replaced). The
+        // history projector must mirror that side effect — otherwise a
+        // [OrderStaledEvent → Canceled] WAL pair surfaces status=Cancelled
+        // with isStale=true while the live runtime book reports
+        // isStale=false.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var clOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var clOrdId = ulong.Parse(clOrdIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = clOrdId, Type = "New" });
+
+        // Append OrderStaledEvent directly through the WAL — easier than
+        // negotiating WorkingOrderBook seeding from the API surface for a
+        // pure projection test. The history projector reads raw WAL events.
+        var store = (B3.Trading.Application.Persistence.IEventStore)
+            f.Services.GetRequiredService(typeof(B3.Trading.Application.Persistence.IEventStore));
+        store.Append(new B3.Trading.Application.Persistence.OrderStaledEvent
+        {
+            ClOrdId = clOrdId,
+            FirmId = "TEST",
+            Reason = "test-suspect",
+            StaledAtUtc = DateTimeOffset.UtcNow,
+            ActorUserId = "admin",
+        });
+        await store.FlushAsync();
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: clOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[clOrdIdStr];
+        Assert.Equal("Cancelled", orig.GetProperty("status").GetString());
+        Assert.False(orig.GetProperty("isStale").GetBoolean(),
+            "terminal Canceled ER must clear the advisory stale overlay (mirrors ExecutionReportProcessor.Apply)");
+    }
+
+    [Fact]
     public async Task OrdersHistory_QuantityOnlyReplaceOfGtdOrder_InheritsTifAndGoodTillDate()
     {
         // P1 regression for #275 pass-6: Order.HydrateReplacement /

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -806,14 +806,19 @@ public class HistoryEndpointTests : IDisposable
             .GetProperty("clOrdId").GetString()!);
 
         // Venue cancel-as-replace: Canceled ER under newId, OrigClOrdId=0.
-        // Runtime intercepts via the replacement registry; the WAL records
-        // the raw Canceled ER. Replay must reproduce the intercept.
+        // Real venue shape — LeavesQuantity=0 / CumulativeQuantity=0 (the
+        // ER is reporting a cancel of the original). The runtime intercepts
+        // via the replacement registry and funnels through
+        // ApplyReplaceAccepted(erLeaves: intent.NewQuantity, erCum: 0); the
+        // history projector must mirror that, hydrating B from the originating
+        // OrderReplaceRequestedEvent's NewQuantity rather than the ER's
+        // zeroed leaves/cum (which would otherwise mark B as Filled).
         var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
             f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
         mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
             ClOrdId: newId,
             ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
-            LeavesQuantity: 10,
+            LeavesQuantity: 0,
             CumulativeQuantity: 0,
             LastQuantity: 0,
             LastPrice: 0m,
@@ -829,10 +834,13 @@ public class HistoryEndpointTests : IDisposable
         Assert.True(byId.ContainsKey(origStr), "original must appear");
         Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
         Assert.Equal("Replaced", byId[origStr].GetProperty("status").GetString());
-        // Replacement hydrated as Working (leaves==NewQty, cum==0) — same
-        // surface state as a true Replaced ER on the same baseline.
+        // Replacement hydrated as Working with leaves==NewQuantity (10) and
+        // cum==0 — proving the projector pulls leaves from the replace
+        // intent, not from the ER's (zeroed) LeavesQuantity. Was previously
+        // masked by a test that happened to set LeavesQuantity==NewQuantity.
         Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
         Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+        Assert.Equal(0L, byId[newId.ToString()].GetProperty("cumulativeQuantity").GetInt64());
     }
 
     [Fact]
@@ -866,10 +874,11 @@ public class HistoryEndpointTests : IDisposable
             f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
 
         // First Canceled ER under newId — cancel-as-replace intercept.
+        // Real venue shape: LeavesQuantity=0 / CumulativeQuantity=0.
         mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
             ClOrdId: newId,
             ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
-            LeavesQuantity: 10,
+            LeavesQuantity: 0,
             CumulativeQuantity: 0,
             LastQuantity: 0,
             LastPrice: 0m,
@@ -928,10 +937,11 @@ public class HistoryEndpointTests : IDisposable
 
         var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
             f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        // Real venue shape: cancel-side ER reports LeavesQuantity=0.
         mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
             ClOrdId: newId,
             ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
-            LeavesQuantity: 10,
+            LeavesQuantity: 0,
             CumulativeQuantity: 0,
             LastQuantity: 0,
             LastPrice: 0m,
@@ -950,6 +960,78 @@ public class HistoryEndpointTests : IDisposable
         Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
         Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
         Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_CancelAsReplaceWithPartiallyFilledOriginal_ReplacementCumResetsToZero()
+    {
+        // P1 #275 pass-5: when the original has accumulated partial fills
+        // before the venue's cancel-as-replace lands, the runtime's
+        // ApplyReplaceAccepted resets the replacement to (leaves: NewQuantity,
+        // cum: 0) — the new ClOrdID is a brand-new order in the book and does
+        // not inherit the predecessor's fills. The history projector must
+        // mirror that: B's leaves come from the OrderReplaceRequestedEvent's
+        // NewQuantity, NOT from the original's residual leaves, and cum is 0
+        // regardless of the predecessor's cumulative.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        // Partial fill: 3 of 10 done, leaves 7.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origId,
+            Type = "Fill",
+            LastQty = 3L,
+            LastPx = 30m,
+        });
+
+        // Modify to a DIFFERENT new quantity (8) so the assertion proves the
+        // value came from the replace intent, not coincidentally from the
+        // original quantity, leaves, or cum.
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 8L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        // Real venue cancel-as-replace shape: LeavesQuantity=0 / cum=0 under newId.
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        // Original goes Replaced (terminal-preservation doesn't apply: it
+        // was PartiallyFilled, not terminal).
+        Assert.Equal("Replaced", byId[origStr].GetProperty("status").GetString());
+        // Replacement: leaves=NewQuantity (8), cum reset to 0, Working —
+        // mirrors ExecutionReportProcessor.ApplyReplaceAccepted.
+        Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
+        Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
+        Assert.Equal(8L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+        Assert.Equal(0L, byId[newId.ToString()].GetProperty("cumulativeQuantity").GetInt64());
     }
 
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -775,6 +775,183 @@ public class HistoryEndpointTests : IDisposable
         Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
     }
 
+    [Fact]
+    public async Task OrdersHistory_CancelAsReplace_OriginalIsReplacedAndNewIsHydrated()
+    {
+        // P1 regression for #275 pass-4: B3MatchingPlatform's "priority-lost"
+        // cancel-as-replace path (issue #241). When the venue implements a
+        // modify by emitting Cancel(B, OrigClOrdId=0) under the replacement's
+        // NEW ClOrdID — never an ExecType=Replaced — the runtime intercepts
+        // via PendingReplacementRegistry.TryConsume and funnels through
+        // ApplyReplaceAccepted. The history projector must mirror that
+        // contract: original A goes Replaced, new B is hydrated from the
+        // ER's leaves/cum, just as if a Replaced ER had been received.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        // Venue cancel-as-replace: Canceled ER under newId, OrigClOrdId=0.
+        // Runtime intercepts via the replacement registry; the WAL records
+        // the raw Canceled ER. Replay must reproduce the intercept.
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.True(byId.ContainsKey(origStr), "original must appear");
+        Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
+        Assert.Equal("Replaced", byId[origStr].GetProperty("status").GetString());
+        // Replacement hydrated as Working (leaves==NewQty, cum==0) — same
+        // surface state as a true Replaced ER on the same baseline.
+        Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
+        Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_CancelAsReplaceThenRealCancel_NewIsCancelled()
+    {
+        // P1 pass-4: after the cancel-as-replace consumes the replace link,
+        // a subsequent Canceled ER on the new ClOrdID must be processed as
+        // a regular cancel of the new order — not re-intercepted as another
+        // cancel-as-replace. Mirrors PendingReplacementRegistry.TryConsume's
+        // remove-on-success contract.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+
+        // First Canceled ER under newId — cancel-as-replace intercept.
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        // Second Canceled ER under newId — must be a regular cancel of the
+        // new (now Working) order, since the link has been consumed.
+        await InjectEr(http, adminToken, new { ClOrdId = newId, Type = "Canceled" });
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.Equal("Replaced", byId[origStr].GetProperty("status").GetString());
+        Assert.Equal("Cancelled", byId[newId.ToString()].GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_CancelAsReplaceAfterOriginalFilled_OriginalStaysFilled()
+    {
+        // P1 pass-4 edge: when the original was already Filled before the
+        // venue's cancel-as-replace lands, the projector's terminal-preservation
+        // (ApplyReplacedTerminal) keeps A=Filled while still hydrating B from
+        // the ER. Mirrors Order.MarkReplaced's terminal-state guard, exactly
+        // as in the ReplaceRacingFinalFill test for the Replaced-ER variant.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        // Fill A fully BEFORE the venue's cancel-as-replace lands.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origId,
+            Type = "Fill",
+            LastQty = 10L,
+            LastPx = 30m,
+        });
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.Equal("Filled", byId[origStr].GetProperty("status").GetString());
+        Assert.Equal(10L, byId[origStr].GetProperty("cumulativeQuantity").GetInt64());
+        // B still hydrated as the replacement.
+        Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
+        Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
+        Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+    }
+
     // -----------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -542,6 +542,239 @@ public class HistoryEndpointTests : IDisposable
         Assert.Equal("Working", byId[cId.ToString()].GetProperty("status").GetString());
     }
 
+    [Fact]
+    public async Task OrdersHistory_ReplacePairAtPageBoundary_BothSiblingsAppearAcrossPages()
+    {
+        // P1 regression for #275 pass-3: a Replaced ER updates BOTH the
+        // original and the replacement projection with the same LastSeq.
+        // The pre-fix cursor filter (a.Seq < c.Seq) silently dropped the
+        // sibling at the boundary whenever pagination split the pair.
+        // The composite (LastSeq, ClOrdId) keyset cursor must surface
+        // both rows across the two pages exactly once.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        // One filler order so we can paginate with limit=1 without the
+        // "single result fits the page" short-circuit.
+        var fillerStr = await SubmitOrder(http, token, qty: 10, price: 29m);
+        await InjectEr(http, adminToken, new { ClOrdId = ulong.Parse(fillerStr), Type = "New" });
+
+        // The replace pair: A submitted + acked, then replaced into B.
+        // The Replaced ER touches both A (terminal) and B (hydrate)
+        // at the same WAL seq.
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origId));
+
+        // Walk every page with limit=1 — boundary necessarily falls
+        // between every adjacent pair, including the replace siblings.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        string? cursor = null;
+        var pages = 0;
+        do
+        {
+            pages++;
+            Assert.True(pages <= 10, "pagination did not terminate");
+            var page = await GetOrdersHistory(http, token, limit: 1, cursor: cursor);
+            foreach (var item in page.Items)
+                Assert.True(seen.Add(item.GetProperty("clOrdId").GetString()!),
+                    "duplicate ClOrdId returned across pages");
+            cursor = page.NextCursor;
+        } while (cursor is not null);
+
+        Assert.Contains(origStr, seen);
+        Assert.Contains(newId.ToString(), seen);
+        Assert.Contains(fillerStr, seen);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_LateFillOnCancelledOrder_PreservesCancelledStatus()
+    {
+        // P1 regression for #275 pass-3: WAL [Canceled(A), Fill(A)] —
+        // the runtime's Order.ApplyCumulativeFill keeps A=Cancelled
+        // (terminal status preserved on late fill). The pre-fix
+        // ApplyEr unconditionally re-mapped Fill → Filled, so
+        // /orders/history reported A=Filled while the live runtime
+        // reported A=Cancelled.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var clOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var clOrdId = ulong.Parse(clOrdIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = clOrdId, Type = "New" });
+        await InjectEr(http, adminToken, new { ClOrdId = clOrdId, Type = "Canceled" });
+        // Late fill ER directly via the mock — the simulator endpoint
+        // refuses to inject fills against an order the runtime book
+        // considers terminal, but the venue can still legally deliver
+        // one (see ExecutionReportProcessor late-fill path).
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: clOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Fill,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 10,
+            LastQuantity: 10,
+            LastPrice: 30m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[clOrdIdStr];
+        Assert.Equal("Cancelled", orig.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_CancelAckWithMissingOrigClOrdId_ResolvesViaCancelLinkMap()
+    {
+        // P1 regression for #275 pass-3: when the venue's Canceled ER
+        // arrives with OrigClOrdId=0 (some EntryPoint SDK versions drop
+        // the field) the runtime falls back to the cancel-link map
+        // populated by OrderCancelService. The history projector now
+        // mirrors that fallback by replaying OrderCancelRequestedEvent
+        // → cancelLinks[cancelClOrdId] = originalClOrdId. Without this
+        // the cancel ack is silently stranded and the original order
+        // never transitions to Cancelled in the history view.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        // DELETE writes OrderCancelRequestedEvent + dispatches a
+        // OrderCancelRequest with a freshly-allocated cancel-side ClOrdID
+        // to the wire. We grab that cancel-side ID from the mock.
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        var cancelsBefore = mock.SubmittedCancels.Count;
+        var del = new HttpRequestMessage(HttpMethod.Delete, $"/orders/{origStr}");
+        del.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var delResp = await http.SendAsync(del);
+        Assert.Equal(HttpStatusCode.NoContent, delResp.StatusCode);
+        var cancelReq = mock.SubmittedCancels.Skip(cancelsBefore).Single();
+        var cancelClOrdId = cancelReq.ClOrdId;
+        Assert.NotEqual(0UL, cancelClOrdId);
+
+        // Venue Canceled ER targeting the cancel-side ID with
+        // OrigClOrdId=0. The history projector must resolve it via the
+        // cancel-link map and apply the cancel to `origId`.
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: cancelClOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.True(byId.ContainsKey(origStr), "original must surface in history");
+        Assert.Equal("Cancelled", byId[origStr].GetProperty("status").GetString());
+
+        // /executions/history: the cancel ack itself must also appear,
+        // resolved through the cancel-link map for firm-isolation.
+        var execPage = await GetExecutionsHistory(http, token);
+        Assert.Contains(execPage.Items,
+            e => e.GetProperty("clOrdId").GetString() == cancelClOrdId.ToString()
+                 && e.GetProperty("kind").GetString() == "Canceled");
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ReplaceAckWithMissingOrigClOrdId_ResolvesViaReplaceLinkMap()
+    {
+        // P1 regression for #275 pass-3: same fallback as the cancel
+        // case above, but the venue's Replaced ER drops OrigClOrdId.
+        // The history projector must replay
+        // OrderReplaceRequestedEvent → replaceLinks[newClOrdId] =
+        // originalClOrdId, recover the original from there, and project
+        // both sides (terminal Replaced on original; hydrate new).
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var newId = ulong.Parse((await modifyResp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        // Venue Replaced ER with OrigClOrdId=0 — must resolve via
+        // replaceLinks[newId] = origId.
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.True(byId.ContainsKey(origStr), "original must appear");
+        Assert.True(byId.ContainsKey(newId.ToString()), "replacement must appear");
+        Assert.Equal("Replaced", byId[origStr].GetProperty("status").GetString());
+        // Replacement is hydrated as Working (leaves==NewQty, cum==0).
+        Assert.Equal("Working", byId[newId.ToString()].GetProperty("status").GetString());
+        Assert.Equal(10L, byId[newId.ToString()].GetProperty("leavesQuantity").GetInt64());
+    }
+
     // -----------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -346,6 +346,202 @@ public class HistoryEndpointTests : IDisposable
         Assert.Equal(6L, replacement.GetProperty("leavesQuantity").GetInt64());
     }
 
+    [Fact]
+    public async Task OrdersHistory_ReplaceRacingFinalFill_OriginalStaysFilled()
+    {
+        // P1 regression for #275 pass-2 review: when the WAL ordering is
+        // [ReplaceRequested(A→B), Fill(A), Replaced(B,Orig=A)] the
+        // projector must mirror Order.MarkReplaced and leave A at Filled.
+        // The previous ApplyReplacedTerminal unconditionally overwrote
+        // status with Replaced, so /orders/history reported A=Replaced
+        // while the live runtime (which short-circuits the late Replaced
+        // ack via MarkReplaced's terminal-state guard) reported Filled.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origClOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origClOrdId = ulong.Parse(origClOrdIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origClOrdId, Type = "New" });
+
+        // Kick off a replace — A is still in the book, so the modify is
+        // accepted and a new ClOrdID B is registered.
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origClOrdIdStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newClOrdId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        // Fill A fully BEFORE the venue's Replaced ack lands. In the
+        // runtime this terminalises A=Filled; the late Replaced ER's
+        // MarkReplaced is then a no-op for A's status (margin transfer
+        // is aborted because A is no longer in the book).
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origClOrdId,
+            Type = "Fill",
+            LastQty = 10L,
+            LastPx = 30m,
+        });
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newClOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origClOrdId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.True(byId.ContainsKey(origClOrdIdStr), "original order must appear in history");
+        var orig = byId[origClOrdIdStr];
+        Assert.Equal("Filled", orig.GetProperty("status").GetString());
+        Assert.Equal(10L, orig.GetProperty("cumulativeQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ReplaceRacingCancel_OriginalStaysCancelled()
+    {
+        // Edge of the same P1: WAL [ReplaceRequested(A→B), Cancel(A),
+        // Replaced(B,Orig=A)] must leave A=Cancelled. MarkReplaced
+        // preserves Cancelled the same way it preserves Filled.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origClOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origClOrdId = ulong.Parse(origClOrdIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origClOrdId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origClOrdIdStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newClOrdId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        await InjectEr(http, adminToken, new { ClOrdId = origClOrdId, Type = "Canceled" });
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newClOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origClOrdId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[origClOrdIdStr];
+        Assert.Equal("Cancelled", orig.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ChainedReplaceWithMidChainCancel_PreservesEachLink()
+    {
+        // P1 chained-edge: A→B→C with B cancelled mid-chain. Expected
+        // projection (matches runtime):
+        //   A = Replaced (terminalised by the first Replaced ER while
+        //       still non-terminal)
+        //   B = Cancelled (Cancel ER lands before the second Replaced
+        //       ER; the late Replaced(C,Orig=B) must NOT regress B)
+        //   C = Working   (hydrated from the second Replaced ER's
+        //       leaves/cum baseline)
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var aIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var aId = ulong.Parse(aIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = aId, Type = "New" });
+
+        // First replace A→B.
+        var put1 = new HttpRequestMessage(HttpMethod.Put, $"/orders/{aIdStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        put1.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var put1Resp = await http.SendAsync(put1);
+        Assert.Equal(HttpStatusCode.Accepted, put1Resp.StatusCode);
+        var bId = ulong.Parse((await put1Resp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        // First Replaced ER terminalises A and hydrates B as Working.
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: bId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: aId));
+
+        // Second replace B→C (B is now Working in the runtime book).
+        var put2 = new HttpRequestMessage(HttpMethod.Put, $"/orders/{bId}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 32m }),
+        };
+        put2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var put2Resp = await http.SendAsync(put2);
+        Assert.Equal(HttpStatusCode.Accepted, put2Resp.StatusCode);
+        var cId = ulong.Parse((await put2Resp.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("clOrdId").GetString()!);
+
+        // Cancel B before the second Replaced lands.
+        await InjectEr(http, adminToken, new { ClOrdId = bId, Type = "Canceled" });
+
+        // Late second Replaced ER: must NOT regress B from Cancelled.
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: cId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: bId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.Equal("Replaced", byId[aIdStr].GetProperty("status").GetString());
+        Assert.Equal("Cancelled", byId[bId.ToString()].GetProperty("status").GetString());
+        Assert.Equal("Working", byId[cId.ToString()].GetProperty("status").GetString());
+    }
+
     // -----------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace B3.Trading.Api.Tests;
 
@@ -255,6 +256,94 @@ public class HistoryEndpointTests : IDisposable
         var alicePage = await GetExecutionsHistory(http, aliceToken);
         Assert.DoesNotContain(alicePage.Items,
             e => e.GetProperty("clOrdId").GetString() == bobClOrdId);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ReplaceThenPartialFill_OriginalIsReplacedAndNewIsPartiallyFilled()
+    {
+        // Regression for #275 P1: the projector used to retarget the
+        // Replaced ER to the original (via OrigClOrdId) and never
+        // hydrate the new ClOrdID — leaving the new order stuck at
+        // PendingNew even though the venue had already accepted the
+        // replacement and the platform's runtime treated it as Working
+        // (or PartiallyFilled after fills). The fix mirrors
+        // ExecutionReportProcessor.ApplyReplaceAccepted +
+        // Order.HydrateReplacement: terminalize the original at
+        // Replaced, hydrate the new one with the ER's leaves/cum
+        // baseline, and let subsequent ERs accumulate normally.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origClOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var origClOrdId = ulong.Parse(origClOrdIdStr);
+        // Drive original to Working — the runtime's modify pipeline
+        // refuses to replace orders that haven't been venue-acked.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origClOrdId,
+            Type = "New",
+        });
+
+        // PUT modifies → the platform writes OrderReplaceRequestedEvent
+        // for the new ClOrdID and dispatches a CancelReplace to the wire.
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origClOrdIdStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newClOrdId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        // Mock-emit the venue's Replaced ER. ClOrdId targets the new
+        // order; OrigClOrdId points back at the original. The runtime
+        // path is unchanged (it goes through ApplyReplaceAccepted +
+        // HydrateReplacement); the WAL append it triggers is what the
+        // history projector will later replay.
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newClOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origClOrdId));
+
+        // Partial fill on the NEW ClOrdID. The simulator endpoint
+        // resolves the order from WorkingOrderBook — proves the
+        // hydrate path also wired the runtime book correctly, but
+        // more importantly the resulting WAL entry exercises the
+        // post-Replaced accumulation that the projector must surface.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = newClOrdId,
+            Type = "PartialFill",
+            LastQty = 4L,
+            LastPx = 31m,
+        });
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        Assert.True(byId.ContainsKey(origClOrdIdStr), "original order must appear in history");
+        Assert.True(byId.ContainsKey(newClOrdId.ToString()), "replacement order must appear in history");
+
+        var orig = byId[origClOrdIdStr];
+        Assert.Equal("Replaced", orig.GetProperty("status").GetString());
+
+        var replacement = byId[newClOrdId.ToString()];
+        Assert.Equal("PartiallyFilled", replacement.GetProperty("status").GetString());
+        Assert.Equal(4L, replacement.GetProperty("cumulativeQuantity").GetInt64());
+        Assert.Equal(6L, replacement.GetProperty("leavesQuantity").GetInt64());
     }
 
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -1034,6 +1034,264 @@ public class HistoryEndpointTests : IDisposable
         Assert.Equal(0L, byId[newId.ToString()].GetProperty("cumulativeQuantity").GetInt64());
     }
 
+    [Fact]
+    public async Task OrdersHistory_CancelEr_PreservesLeavesAndCumFromRuntimeBook()
+    {
+        // P1 regression for #275 pass-6: Order.MarkCancelled only flips
+        // Status — it does NOT touch leaves/cum. A real venue Canceled
+        // ER typically carries LeavesQuantity=0, so the previous
+        // ApplyEr (which copied er.LeavesQuantity into the projection)
+        // showed a 10-lot working order as leaves=0 in /orders/history
+        // while the live runtime kept leaves=10.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var clOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var clOrdId = ulong.Parse(clOrdIdStr);
+        await InjectEr(http, adminToken, new { ClOrdId = clOrdId, Type = "New" });
+
+        // Direct mock emit so we control the Canceled ER's leaves
+        // exactly (the simulator endpoint synthesises leaves=0 by
+        // default, but going through the mock makes the contract
+        // explicit in the test).
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: clOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Canceled,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[clOrdIdStr];
+        Assert.Equal("Cancelled", orig.GetProperty("status").GetString());
+        // Leaves/cum must mirror runtime parity (MarkCancelled is
+        // status-only). Original 10-lot has had no fills.
+        Assert.Equal(10L, orig.GetProperty("leavesQuantity").GetInt64());
+        Assert.Equal(0L, orig.GetProperty("cumulativeQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_RejectedEr_PreservesLeavesAndCumFromRuntimeBook()
+    {
+        // P1 regression for #275 pass-6: Order.MarkRejected is also
+        // status-only. A Rejected ER on a 10-lot pending order with
+        // leaves=0 in the ER must still surface leaves=10 in the
+        // projection (matching the runtime book).
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var clOrdIdStr = await SubmitOrder(http, token, qty: 10, price: 30m);
+        var clOrdId = ulong.Parse(clOrdIdStr);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: clOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Rejected,
+            LeavesQuantity: 0,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: "venue rejected",
+            OrigClOrdId: 0));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[clOrdIdStr];
+        Assert.Equal("Rejected", orig.GetProperty("status").GetString());
+        Assert.Equal(10L, orig.GetProperty("leavesQuantity").GetInt64());
+        Assert.Equal(0L, orig.GetProperty("cumulativeQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_QuantityOnlyReplaceOfGtdOrder_InheritsTifAndGoodTillDate()
+    {
+        // P1 regression for #275 pass-6: Order.HydrateReplacement /
+        // Order.MergeReplacementOptionals INHERIT TIF / StopPrice /
+        // GoodTillDate from the original when the modify request omits
+        // them. The projector previously treated the request fields as
+        // final values, so a quantity-only replace of a GTD order
+        // surfaced TIF=Day + GoodTillDate=null in /orders/history while
+        // the live runtime kept GTD + the original expiry.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var gtd = DateTimeOffset.UtcNow.AddDays(20);
+        var origStr = await SubmitGtdOrder(http, token, qty: 10, price: 30m, goodTillDate: gtd);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        // Quantity-only modify — TIF / StopPrice / GoodTillDate omitted.
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 20L }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        if (modifyResp.StatusCode != HttpStatusCode.Accepted)
+        {
+            var errBody = await modifyResp.Content.ReadAsStringAsync();
+            Assert.Fail($"modify failed: {modifyResp.StatusCode} {errBody}");
+        }
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 20,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var replacement = byId[newId.ToString()];
+        Assert.Equal("GTD", replacement.GetProperty("timeInForce").GetString());
+        Assert.Equal(gtd, replacement.GetProperty("goodTillDate").GetDateTimeOffset());
+        Assert.Equal(20L, replacement.GetProperty("quantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_QuantityOnlyReplaceOfStopOrder_InheritsStopPrice()
+    {
+        // P1 regression for #275 pass-6: a quantity-only replace of a
+        // stop order must inherit the original StopPrice — the modify
+        // pipeline does so via MergeReplacementOptionals; the projector
+        // now mirrors the same merge.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origStr = await SubmitStopLimitOrder(
+            http, token, qty: 10, price: 31m, stopPrice: 30m);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            // Price is supplied explicitly because the modify pipeline
+            // requires NewPrice on stop-limit (limit-vs-stop sanity is
+            // re-evaluated in risk). The Q1.1 inheritance under test is
+            // for StopPrice / TIF / GoodTillDate only — those are the
+            // optionals MergeReplacementOptionals merges.
+            Content = JsonContent.Create(new { Quantity = 20L, Price = 31m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        if (modifyResp.StatusCode != HttpStatusCode.Accepted)
+        {
+            var errBody = await modifyResp.Content.ReadAsStringAsync();
+            Assert.Fail($"modify failed: {modifyResp.StatusCode} {errBody}");
+        }
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 20,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var replacement = byId[newId.ToString()];
+        Assert.Equal("Day", replacement.GetProperty("timeInForce").GetString());
+        Assert.Equal(30m, replacement.GetProperty("stopPrice").GetDecimal());
+        Assert.Equal(20L, replacement.GetProperty("quantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ReplaceTifGtdToDay_ClearsGoodTillDate()
+    {
+        // P1 regression for #275 pass-6: when the replace explicitly
+        // moves TIF GTD → Day, MergeReplacementOptionals auto-clears
+        // GoodTillDate (the trick callers use to shed an inherited
+        // expiry without redundantly nulling it). The projector must
+        // mirror that auto-clear so the history view doesn't drag the
+        // original expiry forward onto a Day order.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var gtd = DateTimeOffset.UtcNow.AddDays(20);
+        var origStr = await SubmitGtdOrder(http, token, qty: 10, price: 30m, goodTillDate: gtd);
+        var origId = ulong.Parse(origStr);
+        await InjectEr(http, adminToken, new { ClOrdId = origId, Type = "New" });
+
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 10L, TimeInForce = "Day" }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 10,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var replacement = byId[newId.ToString()];
+        Assert.Equal("Day", replacement.GetProperty("timeInForce").GetString());
+        var gtdProp = replacement.GetProperty("goodTillDate");
+        Assert.Equal(JsonValueKind.Null, gtdProp.ValueKind);
+    }
+
     // -----------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------
@@ -1096,6 +1354,55 @@ public class HistoryEndpointTests : IDisposable
                 Type = "Limit",
                 Quantity = qty,
                 Price = price,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("clOrdId").GetString()!;
+    }
+
+    private static async Task<string> SubmitGtdOrder(
+        HttpClient http, string token, int qty, decimal price, DateTimeOffset goodTillDate,
+        string symbol = "PETR4")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = symbol,
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+                TimeInForce = "GTD",
+                GoodTillDate = goodTillDate,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("clOrdId").GetString()!;
+    }
+
+    private static async Task<string> SubmitStopLimitOrder(
+        HttpClient http, string token, int qty, decimal price, decimal stopPrice,
+        string symbol = "PETR4")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = symbol,
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "StopLimit",
+                Quantity = qty,
+                Price = price,
+                StopPrice = stopPrice,
             }),
         };
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -1,0 +1,342 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q2.1 (#268). Integration coverage for the WAL-projected history
+/// endpoints. Each test gets a fresh per-test data directory so the
+/// FileEventStore is exercised in isolation; the simulator path is
+/// enabled to drive ERs synchronously without an upstream venue.
+/// </summary>
+public class HistoryEndpointTests : IDisposable
+{
+    private readonly string _dataDir = Path.Combine(
+        Path.GetTempPath(), "b3-history-tests-" + Guid.NewGuid().ToString("N"));
+
+    private IDictionary<string, string?> Overrides() => new Dictionary<string, string?>
+    {
+        ["Trading:Exchange:Mode"] = "Mock",
+        ["Trading:Exchange:AllowErInjection"] = "true",
+        ["Trading:Persistence:Enabled"] = "true",
+        ["Trading:Persistence:DataDirectory"] = _dataDir,
+        ["Trading:Persistence:FirmId"] = "test",
+        // Snap interval is irrelevant for history queries (we replay the
+        // raw WAL), but a long cadence avoids the snapshot service
+        // racing with the test's own writes.
+        ["Trading:Persistence:SnapshotInterval"] = "00:10:00",
+    };
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dataDir))
+                Directory.Delete(_dataDir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; tmp dir leaks are acceptable noise.
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_PaginationRoundTrip_ReturnsAllItemsExactlyOnce()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        const int totalOrders = 7;
+        var posted = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < totalOrders; i++)
+            posted.Add(await SubmitOrder(http, token, qty: 10, price: 30m + i));
+
+        // limit=3 forces ⌈7/3⌉ = 3 pages; final page carries no nextCursor.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        string? cursor = null;
+        var pages = 0;
+        do
+        {
+            pages++;
+            Assert.True(pages <= 5, "pagination did not terminate");
+            var page = await GetOrdersHistory(http, token, limit: 3, cursor: cursor);
+            foreach (var item in page.Items)
+            {
+                Assert.True(seen.Add(item.GetProperty("clOrdId").GetString()!),
+                    "duplicate ClOrdId returned across pages");
+            }
+            cursor = page.NextCursor;
+        } while (cursor is not null);
+
+        Assert.Equal(posted, seen);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_FromInFuture_ReturnsEmpty()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        await SubmitOrder(http, token, qty: 10, price: 30m);
+
+        var fromFuture = DateTimeOffset.UtcNow.AddHours(1).ToString("O");
+        var toFurtherFuture = DateTimeOffset.UtcNow.AddHours(2).ToString("O");
+        var page = await GetOrdersHistory(http, token, from: fromFuture, to: toFurtherFuture);
+        Assert.Empty(page.Items);
+        Assert.Null(page.NextCursor);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_SymbolFilter_OnlyReturnsMatchingSymbol()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        await SubmitOrder(http, token, qty: 10, price: 30m, symbol: "PETR4");
+
+        // No order on UNKNOWN_SYM was submitted.
+        var unknown = await GetOrdersHistory(http, token, symbol: "ZZZZ99");
+        Assert.Empty(unknown.Items);
+
+        var matching = await GetOrdersHistory(http, token, symbol: "PETR4");
+        Assert.NotEmpty(matching.Items);
+        foreach (var item in matching.Items)
+            Assert.Equal("PETR4", item.GetProperty("symbol").GetString());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_FirmIsolation_AliceDoesNotSeeBobsOrders()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var aliceToken = await f.LoginAsync(http);
+        var bobToken = await f.LoginAsync(http, user: "bob");
+
+        var aliceClOrdId = await SubmitOrder(http, aliceToken, qty: 10, price: 30m);
+        var bobClOrdId = await SubmitOrder(http, bobToken, qty: 10, price: 30m);
+
+        var alicePage = await GetOrdersHistory(http, aliceToken);
+        var aliceIds = alicePage.Items.Select(o => o.GetProperty("clOrdId").GetString()).ToHashSet();
+        Assert.Contains(aliceClOrdId, aliceIds);
+        Assert.DoesNotContain(bobClOrdId, aliceIds);
+
+        var bobPage = await GetOrdersHistory(http, bobToken);
+        var bobIds = bobPage.Items.Select(o => o.GetProperty("clOrdId").GetString()).ToHashSet();
+        Assert.Contains(bobClOrdId, bobIds);
+        Assert.DoesNotContain(aliceClOrdId, bobIds);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_Determinism_TwoCallsReturnSameItems()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        for (var i = 0; i < 4; i++)
+            await SubmitOrder(http, token, qty: 10, price: 30m + i);
+
+        var first = await GetOrdersHistory(http, token);
+        var second = await GetOrdersHistory(http, token);
+
+        Assert.Equal(first.Items.Count, second.Items.Count);
+        for (var i = 0; i < first.Items.Count; i++)
+        {
+            Assert.Equal(
+                first.Items[i].GetProperty("clOrdId").GetString(),
+                second.Items[i].GetProperty("clOrdId").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task OrdersHistory_MalformedCursor_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            "/orders/history?cursor=" + Uri.EscapeDataString("!!!not-base64!!!"));
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_LimitOver500_IsClamped()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        await SubmitOrder(http, token, qty: 10, price: 30m);
+
+        // Asking for 10_000 must NOT 400 — clamped to 500. With one
+        // order in the WAL the page necessarily fits below the cap.
+        var page = await GetOrdersHistory(http, token, limit: 10_000);
+        Assert.NotEmpty(page.Items);
+        Assert.Null(page.NextCursor);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_ToBeforeFrom_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var from = DateTimeOffset.UtcNow.ToString("O");
+        var to = DateTimeOffset.UtcNow.AddHours(-1).ToString("O");
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"/orders/history?from={Uri.EscapeDataString(from)}&to={Uri.EscapeDataString(to)}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task OrdersHistory_Unauthenticated_Returns401()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var resp = await http.GetAsync("/orders/history");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExecutionsHistory_AfterFill_ReturnsErRows()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var clOrdId = await SubmitOrder(http, token, qty: 10, price: 30m);
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = ulong.Parse(clOrdId),
+            Type = "Fill",
+            LastQty = 10L,
+            LastPx = 30m,
+        });
+
+        var page = await GetExecutionsHistory(http, token);
+        Assert.NotEmpty(page.Items);
+        var matching = page.Items.Where(e => e.GetProperty("clOrdId").GetString() == clOrdId).ToList();
+        Assert.NotEmpty(matching);
+        Assert.Contains(matching, e => e.GetProperty("kind").GetString() == "Fill");
+    }
+
+    [Fact]
+    public async Task ExecutionsHistory_FirmIsolation_AliceDoesNotSeeBobsExecutions()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var aliceToken = await f.LoginAsync(http);
+        var bobToken = await f.LoginAsync(http, user: "bob");
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var bobClOrdId = await SubmitOrder(http, bobToken, qty: 10, price: 30m);
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = ulong.Parse(bobClOrdId),
+            Type = "Fill",
+            LastQty = 10L,
+            LastPx = 30m,
+        });
+
+        var alicePage = await GetExecutionsHistory(http, aliceToken);
+        Assert.DoesNotContain(alicePage.Items,
+            e => e.GetProperty("clOrdId").GetString() == bobClOrdId);
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private sealed record HistoryPage(IReadOnlyList<JsonElement> Items, string? NextCursor);
+
+    private static async Task<HistoryPage> GetOrdersHistory(
+        HttpClient http, string token, int? limit = null, string? cursor = null,
+        string? from = null, string? to = null, string? symbol = null)
+    {
+        return await GetHistory(http, token, "/orders/history", limit, cursor, from, to, symbol);
+    }
+
+    private static async Task<HistoryPage> GetExecutionsHistory(
+        HttpClient http, string token, int? limit = null, string? cursor = null,
+        string? from = null, string? to = null, string? symbol = null)
+    {
+        return await GetHistory(http, token, "/executions/history", limit, cursor, from, to, symbol);
+    }
+
+    private static async Task<HistoryPage> GetHistory(
+        HttpClient http, string token, string path,
+        int? limit, string? cursor, string? from, string? to, string? symbol)
+    {
+        var qs = new StringBuilder();
+        void Add(string k, string? v)
+        {
+            if (string.IsNullOrEmpty(v)) return;
+            qs.Append(qs.Length == 0 ? '?' : '&');
+            qs.Append(k); qs.Append('=');
+            qs.Append(Uri.EscapeDataString(v));
+        }
+        if (limit is { } l) Add("limit", l.ToString());
+        Add("cursor", cursor);
+        Add("from", from);
+        Add("to", to);
+        Add("symbol", symbol);
+
+        var req = new HttpRequestMessage(HttpMethod.Get, path + qs.ToString());
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items").EnumerateArray().ToList();
+        var nextCursor = body.TryGetProperty("nextCursor", out var nc) && nc.ValueKind == JsonValueKind.String
+            ? nc.GetString() : null;
+        return new HistoryPage(items, nextCursor);
+    }
+
+    private static async Task<string> SubmitOrder(
+        HttpClient http, string token, int qty, decimal price, string symbol = "PETR4")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = symbol,
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("clOrdId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
@@ -263,6 +263,38 @@ public class FileEventStoreTests : IDisposable
         Assert.True(thrown, "Expected WalBackpressureException once channel is saturated.");
     }
 
+    [Fact]
+    public async Task FlushAsync_TwoConcurrentCallers_BothCompleteWithoutHanging()
+    {
+        // Regression: FlushBatch used to track only the LAST fence in
+        // a batch — two FlushAsync sentinels landing in the same group-
+        // commit would leave the FIRST caller's TCS uncompleted, hanging
+        // it until cancellation/timeout. With per-fence completion, both
+        // callers must return promptly even when the batcher coalesces
+        // both sentinels into one drain cycle.
+        var opts = OptsForTest();
+        // Force a wide group-commit window so both fences are very
+        // likely to land in the same batch.
+        opts.GroupCommitWindow = TimeSpan.FromMilliseconds(200);
+        opts.GroupCommitMaxRecords = 16;
+        await using var store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+
+        // Append a few records so the writer has buffered work to flush
+        // — exercises the post-batch flush path that completes fences.
+        for (var i = 0; i < 4; i++) store.Append(NewOrder(i));
+
+        // Cap the test at 5s; with the bug the first caller would hang
+        // until its CT expires (here we'd never set one) so the timeout
+        // is what makes the regression observable.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var first = store.FlushAsync(timeout.Token).AsTask();
+        var second = store.FlushAsync(timeout.Token).AsTask();
+
+        await Task.WhenAll(first, second);
+        Assert.True(first.IsCompletedSuccessfully, "first FlushAsync must complete (was hanging on overwritten fence).");
+        Assert.True(second.IsCompletedSuccessfully, "second FlushAsync must complete.");
+    }
+
     private static OrderSubmittedEvent NewOrder(int i) => new()
     {
         ClOrdId = (ulong)(i + 1),


### PR DESCRIPTION
Closes #268.