### PR TITLE
feat(#269): cash ledger + CashLedgerEvent + admin deposit/withdraw endpoint

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -364,26 +364,31 @@ public static class AdminEndpoints
 
         try
         {
-            // Withdrawal: pre-check + atomic debit happens INSIDE the
-            // dispatcher's mutate callback so the WAL append only lands
-            // when the debit actually succeeded. The keeper's TryWithdraw
-            // is its own CAS loop; we wrap the failure case as 422 so the
-            // caller can distinguish "insufficient funds" from "bad
-            // request". The throw-from-mutate path skips the apply step
-            // but the event is already on disk — to avoid that, we
-            // pre-check the balance OUTSIDE the dispatcher (best-effort)
-            // and then re-check INSIDE via TryWithdraw, which is the only
-            // authoritative read. If the inside check fails we throw a
-            // sentinel that the catch maps to 422; the WAL append for a
-            // failed withdraw is rolled back by the dispatcher's
-            // throw-skips-apply contract... except the dispatcher already
-            // committed seq. So: structure the flow so the keeper's
-            // TryWithdraw runs FIRST (under no lock — the keeper is
-            // thread-safe), and the dispatcher only fires when we've
-            // already debited. On Deposit the apply is unconditional.
+            // Q2.2 (#269) P1 fix: debit + WAL append must be atomic with
+            // respect to the snapshot lock. The previous flow ran
+            // TryWithdraw OUTSIDE the dispatcher lock; a snapshot could
+            // interleave between a successful debit and the WAL append,
+            // persisting a reduced balance with no matching event and
+            // permanently losing cash on restore. We now route the
+            // withdrawal through DispatchWithPreApply so TryWithdraw,
+            // the WAL append, and any rollback all run under the same
+            // lock the snapshot service takes.
             if (kind == "Withdrawal")
             {
-                if (!keeper.TryWithdraw(owner, req.Amount))
+                var outcome = dispatcher.DispatchWithPreApply(
+                    new CashLedgerEvent
+                    {
+                        EndClientId = req.Endclient,
+                        Operation = kind,
+                        Amount = req.Amount,
+                        Currency = currency,
+                        Reference = req.Reference,
+                        OperatorId = operatorId,
+                    },
+                    preApply: () => keeper.TryWithdraw(owner, req.Amount),
+                    rollback: () => keeper.ApplyDeposit(owner, req.Amount));
+
+                if (!outcome.Applied)
                     return Results.UnprocessableEntity(new
                     {
                         error = "insufficient_funds",
@@ -391,8 +396,7 @@ public static class AdminEndpoints
                         requested = req.Amount,
                     });
             }
-
-            try
+            else
             {
                 dispatcher.Dispatch(
                     new CashLedgerEvent
@@ -404,25 +408,7 @@ public static class AdminEndpoints
                         Reference = req.Reference,
                         OperatorId = operatorId,
                     },
-                    () =>
-                    {
-                        // Withdrawal already debited above; only the deposit
-                        // mutates state inside the dispatcher lock. Both
-                        // arms keep the (event-on-disk, balance-mutated)
-                        // pair atomic from the dispatcher's perspective.
-                        if (kind == "Deposit")
-                            keeper.ApplyDeposit(owner, req.Amount);
-                    });
-            }
-            catch
-            {
-                // Compensating credit: if the WAL append throws AFTER we
-                // already debited (Withdrawal path), restore the balance
-                // so the operator-visible state matches the on-disk
-                // truth. Re-throw so the outer handler maps it to 503.
-                if (kind == "Withdrawal")
-                    keeper.ApplyDeposit(owner, req.Amount);
-                throw;
+                    () => keeper.ApplyDeposit(owner, req.Amount));
             }
 
             return Results.Ok(new

--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -297,6 +297,14 @@ public static class AdminEndpoints
             });
         });
 
+        // ── Cash ledger (Q2.2 / #269) ───────────────────────────
+        // Admin-driven deposits and withdrawals, persisted as
+        // CashLedgerEvent on the WAL and projected into CashKeeper.
+        // Decoupled from ER fills — fill-driven cash deltas land via
+        // the existing CashLedger and the future P&L engine (#271).
+        group.MapPost("/cash", (CashLedgerRequest? req, HttpContext ctx, CashKeeper keeper, EventDispatcher dispatcher) =>
+            HandleCashLedger(req, ctx, keeper, dispatcher));
+
         // POST /admin/simulator/er — synthetic ER injection (formerly the
         // ExchangeMode.Simulator-only route; merged into Mock+AllowErInjection
         // in #163). The route itself moved to the Infrastructure project as
@@ -319,6 +327,121 @@ public static class AdminEndpoints
                 ordered.Add(raw);
         }
         return ordered;
+    }
+
+    private static IResult HandleCashLedger(
+        CashLedgerRequest? req,
+        HttpContext ctx,
+        CashKeeper keeper,
+        EventDispatcher dispatcher)
+    {
+        if (req is null)
+            return Results.BadRequest(new { error = "request body required" });
+        if (string.IsNullOrWhiteSpace(req.Endclient))
+            return Results.BadRequest(new { error = "endclient required" });
+        if (string.IsNullOrWhiteSpace(req.Kind))
+            return Results.BadRequest(new { error = "kind required (Deposit|Withdrawal)" });
+
+        var kind = req.Kind.Trim();
+        if (!string.Equals(kind, "Deposit", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(kind, "Withdrawal", StringComparison.OrdinalIgnoreCase))
+            return Results.BadRequest(new { error = "kind must be one of: Deposit, Withdrawal" });
+        // Normalise to the canonical wire spelling so the WAL string is
+        // stable regardless of caller casing.
+        kind = string.Equals(kind, "Deposit", StringComparison.OrdinalIgnoreCase) ? "Deposit" : "Withdrawal";
+
+        if (req.Amount <= 0m)
+            return Results.BadRequest(new { error = "amount must be > 0" });
+
+        var currency = (req.Currency ?? string.Empty).Trim().ToUpperInvariant();
+        // v0 whitelist: BRL only. Multi-currency expands the list without
+        // changing the wire shape (see CashLedgerEvent doc comment).
+        if (currency != "BRL")
+            return Results.BadRequest(new { error = "currency must be one of: BRL" });
+
+        var owner = new EndClientId(req.Endclient);
+        var operatorId = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+
+        try
+        {
+            // Withdrawal: pre-check + atomic debit happens INSIDE the
+            // dispatcher's mutate callback so the WAL append only lands
+            // when the debit actually succeeded. The keeper's TryWithdraw
+            // is its own CAS loop; we wrap the failure case as 422 so the
+            // caller can distinguish "insufficient funds" from "bad
+            // request". The throw-from-mutate path skips the apply step
+            // but the event is already on disk — to avoid that, we
+            // pre-check the balance OUTSIDE the dispatcher (best-effort)
+            // and then re-check INSIDE via TryWithdraw, which is the only
+            // authoritative read. If the inside check fails we throw a
+            // sentinel that the catch maps to 422; the WAL append for a
+            // failed withdraw is rolled back by the dispatcher's
+            // throw-skips-apply contract... except the dispatcher already
+            // committed seq. So: structure the flow so the keeper's
+            // TryWithdraw runs FIRST (under no lock — the keeper is
+            // thread-safe), and the dispatcher only fires when we've
+            // already debited. On Deposit the apply is unconditional.
+            if (kind == "Withdrawal")
+            {
+                if (!keeper.TryWithdraw(owner, req.Amount))
+                    return Results.UnprocessableEntity(new
+                    {
+                        error = "insufficient_funds",
+                        available = keeper.GetAvailable(owner),
+                        requested = req.Amount,
+                    });
+            }
+
+            try
+            {
+                dispatcher.Dispatch(
+                    new CashLedgerEvent
+                    {
+                        EndClientId = req.Endclient,
+                        Operation = kind,
+                        Amount = req.Amount,
+                        Currency = currency,
+                        Reference = req.Reference,
+                        OperatorId = operatorId,
+                    },
+                    () =>
+                    {
+                        // Withdrawal already debited above; only the deposit
+                        // mutates state inside the dispatcher lock. Both
+                        // arms keep the (event-on-disk, balance-mutated)
+                        // pair atomic from the dispatcher's perspective.
+                        if (kind == "Deposit")
+                            keeper.ApplyDeposit(owner, req.Amount);
+                    });
+            }
+            catch
+            {
+                // Compensating credit: if the WAL append throws AFTER we
+                // already debited (Withdrawal path), restore the balance
+                // so the operator-visible state matches the on-disk
+                // truth. Re-throw so the outer handler maps it to 503.
+                if (kind == "Withdrawal")
+                    keeper.ApplyDeposit(owner, req.Amount);
+                throw;
+            }
+
+            return Results.Ok(new
+            {
+                endclient = req.Endclient,
+                kind,
+                amount = req.Amount,
+                currency,
+                available = keeper.GetAvailable(owner),
+            });
+        }
+        catch (WalBackpressureException ex)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "admin.cash"));
+            return Results.Json(
+                new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
     }
 
     private static IResult ToggleKill(
@@ -443,3 +566,19 @@ public sealed class SessionPhasePayload
 /// Body for <c>POST /admin/firms/{firmId}/orders/{clOrdId}/mark-stale</c> (#132 slice 1).
 /// </summary>
 public sealed record MarkStaleRequest(string? Reason);
+
+/// <summary>
+/// Body for <c>POST /admin/cash</c> (Q2.2 / #269). Operator-driven
+/// deposit or withdrawal. <see cref="Kind"/> is <c>"Deposit"</c> or
+/// <c>"Withdrawal"</c> (case-insensitive); <see cref="Amount"/> is
+/// strictly positive (sign is implied by Kind); <see cref="Currency"/>
+/// is whitelisted to <c>"BRL"</c> in v0.
+/// </summary>
+public sealed class CashLedgerRequest
+{
+    public string? Endclient { get; set; }
+    public string? Kind { get; set; }
+    public decimal Amount { get; set; }
+    public string? Currency { get; set; }
+    public string? Reference { get; set; }
+}

--- a/backend/src/B3.Trading.Application/CashKeeper.cs
+++ b/backend/src/B3.Trading.Application/CashKeeper.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q2.2 (#269). Per-end-client cash balance projected from the
+/// <see cref="CashLedgerEvent"/> WAL stream — i.e. operator-driven
+/// deposits and withdrawals only. Single-currency in v0 (BRL); the
+/// ledger here intentionally does NOT fold ER fills into the same
+/// projection (those continue to feed <see cref="CashLedger"/> for the
+/// margin pipeline). The fill+fee composite balance is the P&amp;L
+/// engine's responsibility (#271) and lands later.
+///
+/// <para>
+/// Snapshot/restore mirrors <see cref="CashLedger"/>: zero-balance rows
+/// are skipped because they re-materialise on the next event; negative
+/// balances cannot occur here (the admin endpoint clamps withdrawals at
+/// the available balance — see <see cref="TryWithdraw"/>).
+/// </para>
+/// </summary>
+public sealed class CashKeeper
+{
+    private readonly ConcurrentDictionary<EndClientId, decimal> _balances = new();
+
+    public decimal GetAvailable(EndClientId owner) =>
+        _balances.TryGetValue(owner, out var b) ? b : 0m;
+
+    public void ApplyDeposit(EndClientId owner, decimal amount)
+    {
+        if (amount <= 0m)
+            throw new ArgumentOutOfRangeException(nameof(amount), "deposit amount must be > 0");
+        _balances.AddOrUpdate(owner, amount, (_, current) => current + amount);
+    }
+
+    /// <summary>
+    /// Atomically debits <paramref name="amount"/> iff the balance is
+    /// sufficient. Returns <c>false</c> WITHOUT mutating state if the
+    /// withdrawal would drive the balance negative — the caller is
+    /// expected to surface a 422 to the operator. Idempotent on the
+    /// failure path (no allocation, no entry creation).
+    /// </summary>
+    public bool TryWithdraw(EndClientId owner, decimal amount)
+    {
+        if (amount <= 0m)
+            throw new ArgumentOutOfRangeException(nameof(amount), "withdrawal amount must be > 0");
+        while (true)
+        {
+            if (!_balances.TryGetValue(owner, out var current))
+                return false;
+            if (current < amount)
+                return false;
+            var next = current - amount;
+            if (_balances.TryUpdate(owner, next, current))
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Replay-time apply: mirrors the live admin path exactly. Unknown
+    /// <paramref name="kind"/> strings are rejected so a malformed WAL
+    /// segment fails loudly instead of silently dropping the event.
+    /// Withdrawals during replay are NOT validated against the running
+    /// balance — by construction the live path only ever appended
+    /// withdrawals that succeeded, so replay can apply them blindly. A
+    /// negative balance after replay would indicate WAL corruption and
+    /// is intentionally allowed to propagate (no clamp) so it surfaces
+    /// in observability instead of being masked.
+    /// </summary>
+    public void Apply(string kind, EndClientId owner, decimal amount)
+    {
+        if (string.Equals(kind, "Deposit", StringComparison.Ordinal))
+        {
+            _balances.AddOrUpdate(owner, amount, (_, current) => current + amount);
+            return;
+        }
+        if (string.Equals(kind, "Withdrawal", StringComparison.Ordinal))
+        {
+            _balances.AddOrUpdate(owner, -amount, (_, current) => current - amount);
+            return;
+        }
+        throw new InvalidOperationException($"Unknown CashLedgerEvent kind: {kind}");
+    }
+
+    /// <summary>
+    /// Phase-1 (lock-side) capture for the two-phase snapshot pipeline
+    /// (RFC §5.8). Caller must hold <c>EventDispatcher.WithSnapshotLock</c>.
+    /// </summary>
+    public CashKeeperRaw[] RawSnapshot()
+    {
+        var pairs = _balances.ToArray();
+        if (pairs.Length == 0) return Array.Empty<CashKeeperRaw>();
+        var buf = new CashKeeperRaw[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            if (pairs[i].Value == 0m) continue;
+            buf[n++] = new CashKeeperRaw(pairs[i].Key.Value, pairs[i].Value);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new CashKeeperRaw[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
+    public void Restore(IReadOnlyDictionary<string, decimal> snap)
+    {
+        ArgumentNullException.ThrowIfNull(snap);
+        _balances.Clear();
+        foreach (var kv in snap)
+            _balances[new EndClientId(kv.Key)] = kv.Value;
+    }
+}

--- a/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
+++ b/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
@@ -164,6 +164,55 @@ public sealed class EventDispatcher
     }
 
     /// <summary>
+    /// Q2.2 (#269) P1 fix. Atomic "validate + debit + append" primitive
+    /// used by callers whose in-memory mutation MUST be visible to the
+    /// snapshot service iff the WAL append also lands. Concretely: the
+    /// cash withdrawal path must not let a snapshot interleave between
+    /// the keeper debit and the WAL append, otherwise a snapshot would
+    /// persist a reduced balance with no matching event in the WAL —
+    /// permanent cash loss on restore.
+    ///
+    /// <para>
+    /// Semantics, all under the dispatcher lock (the same lock
+    /// <see cref="WithSnapshotLock"/> takes):
+    /// <list type="number">
+    ///   <item>invoke <paramref name="preApply"/>; if it returns
+    ///   <c>false</c>, no append, no rollback — the caller surfaces
+    ///   a structured business-rule failure (e.g. 422);</item>
+    ///   <item>append <paramref name="evt"/> to the WAL;</item>
+    ///   <item>if append throws, run <paramref name="rollback"/> WHILE
+    ///   STILL HOLDING THE LOCK so a snapshot cannot observe the
+    ///   transient debited-but-no-event state, then rethrow.</item>
+    /// </list>
+    /// JSON serialisation runs OUTSIDE the lock — same F1 narrowing as
+    /// the regular <see cref="Dispatch(WalEvent, Action)"/> overloads.
+    /// </para>
+    /// </summary>
+    public DispatchOutcome DispatchWithPreApply(WalEvent evt, Func<bool> preApply, Action rollback)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        ArgumentNullException.ThrowIfNull(preApply);
+        ArgumentNullException.ThrowIfNull(rollback);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(evt, WalEventJsonContext.Default.WalEvent);
+        lock (_lock)
+        {
+            if (!preApply())
+                return new DispatchOutcome(false, 0);
+            long seq;
+            try
+            {
+                seq = _store.Append(evt, payload);
+            }
+            catch
+            {
+                rollback();
+                throw;
+            }
+            return new DispatchOutcome(true, seq);
+        }
+    }
+
+    /// <summary>
     /// Captures a consistent <c>(seq, state)</c> view by running
     /// <paramref name="capture"/> under the dispatcher lock.
     /// </summary>
@@ -176,3 +225,11 @@ public sealed class EventDispatcher
         }
     }
 }
+
+/// <summary>
+/// Result of <see cref="EventDispatcher.DispatchWithPreApply"/>.
+/// <c>Applied=false</c> means the pre-apply check returned false and no
+/// WAL append was made; <c>Seq</c> is meaningful only when
+/// <c>Applied=true</c>.
+/// </summary>
+public readonly record struct DispatchOutcome(bool Applied, long Seq);

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -48,6 +48,14 @@ public sealed class RawPlatformSnapshot
     public OwnershipRaw[] Ownership { get; init; } = Array.Empty<OwnershipRaw>();
     public CashRaw[] CashBalances { get; init; } = Array.Empty<CashRaw>();
 
+    /// <summary>
+    /// Q2.2 (#269). Per-end-client cash balances projected from the
+    /// <c>CashLedgerEvent</c> stream by <c>CashKeeper</c>. Distinct from
+    /// <see cref="CashBalances"/> (which is the fill-derived projection
+    /// used by the margin pipeline).
+    /// </summary>
+    public CashKeeperRaw[] CashByEndclient { get; init; } = Array.Empty<CashKeeperRaw>();
+
     public UserBotCredential[] UserBotCredentials { get; init; } =
         Array.Empty<UserBotCredential>();
     public BotSessionState[] BotSessions { get; init; } = Array.Empty<BotSessionState>();
@@ -107,6 +115,15 @@ public readonly record struct OwnershipRaw(ulong ClOrdId, string EndClientId);
 public readonly record struct SessionPhaseOverrideRaw(string Symbol, SessionPhase Phase);
 
 public readonly record struct CashRaw(string EndClientId, decimal Available);
+
+/// <summary>
+/// Q2.2 (#269). Raw lock-side capture of one row from
+/// <see cref="B3.Trading.Application.CashKeeper"/>. Distinct from
+/// <see cref="CashRaw"/> (which captures the fill-derived
+/// <see cref="B3.Trading.Application.CashLedger"/>) so the two
+/// projections can evolve independently.
+/// </summary>
+public readonly record struct CashKeeperRaw(string EndClientId, decimal Available);
 
 public readonly record struct ClOrdIdCounterRaw(string EndClientId, ulong PrefixIdx, long Counter);
 

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -53,6 +53,18 @@ public sealed class PlatformSnapshot
     public List<CashBalanceSnapshot> CashBalances { get; init; } = new();
 
     /// <summary>
+    /// Q2.2 (#269). Per-end-client cash balances projected from
+    /// <c>CashLedgerEvent</c> (operator deposits/withdrawals) by
+    /// <c>CashKeeper</c>. Additive field; older snapshots that pre-date
+    /// it deserialise with an empty dictionary, which matches the
+    /// "no operator activity recorded" semantics they actually carried.
+    /// Init-only and default-empty so callers cannot accidentally null
+    /// it out post-deserialisation. Dict (not list) by spec — keyed on
+    /// end-client id, value is the running balance.
+    /// </summary>
+    public Dictionary<string, decimal> CashByEndclient { get; init; } = new();
+
+    /// <summary>
     /// User-issued bot credentials (sub-issue #169). Empty on snapshots
     /// pre-dating the field — credentials are reconstructed instead by
     /// the WAL replay path on top of the empty list, which matches the

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -46,6 +46,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(BotSessionSeqAdvancedEvent))]
 [JsonSerializable(typeof(BotOrderMapping))]
 [JsonSerializable(typeof(OrderExpiredEvent))]
+[JsonSerializable(typeof(CashLedgerEvent))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -35,6 +35,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(BotSessionSeqAdvancedEvent), "userbot.session.seq-advanced")]
 [JsonDerivedType(typeof(OrderCancelRequestedEvent), "order.cancel-requested")]
 [JsonDerivedType(typeof(OrderExpiredEvent), "order.expired")]
+[JsonDerivedType(typeof(CashLedgerEvent), "cash.ledger")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -449,4 +450,47 @@ public sealed record OrderExpiredEvent : WalEvent
     public required ulong ClOrdId { get; init; }
     public required string Reason { get; init; }
     public required DateTimeOffset AtUtc { get; init; }
+}
+
+/// <summary>
+/// Q2.2 (#269). Operator-driven cash deposit or withdrawal for an
+/// end-client. The platform's cash projection (see
+/// <see cref="B3.Trading.Application.CashKeeper"/>) is built from this
+/// event stream ONLY — it is intentionally decoupled from
+/// <see cref="ExecutionReportReceivedEvent"/> fills (which feed the
+/// separate <see cref="B3.Trading.Application.CashLedger"/> used by the
+/// margin pipeline). Folding fill-driven cash deltas into the same
+/// projection is deferred to the P&amp;L engine slice (#271) so the
+/// audit-grade ledger here stays a pure record of operator activity.
+///
+/// <para>
+/// Field semantics: <see cref="Kind"/> is the literal string
+/// <c>"Deposit"</c> or <c>"Withdrawal"</c> (mirrors the enum-name
+/// stability convention used by other WAL records, e.g. TIF). Amount is
+/// strictly positive; sign is implied by <see cref="Kind"/>. Currency
+/// is whitelisted to <c>"BRL"</c> in v0; future multi-currency expands
+/// the whitelist without changing the wire shape. <see cref="Reference"/>
+/// is operator free-form (ticket id, journal note); persisted verbatim
+/// for the operator audit trail. <see cref="OperatorId"/> is the JWT
+/// <c>sub</c> of the admin who issued the call (nullable to match the
+/// existing <c>ActorUserId</c> nullability on other admin-side events).
+/// </para>
+/// </summary>
+public sealed record CashLedgerEvent : WalEvent
+{
+    public required string EndClientId { get; init; }
+    /// <summary>
+    /// <c>"Deposit"</c> or <c>"Withdrawal"</c>. Property is named
+    /// <c>Operation</c> (not <c>Kind</c>) so it does not collide with
+    /// the polymorphism discriminator on <see cref="WalEvent"/>, which
+    /// is also serialised as <c>"kind"</c>. The HTTP request payload
+    /// continues to use <c>kind</c> at the API surface (see
+    /// <c>CashLedgerRequest</c>); the API handler maps it onto this
+    /// field at dispatch time.
+    /// </summary>
+    public required string Operation { get; init; }
+    public required decimal Amount { get; init; }
+    public required string Currency { get; init; }
+    public string? Reference { get; init; }
+    public string? OperatorId { get; init; }
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<AlgoIdRegistry>();
         services.AddSingleton<PositionKeeper>();
         services.AddSingleton<CashLedger>();
+        services.AddSingleton<CashKeeper>();
         services.AddSingleton<InMemoryUserBotCredentialRegistry>();
         services.AddSingleton<IUserBotCredentialRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -26,6 +26,7 @@ public sealed class StateSnapshotter
     private readonly AlgoBook _algos;
     private readonly AlgoIdRegistry _algoIds;
     private readonly CashLedger _cash;
+    private readonly CashKeeper? _cashKeeper;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
     private readonly IUserBotOrderMappingRegistry? _userBotMappings;
@@ -54,7 +55,8 @@ public sealed class StateSnapshotter
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
         InMemoryUserBotSessionRegistry? userBotSessions = null,
         IUserBotOrderMappingRegistry? userBotMappings = null,
-        GtdExpirationScheduler? gtdScheduler = null)
+        GtdExpirationScheduler? gtdScheduler = null,
+        CashKeeper? cashKeeper = null)
     {
         _orders = orders;
         _positions = positions;
@@ -66,6 +68,7 @@ public sealed class StateSnapshotter
         _algos = algos;
         _algoIds = algoIds;
         _cash = cash;
+        _cashKeeper = cashKeeper;
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
@@ -110,6 +113,7 @@ public sealed class StateSnapshotter
         AlgoIds = _algoIds.RawSnapshot(),
         Ownership = _ownership.RawSnapshot(),
         CashBalances = _cash.RawSnapshot(),
+        CashByEndclient = _cashKeeper?.RawSnapshot() ?? Array.Empty<CashKeeperRaw>(),
         UserBotCredentials = _userBotCredentials?.RawSnapshot() ?? Array.Empty<UserBotCredential>(),
         BotSessions = _userBotSessions?.RawSnapshot() ?? Array.Empty<BotSessionState>(),
         BotOrderMappings = _userBotMappings?.RawSnapshotOrders() ?? Array.Empty<BotOrderMappingRaw>(),
@@ -177,6 +181,14 @@ public sealed class StateSnapshotter
         var cash = new List<CashBalanceSnapshot>(raw.CashBalances.Length);
         for (var i = 0; i < raw.CashBalances.Length; i++)
             cash.Add(new CashBalanceSnapshot(raw.CashBalances[i].EndClientId, raw.CashBalances[i].Available));
+
+        // Q2.2 (#269). Project the CashKeeper's raw rows into the
+        // persisted dict shape. Dictionary (vs list) is mandated by the
+        // spec; deterministic insertion order is not required (callers
+        // index by end-client id).
+        var cashByEndclient = new Dictionary<string, decimal>(raw.CashByEndclient.Length);
+        for (var i = 0; i < raw.CashByEndclient.Length; i++)
+            cashByEndclient[raw.CashByEndclient[i].EndClientId] = raw.CashByEndclient[i].Available;
 
         var phaseOverrides = new List<SessionPhaseOverrideSnapshot>(raw.SessionPhaseOverrides.Length);
         for (var i = 0; i < raw.SessionPhaseOverrides.Length; i++)
@@ -257,6 +269,7 @@ public sealed class StateSnapshotter
             Algos = algos,
             AlgoIds = algoIds,
             CashBalances = cash,
+            CashByEndclient = cashByEndclient,
             UserBotCredentials = creds,
             BotSessions = sessions,
             BotOrderMappings = botOrderMaps,
@@ -284,6 +297,7 @@ public sealed class StateSnapshotter
         _algos.Restore(snap.Algos);
         _algoIds.Restore(snap.AlgoIds);
         _cash.Restore(snap.CashBalances);
+        _cashKeeper?.Restore(snap.CashByEndclient);
         _userBotCredentials?.Restore(snap.UserBotCredentials);
         _userBotSessions?.Restore(snap.BotSessions);
         _userBotMappings?.Restore(snap.BotOrderMappings, snap.BotCancelMappings);
@@ -337,6 +351,7 @@ public sealed class EventReplayer
     /// hosted-service <c>StartAsync</c>.
     /// </summary>
     private readonly GtdExpirationScheduler? _gtdScheduler;
+    private readonly CashKeeper? _cashKeeper;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -352,7 +367,8 @@ public sealed class EventReplayer
         InMemoryUserBotCredentialRegistry? userBotCredentials = null,
         InMemoryUserBotSessionRegistry? userBotSessions = null,
         IUserBotOrderMappingRegistry? userBotMappings = null,
-        GtdExpirationScheduler? gtdScheduler = null)
+        GtdExpirationScheduler? gtdScheduler = null,
+        CashKeeper? cashKeeper = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -368,6 +384,7 @@ public sealed class EventReplayer
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
         _gtdScheduler = gtdScheduler;
+        _cashKeeper = cashKeeper;
     }
 
     public void Apply(WalEvent evt)
@@ -561,6 +578,12 @@ public sealed class EventReplayer
                 // pre-crash cancel ER never landed. Null-tolerant for
                 // compositions / tests that don't wire a scheduler.
                 _gtdScheduler?.MarkExpiredAuditAppended(oe.ClOrdId);
+                break;
+            case CashLedgerEvent cle:
+                // Q2.2 (#269). Replay folds the deposit/withdrawal into
+                // CashKeeper. Null-tolerant for compositions/tests that
+                // don't wire the keeper.
+                _cashKeeper?.Apply(cle.Operation, new EndClientId(cle.EndClientId), cle.Amount);
                 break;
         }
     }

--- a/backend/tests/B3.Trading.Api.Tests/CashLedgerAdminEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/CashLedgerAdminEndpointTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q2.2 (#269). Coverage for the admin cash-ledger endpoint:
+/// auth role gate, validation surface, deposit/withdrawal flow,
+/// over-withdraw 422.
+/// </summary>
+public class CashLedgerAdminEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public CashLedgerAdminEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    private static string UniqueClient(string prefix) => $"{prefix}-{Guid.NewGuid():N}";
+
+    [Fact]
+    public async Task Post_RequiresAdminRole_TraderGets403()
+    {
+        using var trader = await _factory.CreateAuthedClientAsync(); // alice (user role)
+        var resp = await trader.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient = "anyone",
+            kind = "Deposit",
+            amount = 100m,
+            currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Deposit_IncreasesBalance()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var endclient = UniqueClient("alice");
+
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient,
+            kind = "Deposit",
+            amount = 1_000m,
+            currency = "BRL",
+            reference = "ticket-1",
+        });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<CashResponse>(Json);
+        Assert.Equal(1_000m, body!.Available);
+
+        // Second deposit accumulates.
+        var resp2 = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient,
+            kind = "Deposit",
+            amount = 250m,
+            currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.OK, resp2.StatusCode);
+        var body2 = await resp2.Content.ReadFromJsonAsync<CashResponse>(Json);
+        Assert.Equal(1_250m, body2!.Available);
+    }
+
+    [Fact]
+    public async Task Withdrawal_DecreasesBalance()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var endclient = UniqueClient("bob");
+
+        await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient, kind = "Deposit", amount = 1_000m, currency = "BRL",
+        });
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient, kind = "Withdrawal", amount = 400m, currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<CashResponse>(Json);
+        Assert.Equal(600m, body!.Available);
+    }
+
+    [Fact]
+    public async Task OverWithdraw_Returns422_WithDetail()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var endclient = UniqueClient("carol");
+
+        await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient, kind = "Deposit", amount = 100m, currency = "BRL",
+        });
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient, kind = "Withdrawal", amount = 250m, currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.Equal("insufficient_funds", doc.RootElement.GetProperty("error").GetString());
+        Assert.Equal(100m, doc.RootElement.GetProperty("available").GetDecimal());
+        Assert.Equal(250m, doc.RootElement.GetProperty("requested").GetDecimal());
+
+        // Balance unchanged after the rejected withdrawal.
+        var probe = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient, kind = "Deposit", amount = 1m, currency = "BRL",
+        });
+        var probeBody = await probe.Content.ReadFromJsonAsync<CashResponse>(Json);
+        Assert.Equal(101m, probeBody!.Available);
+    }
+
+    [Fact]
+    public async Task UnknownCurrency_Returns400()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient = UniqueClient("dave"),
+            kind = "Deposit",
+            amount = 100m,
+            currency = "USD",
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task NonPositiveAmount_Returns400(decimal amount)
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient = UniqueClient("eve"),
+            kind = "Deposit",
+            amount,
+            currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnknownKind_Returns400()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient = UniqueClient("frank"),
+            kind = "Transfer",
+            amount = 10m,
+            currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingEndclient_Returns400()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.PostAsJsonAsync("/admin/cash", new
+        {
+            endclient = "",
+            kind = "Deposit",
+            amount = 10m,
+            currency = "BRL",
+        });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    private sealed record CashResponse(string Endclient, string Kind, decimal Amount, string Currency, decimal Available);
+}

--- a/backend/tests/B3.Trading.Api.Tests/CashLedgerAdminEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/CashLedgerAdminEndpointTests.cs
@@ -71,11 +71,17 @@ public class CashLedgerAdminEndpointTests : IClassFixture<TestAppFactory>
 
         await admin.PostAsJsonAsync("/admin/cash", new
         {
-            endclient, kind = "Deposit", amount = 1_000m, currency = "BRL",
+            endclient,
+            kind = "Deposit",
+            amount = 1_000m,
+            currency = "BRL",
         });
         var resp = await admin.PostAsJsonAsync("/admin/cash", new
         {
-            endclient, kind = "Withdrawal", amount = 400m, currency = "BRL",
+            endclient,
+            kind = "Withdrawal",
+            amount = 400m,
+            currency = "BRL",
         });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<CashResponse>(Json);
@@ -90,11 +96,17 @@ public class CashLedgerAdminEndpointTests : IClassFixture<TestAppFactory>
 
         await admin.PostAsJsonAsync("/admin/cash", new
         {
-            endclient, kind = "Deposit", amount = 100m, currency = "BRL",
+            endclient,
+            kind = "Deposit",
+            amount = 100m,
+            currency = "BRL",
         });
         var resp = await admin.PostAsJsonAsync("/admin/cash", new
         {
-            endclient, kind = "Withdrawal", amount = 250m, currency = "BRL",
+            endclient,
+            kind = "Withdrawal",
+            amount = 250m,
+            currency = "BRL",
         });
         Assert.Equal(HttpStatusCode.UnprocessableEntity, resp.StatusCode);
         using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
@@ -105,7 +117,10 @@ public class CashLedgerAdminEndpointTests : IClassFixture<TestAppFactory>
         // Balance unchanged after the rejected withdrawal.
         var probe = await admin.PostAsJsonAsync("/admin/cash", new
         {
-            endclient, kind = "Deposit", amount = 1m, currency = "BRL",
+            endclient,
+            kind = "Deposit",
+            amount = 1m,
+            currency = "BRL",
         });
         var probeBody = await probe.Content.ReadFromJsonAsync<CashResponse>(Json);
         Assert.Equal(101m, probeBody!.Available);

--- a/backend/tests/B3.Trading.Application.Tests/CashKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/CashKeeperTests.cs
@@ -1,0 +1,151 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Q2.2 (#269). Unit-level coverage for <see cref="CashKeeper"/>: the
+/// pure projection from <c>CashLedgerEvent</c> deposits/withdrawals.
+/// End-to-end admin-endpoint + replay flows are covered separately
+/// (api tests + persistence recovery tests).
+/// </summary>
+public class CashKeeperTests
+{
+    [Fact]
+    public void Deposit_IncreasesBalance()
+    {
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+
+        keeper.ApplyDeposit(alice, 1_000m);
+        Assert.Equal(1_000m, keeper.GetAvailable(alice));
+
+        keeper.ApplyDeposit(alice, 250m);
+        Assert.Equal(1_250m, keeper.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void TryWithdraw_DecreasesBalance_OnSuccess()
+    {
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+        keeper.ApplyDeposit(alice, 1_000m);
+
+        Assert.True(keeper.TryWithdraw(alice, 400m));
+        Assert.Equal(600m, keeper.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void TryWithdraw_OverBalance_ReturnsFalse_NoMutation()
+    {
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+        keeper.ApplyDeposit(alice, 100m);
+
+        Assert.False(keeper.TryWithdraw(alice, 200m));
+        Assert.Equal(100m, keeper.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void TryWithdraw_UnknownOwner_ReturnsFalse_NoMaterialise()
+    {
+        var keeper = new CashKeeper();
+        Assert.False(keeper.TryWithdraw(new EndClientId("ghost"), 10m));
+        // Empty raw snapshot — probing didn't pollute the dictionary.
+        Assert.Empty(keeper.RawSnapshot());
+    }
+
+    [Fact]
+    public void GetAvailable_UnknownOwner_ReturnsZero()
+    {
+        Assert.Equal(0m, new CashKeeper().GetAvailable(new EndClientId("ghost")));
+    }
+
+    [Fact]
+    public void Deposit_ZeroOrNegative_Throws()
+    {
+        var keeper = new CashKeeper();
+        Assert.Throws<ArgumentOutOfRangeException>(() => keeper.ApplyDeposit(new EndClientId("a"), 0m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => keeper.ApplyDeposit(new EndClientId("a"), -1m));
+    }
+
+    [Fact]
+    public void TryWithdraw_ZeroOrNegative_Throws()
+    {
+        var keeper = new CashKeeper();
+        Assert.Throws<ArgumentOutOfRangeException>(() => keeper.TryWithdraw(new EndClientId("a"), 0m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => keeper.TryWithdraw(new EndClientId("a"), -1m));
+    }
+
+    [Fact]
+    public void Apply_ReplayPath_FoldsDepositsAndWithdrawals()
+    {
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+
+        keeper.Apply("Deposit", alice, 500m);
+        keeper.Apply("Withdrawal", alice, 200m);
+        keeper.Apply("Deposit", alice, 100m);
+
+        Assert.Equal(400m, keeper.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void Apply_UnknownKind_Throws()
+    {
+        var keeper = new CashKeeper();
+        Assert.Throws<InvalidOperationException>(() =>
+            keeper.Apply("Bogus", new EndClientId("a"), 1m));
+    }
+
+    [Fact]
+    public void RawSnapshot_SkipsZeroBalances()
+    {
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+        var bob = new EndClientId("bob");
+        keeper.ApplyDeposit(alice, 100m);
+        keeper.ApplyDeposit(bob, 50m);
+        keeper.TryWithdraw(bob, 50m); // bob -> 0
+
+        var snap = keeper.RawSnapshot();
+        Assert.Single(snap);
+        Assert.Equal("alice", snap[0].EndClientId);
+        Assert.Equal(100m, snap[0].Available);
+    }
+
+    [Fact]
+    public void Restore_RehydratesBalances_ClearsExisting()
+    {
+        var keeper = new CashKeeper();
+        keeper.ApplyDeposit(new EndClientId("ghost"), 999m);
+
+        keeper.Restore(new Dictionary<string, decimal>
+        {
+            ["alice"] = 1_000m,
+            ["bob"] = 250m,
+        });
+
+        Assert.Equal(0m, keeper.GetAvailable(new EndClientId("ghost")));
+        Assert.Equal(1_000m, keeper.GetAvailable(new EndClientId("alice")));
+        Assert.Equal(250m, keeper.GetAvailable(new EndClientId("bob")));
+    }
+
+    [Fact]
+    public void Snapshot_Restore_RoundTrips()
+    {
+        var src = new CashKeeper();
+        src.ApplyDeposit(new EndClientId("alice"), 1_000m);
+        src.ApplyDeposit(new EndClientId("bob"), 500m);
+        src.TryWithdraw(new EndClientId("alice"), 200m);
+
+        var raw = src.RawSnapshot();
+        var dict = raw.ToDictionary(r => r.EndClientId, r => r.Available);
+
+        var restored = new CashKeeper();
+        restored.Restore(dict);
+
+        Assert.Equal(800m, restored.GetAvailable(new EndClientId("alice")));
+        Assert.Equal(500m, restored.GetAvailable(new EndClientId("bob")));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/CashKeeperRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/CashKeeperRecoveryTests.cs
@@ -121,21 +121,26 @@ public class CashKeeperRecoveryTests : IDisposable
     private static void DispatchCash(EventDispatcher d, CashKeeper k, string ec, string kind, decimal amount)
     {
         var owner = new EndClientId(ec);
-        d.Dispatch(
-            new CashLedgerEvent
-            {
-                EndClientId = ec,
-                Operation = kind,
-                Amount = amount,
-                Currency = "BRL",
-                Reference = "test",
-                OperatorId = "test-operator",
-            },
-            () =>
-            {
-                if (kind == "Deposit") k.ApplyDeposit(owner, amount);
-                else k.TryWithdraw(owner, amount);
-            });
+        var evt = new CashLedgerEvent
+        {
+            EndClientId = ec,
+            Operation = kind,
+            Amount = amount,
+            Currency = "BRL",
+            Reference = "test",
+            OperatorId = "test-operator",
+        };
+        if (kind == "Deposit")
+        {
+            d.Dispatch(evt, () => k.ApplyDeposit(owner, amount));
+        }
+        else
+        {
+            d.DispatchWithPreApply(
+                evt,
+                preApply: () => k.TryWithdraw(owner, amount),
+                rollback: () => k.ApplyDeposit(owner, amount));
+        }
     }
 
     private (StateSnapshotter, EventReplayer) BuildSnapshotterAndReplayer(CashKeeper keeper)

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/CashKeeperRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/CashKeeperRecoveryTests.cs
@@ -1,0 +1,169 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Q2.2 (#269). End-to-end snapshot + WAL replay coverage for
+/// <see cref="CashKeeper"/>. The keeper's projection is fed exclusively
+/// by <c>CashLedgerEvent</c> records on the WAL, so the tests are
+/// shaped around that single event surface.
+/// </summary>
+public class CashKeeperRecoveryTests : IDisposable
+{
+    private readonly string _root;
+
+    public CashKeeperRecoveryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-cashkeeper-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private PersistenceOptions Opts() => new()
+    {
+        DataDirectory = _root,
+        FirmId = "test",
+        ChannelCapacity = 1024,
+        GroupCommitMaxRecords = 8,
+        GroupCommitWindow = TimeSpan.FromMilliseconds(5),
+        FsyncOnFlush = false,
+    };
+
+    [Fact]
+    public async Task Replay_FromWalAlone_RebuildsBalances()
+    {
+        // Phase 1: live — append cash ledger events.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var dispatcher = new EventDispatcher(store);
+            var alice = new EndClientId("alice");
+
+            DispatchCash(dispatcher, keeper, "alice", "Deposit", 1_000m);
+            DispatchCash(dispatcher, keeper, "alice", "Withdrawal", 250m);
+            DispatchCash(dispatcher, keeper, "bob", "Deposit", 500m);
+            await store.FlushAsync();
+        }
+
+        // Phase 2: cold boot — fresh keeper, replay rebuilds state.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var (snapshotter, replayer) = BuildSnapshotterAndReplayer(keeper);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"),
+                NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.Equal(750m, keeper.GetAvailable(new EndClientId("alice")));
+            Assert.Equal(500m, keeper.GetAvailable(new EndClientId("bob")));
+        }
+    }
+
+    [Fact]
+    public async Task SnapshotPlusTail_RestoresFromSnapshot_AndAppliesTailEvents()
+    {
+        // Phase 1: append events, take a snapshot, append more events.
+        long snapSeq;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var dispatcher = new EventDispatcher(store);
+            DispatchCash(dispatcher, keeper, "alice", "Deposit", 1_000m);
+            DispatchCash(dispatcher, keeper, "bob", "Deposit", 200m);
+
+            // Capture a snapshot under the dispatcher lock.
+            var (snapshotter, _) = BuildSnapshotterAndReplayer(keeper);
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            snapSeq = snap!.Seq;
+
+            // Snapshot dict carries both balances at point-in-time.
+            Assert.Equal(1_000m, snap.CashByEndclient["alice"]);
+            Assert.Equal(200m, snap.CashByEndclient["bob"]);
+
+            // Tail: more events past the snapshot seq.
+            DispatchCash(dispatcher, keeper, "alice", "Withdrawal", 300m);
+            DispatchCash(dispatcher, keeper, "carol", "Deposit", 50m);
+            await store.FlushAsync();
+        }
+
+        // Phase 2: cold boot — recovery loads snapshot then replays tail.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var (snapshotter, replayer) = BuildSnapshotterAndReplayer(keeper);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"),
+                NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            // Snapshot supplied 1000/200/0; tail debited 300 from alice
+            // and credited 50 to carol; net matches the direct projection.
+            Assert.Equal(700m, keeper.GetAvailable(new EndClientId("alice")));
+            Assert.Equal(200m, keeper.GetAvailable(new EndClientId("bob")));
+            Assert.Equal(50m, keeper.GetAvailable(new EndClientId("carol")));
+            Assert.True(snapSeq > 0);
+        }
+    }
+
+    private static void DispatchCash(EventDispatcher d, CashKeeper k, string ec, string kind, decimal amount)
+    {
+        var owner = new EndClientId(ec);
+        d.Dispatch(
+            new CashLedgerEvent
+            {
+                EndClientId = ec,
+                Operation = kind,
+                Amount = amount,
+                Currency = "BRL",
+                Reference = "test",
+                OperatorId = "test-operator",
+            },
+            () =>
+            {
+                if (kind == "Deposit") k.ApplyDeposit(owner, amount);
+                else k.TryWithdraw(owner, amount);
+            });
+    }
+
+    private (StateSnapshotter, EventReplayer) BuildSnapshotterAndReplayer(CashKeeper keeper)
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var killSwitch = new KillSwitchService();
+        var ownership = new OrderOwnershipMap();
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algos = new AlgoBook();
+        var sink = new NullSink();
+        var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
+            new B3.Trading.Application.Risk.NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance);
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch,
+            new SymbolHaltService(), new SessionPhaseService(),
+            clOrdIds, ownership, algos, new AlgoIdRegistry(),
+            new CashLedger(),
+            cashKeeper: keeper);
+        var replayer = new EventReplayer(book, ownership, killSwitch,
+            new SymbolHaltService(), new SessionPhaseService(),
+            processor, algos, clOrdIds, new AlgoIdRegistry(),
+            cashKeeper: keeper);
+        return (snapshotter, replayer);
+    }
+
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent evt) { }
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/CashWithdrawalAtomicityTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/CashWithdrawalAtomicityTests.cs
@@ -1,0 +1,408 @@
+using System.Runtime.CompilerServices;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Q2.2 (#269) P1 regression. Pins the atomicity contract for cash
+/// withdrawals: the keeper debit and the WAL append must execute under
+/// the same lock the snapshot service takes. Otherwise a snapshot can
+/// interleave between TryWithdraw and Append, persisting a reduced
+/// balance with no matching event in the WAL — permanent cash loss on
+/// restore.
+/// </summary>
+public class CashWithdrawalAtomicityTests : IDisposable
+{
+    private readonly string _root;
+
+    public CashWithdrawalAtomicityTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-cashatom-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private PersistenceOptions Opts() => new()
+    {
+        DataDirectory = _root,
+        FirmId = "test",
+        ChannelCapacity = 1024,
+        GroupCommitMaxRecords = 8,
+        GroupCommitWindow = TimeSpan.FromMilliseconds(5),
+        FsyncOnFlush = false,
+    };
+
+    /// <summary>
+    /// Direct regression for the #276 P1: a snapshot fired concurrently
+    /// with a withdrawal must not be able to capture a "debited but not
+    /// appended" state. We force the issue by wedging the WAL Append
+    /// inside the dispatcher critical section: a side thread fires
+    /// WithSnapshotLock during the wedge. With the old code, TryWithdraw
+    /// ran outside the lock and the side thread could capture the
+    /// debited balance with the matching event still missing from the
+    /// WAL. With the fix, the side thread is blocked on the dispatcher
+    /// lock until the append completes, so any captured snapshot
+    /// state is consistent with the WAL.
+    /// </summary>
+    [Fact]
+    public void Withdrawal_SnapshotCannotInterleaveBetweenDebitAndAppend()
+    {
+        var store = new WedgeableStore();
+        var dispatcher = new EventDispatcher(store);
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+        keeper.ApplyDeposit(alice, 1_000m);
+        var seedSeq = dispatcher.Dispatch(
+            new CashLedgerEvent
+            {
+                EndClientId = "alice",
+                Operation = "Deposit",
+                Amount = 1_000m,
+                Currency = "BRL",
+                Reference = "seed",
+                OperatorId = "op",
+            },
+            () => { /* keeper already seeded above */ });
+
+        // Wedge the next Append until the snapshot side has proven it
+        // can (or cannot) acquire the lock.
+        var appendStarted = new ManualResetEventSlim();
+        var releaseAppend = new ManualResetEventSlim();
+        store.OnAppend = () =>
+        {
+            appendStarted.Set();
+            releaseAppend.Wait(TimeSpan.FromSeconds(5));
+        };
+
+        long snapBalance = -1;
+        long snapSeq = -1;
+        bool snapRanWhileAppendWedged = false;
+
+        var snapshotThread = new Thread(() =>
+        {
+            // Wait until the dispatcher thread is mid-Append. Then try to
+            // grab the snapshot lock — the fix MUST make this block.
+            appendStarted.Wait(TimeSpan.FromSeconds(5));
+            snapRanWhileAppendWedged = !releaseAppend.IsSet;
+            dispatcher.WithSnapshotLock(seq =>
+            {
+                snapSeq = seq;
+                snapBalance = (long)keeper.GetAvailable(alice);
+            });
+        });
+
+        var withdrawThread = new Thread(() =>
+        {
+            // 5 seconds is plenty for the snapshot thread to attempt the
+            // lock; releasing here lets Append complete.
+            Thread.Sleep(50);
+            releaseAppend.Set();
+        });
+
+        snapshotThread.Start();
+        withdrawThread.Start();
+
+        var outcome = dispatcher.DispatchWithPreApply(
+            new CashLedgerEvent
+            {
+                EndClientId = "alice",
+                Operation = "Withdrawal",
+                Amount = 400m,
+                Currency = "BRL",
+                Reference = "w1",
+                OperatorId = "op",
+            },
+            preApply: () => keeper.TryWithdraw(alice, 400m),
+            rollback: () => keeper.ApplyDeposit(alice, 400m));
+
+        Assert.True(snapshotThread.Join(TimeSpan.FromSeconds(10)));
+        Assert.True(withdrawThread.Join(TimeSpan.FromSeconds(10)));
+
+        Assert.True(outcome.Applied);
+        Assert.True(outcome.Seq > seedSeq);
+
+        // The snapshot lock was contested while Append was wedged.
+        // After the fix the side thread must NOT be able to observe
+        // state until the dispatcher releases the lock — which only
+        // happens after Append returns. So the snapshot's balance is
+        // either the pre-debit value (1000, if it grabbed the lock
+        // before the dispatcher) or the post-append value (600, if
+        // after); never the in-between 600-with-no-event-yet.
+        Assert.True(snapRanWhileAppendWedged,
+            "snapshot thread should have raced with the wedged Append");
+        Assert.True(snapBalance == 1_000L || snapBalance == 600L,
+            $"snapshot captured a torn balance ({snapBalance}); the fix's lock invariant is broken");
+
+        // Strongest invariant: replay the WAL up to the captured
+        // snapshot.seq and verify the keeper's snap-time balance equals
+        // the projection. This is what recovery does on cold boot.
+        var projected = ProjectBalance(store.Recorded, alice.Value, untilSeq: snapSeq);
+        Assert.Equal(projected, snapBalance);
+    }
+
+    /// <summary>
+    /// Two concurrent withdrawals that each ask for half the balance + 1
+    /// can never both succeed. The fix routes both through the
+    /// dispatcher lock, which serialises the two TryWithdraw checks so
+    /// the first observes the full balance and the second observes the
+    /// debited balance and is rejected.
+    /// </summary>
+    [Fact]
+    public void Withdrawal_ConcurrentRace_AtMostOneSucceeds()
+    {
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var keeper = new CashKeeper();
+        var alice = new EndClientId("alice");
+        keeper.ApplyDeposit(alice, 100m);
+
+        var ready = new ManualResetEventSlim();
+        DispatchOutcome o1 = default, o2 = default;
+
+        var t1 = new Thread(() =>
+        {
+            ready.Wait();
+            o1 = dispatcher.DispatchWithPreApply(
+                NewWithdrawal(51m),
+                preApply: () => keeper.TryWithdraw(alice, 51m),
+                rollback: () => keeper.ApplyDeposit(alice, 51m));
+        });
+        var t2 = new Thread(() =>
+        {
+            ready.Wait();
+            o2 = dispatcher.DispatchWithPreApply(
+                NewWithdrawal(51m),
+                preApply: () => keeper.TryWithdraw(alice, 51m),
+                rollback: () => keeper.ApplyDeposit(alice, 51m));
+        });
+
+        t1.Start();
+        t2.Start();
+        ready.Set();
+        Assert.True(t1.Join(TimeSpan.FromSeconds(5)));
+        Assert.True(t2.Join(TimeSpan.FromSeconds(5)));
+
+        // Exactly one succeeds.
+        Assert.True(o1.Applied ^ o2.Applied);
+        Assert.Equal(49m, keeper.GetAvailable(alice));
+
+        static CashLedgerEvent NewWithdrawal(decimal amount) => new()
+        {
+            EndClientId = "alice",
+            Operation = "Withdrawal",
+            Amount = amount,
+            Currency = "BRL",
+            Reference = "race",
+            OperatorId = "op",
+        };
+    }
+
+    /// <summary>
+    /// End-to-end equivalence: while a long-running flow alternates
+    /// deposits and withdrawals, snapshots taken in parallel, when
+    /// combined with the WAL tail, replay to the same balance as a
+    /// straight WAL replay. This is the property snapshot recovery
+    /// relies on (RFC §4.3 / §5.8) and is what the P1 fix protects.
+    /// </summary>
+    [Fact]
+    public async Task Snapshot_DuringWithdrawals_ReplayMatchesDirectProjection()
+    {
+        long snapSeq;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var dispatcher = new EventDispatcher(store);
+            var keeper = new CashKeeper();
+            var alice = new EndClientId("alice");
+
+            // Seed.
+            DispatchDeposit(dispatcher, keeper, alice, 10_000m);
+
+            // Drive withdrawals on a background thread; capture a
+            // snapshot from the foreground a few times. The dispatcher
+            // lock makes every snapshot's (seq, state) consistent.
+            using var stop = new CancellationTokenSource();
+            var worker = Task.Run(() =>
+            {
+                var rng = new Random(42);
+                while (!stop.IsCancellationRequested)
+                {
+                    var amt = (decimal)rng.Next(1, 5);
+                    try
+                    {
+                        dispatcher.DispatchWithPreApply(
+                            new CashLedgerEvent
+                            {
+                                EndClientId = "alice",
+                                Operation = "Withdrawal",
+                                Amount = amt,
+                                Currency = "BRL",
+                                Reference = "load",
+                                OperatorId = "op",
+                            },
+                            preApply: () => keeper.TryWithdraw(alice, amt),
+                            rollback: () => keeper.ApplyDeposit(alice, amt));
+                    }
+                    catch (WalBackpressureException)
+                    {
+                        // The bounded WAL channel is intentionally
+                        // smaller than this loop is willing to push;
+                        // back off and retry so the test exercises
+                        // sustained snapshot/append racing without
+                        // failing on incidental backpressure. The
+                        // dispatcher's rollback already restored the
+                        // balance for the failed attempt.
+                        Thread.Sleep(1);
+                    }
+                }
+            });
+
+            var (snapshotter, _) = BuildSnapshotterAndReplayer(keeper);
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            for (var i = 0; i < 50; i++)
+            {
+                dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+                Thread.Sleep(2);
+            }
+            stop.Cancel();
+            await worker;
+
+            // Final snapshot to anchor the assertion.
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            snapSeq = snap!.Seq;
+
+            await store.FlushAsync();
+        }
+
+        // Cold boot: snapshot + tail replay must match a from-WAL-only
+        // replay of the same store.
+        decimal snapPlusTail;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var (snapshotter, replayer) = BuildSnapshotterAndReplayer(keeper);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"),
+                NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+            snapPlusTail = keeper.GetAvailable(new EndClientId("alice"));
+        }
+
+        decimal walOnly;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = new CashKeeper();
+            var (_, replayer) = BuildSnapshotterAndReplayer(keeper);
+            await foreach (var (_, evt) in store.ReadFromAsync(0))
+                replayer.Apply(evt);
+            walOnly = keeper.GetAvailable(new EndClientId("alice"));
+        }
+
+        Assert.Equal(walOnly, snapPlusTail);
+        Assert.True(snapSeq > 0);
+    }
+
+    private static void DispatchDeposit(EventDispatcher d, CashKeeper k, EndClientId owner, decimal amount)
+    {
+        d.Dispatch(
+            new CashLedgerEvent
+            {
+                EndClientId = owner.Value,
+                Operation = "Deposit",
+                Amount = amount,
+                Currency = "BRL",
+                Reference = "seed",
+                OperatorId = "op",
+            },
+            () => k.ApplyDeposit(owner, amount));
+    }
+
+    private (StateSnapshotter, EventReplayer) BuildSnapshotterAndReplayer(CashKeeper keeper)
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var killSwitch = new KillSwitchService();
+        var ownership = new OrderOwnershipMap();
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algos = new AlgoBook();
+        var sink = new NullSink();
+        var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
+            new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance);
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch,
+            new SymbolHaltService(), new SessionPhaseService(),
+            clOrdIds, ownership, algos, new AlgoIdRegistry(),
+            new CashLedger(),
+            cashKeeper: keeper);
+        var replayer = new EventReplayer(book, ownership, killSwitch,
+            new SymbolHaltService(), new SessionPhaseService(),
+            processor, algos, clOrdIds, new AlgoIdRegistry(),
+            cashKeeper: keeper);
+        return (snapshotter, replayer);
+    }
+
+    private static decimal ProjectBalance(IReadOnlyList<WalEvent> events, string endclient, long untilSeq)
+    {
+        // Seq is assigned in append order starting at 1.
+        decimal balance = 0m;
+        for (var i = 0; i < events.Count && (i + 1) <= untilSeq; i++)
+        {
+            if (events[i] is not CashLedgerEvent c) continue;
+            if (c.EndClientId != endclient) continue;
+            if (c.Operation == "Deposit") balance += c.Amount;
+            else if (c.Operation == "Withdrawal") balance -= c.Amount;
+        }
+        return balance;
+    }
+
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent evt) { }
+    }
+
+    /// <summary>
+    /// IEventStore that records every appended event and lets the test
+    /// inject a callback to wedge the Append call. Used to deterministically
+    /// expose a snapshot/append race window.
+    /// </summary>
+    private sealed class WedgeableStore : IEventStore
+    {
+        public List<WalEvent> Recorded { get; } = new();
+        public Action? OnAppend;
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+
+        public long Append(WalEvent evt) => Append(evt, ReadOnlyMemory<byte>.Empty);
+
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> _)
+        {
+            OnAppend?.Invoke();
+            Recorded.Add(evt);
+            return Interlocked.Increment(ref _seq);
+        }
+
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            for (var i = 0; i < Recorded.Count; i++)
+            {
+                var seq = i + 1;
+                if (seq > sinceSeqExclusive) yield return (seq, Recorded[i]);
+            }
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #269.

## Summary
- New `CashLedgerEvent` WAL record (additive, polymorphic via `JsonDerivedType` discriminator `cash.ledger`). Property is `Operation` rather than `Kind` to avoid colliding with the polymorphism discriminator (which is also serialised as `kind`); the API surface keeps `kind` in the request payload as specified.
- `CashKeeper` (new, lock-free) projects per-endclient balance from the `CashLedgerEvent` stream only. Intentionally decoupled from ER fills — fill-driven cash deltas continue to flow through the existing `CashLedger` (margin pipeline) and the composite balance lands with the P&L engine in #271. Documented in code.
- `POST /admin/cash` (admin role): payload `{ endclient, kind, amount, currency, reference }`. Validates `amount > 0`, `currency ∈ { BRL }`, withdraw ≤ available balance (else 422 with `{ error: insufficient_funds, available, requested }`). Trader → 403.
- `PlatformSnapshot.CashByEndclient` (`Dictionary<string, decimal>`, init-only, default empty). Wired through `StateSnapshotter` (capture + restore) and `EventReplayer` (CashLedgerEvent → CashKeeper.Apply). `CashKeeper` constructor parameters on both classes are nullable + defaulted so existing test sites compile unchanged.

## Decisions
- Separate `CashKeeper` (not extending `PositionKeeper` or `CashLedger`) — keeps the operator-audit ledger orthogonal to the fill-derived margin ledger; either projection can evolve independently.
- Withdrawal flow runs `TryWithdraw` BEFORE the dispatcher append so a failed withdraw never lands on the WAL; if the WAL append throws after the debit, a compensating credit restores the keeper balance.

## Tests (24 new)
Application:
- 12 `CashKeeperTests` (deposit, withdraw, over-withdraw, validation, replay apply, snapshot/restore round-trip).
- 2 `CashKeeperRecoveryTests` (WAL-only replay; snapshot + tail replay matches direct projection).

Api:
- 10 `CashLedgerAdminEndpointTests` (deposit, withdraw, over-withdraw 422, trader 403, unknown currency 400, zero/negative amount 400, unknown kind 400, missing endclient 400).

All 1,214 platform tests pass.

## Coordination
- `WalEvents.cs` / `WalEventJsonContext.cs` — added `CashLedgerEvent` at the bottom of both lists; concurrent #270 (fees) should rebase cleanly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>