### PR TITLE
feat(#271): P&L engine (realized + unrealized) + /pnl/today + WS pnl.me

### DIFF
--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -25,6 +25,14 @@ namespace B3.Trading.Api;
 /// </para>
 ///
 /// <para>
+/// Pass-1 review (#278) P2#4. Response shape matches the issue
+/// contract: parallel <c>realized</c> / <c>unrealized</c> arrays plus
+/// <c>totalRealized</c> / <c>totalUnrealized</c>. The WS
+/// <c>pnl.me</c> channel publishes the SAME projection (snapshot and
+/// delta), shared via <see cref="PnlProjection.Build"/>.
+/// </para>
+///
+/// <para>
 /// Auth: same shape as /positions and /balance — JWT <c>sub</c> is the
 /// end-client identity, query parameters are ignored. The spec mentions
 /// <c>?endClient=…</c> but cross-account reads are not allowed in v1.
@@ -53,19 +61,30 @@ public static class PnlEndpoints
     }
 }
 
-public sealed record PnlSymbolDto(
-    string Symbol,
-    long NetQuantity,
-    decimal AverageEntryPrice,
-    decimal? ReferencePrice,
-    decimal Realized,
-    decimal? Unrealized);
+public sealed record PnlRealizedEntry(string Symbol, decimal Value);
 
+public sealed record PnlUnrealizedEntry(
+    string Symbol,
+    decimal Value,
+    decimal RefPrice,
+    long Position,
+    decimal AvgPrice);
+
+/// <summary>
+/// Pass-1 review (#278) P2#4. Shape mandated by the Q2.4 issue
+/// contract: parallel <c>realized</c> / <c>unrealized</c> arrays plus
+/// the two totals. The unrealized array carries the inputs
+/// (<c>refPrice</c>, <c>position</c>, <c>avgPrice</c>) so a client
+/// can recompute the value locally; only symbols with a live
+/// reference price appear in <c>unrealized</c>, while <c>realized</c>
+/// surfaces every symbol with non-zero realized P&amp;L for the day
+/// (regardless of whether it still has an open position).
+/// </summary>
 public sealed record PnlTodayDto(
-    string Day,
-    decimal RealizedTotal,
-    decimal UnrealizedTotal,
-    IReadOnlyList<PnlSymbolDto> Symbols);
+    IReadOnlyList<PnlRealizedEntry> Realized,
+    IReadOnlyList<PnlUnrealizedEntry> Unrealized,
+    decimal TotalRealized,
+    decimal TotalUnrealized);
 
 /// <summary>
 /// Shared composer for the REST endpoint and the WebSocket
@@ -84,49 +103,35 @@ public static class PnlProjection
         DateOnly? day = null)
     {
         var d = day ?? DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
-        var symbols = new Dictionary<string, (long Qty, decimal Avg, decimal? Ref, decimal Realized, decimal? Unrealized)>(StringComparer.Ordinal);
 
-        // Seed from open positions — these always carry an avg-cost basis
-        // and a (possibly stale) ref-price lookup result.
+        // Unrealized: one row per OPEN position with a live ref price.
+        // Symbols whose ref-price lookup misses are omitted (rather
+        // than reported as 0) so the total stays honest.
+        var unrealized = new List<PnlUnrealizedEntry>();
+        decimal totalUnrealized = 0m;
         foreach (var p in positions.ForEndClient(owner))
         {
-            decimal? rp = null;
-            decimal? un = null;
-            if (refPrice.TryGet(p.Symbol, out var px))
-            {
-                rp = px;
-                un = p.NetQuantity >= 0
-                    ? (px - p.AverageEntryPrice) * p.NetQuantity
-                    : (p.AverageEntryPrice - px) * (-p.NetQuantity);
-            }
-            symbols[p.Symbol] = (p.NetQuantity, p.AverageEntryPrice, rp, 0m, un);
+            if (p.NetQuantity == 0) continue;
+            if (!refPrice.TryGet(p.Symbol, out var px)) continue;
+            var value = p.NetQuantity >= 0
+                ? (px - p.AverageEntryPrice) * p.NetQuantity
+                : (p.AverageEntryPrice - px) * (-p.NetQuantity);
+            unrealized.Add(new PnlUnrealizedEntry(p.Symbol, value, px, p.NetQuantity, p.AverageEntryPrice));
+            totalUnrealized += value;
         }
 
-        // Layer in realized for the day. A symbol may have realized
-        // activity (closed-out earlier) without a current open position
-        // — those rows still appear, with NetQuantity=0 / Unrealized=null.
-        foreach (var (symbol, realized) in pnl.ForEndClientDay(owner.Value, d))
+        // Realized: every symbol with a non-zero realized total for
+        // the day, including symbols whose position has since closed
+        // out (no current position row).
+        var realized = new List<PnlRealizedEntry>();
+        decimal totalRealized = 0m;
+        foreach (var (symbol, value) in pnl.ForEndClientDay(owner.Value, d))
         {
-            if (symbols.TryGetValue(symbol, out var existing))
-            {
-                symbols[symbol] = (existing.Qty, existing.Avg, existing.Ref, realized, existing.Unrealized);
-            }
-            else
-            {
-                symbols[symbol] = (0, 0m, null, realized, null);
-            }
+            if (value == 0m) continue;
+            realized.Add(new PnlRealizedEntry(symbol, value));
+            totalRealized += value;
         }
 
-        var rows = new List<PnlSymbolDto>(symbols.Count);
-        decimal realizedTotal = 0m;
-        decimal unrealizedTotal = 0m;
-        foreach (var kv in symbols)
-        {
-            var v = kv.Value;
-            rows.Add(new PnlSymbolDto(kv.Key, v.Qty, v.Avg, v.Ref, v.Realized, v.Unrealized));
-            realizedTotal += v.Realized;
-            if (v.Unrealized is not null) unrealizedTotal += v.Unrealized.Value;
-        }
-        return new PnlTodayDto(d.ToString("yyyy-MM-dd"), realizedTotal, unrealizedTotal, rows);
+        return new PnlTodayDto(realized, unrealized, totalRealized, totalUnrealized);
     }
 }

--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -107,11 +107,23 @@ public static class PnlProjection
         // Unrealized: one row per OPEN position with a live ref price.
         // Symbols whose ref-price lookup misses are omitted (rather
         // than reported as 0) so the total stays honest.
+        //
+        // Pass-4 review (#278) P1#2. Unknown-basis legacy positions
+        // (seeded from pre-#271 snapshots whose AverageEntryPrice was
+        // zero) carry no usable basis: Position.AverageEntryPrice is
+        // either 0 or some polluted value, so a naive
+        // (refPrice - avg) * qty would publish phantom unrealized
+        // P&L. Skip them entirely — the position simply doesn't
+        // appear in the unrealized array until the legacy leg goes
+        // flat and a real basis is established by a fresh fill (see
+        // PnlKeeper.ApplyFillToAvgCost). The realized side is
+        // unaffected (those rows come from PnlKeeper.ForEndClientDay).
         var unrealized = new List<PnlUnrealizedEntry>();
         decimal totalUnrealized = 0m;
         foreach (var p in positions.ForEndClient(owner))
         {
             if (p.NetQuantity == 0) continue;
+            if (pnl.GetUnknownBasisQty(owner.Value, p.Symbol) != 0) continue;
             if (!refPrice.TryGet(p.Symbol, out var px)) continue;
             var value = p.NetQuantity >= 0
                 ? (px - p.AverageEntryPrice) * p.NetQuantity

--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -1,0 +1,132 @@
+using System.Security.Claims;
+using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// Q2.4 (#271). GET /pnl/today — projects the authenticated end-client's
+/// realized + unrealized P&amp;L for the current UTC day.
+///
+/// <para>
+/// Realized comes straight from <see cref="PnlKeeper"/> (durable: WAL
+/// projection + snapshot). Unrealized is derived on the fly from
+/// <see cref="PositionKeeper"/> + <see cref="IReferencePrice"/> — never
+/// persisted, since the inputs (live position + ref price) move every
+/// tick. Symbols whose ref-price lookup misses are omitted from the
+/// unrealized list (rather than reported as 0) to keep the totals
+/// honest; the symbol still appears in the realized list when it has
+/// realized activity for the day.
+/// </para>
+///
+/// <para>
+/// Auth: same shape as /positions and /balance — JWT <c>sub</c> is the
+/// end-client identity, query parameters are ignored. The spec mentions
+/// <c>?endClient=…</c> but cross-account reads are not allowed in v1.
+/// </para>
+/// </summary>
+public static class PnlEndpoints
+{
+    public static IEndpointRouteBuilder MapPnl(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/pnl/today", [Authorize] (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            PnlKeeper pnl,
+            PositionKeeper positions,
+            IReferencePrice refPrice) =>
+        {
+            var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                      ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
+            var owner = registry.Register(sub);
+            Application.Observability.MetricsRegistry.PnlEndpointRequests.Add(1);
+            var snap = PnlProjection.Build(owner, pnl, positions, refPrice);
+            return Results.Ok(snap);
+        });
+
+        return app;
+    }
+}
+
+public sealed record PnlSymbolDto(
+    string Symbol,
+    long NetQuantity,
+    decimal AverageEntryPrice,
+    decimal? ReferencePrice,
+    decimal Realized,
+    decimal? Unrealized);
+
+public sealed record PnlTodayDto(
+    string Day,
+    decimal RealizedTotal,
+    decimal UnrealizedTotal,
+    IReadOnlyList<PnlSymbolDto> Symbols);
+
+/// <summary>
+/// Shared composer for the REST endpoint and the WebSocket
+/// <c>pnl.me</c> snapshot/delta — both must surface identical numbers
+/// for the same input state. Implemented as a static helper rather than
+/// a class so it stays pure: no DI, no ambient state, easy to test in
+/// isolation.
+/// </summary>
+public static class PnlProjection
+{
+    public static PnlTodayDto Build(
+        EndClientId owner,
+        PnlKeeper pnl,
+        PositionKeeper positions,
+        IReferencePrice refPrice,
+        DateOnly? day = null)
+    {
+        var d = day ?? DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        var symbols = new Dictionary<string, (long Qty, decimal Avg, decimal? Ref, decimal Realized, decimal? Unrealized)>(StringComparer.Ordinal);
+
+        // Seed from open positions — these always carry an avg-cost basis
+        // and a (possibly stale) ref-price lookup result.
+        foreach (var p in positions.ForEndClient(owner))
+        {
+            decimal? rp = null;
+            decimal? un = null;
+            if (refPrice.TryGet(p.Symbol, out var px))
+            {
+                rp = px;
+                un = p.NetQuantity >= 0
+                    ? (px - p.AverageEntryPrice) * p.NetQuantity
+                    : (p.AverageEntryPrice - px) * (-p.NetQuantity);
+            }
+            symbols[p.Symbol] = (p.NetQuantity, p.AverageEntryPrice, rp, 0m, un);
+        }
+
+        // Layer in realized for the day. A symbol may have realized
+        // activity (closed-out earlier) without a current open position
+        // — those rows still appear, with NetQuantity=0 / Unrealized=null.
+        foreach (var (symbol, realized) in pnl.ForEndClientDay(owner.Value, d))
+        {
+            if (symbols.TryGetValue(symbol, out var existing))
+            {
+                symbols[symbol] = (existing.Qty, existing.Avg, existing.Ref, realized, existing.Unrealized);
+            }
+            else
+            {
+                symbols[symbol] = (0, 0m, null, realized, null);
+            }
+        }
+
+        var rows = new List<PnlSymbolDto>(symbols.Count);
+        decimal realizedTotal = 0m;
+        decimal unrealizedTotal = 0m;
+        foreach (var kv in symbols)
+        {
+            var v = kv.Value;
+            rows.Add(new PnlSymbolDto(kv.Key, v.Qty, v.Avg, v.Ref, v.Realized, v.Unrealized));
+            realizedTotal += v.Realized;
+            if (v.Unrealized is not null) unrealizedTotal += v.Unrealized.Value;
+        }
+        return new PnlTodayDto(d.ToString("yyyy-MM-dd"), realizedTotal, unrealizedTotal, rows);
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -10,6 +10,8 @@ public static class Channels
     public const string ExecutionsMe = "executions.me";
     public const string PositionsMe = "positions.me";
     public const string AlgoMe = "algo.me";
+    /// <summary>Q2.4 (#271). Realized + unrealized P&amp;L per end-client.</summary>
+    public const string PnlMe = "pnl.me";
 
     /// <summary>
     /// Q1.5 (#257). Public per-symbol market-data channels of the form
@@ -28,7 +30,7 @@ public static class Channels
     /// <see cref="TryParsePublic"/>.
     /// </summary>
     public static readonly IReadOnlySet<string> All =
-        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe, AlgoMe };
+        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe, AlgoMe, PnlMe };
 
     /// <summary>
     /// Recognises <c>phases.SYMBOL</c> / <c>auction.SYMBOL</c> and

--- a/backend/src/B3.Trading.Api/WebSockets/PnlRefPriceFanOut.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/PnlRefPriceFanOut.cs
@@ -1,0 +1,211 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// Pass-1 review (#278) P1#3. Bridges
+/// <see cref="MarketDataReferencePrice.PriceChanged"/> to the
+/// <c>pnl.me</c> WS channel: when a symbol's mark moves, every owner
+/// holding an open position in that symbol with active subscribers
+/// receives a fresh <see cref="PnlTodayDto"/> delta so unrealized
+/// P&amp;L tracks the latest refprice without waiting for the next fill.
+///
+/// <para>
+/// <b>Throttling.</b> L1 ticks can be very frequent (tens to hundreds
+/// per second per active symbol). To avoid flooding subscribers and
+/// the WS hub channel, fan-out is coalesced PER SYMBOL: the most
+/// recent refprice tick for a symbol enqueues a publish job, and a
+/// single drain task processes the queue with a minimum gap of
+/// <see cref="ThrottleGap"/> between successive publishes for the
+/// same symbol. Multiple ticks arriving inside the gap collapse into
+/// one published delta carrying the latest mark; only the most recent
+/// price ever reaches subscribers, which is the right semantic for a
+/// projection of "current mark to position".
+/// </para>
+///
+/// <para>
+/// <b>Lock ordering.</b> The fan-out is invoked from the drain task
+/// (NOT from <see cref="MarketDataReferencePrice"/>'s tick handler)
+/// so the price-cache write path stays tight. The drain only takes
+/// read locks (PositionKeeper enumeration + PnlKeeper dictionary
+/// reads + SubscriptionManager publish under its own per-owner lock)
+/// — never the EventDispatcher lock and never the PnlKeeper per-key
+/// fill lock — so it cannot deadlock with the live ER path.
+/// </para>
+/// </summary>
+public sealed class PnlRefPriceFanOut : IHostedService, IAsyncDisposable
+{
+    /// <summary>
+    /// Minimum gap between successive <c>pnl.me</c> publishes for the
+    /// same symbol. 200 ms gives ≤ 5 publishes/sec/symbol — enough
+    /// for a smooth UI without saturating the WS channel under busy
+    /// L1 markets. Tunable if real workloads show different needs.
+    /// </summary>
+    public static readonly TimeSpan ThrottleGap = TimeSpan.FromMilliseconds(200);
+
+    private readonly MarketDataReferencePrice _refPrice;
+    private readonly SubscriptionManager _subs;
+    private readonly PnlKeeper _pnl;
+    private readonly PositionKeeper _positions;
+    private readonly IReferencePrice _refPriceLookup;
+    private readonly ILogger<PnlRefPriceFanOut>? _logger;
+    private readonly TimeProvider _clock;
+
+    // Per-symbol last-publish tick. We use the throttle gap to coalesce
+    // bursts; the dictionary grows with the symbol cardinality, which
+    // is bounded by the configured subscription set in production.
+    private readonly ConcurrentDictionary<string, long> _lastPublishedTicks =
+        new(StringComparer.Ordinal);
+
+    // Per-symbol "publish pending" flag so a single drain entry exists
+    // per symbol no matter how many ticks coalesce into it.
+    private readonly ConcurrentDictionary<string, byte> _pending =
+        new(StringComparer.Ordinal);
+
+    // Per-symbol "deferred republish in flight" flag — at most one
+    // Task.Delay continuation is queued per symbol so a hot tick stream
+    // can't accumulate background timers.
+    private readonly ConcurrentDictionary<string, byte> _deferred =
+        new(StringComparer.Ordinal);
+
+    private readonly Channel<string> _channel = Channel.CreateUnbounded<string>(
+        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _drainTask;
+    private int _stopped;
+
+    public PnlRefPriceFanOut(
+        MarketDataReferencePrice refPrice,
+        SubscriptionManager subs,
+        PnlKeeper pnl,
+        PositionKeeper positions,
+        IReferencePrice refPriceLookup,
+        TimeProvider clock,
+        ILogger<PnlRefPriceFanOut>? logger = null)
+    {
+        _refPrice = refPrice;
+        _subs = subs;
+        _pnl = pnl;
+        _positions = positions;
+        _refPriceLookup = refPriceLookup;
+        _clock = clock;
+        _logger = logger;
+        _refPrice.PriceChanged += OnPriceChanged;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _drainTask = Task.Run(DrainAsync);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0) return;
+        _refPrice.PriceChanged -= OnPriceChanged;
+        _cts.Cancel();
+        _channel.Writer.TryComplete();
+        if (_drainTask is not null)
+        {
+            try { await _drainTask.ConfigureAwait(false); } catch { /* best-effort */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private void OnPriceChanged(string symbol)
+    {
+        if (string.IsNullOrEmpty(symbol)) return;
+        // Coalesce: at most one queued entry per symbol.
+        if (_pending.TryAdd(symbol, 0))
+            _channel.Writer.TryWrite(symbol);
+    }
+
+    private async Task DrainAsync()
+    {
+        var reader = _channel.Reader;
+        try
+        {
+            while (await reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var symbol))
+                {
+                    _pending.TryRemove(symbol, out _);
+                    try { PublishForSymbol(symbol); }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning(ex,
+                            "pnl refprice fan-out failed for symbol={Symbol}", symbol);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void PublishForSymbol(string symbol)
+    {
+        // Throttle: skip if we published this symbol within ThrottleGap.
+        // To avoid losing the most recent tick when a burst lands fully
+        // inside the gap, schedule a single deferred republish per
+        // symbol — coalesced via _deferred so a hot stream cannot
+        // accumulate background timers.
+        var nowTicks = _clock.GetUtcNow().UtcTicks;
+        if (_lastPublishedTicks.TryGetValue(symbol, out var last))
+        {
+            var elapsed = nowTicks - last;
+            if (elapsed < ThrottleGap.Ticks)
+            {
+                MetricsRegistry.PnlRefPriceThrottled.Add(1);
+                ScheduleDeferredRepublish(symbol, ThrottleGap.Ticks - elapsed);
+                return;
+            }
+        }
+
+        var holders = _positions.ForSymbol(symbol);
+        if (holders.Count == 0) return;
+
+        // Distinct owners (a symbol position is per-(owner, symbol) so
+        // already distinct per row, but we set-deduplicate defensively).
+        var seenOwners = new HashSet<EndClientId>();
+        var publishCount = 0;
+        foreach (var p in holders)
+        {
+            if (!seenOwners.Add(p.Owner)) continue;
+            if (_subs.CountFor(p.Owner) == 0) continue;
+            var snap = PnlProjection.Build(p.Owner, _pnl, _positions, _refPriceLookup);
+            _subs.Publish(p.Owner, Channels.PnlMe, snap);
+            publishCount++;
+        }
+
+        if (publishCount > 0)
+        {
+            _lastPublishedTicks[symbol] = nowTicks;
+            MetricsRegistry.PnlRefPricePublishes.Add(1);
+        }
+    }
+
+    private void ScheduleDeferredRepublish(string symbol, long remainingTicks)
+    {
+        if (!_deferred.TryAdd(symbol, 0)) return;
+        var delay = TimeSpan.FromTicks(Math.Max(remainingTicks, TimeSpan.TicksPerMillisecond));
+        _ = Task.Delay(delay, _cts.Token).ContinueWith(_ =>
+        {
+            _deferred.TryRemove(symbol, out byte _);
+            if (_pending.TryAdd(symbol, 0))
+                _channel.Writer.TryWrite(symbol);
+        }, CancellationToken.None, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
@@ -31,12 +31,21 @@ public sealed class SubscriptionManager
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
     private readonly AlgoBook _algos;
+    private readonly PnlKeeper? _pnl;
+    private readonly Application.Risk.IReferencePrice? _refPrice;
 
-    public SubscriptionManager(WorkingOrderBook orders, PositionKeeper positions, AlgoBook algos)
+    public SubscriptionManager(
+        WorkingOrderBook orders,
+        PositionKeeper positions,
+        AlgoBook algos,
+        PnlKeeper? pnl = null,
+        Application.Risk.IReferencePrice? refPrice = null)
     {
         _orders = orders;
         _positions = positions;
         _algos = algos;
+        _pnl = pnl;
+        _refPrice = refPrice;
     }
 
     private object LockFor(EndClientId owner) =>
@@ -81,6 +90,9 @@ public sealed class SubscriptionManager
                 Channels.PositionsMe => _positions.ForEndClient(client.Owner).Select(p => p.ToDto()).ToArray(),
                 Channels.ExecutionsMe => Array.Empty<ExecutionDto>(), // no historical exec log in v1
                 Channels.AlgoMe => _algos.EnumerateForOwner(client.FirmId, client.Owner).Select(a => a.ToDto()).ToArray(),
+                Channels.PnlMe => (_pnl is not null && _refPrice is not null)
+                    ? PnlProjection.Build(client.Owner, _pnl, _positions, _refPrice)
+                    : null,
                 _ => null,
             };
 

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
@@ -50,6 +50,8 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
     private readonly SubscriptionManager _subs;
     private readonly WorkingOrderBook _orders;
     private readonly PositionKeeper _positions;
+    private readonly PnlKeeper? _pnl;
+    private readonly Application.Risk.IReferencePrice? _refPrice;
     private readonly ILogger<WebSocketExecutionEventSink>? _logger;
     private readonly Channel<ExecutionEvent> _channel;
     private readonly CancellationTokenSource _cts = new();
@@ -59,11 +61,15 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         SubscriptionManager subs,
         WorkingOrderBook orders,
         PositionKeeper positions,
+        PnlKeeper? pnl = null,
+        Application.Risk.IReferencePrice? refPrice = null,
         ILogger<WebSocketExecutionEventSink>? logger = null)
     {
         _subs = subs;
         _orders = orders;
         _positions = positions;
+        _pnl = pnl;
+        _refPrice = refPrice;
         _logger = logger;
         _channel = Channel.CreateBounded<ExecutionEvent>(
             new BoundedChannelOptions(ChannelCapacity)
@@ -148,6 +154,19 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         {
             var position = _positions.GetOrCreate(ev.Owner, ev.Symbol);
             _subs.Publish(ev.Owner, Channels.PositionsMe, position.ToDto());
+
+            // Q2.4 (#271). pnl.me — fills move both the realized
+            // bucket (via PnlKeeper) and unrealized (via the new
+            // avg-cost basis). Re-project the whole snapshot so
+            // subscribers can swap it in atomically. Note we project
+            // OFF the dispatcher path (this drain is async and
+            // ordered with positions.me — guaranteeing pnl reflects
+            // the same fill the position update reports).
+            if (_pnl is not null && _refPrice is not null)
+            {
+                var pnlSnap = PnlProjection.Build(ev.Owner, _pnl, _positions, _refPrice);
+                _subs.Publish(ev.Owner, Channels.PnlMe, pnlSnap);
+            }
         }
     }
 }

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -401,38 +401,52 @@ public sealed class ExecutionReportProcessor
                         }
                         else
                         {
-                            var realizedDelta = _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
-                            if (realizedDelta != 0m)
-                            {
-                                var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
-                                var running = _pnlKeeper.GetDayRealized(owner.Value, order.Symbol, dayKey) + realizedDelta;
-                                var pnlEvt = new Persistence.RealizedPnlEvent
+                            // Pass-1 review (#278) P1#2. Run the whole
+                            // "advance basis → compute realized delta
+                            // → fold into running total → Append +
+                            // Apply" sequence under PnlKeeper's per-key
+                            // lock. The dispatcher's process-global
+                            // lock is NOT enough because the WAL-
+                            // backpressure fallback path
+                            // (EntryPointExecutionReportRouter) re-
+                            // invokes Apply WITHOUT the dispatcher
+                            // lock — two concurrent fills on the same
+                            // (endClient, symbol) would otherwise
+                            // race and persist inconsistent
+                            // RunningTotal values into the WAL.
+                            var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
+                            var keeperPnl = _pnlKeeper;
+                            _pnlKeeper.ApplyFillUnderLock(
+                                owner.Value, order.Symbol, order.Side, delta, lastPx, dayKey,
+                                ctx =>
                                 {
-                                    ClOrdId = lookupId,
-                                    ExecutionId = executionIdPnl,
-                                    EndClientId = owner.Value,
-                                    Symbol = order.Symbol,
-                                    DayKey = dayKey,
-                                    DeltaRealized = realizedDelta,
-                                    RunningTotal = running,
-                                    TimestampUtc = nowUtcPnl,
-                                };
-                                var keeperPnl = _pnlKeeper;
-                                try
-                                {
-                                    _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
-                                    MetricsRegistry.PnlRealizedAppended.Add(1);
-                                }
-                                catch (Persistence.WalBackpressureException)
-                                {
-                                    MetricsRegistry.WalBackpressure.Add(1,
-                                        new KeyValuePair<string, object?>("call_site", "pnl.dispatch"));
-                                    _logger.LogWarning(
-                                        "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
-                                        lookupId);
-                                    keeperPnl.Apply(pnlEvt);
-                                }
-                            }
+                                    if (ctx.RealizedDelta == 0m) return;
+                                    var pnlEvt = new Persistence.RealizedPnlEvent
+                                    {
+                                        ClOrdId = lookupId,
+                                        ExecutionId = executionIdPnl,
+                                        EndClientId = owner.Value,
+                                        Symbol = order.Symbol,
+                                        DayKey = dayKey,
+                                        DeltaRealized = ctx.RealizedDelta,
+                                        RunningTotal = ctx.RunningTotal,
+                                        TimestampUtc = nowUtcPnl,
+                                    };
+                                    try
+                                    {
+                                        _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
+                                        MetricsRegistry.PnlRealizedAppended.Add(1);
+                                    }
+                                    catch (Persistence.WalBackpressureException)
+                                    {
+                                        MetricsRegistry.WalBackpressure.Add(1,
+                                            new KeyValuePair<string, object?>("call_site", "pnl.dispatch"));
+                                        _logger.LogWarning(
+                                            "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
+                                            lookupId);
+                                        keeperPnl.Apply(pnlEvt);
+                                    }
+                                });
                         }
                     }
                     // Release reserved margin against the actual booked

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -401,52 +401,65 @@ public sealed class ExecutionReportProcessor
                         }
                         else
                         {
-                            // Pass-1 review (#278) P1#2. Run the whole
-                            // "advance basis → compute realized delta
-                            // → fold into running total → Append +
-                            // Apply" sequence under PnlKeeper's per-key
-                            // lock. The dispatcher's process-global
-                            // lock is NOT enough because the WAL-
-                            // backpressure fallback path
-                            // (EntryPointExecutionReportRouter) re-
-                            // invokes Apply WITHOUT the dispatcher
-                            // lock — two concurrent fills on the same
-                            // (endClient, symbol) would otherwise
-                            // race and persist inconsistent
-                            // RunningTotal values into the WAL.
+                            // Pass-2 review (#278) P1#1. The compose-
+                            // realized → advance basis → Append +
+                            // Apply sequence runs under the dispatcher
+                            // lock for both incoming paths:
+                            //
+                            //   * normal live: the ER router calls
+                            //     EventDispatcher.Dispatch which holds
+                            //     the lock for the whole apply
+                            //     callback (the lock is reentrant, so
+                            //     the nested Dispatch below for the
+                            //     RealizedPnlEvent re-acquires it on
+                            //     the same thread);
+                            //   * WAL backpressure: the ER router's
+                            //     fallback wraps the processor's
+                            //     Apply in EventDispatcher.RunExclusive
+                            //     so the same serialisation discipline
+                            //     applies (no WAL append, just the
+                            //     in-memory mutations + nested
+                            //     fee/PnL Dispatch calls).
+                            //
+                            // No per-key lock is taken — the previous
+                            // design's per-key lock created an AB-BA
+                            // inversion against the dispatcher lock on
+                            // the fallback path. Dispatcher
+                            // serialisation is sufficient because all
+                            // live ER processing flows through it.
                             var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
-                            var keeperPnl = _pnlKeeper;
-                            _pnlKeeper.ApplyFillUnderLock(
-                                owner.Value, order.Symbol, order.Side, delta, lastPx, dayKey,
-                                ctx =>
+                            var realized = _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            if (realized != 0m)
+                            {
+                                var prevTotal = _pnlKeeper.GetDayRealized(owner.Value, order.Symbol, dayKey);
+                                var running = prevTotal + realized;
+                                var pnlEvt = new Persistence.RealizedPnlEvent
                                 {
-                                    if (ctx.RealizedDelta == 0m) return;
-                                    var pnlEvt = new Persistence.RealizedPnlEvent
-                                    {
-                                        ClOrdId = lookupId,
-                                        ExecutionId = executionIdPnl,
-                                        EndClientId = owner.Value,
-                                        Symbol = order.Symbol,
-                                        DayKey = dayKey,
-                                        DeltaRealized = ctx.RealizedDelta,
-                                        RunningTotal = ctx.RunningTotal,
-                                        TimestampUtc = nowUtcPnl,
-                                    };
-                                    try
-                                    {
-                                        _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
-                                        MetricsRegistry.PnlRealizedAppended.Add(1);
-                                    }
-                                    catch (Persistence.WalBackpressureException)
-                                    {
-                                        MetricsRegistry.WalBackpressure.Add(1,
-                                            new KeyValuePair<string, object?>("call_site", "pnl.dispatch"));
-                                        _logger.LogWarning(
-                                            "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
-                                            lookupId);
-                                        keeperPnl.Apply(pnlEvt);
-                                    }
-                                });
+                                    ClOrdId = lookupId,
+                                    ExecutionId = executionIdPnl,
+                                    EndClientId = owner.Value,
+                                    Symbol = order.Symbol,
+                                    DayKey = dayKey,
+                                    DeltaRealized = realized,
+                                    RunningTotal = running,
+                                    TimestampUtc = nowUtcPnl,
+                                };
+                                var keeperPnl = _pnlKeeper;
+                                try
+                                {
+                                    _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
+                                    MetricsRegistry.PnlRealizedAppended.Add(1);
+                                }
+                                catch (Persistence.WalBackpressureException)
+                                {
+                                    MetricsRegistry.WalBackpressure.Add(1,
+                                        new KeyValuePair<string, object?>("call_site", "pnl.dispatch"));
+                                    _logger.LogWarning(
+                                        "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
+                                        lookupId);
+                                    keeperPnl.Apply(pnlEvt);
+                                }
+                            }
                         }
                     }
                     // Release reserved margin against the actual booked

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -38,6 +38,7 @@ public sealed class ExecutionReportProcessor
     private readonly CashLedger? _cash;
     private readonly IFeeCalculator? _feeCalculator;
     private readonly FeeKeeper? _feeKeeper;
+    private readonly PnlKeeper? _pnlKeeper;
     private readonly Persistence.EventDispatcher? _dispatcher;
     private readonly PendingReplacementRegistry? _replacements;
     private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
@@ -59,7 +60,8 @@ public sealed class ExecutionReportProcessor
         Scheduling.GtdExpirationScheduler? gtdScheduler = null,
         IFeeCalculator? feeCalculator = null,
         FeeKeeper? feeKeeper = null,
-        Persistence.EventDispatcher? dispatcher = null)
+        Persistence.EventDispatcher? dispatcher = null,
+        PnlKeeper? pnlKeeper = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -76,6 +78,7 @@ public sealed class ExecutionReportProcessor
         _feeCalculator = feeCalculator;
         _feeKeeper = feeKeeper;
         _dispatcher = dispatcher;
+        _pnlKeeper = pnlKeeper;
     }
 
     /// <summary>
@@ -234,6 +237,20 @@ public sealed class ExecutionReportProcessor
                             "Fill delta mismatch for {ClOrdId}: ER lastQty={LastQty}, computed delta={Delta}.",
                             lookupId, lastQty, delta);
                     }
+                    // Q2.4 (#271). Capture the pre-fill avg-cost basis
+                    // BEFORE _positions.ApplyFill mutates it — realized
+                    // delta is computed off the pre-fill state. We read
+                    // off PnlKeeper's parallel basis tracker (kept in
+                    // lockstep with PositionKeeper via
+                    // ApplyFillToAvgCost below) so the snapshot/restore
+                    // path is independent of PositionKeeper.
+                    long preFillQty = 0;
+                    decimal preFillAvg = 0m;
+                    if (_pnlKeeper is not null)
+                    {
+                        var avg = _pnlKeeper.GetAvgCost(owner.Value, order.Symbol);
+                        if (avg is not null) { preFillQty = avg.NetQuantity; preFillAvg = avg.AvgPrice; }
+                    }
                     _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
                     // Book the cash leg of the fill on the same delta as
                     // the position. Buys debit, Sells credit; T+0 settle.
@@ -333,6 +350,88 @@ public sealed class ExecutionReportProcessor
                                     "Dropping FeeAccruedEvent for {ClOrdId} on WAL backpressure; applying fee directly to keeper.",
                                     lookupId);
                                 keeper.Apply(feeEvt);
+                            }
+                        }
+                    }
+                    // Q2.4 (#271). Realized P&L. Compute the delta from
+                    // the pre-fill (qty, avg) snapshot captured above
+                    // and advance the avg-cost basis tracker. Same
+                    // live/replay split as fees:
+                    //
+                    //   Live:    advance avg-cost basis, then Append
+                    //            RealizedPnlEvent + PnlKeeper.Apply
+                    //            under the dispatcher lock — single
+                    //            ER@N, Pnl@N+k ordering preserved.
+                    //   Replay:  defer a pending synth via the pre-fill
+                    //            snapshot. A durable RealizedPnlEvent
+                    //            following in the WAL supersedes it via
+                    //            Apply(RealizedPnlEvent); FinalizeReplay
+                    //            materialises any survivor (true
+                    //            ER-then-crash window).
+                    //
+                    // Same WalBackpressureException swallow policy as
+                    // the fees branch: in-memory state stays accurate,
+                    // audit event is dropped (surfaced as a metric).
+                    if (_pnlKeeper is not null)
+                    {
+                        var nowUtcPnl = eventTimestampUtc ?? DateTimeOffset.UtcNow;
+                        var executionIdPnl = lookupId.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                            + ":" + order.CumulativeQuantity.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        if (isReplay || _dispatcher is null)
+                        {
+                            // Mirror the live-path guard: only register
+                            // a synth when the fill would produce a
+                            // non-zero realized delta. Opening fills
+                            // and same-side adds emit no event in live
+                            // mode, so they have nothing to reconcile
+                            // — registering them would only inflate
+                            // the FinalizeReplay materialisation count.
+                            var wouldRealize = PnlKeeper.ComputeRealizedDelta(preFillQty, preFillAvg, order.Side, delta, lastPx);
+                            if (wouldRealize != 0m)
+                            {
+                                _pnlKeeper.RegisterPendingReplaySynth(
+                                    executionIdPnl, owner.Value, order.Symbol, order.Side,
+                                    delta, lastPx, nowUtcPnl, preFillQty, preFillAvg);
+                            }
+                            // Still advance the basis tracker on replay
+                            // — the durable event Apply path uses
+                            // RunningTotal directly, so basis is purely
+                            // in-memory state used for live computation.
+                            _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
+                        }
+                        else
+                        {
+                            var realizedDelta = _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            if (realizedDelta != 0m)
+                            {
+                                var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
+                                var running = _pnlKeeper.GetDayRealized(owner.Value, order.Symbol, dayKey) + realizedDelta;
+                                var pnlEvt = new Persistence.RealizedPnlEvent
+                                {
+                                    ClOrdId = lookupId,
+                                    ExecutionId = executionIdPnl,
+                                    EndClientId = owner.Value,
+                                    Symbol = order.Symbol,
+                                    DayKey = dayKey,
+                                    DeltaRealized = realizedDelta,
+                                    RunningTotal = running,
+                                    TimestampUtc = nowUtcPnl,
+                                };
+                                var keeperPnl = _pnlKeeper;
+                                try
+                                {
+                                    _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
+                                    MetricsRegistry.PnlRealizedAppended.Add(1);
+                                }
+                                catch (Persistence.WalBackpressureException)
+                                {
+                                    MetricsRegistry.WalBackpressure.Add(1,
+                                        new KeyValuePair<string, object?>("call_site", "pnl.dispatch"));
+                                    _logger.LogWarning(
+                                        "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
+                                        lookupId);
+                                    keeperPnl.Apply(pnlEvt);
+                                }
                             }
                         }
                     }

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataReferencePrice.cs
@@ -186,7 +186,30 @@ public sealed class MarketDataReferencePrice : IReferencePrice, IHostedService
     {
         var key = symbol.Trim();
         _cache[key] = new CacheEntry(price, receivedUtc);
+        // Pass-1 review (#278) P1#3. Notify subscribers (currently the
+        // pnl.me WS fan-out) that this symbol's mark moved. Handlers
+        // are expected to be cheap (per-symbol throttled queue
+        // enqueue) — we do NOT walk subscribers here. Listener
+        // exceptions are swallowed so a misbehaving handler cannot
+        // break the price cache write.
+        var handler = PriceChanged;
+        if (handler is not null)
+        {
+            try { handler(key); }
+            catch { /* defensive: handlers must be tolerant of exceptions */ }
+        }
     }
+
+    /// <summary>
+    /// Pass-1 review (#278) P1#3. Raised AFTER the cache entry for
+    /// <c>symbol</c> has been updated. Fired on every Trade /
+    /// InfoSnapshot update — consumers MUST throttle / coalesce
+    /// before doing expensive work because L1 ticks can be very
+    /// frequent. The published payload is just the symbol so
+    /// consumers can re-read the latest price from
+    /// <see cref="TryGet"/> if they need the value.
+    /// </summary>
+    public event Action<string>? PriceChanged;
 
     private void OnConnectionStateChanged(MarketDataConnectionState state)
     {

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -126,6 +126,21 @@ public static class MetricsRegistry
     public static readonly Counter<long> FeeReplaySynth =
         Meter.CreateCounter<long>("trading.fees.replay_synth");
 
+    // Q2.4 (#271). P&L engine.
+    // pnl.realized_appended — bumped on every successful RealizedPnlEvent
+    // append via the dispatcher path (live, NOT replay). pnl.replay_synth
+    // mirrors the FeeKeeper synth metric: tag reconciled=true when a
+    // durable RealizedPnlEvent superseded a pending synth (happy path),
+    // false when FinalizeReplay had to materialise the synth (the actual
+    // ER-then-crash window). pnl.endpoint_requests counts /pnl/today
+    // hits.
+    public static readonly Counter<long> PnlRealizedAppended =
+        Meter.CreateCounter<long>("trading.pnl.realized_appended");
+    public static readonly Counter<long> PnlReplaySynth =
+        Meter.CreateCounter<long>("trading.pnl.replay_synth");
+    public static readonly Counter<long> PnlEndpointRequests =
+        Meter.CreateCounter<long>("trading.pnl.endpoint_requests");
+
     // WebSocket fan-out
     public static readonly UpDownCounter<int> WsConnectionsActive =
         Meter.CreateUpDownCounter<int>("trading.ws.connections.active");

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -149,6 +149,15 @@ public static class MetricsRegistry
     // pre-#271 snapshot at least once.
     public static readonly Counter<long> PnlLegacySnapshotBasisSeeded =
         Meter.CreateCounter<long>("trading.pnl.legacy_snapshot_basis_seeded");
+    // Pass-2 review (#278) P1#2. Bumped per (endClient, symbol) row
+    // skipped by SeedAvgCostFromLegacyPositions because the legacy
+    // position carries a zero AverageEntryPrice — seeding such a
+    // degenerate row would realize phantom P&L against a zero basis
+    // on the first close after restore. A non-zero count flags a
+    // snapshot containing position rows the host could not derive a
+    // basis from (operator follow-up).
+    public static readonly Counter<long> PnlLegacySnapshotBasisSkippedZero =
+        Meter.CreateCounter<long>("trading.pnl.legacy_snapshot_basis_skipped_zero");
     // Pass-1 review (#278) P1#3. Bumped each time the refprice
     // fan-out coalesced one or more (subscriber, symbol) updates into
     // a single pnl.me delta publish under the per-symbol throttle.

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -158,6 +158,17 @@ public static class MetricsRegistry
     // basis from (operator follow-up).
     public static readonly Counter<long> PnlLegacySnapshotBasisSkippedZero =
         Meter.CreateCounter<long>("trading.pnl.legacy_snapshot_basis_skipped_zero");
+    // Pass-4 review (#278) P2#3. Bumped per (endClient, symbol) row
+    // when Restore observes the same key in BOTH PnlAvgCost AND
+    // PnlUnknownBasis (a malformed snapshot — the two collections are
+    // mutually exclusive by construction in the live keeper). Recovery
+    // applies a "prefer unknown" policy: the avg-cost entry is dropped
+    // so subsequent fills go through the unknown-basis path (realising
+    // 0 instead of phantom against the stale basis), and the metric
+    // surfaces the inconsistency for ops to investigate the snapshot
+    // writer.
+    public static readonly Counter<long> PnlSnapshotBasisInconsistent =
+        Meter.CreateCounter<long>("trading.pnl.snapshot_basis_inconsistent");
     // Pass-1 review (#278) P1#3. Bumped each time the refprice
     // fan-out coalesced one or more (subscriber, symbol) updates into
     // a single pnl.me delta publish under the per-symbol throttle.

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -140,6 +140,22 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.pnl.replay_synth");
     public static readonly Counter<long> PnlEndpointRequests =
         Meter.CreateCounter<long>("trading.pnl.endpoint_requests");
+    // Pass-1 review (#278) P1#1. Bumped once per (endClient, symbol)
+    // row when StateSnapshotter restores a legacy snapshot whose
+    // PnlAvgCost block is empty but Positions has rows — the avg-cost
+    // basis is reconstructed from the position's AverageEntryPrice so
+    // a subsequent close still realises against the carried basis.
+    // A non-zero count just means the platform restored from a
+    // pre-#271 snapshot at least once.
+    public static readonly Counter<long> PnlLegacySnapshotBasisSeeded =
+        Meter.CreateCounter<long>("trading.pnl.legacy_snapshot_basis_seeded");
+    // Pass-1 review (#278) P1#3. Bumped each time the refprice
+    // fan-out coalesced one or more (subscriber, symbol) updates into
+    // a single pnl.me delta publish under the per-symbol throttle.
+    public static readonly Counter<long> PnlRefPricePublishes =
+        Meter.CreateCounter<long>("trading.pnl.refprice_publishes");
+    public static readonly Counter<long> PnlRefPriceThrottled =
+        Meter.CreateCounter<long>("trading.pnl.refprice_throttled");
 
     // WebSocket fan-out
     public static readonly UpDownCounter<int> WsConnectionsActive =

--- a/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
+++ b/backend/src/B3.Trading.Application/Persistence/EventDispatcher.cs
@@ -224,6 +224,38 @@ public sealed class EventDispatcher
             capture(_store.CurrentSeq);
         }
     }
+
+    /// <summary>
+    /// Pass-2 review (#278) P1#1. Runs <paramref name="body"/> under the
+    /// dispatcher lock without an accompanying WAL append. Used by the
+    /// ER router's WAL-backpressure fallback path: when the regular
+    /// <see cref="Dispatch(WalEvent, Action{ExecutionFanOut})"/> throws
+    /// <see cref="WalBackpressureException"/>, the lock has already
+    /// been released, so re-invoking <see cref="ExecutionReportProcessor.Apply"/>
+    /// directly would mutate state — and may itself nest a
+    /// <see cref="Dispatch(WalEvent, Action)"/> for fees / realised
+    /// P&amp;L — without dispatcher serialisation. That opens an AB-BA
+    /// deadlock window against any per-key lock taken inside the
+    /// nested dispatch (and a running-total race even without
+    /// per-key locks).
+    ///
+    /// <para>
+    /// The lock is reentrant (<see cref="System.Threading.Monitor"/>),
+    /// so the nested <c>Dispatch</c> calls inside the body re-acquire
+    /// it on the same thread without blocking. Holding the lock here
+    /// is safe because no I/O happens — the WAL append is being
+    /// SKIPPED on the fallback path; we are only mutating in-memory
+    /// state and may nest channel TryWrites for derived events.
+    /// </para>
+    /// </summary>
+    public void RunExclusive(Action body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        lock (_lock)
+        {
+            body();
+        }
+    }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -85,6 +85,15 @@ public sealed class RawPlatformSnapshot
     public PnlAvgCostRaw[] PnlAvgCost { get; init; } = Array.Empty<PnlAvgCostRaw>();
 
     /// <summary>
+    /// Pass-3 review (#278) P1. Per-(end-client, symbol) "unknown
+    /// basis" qty rows — legacy positions for which the rehydrated
+    /// snapshot carried no usable avg price. Persisted so a
+    /// snapshot+tail recovery doesn't re-skip and re-introduce
+    /// phantom-P&amp;L on the next restart.
+    /// </summary>
+    public PnlUnknownBasisRaw[] PnlUnknownBasis { get; init; } = Array.Empty<PnlUnknownBasisRaw>();
+
+    /// <summary>
     /// Q2.4 (#271). Idempotence guard for <c>PnlKeeper.Apply</c>.
     /// </summary>
     public string[] PnlSeenExecutionIds { get; init; } = Array.Empty<string>();
@@ -177,6 +186,15 @@ public readonly record struct PnlRealizedRaw(string EndClientId, string Symbol, 
 /// in parallel with <see cref="B3.Trading.Application.PositionKeeper"/>.
 /// </summary>
 public readonly record struct PnlAvgCostRaw(string EndClientId, string Symbol, long NetQuantity, decimal AvgPrice);
+
+/// <summary>
+/// Pass-3 review (#278) P1. Raw lock-side capture of one
+/// (end-client, symbol) "unknown basis" qty row tracked by
+/// <see cref="B3.Trading.Application.PnlKeeper"/> after a legacy
+/// snapshot rehydration. Persisting this set keeps a snapshot+tail
+/// recovery from re-creating the phantom-P&amp;L bug on every restart.
+/// </summary>
+public readonly record struct PnlUnknownBasisRaw(string EndClientId, string Symbol, long NetQuantity);
 
 public readonly record struct ClOrdIdCounterRaw(string EndClientId, ulong PrefixIdx, long Counter);
 

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -69,6 +69,26 @@ public sealed class RawPlatformSnapshot
     /// </summary>
     public string[] FeeSeenExecutionIds { get; init; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Q2.4 (#271). Per-(end-client, symbol, day) realized P&amp;L
+    /// projected from the <c>RealizedPnlEvent</c> stream by
+    /// <c>PnlKeeper</c>.
+    /// </summary>
+    public PnlRealizedRaw[] PnlRealizedByEndclientSymbolDay { get; init; } = Array.Empty<PnlRealizedRaw>();
+
+    /// <summary>
+    /// Q2.4 (#271). Per-(end-client, symbol) avg-cost basis tracked
+    /// by <c>PnlKeeper</c> in parallel with <see cref="Positions"/>.
+    /// Required so the keeper can compute realized deltas after a
+    /// snapshot+tail restore even if its peer keepers are wiped.
+    /// </summary>
+    public PnlAvgCostRaw[] PnlAvgCost { get; init; } = Array.Empty<PnlAvgCostRaw>();
+
+    /// <summary>
+    /// Q2.4 (#271). Idempotence guard for <c>PnlKeeper.Apply</c>.
+    /// </summary>
+    public string[] PnlSeenExecutionIds { get; init; } = Array.Empty<string>();
+
     public UserBotCredential[] UserBotCredentials { get; init; } =
         Array.Empty<UserBotCredential>();
     public BotSessionState[] BotSessions { get; init; } = Array.Empty<BotSessionState>();
@@ -144,6 +164,19 @@ public readonly record struct CashKeeperRaw(string EndClientId, decimal Availabl
 /// total for one (end-client, day) bucket.
 /// </summary>
 public readonly record struct FeeKeeperRaw(string EndClientId, DateOnly Day, decimal Total);
+
+/// <summary>
+/// Q2.4 (#271). Raw lock-side capture of one (end-client, symbol, day)
+/// realized-P&amp;L bucket from <see cref="B3.Trading.Application.PnlKeeper"/>.
+/// </summary>
+public readonly record struct PnlRealizedRaw(string EndClientId, string Symbol, DateOnly Day, decimal Realized);
+
+/// <summary>
+/// Q2.4 (#271). Raw lock-side capture of one (end-client, symbol)
+/// avg-cost basis row tracked by <see cref="B3.Trading.Application.PnlKeeper"/>
+/// in parallel with <see cref="B3.Trading.Application.PositionKeeper"/>.
+/// </summary>
+public readonly record struct PnlAvgCostRaw(string EndClientId, string Symbol, long NetQuantity, decimal AvgPrice);
 
 public readonly record struct ClOrdIdCounterRaw(string EndClientId, ulong PrefixIdx, long Counter);
 

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -109,6 +109,16 @@ public sealed class PlatformSnapshot
     public List<PnlAvgCostSnapshot> PnlAvgCost { get; init; } = new();
 
     /// <summary>
+    /// Pass-3 review (#278) P1. Per-(end-client, symbol) "unknown
+    /// basis" qty rows seeded from a legacy <c>Positions</c> row whose
+    /// <c>AverageEntryPrice</c> was zero. Empty on snapshots
+    /// pre-dating the field; recovery code re-derives the set from
+    /// <see cref="Positions"/> in that case via
+    /// <c>PnlKeeper.SeedAvgCostFromLegacyPositions</c>.
+    /// </summary>
+    public List<PnlUnknownBasisSnapshot> PnlUnknownBasis { get; init; } = new();
+
+    /// <summary>
     /// Q2.4 (#271). Idempotence guard for the realized-P&amp;L
     /// projection — the set of <c>RealizedPnlEvent.ExecutionId</c>
     /// values already folded into <see cref="PnlRealizedByEndclientSymbolDay"/>.
@@ -312,6 +322,15 @@ public sealed record PnlAvgCostSnapshot(
     string Symbol,
     long NetQuantity,
     decimal AvgPrice);
+
+/// <summary>
+/// Pass-3 review (#278) P1. Persisted "unknown basis" qty row —
+/// see <see cref="PlatformSnapshot.PnlUnknownBasis"/>.
+/// </summary>
+public sealed record PnlUnknownBasisSnapshot(
+    string EndClientId,
+    string Symbol,
+    long NetQuantity);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -90,6 +90,32 @@ public sealed class PlatformSnapshot
     public List<string> FeeSeenExecutionIds { get; init; } = new();
 
     /// <summary>
+    /// Q2.4 (#271). Per-(end-client, symbol, day) realized-P&amp;L
+    /// running totals projected from the <c>RealizedPnlEvent</c> stream
+    /// by <c>PnlKeeper</c>. Key is
+    /// <c>{endClientId}|{symbol}|{yyyy-MM-dd}</c> (see
+    /// <c>PnlKeeper.FormatRealizedKey</c>); value is the running BRL
+    /// realized total. Empty on snapshots pre-dating the field —
+    /// rebuilt from the WAL alone in that case.
+    /// </summary>
+    public Dictionary<string, decimal> PnlRealizedByEndclientSymbolDay { get; init; } = new();
+
+    /// <summary>
+    /// Q2.4 (#271). Per-(end-client, symbol) avg-cost basis tracked by
+    /// <c>PnlKeeper</c> in parallel with <see cref="Positions"/>. Empty
+    /// on older snapshots; rebuilt from <see cref="Positions"/> by the
+    /// recovery path (<c>PersistenceRecovery</c>) when missing.
+    /// </summary>
+    public List<PnlAvgCostSnapshot> PnlAvgCost { get; init; } = new();
+
+    /// <summary>
+    /// Q2.4 (#271). Idempotence guard for the realized-P&amp;L
+    /// projection — the set of <c>RealizedPnlEvent.ExecutionId</c>
+    /// values already folded into <see cref="PnlRealizedByEndclientSymbolDay"/>.
+    /// </summary>
+    public List<string> PnlSeenExecutionIds { get; init; } = new();
+
+    /// <summary>
     /// User-issued bot credentials (sub-issue #169). Empty on snapshots
     /// pre-dating the field — credentials are reconstructed instead by
     /// the WAL replay path on top of the empty list, which matches the
@@ -276,6 +302,16 @@ public sealed record PositionSnapshot(
 public sealed record CashBalanceSnapshot(
     string EndClientId,
     decimal Available);
+
+/// <summary>
+/// Q2.4 (#271). Avg-cost basis row persisted alongside
+/// <see cref="PlatformSnapshot.PnlRealizedByEndclientSymbolDay"/>.
+/// </summary>
+public sealed record PnlAvgCostSnapshot(
+    string EndClientId,
+    string Symbol,
+    long NetQuantity,
+    decimal AvgPrice);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -48,6 +48,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(OrderExpiredEvent))]
 [JsonSerializable(typeof(CashLedgerEvent))]
 [JsonSerializable(typeof(FeeAccruedEvent))]
+[JsonSerializable(typeof(RealizedPnlEvent))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -37,6 +37,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(OrderExpiredEvent), "order.expired")]
 [JsonDerivedType(typeof(CashLedgerEvent), "cash.ledger")]
 [JsonDerivedType(typeof(FeeAccruedEvent), "fee.accrued")]
+[JsonDerivedType(typeof(RealizedPnlEvent), "pnl.realized")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -564,4 +565,72 @@ public sealed record FeeAccruedEvent : WalEvent
     public required decimal Emolumentos { get; init; }
     public required decimal Liquidacao { get; init; }
     public required decimal Total { get; init; }
+}
+
+/// <summary>
+/// Q2.4 (#271). Realized P&amp;L delta emitted by
+/// <c>ExecutionReportProcessor</c> immediately after a Fill ER on the
+/// opposing side of the current position has been folded into
+/// <c>PositionKeeper</c>. Lands AFTER the originating
+/// <see cref="ExecutionReportReceivedEvent"/> in the WAL by virtue of
+/// the dispatcher's append ordering — the same sequencing rule that
+/// governs <see cref="FeeAccruedEvent"/>.
+///
+/// <para>
+/// <b>Avg-cost basis (decision documented in #271).</b> Realized
+/// proceeds are computed as <c>(price - avgPrice) * closedQty</c> for
+/// long positions and <c>(avgPrice - price) * closedQty</c> for shorts,
+/// where <c>avgPrice</c> is the <i>pre-fill</i>
+/// <c>Position.AverageEntryPrice</c> and <c>closedQty</c> is the portion
+/// of the fill that offset the pre-fill quantity (the remainder, if the
+/// position flipped past zero, opens fresh and contributes no realized
+/// component). Avg-cost is the B3/CVM-standard basis for cash equities
+/// and avoids the per-lot bookkeeping FIFO would require.
+/// </para>
+///
+/// <para>
+/// <b>Idempotence.</b> <see cref="ExecutionId"/> uses the same stable
+/// <c>{ClOrdId}:{CumulativeQuantityAfterFill}</c> shape as
+/// <see cref="FeeAccruedEvent.ExecutionId"/>; <c>PnlKeeper.Apply</c>
+/// dedupes on it so a re-applied event (FIXP retransmit, WAL replay)
+/// is a no-op.
+/// </para>
+///
+/// <para>
+/// <b>GROSS, not NET.</b> <see cref="DeltaRealized"/> /
+/// <see cref="RunningTotal"/> are pre-fee. The Q2.5 statement (#272)
+/// composes fees on top.
+/// </para>
+/// </summary>
+public sealed record RealizedPnlEvent : WalEvent
+{
+    public required ulong ClOrdId { get; init; }
+
+    /// <summary>
+    /// Stable per-fill identity — see the type-level remarks. Format:
+    /// <c>{ClOrdId}:{CumulativeQuantityAfterFill}</c>.
+    /// </summary>
+    public required string ExecutionId { get; init; }
+
+    public required string EndClientId { get; init; }
+    public required string Symbol { get; init; }
+
+    /// <summary>
+    /// UTC day key used to bucket <see cref="DeltaRealized"/>; matches
+    /// <c>DateOnly.FromDateTime(TimestampUtc.UtcDateTime)</c>. Persisted
+    /// explicitly so a future timezone migration cannot retroactively
+    /// re-bucket historical events.
+    /// </summary>
+    public required DateOnly DayKey { get; init; }
+
+    public required decimal DeltaRealized { get; init; }
+
+    /// <summary>
+    /// Cumulative realized for (<see cref="EndClientId"/>,
+    /// <see cref="Symbol"/>, <see cref="DayKey"/>) AFTER applying
+    /// <see cref="DeltaRealized"/>. Persisted so a snapshot+tail
+    /// recovery treats the durable value as authoritative even if the
+    /// avg-cost calculation in the keeper has drifted between runs.
+    /// </summary>
+    public required decimal RunningTotal { get; init; }
 }

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -432,6 +432,29 @@ public sealed class PnlKeeper
             foreach (var row in unknownBasisRows)
                 if (row.NetQuantity != 0)
                     _unknownBasisQty[(row.EndClientId, row.Symbol)] = row.NetQuantity;
+        // Pass-4 review (#278) P2#3. Enforce mutual exclusivity
+        // between _avgCost and _unknownBasisQty after restore. The
+        // live keeper holds these collections strictly disjoint by
+        // construction (ApplyFillToAvgCost moves a key out of one
+        // before populating the other), but a malformed snapshot
+        // could carry the same key in both blocks. Without this
+        // fix-up the Apply path would route fills through the
+        // unknown-basis branch (the first check in
+        // ApplyFillToAvgCost), then once the unknown leg fully
+        // closed the stale _avgCost entry would resurface and the
+        // next fill would realise phantom P&L against it.
+        //
+        // Policy: prefer unknown (best-effort recovery) and surface
+        // the inconsistency on a metric so ops can investigate the
+        // snapshot writer rather than silently masking the bug.
+        if (_unknownBasisQty.Count > 0 && _avgCost.Count > 0)
+        {
+            foreach (var key in _unknownBasisQty.Keys)
+            {
+                if (_avgCost.TryRemove(key, out _))
+                    Observability.MetricsRegistry.PnlSnapshotBasisInconsistent.Add(1);
+            }
+        }
         if (seenExecutionIds is not null)
             foreach (var id in seenExecutionIds)
                 _seenExecutionIds.TryAdd(id, 0);

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -50,6 +50,42 @@ public sealed class PnlKeeper
     /// </summary>
     private readonly ConcurrentDictionary<(string EndClient, string Symbol), AvgCostState> _avgCost = new();
 
+    /// <summary>
+    /// Pass-1 review (#278) P1#2. Per-(end-client, symbol) lock used to
+    /// serialise the whole "compute pre-fill basis → mutate avg-cost →
+    /// fold realized delta into running total → produce
+    /// <see cref="RealizedPnlEvent"/> → keeper Apply" sequence on the
+    /// live path. The dispatcher's process-global lock alone is NOT
+    /// sufficient because the WAL-backpressure fallback path
+    /// (<c>EntryPointExecutionReportRouter</c>) re-invokes
+    /// <c>ExecutionReportProcessor.Apply</c> WITHOUT the dispatcher
+    /// lock — two concurrent fills for the same key on that path would
+    /// otherwise race and persist inconsistent <c>RunningTotal</c>
+    /// values into the WAL.
+    ///
+    /// <para>
+    /// Lock ordering: per-key lock OUTSIDE the dispatcher lock. The
+    /// snapshot path takes the dispatcher lock only and never the
+    /// per-key locks, so a fill in flight does not block snapshots.
+    /// </para>
+    /// </summary>
+    private readonly ConcurrentDictionary<(string EndClient, string Symbol), object> _keyLocks = new();
+
+    private object LockFor(string endClient, string symbol) =>
+        _keyLocks.GetOrAdd((endClient, symbol), static _ => new object());
+
+    /// <summary>
+    /// Public hook for callers that need to perform a multi-step
+    /// operation atomically per (endClient, symbol) — primarily the
+    /// processor's "compute realized + Dispatch + Apply" critical
+    /// section. See <see cref="_keyLocks"/> for the rationale.
+    /// </summary>
+    public T WithKeyLock<T>(string endClient, string symbol, Func<T> body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        lock (LockFor(endClient, symbol)) return body();
+    }
+
     private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
     private readonly ConcurrentDictionary<string, PendingReplaySynth> _pendingReplaySynths = new();
 
@@ -142,26 +178,94 @@ public sealed class PnlKeeper
     /// realized delta this fill produced (computed off the pre-fill
     /// state) so the processor can decide whether to append a
     /// <see cref="RealizedPnlEvent"/>.
+    ///
+    /// <para>
+    /// Pass-1 review (#278) P1#2. The mutation runs under the per-key
+    /// lock (see <see cref="WithKeyLock{T}"/>), eliminating the
+    /// outer-variable capture race that the previous
+    /// <c>AddOrUpdate</c>-based implementation had under contention.
+    /// </para>
     /// </summary>
     public decimal ApplyFillToAvgCost(string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice)
     {
         if (fillQuantity <= 0) return 0m;
         var key = (endClient, symbol);
-        var realized = 0m;
-        _avgCost.AddOrUpdate(key,
-            _ =>
+        lock (LockFor(endClient, symbol))
+        {
+            if (!_avgCost.TryGetValue(key, out var current))
             {
-                // No prior position — opens fresh, no realized.
                 var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
-                return new AvgCostState(signed, fillPrice);
-            },
-            (_, current) =>
-            {
-                realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
-                return ProjectAvgCost(current, side, fillQuantity, fillPrice);
-            });
-        return realized;
+                _avgCost[key] = new AvgCostState(signed, fillPrice);
+                return 0m;
+            }
+            var realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
+            _avgCost[key] = ProjectAvgCost(current, side, fillQuantity, fillPrice);
+            return realized;
+        }
     }
+
+    /// <summary>
+    /// Pass-1 review (#278) P1#2. Atomic per-(endClient, symbol)
+    /// "compute realized + advance basis + fold into running total"
+    /// primitive used by the live ER path. Runs the supplied
+    /// <paramref name="onComputed"/> callback INSIDE the per-key lock
+    /// so the caller can append the <see cref="RealizedPnlEvent"/> to
+    /// the WAL (via the dispatcher) and call <see cref="Apply"/> back
+    /// on this keeper without a second concurrent fill on the same
+    /// key racing the running-total computation.
+    ///
+    /// <para>
+    /// The <paramref name="onComputed"/> callback receives a
+    /// <see cref="PnlFillContext"/> with the pre-fill snapshot, the
+    /// realized delta this fill produced, and the running total AFTER
+    /// folding the delta. Both values are derived from state held
+    /// under the lock, so they are guaranteed consistent with the
+    /// avg-cost mutation already applied.
+    /// </para>
+    ///
+    /// <para>
+    /// The avg-cost is mutated regardless of the realized delta. The
+    /// callback decides whether the realized delta is worth a WAL
+    /// event (matches the existing live-path policy: only non-zero
+    /// realized deltas append a <see cref="RealizedPnlEvent"/>).
+    /// </para>
+    /// </summary>
+    public void ApplyFillUnderLock(
+        string endClient,
+        string symbol,
+        OrderSide side,
+        long fillQuantity,
+        decimal fillPrice,
+        DateOnly day,
+        Action<PnlFillContext> onComputed)
+    {
+        ArgumentNullException.ThrowIfNull(onComputed);
+        if (fillQuantity <= 0) return;
+        var key = (endClient, symbol);
+        lock (LockFor(endClient, symbol))
+        {
+            var pre = _avgCost.TryGetValue(key, out var c) ? c : new AvgCostState(0, 0m);
+            var realized = ComputeRealizedDelta(pre.NetQuantity, pre.AvgPrice, side, fillQuantity, fillPrice);
+            _avgCost[key] = ProjectAvgCost(pre, side, fillQuantity, fillPrice);
+            var prevTotal = _realizedByDay.TryGetValue((endClient, symbol, day), out var t) ? t : 0m;
+            var running = prevTotal + realized;
+            onComputed(new PnlFillContext(pre.NetQuantity, pre.AvgPrice, realized, running));
+        }
+    }
+
+    /// <summary>
+    /// Snapshot of the per-key state produced inside
+    /// <see cref="ApplyFillUnderLock"/>. Carries both the pre-fill
+    /// (qty, avg) so the caller can build the WAL event and the
+    /// already-computed running total so the persisted
+    /// <see cref="RealizedPnlEvent.RunningTotal"/> matches the value
+    /// the keeper observed under the lock.
+    /// </summary>
+    public readonly record struct PnlFillContext(
+        long PreFillQuantity,
+        decimal PreFillAvgPrice,
+        decimal RealizedDelta,
+        decimal RunningTotal);
 
     /// <summary>
     /// Pure projection of the avg-cost state under one fill. Mirrors
@@ -318,6 +422,50 @@ public sealed class PnlKeeper
         if (seenExecutionIds is not null)
             foreach (var id in seenExecutionIds)
                 _seenExecutionIds.TryAdd(id, 0);
+    }
+
+    /// <summary>
+    /// Pass-1 review (#278) P1#1. Backfills the avg-cost basis from
+    /// the snapshot's <see cref="PositionSnapshot"/> rows for every
+    /// (endClient, symbol) NOT already populated by the (newer-format)
+    /// <see cref="PnlAvgCostSnapshot"/> block. Required for legacy
+    /// snapshots taken before #271 shipped: those carry positions but
+    /// no PnlAvgCost block, and without this seed the next sell on a
+    /// pre-existing position would compute realized off a zero basis
+    /// and silently realise nothing.
+    ///
+    /// <para>
+    /// Idempotent: never overwrites an entry that <see cref="Restore"/>
+    /// already loaded from <see cref="PnlAvgCostSnapshot"/> (the
+    /// PnlKeeper's own snapshot block is authoritative when present).
+    /// Skips zero-quantity rows (a flat position carries no basis to
+    /// seed and the snapshot writer already drops them).
+    /// </para>
+    ///
+    /// <para>
+    /// Each seeded row bumps
+    /// <c>trading.pnl.legacy_snapshot_basis_seeded</c> so ops can spot
+    /// the legacy-recovery transition. After the next snapshot is
+    /// taken, <see cref="RawSnapshotAvgCost"/> includes the seeded
+    /// basis and the metric returns to zero on subsequent recoveries.
+    /// </para>
+    /// </summary>
+    public int SeedAvgCostFromLegacyPositions(IEnumerable<PositionSnapshot> positions)
+    {
+        ArgumentNullException.ThrowIfNull(positions);
+        var seeded = 0;
+        foreach (var p in positions)
+        {
+            if (p.NetQuantity == 0) continue;
+            var key = (p.EndClientId, p.Symbol);
+            if (_avgCost.ContainsKey(key)) continue;
+            if (_avgCost.TryAdd(key, new AvgCostState(p.NetQuantity, p.AverageEntryPrice)))
+            {
+                seeded++;
+                Observability.MetricsRegistry.PnlLegacySnapshotBasisSeeded.Add(1);
+            }
+        }
+        return seeded;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -50,42 +50,6 @@ public sealed class PnlKeeper
     /// </summary>
     private readonly ConcurrentDictionary<(string EndClient, string Symbol), AvgCostState> _avgCost = new();
 
-    /// <summary>
-    /// Pass-1 review (#278) P1#2. Per-(end-client, symbol) lock used to
-    /// serialise the whole "compute pre-fill basis → mutate avg-cost →
-    /// fold realized delta into running total → produce
-    /// <see cref="RealizedPnlEvent"/> → keeper Apply" sequence on the
-    /// live path. The dispatcher's process-global lock alone is NOT
-    /// sufficient because the WAL-backpressure fallback path
-    /// (<c>EntryPointExecutionReportRouter</c>) re-invokes
-    /// <c>ExecutionReportProcessor.Apply</c> WITHOUT the dispatcher
-    /// lock — two concurrent fills for the same key on that path would
-    /// otherwise race and persist inconsistent <c>RunningTotal</c>
-    /// values into the WAL.
-    ///
-    /// <para>
-    /// Lock ordering: per-key lock OUTSIDE the dispatcher lock. The
-    /// snapshot path takes the dispatcher lock only and never the
-    /// per-key locks, so a fill in flight does not block snapshots.
-    /// </para>
-    /// </summary>
-    private readonly ConcurrentDictionary<(string EndClient, string Symbol), object> _keyLocks = new();
-
-    private object LockFor(string endClient, string symbol) =>
-        _keyLocks.GetOrAdd((endClient, symbol), static _ => new object());
-
-    /// <summary>
-    /// Public hook for callers that need to perform a multi-step
-    /// operation atomically per (endClient, symbol) — primarily the
-    /// processor's "compute realized + Dispatch + Apply" critical
-    /// section. See <see cref="_keyLocks"/> for the rationale.
-    /// </summary>
-    public T WithKeyLock<T>(string endClient, string symbol, Func<T> body)
-    {
-        ArgumentNullException.ThrowIfNull(body);
-        lock (LockFor(endClient, symbol)) return body();
-    }
-
     private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
     private readonly ConcurrentDictionary<string, PendingReplaySynth> _pendingReplaySynths = new();
 
@@ -180,92 +144,35 @@ public sealed class PnlKeeper
     /// <see cref="RealizedPnlEvent"/>.
     ///
     /// <para>
-    /// Pass-1 review (#278) P1#2. The mutation runs under the per-key
-    /// lock (see <see cref="WithKeyLock{T}"/>), eliminating the
-    /// outer-variable capture race that the previous
-    /// <c>AddOrUpdate</c>-based implementation had under contention.
+    /// Pass-2 review (#278) P1#1. Serialisation is provided by the
+    /// caller (the dispatcher lock on both the live and the
+    /// WAL-backpressure fallback paths — see
+    /// <see cref="EventDispatcher.RunExclusive"/>). No per-key lock is
+    /// taken here: an inner per-key lock under the dispatcher lock is
+    /// fine in isolation, but the previous design also acquired the
+    /// per-key lock OUTSIDE the dispatcher lock on the fallback path
+    /// (router caught WalBackpressureException → no dispatcher lock →
+    /// processor took per-key lock → nested Dispatch took dispatcher
+    /// lock), creating a classic AB-BA inversion against the live
+    /// path. Eliminating the per-key lock removes the inversion;
+    /// dispatcher serialisation is sufficient because all live ER
+    /// processing flows through it.
     /// </para>
     /// </summary>
     public decimal ApplyFillToAvgCost(string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice)
     {
         if (fillQuantity <= 0) return 0m;
         var key = (endClient, symbol);
-        lock (LockFor(endClient, symbol))
+        if (!_avgCost.TryGetValue(key, out var current))
         {
-            if (!_avgCost.TryGetValue(key, out var current))
-            {
-                var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
-                _avgCost[key] = new AvgCostState(signed, fillPrice);
-                return 0m;
-            }
-            var realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
-            _avgCost[key] = ProjectAvgCost(current, side, fillQuantity, fillPrice);
-            return realized;
+            var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
+            _avgCost[key] = new AvgCostState(signed, fillPrice);
+            return 0m;
         }
+        var realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
+        _avgCost[key] = ProjectAvgCost(current, side, fillQuantity, fillPrice);
+        return realized;
     }
-
-    /// <summary>
-    /// Pass-1 review (#278) P1#2. Atomic per-(endClient, symbol)
-    /// "compute realized + advance basis + fold into running total"
-    /// primitive used by the live ER path. Runs the supplied
-    /// <paramref name="onComputed"/> callback INSIDE the per-key lock
-    /// so the caller can append the <see cref="RealizedPnlEvent"/> to
-    /// the WAL (via the dispatcher) and call <see cref="Apply"/> back
-    /// on this keeper without a second concurrent fill on the same
-    /// key racing the running-total computation.
-    ///
-    /// <para>
-    /// The <paramref name="onComputed"/> callback receives a
-    /// <see cref="PnlFillContext"/> with the pre-fill snapshot, the
-    /// realized delta this fill produced, and the running total AFTER
-    /// folding the delta. Both values are derived from state held
-    /// under the lock, so they are guaranteed consistent with the
-    /// avg-cost mutation already applied.
-    /// </para>
-    ///
-    /// <para>
-    /// The avg-cost is mutated regardless of the realized delta. The
-    /// callback decides whether the realized delta is worth a WAL
-    /// event (matches the existing live-path policy: only non-zero
-    /// realized deltas append a <see cref="RealizedPnlEvent"/>).
-    /// </para>
-    /// </summary>
-    public void ApplyFillUnderLock(
-        string endClient,
-        string symbol,
-        OrderSide side,
-        long fillQuantity,
-        decimal fillPrice,
-        DateOnly day,
-        Action<PnlFillContext> onComputed)
-    {
-        ArgumentNullException.ThrowIfNull(onComputed);
-        if (fillQuantity <= 0) return;
-        var key = (endClient, symbol);
-        lock (LockFor(endClient, symbol))
-        {
-            var pre = _avgCost.TryGetValue(key, out var c) ? c : new AvgCostState(0, 0m);
-            var realized = ComputeRealizedDelta(pre.NetQuantity, pre.AvgPrice, side, fillQuantity, fillPrice);
-            _avgCost[key] = ProjectAvgCost(pre, side, fillQuantity, fillPrice);
-            var prevTotal = _realizedByDay.TryGetValue((endClient, symbol, day), out var t) ? t : 0m;
-            var running = prevTotal + realized;
-            onComputed(new PnlFillContext(pre.NetQuantity, pre.AvgPrice, realized, running));
-        }
-    }
-
-    /// <summary>
-    /// Snapshot of the per-key state produced inside
-    /// <see cref="ApplyFillUnderLock"/>. Carries both the pre-fill
-    /// (qty, avg) so the caller can build the WAL event and the
-    /// already-computed running total so the persisted
-    /// <see cref="RealizedPnlEvent.RunningTotal"/> matches the value
-    /// the keeper observed under the lock.
-    /// </summary>
-    public readonly record struct PnlFillContext(
-        long PreFillQuantity,
-        decimal PreFillAvgPrice,
-        decimal RealizedDelta,
-        decimal RunningTotal);
 
     /// <summary>
     /// Pure projection of the avg-cost state under one fill. Mirrors
@@ -457,6 +364,19 @@ public sealed class PnlKeeper
         foreach (var p in positions)
         {
             if (p.NetQuantity == 0) continue;
+            // Pass-2 review (#278) P1#2. A non-flat row with a zero
+            // AverageEntryPrice is degenerate (legacy snapshots
+            // produced before the position keeper started carrying
+            // basis): seeding it would book the next sell as
+            // realized = sellPrice * qty against a zero basis and
+            // surface phantom P&L on the first close after restore.
+            // Skip and surface the count via a dedicated metric so
+            // ops can flag snapshots that needed the guard.
+            if (p.AverageEntryPrice <= 0m)
+            {
+                Observability.MetricsRegistry.PnlLegacySnapshotBasisSkippedZero.Add(1);
+                continue;
+            }
             var key = (p.EndClientId, p.Symbol);
             if (_avgCost.ContainsKey(key)) continue;
             if (_avgCost.TryAdd(key, new AvgCostState(p.NetQuantity, p.AverageEntryPrice)))

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -1,0 +1,346 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q2.4 (#271). Per-(end-client, symbol, day) cumulative <b>realized</b>
+/// P&amp;L projected from the <see cref="RealizedPnlEvent"/> WAL stream
+/// + a per-(end-client, symbol) avg-cost basis state used to compute
+/// fresh <see cref="RealizedPnlEvent.DeltaRealized"/> values for new
+/// fills. Mirrors the snapshot+replay shape of <see cref="FeeKeeper"/>
+/// (#270): seen-set for idempotence, per-day bucketing for daily reset
+/// without losing historical totals, and a deferred replay-synth path
+/// for the ER-then-crash window (#277).
+///
+/// <para>
+/// <b>Avg-cost basis (decision documented in #271).</b> Realized
+/// proceeds are computed as <c>(price - avgPrice) * closedQty</c> for
+/// long positions and <c>(avgPrice - price) * closedQty</c> for shorts,
+/// where <c>closedQty = min(|fillQty|, |preFillQty|)</c> and the
+/// remainder (if the fill flipped the position past zero) opens fresh
+/// at <see cref="OrderSide"/>'s price — matching
+/// <see cref="Position.ApplyFill"/>'s avg-cost reset on flip. <b>Avg
+/// price does not change on offsetting fills</b> until the position
+/// flips through zero (consistent with <see cref="Position.ApplyFill"/>).
+/// </para>
+///
+/// <para>
+/// Unrealized P&amp;L is purely derived
+/// (<c>(refPrice - avgPrice) * position</c> for longs;
+/// <c>(avgPrice - refPrice) * position</c> for shorts) and is NEVER
+/// durable — the GET /pnl/today endpoint and the WS push channel
+/// project it on the fly from <see cref="PositionKeeper"/> +
+/// <c>IReferencePrice</c>.
+/// </para>
+/// </summary>
+public sealed class PnlKeeper
+{
+    /// <summary>Per-(end-client, symbol, day) cumulative realized total.</summary>
+    private readonly ConcurrentDictionary<(string EndClient, string Symbol, DateOnly Day), decimal> _realizedByDay = new();
+
+    /// <summary>
+    /// Per-(end-client, symbol) avg-cost basis: tracked here in PARALLEL
+    /// to <see cref="PositionKeeper"/> so a P&amp;L-only snapshot+restore
+    /// path (no <see cref="PositionKeeper"/> rehydration) round-trips. In
+    /// production both keepers receive every fill and stay in lockstep;
+    /// the parallel track defends against a future refactor that splits
+    /// the snapshots.
+    /// </summary>
+    private readonly ConcurrentDictionary<(string EndClient, string Symbol), AvgCostState> _avgCost = new();
+
+    private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
+    private readonly ConcurrentDictionary<string, PendingReplaySynth> _pendingReplaySynths = new();
+
+    private readonly record struct PendingReplaySynth(
+        string EndClientId, string Symbol, OrderSide Side,
+        long FillQuantity, decimal FillPrice, DateTimeOffset TimestampUtc,
+        long PreFillQuantity, decimal PreFillAvgPrice);
+
+    public sealed record AvgCostState(long NetQuantity, decimal AvgPrice);
+
+    public decimal GetDayRealized(string endClient, string symbol, DateOnly day) =>
+        _realizedByDay.TryGetValue((endClient, symbol, day), out var v) ? v : 0m;
+
+    /// <summary>Sum of realized totals across every (symbol, day) for the end-client on the given day.</summary>
+    public decimal GetDayRealizedTotal(string endClient, DateOnly day)
+    {
+        var sum = 0m;
+        foreach (var kv in _realizedByDay)
+            if (kv.Key.EndClient == endClient && kv.Key.Day == day) sum += kv.Value;
+        return sum;
+    }
+
+    public IEnumerable<(string Symbol, decimal Realized)> ForEndClientDay(string endClient, DateOnly day)
+    {
+        foreach (var kv in _realizedByDay)
+            if (kv.Key.EndClient == endClient && kv.Key.Day == day)
+                yield return (kv.Key.Symbol, kv.Value);
+    }
+
+    public AvgCostState? GetAvgCost(string endClient, string symbol) =>
+        _avgCost.TryGetValue((endClient, symbol), out var s) ? s : null;
+
+    /// <summary>
+    /// Pure avg-cost realized-delta calculator. Public so the ER processor
+    /// can compute the value BEFORE mutating <see cref="PositionKeeper"/>
+    /// (we need the pre-fill (qty, avg) snapshot). Returns 0 for
+    /// same-side fills (which only grow the position) and for the
+    /// no-position case.
+    /// </summary>
+    public static decimal ComputeRealizedDelta(
+        long preFillQty, decimal preFillAvgPrice,
+        OrderSide side, long fillQuantity, decimal fillPrice)
+    {
+        if (fillQuantity <= 0) return 0m;
+        if (preFillQty == 0) return 0m;
+        var fillSign = side == OrderSide.Buy ? 1 : -1;
+        var posSign = Math.Sign(preFillQty);
+        if (fillSign == posSign) return 0m; // same-side fills don't realize
+
+        var closedQty = Math.Min(Math.Abs(preFillQty), fillQuantity);
+        // Long closed by sell  → (price - avg) * closedQty
+        // Short closed by buy  → (avg - price) * closedQty   (posSign = -1)
+        return posSign == 1
+            ? (fillPrice - preFillAvgPrice) * closedQty
+            : (preFillAvgPrice - fillPrice) * closedQty;
+    }
+
+    /// <summary>
+    /// Folds <paramref name="evt"/> into the running totals. Idempotent
+    /// on <see cref="RealizedPnlEvent.ExecutionId"/>: a re-applied event
+    /// with the same id is a no-op. Updates the avg-cost basis state
+    /// based on <paramref name="evt"/> when the caller hasn't already
+    /// done so via <see cref="ApplyFillToAvgCost"/> — i.e. on replay
+    /// from durable events alone, where we project the post-fill avg
+    /// from the pre-fill snapshot embedded in the basis tracker.
+    /// </summary>
+    public bool Apply(RealizedPnlEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        if (_pendingReplaySynths.TryRemove(evt.ExecutionId, out _))
+        {
+            Observability.MetricsRegistry.PnlReplaySynth.Add(1,
+                new KeyValuePair<string, object?>("reconciled", true));
+        }
+        if (!_seenExecutionIds.TryAdd(evt.ExecutionId, 0)) return false;
+        var key = (evt.EndClientId, evt.Symbol, evt.DayKey);
+        // Use the persisted RunningTotal as authoritative — see record
+        // doc-comment. A re-projection from the in-memory delta would
+        // race a snapshot+tail recovery whose snapshot already baked in
+        // an earlier fill but whose avg-cost basis hasn't yet caught up.
+        _realizedByDay[key] = evt.RunningTotal;
+        return true;
+    }
+
+    /// <summary>
+    /// Live-path entry point used by <c>ExecutionReportProcessor</c>:
+    /// updates the avg-cost basis using the same recomputation as
+    /// <see cref="Position.ApplyFill"/> so the keeper's basis tracks
+    /// the position keeper without needing to read it back. Returns the
+    /// realized delta this fill produced (computed off the pre-fill
+    /// state) so the processor can decide whether to append a
+    /// <see cref="RealizedPnlEvent"/>.
+    /// </summary>
+    public decimal ApplyFillToAvgCost(string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice)
+    {
+        if (fillQuantity <= 0) return 0m;
+        var key = (endClient, symbol);
+        var realized = 0m;
+        _avgCost.AddOrUpdate(key,
+            _ =>
+            {
+                // No prior position — opens fresh, no realized.
+                var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
+                return new AvgCostState(signed, fillPrice);
+            },
+            (_, current) =>
+            {
+                realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
+                return ProjectAvgCost(current, side, fillQuantity, fillPrice);
+            });
+        return realized;
+    }
+
+    /// <summary>
+    /// Pure projection of the avg-cost state under one fill. Mirrors
+    /// <see cref="Position.ApplyFill"/>'s avg-price update rules: same
+    /// side grows the average, opposing side keeps it until flip,
+    /// flip-through-zero resets to fill price, flat resets to 0.
+    /// </summary>
+    public static AvgCostState ProjectAvgCost(AvgCostState current, OrderSide side, long quantity, decimal price)
+    {
+        var signed = side == OrderSide.Buy ? quantity : -quantity;
+        var newQty = current.NetQuantity + signed;
+        decimal newAvg;
+        if (current.NetQuantity == 0 || Math.Sign(current.NetQuantity) == Math.Sign(signed))
+        {
+            var prior = (decimal)Math.Abs(current.NetQuantity);
+            var added = (decimal)quantity;
+            var total = prior + added;
+            newAvg = total == 0 ? 0m : ((current.AvgPrice * prior) + (price * added)) / total;
+        }
+        else if (newQty != 0 && Math.Sign(newQty) != Math.Sign(current.NetQuantity))
+        {
+            newAvg = price;
+        }
+        else
+        {
+            newAvg = current.AvgPrice;
+        }
+        if (newQty == 0) newAvg = 0m;
+        return new AvgCostState(newQty, newAvg);
+    }
+
+    /// <summary>
+    /// Pass-3 review (#277) parallel — defers a replay-time synth so a
+    /// durable <see cref="RealizedPnlEvent"/> arriving later in the
+    /// drain can supersede it via <see cref="Apply(RealizedPnlEvent)"/>.
+    /// The pre-fill (qty, avg) snapshot is captured at registration time
+    /// — by the time <see cref="FinalizeReplay"/> runs the avg-cost
+    /// state has already been advanced by other replayed events, so we
+    /// could not recompute the delta from the live state.
+    /// </summary>
+    public void RegisterPendingReplaySynth(
+        string executionId, string endClientId, string symbol,
+        OrderSide side, long fillQuantity, decimal fillPrice,
+        DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice)
+    {
+        ArgumentNullException.ThrowIfNull(executionId);
+        if (_seenExecutionIds.ContainsKey(executionId)) return;
+        _pendingReplaySynths.TryAdd(executionId,
+            new PendingReplaySynth(endClientId, symbol, side, fillQuantity, fillPrice,
+                timestampUtc, preFillQuantity, preFillAvgPrice));
+    }
+
+    /// <summary>
+    /// Materialises any pending replay synths for which no durable
+    /// <see cref="RealizedPnlEvent"/> arrived during recovery — the true
+    /// ER-then-crash window. Each surviving entry is folded into totals
+    /// using the pre-fill snapshot captured at registration time so the
+    /// outcome is deterministic from position state. Increments
+    /// <c>pnl.replay_synth{reconciled=false}</c> per materialised row.
+    /// </summary>
+    public int FinalizeReplay()
+    {
+        if (_pendingReplaySynths.IsEmpty) return 0;
+        var materialised = 0;
+        foreach (var kv in _pendingReplaySynths.ToArray())
+        {
+            if (!_pendingReplaySynths.TryRemove(kv.Key, out var p)) continue;
+            if (!_seenExecutionIds.TryAdd(kv.Key, 0)) continue;
+            var delta = ComputeRealizedDelta(p.PreFillQuantity, p.PreFillAvgPrice, p.Side, p.FillQuantity, p.FillPrice);
+            if (delta != 0m)
+            {
+                var day = DateOnly.FromDateTime(p.TimestampUtc.UtcDateTime);
+                var key = (p.EndClientId, p.Symbol, day);
+                _realizedByDay.AddOrUpdate(key, delta, (_, current) => current + delta);
+            }
+            Observability.MetricsRegistry.PnlReplaySynth.Add(1,
+                new KeyValuePair<string, object?>("reconciled", false));
+            materialised++;
+        }
+        return materialised;
+    }
+
+    // --------- snapshot / restore ---------
+
+    /// <summary>Phase-1 (lock-side) capture of per-day realized totals.</summary>
+    public PnlRealizedRaw[] RawSnapshotRealized()
+    {
+        var pairs = _realizedByDay.ToArray();
+        if (pairs.Length == 0) return Array.Empty<PnlRealizedRaw>();
+        var buf = new PnlRealizedRaw[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            if (pairs[i].Value == 0m) continue;
+            buf[n++] = new PnlRealizedRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Key.Day, pairs[i].Value);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new PnlRealizedRaw[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
+    /// <summary>Phase-1 (lock-side) capture of avg-cost basis rows.</summary>
+    public PnlAvgCostRaw[] RawSnapshotAvgCost()
+    {
+        var pairs = _avgCost.ToArray();
+        if (pairs.Length == 0) return Array.Empty<PnlAvgCostRaw>();
+        var buf = new PnlAvgCostRaw[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            var v = pairs[i].Value;
+            if (v.NetQuantity == 0) continue;
+            buf[n++] = new PnlAvgCostRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, v.NetQuantity, v.AvgPrice);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new PnlAvgCostRaw[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
+    public string[] RawSnapshotSeenIds()
+    {
+        var ids = new string[_seenExecutionIds.Count];
+        var n = 0;
+        foreach (var kv in _seenExecutionIds)
+        {
+            if (n >= ids.Length) break;
+            ids[n++] = kv.Key;
+        }
+        if (n == ids.Length) return ids;
+        var trimmed = new string[n];
+        Array.Copy(ids, trimmed, n);
+        return trimmed;
+    }
+
+    public void Restore(
+        IReadOnlyDictionary<string, decimal> realizedByKey,
+        IEnumerable<PnlAvgCostSnapshot> avgCostRows,
+        IEnumerable<string>? seenExecutionIds = null)
+    {
+        ArgumentNullException.ThrowIfNull(realizedByKey);
+        ArgumentNullException.ThrowIfNull(avgCostRows);
+        _realizedByDay.Clear();
+        _avgCost.Clear();
+        _seenExecutionIds.Clear();
+        foreach (var kv in realizedByKey)
+        {
+            if (!TryParseRealizedKey(kv.Key, out var ec, out var sym, out var day)) continue;
+            _realizedByDay[(ec, sym, day)] = kv.Value;
+        }
+        foreach (var row in avgCostRows)
+            _avgCost[(row.EndClientId, row.Symbol)] = new AvgCostState(row.NetQuantity, row.AvgPrice);
+        if (seenExecutionIds is not null)
+            foreach (var id in seenExecutionIds)
+                _seenExecutionIds.TryAdd(id, 0);
+    }
+
+    /// <summary>
+    /// Composite key serialisation for the snapshot's
+    /// <c>Dictionary&lt;string, decimal&gt;</c> shape. Format:
+    /// <c>{endClient}|{symbol}|{yyyy-MM-dd}</c>.
+    /// </summary>
+    public static string FormatRealizedKey(string endClient, string symbol, DateOnly day) =>
+        endClient + "|" + symbol + "|" + day.ToString("yyyy-MM-dd");
+
+    public static bool TryParseRealizedKey(string key, out string endClient, out string symbol, out DateOnly day)
+    {
+        endClient = string.Empty;
+        symbol = string.Empty;
+        day = default;
+        if (string.IsNullOrEmpty(key)) return false;
+        var lastPipe = key.LastIndexOf('|');
+        if (lastPipe <= 0 || lastPipe == key.Length - 1) return false;
+        if (!DateOnly.TryParseExact(key.AsSpan(lastPipe + 1), "yyyy-MM-dd", out day)) return false;
+        var firstPipe = key.IndexOf('|');
+        if (firstPipe <= 0 || firstPipe == lastPipe) return false;
+        endClient = key.Substring(0, firstPipe);
+        symbol = key.Substring(firstPipe + 1, lastPipe - firstPipe - 1);
+        return true;
+    }
+}

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -50,6 +50,23 @@ public sealed class PnlKeeper
     /// </summary>
     private readonly ConcurrentDictionary<(string EndClient, string Symbol), AvgCostState> _avgCost = new();
 
+    /// <summary>
+    /// Pass-3 review (#278) P1. Per-(end-client, symbol) net quantity
+    /// for positions whose basis is UNKNOWN — i.e. seeded from a legacy
+    /// <see cref="PositionSnapshot"/> row whose <c>AverageEntryPrice</c>
+    /// was zero (pre-#271 snapshot format). Keys here are mutually
+    /// exclusive with <see cref="_avgCost"/>: a key in this set has no
+    /// usable avg-price, so <see cref="ApplyFillToAvgCost"/> realises
+    /// 0 for any fill against it (no phantom P&amp;L from an invented
+    /// basis); fills only adjust the unknown qty until the position
+    /// goes flat (entry removed → next fresh fill establishes a real
+    /// basis via the normal opening path) or flips through zero (the
+    /// closing portion realises 0; the residual opens fresh at the
+    /// fill price as a real basis — matching the standard avg-cost
+    /// convention for sign flips on a known basis).
+    /// </summary>
+    private readonly ConcurrentDictionary<(string EndClient, string Symbol), long> _unknownBasisQty = new();
+
     private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
     private readonly ConcurrentDictionary<string, PendingReplaySynth> _pendingReplaySynths = new();
 
@@ -81,6 +98,16 @@ public sealed class PnlKeeper
 
     public AvgCostState? GetAvgCost(string endClient, string symbol) =>
         _avgCost.TryGetValue((endClient, symbol), out var s) ? s : null;
+
+    /// <summary>
+    /// Pass-3 review (#278) P1. Returns the net quantity carried as
+    /// "unknown basis" for the given key, or 0 when the key has either
+    /// a known basis or no position at all. Exposed for tests and for
+    /// observability — production code paths route through
+    /// <see cref="ApplyFillToAvgCost"/>.
+    /// </summary>
+    public long GetUnknownBasisQty(string endClient, string symbol) =>
+        _unknownBasisQty.TryGetValue((endClient, symbol), out var q) ? q : 0;
 
     /// <summary>
     /// Pure avg-cost realized-delta calculator. Public so the ER processor
@@ -163,6 +190,47 @@ public sealed class PnlKeeper
     {
         if (fillQuantity <= 0) return 0m;
         var key = (endClient, symbol);
+
+        // Pass-3 review (#278) P1. Unknown-basis path: legacy snapshot
+        // seeded a quantity but no usable avg price, so we cannot
+        // compute realized against an invented basis without surfacing
+        // phantom P&L. Realise 0 unconditionally and adjust the
+        // unknown qty by the fill (signed by side):
+        //   * if newQty == 0  → position is flat: drop the unknown
+        //     entry. The next fresh fill goes through the opening
+        //     branch below and establishes a real basis at its price.
+        //   * if newQty flips sign (e.g. legacy long 100 + sell 150
+        //     → short 50): the closing portion (|current|) realises 0
+        //     against the unknown basis; the residual (|newQty|)
+        //     opens fresh at the fill price as a KNOWN basis. This
+        //     matches the standard avg-cost convention for sign flips
+        //     on a known basis (Position.ApplyFill / ProjectAvgCost),
+        //     and is safe because the residual leg is fully attributable
+        //     to the current fill.
+        //   * otherwise (same direction, or shrink without flip):
+        //     update the unknown qty in place. No real basis is
+        //     formed yet — only a flat-then-reopen sequence resets
+        //     the basis to known.
+        if (_unknownBasisQty.TryGetValue(key, out var unknownQty))
+        {
+            var signedFill = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
+            var newQty = unknownQty + signedFill;
+            if (newQty == 0)
+            {
+                _unknownBasisQty.TryRemove(key, out _);
+            }
+            else if (Math.Sign(newQty) != Math.Sign(unknownQty))
+            {
+                _unknownBasisQty.TryRemove(key, out _);
+                _avgCost[key] = new AvgCostState(newQty, fillPrice);
+            }
+            else
+            {
+                _unknownBasisQty[key] = newQty;
+            }
+            return 0m;
+        }
+
         if (!_avgCost.TryGetValue(key, out var current))
         {
             var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
@@ -170,7 +238,15 @@ public sealed class PnlKeeper
             return 0m;
         }
         var realized = ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
-        _avgCost[key] = ProjectAvgCost(current, side, fillQuantity, fillPrice);
+        var projected = ProjectAvgCost(current, side, fillQuantity, fillPrice);
+        if (projected.NetQuantity == 0)
+        {
+            _avgCost.TryRemove(key, out _);
+        }
+        else
+        {
+            _avgCost[key] = projected;
+        }
         return realized;
     }
 
@@ -294,6 +370,30 @@ public sealed class PnlKeeper
         return trimmed;
     }
 
+    /// <summary>
+    /// Pass-3 review (#278) P1. Phase-1 (lock-side) capture of the
+    /// unknown-basis qty rows. Persisted alongside <see cref="RawSnapshotAvgCost"/>
+    /// so a snapshot+tail recovery doesn't lose the "this leg has no
+    /// usable basis" fact and re-seed the same degenerate position
+    /// from <see cref="PositionSnapshot"/> on every restore.
+    /// </summary>
+    public PnlUnknownBasisRaw[] RawSnapshotUnknownBasis()
+    {
+        var pairs = _unknownBasisQty.ToArray();
+        if (pairs.Length == 0) return Array.Empty<PnlUnknownBasisRaw>();
+        var buf = new PnlUnknownBasisRaw[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            if (pairs[i].Value == 0) continue;
+            buf[n++] = new PnlUnknownBasisRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Value);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new PnlUnknownBasisRaw[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
     public string[] RawSnapshotSeenIds()
     {
         var ids = new string[_seenExecutionIds.Count];
@@ -312,12 +412,14 @@ public sealed class PnlKeeper
     public void Restore(
         IReadOnlyDictionary<string, decimal> realizedByKey,
         IEnumerable<PnlAvgCostSnapshot> avgCostRows,
-        IEnumerable<string>? seenExecutionIds = null)
+        IEnumerable<string>? seenExecutionIds = null,
+        IEnumerable<PnlUnknownBasisSnapshot>? unknownBasisRows = null)
     {
         ArgumentNullException.ThrowIfNull(realizedByKey);
         ArgumentNullException.ThrowIfNull(avgCostRows);
         _realizedByDay.Clear();
         _avgCost.Clear();
+        _unknownBasisQty.Clear();
         _seenExecutionIds.Clear();
         foreach (var kv in realizedByKey)
         {
@@ -326,6 +428,10 @@ public sealed class PnlKeeper
         }
         foreach (var row in avgCostRows)
             _avgCost[(row.EndClientId, row.Symbol)] = new AvgCostState(row.NetQuantity, row.AvgPrice);
+        if (unknownBasisRows is not null)
+            foreach (var row in unknownBasisRows)
+                if (row.NetQuantity != 0)
+                    _unknownBasisQty[(row.EndClientId, row.Symbol)] = row.NetQuantity;
         if (seenExecutionIds is not null)
             foreach (var id in seenExecutionIds)
                 _seenExecutionIds.TryAdd(id, 0);
@@ -364,17 +470,28 @@ public sealed class PnlKeeper
         foreach (var p in positions)
         {
             if (p.NetQuantity == 0) continue;
-            // Pass-2 review (#278) P1#2. A non-flat row with a zero
+            // Pass-3 review (#278) P1. A non-flat row with a zero
             // AverageEntryPrice is degenerate (legacy snapshots
             // produced before the position keeper started carrying
-            // basis): seeding it would book the next sell as
-            // realized = sellPrice * qty against a zero basis and
-            // surface phantom P&L on the first close after restore.
-            // Skip and surface the count via a dedicated metric so
-            // ops can flag snapshots that needed the guard.
+            // basis). Previously we simply skipped these rows, but
+            // PositionKeeper STILL holds the open leg — so the next
+            // sell against an existing long became a synthetic SHORT
+            // opening in PnlKeeper at the sell price, and subsequent
+            // fills realised phantom P&L against that invented basis.
+            //
+            // Track the qty as "unknown basis" instead. ApplyFillToAvgCost
+            // then realises 0 for any fill against the unknown leg
+            // (no phantom P&L), adjusts the unknown qty in place,
+            // drops the entry on flat (next fresh fill establishes a
+            // real basis), and treats sign-flips as residual-fresh-open
+            // at the fill price. The skipped_zero counter still bumps
+            // so ops can spot the legacy-recovery transition.
             if (p.AverageEntryPrice <= 0m)
             {
                 Observability.MetricsRegistry.PnlLegacySnapshotBasisSkippedZero.Add(1);
+                var unknownKey = (p.EndClientId, p.Symbol);
+                if (!_avgCost.ContainsKey(unknownKey))
+                    _unknownBasisQty.TryAdd(unknownKey, p.NetQuantity);
                 continue;
             }
             var key = (p.EndClientId, p.Symbol);

--- a/backend/src/B3.Trading.Application/PositionKeeper.cs
+++ b/backend/src/B3.Trading.Application/PositionKeeper.cs
@@ -47,6 +47,26 @@ public sealed class PositionKeeper
         return list;
     }
 
+    /// <summary>
+    /// Pass-1 review (#278) P1#3. Enumerates open (non-flat)
+    /// positions for <paramref name="symbol"/> across every
+    /// end-client. Used by the refprice → <c>pnl.me</c> fan-out to
+    /// resolve which owners should receive an unrealized-P&amp;L
+    /// delta when a symbol's mark moves. Returns a materialised list
+    /// to free the caller from ToArray-on-iterate.
+    /// </summary>
+    public IReadOnlyList<Position> ForSymbol(string symbol)
+    {
+        if (string.IsNullOrEmpty(symbol)) return Array.Empty<Position>();
+        var list = new List<Position>();
+        foreach (var kv in _positions)
+        {
+            if (kv.Key.Symbol == symbol && kv.Value.NetQuantity != 0)
+                list.Add(kv.Value);
+        }
+        return list;
+    }
+
     public IEnumerable<Persistence.PositionSnapshot> Snapshot()
     {
         foreach (var kv in _positions)

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.Configure<FeeOptions>(configuration.GetSection(FeeOptions.SectionName));
         services.AddSingleton<IFeeCalculator, BpsFeeCalculator>();
         services.AddSingleton<FeeKeeper>();
+        services.AddSingleton<PnlKeeper>();
         services.AddSingleton<InMemoryUserBotCredentialRegistry>();
         services.AddSingleton<IUserBotCredentialRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -30,6 +30,7 @@ public static class TradingEndpointsExtensions
         app.MapAlgo();
         app.MapPositions();
         app.MapBalance();
+        app.MapPnl();
         app.MapPolicy();
         app.MapAdmin();
         {

--- a/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
+++ b/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
@@ -96,6 +96,23 @@ public static class MarketDataRegistration
         // event handlers in MarketDataReferencePrice's constructor.
         services.AddHostedService(sp => sp.GetRequiredService<MarketDataReferencePrice>());
 
+        // Pass-1 review (#278) P1#3. Bridge MarketDataReferencePrice
+        // ticks to the pnl.me WS channel so subscribers' unrealized
+        // P&L tracks refprice without needing a fill in between.
+        // Wired only here (i.e. only when the live MD feed is on) AND
+        // only when the application-core composition has registered
+        // SubscriptionManager + PnlKeeper + PositionKeeper. The
+        // SubscriptionManager check keeps the MarketData-only test
+        // scenarios (which don't compose the full hub) green.
+        if (services.Any(d => d.ServiceType == typeof(B3.Trading.Api.WebSockets.SubscriptionManager))
+            && services.Any(d => d.ServiceType == typeof(B3.Trading.Application.PnlKeeper))
+            && services.Any(d => d.ServiceType == typeof(B3.Trading.Application.PositionKeeper)))
+        {
+            services.AddSingleton<B3.Trading.Api.WebSockets.PnlRefPriceFanOut>();
+            services.AddHostedService(sp =>
+                sp.GetRequiredService<B3.Trading.Api.WebSockets.PnlRefPriceFanOut>());
+        }
+
         return services;
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
@@ -85,8 +85,20 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
             // (legacy synchronous-publish path: no fanOut writer); this is
             // a "log dropped, state intact" branch and shows up in metrics
             // as a backpressure event.
-            _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
-                er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId);
+            //
+            // Pass-2 review (#278) P1#1. Take the dispatcher lock for the
+            // whole fallback Apply via RunExclusive so the same
+            // serialisation discipline that the regular Dispatch path
+            // gives us still holds: nested Dispatch calls for derived
+            // fee/PnL events (reentrant on this thread) interleave
+            // safely with concurrent live ER dispatches on other
+            // threads, and there is no AB-BA inversion against any
+            // downstream lock the keepers take. The WAL append is
+            // intentionally skipped here — we are at backpressure —
+            // so holding the dispatcher lock involves no I/O.
+            _dispatcher.RunExclusive(() =>
+                _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
+                    er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId));
         }
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -351,6 +351,18 @@ public sealed class StateSnapshotter
         _cashKeeper?.Restore(snap.CashByEndclient);
         _feeKeeper?.Restore(snap.FeesByEndclientDay, snap.FeeSeenExecutionIds);
         _pnlKeeper?.Restore(snap.PnlRealizedByEndclientSymbolDay, snap.PnlAvgCost, snap.PnlSeenExecutionIds);
+        // Pass-1 review (#278) P1#1. Legacy snapshots taken before
+        // #271 deployed have Positions populated but PnlAvgCost empty.
+        // Without this seed the next sell on a pre-existing position
+        // would compute realized off a zero basis and silently
+        // realise nothing. PositionSnapshot carries AverageEntryPrice
+        // so we reconstruct the basis from there; the seed is a
+        // no-op when PnlAvgCost is already populated (current
+        // snapshot format).
+        if (_pnlKeeper is not null && snap.PnlAvgCost.Count == 0 && snap.Positions.Count > 0)
+        {
+            _pnlKeeper.SeedAvgCostFromLegacyPositions(snap.Positions);
+        }
         _userBotCredentials?.Restore(snap.UserBotCredentials);
         _userBotSessions?.Restore(snap.BotSessions);
         _userBotMappings?.Restore(snap.BotOrderMappings, snap.BotCancelMappings);

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -374,8 +374,18 @@ public sealed class StateSnapshotter
         // would be a no-op for non-zero basis rows but would
         // re-discover the zero-basis rows and double-count the
         // skipped_zero metric).
+        //
+        // Pass-4 review (#278) P1#1. The PnlAvgCost.Count==0 guard
+        // was wrong: a pass-2-shaped snapshot has PnlAvgCost
+        // populated (the non-zero-basis rows seeded under pass-1)
+        // but no PnlUnknownBasis block (the field didn't exist yet),
+        // so the previous gate skipped seeding entirely and the
+        // zero-basis Position rows fell back to the original
+        // phantom-P&L bug. Drop the avg-cost guard and rely on
+        // SeedAvgCostFromLegacyPositions being idempotent (it skips
+        // keys already present in _avgCost), so re-seeding only
+        // adds the zero-basis legacy rows to _unknownBasisQty.
         if (_pnlKeeper is not null
-            && snap.PnlAvgCost.Count == 0
             && snap.PnlUnknownBasis.Count == 0
             && snap.Positions.Count > 0)
         {

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -124,6 +124,7 @@ public sealed class StateSnapshotter
         FeeSeenExecutionIds = _feeKeeper?.RawSnapshotSeenIds() ?? Array.Empty<string>(),
         PnlRealizedByEndclientSymbolDay = _pnlKeeper?.RawSnapshotRealized() ?? Array.Empty<PnlRealizedRaw>(),
         PnlAvgCost = _pnlKeeper?.RawSnapshotAvgCost() ?? Array.Empty<PnlAvgCostRaw>(),
+        PnlUnknownBasis = _pnlKeeper?.RawSnapshotUnknownBasis() ?? Array.Empty<PnlUnknownBasisRaw>(),
         PnlSeenExecutionIds = _pnlKeeper?.RawSnapshotSeenIds() ?? Array.Empty<string>(),
         UserBotCredentials = _userBotCredentials?.RawSnapshot() ?? Array.Empty<UserBotCredential>(),
         BotSessions = _userBotSessions?.RawSnapshot() ?? Array.Empty<BotSessionState>(),
@@ -232,6 +233,12 @@ public sealed class StateSnapshotter
             var a = raw.PnlAvgCost[i];
             pnlAvgCost.Add(new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice));
         }
+        var pnlUnknownBasis = new List<PnlUnknownBasisSnapshot>(raw.PnlUnknownBasis.Length);
+        for (var i = 0; i < raw.PnlUnknownBasis.Length; i++)
+        {
+            var u = raw.PnlUnknownBasis[i];
+            pnlUnknownBasis.Add(new PnlUnknownBasisSnapshot(u.EndClientId, u.Symbol, u.NetQuantity));
+        }
         var pnlSeen = new List<string>(raw.PnlSeenExecutionIds.Length);
         for (var i = 0; i < raw.PnlSeenExecutionIds.Length; i++)
             pnlSeen.Add(raw.PnlSeenExecutionIds[i]);
@@ -320,6 +327,7 @@ public sealed class StateSnapshotter
             FeeSeenExecutionIds = feeSeen,
             PnlRealizedByEndclientSymbolDay = pnlRealized,
             PnlAvgCost = pnlAvgCost,
+            PnlUnknownBasis = pnlUnknownBasis,
             PnlSeenExecutionIds = pnlSeen,
             UserBotCredentials = creds,
             BotSessions = sessions,
@@ -350,7 +358,7 @@ public sealed class StateSnapshotter
         _cash.Restore(snap.CashBalances);
         _cashKeeper?.Restore(snap.CashByEndclient);
         _feeKeeper?.Restore(snap.FeesByEndclientDay, snap.FeeSeenExecutionIds);
-        _pnlKeeper?.Restore(snap.PnlRealizedByEndclientSymbolDay, snap.PnlAvgCost, snap.PnlSeenExecutionIds);
+        _pnlKeeper?.Restore(snap.PnlRealizedByEndclientSymbolDay, snap.PnlAvgCost, snap.PnlSeenExecutionIds, snap.PnlUnknownBasis);
         // Pass-1 review (#278) P1#1. Legacy snapshots taken before
         // #271 deployed have Positions populated but PnlAvgCost empty.
         // Without this seed the next sell on a pre-existing position
@@ -359,7 +367,17 @@ public sealed class StateSnapshotter
         // so we reconstruct the basis from there; the seed is a
         // no-op when PnlAvgCost is already populated (current
         // snapshot format).
-        if (_pnlKeeper is not null && snap.PnlAvgCost.Count == 0 && snap.Positions.Count > 0)
+        //
+        // Pass-3 review (#278) P1. Also gated on PnlUnknownBasis being
+        // empty: a snapshot taken AFTER pass-3 carries the unknown-
+        // basis set explicitly, so we must not re-seed (re-seeding
+        // would be a no-op for non-zero basis rows but would
+        // re-discover the zero-basis rows and double-count the
+        // skipped_zero metric).
+        if (_pnlKeeper is not null
+            && snap.PnlAvgCost.Count == 0
+            && snap.PnlUnknownBasis.Count == 0
+            && snap.Positions.Count > 0)
         {
             _pnlKeeper.SeedAvgCostFromLegacyPositions(snap.Positions);
         }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -28,6 +28,7 @@ public sealed class StateSnapshotter
     private readonly CashLedger _cash;
     private readonly CashKeeper? _cashKeeper;
     private readonly FeeKeeper? _feeKeeper;
+    private readonly PnlKeeper? _pnlKeeper;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
     private readonly IUserBotOrderMappingRegistry? _userBotMappings;
@@ -58,7 +59,8 @@ public sealed class StateSnapshotter
         IUserBotOrderMappingRegistry? userBotMappings = null,
         GtdExpirationScheduler? gtdScheduler = null,
         CashKeeper? cashKeeper = null,
-        FeeKeeper? feeKeeper = null)
+        FeeKeeper? feeKeeper = null,
+        PnlKeeper? pnlKeeper = null)
     {
         _orders = orders;
         _positions = positions;
@@ -72,6 +74,7 @@ public sealed class StateSnapshotter
         _cash = cash;
         _cashKeeper = cashKeeper;
         _feeKeeper = feeKeeper;
+        _pnlKeeper = pnlKeeper;
         _userBotCredentials = userBotCredentials;
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
@@ -119,6 +122,9 @@ public sealed class StateSnapshotter
         CashByEndclient = _cashKeeper?.RawSnapshot() ?? Array.Empty<CashKeeperRaw>(),
         FeesByEndclientDay = _feeKeeper?.RawSnapshot() ?? Array.Empty<FeeKeeperRaw>(),
         FeeSeenExecutionIds = _feeKeeper?.RawSnapshotSeenIds() ?? Array.Empty<string>(),
+        PnlRealizedByEndclientSymbolDay = _pnlKeeper?.RawSnapshotRealized() ?? Array.Empty<PnlRealizedRaw>(),
+        PnlAvgCost = _pnlKeeper?.RawSnapshotAvgCost() ?? Array.Empty<PnlAvgCostRaw>(),
+        PnlSeenExecutionIds = _pnlKeeper?.RawSnapshotSeenIds() ?? Array.Empty<string>(),
         UserBotCredentials = _userBotCredentials?.RawSnapshot() ?? Array.Empty<UserBotCredential>(),
         BotSessions = _userBotSessions?.RawSnapshot() ?? Array.Empty<BotSessionState>(),
         BotOrderMappings = _userBotMappings?.RawSnapshotOrders() ?? Array.Empty<BotOrderMappingRaw>(),
@@ -210,6 +216,26 @@ public sealed class StateSnapshotter
         for (var i = 0; i < raw.FeeSeenExecutionIds.Length; i++)
             feeSeen.Add(raw.FeeSeenExecutionIds[i]);
 
+        // Q2.4 (#271). PnlKeeper rows projected into the persisted
+        // shape. Same dict choice as fees — callers index by composite
+        // key, no deterministic order required. Avg-cost basis is a
+        // list (1:1 with positions) and the seen-set is a flat list.
+        var pnlRealized = new Dictionary<string, decimal>(raw.PnlRealizedByEndclientSymbolDay.Length);
+        for (var i = 0; i < raw.PnlRealizedByEndclientSymbolDay.Length; i++)
+        {
+            var p = raw.PnlRealizedByEndclientSymbolDay[i];
+            pnlRealized[PnlKeeper.FormatRealizedKey(p.EndClientId, p.Symbol, p.Day)] = p.Realized;
+        }
+        var pnlAvgCost = new List<PnlAvgCostSnapshot>(raw.PnlAvgCost.Length);
+        for (var i = 0; i < raw.PnlAvgCost.Length; i++)
+        {
+            var a = raw.PnlAvgCost[i];
+            pnlAvgCost.Add(new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice));
+        }
+        var pnlSeen = new List<string>(raw.PnlSeenExecutionIds.Length);
+        for (var i = 0; i < raw.PnlSeenExecutionIds.Length; i++)
+            pnlSeen.Add(raw.PnlSeenExecutionIds[i]);
+
         var phaseOverrides = new List<SessionPhaseOverrideSnapshot>(raw.SessionPhaseOverrides.Length);
         for (var i = 0; i < raw.SessionPhaseOverrides.Length; i++)
         {
@@ -292,6 +318,9 @@ public sealed class StateSnapshotter
             CashByEndclient = cashByEndclient,
             FeesByEndclientDay = feesByEndclientDay,
             FeeSeenExecutionIds = feeSeen,
+            PnlRealizedByEndclientSymbolDay = pnlRealized,
+            PnlAvgCost = pnlAvgCost,
+            PnlSeenExecutionIds = pnlSeen,
             UserBotCredentials = creds,
             BotSessions = sessions,
             BotOrderMappings = botOrderMaps,
@@ -321,6 +350,7 @@ public sealed class StateSnapshotter
         _cash.Restore(snap.CashBalances);
         _cashKeeper?.Restore(snap.CashByEndclient);
         _feeKeeper?.Restore(snap.FeesByEndclientDay, snap.FeeSeenExecutionIds);
+        _pnlKeeper?.Restore(snap.PnlRealizedByEndclientSymbolDay, snap.PnlAvgCost, snap.PnlSeenExecutionIds);
         _userBotCredentials?.Restore(snap.UserBotCredentials);
         _userBotSessions?.Restore(snap.BotSessions);
         _userBotMappings?.Restore(snap.BotOrderMappings, snap.BotCancelMappings);
@@ -376,6 +406,7 @@ public sealed class EventReplayer
     private readonly GtdExpirationScheduler? _gtdScheduler;
     private readonly CashKeeper? _cashKeeper;
     private readonly FeeKeeper? _feeKeeper;
+    private readonly PnlKeeper? _pnlKeeper;
     private readonly IFeeCalculator? _feeCalculator;
 
     public EventReplayer(
@@ -395,7 +426,8 @@ public sealed class EventReplayer
         GtdExpirationScheduler? gtdScheduler = null,
         CashKeeper? cashKeeper = null,
         FeeKeeper? feeKeeper = null,
-        IFeeCalculator? feeCalculator = null)
+        IFeeCalculator? feeCalculator = null,
+        PnlKeeper? pnlKeeper = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -414,6 +446,7 @@ public sealed class EventReplayer
         _cashKeeper = cashKeeper;
         _feeKeeper = feeKeeper;
         _feeCalculator = feeCalculator;
+        _pnlKeeper = pnlKeeper;
     }
 
     /// <summary>
@@ -429,8 +462,12 @@ public sealed class EventReplayer
     /// </summary>
     public int FinalizeReplay()
     {
-        if (_feeKeeper is null || _feeCalculator is null) return 0;
-        return _feeKeeper.FinalizeReplay(_feeCalculator);
+        var n = 0;
+        if (_feeKeeper is not null && _feeCalculator is not null)
+            n += _feeKeeper.FinalizeReplay(_feeCalculator);
+        if (_pnlKeeper is not null)
+            n += _pnlKeeper.FinalizeReplay();
+        return n;
     }
 
     public void Apply(WalEvent evt)
@@ -638,6 +675,13 @@ public sealed class EventReplayer
                 // untouched (FeeSeenExecutionIds restored alongside the
                 // totals — see StateSnapshotter.Restore).
                 _feeKeeper?.Apply(fae);
+                break;
+            case RealizedPnlEvent rpe:
+                // Q2.4 (#271). Forward to PnlKeeper. Apply uses
+                // RunningTotal as authoritative so a snapshot+tail
+                // recovery converges on the persisted value even if the
+                // basis tracker projection drifts.
+                _pnlKeeper?.Apply(rpe);
                 break;
         }
     }

--- a/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q2.4 (#271). GET /pnl/today happy-path coverage. The endpoint is
+/// AuthN-gated; the projection layer is shared with the WS pnl.me
+/// channel snapshot — exercising it via HTTP is the lowest-risk surface
+/// because route mounting + JWT plumbing get covered for free.
+/// </summary>
+public class PnlEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    public PnlEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task UnauthenticatedGet_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/pnl/today");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task FreshAccount_ReturnsEmptySnapshot()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var body = await client.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
+        Assert.NotNull(body);
+        Assert.Equal(0m, body!.RealizedTotal);
+        Assert.Equal(0m, body.UnrealizedTotal);
+        Assert.Empty(body.Symbols);
+    }
+
+    [Fact]
+    public async Task AfterFillAndRealized_ProjectsRealizedAndUnrealized()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var client = await factory.CreateAuthedClientAsync();
+
+        var pnl = factory.Services.GetRequiredService<PnlKeeper>();
+        var positions = factory.Services.GetRequiredService<PositionKeeper>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        // Open 100 @ 30, then close 50 @ 31 → realized 50, residual 50 @ 30.
+        positions.ApplyFill(owner, "PETR4", OrderSide.Buy, 100, 30m);
+        positions.ApplyFill(owner, "PETR4", OrderSide.Sell, 50, 31m);
+        pnl.ApplyFillToAvgCost(owner.Value, "PETR4", OrderSide.Buy, 100, 30m);
+        pnl.ApplyFillToAvgCost(owner.Value, "PETR4", OrderSide.Sell, 50, 31m);
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        pnl.Apply(new Application.Persistence.RealizedPnlEvent
+        {
+            ClOrdId = 1,
+            ExecutionId = "1:50",
+            EndClientId = owner.Value,
+            Symbol = "PETR4",
+            DayKey = day,
+            DeltaRealized = 50m,
+            RunningTotal = 50m,
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+
+        var body = await client.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
+        Assert.NotNull(body);
+        Assert.Equal(50m, body!.RealizedTotal);
+        // No reference price configured for PETR4 in the test factory →
+        // unrealized list omits the symbol but realized is still
+        // surfaced.
+        var refPrice = factory.Services.GetRequiredService<IReferencePrice>();
+        var hasRef = refPrice.TryGet("PETR4", out var px);
+        var row = Assert.Single(body.Symbols);
+        Assert.Equal("PETR4", row.Symbol);
+        Assert.Equal(50, row.NetQuantity);
+        Assert.Equal(50m, row.Realized);
+        if (hasRef)
+        {
+            Assert.NotNull(row.ReferencePrice);
+            Assert.Equal(px, row.ReferencePrice);
+            Assert.Equal((px - 30m) * 50, row.Unrealized);
+        }
+        else
+        {
+            Assert.Null(row.ReferencePrice);
+            Assert.Null(row.Unrealized);
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
@@ -35,9 +35,10 @@ public class PnlEndpointTests : IClassFixture<TestAppFactory>
 
         var body = await client.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
         Assert.NotNull(body);
-        Assert.Equal(0m, body!.RealizedTotal);
-        Assert.Equal(0m, body.UnrealizedTotal);
-        Assert.Empty(body.Symbols);
+        Assert.Equal(0m, body!.TotalRealized);
+        Assert.Equal(0m, body.TotalUnrealized);
+        Assert.Empty(body.Realized);
+        Assert.Empty(body.Unrealized);
     }
 
     [Fact]
@@ -71,26 +72,29 @@ public class PnlEndpointTests : IClassFixture<TestAppFactory>
 
         var body = await client.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
         Assert.NotNull(body);
-        Assert.Equal(50m, body!.RealizedTotal);
-        // No reference price configured for PETR4 in the test factory →
-        // unrealized list omits the symbol but realized is still
-        // surfaced.
+        Assert.Equal(50m, body!.TotalRealized);
+        var realizedRow = Assert.Single(body.Realized);
+        Assert.Equal("PETR4", realizedRow.Symbol);
+        Assert.Equal(50m, realizedRow.Value);
+
+        // Unrealized appears only when the test ref-price source has
+        // a value for PETR4; the test factory may or may not configure
+        // one — accept both shapes.
         var refPrice = factory.Services.GetRequiredService<IReferencePrice>();
-        var hasRef = refPrice.TryGet("PETR4", out var px);
-        var row = Assert.Single(body.Symbols);
-        Assert.Equal("PETR4", row.Symbol);
-        Assert.Equal(50, row.NetQuantity);
-        Assert.Equal(50m, row.Realized);
-        if (hasRef)
+        if (refPrice.TryGet("PETR4", out var px))
         {
-            Assert.NotNull(row.ReferencePrice);
-            Assert.Equal(px, row.ReferencePrice);
-            Assert.Equal((px - 30m) * 50, row.Unrealized);
+            var unr = Assert.Single(body.Unrealized);
+            Assert.Equal("PETR4", unr.Symbol);
+            Assert.Equal(50, unr.Position);
+            Assert.Equal(30m, unr.AvgPrice);
+            Assert.Equal(px, unr.RefPrice);
+            Assert.Equal((px - 30m) * 50, unr.Value);
+            Assert.Equal((px - 30m) * 50, body.TotalUnrealized);
         }
         else
         {
-            Assert.Null(row.ReferencePrice);
-            Assert.Null(row.Unrealized);
+            Assert.Empty(body.Unrealized);
+            Assert.Equal(0m, body.TotalUnrealized);
         }
     }
 }

--- a/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
@@ -97,4 +97,51 @@ public class PnlEndpointTests : IClassFixture<TestAppFactory>
             Assert.Equal(0m, body.TotalUnrealized);
         }
     }
+
+    [Fact]
+    public void PnlProjection_OmitsUnknownBasisPositions_FromUnrealizedArray()
+    {
+        // Pass-4 (#278) P1#2 — unknown-basis legacy positions carry
+        // no usable AverageEntryPrice, so the projection must NOT
+        // publish phantom unrealized for them on either /pnl/today
+        // (REST) or pnl.me (WS — both share PnlProjection.Build).
+        // Symbols WITH a real basis are still surfaced; the
+        // unknown-basis symbol is simply absent from the unrealized
+        // array, and its (zero) contribution is excluded from the
+        // total.
+        var owner = new EndClientId("alice");
+        var positions = new PositionKeeper();
+        // Real basis: open 100 @ 30.
+        positions.ApplyFill(owner, "PETR4", OrderSide.Buy, 100, 30m);
+        // Legacy zero-basis position: ApplyFill with 0 price seeds
+        // a degenerate AverageEntryPrice, mimicking the pass-2
+        // restore that produced the bug.
+        positions.ApplyFill(owner, "VALE3", OrderSide.Buy, 50, 0m);
+
+        var pnl = new PnlKeeper();
+        pnl.ApplyFillToAvgCost(owner.Value, "PETR4", OrderSide.Buy, 100, 30m);
+        // Mark VALE3 as unknown-basis via the legacy seed path.
+        pnl.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new Application.Persistence.PositionSnapshot(owner.Value, "VALE3", 50, 0m),
+        });
+        Assert.Equal(50, pnl.GetUnknownBasisQty(owner.Value, "VALE3"));
+
+        var refPrice = new StubAllPrices(35m);
+
+        var dto = PnlProjection.Build(owner, pnl, positions, refPrice);
+
+        var unr = Assert.Single(dto.Unrealized);
+        Assert.Equal("PETR4", unr.Symbol);
+        Assert.Equal((35m - 30m) * 100, unr.Value);
+        Assert.Equal(unr.Value, dto.TotalUnrealized);
+        Assert.DoesNotContain(dto.Unrealized, e => e.Symbol == "VALE3");
+    }
+
+    private sealed class StubAllPrices : IReferencePrice
+    {
+        private readonly decimal _px;
+        public StubAllPrices(decimal px) => _px = px;
+        public bool TryGet(string symbol, out decimal price) { price = _px; return true; }
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -1,0 +1,105 @@
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Pass-1 review (#278) P1#3. Regression coverage for the
+/// refprice → <c>pnl.me</c> WS fan-out: a subscriber holding a
+/// position in a symbol must receive a fresh <see cref="PnlTodayDto"/>
+/// delta when the symbol's reference price changes, even with no fill
+/// in between.
+/// </summary>
+public class PnlRefPriceFanOutTests
+{
+    private sealed class StaticFallback : IReferencePrice
+    {
+        public bool TryGet(string symbol, out decimal price) { price = 0m; return false; }
+    }
+
+    private sealed class FakeSubscriber : IMarketDataSubscriber
+    {
+        public event Action<MarketTrade>? Trade;
+#pragma warning disable CS0067
+        public event Action<MarketInfoSnapshot>? InfoSnapshot;
+        public event Action<MarketDataConnectionState>? ConnectionStateChanged;
+        public event Action<MarketSubscribeError>? SubscribeError;
+        public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
+        public event Action<MarketAuctionImbalance>? AuctionImbalance;
+        public event Action<MarketAuctionPrint>? AuctionPrint;
+#pragma warning restore CS0067
+
+        public MarketDataConnectionState State => MarketDataConnectionState.Connected;
+        public long DroppedEventCount => 0;
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void RaiseTrade(string symbol, decimal price, DateTimeOffset ts) =>
+            Trade?.Invoke(new MarketTrade(symbol, 0UL, price, ts));
+    }
+
+    [Fact]
+    public async Task PriceChange_PublishesPnlDeltaToSubscriber()
+    {
+        var positions = new PositionKeeper();
+        var pnl = new PnlKeeper();
+        var owner = new EndClientId("alice");
+        positions.ApplyFill(owner, "PETR4", OrderSide.Buy, 100, 30m);
+        pnl.ApplyFillToAvgCost(owner.Value, "PETR4", OrderSide.Buy, 100, 30m);
+
+        var sub = new FakeSubscriber();
+        var clock = TimeProvider.System;
+        var refPrice = new MarketDataReferencePrice(
+            sub,
+            new StaticFallback(),
+            Options.Create(new MarketDataOptions { WsUrl = "ws://test", Symbols = Array.Empty<string>() }),
+            clock,
+            NullLogger<MarketDataReferencePrice>.Instance);
+
+        var subs = new SubscriptionManager(new WorkingOrderBook(), positions, new AlgoBook(), pnl, refPrice);
+        var client = new SubscribedClient(owner, "TEST");
+        subs.Add(client);
+        subs.SubscribeWithSnapshot(client, Channels.PnlMe);
+        // Drain the snapshot frame so we only observe the delta.
+        Assert.True(client.Reader.TryRead(out _));
+
+        var fanOut = new PnlRefPriceFanOut(refPrice, subs, pnl, positions, refPrice, clock,
+            NullLogger<PnlRefPriceFanOut>.Instance);
+        await fanOut.StartAsync(CancellationToken.None);
+        try
+        {
+            // First refprice tick — should fan-out a delta.
+            sub.RaiseTrade("PETR4", 31m, DateTimeOffset.UtcNow);
+
+            // Drain background channel + publish thread; bounded wait.
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            OutboundMessage? msg = null;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (client.Reader.TryRead(out msg)) break;
+                await Task.Delay(20);
+            }
+            Assert.NotNull(msg);
+            Assert.Equal("delta", msg!.Type);
+            Assert.Equal(Channels.PnlMe, msg.Channel);
+            var dto = Assert.IsType<PnlTodayDto>(msg.Data);
+            var unr = Assert.Single(dto.Unrealized);
+            Assert.Equal("PETR4", unr.Symbol);
+            Assert.Equal(31m, unr.RefPrice);
+            Assert.Equal(100, unr.Position);
+            Assert.Equal(30m, unr.AvgPrice);
+            Assert.Equal((31m - 30m) * 100, unr.Value);
+            Assert.Equal((31m - 30m) * 100, dto.TotalUnrealized);
+        }
+        finally
+        {
+            await fanOut.StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorPnlTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorPnlTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Q2.4 (#271). Integration coverage for the P&amp;L append on the
+/// ExecutionReportProcessor live + replay paths. Mirrors the structure
+/// of <see cref="ExecutionReportProcessorFeeTests"/>.
+/// </summary>
+public class ExecutionReportProcessorPnlTests
+{
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        public ConcurrentQueue<(long Seq, WalEvent Event)> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+        public long Append(WalEvent evt)
+        {
+            var s = Interlocked.Increment(ref _seq);
+            Recorded.Enqueue((s, evt));
+            return s;
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> _) => Append(evt);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static (ExecutionReportProcessor Proc, EventDispatcher Dispatcher,
+        RecordingEventStore Store, PnlKeeper Pnl, OrderOwnershipMap Own,
+        WorkingOrderBook Book, PositionKeeper Positions) Build()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var pnl = new PnlKeeper();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, new NullSink(), new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: null,
+            feeCalculator: null,
+            feeKeeper: null,
+            dispatcher: dispatcher,
+            pnlKeeper: pnl);
+        return (proc, dispatcher, store, pnl, ownership, book, positions);
+    }
+
+    [Fact]
+    public void Live_OpeningFill_NoRealizedEvent_ButAdvancesAvgCost()
+    {
+        var (proc, dispatcher, store, pnl, ownership, book, _) = Build();
+        var owner = new EndClientId("alice");
+        book.TryAdd(new Order(1UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m));
+        ownership.Register(1UL, owner);
+
+        var er = new ExecutionReportReceivedEvent
+        {
+            ClOrdId = 1UL,
+            ExecKind = nameof(ExecKind.Fill),
+            LeavesQuantity = 0,
+            CumulativeQuantity = 100,
+            LastQuantity = 100,
+            LastPrice = 30m,
+            Synthetic = false,
+            OrigClOrdId = 0,
+        };
+        dispatcher.Dispatch(er, fanOut => proc.Apply(
+            1UL, ExecKind.Fill, 0, 100, 100, 30m, null, 0, fanOut));
+
+        // Only the ER is appended — no RealizedPnlEvent for opening fill.
+        Assert.Single(store.Recorded);
+        Assert.IsType<ExecutionReportReceivedEvent>(store.Recorded.ToArray()[0].Event);
+        var s = pnl.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(100, s.NetQuantity);
+        Assert.Equal(30m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void Live_ClosingFill_AppendsRealizedPnlEventAfterEr_AndUpdatesKeeper()
+    {
+        var (proc, dispatcher, store, pnl, ownership, book, _) = Build();
+        var owner = new EndClientId("alice");
+        book.TryAdd(new Order(1UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m));
+        ownership.Register(1UL, owner);
+
+        // Open.
+        var er1 = new ExecutionReportReceivedEvent
+        {
+            ClOrdId = 1UL,
+            ExecKind = nameof(ExecKind.Fill),
+            LeavesQuantity = 0,
+            CumulativeQuantity = 100,
+            LastQuantity = 100,
+            LastPrice = 30m,
+            Synthetic = false,
+            OrigClOrdId = 0,
+        };
+        dispatcher.Dispatch(er1, fanOut => proc.Apply(
+            1UL, ExecKind.Fill, 0, 100, 100, 30m, null, 0, fanOut));
+
+        // Close half on a separate sell order.
+        book.TryAdd(new Order(2UL, owner, "PETR4", 1UL, OrderSide.Sell, OrderType.Limit, 50, 31m));
+        ownership.Register(2UL, owner);
+        var er2 = new ExecutionReportReceivedEvent
+        {
+            ClOrdId = 2UL,
+            ExecKind = nameof(ExecKind.Fill),
+            LeavesQuantity = 0,
+            CumulativeQuantity = 50,
+            LastQuantity = 50,
+            LastPrice = 31m,
+            Synthetic = false,
+            OrigClOrdId = 0,
+        };
+        dispatcher.Dispatch(er2, fanOut => proc.Apply(
+            2UL, ExecKind.Fill, 0, 50, 50, 31m, null, 0, fanOut));
+
+        var rec = store.Recorded.ToArray();
+        // ER1, ER2, RealizedPnlEvent (ordered after its originating ER).
+        Assert.Equal(3, rec.Length);
+        Assert.IsType<ExecutionReportReceivedEvent>(rec[0].Event);
+        Assert.IsType<ExecutionReportReceivedEvent>(rec[1].Event);
+        var rpe = Assert.IsType<RealizedPnlEvent>(rec[2].Event);
+        Assert.Equal(2UL, rpe.ClOrdId);
+        Assert.Equal("2:50", rpe.ExecutionId);
+        Assert.Equal("alice", rpe.EndClientId);
+        Assert.Equal("PETR4", rpe.Symbol);
+        Assert.Equal(50m, rpe.DeltaRealized);
+        Assert.Equal(50m, rpe.RunningTotal);
+        Assert.Equal(50m, pnl.GetDayRealized("alice", "PETR4", rpe.DayKey));
+    }
+
+    [Fact]
+    public void ReplayPath_DefersSynth_NoWalAppend_FinalizeMaterialises()
+    {
+        // Replay: capture pre-fill state then defer. No durable event
+        // arrives → FinalizeReplay materialises the synth (true
+        // ER-then-crash window per #277).
+        var (proc, _, store, pnl, ownership, book, _) = Build();
+        var owner = new EndClientId("alice");
+
+        // Stage 1: open via replay (no realized).
+        book.TryAdd(new Order(10UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 100, 30m));
+        ownership.Register(10UL, owner);
+        proc.Apply(10UL, ExecKind.Fill, 0, 100, 100, 30m, null, 0, null, isReplay: true);
+
+        // Stage 2: closing fill via replay → synth pending.
+        book.TryAdd(new Order(11UL, owner, "PETR4", 1UL, OrderSide.Sell, OrderType.Limit, 50, 31m));
+        ownership.Register(11UL, owner);
+        proc.Apply(11UL, ExecKind.Fill, 0, 50, 50, 31m, null, 0, null, isReplay: true);
+
+        Assert.Empty(store.Recorded);
+        var day = DateOnly.FromDateTime(DateTime.UtcNow);
+        Assert.Equal(0m, pnl.GetDayRealized("alice", "PETR4", day));
+
+        Assert.Equal(1, pnl.FinalizeReplay());
+        Assert.Equal(50m, pnl.GetDayRealized("alice", "PETR4", day));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorPnlTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorPnlTests.cs
@@ -174,4 +174,103 @@ public class ExecutionReportProcessorPnlTests
         Assert.Equal(1, pnl.FinalizeReplay());
         Assert.Equal(50m, pnl.GetDayRealized("alice", "PETR4", day));
     }
+
+    [Fact]
+    public async Task LockOrdering_NormalAndFallbackPaths_NoDeadlock_MonotonicRunningTotal()
+    {
+        // Pass-2 review (#278) P1#1. Regression for the AB-BA
+        // deadlock the per-key lock introduced. Two threads target
+        // the same (endClient, symbol) concurrently:
+        //
+        //   Path A (normal live): EventDispatcher.Dispatch → applies
+        //     processor → nested Dispatch for RealizedPnlEvent
+        //     (reentrant on the same thread).
+        //   Path B (WAL-backpressure fallback): EventDispatcher.RunExclusive
+        //     → applies processor → nested Dispatch for
+        //     RealizedPnlEvent.
+        //
+        // Pre-fix: A holds dispatcher then takes per-key lock; B
+        // takes per-key lock first then nested Dispatch needs
+        // dispatcher → AB-BA deadlock. Post-fix: both paths take the
+        // dispatcher lock, no per-key lock, so they serialise
+        // cleanly and RealizedPnlEvent.RunningTotal is monotonic.
+        var (proc, dispatcher, store, pnl, ownership, book, _) = Build();
+        var owner = new EndClientId("alice");
+
+        // Open 1000 @ 30 so both concurrent sells realise spread.
+        book.TryAdd(new Order(1UL, owner, "PETR4", 1UL, OrderSide.Buy, OrderType.Limit, 1000, 30m));
+        ownership.Register(1UL, owner);
+        dispatcher.Dispatch(
+            new ExecutionReportReceivedEvent
+            {
+                ClOrdId = 1UL,
+                ExecKind = nameof(ExecKind.Fill),
+                LeavesQuantity = 0,
+                CumulativeQuantity = 1000,
+                LastQuantity = 1000,
+                LastPrice = 30m,
+                Synthetic = false,
+                OrigClOrdId = 0,
+            },
+            fanOut => proc.Apply(1UL, ExecKind.Fill, 0, 1000, 1000, 30m, null, 0, fanOut));
+
+        book.TryAdd(new Order(2UL, owner, "PETR4", 1UL, OrderSide.Sell, OrderType.Limit, 100, 31m));
+        ownership.Register(2UL, owner);
+        book.TryAdd(new Order(3UL, owner, "PETR4", 1UL, OrderSide.Sell, OrderType.Limit, 100, 32m));
+        ownership.Register(3UL, owner);
+
+        var ready = new ManualResetEventSlim(false);
+        Task taskA = Task.Run(() =>
+        {
+            ready.Wait();
+            // Normal live path.
+            dispatcher.Dispatch(
+                new ExecutionReportReceivedEvent
+                {
+                    ClOrdId = 2UL,
+                    ExecKind = nameof(ExecKind.Fill),
+                    LeavesQuantity = 0,
+                    CumulativeQuantity = 100,
+                    LastQuantity = 100,
+                    LastPrice = 31m,
+                    Synthetic = false,
+                    OrigClOrdId = 0,
+                },
+                fanOut => proc.Apply(2UL, ExecKind.Fill, 0, 100, 100, 31m, null, 0, fanOut));
+        });
+        Task taskB = Task.Run(() =>
+        {
+            ready.Wait();
+            // Fallback path.
+            dispatcher.RunExclusive(() =>
+                proc.Apply(3UL, ExecKind.Fill, 0, 100, 100, 32m, null, 0));
+        });
+        ready.Set();
+
+        var allDone = Task.WhenAll(taskA, taskB);
+        var completed = await Task.WhenAny(allDone, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(allDone, completed);
+        await allDone; // surface any exception
+
+        var realizedEvents = store.Recorded.ToArray()
+            .Where(r => r.Event is RealizedPnlEvent)
+            .Select(r => (RealizedPnlEvent)r.Event)
+            .ToArray();
+        // Normal path appends a RealizedPnlEvent; fallback path skips
+        // the WAL append by design (it's the backpressure branch).
+        // Either way the keeper's GetDayRealized must reflect both
+        // sells: (31-30)*100 + (32-30)*100 = 100 + 200 = 300.
+        Assert.Equal(300m, pnl.GetDayRealized("alice", "PETR4", DateOnly.FromDateTime(DateTime.UtcNow)));
+
+        // Among the events that DID get appended, RunningTotal must
+        // be monotonically non-decreasing (lock serialisation
+        // guarantees the keeper-vs-WAL view stays consistent).
+        decimal previous = decimal.MinValue;
+        foreach (var e in realizedEvents)
+        {
+            Assert.True(e.RunningTotal >= previous,
+                $"RunningTotal not monotonic: {previous} → {e.RunningTotal}");
+            previous = e.RunningTotal;
+        }
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/RecoveryAndSnapshotTests.cs
@@ -365,6 +365,51 @@ public class RecoveryAndSnapshotTests : IDisposable
     }
 
     [Fact]
+    public void StateSnapshotter_Restore_SeedsLegacyZeroBasis_FromPass2ShapedSnapshot()
+    {
+        // Pass-4 (#278) P1#1 — a pass-2-shaped snapshot has
+        // PnlAvgCost populated (the non-zero-basis rows seeded by
+        // pass-1's SeedAvgCostFromLegacyPositions) but no
+        // PnlUnknownBasis block (the field didn't exist yet). The
+        // previous gate (PnlAvgCost.Count == 0 && PnlUnknownBasis.Count == 0)
+        // refused to seed in this case, leaving zero-basis Position
+        // rows as phantom-P&L sources. Seeding must run whenever
+        // PnlUnknownBasis is empty; SeedAvgCostFromLegacyPositions
+        // is idempotent on existing _avgCost keys, so we only add
+        // _unknownBasisQty for the zero-basis rows that need it.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot("alice", "PETR4", 100, 25m), // already in PnlAvgCost
+                new PositionSnapshot("alice", "VALE3", 50, 0m),   // legacy zero-basis row
+            },
+            PnlAvgCost = { new PnlAvgCostSnapshot("alice", "PETR4", 100, 25m) },
+            // PnlUnknownBasis intentionally empty — pass-2 snapshot.
+        };
+
+        var pnl = new PnlKeeper();
+        var snapshotter = new StateSnapshotter(
+            new WorkingOrderBook(), new PositionKeeper(), new KillSwitchService(),
+            new SymbolHaltService(), new SessionPhaseService(),
+            new ClOrdIdPrefixRegistry(), new OrderOwnershipMap(), new AlgoBook(),
+            new AlgoIdRegistry(), new CashLedger(),
+            pnlKeeper: pnl);
+        snapshotter.Restore(snap);
+
+        // Existing PnlAvgCost row preserved, zero-basis row tracked
+        // as unknown.
+        var known = pnl.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(100, known.NetQuantity);
+        Assert.Equal(25m, known.AvgPrice);
+        Assert.Equal(50, pnl.GetUnknownBasisQty("alice", "VALE3"));
+
+        // Next sell on the unknown leg realises 0 (not phantom).
+        Assert.Equal(0m, pnl.ApplyFillToAvgCost("alice", "VALE3", OrderSide.Sell, 50, 33m));
+    }
+
+    [Fact]
     public void EventReplayer_AdvancesClOrdIdWatermark_FromOrderSubmittedAndReplaceAndEr()
     {
         // #157 — full coverage: OrderSubmittedEvent, OrderReplaceRequestedEvent

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -282,16 +282,20 @@ public class PnlKeeperTests
         // zero AverageEntryPrice is degenerate: seeding it would
         // book the next sell as realized = sellPrice * qty against
         // a zero basis, surfacing phantom realized P&L on first
-        // close after restore. Guard skips the row so the keeper
-        // simply has no basis until a fresh fill establishes one.
+        // close after restore. Pass-3 (#278) tracks the qty as
+        // "unknown basis" instead of dropping it on the floor —
+        // GetAvgCost still returns null for the key (no usable
+        // basis), but ApplyFillToAvgCost realises 0 against the
+        // tracked unknown leg instead of opening a synthetic short
+        // at the sell price.
         var k = new PnlKeeper();
         k.Restore(
             new Dictionary<string, decimal>(),
             Array.Empty<PnlAvgCostSnapshot>());
         var positions = new[]
         {
-            new PositionSnapshot("alice", "PETR4", 100, 0m),  // zero basis, skipped
-            new PositionSnapshot("bob", "VALE3", -50, 0m),    // zero basis, skipped
+            new PositionSnapshot("alice", "PETR4", 100, 0m),  // zero basis, unknown
+            new PositionSnapshot("bob", "VALE3", -50, 0m),    // zero basis, unknown
             new PositionSnapshot("carol", "ITSA4", 75, 12m),  // valid basis, seeded
         };
 
@@ -299,15 +303,165 @@ public class PnlKeeperTests
         Assert.Equal(1, seeded);
         Assert.Null(k.GetAvgCost("alice", "PETR4"));
         Assert.Null(k.GetAvgCost("bob", "VALE3"));
+        Assert.Equal(100, k.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Equal(-50, k.GetUnknownBasisQty("bob", "VALE3"));
         var c = k.GetAvgCost("carol", "ITSA4")!;
         Assert.Equal(75, c.NetQuantity);
         Assert.Equal(12m, c.AvgPrice);
 
-        // The next sell on a skipped key opens fresh at the fill
-        // price (no pre-existing basis tracker entry → opening fill
-        // path), so realized = 0 — i.e. no phantom P&L is booked.
+        // The next sell on a tracked-unknown key realises 0 — it
+        // closes against the unknown leg, not against an invented
+        // basis. (Previously it would have opened a synthetic
+        // short at the sell price and surfaced phantom P&L on
+        // subsequent fills.)
         var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 50, 31m);
         Assert.Equal(0m, realized);
         Assert.Equal(0m, k.GetDayRealized("alice", "PETR4", Day));
+        Assert.Equal(50, k.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Null(k.GetAvgCost("alice", "PETR4"));
+    }
+
+    [Fact]
+    public void LegacyZeroBasisSnapshot_FirstSell_RealizesZero_NotPhantom()
+    {
+        // Sanity guard for the Pass-3 (#278) P1 fix. A legacy
+        // long position with no carried basis must NOT book any
+        // realized P&L on the first close — it closes against the
+        // unknown leg.
+        var k = new PnlKeeper();
+        k.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),
+        });
+
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 40, 31m);
+        Assert.Equal(0m, realized);
+        Assert.Equal(60, k.GetUnknownBasisQty("alice", "PETR4"));
+    }
+
+    [Fact]
+    public void LegacyZeroBasisSnapshot_BuyAfterPartialSell_DoesNotRealizePhantom()
+    {
+        // Pass-3 (#278) P1 — sell partial → buy more → sell again.
+        // All fills against the unknown leg realise 0; only after
+        // the unknown leg goes flat does a real basis form, and
+        // only after that real basis forms can a close realise a
+        // non-zero spread.
+        var k = new PnlKeeper();
+        k.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),
+        });
+
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 30, 32m));
+        Assert.Equal(70, k.GetUnknownBasisQty("alice", "PETR4"));
+
+        // Same-side add to the unknown leg — still unknown, still 0.
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 20, 33m));
+        Assert.Equal(90, k.GetUnknownBasisQty("alice", "PETR4"));
+
+        // Sell back down — still unknown, still 0.
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 40, 34m));
+        Assert.Equal(50, k.GetUnknownBasisQty("alice", "PETR4"));
+
+        Assert.Null(k.GetAvgCost("alice", "PETR4"));
+        Assert.Equal(0m, k.GetDayRealized("alice", "PETR4", Day));
+    }
+
+    [Fact]
+    public void LegacyZeroBasisSnapshot_FullCloseAndReopen_EstablishesBasisFromFirstFreshFill()
+    {
+        // Pass-3 (#278) P1 — close to flat, then a new buy → next
+        // sell realises correctly using the fresh basis.
+        var k = new PnlKeeper();
+        k.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),
+        });
+
+        // Close the unknown leg fully — realise 0.
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 100, 31m));
+        Assert.Equal(0, k.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Null(k.GetAvgCost("alice", "PETR4"));
+
+        // Fresh open at a known price.
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 50, 28m));
+        var s = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(50, s.NetQuantity);
+        Assert.Equal(28m, s.AvgPrice);
+
+        // Now a sell at 30 realises (30-28)*40 = 80 against the fresh basis.
+        Assert.Equal(80m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 40, 30m));
+    }
+
+    [Fact]
+    public void LegacyZeroBasisSnapshot_SignFlip_TreatsResidualAsFreshOpen()
+    {
+        // Pass-3 (#278) P1 — long 100 unknown basis + sell 150 →
+        // realised 0 for the 100 closed against the unknown leg,
+        // residual 50 short opens at the fill price as a KNOWN
+        // basis. Next buy then realises against that fresh basis.
+        var k = new PnlKeeper();
+        k.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),
+        });
+
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 150, 31m));
+        Assert.Equal(0, k.GetUnknownBasisQty("alice", "PETR4"));
+        var s = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(-50, s.NetQuantity);
+        Assert.Equal(31m, s.AvgPrice);
+
+        // Buy back the 50 short @ 29 → short profit (31-29)*50 = 100.
+        Assert.Equal(100m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 50, 29m));
+    }
+
+    [Fact]
+    public void UnknownBasis_RoundTripsThroughSnapshotRestore()
+    {
+        // Pass-3 (#278) P1 — the unknown-basis set must be
+        // persisted alongside the avg-cost block so a snapshot+tail
+        // recovery doesn't re-skip and re-introduce the phantom-
+        // P&L bug on every restart. Mid-recovery state must match
+        // a single-pass recovery.
+        var src = new PnlKeeper();
+        src.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),
+            new PositionSnapshot("bob", "VALE3", -50, 0m),
+            new PositionSnapshot("carol", "ITSA4", 200, 12m), // known basis
+        });
+        // Mutate the unknown leg before snapshotting.
+        src.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 30, 32m); // unknown 70
+
+        var avg = src.RawSnapshotAvgCost();
+        var unknown = src.RawSnapshotUnknownBasis();
+        var realized = src.RawSnapshotRealized();
+        var seen = src.RawSnapshotSeenIds();
+
+        var avgList = avg.Select(a => new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice));
+        var unknownList = unknown.Select(u => new PnlUnknownBasisSnapshot(u.EndClientId, u.Symbol, u.NetQuantity));
+        var realizedDict = realized.ToDictionary(
+            r => PnlKeeper.FormatRealizedKey(r.EndClientId, r.Symbol, r.Day),
+            r => r.Realized);
+
+        var dst = new PnlKeeper();
+        dst.Restore(realizedDict, avgList, seen, unknownList);
+
+        Assert.Equal(70, dst.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Equal(-50, dst.GetUnknownBasisQty("bob", "VALE3"));
+        Assert.Null(dst.GetAvgCost("alice", "PETR4"));
+        Assert.Null(dst.GetAvgCost("bob", "VALE3"));
+        var c = dst.GetAvgCost("carol", "ITSA4")!;
+        Assert.Equal(200, c.NetQuantity);
+        Assert.Equal(12m, c.AvgPrice);
+
+        // A fill on the restored unknown leg still realises 0 —
+        // i.e. the post-restore behaviour matches the live
+        // pre-snapshot state.
+        Assert.Equal(0m, dst.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 70, 33m));
+        Assert.Equal(0, dst.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Null(dst.GetAvgCost("alice", "PETR4"));
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -464,4 +464,62 @@ public class PnlKeeperTests
         Assert.Equal(0, dst.GetUnknownBasisQty("alice", "PETR4"));
         Assert.Null(dst.GetAvgCost("alice", "PETR4"));
     }
+
+    [Fact]
+    public void Restore_PrefersUnknownBasis_WhenSnapshotCarriesBothBlocks()
+    {
+        // Pass-4 (#278) P2#3 — a malformed snapshot containing the
+        // same key in BOTH PnlAvgCost and PnlUnknownBasis must not
+        // leave a stale avg-cost entry that would resurface after
+        // the unknown leg fully closes and silently realise phantom
+        // P&L on the next fill. Restore enforces mutual exclusivity
+        // by dropping the avg-cost entry (prefer unknown) and
+        // bumping the basis_inconsistent metric.
+        var dst = new PnlKeeper();
+        var avgList = new[] { new PnlAvgCostSnapshot("alice", "PETR4", 100, 25m) };
+        var unknownList = new[] { new PnlUnknownBasisSnapshot("alice", "PETR4", 100) };
+        dst.Restore(new Dictionary<string, decimal>(), avgList, null, unknownList);
+
+        // Avg-cost for the duplicated key was dropped; unknown wins.
+        Assert.Null(dst.GetAvgCost("alice", "PETR4"));
+        Assert.Equal(100, dst.GetUnknownBasisQty("alice", "PETR4"));
+
+        // Closing the unknown leg fully realises 0 — and there is
+        // no stale avg-cost entry left behind to corrupt subsequent
+        // fills.
+        Assert.Equal(0m, dst.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 100, 30m));
+        Assert.Equal(0, dst.GetUnknownBasisQty("alice", "PETR4"));
+        Assert.Null(dst.GetAvgCost("alice", "PETR4"));
+
+        // A fresh fill after the leg goes flat establishes a real
+        // basis at the fill price (not invented from the prior
+        // stale avg).
+        Assert.Equal(0m, dst.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 50, 40m));
+        var s = dst.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(50, s.NetQuantity);
+        Assert.Equal(40m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void Restore_LeavesDisjointKeysUntouched()
+    {
+        // Pass-4 (#278) P2#3 — the dedup pass must only affect keys
+        // that appear in BOTH dicts; non-overlapping rows are
+        // preserved exactly.
+        var dst = new PnlKeeper();
+        var avgList = new[]
+        {
+            new PnlAvgCostSnapshot("alice", "PETR4", 100, 25m),
+            new PnlAvgCostSnapshot("bob", "VALE3", -50, 60m),
+        };
+        var unknownList = new[]
+        {
+            new PnlUnknownBasisSnapshot("carol", "ITSA4", 200),
+        };
+        dst.Restore(new Dictionary<string, decimal>(), avgList, null, unknownList);
+
+        Assert.Equal(100, dst.GetAvgCost("alice", "PETR4")!.NetQuantity);
+        Assert.Equal(-50, dst.GetAvgCost("bob", "VALE3")!.NetQuantity);
+        Assert.Equal(200, dst.GetUnknownBasisQty("carol", "ITSA4"));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -276,68 +276,38 @@ public class PnlKeeperTests
     }
 
     [Fact]
-    public async Task ApplyFillUnderLock_SerialisesConcurrentFillsForSameKey()
+    public void SeedAvgCostFromLegacyPositions_SkipsZeroAvgPriceRows()
     {
-        // Pass-1 review (#278) P1#2. Two concurrent fills for the
-        // same (endClient, symbol) must not race the running-total
-        // computation. The per-key lock guarantees that the realized
-        // delta and running total observed by each callback are
-        // consistent with the in-memory state visible at the time of
-        // the lock acquisition.
+        // Pass-2 review (#278) P1#2. A non-flat position row with a
+        // zero AverageEntryPrice is degenerate: seeding it would
+        // book the next sell as realized = sellPrice * qty against
+        // a zero basis, surfacing phantom realized P&L on first
+        // close after restore. Guard skips the row so the keeper
+        // simply has no basis until a fresh fill establishes one.
         var k = new PnlKeeper();
-        // Open 1000 @ 30 so both concurrent sells realise spread.
-        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 1000, 30m);
+        k.Restore(
+            new Dictionary<string, decimal>(),
+            Array.Empty<PnlAvgCostSnapshot>());
+        var positions = new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 0m),  // zero basis, skipped
+            new PositionSnapshot("bob", "VALE3", -50, 0m),    // zero basis, skipped
+            new PositionSnapshot("carol", "ITSA4", 75, 12m),  // valid basis, seeded
+        };
 
-        var observed = new System.Collections.Concurrent.ConcurrentBag<(decimal Delta, decimal Running)>();
-        var t1 = Task.Run(() => k.ApplyFillUnderLock(
-            "alice", "PETR4", OrderSide.Sell, 100, 31m, Day,
-            ctx =>
-            {
-                observed.Add((ctx.RealizedDelta, ctx.RunningTotal));
-                k.Apply(new RealizedPnlEvent
-                {
-                    ClOrdId = 1,
-                    ExecutionId = "1:100",
-                    EndClientId = "alice",
-                    Symbol = "PETR4",
-                    DayKey = Day,
-                    DeltaRealized = ctx.RealizedDelta,
-                    RunningTotal = ctx.RunningTotal,
-                    TimestampUtc = Ts,
-                });
-            }));
-        var t2 = Task.Run(() => k.ApplyFillUnderLock(
-            "alice", "PETR4", OrderSide.Sell, 100, 32m, Day,
-            ctx =>
-            {
-                observed.Add((ctx.RealizedDelta, ctx.RunningTotal));
-                k.Apply(new RealizedPnlEvent
-                {
-                    ClOrdId = 2,
-                    ExecutionId = "2:100",
-                    EndClientId = "alice",
-                    Symbol = "PETR4",
-                    DayKey = Day,
-                    DeltaRealized = ctx.RealizedDelta,
-                    RunningTotal = ctx.RunningTotal,
-                    TimestampUtc = Ts,
-                });
-            }));
-        await Task.WhenAll(t1, t2);
+        var seeded = k.SeedAvgCostFromLegacyPositions(positions);
+        Assert.Equal(1, seeded);
+        Assert.Null(k.GetAvgCost("alice", "PETR4"));
+        Assert.Null(k.GetAvgCost("bob", "VALE3"));
+        var c = k.GetAvgCost("carol", "ITSA4")!;
+        Assert.Equal(75, c.NetQuantity);
+        Assert.Equal(12m, c.AvgPrice);
 
-        // Realised: (31-30)*100 = 100 and (32-30)*100 = 200. The
-        // observed (delta, running) pairs depend on lock acquisition
-        // order, but the invariants are: sum of deltas = 300; the
-        // larger running equals 300; the smaller running equals the
-        // delta of the fill that won the lock first; the keeper's
-        // final GetDayRealized must be 300.
-        var ordered = observed.OrderBy(o => o.Running).ToArray();
-        Assert.Equal(2, ordered.Length);
-        Assert.Equal(ordered[0].Delta, ordered[0].Running); // first under lock
-        Assert.Equal(300m, ordered[1].Running);
-        Assert.Equal(300m, ordered[0].Delta + ordered[1].Delta);
-        Assert.Contains(ordered, o => o.Delta == 100m);
-        Assert.Contains(ordered, o => o.Delta == 200m);
-        Assert.Equal(300m, k.GetDayRealized("alice", "PETR4", Day));
+        // The next sell on a skipped key opens fresh at the fill
+        // price (no pre-existing basis tracker entry → opening fill
+        // path), so realized = 0 — i.e. no phantom P&L is booked.
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 50, 31m);
+        Assert.Equal(0m, realized);
+        Assert.Equal(0m, k.GetDayRealized("alice", "PETR4", Day));
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -1,0 +1,219 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Q2.4 (#271). Unit-level coverage for <see cref="PnlKeeper"/>.
+/// End-to-end snapshot+replay coverage lives in
+/// <c>PnlKeeperRecoveryTests</c>; ER integration in
+/// <c>ExecutionReportProcessorPnlTests</c>.
+/// </summary>
+public class PnlKeeperTests
+{
+    private static readonly DateOnly Day = new(2025, 1, 15);
+    private static readonly DateTimeOffset Ts = new(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static RealizedPnlEvent Evt(ulong clOrdId, ulong cumQty, string ec, string sym, decimal delta, decimal running, DateOnly day)
+        => new()
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = clOrdId + ":" + cumQty,
+            EndClientId = ec,
+            Symbol = sym,
+            DayKey = day,
+            DeltaRealized = delta,
+            RunningTotal = running,
+            TimestampUtc = Ts,
+        };
+
+    [Fact]
+    public void Buy_Then_Buy_GrowsAvg_NoRealized()
+    {
+        var k = new PnlKeeper();
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 30m));
+        Assert.Equal(0m, k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 32m));
+        var s = k.GetAvgCost("alice", "PETR4");
+        Assert.NotNull(s);
+        Assert.Equal(200, s!.NetQuantity);
+        Assert.Equal(31m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void Buy_Then_Sell_PartialClose_RealizesAtSpread_AvgUnchanged()
+    {
+        var k = new PnlKeeper();
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 30m);
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 50, 31m);
+        Assert.Equal(50m, realized); // (31-30)*50
+        var s = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(50, s.NetQuantity);
+        Assert.Equal(30m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void Buy_Then_Sell_FlipThroughZero_ResetsAvgToFillPrice()
+    {
+        var k = new PnlKeeper();
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 30m);
+        // Sell 150 @ 31 → close 100 @ +1 = 100; remaining 50 opens short @ 31.
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 150, 31m);
+        Assert.Equal(100m, realized);
+        var s = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(-50, s.NetQuantity);
+        Assert.Equal(31m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void Short_ClosedByBuy_RealizesNegativeSpread()
+    {
+        var k = new PnlKeeper();
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 100, 30m);
+        // Buy back 50 @ 28 → short profit (30-28)*50 = 100.
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 50, 28m);
+        Assert.Equal(100m, realized);
+        var s = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(-50, s.NetQuantity);
+        Assert.Equal(30m, s.AvgPrice);
+    }
+
+    [Fact]
+    public void ComputeRealizedDelta_ZeroPosition_ReturnsZero()
+        => Assert.Equal(0m, PnlKeeper.ComputeRealizedDelta(0, 0m, OrderSide.Sell, 50, 30m));
+
+    [Fact]
+    public void ComputeRealizedDelta_SameSide_ReturnsZero()
+        => Assert.Equal(0m, PnlKeeper.ComputeRealizedDelta(100, 30m, OrderSide.Buy, 50, 31m));
+
+    [Fact]
+    public void Apply_AdvancesDayTotal()
+    {
+        var k = new PnlKeeper();
+        Assert.True(k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day)));
+        Assert.True(k.Apply(Evt(2, 50, "alice", "PETR4", 30m, 80m, Day)));
+        Assert.Equal(80m, k.GetDayRealized("alice", "PETR4", Day));
+        Assert.Equal(80m, k.GetDayRealizedTotal("alice", Day));
+    }
+
+    [Fact]
+    public void Apply_CrossDay_BucketsSeparately()
+    {
+        var k = new PnlKeeper();
+        var d2 = new DateOnly(2025, 1, 16);
+        k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day));
+        k.Apply(Evt(2, 50, "alice", "PETR4", 7m, 7m, d2));
+        Assert.Equal(50m, k.GetDayRealized("alice", "PETR4", Day));
+        Assert.Equal(7m, k.GetDayRealized("alice", "PETR4", d2));
+    }
+
+    [Fact]
+    public void Apply_CrossSymbol_BucketsSeparately()
+    {
+        var k = new PnlKeeper();
+        k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day));
+        k.Apply(Evt(2, 50, "alice", "VALE3", 30m, 30m, Day));
+        Assert.Equal(50m, k.GetDayRealized("alice", "PETR4", Day));
+        Assert.Equal(30m, k.GetDayRealized("alice", "VALE3", Day));
+        Assert.Equal(80m, k.GetDayRealizedTotal("alice", Day));
+    }
+
+    [Fact]
+    public void Apply_DuplicateExecutionId_Idempotent()
+    {
+        var k = new PnlKeeper();
+        var e = Evt(1, 50, "alice", "PETR4", 50m, 50m, Day);
+        Assert.True(k.Apply(e));
+        Assert.False(k.Apply(e));
+        Assert.Equal(50m, k.GetDayRealized("alice", "PETR4", Day));
+    }
+
+    [Fact]
+    public void Apply_UsesRunningTotal_NotDelta()
+    {
+        // Snapshot+tail recovery: the snapshot baked in 100 already,
+        // and the tail event reports running=130 / delta=30. After
+        // Apply we must report 130, not 100+30 (would be the same here
+        // by coincidence) — and not "previous + delta" if previous
+        // started from a different baseline.
+        var k = new PnlKeeper();
+        // Pretend snapshot restored 200.
+        k.Restore(
+            new Dictionary<string, decimal> { [PnlKeeper.FormatRealizedKey("alice", "PETR4", Day)] = 200m },
+            Array.Empty<PnlAvgCostSnapshot>());
+        // Tail reapplies an event whose running is the authoritative 130.
+        Assert.True(k.Apply(Evt(1, 50, "alice", "PETR4", 30m, 130m, Day)));
+        Assert.Equal(130m, k.GetDayRealized("alice", "PETR4", Day));
+    }
+
+    [Fact]
+    public void Snapshot_Restore_RoundTrips()
+    {
+        var src = new PnlKeeper();
+        src.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 30m);
+        src.ApplyFillToAvgCost("alice", "VALE3", OrderSide.Sell, 50, 60m);
+        src.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day));
+
+        var realized = src.RawSnapshotRealized();
+        var avg = src.RawSnapshotAvgCost();
+        var seen = src.RawSnapshotSeenIds();
+        var dict = realized.ToDictionary(
+            r => PnlKeeper.FormatRealizedKey(r.EndClientId, r.Symbol, r.Day),
+            r => r.Realized);
+        var avgList = avg.Select(a => new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice));
+
+        var dst = new PnlKeeper();
+        dst.Restore(dict, avgList, seen);
+
+        Assert.Equal(50m, dst.GetDayRealized("alice", "PETR4", Day));
+        var ap = dst.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(100, ap.NetQuantity);
+        Assert.Equal(30m, ap.AvgPrice);
+        var av = dst.GetAvgCost("alice", "VALE3")!;
+        Assert.Equal(-50, av.NetQuantity);
+        Assert.Equal(60m, av.AvgPrice);
+        // Seen-set survived.
+        Assert.False(dst.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day)));
+    }
+
+    [Fact]
+    public void RawSnapshotAvgCost_SkipsFlat()
+    {
+        var k = new PnlKeeper();
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 100, 31m);
+        Assert.Empty(k.RawSnapshotAvgCost());
+    }
+
+    [Fact]
+    public void FormatRealizedKey_ParsesBack()
+    {
+        var key = PnlKeeper.FormatRealizedKey("alice", "PETR4", Day);
+        Assert.True(PnlKeeper.TryParseRealizedKey(key, out var ec, out var sym, out var d));
+        Assert.Equal("alice", ec);
+        Assert.Equal("PETR4", sym);
+        Assert.Equal(Day, d);
+    }
+
+    [Fact]
+    public void FinalizeReplay_NoSurvivors_WhenAllReconciled()
+    {
+        var k = new PnlKeeper();
+        k.RegisterPendingReplaySynth("1:50", "alice", "PETR4", OrderSide.Sell, 50, 31m, Ts, 100, 30m);
+        // A durable event matching the same execution arrives in WAL drain.
+        k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day));
+        Assert.Equal(0, k.FinalizeReplay());
+        Assert.Equal(50m, k.GetDayRealized("alice", "PETR4", Day));
+    }
+
+    [Fact]
+    public void FinalizeReplay_MaterialisesSurvivors_FromPreFillSnapshot()
+    {
+        var k = new PnlKeeper();
+        k.RegisterPendingReplaySynth("1:50", "alice", "PETR4", OrderSide.Sell, 50, 31m, Ts, 100, 30m);
+        Assert.Equal(1, k.FinalizeReplay());
+        Assert.Equal(50m, k.GetDayRealized("alice", "PETR4", Day));
+        // Idempotent: surviving execution id is now in the seen-set.
+        Assert.False(k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day)));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -216,4 +216,128 @@ public class PnlKeeperTests
         // Idempotent: surviving execution id is now in the seen-set.
         Assert.False(k.Apply(Evt(1, 50, "alice", "PETR4", 50m, 50m, Day)));
     }
+
+    [Fact]
+    public void SeedAvgCostFromLegacyPositions_FillsBasis_WhenPnlAvgCostEmpty()
+    {
+        // Pass-1 review (#278) P1#1. Legacy snapshot scenario:
+        // PnlAvgCost block is empty (pre-#271 snapshot) but Positions
+        // has rows. The next sell on PETR4 must realise against the
+        // basis carried by PositionSnapshot.AverageEntryPrice.
+        var k = new PnlKeeper();
+        k.Restore(
+            new Dictionary<string, decimal>(),
+            Array.Empty<PnlAvgCostSnapshot>());
+        var positions = new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 30m),
+            new PositionSnapshot("bob", "VALE3", -50, 60m),
+            new PositionSnapshot("carol", "ITSA4", 0, 0m), // flat skipped
+        };
+
+        var seeded = k.SeedAvgCostFromLegacyPositions(positions);
+        Assert.Equal(2, seeded);
+
+        var ap = k.GetAvgCost("alice", "PETR4")!;
+        Assert.Equal(100, ap.NetQuantity);
+        Assert.Equal(30m, ap.AvgPrice);
+        var bp = k.GetAvgCost("bob", "VALE3")!;
+        Assert.Equal(-50, bp.NetQuantity);
+        Assert.Equal(60m, bp.AvgPrice);
+        Assert.Null(k.GetAvgCost("carol", "ITSA4"));
+
+        // Selling 50 of PETR4 @ 31 must now realise the (31-30)*50 = 50
+        // spread against the seeded basis — without the seed the
+        // realised value would be silently zero.
+        var realized = k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Sell, 50, 31m);
+        Assert.Equal(50m, realized);
+    }
+
+    [Fact]
+    public void SeedAvgCostFromLegacyPositions_PreservesExistingPnlAvgCost()
+    {
+        // Snapshot already has PnlAvgCost rows — the legacy seed must
+        // be a no-op for those keys (PnlKeeper's own block is
+        // authoritative when present).
+        var k = new PnlKeeper();
+        k.Restore(
+            new Dictionary<string, decimal>(),
+            new[] { new PnlAvgCostSnapshot("alice", "PETR4", 100, 25m) });
+
+        var seeded = k.SeedAvgCostFromLegacyPositions(new[]
+        {
+            new PositionSnapshot("alice", "PETR4", 100, 30m), // mismatched basis
+            new PositionSnapshot("alice", "VALE3", 200, 40m), // not in PnlAvgCost
+        });
+
+        Assert.Equal(1, seeded);
+        Assert.Equal(25m, k.GetAvgCost("alice", "PETR4")!.AvgPrice);
+        Assert.Equal(40m, k.GetAvgCost("alice", "VALE3")!.AvgPrice);
+    }
+
+    [Fact]
+    public async Task ApplyFillUnderLock_SerialisesConcurrentFillsForSameKey()
+    {
+        // Pass-1 review (#278) P1#2. Two concurrent fills for the
+        // same (endClient, symbol) must not race the running-total
+        // computation. The per-key lock guarantees that the realized
+        // delta and running total observed by each callback are
+        // consistent with the in-memory state visible at the time of
+        // the lock acquisition.
+        var k = new PnlKeeper();
+        // Open 1000 @ 30 so both concurrent sells realise spread.
+        k.ApplyFillToAvgCost("alice", "PETR4", OrderSide.Buy, 1000, 30m);
+
+        var observed = new System.Collections.Concurrent.ConcurrentBag<(decimal Delta, decimal Running)>();
+        var t1 = Task.Run(() => k.ApplyFillUnderLock(
+            "alice", "PETR4", OrderSide.Sell, 100, 31m, Day,
+            ctx =>
+            {
+                observed.Add((ctx.RealizedDelta, ctx.RunningTotal));
+                k.Apply(new RealizedPnlEvent
+                {
+                    ClOrdId = 1,
+                    ExecutionId = "1:100",
+                    EndClientId = "alice",
+                    Symbol = "PETR4",
+                    DayKey = Day,
+                    DeltaRealized = ctx.RealizedDelta,
+                    RunningTotal = ctx.RunningTotal,
+                    TimestampUtc = Ts,
+                });
+            }));
+        var t2 = Task.Run(() => k.ApplyFillUnderLock(
+            "alice", "PETR4", OrderSide.Sell, 100, 32m, Day,
+            ctx =>
+            {
+                observed.Add((ctx.RealizedDelta, ctx.RunningTotal));
+                k.Apply(new RealizedPnlEvent
+                {
+                    ClOrdId = 2,
+                    ExecutionId = "2:100",
+                    EndClientId = "alice",
+                    Symbol = "PETR4",
+                    DayKey = Day,
+                    DeltaRealized = ctx.RealizedDelta,
+                    RunningTotal = ctx.RunningTotal,
+                    TimestampUtc = Ts,
+                });
+            }));
+        await Task.WhenAll(t1, t2);
+
+        // Realised: (31-30)*100 = 100 and (32-30)*100 = 200. The
+        // observed (delta, running) pairs depend on lock acquisition
+        // order, but the invariants are: sum of deltas = 300; the
+        // larger running equals 300; the smaller running equals the
+        // delta of the fill that won the lock first; the keeper's
+        // final GetDayRealized must be 300.
+        var ordered = observed.OrderBy(o => o.Running).ToArray();
+        Assert.Equal(2, ordered.Length);
+        Assert.Equal(ordered[0].Delta, ordered[0].Running); // first under lock
+        Assert.Equal(300m, ordered[1].Running);
+        Assert.Equal(300m, ordered[0].Delta + ordered[1].Delta);
+        Assert.Contains(ordered, o => o.Delta == 100m);
+        Assert.Contains(ordered, o => o.Delta == 200m);
+        Assert.Equal(300m, k.GetDayRealized("alice", "PETR4", Day));
+    }
 }


### PR DESCRIPTION
Closes #271

## Summary

Q2.4 P&L engine. Mirrors the FeeKeeper (#270) snapshot/replay shape, with an avg-cost basis tracker added so realized P&L can be computed off the pre-fill state.

### Realized P&L (durable)
- Every closing/flipping fill emits a `RealizedPnlEvent` (in WAL order, after its originating ER) carrying the day-bucketed running total.
- `PnlKeeper` projects the events; persisted `RunningTotal` is authoritative on `Apply` so snapshot+tail recovery converges on the written value even if the avg-cost projection drifts.
- Replay follows the FeeKeeper crash-window pattern: pending synth registered under the pre-fill (qty, avg) snapshot, durable event supersedes via `Apply` (reconciled=true), `FinalizeReplay` materialises survivors (reconciled=false).

### Unrealized P&L (derived)
- Computed on the fly from `PositionKeeper` + `IReferencePrice`. Never persisted (the inputs move every tick).
- Symbols whose ref-price lookup misses are omitted from the unrealized list to keep totals honest; they still appear in the realized list when active.

### Surfaces
- `GET /pnl/today` — JWT `sub` is the end-client (same auth shape as `/positions`, `/balance`).
- WS channel `pnl.me` — snapshot on subscribe, delta on every fill (via `WebSocketExecutionEventSink`). REST + WS share `PnlProjection.Build` so numbers match exactly.

### ER processor wiring
Apply order: positions → cash → fees → **pnl** → margin (P&L derives from position state changes; margin release runs last). Same WAL-backpressure swallow policy as fees.

### Metrics
- `trading.pnl.realized_appended`
- `trading.pnl.replay_synth{reconciled=true|false}`
- `trading.pnl.endpoint_requests`

### Tests
- `PnlKeeperTests` (16): avg-cost math (open / partial close / flip / short), idempotence, cross-day, snapshot round-trip, replay synth reconcile + materialise.
- `ExecutionReportProcessorPnlTests` (3): live opening fill emits no event, live closing fill appends after ER + updates keeper, replay defers + finalize materialises.
- `PnlEndpointTests` (3): unauth 401, fresh account empty, after-fill projection.
- All 1313 existing + new tests pass; `dotnet format --verify-no-changes` clean.