### PR TITLE
feat(#272): daily statement generator (JSON + CSV) + IR day-trade pre-calc

### DIFF
--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -1,0 +1,227 @@
+using System.Globalization;
+using System.Security.Claims;
+using System.Text;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// Q2.5 (#272). Daily statement endpoints — JSON and CSV — projected on
+/// demand from the WAL plus the live <see cref="PositionKeeper"/> for
+/// the intraday-today path.
+///
+/// <list type="bullet">
+///   <item><c>GET /statement/{dayKey?}</c> — JSON. Default
+///   <c>dayKey</c> is today (UTC).</item>
+///   <item><c>GET /statement/{dayKey}.csv</c> — same projection as a
+///   multi-section UTF-8 BOM CSV (Excel-friendly).</item>
+/// </list>
+///
+/// <para>
+/// The economic logic lives in <see cref="StatementProjection"/> so the
+/// HTTP layer here is only responsible for: auth resolution, dayKey
+/// parsing/validation, draining the WAL writer, and rendering. Both
+/// routes share the same projection call so JSON and CSV cannot drift.
+/// </para>
+/// </summary>
+public static class StatementEndpoints
+{
+    public static IEndpointRouteBuilder MapStatement(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/statement/{dayKey?}", [Authorize] async (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            IEventStore store,
+            PositionKeeper positions,
+            string? dayKey,
+            CancellationToken ct) =>
+        {
+            if (!TryResolveDay(dayKey, out var day, out var error))
+                return error!;
+            var owner = ResolveOwner(ctx, registry);
+            Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
+                1, new KeyValuePair<string, object?>("format", "json"));
+            var dto = await BuildAsync(owner, day, store, positions, ct);
+            EmitDayTradeMetric(dto);
+            return Results.Ok(dto);
+        });
+
+        app.MapGet("/statement/{dayKey}.csv", [Authorize] async (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            IEventStore store,
+            PositionKeeper positions,
+            string dayKey,
+            CancellationToken ct) =>
+        {
+            if (!TryResolveDay(dayKey, out var day, out var error))
+                return error!;
+            var owner = ResolveOwner(ctx, registry);
+            Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
+                1, new KeyValuePair<string, object?>("format", "csv"));
+            var dto = await BuildAsync(owner, day, store, positions, ct);
+            EmitDayTradeMetric(dto);
+            var bytes = RenderCsv(dto);
+            return Results.File(
+                bytes,
+                contentType: "text/csv; charset=utf-8",
+                fileDownloadName: $"statement-{dto.DayKey}.csv");
+        });
+
+        return app;
+    }
+
+    private static async Task<DailyStatementDto> BuildAsync(
+        EndClientId owner, DateOnly day, IEventStore store, PositionKeeper positions, CancellationToken ct)
+    {
+        // Drain the writer so an event appended an instant ago is in
+        // the read view. Mirrors HistoryEndpoints' guarantee — the
+        // statement must reflect every fill the API has acknowledged.
+        await store.FlushAsync(ct);
+
+        var snapshotSeq = store.CurrentSeq;
+        var wal = new List<(long Seq, WalEvent Event)>(capacity: 256);
+        await foreach (var entry in store.ReadFromAsync(0, ct))
+        {
+            if (entry.Seq > snapshotSeq) break;
+            wal.Add(entry);
+        }
+
+        var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        // Live positions only count when the caller is asking about the
+        // CURRENT day — for past days we project positions from the WAL
+        // slice (the keeper has long since advanced past that snapshot).
+        var live = day == today ? positions : null;
+        return StatementProjection.Build(owner, day, wal, live);
+    }
+
+    private static void EmitDayTradeMetric(DailyStatementDto dto)
+    {
+        if (dto.IrDayTrade.PerSymbol.Count > 0)
+            Application.Observability.MetricsRegistry.StatementDayTradeDetected.Add(1);
+    }
+
+    private static bool TryResolveDay(string? raw, out DateOnly day, out IResult? error)
+    {
+        var todayUtc = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            day = todayUtc;
+            return true;
+        }
+        if (!DateOnly.TryParseExact(raw, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out day))
+        {
+            error = Results.BadRequest(new { error = $"invalid dayKey '{raw}' (expected YYYY-MM-DD)" });
+            return false;
+        }
+        if (day > todayUtc)
+        {
+            error = Results.NotFound(new { error = $"dayKey '{raw}' is in the future" });
+            return false;
+        }
+        return true;
+    }
+
+    private static EndClientId ResolveOwner(HttpContext ctx, EndClientRegistry registry)
+    {
+        var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                  ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
+        return registry.Register(sub);
+    }
+
+    // -----------------------------------------------------------------
+    // CSV rendering
+    // -----------------------------------------------------------------
+
+    private static readonly byte[] Utf8Bom = new byte[] { 0xEF, 0xBB, 0xBF };
+
+    private static byte[] RenderCsv(DailyStatementDto dto)
+    {
+        var sb = new StringBuilder(1024);
+
+        WriteSectionHeader(sb, "positions");
+        sb.Append("symbol,netQty,avgPrice\r\n");
+        foreach (var p in dto.Positions)
+            sb.Append(Csv(p.Symbol)).Append(',').Append(Num(p.NetQty)).Append(',').Append(Num(p.AvgPrice)).Append("\r\n");
+        sb.Append("\r\n");
+
+        WriteSectionHeader(sb, "fills");
+        sb.Append("executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc\r\n");
+        foreach (var f in dto.Fills)
+        {
+            sb.Append(Csv(f.ExecutionId)).Append(',')
+              .Append(Csv(f.ClOrdId)).Append(',')
+              .Append(Csv(f.OrderId)).Append(',')
+              .Append(Csv(f.Symbol)).Append(',')
+              .Append(Csv(f.Side)).Append(',')
+              .Append(Num(f.Quantity)).Append(',')
+              .Append(Num(f.Price)).Append(',')
+              .Append(f.TimestampUtc.ToString("O", CultureInfo.InvariantCulture))
+              .Append("\r\n");
+        }
+        sb.Append("\r\n");
+
+        WriteSectionHeader(sb, "fees");
+        sb.Append("feeType,total\r\n");
+        foreach (var fee in dto.Fees)
+            sb.Append(Csv(fee.FeeType)).Append(',').Append(Num(fee.Total)).Append("\r\n");
+        sb.Append(Csv("totalFees")).Append(',').Append(Num(dto.FeesTotal)).Append("\r\n");
+        sb.Append("\r\n");
+
+        WriteSectionHeader(sb, "pnl-summary");
+        sb.Append("metric,value\r\n");
+        sb.Append("realizedGross,").Append(Num(dto.Pnl.RealizedGross)).Append("\r\n");
+        sb.Append("totalFees,").Append(Num(dto.Pnl.TotalFees)).Append("\r\n");
+        sb.Append("realizedNet,").Append(Num(dto.Pnl.RealizedNet)).Append("\r\n");
+        sb.Append("\r\n");
+
+        WriteSectionHeader(sb, "ir-day-trade (informational)");
+        sb.Append("symbol,qtyMatched,grossProfit,taxableProfit,taxAmount\r\n");
+        foreach (var r in dto.IrDayTrade.PerSymbol)
+        {
+            sb.Append(Csv(r.Symbol)).Append(',')
+              .Append(Num(r.QtyMatched)).Append(',')
+              .Append(Num(r.GrossProfit)).Append(',')
+              .Append(Num(r.TaxableProfit)).Append(',')
+              .Append(Num(r.TaxAmount))
+              .Append("\r\n");
+        }
+        sb.Append("totalTax,,,,").Append(Num(dto.IrDayTrade.TotalTax)).Append("\r\n");
+
+        var payload = Encoding.UTF8.GetBytes(sb.ToString());
+        var withBom = new byte[Utf8Bom.Length + payload.Length];
+        Buffer.BlockCopy(Utf8Bom, 0, withBom, 0, Utf8Bom.Length);
+        Buffer.BlockCopy(payload, 0, withBom, Utf8Bom.Length, payload.Length);
+        return withBom;
+    }
+
+    private static void WriteSectionHeader(StringBuilder sb, string name) =>
+        sb.Append("# ").Append(name).Append("\r\n");
+
+    private static string Num(decimal v) => v.ToString(CultureInfo.InvariantCulture);
+    private static string Num(long v) => v.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// RFC4180-ish field escape: wrap in quotes when the value contains
+    /// a comma, quote, CR, or LF; double up internal quotes.
+    /// </summary>
+    private static string Csv(string v)
+    {
+        if (string.IsNullOrEmpty(v)) return string.Empty;
+        var needsQuote = false;
+        for (var i = 0; i < v.Length; i++)
+        {
+            var c = v[i];
+            if (c == ',' || c == '"' || c == '\r' || c == '\n') { needsQuote = true; break; }
+        }
+        if (!needsQuote) return v;
+        return "\"" + v.Replace("\"", "\"\"") + "\"";
+    }
+}

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -84,57 +84,46 @@ public static class StatementEndpoints
         EventDispatcher dispatcher, CancellationToken ct)
     {
         var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
-        long snapshotSeq;
-        IReadOnlyList<PositionRowDto>? livePositionsSnapshot;
+        var isToday = day == today;
 
-        if (day == today)
+        // Pass-2 review (#279) P1. Both today and past-day paths capture
+        // the WAL upper-bound under EventDispatcher.RunExclusive so a
+        // fill ER whose nested Fee/RealizedPnl dispatches are still
+        // mid-flight on another thread cannot split across the seq cap:
+        // the dispatcher lock guarantees the three appends land before
+        // RunExclusive's body observes CurrentSeq. Without it the past-
+        // day path could observe an ER without its matching fee/PnL —
+        // possible near UTC day rollover when a late ER timestamped
+        // "yesterday" is still being dispatched while the reader caps
+        // the WAL for yesterday's statement. Today's path additionally
+        // snapshots the live PositionKeeper rows under the same lock
+        // because the projection consumes them; past-day projection is
+        // pure WAL so we skip the keeper snapshot there. The exclusive
+        // section stays tiny — no I/O — and the WAL scan + projection
+        // run after we exit the lock.
+        long capturedSeq = 0;
+        IReadOnlyList<PositionRowDto>? capturedPositions = null;
+        dispatcher.RunExclusive(() =>
         {
-            // Pass-2 review (#279) P1. Today's statement reads three
-            // streams that the dispatcher mutates atomically per fill:
-            // the WAL (caps our scan), the PositionKeeper (live qty +
-            // avg price), and the fee/PnL events the dispatcher nests
-            // off the same fill. If we sampled them in sequence WITHOUT
-            // the dispatcher lock a new fill could land in
-            // PositionKeeper after we capped the WAL scan, producing a
-            // torn snapshot where the position reflects N+1 fills but
-            // the fills/fees/realized rows reflect only N. Capture the
-            // WAL upper-bound and the position rows under
-            // EventDispatcher.RunExclusive — the same serialisation
-            // discipline EntryPointExecutionReportRouter uses on the
-            // WAL-backpressure fallback — so the three views agree.
-            long capturedSeq = 0;
-            IReadOnlyList<PositionRowDto>? capturedPositions = null;
-            dispatcher.RunExclusive(() =>
+            capturedSeq = store.CurrentSeq;
+            if (!isToday) return;
+            var rows = new List<PositionRowDto>();
+            foreach (var p in positions.ForEndClient(owner))
             {
-                capturedSeq = store.CurrentSeq;
-                var rows = new List<PositionRowDto>();
-                foreach (var p in positions.ForEndClient(owner))
-                {
-                    if (p.NetQuantity == 0) continue;
-                    rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
-                }
-                rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
-                capturedPositions = rows;
-            });
-            snapshotSeq = capturedSeq;
-            livePositionsSnapshot = capturedPositions;
+                if (p.NetQuantity == 0) continue;
+                rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+            }
+            rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+            capturedPositions = rows;
+        });
+        var snapshotSeq = capturedSeq;
+        var livePositionsSnapshot = capturedPositions;
 
-            // Drain the writer AFTER taking the dispatcher snapshot so
-            // every entry with seq <= snapshotSeq is durable and
-            // visible to ReadFromAsync. FlushAsync runs outside the
-            // lock — we do not want async I/O while serialising new
-            // dispatches.
-            await store.FlushAsync(ct);
-        }
-        else
-        {
-            // Past-day statements are a pure WAL projection — the
-            // keepers have long since advanced past that snapshot, so
-            // there is no live state to capture and nothing to lock.
-            await store.FlushAsync(ct);
-            snapshotSeq = store.CurrentSeq;
-            livePositionsSnapshot = null;
-        }
+        // Drain the writer AFTER taking the dispatcher snapshot so
+        // every entry with seq <= snapshotSeq is durable and visible
+        // to ReadFromAsync. FlushAsync runs outside the lock — we do
+        // not want async I/O while serialising new dispatches.
+        await store.FlushAsync(ct);
 
         var wal = new List<(long Seq, WalEvent Event)>(capacity: 256);
         await foreach (var entry in store.ReadFromAsync(0, ct))

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -39,6 +39,7 @@ public static class StatementEndpoints
             EndClientRegistry registry,
             IEventStore store,
             PositionKeeper positions,
+            EventDispatcher dispatcher,
             string? dayKey,
             CancellationToken ct) =>
         {
@@ -47,7 +48,7 @@ public static class StatementEndpoints
             var owner = ResolveOwner(ctx, registry);
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "json"));
-            var dto = await BuildAsync(owner, day, store, positions, ct);
+            var dto = await BuildAsync(owner, day, store, positions, dispatcher, ct);
             EmitDayTradeMetric(dto);
             return Results.Ok(dto);
         });
@@ -57,6 +58,7 @@ public static class StatementEndpoints
             EndClientRegistry registry,
             IEventStore store,
             PositionKeeper positions,
+            EventDispatcher dispatcher,
             string dayKey,
             CancellationToken ct) =>
         {
@@ -65,7 +67,7 @@ public static class StatementEndpoints
             var owner = ResolveOwner(ctx, registry);
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "csv"));
-            var dto = await BuildAsync(owner, day, store, positions, ct);
+            var dto = await BuildAsync(owner, day, store, positions, dispatcher, ct);
             EmitDayTradeMetric(dto);
             var bytes = RenderCsv(dto);
             return Results.File(
@@ -78,14 +80,62 @@ public static class StatementEndpoints
     }
 
     private static async Task<DailyStatementDto> BuildAsync(
-        EndClientId owner, DateOnly day, IEventStore store, PositionKeeper positions, CancellationToken ct)
+        EndClientId owner, DateOnly day, IEventStore store, PositionKeeper positions,
+        EventDispatcher dispatcher, CancellationToken ct)
     {
-        // Drain the writer so an event appended an instant ago is in
-        // the read view. Mirrors HistoryEndpoints' guarantee — the
-        // statement must reflect every fill the API has acknowledged.
-        await store.FlushAsync(ct);
+        var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        long snapshotSeq;
+        IReadOnlyList<PositionRowDto>? livePositionsSnapshot;
 
-        var snapshotSeq = store.CurrentSeq;
+        if (day == today)
+        {
+            // Pass-2 review (#279) P1. Today's statement reads three
+            // streams that the dispatcher mutates atomically per fill:
+            // the WAL (caps our scan), the PositionKeeper (live qty +
+            // avg price), and the fee/PnL events the dispatcher nests
+            // off the same fill. If we sampled them in sequence WITHOUT
+            // the dispatcher lock a new fill could land in
+            // PositionKeeper after we capped the WAL scan, producing a
+            // torn snapshot where the position reflects N+1 fills but
+            // the fills/fees/realized rows reflect only N. Capture the
+            // WAL upper-bound and the position rows under
+            // EventDispatcher.RunExclusive — the same serialisation
+            // discipline EntryPointExecutionReportRouter uses on the
+            // WAL-backpressure fallback — so the three views agree.
+            long capturedSeq = 0;
+            IReadOnlyList<PositionRowDto>? capturedPositions = null;
+            dispatcher.RunExclusive(() =>
+            {
+                capturedSeq = store.CurrentSeq;
+                var rows = new List<PositionRowDto>();
+                foreach (var p in positions.ForEndClient(owner))
+                {
+                    if (p.NetQuantity == 0) continue;
+                    rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+                }
+                rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+                capturedPositions = rows;
+            });
+            snapshotSeq = capturedSeq;
+            livePositionsSnapshot = capturedPositions;
+
+            // Drain the writer AFTER taking the dispatcher snapshot so
+            // every entry with seq <= snapshotSeq is durable and
+            // visible to ReadFromAsync. FlushAsync runs outside the
+            // lock — we do not want async I/O while serialising new
+            // dispatches.
+            await store.FlushAsync(ct);
+        }
+        else
+        {
+            // Past-day statements are a pure WAL projection — the
+            // keepers have long since advanced past that snapshot, so
+            // there is no live state to capture and nothing to lock.
+            await store.FlushAsync(ct);
+            snapshotSeq = store.CurrentSeq;
+            livePositionsSnapshot = null;
+        }
+
         var wal = new List<(long Seq, WalEvent Event)>(capacity: 256);
         await foreach (var entry in store.ReadFromAsync(0, ct))
         {
@@ -93,12 +143,7 @@ public static class StatementEndpoints
             wal.Add(entry);
         }
 
-        var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
-        // Live positions only count when the caller is asking about the
-        // CURRENT day — for past days we project positions from the WAL
-        // slice (the keeper has long since advanced past that snapshot).
-        var live = day == today ? positions : null;
-        return StatementProjection.Build(owner, day, wal, live);
+        return StatementProjection.Build(owner, day, wal, livePositionsSnapshot);
     }
 
     private static void EmitDayTradeMetric(DailyStatementDto dto)
@@ -142,7 +187,7 @@ public static class StatementEndpoints
 
     private static readonly byte[] Utf8Bom = new byte[] { 0xEF, 0xBB, 0xBF };
 
-    private static byte[] RenderCsv(DailyStatementDto dto)
+    internal static byte[] RenderCsv(DailyStatementDto dto)
     {
         var sb = new StringBuilder(1024);
 
@@ -212,7 +257,7 @@ public static class StatementEndpoints
     /// RFC4180-ish field escape: wrap in quotes when the value contains
     /// a comma, quote, CR, or LF; double up internal quotes.
     /// </summary>
-    private static string Csv(string v)
+    internal static string Csv(string v)
     {
         if (string.IsNullOrEmpty(v)) return string.Empty;
         var needsQuote = false;

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -140,6 +140,17 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.pnl.replay_synth");
     public static readonly Counter<long> PnlEndpointRequests =
         Meter.CreateCounter<long>("trading.pnl.endpoint_requests");
+
+    // Q2.5 (#272). Daily statement endpoint counters.
+    // statement.endpoint_requests is tagged with {format=json|csv} so
+    // operators can split JSON consumers from CSV exports. The
+    // day_trade_detected gauge increments per request that returned at
+    // least one IR day-trade row (informational only; not driving any
+    // tax collection on the platform).
+    public static readonly Counter<long> StatementEndpointRequests =
+        Meter.CreateCounter<long>("trading.statement.endpoint_requests");
+    public static readonly Counter<long> StatementDayTradeDetected =
+        Meter.CreateCounter<long>("trading.statement.day_trade_detected");
     // Pass-1 review (#278) P1#1. Bumped once per (endClient, symbol)
     // row when StateSnapshotter restores a legacy snapshot whose
     // PnlAvgCost block is empty but Positions has rows — the avg-cost

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -1,0 +1,345 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q2.5 (#272). Pure projection that turns a WAL slice into the daily
+/// statement DTO consumed by <c>GET /statement/{dayKey}</c> (JSON and
+/// CSV). Lives in Application (not in the HTTP layer) so it is trivially
+/// unit-testable without spinning the host.
+///
+/// <para>
+/// <b>Day boundary.</b> The day key is a UTC <see cref="DateOnly"/> —
+/// matches the canonical boundary already used by
+/// <see cref="FeeKeeper"/> and <see cref="PnlKeeper"/>
+/// (<c>DateOnly.FromDateTime(ts.UtcDateTime)</c>). The issue mentions a
+/// São Paulo session boundary; that mapping is a future projection
+/// concern (any TZ conversion happens at the API surface, not here) so
+/// every keeper / event in the platform stays in lockstep.
+/// </para>
+///
+/// <para>
+/// <b>Positions snapshot.</b> Always derived from the live
+/// <see cref="PositionKeeper"/> when <paramref name="useLivePositions"/>
+/// is <c>true</c> (today, intraday); past days are projected from the
+/// WAL by replaying every fill ER from genesis up to the end of the
+/// requested day. This keeps the projection a pure function over the
+/// WAL slice the caller passes in.
+/// </para>
+///
+/// <para>
+/// <b>IR day-trade pre-calc.</b> Pure informational. For each
+/// (endClient, symbol) on the day, we walk the fills in timestamp
+/// order, FIFO-pairing buys against sells; for each matched lot the
+/// gross profit is <c>(sellPrice - buyPrice) * matchedQty</c>. The
+/// taxable amount per symbol is <c>max(grossProfit, 0)</c> — losses on
+/// one symbol do NOT offset gains on another (B3 day-trade tax is
+/// computed per-symbol per-day under the simplified projection here).
+/// The tax rate is 20% (CVM/RFB cash equities day-trade). The whole
+/// block is flagged <c>informationalOnly=true, notCollected=true</c>:
+/// the platform never withholds anything against the result, it just
+/// surfaces it for the trader's own bookkeeping.
+/// </para>
+/// </summary>
+public static class StatementProjection
+{
+    public const decimal IrDayTradeRate = 0.20m;
+
+    /// <summary>
+    /// Build the statement DTO for <paramref name="owner"/> on
+    /// <paramref name="dayKey"/> from the WAL events in
+    /// <paramref name="walEvents"/> (already filtered to the day, but
+    /// re-filtered defensively below). When
+    /// <paramref name="livePositions"/> is non-null its
+    /// <see cref="PositionKeeper.ForEndClient"/> output is used for the
+    /// positions snapshot (today, intraday); otherwise positions are
+    /// projected from <paramref name="walEventsAllTime"/> up to the end
+    /// of <paramref name="dayKey"/>.
+    /// </summary>
+    public static DailyStatementDto Build(
+        EndClientId owner,
+        DateOnly dayKey,
+        IReadOnlyList<(long Seq, WalEvent Event)> walEventsAllTime,
+        PositionKeeper? livePositions)
+    {
+        ArgumentNullException.ThrowIfNull(walEventsAllTime);
+
+        var dayStart = new DateTimeOffset(dayKey.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+        var dayEnd = dayStart.AddDays(1);
+
+        // ----------------- fills + ownership side-table -----------------
+        // ER events carry no owner/symbol; resubstitute them from the
+        // matching OrderSubmittedEvent. This mirrors HistoryEndpoints'
+        // ownerByClOrdId map but without the cancel/replace fallback
+        // complexity: for a daily statement we only care about Fill /
+        // PartialFill ERs, which always land on the original ClOrdID
+        // and never on a cancel-side or replace-side one.
+        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side)>();
+        var fills = new List<FillRowDto>();
+        var feesByType = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        decimal realizedGross = 0m;
+
+        foreach (var (_, evt) in walEventsAllTime)
+        {
+            switch (evt)
+            {
+                case OrderSubmittedEvent o:
+                    ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol, o.Side);
+                    break;
+
+                case OrderReplaceRequestedEvent rr:
+                    // A replace creates a brand-new ClOrdID that becomes
+                    // its own working order; subsequent fill ERs arrive
+                    // under it, so register ownership for the new ID
+                    // too.
+                    ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
+                    break;
+
+                case ExecutionReportReceivedEvent er:
+                    if (er.TimestampUtc < dayStart || er.TimestampUtc >= dayEnd) break;
+                    if (!Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind)) break;
+                    if (kind is not (ExecKind.Fill or ExecKind.PartialFill)) break;
+                    if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) break;
+                    if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) break;
+                    fills.Add(new FillRowDto(
+                        ExecutionId: $"{er.ClOrdId}:{er.CumulativeQuantity}",
+                        ClOrdId: er.ClOrdId.ToString(),
+                        OrderId: er.ClOrdId.ToString(),
+                        Symbol: meta.Symbol,
+                        Side: meta.Side,
+                        Quantity: er.LastQuantity,
+                        Price: er.LastPrice,
+                        TimestampUtc: er.TimestampUtc));
+                    break;
+
+                case FeeAccruedEvent fee:
+                    if (fee.TimestampUtc < dayStart || fee.TimestampUtc >= dayEnd) break;
+                    if (!string.Equals(fee.EndClientId, owner.Value, StringComparison.Ordinal)) break;
+                    AddFee(feesByType, "brokerage", fee.Brokerage);
+                    AddFee(feesByType, "emolumentos", fee.Emolumentos);
+                    AddFee(feesByType, "liquidacao", fee.Liquidacao);
+                    break;
+
+                case RealizedPnlEvent pnl:
+                    if (pnl.TimestampUtc < dayStart || pnl.TimestampUtc >= dayEnd) break;
+                    if (!string.Equals(pnl.EndClientId, owner.Value, StringComparison.Ordinal)) break;
+                    if (pnl.DayKey != dayKey) break;
+                    realizedGross += pnl.DeltaRealized;
+                    break;
+            }
+        }
+
+        var feeRows = new List<FeeRowDto>(feesByType.Count);
+        decimal totalFees = 0m;
+        foreach (var kv in feesByType.OrderBy(k => k.Key, StringComparer.Ordinal))
+        {
+            feeRows.Add(new FeeRowDto(kv.Key, kv.Value));
+            totalFees += kv.Value;
+        }
+
+        // ----------------- positions snapshot -----------------
+        IReadOnlyList<PositionRowDto> positions;
+        if (livePositions is not null)
+        {
+            var live = new List<PositionRowDto>();
+            foreach (var p in livePositions.ForEndClient(owner))
+            {
+                if (p.NetQuantity == 0) continue;
+                live.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+            }
+            live.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+            positions = live;
+        }
+        else
+        {
+            positions = ProjectPositionsFromWal(owner, dayEnd, walEventsAllTime, ownerByClOrdId);
+        }
+
+        // ----------------- IR day-trade pre-calc -----------------
+        var ir = ComputeIrDayTrade(fills);
+
+        return new DailyStatementDto(
+            DayKey: dayKey.ToString("yyyy-MM-dd"),
+            Positions: positions,
+            Fills: fills,
+            Fees: feeRows,
+            FeesTotal: totalFees,
+            Pnl: new PnlSummaryDto(realizedGross, totalFees, realizedGross - totalFees),
+            IrDayTrade: ir);
+    }
+
+    private static void AddFee(Dictionary<string, decimal> bag, string key, decimal value)
+    {
+        if (value == 0m) return;
+        bag[key] = bag.TryGetValue(key, out var prior) ? prior + value : value;
+    }
+
+    private static IReadOnlyList<PositionRowDto> ProjectPositionsFromWal(
+        EndClientId owner,
+        DateTimeOffset dayEnd,
+        IReadOnlyList<(long Seq, WalEvent Event)> wal,
+        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side)> ownerByClOrdId)
+    {
+        // Replay every fill ER from genesis up to (but not including)
+        // dayEnd. Cumulative net qty + avg price is computed via a
+        // throwaway PositionKeeper so we share the exact ApplyFill
+        // semantics (including the flip-past-zero reset).
+        var keeper = new PositionKeeper();
+        foreach (var (_, evt) in wal)
+        {
+            if (evt is not ExecutionReportReceivedEvent er) continue;
+            if (er.TimestampUtc >= dayEnd) continue;
+            if (!Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind)) continue;
+            if (kind is not (ExecKind.Fill or ExecKind.PartialFill)) continue;
+            if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) continue;
+            if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) continue;
+            if (!Enum.TryParse<OrderSide>(meta.Side, ignoreCase: true, out var side)) continue;
+            if (er.LastQuantity <= 0) continue;
+            keeper.ApplyFill(owner, meta.Symbol, side, er.LastQuantity, er.LastPrice);
+        }
+
+        var rows = new List<PositionRowDto>();
+        foreach (var p in keeper.ForEndClient(owner))
+        {
+            if (p.NetQuantity == 0) continue;
+            rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+        }
+        rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+        return rows;
+    }
+
+    /// <summary>
+    /// FIFO pair buys vs sells within the same symbol on the day. For
+    /// every matched lot we record <c>(sellPrice - buyPrice) * qty</c>
+    /// as gross profit; taxable per symbol is <c>max(gross, 0)</c> and
+    /// the tax is 20% of that. Losses do NOT offset gains across
+    /// different symbols — kept intentionally simple, the block is
+    /// informational only.
+    /// </summary>
+    private static IrDayTradeDto ComputeIrDayTrade(IReadOnlyList<FillRowDto> fills)
+    {
+        var perSymbol = new List<IrDayTradeRowDto>();
+        decimal totalTax = 0m;
+
+        // Bucket fills by symbol then process in timestamp order.
+        var bySymbol = fills
+            .GroupBy(f => f.Symbol, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        foreach (var group in bySymbol)
+        {
+            var ordered = group.OrderBy(f => f.TimestampUtc).ToList();
+            // Track residual buy and sell lots as FIFO queues of (qty, price).
+            var buyLots = new Queue<(long Qty, decimal Price)>();
+            var sellLots = new Queue<(long Qty, decimal Price)>();
+            long matchedQty = 0;
+            decimal grossProfit = 0m;
+
+            foreach (var fill in ordered)
+            {
+                var isBuy = string.Equals(fill.Side, nameof(OrderSide.Buy), StringComparison.OrdinalIgnoreCase);
+                var qty = fill.Quantity;
+                var price = fill.Price;
+
+                if (isBuy)
+                {
+                    // Match against existing sell lots first (the trader
+                    // opened a short earlier in the day and is now
+                    // closing it).
+                    while (qty > 0 && sellLots.Count > 0)
+                    {
+                        var head = sellLots.Peek();
+                        var take = Math.Min(qty, head.Qty);
+                        grossProfit += (head.Price - price) * take;
+                        matchedQty += take;
+                        qty -= take;
+                        if (take == head.Qty) sellLots.Dequeue();
+                        else { sellLots.Dequeue(); sellLots.Enqueue((head.Qty - take, head.Price)); RotateToFront(sellLots); }
+                    }
+                    if (qty > 0) buyLots.Enqueue((qty, price));
+                }
+                else
+                {
+                    while (qty > 0 && buyLots.Count > 0)
+                    {
+                        var head = buyLots.Peek();
+                        var take = Math.Min(qty, head.Qty);
+                        grossProfit += (price - head.Price) * take;
+                        matchedQty += take;
+                        qty -= take;
+                        if (take == head.Qty) buyLots.Dequeue();
+                        else { buyLots.Dequeue(); buyLots.Enqueue((head.Qty - take, head.Price)); RotateToFront(buyLots); }
+                    }
+                    if (qty > 0) sellLots.Enqueue((qty, price));
+                }
+            }
+
+            if (matchedQty == 0) continue;
+            var taxable = grossProfit > 0 ? grossProfit : 0m;
+            var tax = decimal.Round(taxable * IrDayTradeRate, 2, MidpointRounding.AwayFromZero);
+            perSymbol.Add(new IrDayTradeRowDto(group.Key, matchedQty, grossProfit, taxable, tax));
+            totalTax += tax;
+        }
+
+        return new IrDayTradeDto(
+            InformationalOnly: true,
+            NotCollected: true,
+            Rate: IrDayTradeRate,
+            PerSymbol: perSymbol,
+            TotalTax: totalTax);
+    }
+
+    // The Queue<T> we use does not support index access, so when we
+    // partially consume the head we re-enqueue the remainder. That
+    // pushes it to the tail; rotate it back to the front so the FIFO
+    // invariant holds (the partially-consumed lot is still the oldest
+    // open contra-lot).
+    private static void RotateToFront<T>(Queue<T> q)
+    {
+        // After we dequeued+enqueued the partial residual it sits at
+        // the tail. Walk every other element to the back so the
+        // partial-residual ends up at the head again.
+        var n = q.Count - 1;
+        for (var i = 0; i < n; i++) q.Enqueue(q.Dequeue());
+    }
+}
+
+public sealed record DailyStatementDto(
+    string DayKey,
+    IReadOnlyList<PositionRowDto> Positions,
+    IReadOnlyList<FillRowDto> Fills,
+    IReadOnlyList<FeeRowDto> Fees,
+    decimal FeesTotal,
+    PnlSummaryDto Pnl,
+    IrDayTradeDto IrDayTrade);
+
+public sealed record PositionRowDto(string Symbol, long NetQty, decimal AvgPrice);
+
+public sealed record FillRowDto(
+    string ExecutionId,
+    string ClOrdId,
+    string OrderId,
+    string Symbol,
+    string Side,
+    long Quantity,
+    decimal Price,
+    DateTimeOffset TimestampUtc);
+
+public sealed record FeeRowDto(string FeeType, decimal Total);
+
+public sealed record PnlSummaryDto(decimal RealizedGross, decimal TotalFees, decimal RealizedNet);
+
+public sealed record IrDayTradeDto(
+    bool InformationalOnly,
+    bool NotCollected,
+    decimal Rate,
+    IReadOnlyList<IrDayTradeRowDto> PerSymbol,
+    decimal TotalTax);
+
+public sealed record IrDayTradeRowDto(
+    string Symbol,
+    long QtyMatched,
+    decimal GrossProfit,
+    decimal TaxableProfit,
+    decimal TaxAmount);

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -20,12 +20,16 @@ namespace B3.Trading.Application;
 /// </para>
 ///
 /// <para>
-/// <b>Positions snapshot.</b> Always derived from the live
-/// <see cref="PositionKeeper"/> when <paramref name="useLivePositions"/>
-/// is <c>true</c> (today, intraday); past days are projected from the
-/// WAL by replaying every fill ER from genesis up to the end of the
-/// requested day. This keeps the projection a pure function over the
-/// WAL slice the caller passes in.
+/// <b>Positions snapshot.</b> Always derived from a caller-provided
+/// immutable snapshot (<see cref="PositionRowDto"/> list) when one is
+/// supplied — the API layer captures that under
+/// <see cref="Persistence.EventDispatcher.RunExclusive(System.Action)"/>
+/// alongside the WAL upper-bound so today's statement cannot tear (a
+/// new fill cannot land in <see cref="PositionKeeper"/> after the WAL
+/// scan stopped). Past days are projected from the WAL by replaying
+/// every fill ER from genesis up to the end of the requested day. This
+/// keeps the projection a pure function over the WAL slice the caller
+/// passes in.
 /// </para>
 ///
 /// <para>
@@ -49,19 +53,22 @@ public static class StatementProjection
     /// <summary>
     /// Build the statement DTO for <paramref name="owner"/> on
     /// <paramref name="dayKey"/> from the WAL events in
-    /// <paramref name="walEvents"/> (already filtered to the day, but
+    /// <paramref name="walEventsAllTime"/> (already filtered to the day, but
     /// re-filtered defensively below). When
-    /// <paramref name="livePositions"/> is non-null its
-    /// <see cref="PositionKeeper.ForEndClient"/> output is used for the
-    /// positions snapshot (today, intraday); otherwise positions are
+    /// <paramref name="livePositionsSnapshot"/> is non-null it is used
+    /// verbatim as the positions snapshot (already sorted and
+    /// zero-quantity-filtered by the caller); otherwise positions are
     /// projected from <paramref name="walEventsAllTime"/> up to the end
-    /// of <paramref name="dayKey"/>.
+    /// of <paramref name="dayKey"/>. The caller is responsible for
+    /// capturing the snapshot atomically with the WAL upper-bound used
+    /// to bound <paramref name="walEventsAllTime"/> (today path takes
+    /// both under <see cref="Persistence.EventDispatcher.RunExclusive(System.Action)"/>).
     /// </summary>
     public static DailyStatementDto Build(
         EndClientId owner,
         DateOnly dayKey,
         IReadOnlyList<(long Seq, WalEvent Event)> walEventsAllTime,
-        PositionKeeper? livePositions)
+        IReadOnlyList<PositionRowDto>? livePositionsSnapshot)
     {
         ArgumentNullException.ThrowIfNull(walEventsAllTime);
 
@@ -140,16 +147,9 @@ public static class StatementProjection
 
         // ----------------- positions snapshot -----------------
         IReadOnlyList<PositionRowDto> positions;
-        if (livePositions is not null)
+        if (livePositionsSnapshot is not null)
         {
-            var live = new List<PositionRowDto>();
-            foreach (var p in livePositions.ForEndClient(owner))
-            {
-                if (p.NetQuantity == 0) continue;
-                live.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
-            }
-            live.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
-            positions = live;
+            positions = livePositionsSnapshot;
         }
         else
         {

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -31,6 +31,7 @@ public static class TradingEndpointsExtensions
         app.MapPositions();
         app.MapBalance();
         app.MapPnl();
+        app.MapStatement();
         app.MapPolicy();
         app.MapAdmin();
         {

--- a/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
@@ -5,6 +5,8 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace B3.Trading.Api.Tests;
@@ -352,6 +354,157 @@ public class StatementEndpointTests : IDisposable
         Assert.Equal(FillCount, finalFills.Count);
         var finalPos = Assert.Single(final.GetProperty("positions").EnumerateArray());
         Assert.Equal((long)FillCount, finalPos.GetProperty("netQty").GetInt64());
+    }
+
+    [Fact]
+    public async Task PastDayConcurrentDispatch_StatementRead_NeverProducesTornSnapshot()
+    {
+        // Pass-2 review (#279) P1 regression — past-day path. Near UTC
+        // day rollover a late ER timestamped for the requested "past"
+        // day can be in the middle of its dispatch chain (ER append +
+        // nested FeeAccrued + nested RealizedPnl, all under one
+        // dispatcher lock) while a reader caps the WAL for that past
+        // day. Before the fix the past-day path read store.CurrentSeq
+        // OUTSIDE the dispatcher lock so it could stop the WAL scan in
+        // between the ER and its nested fee/PnL, projecting a fill
+        // without its matching fees / realized PnL. With the fix the
+        // upper-bound capture runs under EventDispatcher.RunExclusive
+        // so the cap can only land on a quiescent point — either
+        // BEFORE the ER or AFTER its full nested chain.
+        //
+        // Per-fill we dispatch ER (yesterday) + nested FeeAccrued
+        // (brokerage=1m, yesterday) under a single Dispatch call so the
+        // append-order discipline mirrors production. Invariant: the
+        // brokerage total returned by the endpoint equals 1m * fills
+        // count for every observed response.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var dispatcher = f.Services.GetRequiredService<EventDispatcher>();
+        var registry = f.Services.GetRequiredService<EndClientRegistry>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        var yesterday = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime).AddDays(-1);
+        var yesterdayTs = new DateTimeOffset(yesterday.ToDateTime(new TimeOnly(10, 0)), TimeSpan.Zero);
+        var yesterdayKey = yesterday.ToString("yyyy-MM-dd");
+
+        const int FillCount = 40;
+        var clOrdIds = new List<ulong>(FillCount);
+        for (var i = 0; i < FillCount; i++)
+        {
+            var clOrdId = (ulong)(900_000UL + (uint)i);
+            clOrdIds.Add(clOrdId);
+            dispatcher.Dispatch(
+                new OrderSubmittedEvent
+                {
+                    ClOrdId = clOrdId,
+                    EndClientId = owner.Value,
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = nameof(OrderSide.Buy),
+                    Type = nameof(OrderType.Limit),
+                    Quantity = 1,
+                    Price = 30m,
+                    TimestampUtc = yesterdayTs,
+                },
+                () => { });
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var tornObserved = false;
+        string? tornDetail = null;
+        var readerStopped = 0;
+
+        var readerTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested && Volatile.Read(ref readerStopped) == 0)
+                {
+                    JsonElement dto;
+                    try
+                    {
+                        dto = await GetStatement(http, token, yesterdayKey);
+                    }
+                    catch (OperationCanceledException) { break; }
+
+                    var fillsCount = dto.GetProperty("fills").GetArrayLength();
+                    decimal brokerage = 0m;
+                    foreach (var fee in dto.GetProperty("fees").EnumerateArray())
+                    {
+                        if (string.Equals(fee.GetProperty("feeType").GetString(), "brokerage", StringComparison.Ordinal))
+                            brokerage = fee.GetProperty("total").GetDecimal();
+                    }
+                    if (brokerage != fillsCount * 1m)
+                    {
+                        tornObserved = true;
+                        tornDetail = $"fills={fillsCount} brokerage={brokerage}";
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on shutdown */ }
+        });
+
+        await Parallel.ForEachAsync(clOrdIds, new ParallelOptions { MaxDegreeOfParallelism = 8 },
+            async (clOrdId, _) =>
+            {
+                await Task.Yield();
+                dispatcher.Dispatch(
+                    new ExecutionReportReceivedEvent
+                    {
+                        ClOrdId = clOrdId,
+                        ExecKind = nameof(ExecKind.Fill),
+                        LeavesQuantity = 0,
+                        CumulativeQuantity = 1,
+                        LastQuantity = 1,
+                        LastPrice = 30m,
+                        Synthetic = true,
+                        TimestampUtc = yesterdayTs,
+                    },
+                    () =>
+                    {
+                        // Nested dispatch — reentrant on the dispatcher
+                        // lock — mirrors how ExecutionReportProcessor
+                        // emits FeeAccrued from inside the ER apply.
+                        dispatcher.Dispatch(
+                            new FeeAccruedEvent
+                            {
+                                ClOrdId = clOrdId,
+                                ExecutionId = $"{clOrdId}:1",
+                                EndClientId = owner.Value,
+                                Symbol = "PETR4",
+                                Side = nameof(OrderSide.Buy),
+                                FillQuantity = 1,
+                                FillPrice = 30m,
+                                Notional = 30m,
+                                Brokerage = 1m,
+                                Emolumentos = 0m,
+                                Liquidacao = 0m,
+                                Total = 1m,
+                                TimestampUtc = yesterdayTs,
+                            },
+                            () => { });
+                    });
+            });
+
+        await Task.Delay(200);
+        Interlocked.Exchange(ref readerStopped, 1);
+        await readerTask;
+
+        Assert.False(tornObserved, $"observed torn past-day statement snapshot: {tornDetail}");
+
+        var final = await GetStatement(http, token, yesterdayKey);
+        Assert.Equal(FillCount, final.GetProperty("fills").GetArrayLength());
+        decimal finalBrokerage = 0m;
+        foreach (var fee in final.GetProperty("fees").EnumerateArray())
+        {
+            if (string.Equals(fee.GetProperty("feeType").GetString(), "brokerage", StringComparison.Ordinal))
+                finalBrokerage = fee.GetProperty("total").GetDecimal();
+        }
+        Assert.Equal(FillCount * 1m, finalBrokerage);
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
@@ -1,0 +1,373 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Application;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q2.5 (#272). HTTP integration coverage for the daily statement
+/// endpoints (JSON + CSV). Mirrors the
+/// <c>HistoryEndpointTests</c> shape: per-test data dir + mock
+/// EntryPoint client so fill ERs land on the WAL synchronously,
+/// JWT-auth via the standard test login.
+/// </summary>
+public class StatementEndpointTests : IDisposable
+{
+    private readonly string _dataDir = Path.Combine(
+        Path.GetTempPath(), "b3-statement-tests-" + Guid.NewGuid().ToString("N"));
+
+    private IDictionary<string, string?> Overrides() => new Dictionary<string, string?>
+    {
+        ["Trading:Exchange:Mode"] = "Mock",
+        ["Trading:Exchange:AllowErInjection"] = "true",
+        ["Trading:Persistence:Enabled"] = "true",
+        ["Trading:Persistence:DataDirectory"] = _dataDir,
+        ["Trading:Persistence:FirmId"] = "test",
+        ["Trading:Persistence:SnapshotInterval"] = "00:10:00",
+    };
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_dataDir))
+                Directory.Delete(_dataDir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort tmp cleanup.
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Returns401()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var resp = await http.GetAsync("/statement");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task EmptyDay_ReturnsEmptyStatementWithZeroTotals()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var req = Bearer(HttpMethod.Get, "/statement", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime).ToString("yyyy-MM-dd"),
+            dto.GetProperty("dayKey").GetString());
+        Assert.Empty(dto.GetProperty("positions").EnumerateArray());
+        Assert.Empty(dto.GetProperty("fills").EnumerateArray());
+        Assert.Empty(dto.GetProperty("fees").EnumerateArray());
+        Assert.Equal(0m, dto.GetProperty("feesTotal").GetDecimal());
+        Assert.Equal(0m, dto.GetProperty("pnl").GetProperty("realizedGross").GetDecimal());
+        Assert.Equal(0m, dto.GetProperty("pnl").GetProperty("realizedNet").GetDecimal());
+        Assert.True(dto.GetProperty("irDayTrade").GetProperty("informationalOnly").GetBoolean());
+        Assert.True(dto.GetProperty("irDayTrade").GetProperty("notCollected").GetBoolean());
+        Assert.Equal(0m, dto.GetProperty("irDayTrade").GetProperty("totalTax").GetDecimal());
+    }
+
+    [Fact]
+    public async Task WithFills_TotalsMatchManualSum()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var c1 = ulong.Parse(await SubmitBuy(http, token, qty: 100, price: 30m));
+        await InjectFill(http, adminToken, c1, qty: 100, price: 30m);
+
+        var dto = await GetStatement(http, token);
+        Assert.NotEmpty(dto.GetProperty("fills").EnumerateArray());
+        var fill = Assert.Single(dto.GetProperty("fills").EnumerateArray());
+        Assert.Equal(100L, fill.GetProperty("quantity").GetInt64());
+        Assert.Equal(30m, fill.GetProperty("price").GetDecimal());
+        Assert.Equal("Buy", fill.GetProperty("side").GetString());
+
+        // After a single 100-share buy the live position is 100 @ 30 —
+        // the projection MUST use the live PositionKeeper for today.
+        var pos = Assert.Single(dto.GetProperty("positions").EnumerateArray());
+        Assert.Equal(100L, pos.GetProperty("netQty").GetInt64());
+        Assert.Equal(30m, pos.GetProperty("avgPrice").GetDecimal());
+
+        // FeeKeeper writes a FeeAccruedEvent per fill → feesTotal > 0.
+        var feesTotal = dto.GetProperty("feesTotal").GetDecimal();
+        Assert.True(feesTotal > 0m, "expected non-zero feesTotal after a fill");
+        var pnl = dto.GetProperty("pnl");
+        Assert.Equal(pnl.GetProperty("realizedGross").GetDecimal() - feesTotal,
+            pnl.GetProperty("realizedNet").GetDecimal());
+    }
+
+    [Fact]
+    public async Task IntradayDayTrade_AppliesTwentyPercentInformationalTax()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var buyId = ulong.Parse(await SubmitBuy(http, token, qty: 100, price: 30m));
+        await InjectFill(http, adminToken, buyId, qty: 100, price: 30m);
+        var sellId = ulong.Parse(await SubmitSell(http, token, qty: 100, price: 32m));
+        await InjectFill(http, adminToken, sellId, qty: 100, price: 32m);
+
+        var dto = await GetStatement(http, token);
+        var perSymbol = dto.GetProperty("irDayTrade").GetProperty("perSymbol").EnumerateArray().ToList();
+        var ir = Assert.Single(perSymbol);
+        Assert.Equal("PETR4", ir.GetProperty("symbol").GetString());
+        Assert.Equal(100L, ir.GetProperty("qtyMatched").GetInt64());
+        Assert.Equal(200m, ir.GetProperty("grossProfit").GetDecimal());
+        Assert.Equal(200m, ir.GetProperty("taxableProfit").GetDecimal());
+        Assert.Equal(40.00m, ir.GetProperty("taxAmount").GetDecimal());
+        Assert.Equal(40.00m, dto.GetProperty("irDayTrade").GetProperty("totalTax").GetDecimal());
+    }
+
+    [Fact]
+    public async Task NoDayTrade_ReturnsZeroIrTax()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        // Buy only — no offsetting same-day sell.
+        var buyId = ulong.Parse(await SubmitBuy(http, token, qty: 50, price: 30m));
+        await InjectFill(http, adminToken, buyId, qty: 50, price: 30m);
+
+        var dto = await GetStatement(http, token);
+        Assert.Empty(dto.GetProperty("irDayTrade").GetProperty("perSymbol").EnumerateArray());
+        Assert.Equal(0m, dto.GetProperty("irDayTrade").GetProperty("totalTax").GetDecimal());
+    }
+
+    [Fact]
+    public async Task CsvEndpoint_IsParseableAndCarriesUtf8Bom()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var buyId = ulong.Parse(await SubmitBuy(http, token, qty: 100, price: 30m));
+        await InjectFill(http, adminToken, buyId, qty: 100, price: 30m);
+
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime).ToString("yyyy-MM-dd");
+        var req = Bearer(HttpMethod.Get, $"/statement/{day}.csv", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("text/csv", resp.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", resp.Content.Headers.ContentType?.CharSet);
+        Assert.Equal($"statement-{day}.csv", resp.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+
+        var bytes = await resp.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length >= 3, "csv payload is unexpectedly short");
+        Assert.Equal(0xEF, bytes[0]);
+        Assert.Equal(0xBB, bytes[1]);
+        Assert.Equal(0xBF, bytes[2]);
+
+        // Strip the BOM then parse each section with the standard
+        // System library's TextFieldParser-equivalent: a simple
+        // string-splitter is enough for the deterministic data we
+        // emit (no embedded commas/newlines in the test fixture).
+        var text = Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        Assert.Contains("# positions", text);
+        Assert.Contains("# fills", text);
+        Assert.Contains("# fees", text);
+        Assert.Contains("# pnl-summary", text);
+        Assert.Contains("# ir-day-trade (informational)", text);
+
+        // Round-trip the fills section through a generic CSV reader to
+        // prove it's parseable. We isolate the block following
+        // "# fills" until the next blank line and feed it through
+        // System.Text-based splitting (Spec calls out "standard reader" —
+        // the format is RFC4180-ish so anything compliant works).
+        var fillsBlock = ExtractSection(text, "# fills");
+        var rows = ParseCsv(fillsBlock);
+        Assert.True(rows.Count >= 2, "expected header + at least one row");
+        // Header columns
+        Assert.Equal("executionId", rows[0][0]);
+        Assert.Equal("clOrdId", rows[0][1]);
+        Assert.Equal("symbol", rows[0][3]);
+        Assert.Equal("side", rows[0][4]);
+        Assert.Equal("quantity", rows[0][5]);
+        Assert.Equal("price", rows[0][6]);
+        // Row[1] is the one and only fill — PETR4 Buy 100 @ 30.
+        Assert.Equal("PETR4", rows[1][3]);
+        Assert.Equal("Buy", rows[1][4]);
+        Assert.Equal("100", rows[1][5]);
+        Assert.Equal("30", rows[1][6]);
+    }
+
+    [Fact]
+    public async Task EndpointScope_TraderOnlySeesOwnEndClient()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var aliceToken = await f.LoginAsync(http);
+        var bobToken = await f.LoginAsync(http, user: "bob");
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var aliceBuy = ulong.Parse(await SubmitBuy(http, aliceToken, qty: 10, price: 30m));
+        await InjectFill(http, adminToken, aliceBuy, qty: 10, price: 30m);
+        var bobBuy = ulong.Parse(await SubmitBuy(http, bobToken, qty: 20, price: 30m));
+        await InjectFill(http, adminToken, bobBuy, qty: 20, price: 30m);
+
+        var aliceDto = await GetStatement(http, aliceToken);
+        var aliceFills = aliceDto.GetProperty("fills").EnumerateArray().ToList();
+        var aliceFill = Assert.Single(aliceFills);
+        Assert.Equal(10L, aliceFill.GetProperty("quantity").GetInt64());
+        Assert.DoesNotContain(aliceFills, fill => fill.GetProperty("clOrdId").GetString() == bobBuy.ToString());
+
+        var bobDto = await GetStatement(http, bobToken);
+        var bobFills = bobDto.GetProperty("fills").EnumerateArray().ToList();
+        var bobFill = Assert.Single(bobFills);
+        Assert.Equal(20L, bobFill.GetProperty("quantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task FutureDayKey_Returns404()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var future = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime).AddDays(7).ToString("yyyy-MM-dd");
+        var req = Bearer(HttpMethod.Get, $"/statement/{future}", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MalformedDayKey_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var req = Bearer(HttpMethod.Get, "/statement/not-a-date", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private static HttpRequestMessage Bearer(HttpMethod method, string url, string token)
+    {
+        var req = new HttpRequestMessage(method, url);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return req;
+    }
+
+    private static async Task<JsonElement> GetStatement(HttpClient http, string token, string? dayKey = null)
+    {
+        var url = dayKey is null ? "/statement" : $"/statement/{dayKey}";
+        var req = Bearer(HttpMethod.Get, url, token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static Task<string> SubmitBuy(HttpClient http, string token, int qty, decimal price) =>
+        SubmitOrder(http, token, "Buy", qty, price);
+
+    private static Task<string> SubmitSell(HttpClient http, string token, int qty, decimal price) =>
+        SubmitOrder(http, token, "Sell", qty, price);
+
+    private static async Task<string> SubmitOrder(HttpClient http, string token, string side, int qty, decimal price)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = side,
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("clOrdId").GetString()!;
+    }
+
+    private static async Task InjectFill(HttpClient http, string adminToken, ulong clOrdId, long qty, decimal price)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = clOrdId,
+                Type = "Fill",
+                LastQty = qty,
+                LastPx = price,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    private static string ExtractSection(string csv, string header)
+    {
+        var lines = csv.Split(new[] { "\r\n" }, StringSplitOptions.None);
+        var i = Array.IndexOf(lines, header);
+        Assert.True(i >= 0, $"section header not found: {header}");
+        var sb = new StringBuilder();
+        for (var j = i + 1; j < lines.Length; j++)
+        {
+            if (lines[j].Length == 0) break;
+            if (sb.Length > 0) sb.Append("\r\n");
+            sb.Append(lines[j]);
+        }
+        return sb.ToString();
+    }
+
+    private static List<string[]> ParseCsv(string block)
+    {
+        // RFC4180-lite: rows separated by CRLF, fields by comma,
+        // optional double-quote wrap with embedded "" escape. Returns
+        // the parsed rows so callers can assert on column shape.
+        var rows = new List<string[]>();
+        foreach (var line in block.Split(new[] { "\r\n" }, StringSplitOptions.None))
+        {
+            if (line.Length == 0) continue;
+            var fields = new List<string>();
+            var sb = new StringBuilder();
+            var inQuotes = false;
+            for (var i = 0; i < line.Length; i++)
+            {
+                var c = line[i];
+                if (inQuotes)
+                {
+                    if (c == '"' && i + 1 < line.Length && line[i + 1] == '"') { sb.Append('"'); i++; }
+                    else if (c == '"') inQuotes = false;
+                    else sb.Append(c);
+                }
+                else
+                {
+                    if (c == ',') { fields.Add(sb.ToString()); sb.Clear(); }
+                    else if (c == '"' && sb.Length == 0) inQuotes = true;
+                    else sb.Append(c);
+                }
+            }
+            fields.Add(sb.ToString());
+            rows.Add(fields.ToArray());
+        }
+        return rows;
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
@@ -258,6 +258,195 @@ public class StatementEndpointTests : IDisposable
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task ConcurrentFills_StatementRead_NeverProducesTornSnapshot()
+    {
+        // Pass-2 review (#279) P1 regression. Drive many fills
+        // concurrently with many statement reads on the SAME end-client
+        // for today (the path that mixes WAL projection with live
+        // PositionKeeper state). Every snapshot the endpoint hands back
+        // must be internally consistent:
+        //
+        //   sum(buy.fillQty - sell.fillQty)  ==  position.netQty
+        //
+        // for each symbol. Before the fix the endpoint sampled the WAL
+        // and the keeper in sequence WITHOUT the dispatcher lock, so a
+        // fill landing between the WAL cap and the keeper read would
+        // bump netQty above the sum-of-fills slice. With the fix both
+        // captures happen under EventDispatcher.RunExclusive, so the
+        // race cannot be observed.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        const int FillCount = 40;
+        var clOrdIds = new List<ulong>(FillCount);
+        for (var i = 0; i < FillCount; i++)
+            clOrdIds.Add(ulong.Parse(await SubmitBuy(http, token, qty: 1, price: 30m)));
+
+        // Reader task: hammer GET /statement and assert consistency on
+        // every response. Runs until all fills have been injected and
+        // we have observed the final consistent state at least once.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var tornObserved = false;
+        string? tornDetail = null;
+        var readerStopped = 0;
+
+        var readerTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested && Volatile.Read(ref readerStopped) == 0)
+                {
+                    JsonElement dto;
+                    try
+                    {
+                        dto = await GetStatement(http, token);
+                    }
+                    catch (OperationCanceledException) { break; }
+
+                    var fillsQty = 0L;
+                    foreach (var fill in dto.GetProperty("fills").EnumerateArray())
+                    {
+                        var side = fill.GetProperty("side").GetString();
+                        var qty = fill.GetProperty("quantity").GetInt64();
+                        fillsQty += string.Equals(side, "Buy", StringComparison.Ordinal) ? qty : -qty;
+                    }
+
+                    var netQty = 0L;
+                    foreach (var pos in dto.GetProperty("positions").EnumerateArray())
+                    {
+                        if (pos.GetProperty("symbol").GetString() == "PETR4")
+                            netQty = pos.GetProperty("netQty").GetInt64();
+                    }
+
+                    if (fillsQty != netQty)
+                    {
+                        tornObserved = true;
+                        tornDetail = $"fillsQty={fillsQty} netQty={netQty}";
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on shutdown */ }
+        });
+
+        // Writer: inject fills concurrently in small batches so the
+        // reader actually sees state changing under it.
+        await Parallel.ForEachAsync(clOrdIds, new ParallelOptions { MaxDegreeOfParallelism = 8 },
+            async (clOrdId, _) => await InjectFill(http, adminToken, clOrdId, qty: 1, price: 30m));
+
+        // Give the reader a few more spins after the writes settle so
+        // it captures the post-write steady state.
+        await Task.Delay(200);
+        Interlocked.Exchange(ref readerStopped, 1);
+        await readerTask;
+
+        Assert.False(tornObserved, $"observed torn statement snapshot: {tornDetail}");
+
+        // Final sanity: after all writes complete the steady-state
+        // statement must report the full FillCount across both views.
+        var final = await GetStatement(http, token);
+        var finalFills = final.GetProperty("fills").EnumerateArray().ToList();
+        Assert.Equal(FillCount, finalFills.Count);
+        var finalPos = Assert.Single(final.GetProperty("positions").EnumerateArray());
+        Assert.Equal((long)FillCount, finalPos.GetProperty("netQty").GetInt64());
+    }
+
+    [Fact]
+    public void CsvWriter_RoundTripsFieldsWithCommasQuotesAndNewlines()
+    {
+        // Pass-2 review (#279) P2 regression. Build a DTO that pushes
+        // every RFC4180 escape rule through StatementEndpoints.Csv via
+        // RenderCsv, then re-parse with our RFC4180 reader and assert
+        // bit-for-bit equality of the field contents. Proves the CSV
+        // producer correctly:
+        //   - wraps fields containing commas,
+        //   - wraps fields containing double-quotes and doubles the
+        //     internal quotes,
+        //   - wraps fields containing CR / LF and preserves them.
+        var tricky = new[]
+        {
+            "comma,inside",
+            "quote\"inside",
+            "newline\ninside",
+            "crlf\r\ninside",
+            "all,three\"things\nhere",
+            "leading\"and,trailing",
+        };
+        var fills = tricky.Select((s, i) => new FillRowDto(
+            ExecutionId: s,
+            ClOrdId: (i + 1).ToString(CultureInfo.InvariantCulture),
+            OrderId: (i + 1).ToString(CultureInfo.InvariantCulture),
+            Symbol: s,
+            Side: "Buy",
+            Quantity: 1,
+            Price: 30m,
+            TimestampUtc: new DateTimeOffset(2024, 6, 17, 10, 0, 0, TimeSpan.Zero))).ToList();
+        var dto = new DailyStatementDto(
+            DayKey: "2024-06-17",
+            Positions: Array.Empty<PositionRowDto>(),
+            Fills: fills,
+            Fees: Array.Empty<FeeRowDto>(),
+            FeesTotal: 0m,
+            Pnl: new PnlSummaryDto(0m, 0m, 0m),
+            IrDayTrade: new IrDayTradeDto(true, true, 0.20m, Array.Empty<IrDayTradeRowDto>(), 0m));
+
+        var bytes = StatementEndpoints.RenderCsv(dto);
+        // Strip BOM, parse the whole document with the RFC4180 reader,
+        // then locate the fills section and round-trip every row.
+        var text = Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        var allRows = ParseCsv(text);
+        // Walk rows: skip until we see `# fills`, then take the header
+        // and following rows until a blank row or the next `#`-prefixed
+        // section marker. ExtractSection's naive text split can't
+        // survive embedded CR/LF inside quoted fields — parsing first
+        // and walking rows can.
+        var startIdx = -1;
+        for (var i = 0; i < allRows.Count; i++)
+        {
+            if (allRows[i].Length >= 1 && allRows[i][0] == "# fills") { startIdx = i + 1; break; }
+        }
+        Assert.True(startIdx > 0, "fills section header not found in CSV output");
+        var rows = new List<string[]>();
+        for (var i = startIdx; i < allRows.Count; i++)
+        {
+            var r = allRows[i];
+            if (r.Length == 0 || (r.Length == 1 && r[0].Length == 0)) break;
+            if (r.Length >= 1 && r[0].StartsWith("# ", StringComparison.Ordinal)) break;
+            rows.Add(r);
+        }
+
+        // rows[0] is the header.
+        Assert.Equal("executionId", rows[0][0]);
+        Assert.Equal(fills.Count + 1, rows.Count);
+        for (var i = 0; i < fills.Count; i++)
+        {
+            var row = rows[i + 1];
+            Assert.Equal(fills[i].ExecutionId, row[0]);
+            Assert.Equal(fills[i].Symbol, row[3]);
+        }
+    }
+
+    [Fact]
+    public void CsvParser_HandlesQuotedCommasNewlinesAndEscapedQuotes()
+    {
+        // Direct parser unit-test: feeds the RFC4180 reader hand-crafted
+        // edge-case input (the exact shapes the StatementEndpoints
+        // writer can emit) and asserts the parsed cells. If this test
+        // and the writer-round-trip test are both green the producer is
+        // genuinely RFC4180-compliant, not just "looks right".
+        var csv = "a,b,c\r\n" +
+                  "\"x,y\",\"line1\r\nline2\",\"he said \"\"hi\"\"\"\r\n" +
+                  "plain,\"with,comma\",end\r\n";
+        var rows = ParseCsv(csv);
+        Assert.Equal(3, rows.Count);
+        Assert.Equal(new[] { "a", "b", "c" }, rows[0]);
+        Assert.Equal(new[] { "x,y", "line1\r\nline2", "he said \"hi\"" }, rows[1]);
+        Assert.Equal(new[] { "plain", "with,comma", "end" }, rows[2]);
+    }
+
     // -----------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------
@@ -339,32 +528,76 @@ public class StatementEndpointTests : IDisposable
 
     private static List<string[]> ParseCsv(string block)
     {
-        // RFC4180-lite: rows separated by CRLF, fields by comma,
-        // optional double-quote wrap with embedded "" escape. Returns
-        // the parsed rows so callers can assert on column shape.
+        // RFC4180-compliant parser:
+        //   - Fields separated by comma, records by CRLF (LF tolerated).
+        //   - Fields may be wrapped in double quotes.
+        //   - Inside a quoted field, "" escapes a literal quote and
+        //     embedded commas / CR / LF are preserved as data, so a
+        //     single record can span multiple physical lines.
+        // Used to round-trip the statement CSV (whose producer escapes
+        // commas, quotes, and newlines per the same rules) so the test
+        // proves the producer is genuinely RFC4180-clean rather than
+        // "looks right on tidy fixtures".
         var rows = new List<string[]>();
-        foreach (var line in block.Split(new[] { "\r\n" }, StringSplitOptions.None))
+        var fields = new List<string>();
+        var sb = new StringBuilder();
+        var inQuotes = false;
+        for (var i = 0; i < block.Length; i++)
         {
-            if (line.Length == 0) continue;
-            var fields = new List<string>();
-            var sb = new StringBuilder();
-            var inQuotes = false;
-            for (var i = 0; i < line.Length; i++)
+            var c = block[i];
+            if (inQuotes)
             {
-                var c = line[i];
-                if (inQuotes)
+                if (c == '"')
                 {
-                    if (c == '"' && i + 1 < line.Length && line[i + 1] == '"') { sb.Append('"'); i++; }
-                    else if (c == '"') inQuotes = false;
-                    else sb.Append(c);
+                    if (i + 1 < block.Length && block[i + 1] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                    }
                 }
                 else
                 {
-                    if (c == ',') { fields.Add(sb.ToString()); sb.Clear(); }
-                    else if (c == '"' && sb.Length == 0) inQuotes = true;
-                    else sb.Append(c);
+                    sb.Append(c);
                 }
             }
+            else
+            {
+                if (c == '"' && sb.Length == 0)
+                {
+                    inQuotes = true;
+                }
+                else if (c == ',')
+                {
+                    fields.Add(sb.ToString());
+                    sb.Clear();
+                }
+                else if (c == '\r')
+                {
+                    if (i + 1 < block.Length && block[i + 1] == '\n') i++;
+                    fields.Add(sb.ToString());
+                    sb.Clear();
+                    rows.Add(fields.ToArray());
+                    fields = new List<string>();
+                }
+                else if (c == '\n')
+                {
+                    fields.Add(sb.ToString());
+                    sb.Clear();
+                    rows.Add(fields.ToArray());
+                    fields = new List<string>();
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+        }
+        if (sb.Length > 0 || fields.Count > 0)
+        {
             fields.Add(sb.ToString());
             rows.Add(fields.ToArray());
         }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -23,7 +23,7 @@ public class StatementProjectionTests
     {
         var wal = Array.Empty<(long Seq, WalEvent Event)>();
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         Assert.Equal("2024-06-17", dto.DayKey);
         Assert.Empty(dto.Positions);
@@ -61,7 +61,7 @@ public class StatementProjectionTests
             (7, Realized(2UL, Alice, "PETR4", 100m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         Assert.Equal(2, dto.Fills.Count);
         Assert.Contains(dto.Fills, f => f.Side == "Buy" && f.Quantity == 100);
@@ -99,7 +99,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 32m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal("PETR4", ir.Symbol);
@@ -123,7 +123,7 @@ public class StatementProjectionTests
             (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         Assert.Empty(dto.IrDayTrade.PerSymbol);
         Assert.Equal(0m, dto.IrDayTrade.TotalTax);
@@ -145,7 +145,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 28m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal(-200m, ir.GrossProfit);
@@ -168,7 +168,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 60, last: 60, price: 31m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal(60, ir.QtyMatched);
@@ -197,7 +197,7 @@ public class StatementProjectionTests
             (7, Realized(2UL, Bob, "PETR4", 999m, at: DayStart.AddHours(11))),
         };
 
-        var aliceDto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var aliceDto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
         Assert.Single(aliceDto.Fills);
         Assert.Equal(100, aliceDto.Fills[0].Quantity);
         Assert.Equal(1m, aliceDto.FeesTotal);
@@ -205,7 +205,7 @@ public class StatementProjectionTests
         var pos = Assert.Single(aliceDto.Positions);
         Assert.Equal(100, pos.NetQty);
 
-        var bobDto = StatementProjection.Build(Bob, Day, wal, livePositions: null);
+        var bobDto = StatementProjection.Build(Bob, Day, wal, livePositionsSnapshot: null);
         Assert.Single(bobDto.Fills);
         Assert.Equal(50, bobDto.Fills[0].Quantity);
         Assert.Equal(5m, bobDto.FeesTotal);
@@ -229,7 +229,7 @@ public class StatementProjectionTests
             (6, Er(3UL, ExecKind.Fill, 0, 30, 30, 32m, next)),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
         var fill = Assert.Single(dto.Fills);
         Assert.Equal(20, fill.Quantity);
         Assert.Equal(31m, fill.Price);
@@ -238,6 +238,70 @@ public class StatementProjectionTests
         // and Day's fill (20), excludes the Day+1 fill.
         var pos = Assert.Single(dto.Positions);
         Assert.Equal(30, pos.NetQty);
+    }
+
+    [Fact]
+    public void DayTradeMixedProfitAndLoss_NetsWithinSymbol()
+    {
+        // Pass-2 review (#279) P2 regression. Within the SAME end-client
+        // and SAME symbol on the SAME day FIFO can pair lots that
+        // produce both profits and losses; the projection must net
+        // them (per-symbol) before applying the 20% rate:
+        //   buy  100 @ 30  →  buy lot1 (100 @ 30)
+        //   buy  100 @ 35  →  buy lot2 (100 @ 35)
+        //   sell 100 @ 40  →  pairs FIFO against lot1 → +(40-30)*100 = +1000
+        //   sell 100 @ 31  →  pairs FIFO against lot2 → +(31-35)*100 =  -400
+        //   net per-symbol gross =  600  →  taxable 600 → tax 120.00
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, 0, 100, 100, 30m, DayStart.AddHours(10))),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Buy, 100, 35m)),
+            (4, Er(2UL, ExecKind.Fill, 0, 100, 100, 35m, DayStart.AddHours(11))),
+            (5, Submit(3UL, Alice, "PETR4", OrderSide.Sell, 100, 40m)),
+            (6, Er(3UL, ExecKind.Fill, 0, 100, 100, 40m, DayStart.AddHours(12))),
+            (7, Submit(4UL, Alice, "PETR4", OrderSide.Sell, 100, 31m)),
+            (8, Er(4UL, ExecKind.Fill, 0, 100, 100, 31m, DayStart.AddHours(13))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+
+        var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
+        Assert.Equal("PETR4", ir.Symbol);
+        Assert.Equal(200, ir.QtyMatched);
+        Assert.Equal(600m, ir.GrossProfit);
+        Assert.Equal(600m, ir.TaxableProfit);
+        Assert.Equal(120.00m, ir.TaxAmount);
+        Assert.Equal(120.00m, dto.IrDayTrade.TotalTax);
+    }
+
+    [Fact]
+    public void DayTradeMixedProfitAndLoss_NetLossYieldsZeroTaxWithNoCredit()
+    {
+        // Same shape as the profit case but the loss leg dominates:
+        //   buy  100 @ 30, buy 100 @ 35
+        //   sell 100 @ 32  → +(32-30)*100 = +200
+        //   sell 100 @ 25  → +(25-35)*100 = -1000
+        //   net gross = -800 → taxable = 0 → tax = 0 (no credit carried).
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, 0, 100, 100, 30m, DayStart.AddHours(10))),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Buy, 100, 35m)),
+            (4, Er(2UL, ExecKind.Fill, 0, 100, 100, 35m, DayStart.AddHours(11))),
+            (5, Submit(3UL, Alice, "PETR4", OrderSide.Sell, 100, 32m)),
+            (6, Er(3UL, ExecKind.Fill, 0, 100, 100, 32m, DayStart.AddHours(12))),
+            (7, Submit(4UL, Alice, "PETR4", OrderSide.Sell, 100, 25m)),
+            (8, Er(4UL, ExecKind.Fill, 0, 100, 100, 25m, DayStart.AddHours(13))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+
+        var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
+        Assert.Equal(-800m, ir.GrossProfit);
+        Assert.Equal(0m, ir.TaxableProfit);
+        Assert.Equal(0m, ir.TaxAmount);
+        Assert.Equal(0m, dto.IrDayTrade.TotalTax);
     }
 
     // -----------------------------------------------------------------

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -1,0 +1,312 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Q2.5 (#272). Pure-projection coverage for the daily statement DTO.
+/// Each test fabricates a minimal WAL slice (submit + ER + fee + pnl
+/// events) and asserts on the projection output — no host boot, no
+/// HTTP plumbing — so the economic logic (FIFO day-trade pairing,
+/// fee aggregation, gross/net P&amp;L) can be exercised in isolation.
+/// </summary>
+public class StatementProjectionTests
+{
+    private static readonly EndClientId Alice = new("alice");
+    private static readonly EndClientId Bob = new("bob");
+    private static readonly DateOnly Day = new(2024, 6, 17);
+    private static readonly DateTimeOffset DayStart = new(Day.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+
+    [Fact]
+    public void EmptyDay_ReturnsEmptyStatement_AllTotalsZero()
+    {
+        var wal = Array.Empty<(long Seq, WalEvent Event)>();
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        Assert.Equal("2024-06-17", dto.DayKey);
+        Assert.Empty(dto.Positions);
+        Assert.Empty(dto.Fills);
+        Assert.Empty(dto.Fees);
+        Assert.Equal(0m, dto.FeesTotal);
+        Assert.Equal(0m, dto.Pnl.RealizedGross);
+        Assert.Equal(0m, dto.Pnl.TotalFees);
+        Assert.Equal(0m, dto.Pnl.RealizedNet);
+        Assert.True(dto.IrDayTrade.InformationalOnly);
+        Assert.True(dto.IrDayTrade.NotCollected);
+        Assert.Equal(0.20m, dto.IrDayTrade.Rate);
+        Assert.Empty(dto.IrDayTrade.PerSymbol);
+        Assert.Equal(0m, dto.IrDayTrade.TotalTax);
+    }
+
+    [Fact]
+    public void WithFillsFeesAndRealized_TotalsMatchManualSum()
+    {
+        // alice: 100 PETR4 @ 30 buy, then 50 @ 32 sell.
+        // Realized gross = (32 - 30) * 50 = 100.
+        // Fees: brokerage 1.20, emolumentos 0.30, liquidacao 0.10 per fill.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Fee(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m,
+                brokerage: 1.20m, emolumentos: 0.30m, liquidacao: 0.10m,
+                at: DayStart.AddHours(10))),
+            (4, Submit(2UL, Alice, "PETR4", OrderSide.Sell, 50, 32m)),
+            (5, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 32m, at: DayStart.AddHours(11))),
+            (6, Fee(2UL, Alice, "PETR4", OrderSide.Sell, 50, 32m,
+                brokerage: 0.80m, emolumentos: 0.10m, liquidacao: 0.05m,
+                at: DayStart.AddHours(11))),
+            (7, Realized(2UL, Alice, "PETR4", 100m, at: DayStart.AddHours(11))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        Assert.Equal(2, dto.Fills.Count);
+        Assert.Contains(dto.Fills, f => f.Side == "Buy" && f.Quantity == 100);
+        Assert.Contains(dto.Fills, f => f.Side == "Sell" && f.Quantity == 50);
+
+        // Fee aggregation by feeType.
+        var feeByType = dto.Fees.ToDictionary(f => f.FeeType, f => f.Total);
+        Assert.Equal(2.00m, feeByType["brokerage"]);
+        Assert.Equal(0.40m, feeByType["emolumentos"]);
+        Assert.Equal(0.15m, feeByType["liquidacao"]);
+        Assert.Equal(2.55m, dto.FeesTotal);
+
+        Assert.Equal(100m, dto.Pnl.RealizedGross);
+        Assert.Equal(2.55m, dto.Pnl.TotalFees);
+        Assert.Equal(97.45m, dto.Pnl.RealizedNet);
+
+        // Position snapshot (projected from WAL): 50 long @ 30.
+        var pos = Assert.Single(dto.Positions);
+        Assert.Equal("PETR4", pos.Symbol);
+        Assert.Equal(50, pos.NetQty);
+        Assert.Equal(30m, pos.AvgPrice);
+    }
+
+    [Fact]
+    public void DayTradeIntradayProfit_AppliesTwentyPercentInformationalTax()
+    {
+        // alice buys 100 PETR4 @ 30 at 10:00 then sells 100 @ 32 at 11:00.
+        // FIFO pair: matched 100, gross = (32-30)*100 = 200, taxable = 200,
+        // tax = 200 * 0.20 = 40.00.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Sell, 100, 32m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 32m, at: DayStart.AddHours(11))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
+        Assert.Equal("PETR4", ir.Symbol);
+        Assert.Equal(100, ir.QtyMatched);
+        Assert.Equal(200m, ir.GrossProfit);
+        Assert.Equal(200m, ir.TaxableProfit);
+        Assert.Equal(40.00m, ir.TaxAmount);
+        Assert.Equal(40.00m, dto.IrDayTrade.TotalTax);
+        Assert.True(dto.IrDayTrade.InformationalOnly);
+        Assert.True(dto.IrDayTrade.NotCollected);
+    }
+
+    [Fact]
+    public void NoDayTradePair_ReturnsZeroIrTax()
+    {
+        // Only one side of the trade lands today (buy with no offsetting
+        // sell). Day-trade detection requires both sides on the SAME day.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        Assert.Empty(dto.IrDayTrade.PerSymbol);
+        Assert.Equal(0m, dto.IrDayTrade.TotalTax);
+    }
+
+    [Fact]
+    public void DayTradeLoss_ProducesZeroTaxOnThatSymbol()
+    {
+        // alice buys 100 PETR4 @ 30, sells 100 @ 28 → loss of 200.
+        // Taxable = max(-200, 0) = 0; tax = 0. The losing symbol still
+        // shows up in the per-symbol list (matched qty > 0) so the
+        // trader can see the realized day-trade activity, but it adds
+        // nothing to totalTax.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Sell, 100, 28m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 28m, at: DayStart.AddHours(11))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
+        Assert.Equal(-200m, ir.GrossProfit);
+        Assert.Equal(0m, ir.TaxableProfit);
+        Assert.Equal(0m, ir.TaxAmount);
+        Assert.Equal(0m, dto.IrDayTrade.TotalTax);
+    }
+
+    [Fact]
+    public void DayTradePartialFifo_OnlyMatchesIntradayQuantity()
+    {
+        // alice buys 100 @ 30 then sells 60 @ 31. FIFO matches 60 lots
+        // → gross = (31-30)*60 = 60; tax = 12.00. Residual 40 long
+        // remains in positions but is not matched.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Sell, 60, 31m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 60, last: 60, price: 31m, at: DayStart.AddHours(11))),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+
+        var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
+        Assert.Equal(60, ir.QtyMatched);
+        Assert.Equal(60m, ir.GrossProfit);
+        Assert.Equal(12.00m, ir.TaxAmount);
+
+        var pos = Assert.Single(dto.Positions);
+        Assert.Equal(40, pos.NetQty);
+    }
+
+    [Fact]
+    public void ScopeIsolation_ProjectionFiltersOutOtherEndClients()
+    {
+        // alice and bob both trade PETR4 today. alice's statement must
+        // surface ONLY alice's fills/fees/pnl/positions.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Fee(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m,
+                brokerage: 1m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(10))),
+            (4, Submit(2UL, Bob, "PETR4", OrderSide.Buy, 50, 30m)),
+            (5, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 30m, at: DayStart.AddHours(10))),
+            (6, Fee(2UL, Bob, "PETR4", OrderSide.Buy, 50, 30m,
+                brokerage: 5m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(10))),
+            (7, Realized(2UL, Bob, "PETR4", 999m, at: DayStart.AddHours(11))),
+        };
+
+        var aliceDto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        Assert.Single(aliceDto.Fills);
+        Assert.Equal(100, aliceDto.Fills[0].Quantity);
+        Assert.Equal(1m, aliceDto.FeesTotal);
+        Assert.Equal(0m, aliceDto.Pnl.RealizedGross);
+        var pos = Assert.Single(aliceDto.Positions);
+        Assert.Equal(100, pos.NetQty);
+
+        var bobDto = StatementProjection.Build(Bob, Day, wal, livePositions: null);
+        Assert.Single(bobDto.Fills);
+        Assert.Equal(50, bobDto.Fills[0].Quantity);
+        Assert.Equal(5m, bobDto.FeesTotal);
+        Assert.Equal(999m, bobDto.Pnl.RealizedGross);
+    }
+
+    [Fact]
+    public void EventsOutsideDay_AreExcludedFromTheDayProjection()
+    {
+        // A fill on Day-1 and a fill on Day+1 must not show up on Day's
+        // statement; only the in-window fill is surfaced.
+        var prev = DayStart.AddDays(-1).AddHours(11);
+        var next = DayStart.AddDays(1).AddHours(11);
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, Submit(1UL, Alice, "PETR4", OrderSide.Buy, 10, 30m)),
+            (2, Er(1UL, ExecKind.Fill, 0, 10, 10, 30m, prev)),
+            (3, Submit(2UL, Alice, "PETR4", OrderSide.Buy, 20, 31m)),
+            (4, Er(2UL, ExecKind.Fill, 0, 20, 20, 31m, DayStart.AddHours(10))),
+            (5, Submit(3UL, Alice, "PETR4", OrderSide.Buy, 30, 32m)),
+            (6, Er(3UL, ExecKind.Fill, 0, 30, 30, 32m, next)),
+        };
+
+        var dto = StatementProjection.Build(Alice, Day, wal, livePositions: null);
+        var fill = Assert.Single(dto.Fills);
+        Assert.Equal(20, fill.Quantity);
+        Assert.Equal(31m, fill.Price);
+
+        // Positions are end-of-day (Day): includes the Day-1 fill (10)
+        // and Day's fill (20), excludes the Day+1 fill.
+        var pos = Assert.Single(dto.Positions);
+        Assert.Equal(30, pos.NetQty);
+    }
+
+    // -----------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------
+
+    private static OrderSubmittedEvent Submit(ulong clOrdId, EndClientId owner, string symbol, OrderSide side, long qty, decimal price) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            EndClientId = owner.Value,
+            FirmId = "TEST",
+            Symbol = symbol,
+            SecurityId = 4321UL,
+            Side = side.ToString(),
+            Type = "Limit",
+            Quantity = qty,
+            Price = price,
+            TimestampUtc = DayStart.AddHours(9),
+        };
+
+    private static ExecutionReportReceivedEvent Er(
+        ulong clOrdId, ExecKind kind, long leaves, long cum, long last, decimal price, DateTimeOffset at) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            ExecKind = kind.ToString(),
+            LeavesQuantity = leaves,
+            CumulativeQuantity = cum,
+            LastQuantity = last,
+            LastPrice = price,
+            Synthetic = false,
+            TimestampUtc = at,
+        };
+
+    private static FeeAccruedEvent Fee(
+        ulong clOrdId, EndClientId owner, string symbol, OrderSide side, long qty, decimal price,
+        decimal brokerage, decimal emolumentos, decimal liquidacao, DateTimeOffset at)
+    {
+        var notional = qty * price;
+        return new FeeAccruedEvent
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = $"{clOrdId}:{qty}",
+            EndClientId = owner.Value,
+            Symbol = symbol,
+            Side = side.ToString(),
+            FillQuantity = qty,
+            FillPrice = price,
+            Notional = notional,
+            Brokerage = brokerage,
+            Emolumentos = emolumentos,
+            Liquidacao = liquidacao,
+            Total = brokerage + emolumentos + liquidacao,
+            TimestampUtc = at,
+        };
+    }
+
+    private static RealizedPnlEvent Realized(
+        ulong clOrdId, EndClientId owner, string symbol, decimal delta, DateTimeOffset at) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = $"{clOrdId}:r",
+            EndClientId = owner.Value,
+            Symbol = symbol,
+            DayKey = DateOnly.FromDateTime(at.UtcDateTime),
+            DeltaRealized = delta,
+            RunningTotal = delta,
+            TimestampUtc = at,
+        };
+}


### PR DESCRIPTION
Closes #272

## Summary
Adds `GET /statement/{dayKey?}` (JSON) and `GET /statement/{dayKey}.csv` (multi-section CSV) to the trading host. Both routes share a pure projection (`StatementProjection.Build`) over the WAL so JSON and CSV cannot drift.

## What the statement contains
- **positions** — live `PositionKeeper` for today; replayed from the WAL for past days
- **fills** — Fill / PartialFill ERs in the day window, owner/symbol resolved via OrderSubmitted + OrderReplaceRequested side-table
- **fees** — aggregated by fee-type (brokerage / emolumentos / liquidacao) from `FeeAccruedEvent` plus a `feesTotal`
- **pnl** — `{ realizedGross, totalFees, realizedNet }` (gross from `RealizedPnlEvent.DeltaRealized`)
- **irDayTrade** — informational pre-calc: FIFO pair buys vs sells per-symbol, 20% rate on `max(profit, 0)`. Flagged `informationalOnly: true`, `notCollected: true`. The platform never withholds.

## CSV details
UTF-8 BOM, CRLF lines, RFC4180-ish quoting. Sections: `# positions`, `# fills`, `# fees`, `# pnl-summary`, `# ir-day-trade (informational)`. `Content-Type: text/csv; charset=utf-8`. `Content-Disposition: attachment; filename="statement-YYYY-MM-DD.csv"`.

## Auth / errors
JWT-auth — end-client is the `sub` claim, mirroring `/pnl/today`. Future `dayKey` → 404. Malformed `dayKey` → 400.

## Day boundary
UTC `DateOnly`, matching `FeeKeeper`, `PnlKeeper`, and `RealizedPnlEvent.DayKey` already on disk. SP-TZ projection is a future concern at the API surface so keepers stay in lockstep with the WAL.

## Metrics
- `trading.statement.endpoint_requests{format=json|csv}`
- `trading.statement.day_trade_detected`

## Tests
- `StatementProjectionTests` (Application.Tests, 8 pure tests): empty day, fills/fees/pnl totals, day-trade with profit, no day-trade, day-trade loss, FIFO partial pairing, scope isolation, out-of-window exclusion.
- `StatementEndpointTests` (Api.Tests, 9 integration tests): 401, empty day, with fills, IR day-trade pair, no day-trade, CSV parseable with BOM, scope isolation alice/bob, future day → 404, malformed → 400.

`dotnet test B3TradingPlatform.slnx` → 1344 passed / 0 failed / 30 skipped.
`dotnet format B3TradingPlatform.slnx --verify-no-changes` → clean.