### PR TITLE
feat(#281): VWAP algo (volume curve estimator + slice scheduler)

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -134,6 +134,38 @@ public static class AlgoEndpoints
                         childType, req.Twap.ChildPrice);
                     break;
 
+                case AlgoType.Vwap:
+                    // Q3.1 (#281). VWAP mirrors TWAP's surface conventions
+                    // — kept on the same POST /algo endpoint so the
+                    // discriminator-by-Type pattern stays consistent.
+                    if (req.Vwap is null)
+                        return Results.BadRequest(new { error = "vwap parameters are required for type=Vwap" });
+                    if (!Enum.TryParse<OrderType>(req.Vwap.ChildOrderType, ignoreCase: true, out var vwapChildType))
+                        return Results.BadRequest(new { error = $"invalid vwap.childOrderType '{req.Vwap.ChildOrderType}'" });
+                    if (vwapChildType is not (OrderType.Limit or OrderType.Market))
+                        return Results.BadRequest(new { error = "vwap.childOrderType must be Limit or Market" });
+                    if (req.Vwap.EndUtc <= req.Vwap.StartUtc)
+                        return Results.BadRequest(new { error = "vwap.endUtc must be greater than vwap.startUtc" });
+                    if (vwapChildType == OrderType.Limit && req.Vwap.ChildPrice is null)
+                        return Results.BadRequest(new { error = "vwap.childPrice is required when vwap.childOrderType is Limit" });
+                    var tickSeconds = req.Vwap.TickIntervalSeconds ?? 30d;
+                    if (tickSeconds <= 0)
+                        return Results.BadRequest(new { error = "vwap.tickIntervalSeconds must be positive" });
+                    if (req.Vwap.SliceMaxPct is { } smp && (smp <= 0 || smp > 1))
+                        return Results.BadRequest(new { error = "vwap.sliceMaxPct must be in (0, 1]" });
+                    if (req.Vwap.ParticipationCap is { } pc && (pc <= 0 || pc > 1))
+                        return Results.BadRequest(new { error = "vwap.participationCap must be in (0, 1]" });
+                    parameters = new VwapParameters(
+                        req.Vwap.StartUtc,
+                        req.Vwap.EndUtc,
+                        vwapChildType,
+                        req.Vwap.ChildPrice,
+                        TimeSpan.FromSeconds(tickSeconds),
+                        req.Vwap.SliceMaxPct,
+                        req.Vwap.PriceLimit,
+                        req.Vwap.ParticipationCap);
+                    break;
+
                 default:
                     return Results.BadRequest(new { error = $"unsupported algo type '{type}'" });
             }
@@ -166,6 +198,14 @@ public static class AlgoEndpoints
                         TwapSliceCount = (parameters as TwapParameters)?.SliceCount,
                         TwapChildOrderType = (parameters as TwapParameters)?.ChildOrderType.ToString(),
                         TwapChildPrice = (parameters as TwapParameters)?.ChildPrice,
+                        VwapStartUtc = (parameters as VwapParameters)?.StartUtc,
+                        VwapEndUtc = (parameters as VwapParameters)?.EndUtc,
+                        VwapChildOrderType = (parameters as VwapParameters)?.ChildOrderType.ToString(),
+                        VwapChildPrice = (parameters as VwapParameters)?.ChildPrice,
+                        VwapTickIntervalTicks = (parameters as VwapParameters)?.TickInterval.Ticks,
+                        VwapSliceMaxPct = (parameters as VwapParameters)?.SliceMaxPct,
+                        VwapPriceLimit = (parameters as VwapParameters)?.PriceLimit,
+                        VwapParticipationCap = (parameters as VwapParameters)?.ParticipationCap,
                     },
                     () => algos.TryAdd(algo));
             }
@@ -295,7 +335,8 @@ public sealed record CreateAlgoRequest(
     string Type,
     long TotalQuantity,
     CreateAlgoIcebergParams? Iceberg,
-    CreateAlgoTwapParams? Twap);
+    CreateAlgoTwapParams? Twap,
+    CreateAlgoVwapParams? Vwap = null);
 
 public sealed record CreateAlgoIcebergParams(long DisplayQuantity, decimal? LimitPrice);
 
@@ -305,3 +346,18 @@ public sealed record CreateAlgoTwapParams(
     int SliceCount,
     string ChildOrderType,
     decimal? ChildPrice);
+
+/// <summary>
+/// HTTP request shape for the VWAP parameter block (Q3.1 / #281).
+/// <see cref="TickIntervalSeconds"/> defaults to 30s when null — matches
+/// the issue spec default.
+/// </summary>
+public sealed record CreateAlgoVwapParams(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    string ChildOrderType,
+    decimal? ChildPrice,
+    double? TickIntervalSeconds = null,
+    decimal? SliceMaxPct = null,
+    decimal? PriceLimit = null,
+    decimal? ParticipationCap = null);

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -160,7 +160,8 @@ public sealed record AlgoDto(
     DateTimeOffset CreatedAtUtc,
     DateTimeOffset? TerminalAtUtc,
     IcebergParamsDto? Iceberg,
-    TwapParamsDto? Twap);
+    TwapParamsDto? Twap,
+    VwapParamsDto? Vwap = null);
 
 public sealed record IcebergParamsDto(long DisplayQuantity, decimal? LimitPrice);
 
@@ -170,6 +171,22 @@ public sealed record TwapParamsDto(
     int SliceCount,
     string ChildOrderType,
     decimal? ChildPrice);
+
+/// <summary>
+/// Wire shape for VWAP parameters (Q3.1 / #281). Tick interval is
+/// surfaced in seconds (the WAL persists ticks; this is a UX choice for
+/// the JSON wire) so dashboards and clients don't have to know the
+/// .NET tick unit.
+/// </summary>
+public sealed record VwapParamsDto(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    string ChildOrderType,
+    decimal? ChildPrice,
+    double TickIntervalSeconds,
+    decimal? SliceMaxPct,
+    decimal? PriceLimit,
+    decimal? ParticipationCap);
 
 public static class DtoMappings
 {
@@ -195,6 +212,10 @@ public static class DtoMappings
         TwapParamsDto? twap = a.Parameters is TwapParameters tp
             ? new TwapParamsDto(tp.StartUtc, tp.EndUtc, tp.SliceCount, tp.ChildOrderType.ToString(), tp.ChildPrice)
             : null;
+        VwapParamsDto? vwap = a.Parameters is VwapParameters vp
+            ? new VwapParamsDto(vp.StartUtc, vp.EndUtc, vp.ChildOrderType.ToString(), vp.ChildPrice,
+                vp.TickInterval.TotalSeconds, vp.SliceMaxPct, vp.PriceLimit, vp.ParticipationCap)
+            : null;
         return new AlgoDto(
             a.AlgoId.ToString(),
             a.Symbol,
@@ -209,6 +230,7 @@ public static class DtoMappings
             a.CreatedAtUtc,
             a.TerminalAtUtc,
             iceberg,
-            twap);
+            twap,
+            vwap);
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -78,6 +78,7 @@ public sealed class AlgoEngine : BackgroundService
     private readonly ILogger<AlgoEngine> _logger;
     private readonly OrderOwnershipMap _ownership;
     private readonly VolumeCurveEstimator? _vwapCurve;
+    private readonly MarketDataVolumePump? _volumePump;
 
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
@@ -97,7 +98,8 @@ public sealed class AlgoEngine : BackgroundService
         TimeProvider clock,
         ILogger<AlgoEngine> logger,
         OrderOwnershipMap ownership,
-        VolumeCurveEstimator? vwapCurve = null)
+        VolumeCurveEstimator? vwapCurve = null,
+        MarketDataVolumePump? volumePump = null)
     {
         _queue = queue;
         _algos = algos;
@@ -111,6 +113,7 @@ public sealed class AlgoEngine : BackgroundService
         _logger = logger;
         _ownership = ownership;
         _vwapCurve = vwapCurve;
+        _volumePump = volumePump;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -249,6 +252,18 @@ public sealed class AlgoEngine : BackgroundService
     {
         if (algo.IsTerminal) return;
         if (algo.Status == AlgoStatus.Cancelling) return;
+
+        // Pass-1 review (#294) P1. VWAP needs the SDK subscribed to its
+        // symbol so the VolumeCurveEstimator receives trade prints; without
+        // a non-empty curve and ParticipationCap set, VwapPlan.SliceQty
+        // returns 0 until window expiry → silent no-op algo. The pump
+        // dedupes per symbol so repeated calls (reactor re-evaluation,
+        // multiple parents on the same symbol, WAL replay-driven
+        // reconciliation) collapse to one SDK Subscribe per process.
+        if (algo.Type == AlgoType.Vwap && _volumePump is not null)
+        {
+            await _volumePump.EnsureSubscribedAsync(algo.Symbol, ct).ConfigureAwait(false);
+        }
 
         if (rt.LiveChildClOrdId is { } existing)
         {

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -76,6 +77,7 @@ public sealed class AlgoEngine : BackgroundService
     private readonly TimeProvider _clock;
     private readonly ILogger<AlgoEngine> _logger;
     private readonly OrderOwnershipMap _ownership;
+    private readonly VolumeCurveEstimator? _vwapCurve;
 
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
@@ -94,7 +96,8 @@ public sealed class AlgoEngine : BackgroundService
         EventDispatcher dispatcher,
         TimeProvider clock,
         ILogger<AlgoEngine> logger,
-        OrderOwnershipMap ownership)
+        OrderOwnershipMap ownership,
+        VolumeCurveEstimator? vwapCurve = null)
     {
         _queue = queue;
         _algos = algos;
@@ -107,6 +110,7 @@ public sealed class AlgoEngine : BackgroundService
         _clock = clock;
         _logger = logger;
         _ownership = ownership;
+        _vwapCurve = vwapCurve;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -302,6 +306,41 @@ public sealed class AlgoEngine : BackgroundService
                 return;
             }
         }
+        else if (algo.Type == AlgoType.Vwap && algo.Parameters is VwapParameters vp)
+        {
+            // VWAP: same shape as TWAP but the slice-quantity decision
+            // is driven by the live volume curve via ComputeNextSlice.
+            // Empty slots (gap <= 0) are skipped by advancing
+            // NextSliceSeq without submitting — keeps the slot index in
+            // step with the deterministic plannedAtUtc grid so recovery
+            // is unambiguous.
+            var now = _clock.GetUtcNow();
+            if (now >= vp.EndUtc)
+            {
+                await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
+                return;
+            }
+
+            // Skip any already-due empty slots up to the first one with
+            // qty > 0 (or the first one not yet due, whichever comes
+            // first). The scheduler ticks every 100ms so the catch-up
+            // loop runs at most until the volume curve produces a non-
+            // zero gap or we hit the future.
+            while (true)
+            {
+                var dueAt = VwapPlan.PlannedAtUtc(vp.StartUtc, vp.TickInterval, rt.NextSliceSeq);
+                if (now < dueAt) return;
+                if (dueAt >= vp.EndUtc)
+                {
+                    // No more in-window slots; let the window-expiry
+                    // path drive the terminal transition.
+                    return;
+                }
+                var (qty, _, _, _) = ComputeVwapSlice(algo, vp, dueAt);
+                if (qty > 0) break;
+                rt.NextSliceSeq++;
+            }
+        }
 
         await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
     }
@@ -370,6 +409,17 @@ public sealed class AlgoEngine : BackgroundService
                     }
                     return;
                 }
+                if (algo.Type == AlgoType.Vwap && algo.Parameters is VwapParameters vpFilled)
+                {
+                    // VWAP child finished but residue remains. Mirror
+                    // TWAP: scheduler will re-fire at the next slot.
+                    // Window-expired-during-child-fill same handling.
+                    if (_clock.GetUtcNow() >= vpFilled.EndUtc)
+                    {
+                        await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
+                    }
+                    return;
+                }
                 await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
                 return;
 
@@ -392,6 +442,10 @@ public sealed class AlgoEngine : BackgroundService
                     // VenueCancelled.
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
                 }
+                else if (IsVwapWindowExpired(algo))
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
+                }
                 else
                 {
                     // Venue cancelled the child without operator request
@@ -410,6 +464,11 @@ public sealed class AlgoEngine : BackgroundService
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.TwapWindowExpired).ConfigureAwait(false);
                     return;
                 }
+                if (IsVwapWindowExpired(algo))
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
+                    return;
+                }
                 await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
                 return;
         }
@@ -419,6 +478,11 @@ public sealed class AlgoEngine : BackgroundService
         algo.Type == AlgoType.Twap
         && algo.Parameters is TwapParameters tp
         && _clock.GetUtcNow() >= tp.EndUtc;
+
+    private bool IsVwapWindowExpired(Algo algo) =>
+        algo.Type == AlgoType.Vwap
+        && algo.Parameters is VwapParameters vp
+        && _clock.GetUtcNow() >= vp.EndUtc;
 
     private async Task OnCancelRequestedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
     {
@@ -474,6 +538,14 @@ public sealed class AlgoEngine : BackgroundService
         var (sliceQty, slicePrice) = ComputeNextSlice(algo);
         if (sliceQty <= 0)
         {
+            if (algo.Type == AlgoType.Vwap)
+            {
+                // VWAP: empty slot — the parent is ahead of the curve.
+                // Advance NextSliceSeq so the next scheduler tick
+                // evaluates the next slot. Do NOT mark terminal.
+                rt.NextSliceSeq++;
+                return;
+            }
             // Should be unreachable (RemainingQuantity == 0 is checked by
             // callers) — defensive log + complete.
             await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
@@ -485,8 +557,23 @@ public sealed class AlgoEngine : BackgroundService
         {
             IcebergParameters => OrderType.Limit,
             TwapParameters tp => tp.ChildOrderType,
+            VwapParameters vp => vp.ChildOrderType,
             _ => OrderType.Limit,
         };
+
+        // Capture VWAP audit envelope inputs BEFORE submit so we can WAL
+        // them once the venue accepts the child. Recompute is cheap and
+        // it keeps the envelope honest under retry loops.
+        long vwapTargetCum = 0, vwapExecutedCum = 0;
+        DateTimeOffset vwapPlannedAt = default;
+        if (algo.Parameters is VwapParameters vpForAudit)
+        {
+            vwapPlannedAt = VwapPlan.PlannedAtUtc(vpForAudit.StartUtc, vpForAudit.TickInterval, sliceSeq);
+            var (_, _, target, gap) = ComputeVwapSlice(algo, vpForAudit, vwapPlannedAt);
+            vwapTargetCum = target;
+            vwapExecutedCum = algo.FilledQuantity;
+            MetricsRegistry.AlgoVwapTargetVsActualDiff.Record(gap);
+        }
 
         for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
         {
@@ -527,6 +614,32 @@ public sealed class AlgoEngine : BackgroundService
                     rt.RetryAttempts = 0;
                     MetricsRegistry.AlgoChildrenSubmitted.Add(1,
                         new KeyValuePair<string, object?>("type", algo.Type.ToString().ToLowerInvariant()));
+                    if (algo.Type == AlgoType.Vwap)
+                    {
+                        MetricsRegistry.AlgoVwapSlicesEmitted.Add(1);
+                        // Best-effort audit envelope. WAL backpressure
+                        // here is non-fatal — recovery doesn't need it.
+                        try
+                        {
+                            _dispatcher.Dispatch(
+                                new AlgoVwapSlicedEvent
+                                {
+                                    AlgoId = algo.AlgoId,
+                                    FirmId = algo.FirmId,
+                                    SliceSeq = sliceSeq,
+                                    TargetCumQty = vwapTargetCum,
+                                    ExecutedCum = vwapExecutedCum,
+                                    SliceQty = sliceQty,
+                                    PlannedAtUtc = vwapPlannedAt,
+                                },
+                                static () => { });
+                        }
+                        catch (WalBackpressureException)
+                        {
+                            MetricsRegistry.WalBackpressure.Add(1,
+                                new KeyValuePair<string, object?>("call_site", "algo.vwap.sliced"));
+                        }
+                    }
                     _algoSink.PublishAlgoSnapshot(algo.Owner, algo.FirmId, algo.AlgoId);
                     return;
 
@@ -612,6 +725,10 @@ public sealed class AlgoEngine : BackgroundService
         }
 
         _algoSink.PublishAlgoSnapshot(algo.Owner, algo.FirmId, algo.AlgoId);
+        if (algo.Type == AlgoType.Vwap && status == AlgoStatus.Cancelled)
+        {
+            MetricsRegistry.AlgoVwapCancelled.Add(1);
+        }
         await Task.CompletedTask;
     }
 
@@ -641,9 +758,60 @@ public sealed class AlgoEngine : BackgroundService
                     var qty = Math.Min(planned, algo.RemainingQuantity);
                     return (qty, tp.ChildPrice);
                 }
+            case VwapParameters vp:
+                {
+                    var rt = _runtime[(algo.FirmId, algo.AlgoId)];
+                    var dueAt = VwapPlan.PlannedAtUtc(vp.StartUtc, vp.TickInterval, rt.NextSliceSeq);
+                    var (qty, price, _, _) = ComputeVwapSlice(algo, vp, dueAt);
+                    return (qty, price);
+                }
             default:
                 return (algo.RemainingQuantity, null);
         }
+    }
+
+    /// <summary>
+    /// VWAP slice computation: ask the curve for the CDF at the slot's
+    /// <c>plannedAtUtc</c>, derive the target cumulative qty, apply the
+    /// per-slice caps. Returns <c>(qty, price, targetCum, gap)</c> so the
+    /// emission path can record the audit envelope without recomputing.
+    /// </summary>
+    private (long Qty, decimal? Price, long TargetCum, long Gap) ComputeVwapSlice(
+        Algo algo, VwapParameters vp, DateTimeOffset evaluateAtUtc)
+    {
+        var cdf = _vwapCurve?.CdfAt(algo.Symbol, vp.StartUtc, vp.EndUtc, evaluateAtUtc)
+            ?? UniformCdf(vp.StartUtc, vp.EndUtc, evaluateAtUtc);
+        var targetCum = VwapPlan.TargetCumQty(algo.TotalQuantity, cdf);
+        long recentMarketVolume = 0;
+        if (vp.ParticipationCap is { } && _vwapCurve is not null)
+        {
+            // "Recent" volume window = one tick interval prior to now.
+            // Smaller windows over-react to micro-bursts; larger windows
+            // mute the cap. One tick interval matches the slice cadence.
+            var lookback = evaluateAtUtc - vp.TickInterval;
+            if (lookback < vp.StartUtc) lookback = vp.StartUtc;
+            recentMarketVolume = _vwapCurve.VolumeBetween(algo.Symbol, lookback, evaluateAtUtc);
+        }
+        var executedCum = algo.FilledQuantity;
+        var gap = targetCum - executedCum;
+        var qty = VwapPlan.SliceQty(
+            targetCum,
+            executedCum,
+            algo.RemainingQuantity,
+            algo.TotalQuantity,
+            vp.SliceMaxPct,
+            vp.ParticipationCap,
+            recentMarketVolume);
+        var price = VwapPlan.ClampPrice(vp.ChildPrice, vp.PriceLimit, algo.Side);
+        return (qty, price, targetCum, gap);
+    }
+
+    private static double UniformCdf(DateTimeOffset start, DateTimeOffset end, DateTimeOffset at)
+    {
+        if (end <= start) return 0;
+        if (at <= start) return 0;
+        if (at >= end) return 1;
+        return (at - start).TotalSeconds / (end - start).TotalSeconds;
     }
 
     private static bool IsChildTerminal(Order o) =>

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -147,46 +147,89 @@ public sealed class AlgoScheduler : BackgroundService
         var algos = _algos.EnumerateAll(includeTerminal: false);
         foreach (var algo in algos)
         {
-            if (algo.Type != AlgoType.Twap) continue;
             if (algo.IsTerminal) continue;
             if (algo.Status == AlgoStatus.Cancelling) continue;
-            if (algo.Parameters is not TwapParameters tp) continue;
 
-            // Window expiry is independent of slice progress: even if more
-            // slices are nominally scheduled, once endUtc has passed the
-            // engine must promote to Expired so the parent stops counting
-            // as "live work" everywhere.
-            if (now >= tp.EndUtc)
+            if (algo.Type == AlgoType.Twap && algo.Parameters is TwapParameters tp)
             {
-                Enqueue(algo);
+                TickTwap(algo, tp, now);
                 continue;
             }
 
-            // Determine "is there a live child?" and "what's the next
-            // slice we owe?" by scanning the order book — the scheduler
-            // intentionally does not share state with the engine to keep
-            // the threads decoupled (RFC §4.11 commitment 1).
-            int maxSeq = -1;
-            bool hasLiveChild = false;
-            foreach (var child in _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId))
+            if (algo.Type == AlgoType.Vwap && algo.Parameters is VwapParameters vp)
             {
-                if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
-                if (!IsChildTerminal(child)) hasLiveChild = true;
+                TickVwap(algo, vp, now);
+                continue;
             }
-            if (hasLiveChild) continue;
-
-            var nextSeq = maxSeq + 1;
-            if (nextSeq >= tp.SliceCount) continue; // plan exhausted; wait for endUtc
-
-            var dueAt = TwapPlan.PlannedAtUtc(tp.StartUtc, tp.EndUtc, tp.SliceCount, nextSeq);
-            if (now < dueAt) continue;
-
-            // Slice fire: capture jitter as (now - plannedAtUtc) before
-            // the channel write so dropped signals still surface in the
-            // metric.
-            MetricsRegistry.AlgoTwapSliceFireJitter.Record((now - dueAt).TotalMilliseconds);
-            Enqueue(algo);
         }
+    }
+
+    private void TickTwap(Algo algo, TwapParameters tp, DateTimeOffset now)
+    {
+        // Window expiry is independent of slice progress: even if more
+        // slices are nominally scheduled, once endUtc has passed the
+        // engine must promote to Expired so the parent stops counting
+        // as "live work" everywhere.
+        if (now >= tp.EndUtc)
+        {
+            Enqueue(algo);
+            return;
+        }
+
+        // Determine "is there a live child?" and "what's the next
+        // slice we owe?" by scanning the order book — the scheduler
+        // intentionally does not share state with the engine to keep
+        // the threads decoupled (RFC §4.11 commitment 1).
+        int maxSeq = -1;
+        bool hasLiveChild = false;
+        foreach (var child in _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId))
+        {
+            if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
+            if (!IsChildTerminal(child)) hasLiveChild = true;
+        }
+        if (hasLiveChild) return;
+
+        var nextSeq = maxSeq + 1;
+        if (nextSeq >= tp.SliceCount) return; // plan exhausted; wait for endUtc
+
+        var dueAt = TwapPlan.PlannedAtUtc(tp.StartUtc, tp.EndUtc, tp.SliceCount, nextSeq);
+        if (now < dueAt) return;
+
+        // Slice fire: capture jitter as (now - plannedAtUtc) before
+        // the channel write so dropped signals still surface in the
+        // metric.
+        MetricsRegistry.AlgoTwapSliceFireJitter.Record((now - dueAt).TotalMilliseconds);
+        Enqueue(algo);
+    }
+
+    private void TickVwap(Algo algo, VwapParameters vp, DateTimeOffset now)
+    {
+        // VWAP mirrors TWAP scheduling: window-expired parents need an
+        // engine pass to mark Expired; otherwise enqueue at most one
+        // Created signal per parent per tick so the engine evaluates
+        // the slice (it owns the catch-up loop for empty slots — see
+        // OnCreatedAsync).
+        if (now >= vp.EndUtc)
+        {
+            Enqueue(algo);
+            return;
+        }
+
+        int maxSeq = -1;
+        bool hasLiveChild = false;
+        foreach (var child in _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId))
+        {
+            if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
+            if (!IsChildTerminal(child)) hasLiveChild = true;
+        }
+        if (hasLiveChild) return;
+
+        var nextSeq = maxSeq + 1;
+        var dueAt = VwapPlan.PlannedAtUtc(vp.StartUtc, vp.TickInterval, nextSeq);
+        if (now < dueAt) return;
+        if (dueAt >= vp.EndUtc) return; // window passed at the slot boundary
+
+        Enqueue(algo);
     }
 
     private void Enqueue(Algo algo)

--- a/backend/src/B3.Trading.Application/Algo/VwapPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/VwapPlan.cs
@@ -145,8 +145,19 @@ public static class VwapPlan
             capped = Math.Min(capped, maxSlice);
         }
 
-        if (participationCap is { } pcap && pcap > 0 && recentMarketVolume > 0)
+        if (participationCap is { } pcap && pcap > 0)
         {
+            if (recentMarketVolume <= 0)
+            {
+                // Pass-1 review (#294) P1#2 fix. If we have no recent
+                // market activity baseline, participation rate is
+                // undefined: we cannot guarantee we won't exceed the
+                // cap. Treat the cap as zero — emit NO slice this tick
+                // and let the next tick re-evaluate once trades arrive.
+                // Per RFC: a hard cap is hard; never guess past it.
+                return 0;
+            }
+
             var maxByMarket = (long)Math.Floor((decimal)recentMarketVolume * pcap);
             if (maxByMarket < 1) maxByMarket = 1;
             capped = Math.Min(capped, maxByMarket);

--- a/backend/src/B3.Trading.Application/Algo/VwapPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/VwapPlan.cs
@@ -1,0 +1,173 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pure helpers for the VWAP (Volume-Weighted Average Price) slice
+/// scheduler (Q3.1 / #281). Mirrors the design of <see cref="TwapPlan"/>:
+/// the plan is fully derivable from the parent parameters + the
+/// volume-curve estimator's CDF + the parent's current executed cum, so
+/// the scheduler and the engine can compute the same target without
+/// sharing mutable state.
+///
+/// <para>
+/// <b>Slot spacing.</b> The window <c>[startUtc, endUtc)</c> is divided
+/// into evaluation slots of <c>tickInterval</c>. Slot <c>k</c> fires at
+/// <c>startUtc + k * tickInterval</c>; the last slot is the largest
+/// <c>k</c> such that <c>plannedAtUtc &lt; endUtc</c>. The window expiry
+/// itself is enforced separately (no slot is scheduled at or after
+/// <c>endUtc</c>), same convention as <see cref="TwapPlan"/>.
+/// </para>
+///
+/// <para>
+/// <b>Target curve.</b> <c>targetCumQty(t) = totalQty * F(t)</c> where
+/// <c>F</c> is the volume-curve CDF supplied by the caller (the
+/// <c>VolumeCurveEstimator</c> in production; an identity / uniform stub
+/// in tests). F is clamped to <c>[0, 1]</c>; out-of-window samples
+/// saturate at the boundaries.
+/// </para>
+///
+/// <para>
+/// <b>Slice quantity.</b> At each slot the engine asks "what should I
+/// submit?" via <see cref="SliceQty"/>: it computes the gap between the
+/// target cumulative quantity and what has already executed, then applies
+/// the per-slice caps (<c>sliceMaxPct</c>, <c>participationCap</c>) and
+/// the parent's <c>remainingQuantity</c>. Returns 0 when the parent is
+/// ahead of the curve — the engine treats that as "skip this slot, wait
+/// for the next tick".
+/// </para>
+///
+/// <para>
+/// <b>Determinism.</b> Like <see cref="TwapPlan"/>, the offset is
+/// computed in ticks so the same call from the scheduler thread and the
+/// engine thread produces byte-identical results. Without this, the two
+/// threads could disagree about whether a slot is due and slice-fire
+/// would race.
+/// </para>
+/// </summary>
+public static class VwapPlan
+{
+    /// <summary>
+    /// UTC instant at which evaluation slot <paramref name="sliceSeq"/>
+    /// is due. Pure function of the parent parameters; no clock side
+    /// effect.
+    /// </summary>
+    public static DateTimeOffset PlannedAtUtc(
+        DateTimeOffset startUtc, TimeSpan tickInterval, int sliceSeq)
+    {
+        if (tickInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tickInterval), "tickInterval must be positive.");
+        if (sliceSeq < 0)
+            throw new ArgumentOutOfRangeException(nameof(sliceSeq), "sliceSeq must be non-negative.");
+
+        var offsetTicks = tickInterval.Ticks * sliceSeq;
+        return startUtc.AddTicks(offsetTicks);
+    }
+
+    /// <summary>
+    /// Number of evaluation slots in the window. The last slot fires
+    /// strictly before <c>endUtc</c>; window expiry is the engine's
+    /// separate boundary.
+    /// </summary>
+    public static int SlotCount(DateTimeOffset startUtc, DateTimeOffset endUtc, TimeSpan tickInterval)
+    {
+        if (endUtc <= startUtc)
+            throw new ArgumentException("endUtc must be after startUtc.", nameof(endUtc));
+        if (tickInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tickInterval), "tickInterval must be positive.");
+
+        var windowTicks = (endUtc - startUtc).Ticks;
+        // ceil so any non-empty window has at least one slot at startUtc.
+        var slots = (int)((windowTicks + tickInterval.Ticks - 1) / tickInterval.Ticks);
+        return Math.Max(1, slots);
+    }
+
+    /// <summary>
+    /// Target cumulative quantity at <paramref name="at"/>:
+    /// <c>round(totalQty * cdf)</c>. The caller clamps <paramref name="cdf"/>
+    /// to <c>[0, 1]</c>; we still defensively clip to handle floating-
+    /// point fuzz from the estimator.
+    /// </summary>
+    public static long TargetCumQty(long totalQuantity, double cdf)
+    {
+        if (totalQuantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(totalQuantity), "totalQuantity must be positive.");
+        if (double.IsNaN(cdf) || cdf <= 0) return 0;
+        if (cdf >= 1) return totalQuantity;
+        // Round to nearest to keep the target curve close to the analytic
+        // value; the per-slice cap downstream limits any rounding error
+        // to one share of slice quantity.
+        var v = (long)Math.Round(totalQuantity * cdf, MidpointRounding.AwayFromZero);
+        return Math.Clamp(v, 0L, totalQuantity);
+    }
+
+    /// <summary>
+    /// Quantity to submit at the current evaluation slot. Computed as:
+    /// <c>min(targetCumQty - executedCum, remainingQty, sliceMaxPct*total,
+    /// participationCap*recentMarketVolume)</c>. Returns 0 when the
+    /// parent is ahead of the curve — the engine treats that as "skip
+    /// this slot, wait for the next tick".
+    /// </summary>
+    /// <param name="targetCumQty">Output of <see cref="TargetCumQty"/> at
+    /// the slot's <c>plannedAtUtc</c>.</param>
+    /// <param name="executedCum">Sum of fills already booked against the
+    /// parent.</param>
+    /// <param name="remainingQuantity">Parent's residue
+    /// (<c>totalQty - executedCum</c>); the engine passes
+    /// <c>Algo.RemainingQuantity</c> which is monotonic-non-increasing.</param>
+    /// <param name="totalQuantity">Parent total (for the sliceMaxPct cap).</param>
+    /// <param name="sliceMaxPct">Per-slice fraction cap; null = no cap.</param>
+    /// <param name="participationCap">Per-slice fraction of recent market
+    /// volume; null = no cap.</param>
+    /// <param name="recentMarketVolume">Volume seen in the current
+    /// participation window. Pair with <paramref name="participationCap"/>;
+    /// ignored when either is null.</param>
+    public static long SliceQty(
+        long targetCumQty,
+        long executedCum,
+        long remainingQuantity,
+        long totalQuantity,
+        decimal? sliceMaxPct,
+        decimal? participationCap,
+        long recentMarketVolume)
+    {
+        if (totalQuantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(totalQuantity));
+        if (remainingQuantity <= 0) return 0;
+
+        var gap = targetCumQty - executedCum;
+        if (gap <= 0) return 0;
+
+        var capped = Math.Min(gap, remainingQuantity);
+
+        if (sliceMaxPct is { } pct && pct > 0)
+        {
+            var maxSlice = (long)Math.Floor((decimal)totalQuantity * pct);
+            if (maxSlice < 1) maxSlice = 1; // a 0% cap would freeze the algo
+            capped = Math.Min(capped, maxSlice);
+        }
+
+        if (participationCap is { } pcap && pcap > 0 && recentMarketVolume > 0)
+        {
+            var maxByMarket = (long)Math.Floor((decimal)recentMarketVolume * pcap);
+            if (maxByMarket < 1) maxByMarket = 1;
+            capped = Math.Min(capped, maxByMarket);
+        }
+
+        return Math.Max(0, capped);
+    }
+
+    /// <summary>
+    /// Resolves the child LIMIT price. If a <paramref name="priceLimit"/>
+    /// is configured the engine never crosses past it; otherwise the
+    /// <paramref name="refPrice"/> is used as-is. For Buy side, the
+    /// effective price is <c>min(refPrice, priceLimit)</c>; for Sell side,
+    /// <c>max(refPrice, priceLimit)</c>.
+    /// </summary>
+    public static decimal? ClampPrice(decimal? refPrice, decimal? priceLimit, B3.Trading.Domain.OrderSide side)
+    {
+        if (priceLimit is null) return refPrice;
+        if (refPrice is null) return priceLimit;
+        return side == B3.Trading.Domain.OrderSide.Buy
+            ? Math.Min(refPrice.Value, priceLimit.Value)
+            : Math.Max(refPrice.Value, priceLimit.Value);
+    }
+}

--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -137,6 +137,14 @@ public sealed class AlgoBook
         int? twapSliceCount = null;
         string? twapChildType = null;
         decimal? twapChildPrice = null;
+        DateTimeOffset? vwapStart = null;
+        DateTimeOffset? vwapEnd = null;
+        string? vwapChildType = null;
+        decimal? vwapChildPrice = null;
+        long? vwapTickIntervalTicks = null;
+        decimal? vwapSliceMaxPct = null;
+        decimal? vwapPriceLimit = null;
+        decimal? vwapParticipationCap = null;
 
         switch (a.Parameters)
         {
@@ -151,6 +159,16 @@ public sealed class AlgoBook
                 twapChildType = tp.ChildOrderType.ToString();
                 twapChildPrice = tp.ChildPrice;
                 break;
+            case VwapParameters vp:
+                vwapStart = vp.StartUtc;
+                vwapEnd = vp.EndUtc;
+                vwapChildType = vp.ChildOrderType.ToString();
+                vwapChildPrice = vp.ChildPrice;
+                vwapTickIntervalTicks = vp.TickInterval.Ticks;
+                vwapSliceMaxPct = vp.SliceMaxPct;
+                vwapPriceLimit = vp.PriceLimit;
+                vwapParticipationCap = vp.ParticipationCap;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -159,7 +177,9 @@ public sealed class AlgoBook
             r.Status.ToString(), r.Reason.ToString(),
             a.CreatedAtUtc, r.TerminalAtUtc,
             icebergDisplay, icebergLimit,
-            twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice);
+            twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice,
+            vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
+            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap);
     }
 
     public void Restore(IEnumerable<Persistence.AlgoSnapshot> snaps)
@@ -189,6 +209,14 @@ public sealed class AlgoBook
         int? twapSliceCount = null;
         string? twapChildType = null;
         decimal? twapChildPrice = null;
+        DateTimeOffset? vwapStart = null;
+        DateTimeOffset? vwapEnd = null;
+        string? vwapChildType = null;
+        decimal? vwapChildPrice = null;
+        long? vwapTickIntervalTicks = null;
+        decimal? vwapSliceMaxPct = null;
+        decimal? vwapPriceLimit = null;
+        decimal? vwapParticipationCap = null;
 
         switch (a.Parameters)
         {
@@ -203,6 +231,16 @@ public sealed class AlgoBook
                 twapChildType = tp.ChildOrderType.ToString();
                 twapChildPrice = tp.ChildPrice;
                 break;
+            case VwapParameters vp:
+                vwapStart = vp.StartUtc;
+                vwapEnd = vp.EndUtc;
+                vwapChildType = vp.ChildOrderType.ToString();
+                vwapChildPrice = vp.ChildPrice;
+                vwapTickIntervalTicks = vp.TickInterval.Ticks;
+                vwapSliceMaxPct = vp.SliceMaxPct;
+                vwapPriceLimit = vp.PriceLimit;
+                vwapParticipationCap = vp.ParticipationCap;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -211,7 +249,9 @@ public sealed class AlgoBook
             a.Status.ToString(), a.TerminalReason.ToString(),
             a.CreatedAtUtc, a.TerminalAtUtc,
             icebergDisplay, icebergLimit,
-            twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice);
+            twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice,
+            vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
+            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap);
     }
 
     internal static Algo FromSnapshot(Persistence.AlgoSnapshot s)
@@ -232,6 +272,15 @@ public sealed class AlgoBook
                 s.TwapSliceCount ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapSliceCount."),
                 Enum.Parse<OrderType>(s.TwapChildOrderType ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing TwapChildOrderType.")),
                 s.TwapChildPrice),
+            AlgoType.Vwap => new VwapParameters(
+                s.VwapStartUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing VwapStartUtc."),
+                s.VwapEndUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing VwapEndUtc."),
+                Enum.Parse<OrderType>(s.VwapChildOrderType ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing VwapChildOrderType.")),
+                s.VwapChildPrice,
+                TimeSpan.FromTicks(s.VwapTickIntervalTicks ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing VwapTickIntervalTicks.")),
+                s.VwapSliceMaxPct,
+                s.VwapPriceLimit,
+                s.VwapParticipationCap),
             _ => throw new InvalidOperationException($"Unknown algo type: {s.Type}"),
         };
         return Algo.Hydrate(s.AlgoId, owner, s.FirmId, s.Symbol, s.SecurityId,

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
@@ -12,6 +12,7 @@ public readonly record struct MarketTrade(
     string Symbol,
     ulong SecurityId,
     decimal Price,
+    long Qty,
     DateTimeOffset ReceivedUtc);
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
@@ -43,15 +43,25 @@ public sealed class MarketDataVolumePump : IHostedService
     private readonly VolumeCurveEstimator _estimator;
     private readonly ILogger<MarketDataVolumePump>? _logger;
 
-    // Subscribed-symbol set, kept idempotent so repeated EnsureSubscribed
-    // calls (multiple VWAP parents on the same symbol, reactor re-evaluations)
-    // map to exactly one SDK Subscribe per process lifetime. We deliberately
-    // do NOT unsubscribe on parent terminal / cancel: subscriptions are
-    // cheap on the SDK side, and ref-counting across Iceberg/TWAP/VWAP
-    // parents sharing a symbol is a footgun we can defer until a concrete
-    // use case asks for it. Trade-off: idle symbols accumulate forever in
-    // long-running processes; acceptable for v0 given the small active set.
-    private readonly ConcurrentDictionary<string, byte> _subscribed =
+    // In-flight + completed subscribe tasks, keyed by symbol. Acts as both
+    // the dedup cache (a successfully-completed task short-circuits future
+    // calls) and the concurrent-first-call coalescer (two threads racing
+    // EnsureSubscribedAsync(sym) await the same Task). On failure the entry
+    // is removed so the next call retries — pass-3 review (#294) P1 fix.
+    //
+    // Lazy<Task> is the coalescer: ConcurrentDictionary.GetOrAdd does NOT
+    // guarantee single factory invocation under contention, but constructing
+    // a Lazy is side-effect-free; only the winning Lazy's Value getter runs
+    // the SubscribeAsync. ExecutionAndPublication ensures the inner factory
+    // runs exactly once per Lazy.
+    //
+    // We deliberately do NOT unsubscribe on parent terminal / cancel:
+    // subscriptions are cheap on the SDK side, and ref-counting across
+    // Iceberg/TWAP/VWAP parents sharing a symbol is a footgun we can defer
+    // until a concrete use case asks for it. Trade-off: idle symbols
+    // accumulate forever in long-running processes; acceptable for v0 given
+    // the small active set.
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _subscribed =
         new(StringComparer.OrdinalIgnoreCase);
 
     public MarketDataVolumePump(
@@ -71,34 +81,63 @@ public sealed class MarketDataVolumePump : IHostedService
     /// <summary>
     /// Idempotently subscribes the underlying <see cref="IMarketDataSubscriber"/>
     /// to trade prints for <paramref name="symbol"/>. Safe to call from any
-    /// thread; the SDK call happens at most once per (symbol, process).
-    /// Must be invoked before a VWAP parent starts ticking — see
+    /// thread; the SDK call happens at most once per (symbol, process) on the
+    /// success path. Concurrent first calls for the same symbol are coalesced
+    /// into a single in-flight SDK Subscribe via the
+    /// <c>ConcurrentDictionary&lt;string, Task&gt;</c> cache. Must be invoked
+    /// before a VWAP parent starts ticking — see
     /// <c>AlgoEngine.OnCreatedAsync</c> for the wiring.
+    ///
+    /// <para>
+    /// Pass-3 review (#294) P1: a failed SDK Subscribe is NOT cached, so the
+    /// next caller (next <c>AlgoCreatedSignal</c> / reactor re-evaluation)
+    /// retries. Exceptions are swallowed (per existing policy) so the
+    /// creation flow isn't broken, but logged as warnings so operators see
+    /// the retry loop. Without this, a single SDK not-ready / quota / unknown-
+    /// symbol error at cold boot would poison the cache and the algo would
+    /// never receive trades.
+    /// </para>
     /// </summary>
     public async ValueTask EnsureSubscribedAsync(string symbol, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(symbol)) return;
         var key = symbol.Trim();
-        if (!_subscribed.TryAdd(key, 0)) return;
 
+        // Concurrent first-call race: GetOrAdd can invoke the value factory
+        // multiple times under contention but only one Lazy wins. Lazy
+        // (ExecutionAndPublication, the default) then ensures the inner
+        // SubscribeAsync runs exactly once. The first caller's CT is the
+        // one observed by the SDK call — subsequent awaiters just observe
+        // the shared task's outcome.
+        var lazy = _subscribed.GetOrAdd(key, k =>
+            new Lazy<Task>(() => SubscribeOnceAsync(k, ct)));
+        await lazy.Value.ConfigureAwait(false);
+    }
+
+    private async Task SubscribeOnceAsync(string key, CancellationToken ct)
+    {
         try
         {
             await _subscriber.SubscribeAsync(key, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            // Caller is shutting down; let it propagate but allow a later
-            // retry by clearing the dedup marker.
+            // Caller is shutting down. Drop the dedup entry so a later
+            // (post-shutdown-cancel) caller can retry. Propagate so the
+            // awaiter sees the cancel.
             _subscribed.TryRemove(key, out _);
             throw;
         }
         catch (Exception ex)
         {
-            // Keep the symbol marked subscribed so we don't hammer the SDK
-            // on every algo creation: the SDK's auto-resubscribe-on-reconnect
-            // will retry. Surface the failure so ops sees what happened.
+            // P1 fix: do NOT keep the symbol marked subscribed on failure.
+            // The next EnsureSubscribedAsync(key) call (e.g., next
+            // AlgoCreatedSignal or reactor re-evaluation) will retry.
+            // Swallow the exception so the creation flow stays intact,
+            // but log a warning so operators see the retry loop.
+            _subscribed.TryRemove(key, out _);
             _logger?.LogWarning(ex,
-                "MarketDataVolumePump SubscribeAsync failed for {Symbol}; SDK auto-resubscribe will retry on next reconnect.",
+                "MarketDataVolumePump SubscribeAsync failed for {Symbol}; entry cleared, next EnsureSubscribedAsync call will retry.",
                 key);
         }
     }

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Hosting;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.1 (#281) / pass-1 review #294 P1#1A fix. Bridges live trade
+/// prints from <see cref="IMarketDataSubscriber.Trade"/> into the
+/// per-symbol <see cref="VolumeCurveEstimator"/> so the VWAP slice
+/// scheduler actually sees the venue's intraday volume curve.
+///
+/// <para>
+/// Lives as an <see cref="IHostedService"/> for the same reason as
+/// <see cref="MarketDataReferencePrice"/>: DI must construct the pump
+/// (and attach its handler to the subscriber) BEFORE the subscriber's
+/// connect/subscribe loop starts, otherwise early trade prints in the
+/// gap would be silently dropped. <c>StartAsync</c> / <c>StopAsync</c>
+/// are no-ops — the work is purely wiring done in the constructor.
+/// </para>
+///
+/// <para>
+/// We fan-in every trade for every subscribed symbol; the estimator
+/// is sparse per <c>(symbol, day)</c> so untouched symbols cost
+/// nothing. <see cref="VolumeCurveEstimator.RecordTrade"/> already
+/// guards against non-positive qty / empty symbol, so the handler
+/// stays a one-liner.
+/// </para>
+/// </summary>
+public sealed class MarketDataVolumePump : IHostedService
+{
+    private readonly IMarketDataSubscriber _subscriber;
+    private readonly VolumeCurveEstimator _estimator;
+
+    public MarketDataVolumePump(IMarketDataSubscriber subscriber, VolumeCurveEstimator estimator)
+    {
+        _subscriber = subscriber;
+        _estimator = estimator;
+        _subscriber.Trade += OnTrade;
+    }
+
+    private void OnTrade(MarketTrade t) =>
+        _estimator.RecordTrade(t.Symbol, t.Qty, t.ReceivedUtc);
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscriber.Trade -= OnTrade;
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataVolumePump.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Application.MarketData;
 
@@ -24,21 +26,82 @@ namespace B3.Trading.Application.MarketData;
 /// guards against non-positive qty / empty symbol, so the handler
 /// stays a one-liner.
 /// </para>
+///
+/// <para>
+/// Pass-2 review (#294) P1: also exposes <see cref="EnsureSubscribedAsync"/>
+/// so the algo engine can demand-subscribe to symbols that VWAP parents
+/// reference but the static <c>Trading:MarketData:Symbols</c> list does
+/// not cover. Without dynamic subscribe the SDK never delivers trade
+/// prints for those symbols, the estimator stays empty, and with
+/// <see cref="VwapParameters.ParticipationCap"/> set the slice scheduler
+/// emits zero-qty slices until window expiry → silent no-op algo.
+/// </para>
 /// </summary>
 public sealed class MarketDataVolumePump : IHostedService
 {
     private readonly IMarketDataSubscriber _subscriber;
     private readonly VolumeCurveEstimator _estimator;
+    private readonly ILogger<MarketDataVolumePump>? _logger;
 
-    public MarketDataVolumePump(IMarketDataSubscriber subscriber, VolumeCurveEstimator estimator)
+    // Subscribed-symbol set, kept idempotent so repeated EnsureSubscribed
+    // calls (multiple VWAP parents on the same symbol, reactor re-evaluations)
+    // map to exactly one SDK Subscribe per process lifetime. We deliberately
+    // do NOT unsubscribe on parent terminal / cancel: subscriptions are
+    // cheap on the SDK side, and ref-counting across Iceberg/TWAP/VWAP
+    // parents sharing a symbol is a footgun we can defer until a concrete
+    // use case asks for it. Trade-off: idle symbols accumulate forever in
+    // long-running processes; acceptable for v0 given the small active set.
+    private readonly ConcurrentDictionary<string, byte> _subscribed =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public MarketDataVolumePump(
+        IMarketDataSubscriber subscriber,
+        VolumeCurveEstimator estimator,
+        ILogger<MarketDataVolumePump>? logger = null)
     {
         _subscriber = subscriber;
         _estimator = estimator;
+        _logger = logger;
         _subscriber.Trade += OnTrade;
     }
 
     private void OnTrade(MarketTrade t) =>
         _estimator.RecordTrade(t.Symbol, t.Qty, t.ReceivedUtc);
+
+    /// <summary>
+    /// Idempotently subscribes the underlying <see cref="IMarketDataSubscriber"/>
+    /// to trade prints for <paramref name="symbol"/>. Safe to call from any
+    /// thread; the SDK call happens at most once per (symbol, process).
+    /// Must be invoked before a VWAP parent starts ticking — see
+    /// <c>AlgoEngine.OnCreatedAsync</c> for the wiring.
+    /// </summary>
+    public async ValueTask EnsureSubscribedAsync(string symbol, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        var key = symbol.Trim();
+        if (!_subscribed.TryAdd(key, 0)) return;
+
+        try
+        {
+            await _subscriber.SubscribeAsync(key, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller is shutting down; let it propagate but allow a later
+            // retry by clearing the dedup marker.
+            _subscribed.TryRemove(key, out _);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Keep the symbol marked subscribed so we don't hammer the SDK
+            // on every algo creation: the SDK's auto-resubscribe-on-reconnect
+            // will retry. Surface the failure so ops sees what happened.
+            _logger?.LogWarning(ex,
+                "MarketDataVolumePump SubscribeAsync failed for {Symbol}; SDK auto-resubscribe will retry on next reconnect.",
+                key);
+        }
+    }
 
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
+++ b/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
@@ -22,12 +22,11 @@ namespace B3.Trading.Application.MarketData;
 /// </para>
 ///
 /// <para>
-/// <b>Data source.</b> v0 only consumes live intraday volume. The
-/// repo's <c>MarketTrade</c> shape currently lacks a quantity field
-/// (only price + timestamp), so the host wiring of "subscribe to
-/// marketdata.trades.${symbol}" is left as a TODO — the estimator is
-/// already API-stable so a future patch wiring qty-bearing trades is
-/// purely additive. Tests drive <see cref="RecordTrade"/> directly.
+/// <b>Data source.</b> Live intraday volume is pushed in by the
+/// <c>MarketDataVolumePump</c> hosted service, which subscribes to
+/// <c>IMarketDataSubscriber.Trade</c> and forwards <c>(symbol, qty,
+/// receivedUtc)</c> here. Tests drive <see cref="RecordTrade"/>
+/// directly.
 /// </para>
 ///
 /// <para>
@@ -89,11 +88,22 @@ public sealed class VolumeCurveEstimator
     }
 
     /// <summary>
-    /// CDF value in <c>[0, 1]</c> for the fraction of expected volume
-    /// that has accumulated between <paramref name="startUtc"/> and
-    /// <paramref name="atUtc"/>, normalised by the total volume in
-    /// <c>[startUtc, endUtc]</c>. Uniform fallback when the symbol has
-    /// no observed volume in <c>[startUtc, endUtc]</c>.
+    /// CDF value in <c>[0, 1]</c> for the fraction of expected window
+    /// volume that has accumulated between <paramref name="startUtc"/>
+    /// and <paramref name="atUtc"/>.
+    ///
+    /// <para>
+    /// <b>Blended denominator.</b> Pass-1 review (#294) P1#1B fix. The
+    /// denominator is NOT just the observed-so-far volume in
+    /// <c>[start, at)</c> — that would make the CDF jump to 1.0 the
+    /// moment the first bucket records any volume, causing the VWAP
+    /// scheduler to over-slice early in the day. Instead we estimate
+    /// the total window volume as
+    /// <c>observed[start..at] + extrapolation[at..end]</c>, where the
+    /// extrapolation projects the so-far run-rate forward to fill the
+    /// remaining bucket count. If we have no observed volume yet, fall
+    /// back to a uniform (TWAP-shaped) CDF.
+    /// </para>
     /// </summary>
     public double CdfAt(string symbol, DateTimeOffset startUtc, DateTimeOffset endUtc, DateTimeOffset atUtc)
     {
@@ -101,20 +111,45 @@ public sealed class VolumeCurveEstimator
         if (atUtc <= startUtc) return 0;
         if (atUtc >= endUtc) return 1;
 
-        var totalInWindow = VolumeBetween(symbol, startUtc, endUtc);
-        if (totalInWindow <= 0)
+        var observedToAt = VolumeBetween(symbol, startUtc, atUtc);
+        if (observedToAt <= 0)
         {
             // Uniform fallback. Mirrors a TWAP-shaped curve so the
             // engine still makes forward progress when the estimator
-            // hasn't seen anything yet.
+            // hasn't seen anything yet in [start, at).
             return (atUtc - startUtc).TotalSeconds / (endUtc - startUtc).TotalSeconds;
         }
 
-        var elapsed = VolumeBetween(symbol, startUtc, atUtc);
-        var cdf = (double)elapsed / totalInWindow;
+        // Blend with extrapolation for [at, end] so the denominator is
+        // a *predicted total*, not just observed-so-far. We work in
+        // bucket counts (not seconds) because RecordTrade quantises
+        // into buckets — using seconds here would let sub-bucket
+        // arithmetic skew the run-rate at low elapsed times.
+        var elapsedBuckets = Math.Max(1L, BucketsBetween(startUtc, atUtc));
+        var remainingBuckets = Math.Max(0L, BucketsBetween(atUtc, endUtc));
+        var runRatePerBucket = (double)observedToAt / elapsedBuckets;
+        var extrapolatedRemainder = runRatePerBucket * remainingBuckets;
+        var denominator = observedToAt + extrapolatedRemainder;
+        if (denominator <= 0) return 0;
+
+        var cdf = observedToAt / denominator;
         if (cdf < 0) return 0;
         if (cdf > 1) return 1;
         return cdf;
+    }
+
+    /// <summary>
+    /// Whole-bucket count between two instants, used by the CDF blend
+    /// so the run-rate maths is unit-consistent with how RecordTrade
+    /// quantises observations into buckets. Always returns at least 0.
+    /// </summary>
+    private long BucketsBetween(DateTimeOffset fromUtc, DateTimeOffset toUtc)
+    {
+        if (toUtc <= fromUtc) return 0;
+        var span = toUtc - fromUtc;
+        // ceil so a partial bucket at the boundary contributes one
+        // "evaluated" bucket — keeps the blend monotone.
+        return (span.Ticks + _bucketSize.Ticks - 1) / _bucketSize.Ticks;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
+++ b/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Per-symbol intraday volume curve estimator (Q3.1 / #281).
+///
+/// <para>
+/// Bucketing: <see cref="DefaultBucketSize"/> (5 minutes) across each UTC
+/// trading day. Each call to <see cref="RecordTrade"/> with
+/// <c>(symbol, qty, utc)</c> accrues qty into the bucket for the day-key
+/// of <c>utc</c>. The CDF for a window <c>[start, end]</c> at time
+/// <c>at</c> is <c>volumeIn(start..at) / volumeIn(start..end)</c>.
+/// </para>
+///
+/// <para>
+/// <b>Fallback.</b> When the symbol has no observed volume in the window
+/// (e.g. on a fresh boot before any trade arrives), the estimator
+/// returns a uniform CDF — <c>(at - start) / (end - start)</c> — so the
+/// VWAP slice scheduler degrades gracefully into a TWAP-shaped
+/// distribution.
+/// </para>
+///
+/// <para>
+/// <b>Data source.</b> v0 only consumes live intraday volume. The
+/// repo's <c>MarketTrade</c> shape currently lacks a quantity field
+/// (only price + timestamp), so the host wiring of "subscribe to
+/// marketdata.trades.${symbol}" is left as a TODO — the estimator is
+/// already API-stable so a future patch wiring qty-bearing trades is
+/// purely additive. Tests drive <see cref="RecordTrade"/> directly.
+/// </para>
+///
+/// <para>
+/// <b>Persistence.</b> Historical (cross-day) curve persistence is
+/// explicitly OUT OF SCOPE for #281 — the estimator forgets buckets
+/// outside the in-memory <see cref="MaxRetentionDays"/> window. Future
+/// work can layer a snapshot/replay path on top without changing the
+/// public API.
+/// </para>
+///
+/// <para>
+/// All operations are O(1) amortised; the per-day-per-symbol bucket
+/// arrays are sparse (lazy-initialised on first trade) and small
+/// (288 buckets/day at 5min granularity).
+/// </para>
+/// </summary>
+public sealed class VolumeCurveEstimator
+{
+    public static readonly TimeSpan DefaultBucketSize = TimeSpan.FromMinutes(5);
+    public const int MaxRetentionDays = 7;
+
+    private readonly TimeSpan _bucketSize;
+    private readonly ConcurrentDictionary<(string Symbol, DateOnly Day), long[]> _buckets = new();
+
+    public VolumeCurveEstimator() : this(DefaultBucketSize) { }
+
+    public VolumeCurveEstimator(TimeSpan bucketSize)
+    {
+        if (bucketSize <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(bucketSize));
+        _bucketSize = bucketSize;
+    }
+
+    public TimeSpan BucketSize => _bucketSize;
+
+    /// <summary>
+    /// Bucket count per UTC day. 288 at the 5-min default.
+    /// </summary>
+    public int BucketsPerDay => (int)(TimeSpan.FromDays(1).Ticks / _bucketSize.Ticks);
+
+    /// <summary>
+    /// Accrues <paramref name="qty"/> shares to the bucket containing
+    /// <paramref name="atUtc"/> for <paramref name="symbol"/>. Non-positive
+    /// qty is silently ignored — the caller doesn't need a guard.
+    /// </summary>
+    public void RecordTrade(string symbol, long qty, DateTimeOffset atUtc)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        if (qty <= 0) return;
+
+        var day = DateOnly.FromDateTime(atUtc.UtcDateTime);
+        var bucket = BucketIndex(atUtc);
+        var arr = _buckets.GetOrAdd((symbol, day), _ => new long[BucketsPerDay]);
+        // Coarse atomic add; concurrent trades for the same bucket are
+        // rare in our load profile but we want no torn writes.
+        Interlocked.Add(ref arr[bucket], qty);
+
+        TrimRetention(symbol);
+    }
+
+    /// <summary>
+    /// CDF value in <c>[0, 1]</c> for the fraction of expected volume
+    /// that has accumulated between <paramref name="startUtc"/> and
+    /// <paramref name="atUtc"/>, normalised by the total volume in
+    /// <c>[startUtc, endUtc]</c>. Uniform fallback when the symbol has
+    /// no observed volume in <c>[startUtc, endUtc]</c>.
+    /// </summary>
+    public double CdfAt(string symbol, DateTimeOffset startUtc, DateTimeOffset endUtc, DateTimeOffset atUtc)
+    {
+        if (endUtc <= startUtc) return 0;
+        if (atUtc <= startUtc) return 0;
+        if (atUtc >= endUtc) return 1;
+
+        var totalInWindow = VolumeBetween(symbol, startUtc, endUtc);
+        if (totalInWindow <= 0)
+        {
+            // Uniform fallback. Mirrors a TWAP-shaped curve so the
+            // engine still makes forward progress when the estimator
+            // hasn't seen anything yet.
+            return (atUtc - startUtc).TotalSeconds / (endUtc - startUtc).TotalSeconds;
+        }
+
+        var elapsed = VolumeBetween(symbol, startUtc, atUtc);
+        var cdf = (double)elapsed / totalInWindow;
+        if (cdf < 0) return 0;
+        if (cdf > 1) return 1;
+        return cdf;
+    }
+
+    /// <summary>
+    /// Sum of recorded volume in <c>[fromUtc, toUtc)</c> for
+    /// <paramref name="symbol"/>. Spans day boundaries by walking the
+    /// per-day bucket arrays. Public for tests + for the participation
+    /// cap (engine asks "how much has traded recently?").
+    /// </summary>
+    public long VolumeBetween(string symbol, DateTimeOffset fromUtc, DateTimeOffset toUtc)
+    {
+        if (toUtc <= fromUtc) return 0;
+        long total = 0;
+        var bucketsPerDay = BucketsPerDay;
+        var day = DateOnly.FromDateTime(fromUtc.UtcDateTime);
+        var endDay = DateOnly.FromDateTime(toUtc.UtcDateTime);
+        while (day <= endDay)
+        {
+            if (_buckets.TryGetValue((symbol, day), out var arr))
+            {
+                var dayStart = new DateTimeOffset(day.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+                var rangeStart = fromUtc > dayStart ? fromUtc : dayStart;
+                var rangeEnd = toUtc < dayStart.AddDays(1) ? toUtc : dayStart.AddDays(1);
+                if (rangeEnd > rangeStart)
+                {
+                    var firstBucket = BucketIndex(rangeStart);
+                    // Inclusive lower bound, exclusive upper bound.
+                    var lastBucket = BucketIndex(rangeEnd.AddTicks(-1));
+                    for (var b = firstBucket; b <= lastBucket && b < bucketsPerDay; b++)
+                        total += Interlocked.Read(ref arr[b]);
+                }
+            }
+            day = day.AddDays(1);
+        }
+        return total;
+    }
+
+    /// <summary>
+    /// Drops day-keys older than <see cref="MaxRetentionDays"/> for the
+    /// given symbol. Cheap (one Keys snapshot per call); could be moved
+    /// to a periodic sweep if profiling ever flags it.
+    /// </summary>
+    private void TrimRetention(string symbol)
+    {
+        var cutoff = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-MaxRetentionDays);
+        foreach (var key in _buckets.Keys)
+        {
+            if (key.Symbol == symbol && key.Day < cutoff)
+                _buckets.TryRemove(key, out _);
+        }
+    }
+
+    private int BucketIndex(DateTimeOffset utc)
+    {
+        var midnight = new DateTimeOffset(
+            DateOnly.FromDateTime(utc.UtcDateTime).ToDateTime(TimeOnly.MinValue),
+            TimeSpan.Zero);
+        var offset = (utc - midnight).Ticks;
+        var idx = (int)(offset / _bucketSize.Ticks);
+        // Defensive clamp; midnight wraparound or non-power-of-2 bucket
+        // sizes could in theory push idx to BucketsPerDay.
+        return Math.Clamp(idx, 0, BucketsPerDay - 1);
+    }
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -252,6 +252,28 @@ public static class MetricsRegistry
             "trading.algo.signal_queue_depth",
             description: "Estimated number of signals queued for the AlgoEngine consumer.");
 
+    // Q3.1 (#281) — VWAP slice scheduler observability. Mirrors the
+    // TWAP block above. SlicesEmitted is the count of child orders the
+    // engine actually placed (zero-quantity slots are skipped, not
+    // counted here). TargetVsActualDiff is the signed gap between the
+    // target cumulative curve and what has executed at the moment of
+    // slice emission (positive = engine is behind, negative = ahead /
+    // overfilled). Cancelled bumps for every VWAP parent reaching the
+    // <c>Cancelled</c> terminal state.
+    public static readonly Counter<long> AlgoVwapSlicesEmitted =
+        Meter.CreateCounter<long>(
+            "trading.algo.vwap.slices_emitted",
+            description: "Child orders submitted by the VWAP slice scheduler.");
+    public static readonly Histogram<long> AlgoVwapTargetVsActualDiff =
+        Meter.CreateHistogram<long>(
+            "trading.algo.vwap.target_vs_actual_diff",
+            unit: "shares",
+            description: "targetCumQty − executedCum at the moment a VWAP slice is evaluated.");
+    public static readonly Counter<long> AlgoVwapCancelled =
+        Meter.CreateCounter<long>(
+            "trading.algo.vwap.cancelled",
+            description: "VWAP parents reaching the Cancelled terminal state.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -301,7 +301,16 @@ public sealed record AlgoSnapshot(
     DateTimeOffset? TwapEndUtc = null,
     int? TwapSliceCount = null,
     string? TwapChildOrderType = null,
-    decimal? TwapChildPrice = null);
+    decimal? TwapChildPrice = null,
+    // Q3.1 (#281) — VWAP fields, mirror the TWAP block.
+    DateTimeOffset? VwapStartUtc = null,
+    DateTimeOffset? VwapEndUtc = null,
+    string? VwapChildOrderType = null,
+    decimal? VwapChildPrice = null,
+    long? VwapTickIntervalTicks = null,
+    decimal? VwapSliceMaxPct = null,
+    decimal? VwapPriceLimit = null,
+    decimal? VwapParticipationCap = null);
 
 public sealed record PositionSnapshot(
     string EndClientId,

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -37,6 +37,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(AlgoCreatedEvent))]
 [JsonSerializable(typeof(AlgoCancelRequestedEvent))]
 [JsonSerializable(typeof(AlgoTerminalStateRecordedEvent))]
+[JsonSerializable(typeof(AlgoVwapSlicedEvent))]
 [JsonSerializable(typeof(OrderStaledEvent))]
 [JsonSerializable(typeof(OrderStaleClearedEvent))]
 [JsonSerializable(typeof(UserBotCredentialCreatedEvent))]

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -26,6 +26,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoCreatedEvent), "algo.created")]
 [JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
+[JsonDerivedType(typeof(AlgoVwapSlicedEvent), "algo.vwap.sliced")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
@@ -293,6 +294,18 @@ public sealed record AlgoCreatedEvent : WalEvent
     public int? TwapSliceCount { get; init; }
     public string? TwapChildOrderType { get; init; }   // "Limit" | "Market"
     public decimal? TwapChildPrice { get; init; }
+
+    // Q3.1 (#281) — VWAP fields. Mirror the TWAP block above; only the
+    // block matching <see cref="Type"/> = "Vwap" is populated. Additive
+    // — older replays / snapshots without these fields stay valid.
+    public DateTimeOffset? VwapStartUtc { get; init; }
+    public DateTimeOffset? VwapEndUtc { get; init; }
+    public string? VwapChildOrderType { get; init; }   // "Limit" | "Market"
+    public decimal? VwapChildPrice { get; init; }
+    public long? VwapTickIntervalTicks { get; init; }
+    public decimal? VwapSliceMaxPct { get; init; }
+    public decimal? VwapPriceLimit { get; init; }
+    public decimal? VwapParticipationCap { get; init; }
 }
 
 /// <summary>
@@ -321,6 +334,26 @@ public sealed record AlgoTerminalStateRecordedEvent : WalEvent
     public required string Status { get; init; }    // AlgoStatus enum name
     public required string Reason { get; init; }    // AlgoTerminalReason enum name
     public required DateTimeOffset AtUtc { get; init; }
+}
+
+/// <summary>
+/// Q3.1 (#281). Per-slice audit envelope for VWAP parents — captures the
+/// target/actual curve gap at slice-emit time. NOT replayed for state
+/// reconstruction (the slice itself is recorded via the child
+/// <see cref="OrderSubmittedEvent"/>, same as TWAP); the engine treats
+/// this event as observability-only so a future omission of the WAL
+/// write would not desynchronise recovery. Mirrors the <c>AlgoVwapSliced</c>
+/// label called out in the issue body.
+/// </summary>
+public sealed record AlgoVwapSlicedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required int SliceSeq { get; init; }
+    public required long TargetCumQty { get; init; }
+    public required long ExecutedCum { get; init; }
+    public required long SliceQty { get; init; }
+    public required DateTimeOffset PlannedAtUtc { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Domain/Algo.cs
+++ b/backend/src/B3.Trading.Domain/Algo.cs
@@ -4,6 +4,7 @@ public enum AlgoType
 {
     Iceberg,
     Twap,
+    Vwap,
 }
 
 /// <summary>
@@ -38,6 +39,8 @@ public enum AlgoTerminalReason
     TwapWindowExpired,
     RetriesExhausted,
     Drained,
+    /// <summary>VWAP window expired (Q3.1 / #281). Mirrors <see cref="TwapWindowExpired"/>.</summary>
+    VwapWindowExpired,
 }
 
 /// <summary>
@@ -55,6 +58,43 @@ public sealed record TwapParameters(
     int SliceCount,
     OrderType ChildOrderType,
     decimal? ChildPrice) : AlgoParameters;
+
+/// <summary>
+/// VWAP (Volume-Weighted Average Price) parameters (Q3.1 / #281).
+///
+/// <para>
+/// Unlike <see cref="TwapParameters"/> the per-slice quantity is NOT
+/// deterministic from these fields alone — it depends on the live
+/// volume-curve estimate maintained by <c>VolumeCurveEstimator</c> plus
+/// the participation/slice caps below. The engine evaluates the gap
+/// between the target cumulative curve and what has actually filled at
+/// every scheduler tick (default 30s).
+/// </para>
+///
+/// <para>
+/// <b>TickInterval</b> controls how often the engine asks "do I owe more
+/// quantity now?". Defaults to 30s per the issue spec — small enough to
+/// react to curve drift, large enough that we don't blast the venue with
+/// micro-orders.
+/// </para>
+///
+/// <para><b>SliceMaxPct</b>: per-slice quantity cap as a fraction of
+/// <c>totalQty</c> (e.g. <c>0.10m</c> = 10%). Null = no cap.</para>
+/// <para><b>ParticipationCap</b>: per-slice quantity cap as a fraction of
+/// recently observed market volume (in the current bucket). Null = no cap.</para>
+/// <para><b>PriceLimit</b>: hard limit price for child LIMIT orders. The
+/// engine uses <see cref="ChildPrice"/> as the reference and never crosses
+/// past <c>PriceLimit</c>. Null = use <see cref="ChildPrice"/> only.</para>
+/// </summary>
+public sealed record VwapParameters(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    OrderType ChildOrderType,
+    decimal? ChildPrice,
+    TimeSpan TickInterval,
+    decimal? SliceMaxPct = null,
+    decimal? PriceLimit = null,
+    decimal? ParticipationCap = null) : AlgoParameters;
 
 /// <summary>
 /// Parent algo aggregate, sibling to <see cref="Order"/>. v0 stores only
@@ -228,6 +268,7 @@ public sealed class Algo
         {
             AlgoType.Iceberg => parameters is IcebergParameters,
             AlgoType.Twap => parameters is TwapParameters,
+            AlgoType.Vwap => parameters is VwapParameters,
             _ => false,
         };
         if (!ok)

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -114,13 +114,15 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the
         // Iceberg state machine; slice 6 adds the AlgoScheduler hosted service that
         // drives TWAP slice firing on a separate thread (RFC §4.11 commitment 1).
-        // Q3.1 (#281) wires the VWAP volume-curve estimator as a singleton so
-        // future market-data adapters can push live trade qty into it; the
-        // engine takes an optional ctor dependency on it and falls back to a
-        // uniform CDF when null.
+        // Q3.1 (#281) wires the VWAP volume-curve estimator as a singleton.
+        // The MarketDataVolumePump hosted service (#294 P1#1A) bridges
+        // IMarketDataSubscriber.Trade → VolumeCurveEstimator.RecordTrade so
+        // the engine sees the venue's live intraday volume; without the pump
+        // the estimator stays empty and the engine falls back to uniform CDF.
         services.AddSingleton<AlgoSignalQueue>();
         services.AddSingleton<IAlgoSignalQueue>(sp => sp.GetRequiredService<AlgoSignalQueue>());
         services.AddSingleton<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+        services.AddHostedService<B3.Trading.Application.MarketData.MarketDataVolumePump>();
         services.AddHostedService<AlgoEngine>();
         services.AddHostedService<AlgoScheduler>();
 

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -122,7 +122,14 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<AlgoSignalQueue>();
         services.AddSingleton<IAlgoSignalQueue>(sp => sp.GetRequiredService<AlgoSignalQueue>());
         services.AddSingleton<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
-        services.AddHostedService<B3.Trading.Application.MarketData.MarketDataVolumePump>();
+        // Pump is registered as a concrete singleton AND wired into the
+        // hosted-service collection through the same instance so AlgoEngine
+        // can take an optional ctor dependency on it for the per-VWAP
+        // EnsureSubscribedAsync demand-subscribe (#294 pass-2 P1) without
+        // splitting startup ordering across two instances.
+        services.AddSingleton<B3.Trading.Application.MarketData.MarketDataVolumePump>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.MarketData.MarketDataVolumePump>());
         services.AddHostedService<AlgoEngine>();
         services.AddHostedService<AlgoScheduler>();
 

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -114,8 +114,13 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the
         // Iceberg state machine; slice 6 adds the AlgoScheduler hosted service that
         // drives TWAP slice firing on a separate thread (RFC §4.11 commitment 1).
+        // Q3.1 (#281) wires the VWAP volume-curve estimator as a singleton so
+        // future market-data adapters can push live trade qty into it; the
+        // engine takes an optional ctor dependency on it and falls back to a
+        // uniform CDF when null.
         services.AddSingleton<AlgoSignalQueue>();
         services.AddSingleton<IAlgoSignalQueue>(sp => sp.GetRequiredService<AlgoSignalQueue>());
+        services.AddSingleton<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
         services.AddHostedService<AlgoEngine>();
         services.AddHostedService<AlgoScheduler>();
 

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -95,6 +95,7 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
             Symbol: ev.Symbol,
             SecurityId: ev.SecurityId,
             Price: ev.Price,
+            Qty: ev.Qty,
             ReceivedUtc: new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc))));
     }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -743,6 +743,15 @@ public sealed class EventReplayer
                 ac.TwapSliceCount ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapSliceCount."),
                 Enum.Parse<OrderType>(ac.TwapChildOrderType ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing TwapChildOrderType."), ignoreCase: true),
                 ac.TwapChildPrice),
+            AlgoType.Vwap => new VwapParameters(
+                ac.VwapStartUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing VwapStartUtc."),
+                ac.VwapEndUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing VwapEndUtc."),
+                Enum.Parse<OrderType>(ac.VwapChildOrderType ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing VwapChildOrderType."), ignoreCase: true),
+                ac.VwapChildPrice,
+                TimeSpan.FromTicks(ac.VwapTickIntervalTicks ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing VwapTickIntervalTicks.")),
+                ac.VwapSliceMaxPct,
+                ac.VwapPriceLimit,
+                ac.VwapParticipationCap),
             _ => throw new InvalidOperationException($"Unknown algo type: {ac.Type}"),
         };
         _algos.TryAdd(new Algo(ac.AlgoId, owner, ac.FirmId, ac.Symbol, ac.SecurityId,

--- a/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
@@ -146,7 +146,7 @@ public class AlgoEndpointsTests
         {
             Symbol = "PETR4",
             Side = "Buy",
-            Type = "Vwap", // not in v0 enum
+            Type = "Sniper", // not a valid algo type
             TotalQuantity = 100,
         });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -41,7 +41,7 @@ public class PnlRefPriceFanOutTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public void RaiseTrade(string symbol, decimal price, DateTimeOffset ts) =>
-            Trade?.Invoke(new MarketTrade(symbol, 0UL, price, ts));
+            Trade?.Invoke(new MarketTrade(symbol, 0UL, price, 0L, ts));
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -5,6 +5,7 @@ using System.Text;
 using B3.Trading.Api.Auth;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace B3.Trading.Api.Tests;
@@ -22,6 +23,7 @@ public class TestAppFactory : WebApplicationFactory<Program>
     public const int TestIterations = 10_000; // fast for tests
 
     private IDictionary<string, string?>? _configOverrides;
+    private Action<IServiceCollection>? _serviceOverrides;
 
     /// <summary>
     /// Builds a factory with extra config keys layered on top of the
@@ -31,13 +33,28 @@ public class TestAppFactory : WebApplicationFactory<Program>
     /// (not a public ctor) so xUnit's <c>IClassFixture</c> still binds.
     /// </summary>
     public static TestAppFactory WithOverrides(IDictionary<string, string?> configOverrides)
-        => new TestAppFactoryWithOverrides(configOverrides);
+        => new TestAppFactoryWithOverrides(configOverrides, services: null);
+
+    /// <summary>
+    /// Same as <see cref="WithOverrides(IDictionary{string, string?})"/> plus
+    /// a hook to mutate the DI container (replace registered services with
+    /// recording/fake doubles). Applied after the host's own ConfigureServices
+    /// pass via <c>ConfigureTestServices</c>, so it can <c>RemoveAll</c> a
+    /// service the host registered and re-register a stub in its place.
+    /// </summary>
+    public static TestAppFactory WithOverrides(
+        IDictionary<string, string?> configOverrides,
+        Action<IServiceCollection> services)
+        => new TestAppFactoryWithOverrides(configOverrides, services);
 
     private sealed class TestAppFactoryWithOverrides : TestAppFactory
     {
-        public TestAppFactoryWithOverrides(IDictionary<string, string?> overrides)
+        public TestAppFactoryWithOverrides(
+            IDictionary<string, string?> overrides,
+            Action<IServiceCollection>? services)
         {
             base._configOverrides = overrides;
+            base._serviceOverrides = services;
         }
     }
 
@@ -109,6 +126,12 @@ public class TestAppFactory : WebApplicationFactory<Program>
             if (_configOverrides is not null)
                 cb.AddInMemoryCollection(_configOverrides);
         });
+
+        if (_serviceOverrides is not null)
+        {
+            builder.ConfigureServices(s => _serviceOverrides!(s));
+        }
+
         return base.CreateHost(builder);
     }
 

--- a/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
@@ -252,6 +252,59 @@ public class VwapAlgoEndpointTests
         Assert.Equal(31m, vwap.GetProperty("priceLimit").GetDecimal());
     }
 
+    // ───────────────────── Cancel-mid-flight (#294 P2) ─────────────────────
+
+    [Fact]
+    public async Task Vwap_CancelMidFlight_CancelsLiveChildAndTerminalEmittedOnce()
+    {
+        // Pass-1 review (#294) P2. After at least one slice is in-flight,
+        // DELETE drives the parent into Cancelling, the engine cancels
+        // the live child, and on the cancel-ack the parent reaches
+        // Cancelled. A second DELETE after terminal is a no-op (409,
+        // not another terminal); terminal state is recorded exactly
+        // once — re-reading /algo returns the same TerminalAtUtc.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            VwapBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(10),
+                tickSeconds: 0.2));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var inFlight = await WaitForAnyChild(book, algoId);
+
+        // Operator cancel.
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, del.StatusCode);
+
+        // The engine emits a cancel for the live child to the mock
+        // venue; ack it by injecting Canceled — that drives the parent
+        // from Cancelling to Cancelled.
+        await InjectEr(http, adminToken, inFlight.ClOrdId, "Canceled");
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Cancelled");
+        var snap1 = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("UserCancelled", snap1.GetProperty("terminalReason").GetString());
+        var terminalAt1 = snap1.GetProperty("terminalAtUtc").GetDateTimeOffset();
+
+        // Second DELETE after terminal: not Accepted, and crucially the
+        // terminal timestamp must not move (no second terminal event).
+        var req2 = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del2 = await http.SendAsync(req2);
+        Assert.Equal(HttpStatusCode.Conflict, del2.StatusCode);
+
+        await Task.Delay(50); // give any (incorrect) re-emission a chance to land
+        var snap2 = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("Cancelled", snap2.GetProperty("status").GetString());
+        Assert.Equal(terminalAt1, snap2.GetProperty("terminalAtUtc").GetDateTimeOffset());
+    }
+
     // ───────────────────────── helpers (parallel to AlgoTwapIntegrationTests) ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using B3.Trading.Application;
 using B3.Trading.Domain;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace B3.Trading.Api.Tests;
 
@@ -254,6 +255,45 @@ public class VwapAlgoEndpointTests
 
     // ───────────────────── Cancel-mid-flight (#294 P2) ─────────────────────
 
+    /// <summary>
+    /// Recording <see cref="IAlgoEventSink"/> used by the cancel-mid-flight
+    /// test (#294 pass-2 P2) to assert exactly-once terminal emission.
+    /// <c>PublishAlgoSnapshot</c> is invoked on every algo state transition
+    /// (PendingNew → Working → Cancelling → Cancelled), so we capture the
+    /// algo's status AT THE TIME of the publish and count only the ones
+    /// observed in a terminal state. A duplicate <c>RecordTerminalAsync</c>
+    /// would surface as two terminal publishes for the same algoId.
+    /// </summary>
+    private sealed class RecordingAlgoEventSink : IAlgoEventSink
+    {
+        private readonly AlgoBook _book;
+        private readonly object _gate = new();
+        private readonly List<(ulong AlgoId, AlgoStatus Status)> _publishes = new();
+
+        public RecordingAlgoEventSink(AlgoBook book) => _book = book;
+
+        public void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId)
+        {
+            if (!_book.TryGet(firmId, algoId, out var algo) || algo is null) return;
+            lock (_gate)
+            {
+                _publishes.Add((algoId, algo.Status));
+            }
+        }
+
+        public int TerminalPublishCount(ulong algoId)
+        {
+            lock (_gate)
+            {
+                return _publishes.Count(p => p.AlgoId == algoId && IsTerminal(p.Status));
+            }
+        }
+
+        private static bool IsTerminal(AlgoStatus s) =>
+            s is AlgoStatus.Cancelled or AlgoStatus.Completed
+              or AlgoStatus.Expired or AlgoStatus.Suspended;
+    }
+
     [Fact]
     public async Task Vwap_CancelMidFlight_CancelsLiveChildAndTerminalEmittedOnce()
     {
@@ -262,11 +302,30 @@ public class VwapAlgoEndpointTests
         // the live child, and on the cancel-ack the parent reaches
         // Cancelled. A second DELETE after terminal is a no-op (409,
         // not another terminal); terminal state is recorded exactly
-        // once — re-reading /algo returns the same TerminalAtUtc.
-        using var f = TestAppFactory.WithOverrides(Simulator());
+        // once.
+        //
+        // Pass-2 review (#294) P2: explicit count assertion via a
+        // recording IAlgoEventSink — verifies exactly one terminal
+        // publish for this algoId after both DELETEs. Without this
+        // a regression that emits a duplicate AlgoTerminalStateRecorded
+        // event would still leave TerminalAtUtc stable (the aggregate
+        // refuses to re-transition) yet flood downstream listeners with
+        // a phantom terminal — this assertion catches that.
+        RecordingAlgoEventSink? sink = null;
+        using var f = TestAppFactory.WithOverrides(Simulator(), services =>
+        {
+            services.RemoveAll<IAlgoEventSink>();
+            services.AddSingleton<IAlgoEventSink>(sp =>
+                sink = new RecordingAlgoEventSink(sp.GetRequiredService<AlgoBook>()));
+        });
         using var http = f.CreateClient();
         var userToken = await f.LoginAsync(http);
         var adminToken = await f.LoginAsync(http, "admin");
+
+        // Force resolution so the singleton is constructed and `sink`
+        // captures a non-null reference before the algo flow starts.
+        _ = f.Services.GetRequiredService<IAlgoEventSink>();
+        Assert.NotNull(sink);
 
         var now = DateTimeOffset.UtcNow;
         var algoId = await PostAlgo(http, userToken,
@@ -303,6 +362,10 @@ public class VwapAlgoEndpointTests
         var snap2 = await GetAlgo(http, userToken, algoId);
         Assert.Equal("Cancelled", snap2.GetProperty("status").GetString());
         Assert.Equal(terminalAt1, snap2.GetProperty("terminalAtUtc").GetDateTimeOffset());
+
+        // Pass-2 review (#294) P2. Exactly-one terminal publish.
+        var algoIdNum = ulong.Parse(algoId);
+        Assert.Equal(1, sink!.TerminalPublishCount(algoIdNum));
     }
 
     // ───────────────────────── helpers (parallel to AlgoTwapIntegrationTests) ─────────────────────────

--- a/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
@@ -1,0 +1,346 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the VWAP algo (Q3.1 / #281). Mirrors the
+/// shape of <see cref="AlgoTwapIntegrationTests"/>: real wall-clock with
+/// tightly-bounded sub-second windows so the scheduler ticks (100ms) and
+/// the engine reactor exercise the full VWAP path.
+/// </summary>
+public class VwapAlgoEndpointTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object VwapBody(long total, DateTimeOffset start, DateTimeOffset end,
+        double tickSeconds = 0.2, string childType = "Limit", decimal? childPrice = 30m,
+        decimal? sliceMaxPct = null, decimal? participationCap = null, decimal? priceLimit = null) => new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Vwap",
+            TotalQuantity = total,
+            Vwap = new
+            {
+                StartUtc = start,
+                EndUtc = end,
+                ChildOrderType = childType,
+                ChildPrice = childPrice,
+                TickIntervalSeconds = tickSeconds,
+                SliceMaxPct = sliceMaxPct,
+                ParticipationCap = participationCap,
+                PriceLimit = priceLimit,
+            },
+        };
+
+    // ───────────────────────── POST validation ─────────────────────────
+
+    [Fact]
+    public async Task PostAlgo_VwapWithoutParams_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Vwap",
+                TotalQuantity = 100,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_VwapEndBeforeStart_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(VwapBody(100, now.AddMinutes(5), now.AddMinutes(1))),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_VwapSliceMaxPctOutOfRange_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(VwapBody(100, now, now.AddMinutes(1), sliceMaxPct: 1.5m)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_VwapLimitWithoutPrice_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(VwapBody(100, now, now.AddMinutes(1), childPrice: null)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ───────────────────────── Happy-path slice firing ─────────────────────────
+
+    [Fact]
+    public async Task Vwap_SlicesUntilCompleted_UniformFallbackBehavesLikeTwap()
+    {
+        // No prior trade volume is recorded, so the estimator returns the
+        // uniform CDF — VWAP degrades to TWAP-shaped slicing. Window
+        // already open (start in past), 1.6s long, tick=200ms ⇒ 8 slots.
+        // The first slot fires immediately and subsequent slots fire as
+        // each child terminalizes.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            VwapBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(2),
+                tickSeconds: 0.2));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+
+        // Fill the first slice; expect at least one more to follow.
+        // The engine's catch-up loop may skip the seq=0 slot because the
+        // CDF evaluated at startUtc is 0 (no gap to fill); we just want
+        // *any* slice to fire first.
+        var first = await WaitForAnyChild(book, algoId);
+        await InjectEr(http, adminToken, first.ClOrdId, "Fill", lastQty: first.Quantity);
+        var seenSeqs = new HashSet<int> { first.AlgoSliceSeq!.Value };
+        long filled = first.Quantity;
+
+        // Fill subsequent slices until the parent reports Completed.
+        // Cap the loop so a stuck parent surfaces as a timeout rather
+        // than an infinite spin.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            var snap = await GetAlgo(http, userToken, algoId);
+            var status = snap.GetProperty("status").GetString();
+            if (status == "Completed") break;
+            if (status == "Expired") break;
+
+            var next = book.EnumerateChildrenOf("default", ulong.Parse(algoId))
+                .FirstOrDefault(c => c.AlgoSliceSeq is { } s && seenSeqs.Add(s));
+            if (next is null) { await Task.Delay(20); continue; }
+            await InjectEr(http, adminToken, next.ClOrdId, "Fill", lastQty: next.Quantity);
+            filled += next.Quantity;
+            if (filled >= 400) break;
+        }
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed", "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        // Either path is acceptable: a fast-enough scheduler completes
+        // the parent before endUtc; a slower one ends with the window
+        // expiring on a partial fill. What we're asserting is that the
+        // VWAP engine actually sliced and filled work via the curve
+        // (regression against the engine going silent or refusing to
+        // submit any child).
+        var filledQty = algo.GetProperty("filledQuantity").GetInt64();
+        Assert.True(filledQty > 0, $"expected some VWAP fills, got {filledQty}");
+    }
+
+    [Fact]
+    public async Task Vwap_WindowExpiresWithoutFill_BecomesExpired()
+    {
+        // Tight 500ms window; one child fires, then we let it sit
+        // untouched until past endUtc and finally cancel via simulator.
+        // The engine routes the parent to Expired/VwapWindowExpired
+        // because endUtc has already passed when the child terminalizes.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            VwapBody(total: 100, start: now.AddSeconds(-1), end: now.AddMilliseconds(500),
+                tickSeconds: 0.2));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var s0 = await WaitForAnyChild(book, algoId);
+
+        await Task.Delay(900);
+        await InjectEr(http, adminToken, s0.ClOrdId, "Canceled");
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("VwapWindowExpired", algo.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Vwap_NoChild_WindowAlreadyExpired_BecomesExpired()
+    {
+        // Submitted with the whole window already in the past — same
+        // edge case as TWAP's expiry-without-child path.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            VwapBody(total: 100, start: now.AddSeconds(-2), end: now.AddSeconds(-1),
+                tickSeconds: 0.2));
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("VwapWindowExpired", algo.GetProperty("terminalReason").GetString());
+        Assert.Equal(0, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task GetAlgo_ReturnsVwapParametersInDto()
+    {
+        // Round-trips the VWAP parameters through the DTO mapper so the
+        // surface stays stable for the frontend.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, token,
+            VwapBody(total: 200, start: now.AddSeconds(10), end: now.AddSeconds(70),
+                tickSeconds: 5, sliceMaxPct: 0.25m, priceLimit: 31m));
+
+        var algo = await GetAlgo(http, token, algoId);
+        Assert.Equal("Vwap", algo.GetProperty("type").GetString());
+        var vwap = algo.GetProperty("vwap");
+        Assert.Equal(5.0, vwap.GetProperty("tickIntervalSeconds").GetDouble(), 3);
+        Assert.Equal(0.25m, vwap.GetProperty("sliceMaxPct").GetDecimal());
+        Assert.Equal(31m, vwap.GetProperty("priceLimit").GetDecimal());
+    }
+
+    // ───────────────────────── helpers (parallel to AlgoTwapIntegrationTests) ─────────────────────────
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<Order> WaitForChild(WorkingOrderBook book, string algoIdStr, int expectedSeq)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var match = book.EnumerateChildrenOf("default", algoId)
+                .FirstOrDefault(c => c.AlgoSliceSeq == expectedSeq);
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"Child for algo {algoIdStr} seq {expectedSeq} did not appear within 5s.");
+    }
+
+    private static Order? TryGetChild(WorkingOrderBook book, string algoIdStr, int expectedSeq)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        return book.EnumerateChildrenOf("default", algoId)
+            .FirstOrDefault(c => c.AlgoSliceSeq == expectedSeq);
+    }
+
+    private static async Task<Order> WaitForAnyChild(WorkingOrderBook book, string algoIdStr)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var match = book.EnumerateChildrenOf("default", algoId).FirstOrDefault();
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"No child for algo {algoIdStr} within 5s.");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/VwapPlanTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/VwapPlanTests.cs
@@ -168,10 +168,24 @@ public class VwapPlanTests
     }
 
     [Fact]
-    public void SliceQty_ParticipationIgnored_WhenNoRecentVolume()
+    public void SliceQty_ParticipationCapWithNoRecentVolume_EmitsNoSlice()
     {
-        // No recent volume → ignore the cap rather than going to 0.
-        Assert.Equal(300, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.20m, 0));
+        // Pass-1 review (#294) P1#2: when participationCap is set but
+        // recentMarketVolume is 0 we have no baseline to compute a safe
+        // size against. Treat the cap as a hard zero — emit NO slice
+        // this tick rather than ignoring the cap. Re-evaluation happens
+        // on the next tick once trades arrive.
+        Assert.Equal(0, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.20m, 0));
+    }
+
+    [Fact]
+    public void SliceQty_ParticipationCapHonoured_WhenRecentVolumeNonZero()
+    {
+        // Regression: positive recent volume still clamps to the cap
+        // (10% of 5000 = 500, gap=300 → take 300; cap doesn't bind here).
+        Assert.Equal(300, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.10m, 5000));
+        // And does bind when smaller than the gap.
+        Assert.Equal(200, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.10m, 2000));
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/Algo/VwapPlanTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/VwapPlanTests.cs
@@ -1,0 +1,222 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class VwapPlanTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset End = new(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Tick = TimeSpan.FromSeconds(30);
+
+    // ───────────────────────── PlannedAtUtc ─────────────────────────
+
+    [Fact]
+    public void PlannedAtUtc_FirstSlotFiresAtStart()
+    {
+        Assert.Equal(Start, VwapPlan.PlannedAtUtc(Start, Tick, 0));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_EvenSpacing()
+    {
+        Assert.Equal(Start.AddSeconds(30), VwapPlan.PlannedAtUtc(Start, Tick, 1));
+        Assert.Equal(Start.AddSeconds(60), VwapPlan.PlannedAtUtc(Start, Tick, 2));
+        Assert.Equal(Start.AddSeconds(300), VwapPlan.PlannedAtUtc(Start, Tick, 10));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_DeterministicAcrossInvocations()
+    {
+        // Scheduler + engine recompute independently; drift would
+        // split-brain the tick. Hammer the helper for byte-equality.
+        for (var seq = 0; seq < 20; seq++)
+        {
+            var a = VwapPlan.PlannedAtUtc(Start, Tick, seq);
+            var b = VwapPlan.PlannedAtUtc(Start, Tick, seq);
+            Assert.Equal(a, b);
+        }
+    }
+
+    [Fact]
+    public void PlannedAtUtc_RejectsNonPositiveTickInterval()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            VwapPlan.PlannedAtUtc(Start, TimeSpan.Zero, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            VwapPlan.PlannedAtUtc(Start, TimeSpan.FromSeconds(-1), 0));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_RejectsNegativeSliceSeq()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            VwapPlan.PlannedAtUtc(Start, Tick, -1));
+    }
+
+    // ───────────────────────── SlotCount ─────────────────────────
+
+    [Fact]
+    public void SlotCount_EvenWindowDivision()
+    {
+        // 1h / 30s = 120 slots
+        Assert.Equal(120, VwapPlan.SlotCount(Start, End, Tick));
+    }
+
+    [Fact]
+    public void SlotCount_RoundsUpForFractionalRemainder()
+    {
+        // 65s / 30s = 2.17 → 3 slots so the tail is reachable
+        Assert.Equal(3, VwapPlan.SlotCount(Start, Start.AddSeconds(65), Tick));
+    }
+
+    [Fact]
+    public void SlotCount_AlwaysAtLeastOneSlot()
+    {
+        Assert.Equal(1, VwapPlan.SlotCount(Start, Start.AddTicks(1), Tick));
+    }
+
+    [Fact]
+    public void SlotCount_RejectsInvalidWindow()
+    {
+        Assert.Throws<ArgumentException>(() => VwapPlan.SlotCount(Start, Start, Tick));
+        Assert.Throws<ArgumentException>(() => VwapPlan.SlotCount(End, Start, Tick));
+    }
+
+    // ───────────────────────── TargetCumQty ─────────────────────────
+
+    [Fact]
+    public void TargetCumQty_ClampedAtBoundaries()
+    {
+        Assert.Equal(0, VwapPlan.TargetCumQty(1000, 0));
+        Assert.Equal(0, VwapPlan.TargetCumQty(1000, -0.1));
+        Assert.Equal(1000, VwapPlan.TargetCumQty(1000, 1));
+        Assert.Equal(1000, VwapPlan.TargetCumQty(1000, 1.5));
+    }
+
+    [Fact]
+    public void TargetCumQty_RoundsToNearest()
+    {
+        Assert.Equal(500, VwapPlan.TargetCumQty(1000, 0.5));
+        Assert.Equal(250, VwapPlan.TargetCumQty(1000, 0.25));
+        Assert.Equal(333, VwapPlan.TargetCumQty(1000, 1.0 / 3.0));
+    }
+
+    [Fact]
+    public void TargetCumQty_NaN_ReturnsZero()
+    {
+        Assert.Equal(0, VwapPlan.TargetCumQty(1000, double.NaN));
+    }
+
+    [Fact]
+    public void TargetCumQty_RejectsNonPositiveTotal()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => VwapPlan.TargetCumQty(0, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => VwapPlan.TargetCumQty(-1, 0.5));
+    }
+
+    // ───────────────────────── SliceQty ─────────────────────────
+
+    [Fact]
+    public void SliceQty_ReturnsGap_WhenNoCapsConfigured()
+    {
+        // target 500 - executed 200 = gap 300, plenty of remaining.
+        Assert.Equal(300, VwapPlan.SliceQty(500, 200, 800, 1000, null, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_ZeroOrNegativeGap_ReturnsZero()
+    {
+        // Parent is ahead of curve — engine should skip this slot.
+        Assert.Equal(0, VwapPlan.SliceQty(500, 600, 400, 1000, null, null, 0));
+        Assert.Equal(0, VwapPlan.SliceQty(500, 500, 500, 1000, null, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_CappedByRemaining()
+    {
+        // gap 300 but only 100 remaining.
+        Assert.Equal(100, VwapPlan.SliceQty(500, 200, 100, 1000, null, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_ZeroRemaining_ReturnsZero()
+    {
+        Assert.Equal(0, VwapPlan.SliceQty(500, 0, 0, 1000, null, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_CappedBySliceMaxPct()
+    {
+        // 10% of 1000 = 100, but gap is 300.
+        Assert.Equal(100, VwapPlan.SliceQty(500, 200, 800, 1000, 0.10m, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_SliceMaxPctZeroCap_StillAllowsOneShare()
+    {
+        // A literal 0% cap would freeze the algo; floor to 1 share.
+        Assert.Equal(1, VwapPlan.SliceQty(500, 200, 800, 1000, 0.00001m, null, 0));
+    }
+
+    [Fact]
+    public void SliceQty_CappedByParticipation()
+    {
+        // 20% of recent market 500 = 100, but gap is 300.
+        Assert.Equal(100, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.20m, 500));
+    }
+
+    [Fact]
+    public void SliceQty_ParticipationIgnored_WhenNoRecentVolume()
+    {
+        // No recent volume → ignore the cap rather than going to 0.
+        Assert.Equal(300, VwapPlan.SliceQty(500, 200, 800, 1000, null, 0.20m, 0));
+    }
+
+    [Fact]
+    public void SliceQty_AllCapsCombined_TakesMinimum()
+    {
+        // gap=300, remaining=800, sliceMaxPct=15%*1000=150,
+        // participation=10%*1000=100 → take 100.
+        Assert.Equal(100, VwapPlan.SliceQty(500, 200, 800, 1000, 0.15m, 0.10m, 1000));
+    }
+
+    [Fact]
+    public void SliceQty_RejectsNonPositiveTotal()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => VwapPlan.SliceQty(0, 0, 100, 0, null, null, 0));
+    }
+
+    // ───────────────────────── ClampPrice ─────────────────────────
+
+    [Fact]
+    public void ClampPrice_BuyTakesMin()
+    {
+        // Buy never pays more than the priceLimit ceiling.
+        Assert.Equal(10m, VwapPlan.ClampPrice(12m, 10m, OrderSide.Buy));
+        Assert.Equal(8m, VwapPlan.ClampPrice(8m, 10m, OrderSide.Buy));
+    }
+
+    [Fact]
+    public void ClampPrice_SellTakesMax()
+    {
+        // Sell never accepts less than the priceLimit floor.
+        Assert.Equal(10m, VwapPlan.ClampPrice(8m, 10m, OrderSide.Sell));
+        Assert.Equal(12m, VwapPlan.ClampPrice(12m, 10m, OrderSide.Sell));
+    }
+
+    [Fact]
+    public void ClampPrice_NoLimit_ReturnsRefPrice()
+    {
+        Assert.Equal(12m, VwapPlan.ClampPrice(12m, null, OrderSide.Buy));
+        Assert.Null(VwapPlan.ClampPrice(null, null, OrderSide.Buy));
+    }
+
+    [Fact]
+    public void ClampPrice_NoRefPrice_ReturnsLimit()
+    {
+        Assert.Equal(10m, VwapPlan.ClampPrice(null, 10m, OrderSide.Buy));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -1,0 +1,76 @@
+using B3.Trading.Application.MarketData;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// Pass-1 review (#294) P1#1A. The volume-curve estimator must see
+/// every live trade for the symbols the VWAP engine cares about. These
+/// tests assert the wiring shape — synthesise <see cref="MarketTrade"/>
+/// events through a fake <see cref="IMarketDataSubscriber"/> and check
+/// they accrue into the estimator's per-symbol buckets.
+/// </summary>
+public class MarketDataVolumePumpTests
+{
+    [Fact]
+    public async Task Trades_RaisedBySubscriber_AccrueIntoEstimator()
+    {
+        var subscriber = new FakeSubscriber();
+        var estimator = new VolumeCurveEstimator();
+        var pump = new MarketDataVolumePump(subscriber, estimator);
+        await pump.StartAsync(default);
+
+        var t0 = new DateTimeOffset(DateTime.UtcNow.Date.AddHours(13), TimeSpan.Zero);
+        subscriber.RaiseTrade(new MarketTrade("PETR4", 1UL, 30m, 100L, t0));
+        subscriber.RaiseTrade(new MarketTrade("PETR4", 1UL, 31m, 200L, t0.AddMinutes(1)));
+        subscriber.RaiseTrade(new MarketTrade("VALE3", 2UL, 60m, 50L, t0));
+
+        Assert.Equal(300, estimator.VolumeBetween("PETR4", t0, t0.AddMinutes(5)));
+        Assert.Equal(50, estimator.VolumeBetween("VALE3", t0, t0.AddMinutes(5)));
+
+        // After StopAsync the pump unsubscribes — further trades should
+        // not accrue. Catches a regression where the handler is wired
+        // twice (StartAsync re-adds) or never detached.
+        await pump.StopAsync(default);
+        subscriber.RaiseTrade(new MarketTrade("PETR4", 1UL, 30m, 999L, t0.AddMinutes(2)));
+        Assert.Equal(300, estimator.VolumeBetween("PETR4", t0, t0.AddMinutes(5)));
+    }
+
+    [Fact]
+    public async Task NonPositiveQty_IsIgnored_BySubscriberContract()
+    {
+        // The estimator already guards against non-positive qty; this
+        // exercises the integrated path so a future refactor that drops
+        // the guard surfaces here.
+        var subscriber = new FakeSubscriber();
+        var estimator = new VolumeCurveEstimator();
+        var pump = new MarketDataVolumePump(subscriber, estimator);
+        await pump.StartAsync(default);
+
+        var t0 = new DateTimeOffset(DateTime.UtcNow.Date.AddHours(13), TimeSpan.Zero);
+        subscriber.RaiseTrade(new MarketTrade("PETR4", 1UL, 30m, 0L, t0));
+        subscriber.RaiseTrade(new MarketTrade("PETR4", 1UL, 30m, -10L, t0));
+
+        Assert.Equal(0, estimator.VolumeBetween("PETR4", t0, t0.AddMinutes(5)));
+    }
+
+    private sealed class FakeSubscriber : IMarketDataSubscriber
+    {
+        public MarketDataConnectionState State => MarketDataConnectionState.Connected;
+        public long DroppedEventCount => 0;
+        public event Action<MarketTrade>? Trade;
+#pragma warning disable CS0067 // unused in this test
+        public event Action<MarketInfoSnapshot>? InfoSnapshot;
+        public event Action<MarketDataConnectionState>? ConnectionStateChanged;
+        public event Action<MarketSubscribeError>? SubscribeError;
+        public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
+        public event Action<MarketAuctionImbalance>? AuctionImbalance;
+        public event Action<MarketAuctionPrint>? AuctionPrint;
+#pragma warning restore CS0067
+
+        public void RaiseTrade(MarketTrade t) => Trade?.Invoke(t);
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -107,18 +107,68 @@ public class MarketDataVolumePumpTests
     }
 
     [Fact]
-    public async Task EnsureSubscribedAsync_SdkThrows_KeepsDedupAndDoesNotPropagate()
+    public async Task EnsureSubscribedAsync_SdkThrows_DoesNotPoisonCache_NextCallRetries()
     {
-        // SDK failures must not abort the VWAP creation path — the SDK's
-        // auto-resubscribe-on-reconnect will retry. The dedup marker is
-        // kept so we don't hammer the SDK on every reactor tick.
+        // Pass-3 review (#294) P1. A failed initial Subscribe used to mark
+        // the symbol in the dedup set BEFORE calling the SDK and swallow
+        // the exception — so a single not-ready / quota / unknown-symbol
+        // error at cold boot would permanently poison the cache and the
+        // algo would never receive trades. New contract: on failure the
+        // entry is cleared and the next EnsureSubscribedAsync(key) call
+        // retries the SDK call. Exceptions remain swallowed so the
+        // creation flow isn't broken.
         var subscriber = new FakeSubscriber { ThrowOnSubscribe = true };
         var pump = new MarketDataVolumePump(subscriber, new VolumeCurveEstimator());
 
         await pump.EnsureSubscribedAsync("PETR4");
         await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("PETR4");
+
+        Assert.Equal(3, subscriber.SubscribeCallsFor("PETR4"));
+
+        // Once the SDK recovers, the next call succeeds and the dedup
+        // marker sticks — further calls short-circuit.
+        subscriber.ThrowOnSubscribe = false;
+        await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("PETR4");
+
+        Assert.Equal(4, subscriber.SubscribeCallsFor("PETR4"));
+    }
+
+    [Fact]
+    public async Task EnsureSubscribedAsync_ConcurrentFirstCall_IssuesExactlyOneSdkCall()
+    {
+        // Pass-3 review (#294) P1. Two threads calling EnsureSubscribedAsync
+        // for the same not-yet-subscribed symbol must coalesce to exactly
+        // one SDK Subscribe — Lazy<Task> guarantees the inner factory
+        // (SubscribeOnceAsync) runs once even if GetOrAdd's value factory
+        // is invoked multiple times under contention.
+        var gate = new TaskCompletionSource();
+        var subscriber = new FakeSubscriber { SubscribeGate = gate.Task };
+        var pump = new MarketDataVolumePump(subscriber, new VolumeCurveEstimator());
+
+        const int racers = 32;
+        var tasks = new Task[racers];
+        using var startBarrier = new Barrier(racers);
+        for (var i = 0; i < racers; i++)
+        {
+            tasks[i] = Task.Run(async () =>
+            {
+                startBarrier.SignalAndWait();
+                await pump.EnsureSubscribedAsync("PETR4");
+            });
+        }
+
+        // Give racers a moment to all hit GetOrAdd before we let the SDK
+        // call complete. Without the gate the first racer might finish
+        // before the others arrive and the test would no longer exercise
+        // the coalescing path.
+        await Task.Delay(50);
+        gate.SetResult();
+        await Task.WhenAll(tasks);
 
         Assert.Equal(1, subscriber.SubscribeCallsFor("PETR4"));
+        Assert.Equal(1, subscriber.TotalSubscribeCalls);
     }
 
     private sealed class FakeSubscriber : IMarketDataSubscriber
@@ -126,7 +176,8 @@ public class MarketDataVolumePumpTests
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> _subs =
             new(StringComparer.OrdinalIgnoreCase);
 
-        public bool ThrowOnSubscribe { get; init; }
+        public bool ThrowOnSubscribe { get; set; }
+        public Task? SubscribeGate { get; init; }
         public int TotalSubscribeCalls => _subs.Values.Sum();
         public int SubscribeCallsFor(string symbol) =>
             _subs.TryGetValue(symbol, out var n) ? n : 0;
@@ -145,12 +196,13 @@ public class MarketDataVolumePumpTests
 
         public void RaiseTrade(MarketTrade t) => Trade?.Invoke(t);
         public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
+        public async ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
         {
             _subs.AddOrUpdate(symbol, 1, (_, n) => n + 1);
+            if (SubscribeGate is not null)
+                await SubscribeGate.ConfigureAwait(false);
             if (ThrowOnSubscribe)
                 throw new InvalidOperationException("simulated SDK Subscribe failure");
-            return ValueTask.CompletedTask;
         }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -54,8 +54,83 @@ public class MarketDataVolumePumpTests
         Assert.Equal(0, estimator.VolumeBetween("PETR4", t0, t0.AddMinutes(5)));
     }
 
+    [Fact]
+    public async Task EnsureSubscribedAsync_IsIdempotent_OneSdkCallPerSymbol()
+    {
+        // Pass-2 review (#294) P1. EnsureSubscribedAsync is the demand-
+        // subscribe path used by AlgoEngine.OnCreatedAsync for VWAP
+        // parents. Repeated calls (reactor re-evaluation, several VWAP
+        // parents on the same symbol) must collapse to exactly one
+        // SDK Subscribe per (symbol, process).
+        var subscriber = new FakeSubscriber();
+        var estimator = new VolumeCurveEstimator();
+        var pump = new MarketDataVolumePump(subscriber, estimator);
+
+        await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("petr4"); // case-insensitive dedup
+        await pump.EnsureSubscribedAsync("PETR4");
+
+        Assert.Equal(1, subscriber.SubscribeCallsFor("PETR4"));
+        Assert.Equal(1, subscriber.TotalSubscribeCalls);
+    }
+
+    [Fact]
+    public async Task EnsureSubscribedAsync_DistinctSymbols_SubscribeIndependently()
+    {
+        var subscriber = new FakeSubscriber();
+        var estimator = new VolumeCurveEstimator();
+        var pump = new MarketDataVolumePump(subscriber, estimator);
+
+        await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("VALE3");
+        await pump.EnsureSubscribedAsync("PETR4"); // duplicate of first
+        await pump.EnsureSubscribedAsync("ITUB4");
+
+        Assert.Equal(1, subscriber.SubscribeCallsFor("PETR4"));
+        Assert.Equal(1, subscriber.SubscribeCallsFor("VALE3"));
+        Assert.Equal(1, subscriber.SubscribeCallsFor("ITUB4"));
+        Assert.Equal(3, subscriber.TotalSubscribeCalls);
+    }
+
+    [Fact]
+    public async Task EnsureSubscribedAsync_NullOrWhitespace_IsNoOp()
+    {
+        var subscriber = new FakeSubscriber();
+        var pump = new MarketDataVolumePump(subscriber, new VolumeCurveEstimator());
+
+        await pump.EnsureSubscribedAsync("");
+        await pump.EnsureSubscribedAsync("   ");
+        await pump.EnsureSubscribedAsync(null!);
+
+        Assert.Equal(0, subscriber.TotalSubscribeCalls);
+    }
+
+    [Fact]
+    public async Task EnsureSubscribedAsync_SdkThrows_KeepsDedupAndDoesNotPropagate()
+    {
+        // SDK failures must not abort the VWAP creation path — the SDK's
+        // auto-resubscribe-on-reconnect will retry. The dedup marker is
+        // kept so we don't hammer the SDK on every reactor tick.
+        var subscriber = new FakeSubscriber { ThrowOnSubscribe = true };
+        var pump = new MarketDataVolumePump(subscriber, new VolumeCurveEstimator());
+
+        await pump.EnsureSubscribedAsync("PETR4");
+        await pump.EnsureSubscribedAsync("PETR4");
+
+        Assert.Equal(1, subscriber.SubscribeCallsFor("PETR4"));
+    }
+
     private sealed class FakeSubscriber : IMarketDataSubscriber
     {
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> _subs =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public bool ThrowOnSubscribe { get; init; }
+        public int TotalSubscribeCalls => _subs.Values.Sum();
+        public int SubscribeCallsFor(string symbol) =>
+            _subs.TryGetValue(symbol, out var n) ? n : 0;
+
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;
         public long DroppedEventCount => 0;
         public event Action<MarketTrade>? Trade;
@@ -70,7 +145,13 @@ public class MarketDataVolumePumpTests
 
         public void RaiseTrade(MarketTrade t) => Trade?.Invoke(t);
         public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
+        {
+            _subs.AddOrUpdate(symbol, 1, (_, n) => n + 1);
+            if (ThrowOnSubscribe)
+                throw new InvalidOperationException("simulated SDK Subscribe failure");
+            return ValueTask.CompletedTask;
+        }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
@@ -1,0 +1,135 @@
+using B3.Trading.Application.MarketData;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+public class VolumeCurveEstimatorTests
+{
+    private static readonly DateTimeOffset Day1Start = new(
+        DateOnly.FromDateTime(DateTime.UtcNow).ToDateTime(TimeOnly.MinValue),
+        TimeSpan.Zero);
+    private const string Sym = "PETR4";
+
+    [Fact]
+    public void CdfAt_NoData_ReturnsUniformFallback()
+    {
+        // Mirrors a TWAP-shaped curve so the engine still makes progress
+        // before any trade arrives.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        var end = start.AddHours(1);
+        var mid = start.AddMinutes(30);
+
+        Assert.Equal(0.5, sut.CdfAt(Sym, start, end, mid), 6);
+    }
+
+    [Fact]
+    public void CdfAt_BeforeStart_Zero_AfterEnd_One()
+    {
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        var end = start.AddHours(1);
+        Assert.Equal(0d, sut.CdfAt(Sym, start, end, start.AddMinutes(-5)));
+        Assert.Equal(0d, sut.CdfAt(Sym, start, end, start));
+        Assert.Equal(1d, sut.CdfAt(Sym, start, end, end));
+        Assert.Equal(1d, sut.CdfAt(Sym, start, end, end.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void CdfAt_UsesObservedVolume_WhenAvailable()
+    {
+        // Concentrate volume in first half of window: cdf at midpoint > 0.5.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        var end = start.AddHours(1);
+        var mid = start.AddMinutes(30);
+
+        sut.RecordTrade(Sym, 1000, start.AddMinutes(5));
+        sut.RecordTrade(Sym, 1000, start.AddMinutes(15));
+        sut.RecordTrade(Sym, 200, start.AddMinutes(45));
+
+        var cdf = sut.CdfAt(Sym, start, end, mid);
+        Assert.True(cdf > 0.9, $"expected cdf > 0.9 at midpoint, got {cdf}");
+    }
+
+    [Fact]
+    public void CdfAt_Monotonic_NonDecreasing()
+    {
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        var end = start.AddHours(1);
+        sut.RecordTrade(Sym, 100, start.AddMinutes(5));
+        sut.RecordTrade(Sym, 500, start.AddMinutes(35));
+
+        double prev = 0;
+        for (var m = 0; m <= 60; m += 5)
+        {
+            var cdf = sut.CdfAt(Sym, start, end, start.AddMinutes(m));
+            Assert.True(cdf >= prev, $"cdf went down at minute {m}: {prev} → {cdf}");
+            prev = cdf;
+        }
+    }
+
+    [Fact]
+    public void VolumeBetween_SumsAcrossBuckets()
+    {
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        sut.RecordTrade(Sym, 100, start.AddMinutes(1));   // bucket 0
+        sut.RecordTrade(Sym, 200, start.AddMinutes(6));   // bucket 1
+        sut.RecordTrade(Sym, 300, start.AddMinutes(11));  // bucket 2
+
+        Assert.Equal(600, sut.VolumeBetween(Sym, start, start.AddMinutes(15)));
+        Assert.Equal(300, sut.VolumeBetween(Sym, start, start.AddMinutes(10)));
+    }
+
+    [Fact]
+    public void VolumeBetween_DifferentSymbol_Isolated()
+    {
+        var sut = new VolumeCurveEstimator();
+        var t = Day1Start.AddHours(9);
+        sut.RecordTrade("PETR4", 100, t);
+        sut.RecordTrade("VALE3", 200, t);
+        Assert.Equal(100, sut.VolumeBetween("PETR4", t, t.AddMinutes(5)));
+        Assert.Equal(200, sut.VolumeBetween("VALE3", t, t.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void VolumeBetween_SpansDayBoundary()
+    {
+        var sut = new VolumeCurveEstimator();
+        var preMidnight = Day1Start.AddDays(1).AddMinutes(-10);
+        var postMidnight = Day1Start.AddDays(1).AddMinutes(5);
+        sut.RecordTrade(Sym, 100, preMidnight);
+        sut.RecordTrade(Sym, 200, postMidnight);
+
+        Assert.Equal(300, sut.VolumeBetween(Sym, preMidnight.AddMinutes(-1), postMidnight.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void RecordTrade_IgnoresNonPositiveQty()
+    {
+        var sut = new VolumeCurveEstimator();
+        var t = Day1Start.AddHours(9);
+        sut.RecordTrade(Sym, 0, t);
+        sut.RecordTrade(Sym, -100, t);
+        Assert.Equal(0, sut.VolumeBetween(Sym, t, t.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void RecordTrade_IgnoresEmptySymbol()
+    {
+        var sut = new VolumeCurveEstimator();
+        var t = Day1Start.AddHours(9);
+        sut.RecordTrade("", 100, t);
+        sut.RecordTrade("   ", 100, t);
+        Assert.Equal(0, sut.VolumeBetween("", t, t.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void BucketsPerDay_DefaultIs288()
+    {
+        var sut = new VolumeCurveEstimator();
+        Assert.Equal(288, sut.BucketsPerDay);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
@@ -36,9 +36,14 @@ public class VolumeCurveEstimatorTests
     }
 
     [Fact]
-    public void CdfAt_UsesObservedVolume_WhenAvailable()
+    public void CdfAt_UsesObservedVolume_BlendedWithExtrapolation()
     {
-        // Concentrate volume in first half of window: cdf at midpoint > 0.5.
+        // Pass-1 review (#294) P1#1B: at any point inside the window
+        // the CDF denominator is observed[start..at] +
+        // extrapolated[at..end]. With all observed volume in the first
+        // half (run-rate identical to remainder extrapolation) the CDF
+        // at the midpoint is 0.5 — NOT 1.0 as the old normalisation
+        // would have wrongly returned.
         var sut = new VolumeCurveEstimator();
         var start = Day1Start.AddHours(9);
         var end = start.AddHours(1);
@@ -46,10 +51,31 @@ public class VolumeCurveEstimatorTests
 
         sut.RecordTrade(Sym, 1000, start.AddMinutes(5));
         sut.RecordTrade(Sym, 1000, start.AddMinutes(15));
-        sut.RecordTrade(Sym, 200, start.AddMinutes(45));
 
         var cdf = sut.CdfAt(Sym, start, end, mid);
-        Assert.True(cdf > 0.9, $"expected cdf > 0.9 at midpoint, got {cdf}");
+        Assert.Equal(0.5, cdf, 6);
+    }
+
+    [Fact]
+    public void CdfAt_DoesNotJumpToOne_AfterSingleObservedBucket()
+    {
+        // Pass-1 review (#294) P1#1B regression. Window is 1h; only the
+        // very first 5-min bucket has any volume. Evaluated 30min in,
+        // the *old* code returned 1.0 (observed/observed = 1) which made
+        // the VWAP scheduler think the day was done and over-slice. The
+        // blended denominator keeps the CDF well below 1.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        var end = start.AddHours(1);
+        var at = start.AddMinutes(30);
+
+        sut.RecordTrade(Sym, 500, start.AddMinutes(1)); // bucket 0 only
+
+        var cdf = sut.CdfAt(Sym, start, end, at);
+        Assert.True(cdf < 0.9, $"expected blended cdf < 0.9, got {cdf}");
+        // With 1 observed bucket out of 6 elapsed and 6 remaining, the
+        // run-rate extrapolation drops the cdf well below 0.5.
+        Assert.True(cdf > 0, $"expected positive cdf, got {cdf}");
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
@@ -233,7 +233,7 @@ internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     public void RaiseTrade(string symbol, decimal price, DateTimeOffset ts) =>
-        Trade?.Invoke(new MarketTrade(symbol, 0UL, price, ts));
+        Trade?.Invoke(new MarketTrade(symbol, 0UL, price, 0L, ts));
 
     public void RaiseInfo(MarketInfoSnapshot s) => InfoSnapshot?.Invoke(s);
 

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -204,6 +204,106 @@ public class AlgoRecoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task VwapAlgo_ReplayedFromWal_ReproduceParentAggregate()
+    {
+        // Pass-1 review (#294) P2. Mirrors the Iceberg WAL-replay test
+        // above for VWAP: the AlgoCreatedEvent VWAP block + the parent
+        // cancel + terminal events round-trip through a cold-boot WAL
+        // replay back into an AlgoBook with the same shape.
+        var createdAt = new DateTimeOffset(2026, 5, 4, 13, 0, 0, TimeSpan.Zero);
+        var vwapStart = createdAt;
+        var vwapEnd = createdAt.AddMinutes(30);
+        var terminalAt = createdAt.AddSeconds(5);
+        var tick = TimeSpan.FromSeconds(30);
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 300UL,
+                    EndClientId = "carol",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Vwap",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    VwapStartUtc = vwapStart,
+                    VwapEndUtc = vwapEnd,
+                    VwapChildOrderType = "Limit",
+                    VwapChildPrice = 30m,
+                    VwapTickIntervalTicks = tick.Ticks,
+                    VwapSliceMaxPct = 0.20m,
+                    VwapPriceLimit = 31m,
+                    VwapParticipationCap = 0.10m,
+                },
+                () => algos.TryAdd(new Algo(300UL, new EndClientId("carol"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Vwap, 5000,
+                    new VwapParameters(vwapStart, vwapEnd, OrderType.Limit, 30m, tick, 0.20m, 31m, 0.10m), createdAt)));
+
+            dispatcher.Dispatch(
+                new AlgoVwapSlicedEvent
+                {
+                    AlgoId = 300UL,
+                    FirmId = "TEST",
+                    SliceSeq = 0,
+                    TargetCumQty = 100,
+                    ExecutedCum = 0,
+                    SliceQty = 100,
+                    PlannedAtUtc = vwapStart,
+                },
+                () => { /* observability-only: no aggregate mutation */ });
+
+            dispatcher.Dispatch(
+                new AlgoCancelRequestedEvent { AlgoId = 300UL, FirmId = "TEST", ActorUserId = "ops" },
+                () => algos.TryGet("TEST", 300UL, out var a).Then(() => a!.RequestCancel()));
+
+            dispatcher.Dispatch(
+                new AlgoTerminalStateRecordedEvent
+                {
+                    AlgoId = 300UL,
+                    FirmId = "TEST",
+                    Status = "Cancelled",
+                    Reason = "UserCancelled",
+                    AtUtc = terminalAt,
+                },
+                () => algos.TryGet("TEST", 300UL, out var a).Then(() =>
+                    a!.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, terminalAt)));
+        }
+
+        // Cold-boot replay.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var algoIds = new AlgoIdRegistry();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.True(algos.TryGet("TEST", 300UL, out var algo) && algo is not null);
+            Assert.Equal(AlgoStatus.Cancelled, algo!.Status);
+            Assert.Equal(AlgoTerminalReason.UserCancelled, algo.TerminalReason);
+            Assert.Equal(terminalAt, algo.TerminalAtUtc);
+            Assert.Equal(AlgoType.Vwap, algo.Type);
+            var vp = Assert.IsType<VwapParameters>(algo.Parameters);
+            Assert.Equal(vwapStart, vp.StartUtc);
+            Assert.Equal(vwapEnd, vp.EndUtc);
+            Assert.Equal(OrderType.Limit, vp.ChildOrderType);
+            Assert.Equal(30m, vp.ChildPrice);
+            Assert.Equal(tick, vp.TickInterval);
+            Assert.Equal(0.20m, vp.SliceMaxPct);
+            Assert.Equal(31m, vp.PriceLimit);
+            Assert.Equal(0.10m, vp.ParticipationCap);
+        }
+    }
+
+    [Fact]
     public void AlgoBook_EnumerateForOwner_ExcludesTerminalByDefault()
     {
         var algos = new AlgoBook();


### PR DESCRIPTION
Closes #281

Implements Q3.1: VWAP algo (volume curve estimator + slice scheduler) on top of the existing TWAP architecture. **Additive only**; no TWAP or Iceberg behavior changes.

## What changed

### Domain & WAL
- `AlgoType.Vwap`, `VwapParameters` record, `AlgoTerminalReason.VwapWindowExpired`.
- Extended `AlgoCreatedEvent` with 8 VWAP fields (Started → reuse). New `AlgoVwapSlicedEvent` audit envelope. Reuses `AlgoTerminalStateRecordedEvent` for Finished/Cancelled.

### Application
- **`VwapPlan`** — pure helpers: `PlannedAtUtc`, `SlotCount`, `TargetCumQty`, `SliceQty` (with caps), `ClampPrice`.
- **`VolumeCurveEstimator`** — per-symbol intraday volume buckets (5-min, 7-day retention) with uniform-CDF fallback. Wired as a singleton in DI. Live trade ingestion is API-stable but deferred (`MarketTrade` lacks qty); tests drive `RecordTrade` directly.
- **`AlgoEngine`** — VWAP cases for `OnCreatedAsync` (window expiry, catch-up loop that skips empty slots), `OnChildErAsync`, `ComputeNextSlice`, `SubmitNextSliceAsync` (zero-qty advances `NextSliceSeq` instead of terminalizing).
- **`AlgoScheduler`** — `TickVwap` mirroring `TickTwap`; one signal per parent per tick.
- 3 new metrics: `algo.vwap.slices_emitted`, `algo.vwap.target_vs_actual_diff`, `algo.vwap.cancelled`.

### Persistence
- `AlgoSnapshot` carries the 8 VWAP fields, `AlgoBook.FromSnapshot` rehydrates them, `StateSnapshotter` replays VWAP creates.

### REST
- `POST /algo` accepts `Type=Vwap` with a `Vwap` parameter block (kept on the same discriminator endpoint as TWAP/Iceberg for surface consistency; this departs from the issue's `/algos/vwap` suggestion). Full validation: childOrderType, window, childPrice for Limit, tickInterval > 0, sliceMaxPct & participationCap ∈ (0,1].
- `AlgoDto` round-trips a `vwap` block with `tickIntervalSeconds`.

## Tests
- 37 unit tests in `VwapPlanTests` (slot scheduling, target curve, slice caps, price clamp).
- 10 unit tests in `VolumeCurveEstimatorTests` (uniform fallback, observed-volume CDF, monotonicity, day-boundary, symbol isolation).
- 8 end-to-end tests in `VwapAlgoEndpointTests` (POST validation × 4, slice firing through `TestAppFactory`, window-expired terminal reason, DTO round-trip).

Full suite: **1395 passed, 0 failed**; `dotnet format --verify-no-changes` clean.
