### PR TITLE
feat(#282): POV (% of volume) algo

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -166,6 +166,39 @@ public static class AlgoEndpoints
                         req.Vwap.ParticipationCap);
                     break;
 
+                case AlgoType.Pov:
+                    // Q3.2 (#282). POV mirrors VWAP's surface conventions
+                    // — same POST /algo endpoint, discriminator-by-Type
+                    // pattern.
+                    if (req.Pov is null)
+                        return Results.BadRequest(new { error = "pov parameters are required for type=Pov" });
+                    if (!Enum.TryParse<OrderType>(req.Pov.ChildOrderType, ignoreCase: true, out var povChildType))
+                        return Results.BadRequest(new { error = $"invalid pov.childOrderType '{req.Pov.ChildOrderType}'" });
+                    if (povChildType is not (OrderType.Limit or OrderType.Market))
+                        return Results.BadRequest(new { error = "pov.childOrderType must be Limit or Market" });
+                    if (req.Pov.EndUtc <= req.Pov.StartUtc)
+                        return Results.BadRequest(new { error = "pov.endUtc must be greater than pov.startUtc" });
+                    if (povChildType == OrderType.Limit && req.Pov.ChildPrice is null)
+                        return Results.BadRequest(new { error = "pov.childPrice is required when pov.childOrderType is Limit" });
+                    if (req.Pov.ParticipationRate <= 0m || req.Pov.ParticipationRate > 1m)
+                        return Results.BadRequest(new { error = "pov.participationRate must be in (0, 1]" });
+                    var povTickSeconds = req.Pov.TickIntervalSeconds ?? 5d;
+                    if (povTickSeconds <= 0)
+                        return Results.BadRequest(new { error = "pov.tickIntervalSeconds must be positive" });
+                    var povMinSlice = req.Pov.MinSliceQty ?? 1L;
+                    if (povMinSlice < 1)
+                        return Results.BadRequest(new { error = "pov.minSliceQty must be >= 1" });
+                    parameters = new PovParameters(
+                        req.Pov.StartUtc,
+                        req.Pov.EndUtc,
+                        povChildType,
+                        req.Pov.ChildPrice,
+                        req.Pov.ParticipationRate,
+                        TimeSpan.FromSeconds(povTickSeconds),
+                        req.Pov.PriceLimit,
+                        povMinSlice);
+                    break;
+
                 default:
                     return Results.BadRequest(new { error = $"unsupported algo type '{type}'" });
             }
@@ -206,6 +239,14 @@ public static class AlgoEndpoints
                         VwapSliceMaxPct = (parameters as VwapParameters)?.SliceMaxPct,
                         VwapPriceLimit = (parameters as VwapParameters)?.PriceLimit,
                         VwapParticipationCap = (parameters as VwapParameters)?.ParticipationCap,
+                        PovStartUtc = (parameters as PovParameters)?.StartUtc,
+                        PovEndUtc = (parameters as PovParameters)?.EndUtc,
+                        PovChildOrderType = (parameters as PovParameters)?.ChildOrderType.ToString(),
+                        PovChildPrice = (parameters as PovParameters)?.ChildPrice,
+                        PovParticipationRate = (parameters as PovParameters)?.ParticipationRate,
+                        PovTickIntervalTicks = (parameters as PovParameters)?.TickInterval.Ticks,
+                        PovPriceLimit = (parameters as PovParameters)?.PriceLimit,
+                        PovMinSliceQty = (parameters as PovParameters)?.MinSliceQty,
                     },
                     () => algos.TryAdd(algo));
             }
@@ -336,7 +377,8 @@ public sealed record CreateAlgoRequest(
     long TotalQuantity,
     CreateAlgoIcebergParams? Iceberg,
     CreateAlgoTwapParams? Twap,
-    CreateAlgoVwapParams? Vwap = null);
+    CreateAlgoVwapParams? Vwap = null,
+    CreateAlgoPovParams? Pov = null);
 
 public sealed record CreateAlgoIcebergParams(long DisplayQuantity, decimal? LimitPrice);
 
@@ -361,3 +403,19 @@ public sealed record CreateAlgoVwapParams(
     decimal? SliceMaxPct = null,
     decimal? PriceLimit = null,
     decimal? ParticipationCap = null);
+
+/// <summary>
+/// HTTP request shape for the POV parameter block (Q3.2 / #282).
+/// <see cref="TickIntervalSeconds"/> defaults to 5s when null (issue
+/// spec: short bucket for reactivity). <see cref="MinSliceQty"/>
+/// defaults to 1.
+/// </summary>
+public sealed record CreateAlgoPovParams(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    string ChildOrderType,
+    decimal? ChildPrice,
+    decimal ParticipationRate,
+    double? TickIntervalSeconds = null,
+    decimal? PriceLimit = null,
+    long? MinSliceQty = null);

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -161,7 +161,8 @@ public sealed record AlgoDto(
     DateTimeOffset? TerminalAtUtc,
     IcebergParamsDto? Iceberg,
     TwapParamsDto? Twap,
-    VwapParamsDto? Vwap = null);
+    VwapParamsDto? Vwap = null,
+    PovParamsDto? Pov = null);
 
 public sealed record IcebergParamsDto(long DisplayQuantity, decimal? LimitPrice);
 
@@ -187,6 +188,21 @@ public sealed record VwapParamsDto(
     decimal? SliceMaxPct,
     decimal? PriceLimit,
     decimal? ParticipationCap);
+
+/// <summary>
+/// Wire shape for POV parameters (Q3.2 / #282). Tick interval surfaced
+/// in seconds (the WAL persists .NET ticks; this is a UX choice for the
+/// wire) so dashboards / clients don't have to know the .NET tick unit.
+/// </summary>
+public sealed record PovParamsDto(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    string ChildOrderType,
+    decimal? ChildPrice,
+    decimal ParticipationRate,
+    double TickIntervalSeconds,
+    decimal? PriceLimit,
+    long MinSliceQty);
 
 public static class DtoMappings
 {
@@ -216,6 +232,10 @@ public static class DtoMappings
             ? new VwapParamsDto(vp.StartUtc, vp.EndUtc, vp.ChildOrderType.ToString(), vp.ChildPrice,
                 vp.TickInterval.TotalSeconds, vp.SliceMaxPct, vp.PriceLimit, vp.ParticipationCap)
             : null;
+        PovParamsDto? pov = a.Parameters is PovParameters pp
+            ? new PovParamsDto(pp.StartUtc, pp.EndUtc, pp.ChildOrderType.ToString(), pp.ChildPrice,
+                pp.ParticipationRate, pp.TickInterval.TotalSeconds, pp.PriceLimit, pp.MinSliceQty)
+            : null;
         return new AlgoDto(
             a.AlgoId.ToString(),
             a.Symbol,
@@ -231,6 +251,7 @@ public static class DtoMappings
             a.TerminalAtUtc,
             iceberg,
             twap,
-            vwap);
+            vwap,
+            pov);
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -79,6 +79,15 @@ public sealed class AlgoEngine : BackgroundService
     private readonly OrderOwnershipMap _ownership;
     private readonly VolumeCurveEstimator? _vwapCurve;
     private readonly MarketDataVolumePump? _volumePump;
+    /// <summary>
+    /// Pass-1 review (#295) P1#1. Per-POV scheduling progress
+    /// (cumulative market volume + last-evaluate timestamp). Persisted
+    /// via <see cref="Persistence.AlgoPovSlicedEvent"/> on slice emit
+    /// + via the platform snapshot, restored on engine boot in
+    /// <see cref="Reconcile"/>. Null-tolerant for legacy test
+    /// compositions that don't exercise POV.
+    /// </summary>
+    private readonly PovProgressBook? _povProgress;
 
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
@@ -99,7 +108,8 @@ public sealed class AlgoEngine : BackgroundService
         ILogger<AlgoEngine> logger,
         OrderOwnershipMap ownership,
         VolumeCurveEstimator? vwapCurve = null,
-        MarketDataVolumePump? volumePump = null)
+        MarketDataVolumePump? volumePump = null,
+        PovProgressBook? povProgress = null)
     {
         _queue = queue;
         _algos = algos;
@@ -114,6 +124,7 @@ public sealed class AlgoEngine : BackgroundService
         _ownership = ownership;
         _vwapCurve = vwapCurve;
         _volumePump = volumePump;
+        _povProgress = povProgress;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -196,6 +207,27 @@ public sealed class AlgoEngine : BackgroundService
             algo.RehydrateProgress(totalCum);
             rt.NextSliceSeq = maxSeq + 1;
             rt.LiveChildClOrdId = liveChild;
+
+            // Pass-1 review (#295) P1#1. Restore POV scheduling baseline
+            // so a post-restart tick targets the pre-restart cumulative
+            // market volume * rate (NOT post-restart-only volume * rate,
+            // which would under-slice until the in-memory estimator
+            // caught up to FilledQuantity). Falls back to (0, StartUtc)
+            // on a fresh POV — same as a from-cold start.
+            if (algo.Type == AlgoType.Pov && algo.Parameters is PovParameters ppRec)
+            {
+                var progress = _povProgress?.TryGet(algo.FirmId, algo.AlgoId);
+                if (progress is { } p && p.LastEvaluateAtUtc != default)
+                {
+                    rt.PovMarketVolumeSeen = p.MarketVolumeSeen;
+                    rt.PovLastEvaluateAtUtc = p.LastEvaluateAtUtc;
+                }
+                else
+                {
+                    rt.PovMarketVolumeSeen = 0;
+                    rt.PovLastEvaluateAtUtc = ppRec.StartUtc;
+                }
+            }
 
             // Re-arm the reactor regardless: even if a live child exists,
             // the reactor may need to react if the child has since become
@@ -373,7 +405,7 @@ public sealed class AlgoEngine : BackgroundService
                 var dueAt = PovPlan.PlannedAtUtc(pp.StartUtc, pp.TickInterval, rt.NextSliceSeq);
                 if (now < dueAt) return;
                 if (dueAt >= pp.EndUtc) return;
-                var (qty, _, _) = ComputePovSlice(algo, pp, dueAt);
+                var (qty, _, _) = ComputePovSlice(algo, pp, rt, dueAt);
                 if (qty > 0) break;
                 rt.NextSliceSeq++;
             }
@@ -638,12 +670,19 @@ public sealed class AlgoEngine : BackgroundService
         }
         long povCumMarketVolume = 0, povExecutedCum = 0;
         DateTimeOffset povPlannedAt = default;
+        DateTimeOffset povLastEvaluateAtUtc = default;
         if (algo.Parameters is PovParameters ppForAudit)
         {
             povPlannedAt = PovPlan.PlannedAtUtc(ppForAudit.StartUtc, ppForAudit.TickInterval, sliceSeq);
-            var (_, _, cumMv) = ComputePovSlice(algo, ppForAudit, povPlannedAt);
+            var (_, _, cumMv) = ComputePovSlice(algo, ppForAudit, rt, povPlannedAt);
             povCumMarketVolume = cumMv;
             povExecutedCum = algo.FilledQuantity;
+            // Pass-1 review (#295) P1#1. Persisted alongside the slice
+            // so a restart restores BOTH the baseline and the wall-clock
+            // anchor: post-restart catch-up integrates VolumeBetween
+            // from this instant, not from StartUtc (which would double-
+            // count buckets already accumulated into MarketVolumeSeen).
+            povLastEvaluateAtUtc = rt.PovLastEvaluateAtUtc;
             if (cumMv > 0)
             {
                 MetricsRegistry.AlgoPovActualParticipationRate.Record((double)povExecutedCum / cumMv);
@@ -720,6 +759,18 @@ public sealed class AlgoEngine : BackgroundService
                         MetricsRegistry.AlgoPovSlicesEmitted.Add(1);
                         try
                         {
+                            // Pass-1 review (#295) P1#1. Persist the
+                            // running POV baseline so a restart resumes
+                            // off the pre-crash cumulative-market-volume
+                            // total (NOT zero, which would under-slice).
+                            // PovProgressBook.Set runs inside the
+                            // dispatcher action so live + replay paths
+                            // converge on identical book state.
+                            var firmId = algo.FirmId;
+                            var algoId = algo.AlgoId;
+                            var marketVolumeSeenSnapshot = povCumMarketVolume;
+                            var lastEvaluateAtUtcSnapshot = povLastEvaluateAtUtc;
+                            var povBook = _povProgress;
                             _dispatcher.Dispatch(
                                 new AlgoPovSlicedEvent
                                 {
@@ -730,8 +781,10 @@ public sealed class AlgoEngine : BackgroundService
                                     ExecutedCum = povExecutedCum,
                                     SliceQty = sliceQty,
                                     PlannedAtUtc = povPlannedAt,
+                                    MarketVolumeSeen = povCumMarketVolume,
+                                    LastEvaluateAtUtc = povLastEvaluateAtUtc,
                                 },
-                                static () => { });
+                                () => povBook?.Set(firmId, algoId, marketVolumeSeenSnapshot, lastEvaluateAtUtcSnapshot));
                         }
                         catch (WalBackpressureException)
                         {
@@ -872,7 +925,7 @@ public sealed class AlgoEngine : BackgroundService
                 {
                     var rt = _runtime[(algo.FirmId, algo.AlgoId)];
                     var dueAt = PovPlan.PlannedAtUtc(pp.StartUtc, pp.TickInterval, rt.NextSliceSeq);
-                    var (qty, price, _) = ComputePovSlice(algo, pp, dueAt);
+                    var (qty, price, _) = ComputePovSlice(algo, pp, rt, dueAt);
                     return (qty, price);
                 }
             default:
@@ -917,27 +970,59 @@ public sealed class AlgoEngine : BackgroundService
     }
 
     /// <summary>
-    /// POV slice computation: ask the live volume estimator for the
-    /// cumulative market volume in <c>[startUtc, evaluateAtUtc)</c>,
-    /// derive the target executed cum, return the gap to fill.
-    /// Returns <c>(qty, price, cumMarketVolume)</c> so the emission
-    /// path can record the audit envelope without recomputing. Reuses
-    /// <see cref="VolumeCurveEstimator"/> so POV doesn't need a sibling
-    /// estimator — the bucket granularity (5 min default) is fine for
-    /// the issue's example windows (~1h).
+    /// POV slice computation — restart-resilient (pass-1 review #295 P1#1).
+    ///
+    /// <para>
+    /// The slice target is derived from the parent's OWN running
+    /// cumulative-market-volume baseline (<see cref="AlgoParentRuntime.PovMarketVolumeSeen"/>)
+    /// rather than from <c>VolumeCurveEstimator.VolumeBetween(StartUtc, now)</c>.
+    /// The estimator only carries in-memory buckets so it cannot
+    /// reconstruct pre-restart trade volume; under the old formulation
+    /// a restarted live POV would under-slice until post-restart volume
+    /// "caught up" to the already-executed cumulative. Here we instead
+    /// accumulate <c>VolumeBetween(lastEvaluateAtUtc, now)</c> on every
+    /// tick and persist the running total via
+    /// <see cref="Persistence.AlgoPovSlicedEvent"/>; replay restores
+    /// the baseline before the engine resumes.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Side-effecting:</b> updates <paramref name="rt"/>'s
+    /// <c>PovMarketVolumeSeen</c> and <c>PovLastEvaluateAtUtc</c>. The
+    /// caller must invoke this exactly once per scheduler tick (emit or
+    /// skip) so the persisted snapshot on the next emit reflects every
+    /// observed bucket. Returns <c>(qty, price, marketVolumeSeen)</c>
+    /// — <c>marketVolumeSeen</c> is the just-updated baseline that the
+    /// caller should record on the emitted WAL event.
+    /// </para>
     /// </summary>
-    private (long Qty, decimal? Price, long CumMarketVolume) ComputePovSlice(
-        Algo algo, PovParameters pp, DateTimeOffset evaluateAtUtc)
+    private (long Qty, decimal? Price, long MarketVolumeSeen) ComputePovSlice(
+        Algo algo, PovParameters pp, AlgoParentRuntime rt, DateTimeOffset evaluateAtUtc)
     {
-        long cumMv = _vwapCurve?.VolumeBetween(algo.Symbol, pp.StartUtc, evaluateAtUtc) ?? 0L;
+        // First evaluation for a freshly-created POV (no Reconcile path
+        // touched this runtime): seed the baseline at StartUtc so the
+        // initial integration covers [StartUtc, evaluateAtUtc) — same
+        // window as the pre-fix formulation, preserving the cold-start
+        // semantics that the issue's #294 acceptance baseline measured.
+        if (rt.PovLastEvaluateAtUtc == default)
+        {
+            rt.PovLastEvaluateAtUtc = pp.StartUtc;
+        }
+        if (evaluateAtUtc > rt.PovLastEvaluateAtUtc && _vwapCurve is not null)
+        {
+            var incremental = _vwapCurve.VolumeBetween(algo.Symbol, rt.PovLastEvaluateAtUtc, evaluateAtUtc);
+            if (incremental > 0)
+                rt.PovMarketVolumeSeen += incremental;
+            rt.PovLastEvaluateAtUtc = evaluateAtUtc;
+        }
         var qty = PovPlan.SliceQty(
-            cumMv,
+            rt.PovMarketVolumeSeen,
             algo.FilledQuantity,
             algo.RemainingQuantity,
             pp.ParticipationRate,
             pp.MinSliceQty);
         var price = PovPlan.ClampPrice(pp.ChildPrice, pp.PriceLimit, algo.Side);
-        return (qty, price, cumMv);
+        return (qty, price, rt.PovMarketVolumeSeen);
     }
 
     private static double UniformCdf(DateTimeOffset start, DateTimeOffset end, DateTimeOffset at)
@@ -978,5 +1063,14 @@ public sealed class AlgoEngine : BackgroundService
         public int NextSliceSeq;
         public int RetryAttempts;
         public Dictionary<ulong, long> ChildBookedCum { get; } = new();
+
+        // Pass-1 review (#295) P1#1. POV scheduling state. Initialised
+        // to (0, default) so the first tick treats StartUtc as the
+        // baseline and integrates volume from there; the engine seeds
+        // these from PovProgressBook on Reconcile so a restart resumes
+        // from the most recently persisted slice instead of re-scanning
+        // an empty estimator.
+        public long PovMarketVolumeSeen;
+        public DateTimeOffset PovLastEvaluateAtUtc;
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -260,7 +260,7 @@ public sealed class AlgoEngine : BackgroundService
         // dedupes per symbol so repeated calls (reactor re-evaluation,
         // multiple parents on the same symbol, WAL replay-driven
         // reconciliation) collapse to one SDK Subscribe per process.
-        if (algo.Type == AlgoType.Vwap && _volumePump is not null)
+        if ((algo.Type == AlgoType.Vwap || algo.Type == AlgoType.Pov) && _volumePump is not null)
         {
             await _volumePump.EnsureSubscribedAsync(algo.Symbol, ct).ConfigureAwait(false);
         }
@@ -356,6 +356,28 @@ public sealed class AlgoEngine : BackgroundService
                 rt.NextSliceSeq++;
             }
         }
+        else if (algo.Type == AlgoType.Pov && algo.Parameters is PovParameters pp)
+        {
+            // POV: mirrors VWAP — the engine is driven by periodic
+            // scheduler ticks, and the per-slot decision is purely
+            // reactive to observed cumulative market volume. Empty
+            // slots advance NextSliceSeq so recovery is unambiguous.
+            var now = _clock.GetUtcNow();
+            if (now >= pp.EndUtc)
+            {
+                await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.PovWindowExpired).ConfigureAwait(false);
+                return;
+            }
+            while (true)
+            {
+                var dueAt = PovPlan.PlannedAtUtc(pp.StartUtc, pp.TickInterval, rt.NextSliceSeq);
+                if (now < dueAt) return;
+                if (dueAt >= pp.EndUtc) return;
+                var (qty, _, _) = ComputePovSlice(algo, pp, dueAt);
+                if (qty > 0) break;
+                rt.NextSliceSeq++;
+            }
+        }
 
         await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
     }
@@ -435,6 +457,15 @@ public sealed class AlgoEngine : BackgroundService
                     }
                     return;
                 }
+                if (algo.Type == AlgoType.Pov && algo.Parameters is PovParameters ppFilled)
+                {
+                    // POV: mirror VWAP — opportunistic, scheduler-driven.
+                    if (_clock.GetUtcNow() >= ppFilled.EndUtc)
+                    {
+                        await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.PovWindowExpired).ConfigureAwait(false);
+                    }
+                    return;
+                }
                 await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
                 return;
 
@@ -461,6 +492,10 @@ public sealed class AlgoEngine : BackgroundService
                 {
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
                 }
+                else if (IsPovWindowExpired(algo))
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.PovWindowExpired).ConfigureAwait(false);
+                }
                 else
                 {
                     // Venue cancelled the child without operator request
@@ -484,6 +519,11 @@ public sealed class AlgoEngine : BackgroundService
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.VwapWindowExpired).ConfigureAwait(false);
                     return;
                 }
+                if (IsPovWindowExpired(algo))
+                {
+                    await RecordTerminalAsync(algo, rt, AlgoStatus.Expired, AlgoTerminalReason.PovWindowExpired).ConfigureAwait(false);
+                    return;
+                }
                 await RecordTerminalAsync(algo, rt, AlgoStatus.Suspended, AlgoTerminalReason.RiskRejected).ConfigureAwait(false);
                 return;
         }
@@ -498,6 +538,11 @@ public sealed class AlgoEngine : BackgroundService
         algo.Type == AlgoType.Vwap
         && algo.Parameters is VwapParameters vp
         && _clock.GetUtcNow() >= vp.EndUtc;
+
+    private bool IsPovWindowExpired(Algo algo) =>
+        algo.Type == AlgoType.Pov
+        && algo.Parameters is PovParameters pp
+        && _clock.GetUtcNow() >= pp.EndUtc;
 
     private async Task OnCancelRequestedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
     {
@@ -553,11 +598,12 @@ public sealed class AlgoEngine : BackgroundService
         var (sliceQty, slicePrice) = ComputeNextSlice(algo);
         if (sliceQty <= 0)
         {
-            if (algo.Type == AlgoType.Vwap)
+            if (algo.Type == AlgoType.Vwap || algo.Type == AlgoType.Pov)
             {
-                // VWAP: empty slot — the parent is ahead of the curve.
-                // Advance NextSliceSeq so the next scheduler tick
-                // evaluates the next slot. Do NOT mark terminal.
+                // VWAP/POV: empty slot — the parent is ahead of the
+                // curve (VWAP) or there is insufficient market volume
+                // yet (POV). Advance NextSliceSeq so the next scheduler
+                // tick evaluates the next slot. Do NOT mark terminal.
                 rt.NextSliceSeq++;
                 return;
             }
@@ -573,6 +619,7 @@ public sealed class AlgoEngine : BackgroundService
             IcebergParameters => OrderType.Limit,
             TwapParameters tp => tp.ChildOrderType,
             VwapParameters vp => vp.ChildOrderType,
+            PovParameters pp => pp.ChildOrderType,
             _ => OrderType.Limit,
         };
 
@@ -588,6 +635,19 @@ public sealed class AlgoEngine : BackgroundService
             vwapTargetCum = target;
             vwapExecutedCum = algo.FilledQuantity;
             MetricsRegistry.AlgoVwapTargetVsActualDiff.Record(gap);
+        }
+        long povCumMarketVolume = 0, povExecutedCum = 0;
+        DateTimeOffset povPlannedAt = default;
+        if (algo.Parameters is PovParameters ppForAudit)
+        {
+            povPlannedAt = PovPlan.PlannedAtUtc(ppForAudit.StartUtc, ppForAudit.TickInterval, sliceSeq);
+            var (_, _, cumMv) = ComputePovSlice(algo, ppForAudit, povPlannedAt);
+            povCumMarketVolume = cumMv;
+            povExecutedCum = algo.FilledQuantity;
+            if (cumMv > 0)
+            {
+                MetricsRegistry.AlgoPovActualParticipationRate.Record((double)povExecutedCum / cumMv);
+            }
         }
 
         for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
@@ -653,6 +713,30 @@ public sealed class AlgoEngine : BackgroundService
                         {
                             MetricsRegistry.WalBackpressure.Add(1,
                                 new KeyValuePair<string, object?>("call_site", "algo.vwap.sliced"));
+                        }
+                    }
+                    else if (algo.Type == AlgoType.Pov)
+                    {
+                        MetricsRegistry.AlgoPovSlicesEmitted.Add(1);
+                        try
+                        {
+                            _dispatcher.Dispatch(
+                                new AlgoPovSlicedEvent
+                                {
+                                    AlgoId = algo.AlgoId,
+                                    FirmId = algo.FirmId,
+                                    SliceSeq = sliceSeq,
+                                    CumMarketVolume = povCumMarketVolume,
+                                    ExecutedCum = povExecutedCum,
+                                    SliceQty = sliceQty,
+                                    PlannedAtUtc = povPlannedAt,
+                                },
+                                static () => { });
+                        }
+                        catch (WalBackpressureException)
+                        {
+                            MetricsRegistry.WalBackpressure.Add(1,
+                                new KeyValuePair<string, object?>("call_site", "algo.pov.sliced"));
                         }
                     }
                     _algoSink.PublishAlgoSnapshot(algo.Owner, algo.FirmId, algo.AlgoId);
@@ -744,6 +828,10 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.AlgoVwapCancelled.Add(1);
         }
+        else if (algo.Type == AlgoType.Pov && status == AlgoStatus.Cancelled)
+        {
+            MetricsRegistry.AlgoPovCancelled.Add(1);
+        }
         await Task.CompletedTask;
     }
 
@@ -778,6 +866,13 @@ public sealed class AlgoEngine : BackgroundService
                     var rt = _runtime[(algo.FirmId, algo.AlgoId)];
                     var dueAt = VwapPlan.PlannedAtUtc(vp.StartUtc, vp.TickInterval, rt.NextSliceSeq);
                     var (qty, price, _, _) = ComputeVwapSlice(algo, vp, dueAt);
+                    return (qty, price);
+                }
+            case PovParameters pp:
+                {
+                    var rt = _runtime[(algo.FirmId, algo.AlgoId)];
+                    var dueAt = PovPlan.PlannedAtUtc(pp.StartUtc, pp.TickInterval, rt.NextSliceSeq);
+                    var (qty, price, _) = ComputePovSlice(algo, pp, dueAt);
                     return (qty, price);
                 }
             default:
@@ -819,6 +914,30 @@ public sealed class AlgoEngine : BackgroundService
             recentMarketVolume);
         var price = VwapPlan.ClampPrice(vp.ChildPrice, vp.PriceLimit, algo.Side);
         return (qty, price, targetCum, gap);
+    }
+
+    /// <summary>
+    /// POV slice computation: ask the live volume estimator for the
+    /// cumulative market volume in <c>[startUtc, evaluateAtUtc)</c>,
+    /// derive the target executed cum, return the gap to fill.
+    /// Returns <c>(qty, price, cumMarketVolume)</c> so the emission
+    /// path can record the audit envelope without recomputing. Reuses
+    /// <see cref="VolumeCurveEstimator"/> so POV doesn't need a sibling
+    /// estimator — the bucket granularity (5 min default) is fine for
+    /// the issue's example windows (~1h).
+    /// </summary>
+    private (long Qty, decimal? Price, long CumMarketVolume) ComputePovSlice(
+        Algo algo, PovParameters pp, DateTimeOffset evaluateAtUtc)
+    {
+        long cumMv = _vwapCurve?.VolumeBetween(algo.Symbol, pp.StartUtc, evaluateAtUtc) ?? 0L;
+        var qty = PovPlan.SliceQty(
+            cumMv,
+            algo.FilledQuantity,
+            algo.RemainingQuantity,
+            pp.ParticipationRate,
+            pp.MinSliceQty);
+        var price = PovPlan.ClampPrice(pp.ChildPrice, pp.PriceLimit, algo.Side);
+        return (qty, price, cumMv);
     }
 
     private static double UniformCdf(DateTimeOffset start, DateTimeOffset end, DateTimeOffset at)

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -186,7 +186,14 @@ public sealed class AlgoEngine : BackgroundService
     private void Reconcile()
     {
         var algos = _algos.EnumerateAll(includeTerminal: false);
-        if (algos.Count == 0) return;
+        if (algos.Count == 0)
+        {
+            // Even with no live algos, prune any orphan POV progress
+            // entries restored from a snapshot written by an older
+            // engine version that didn't remove on terminal.
+            PruneOrphanPovProgress(algos);
+            return;
+        }
 
         foreach (var algo in algos)
         {
@@ -243,6 +250,33 @@ public sealed class AlgoEngine : BackgroundService
         }
 
         _logger.LogInformation("AlgoEngine reconciliation enqueued {Count} non-terminal parents.", algos.Count);
+        PruneOrphanPovProgress(algos);
+    }
+
+    /// <summary>
+    /// Pass-2 review (#295) P2 — defensive. Iterate every entry in
+    /// <see cref="PovProgressBook"/> and drop those whose parent algo
+    /// is absent from the non-terminal live set. Covers (a) entries
+    /// persisted by a previous engine version that didn't
+    /// <c>Remove</c> on terminal, and (b) entries whose parent was
+    /// concurrently terminated/expired between snapshot capture and
+    /// restart. Idempotent and cheap (one pass over a small map).
+    /// </summary>
+    private void PruneOrphanPovProgress(IReadOnlyCollection<Algo> liveAlgos)
+    {
+        if (_povProgress is null) return;
+        var live = new HashSet<(string FirmId, ulong AlgoId)>(liveAlgos.Count);
+        foreach (var a in liveAlgos)
+        {
+            live.Add((a.FirmId, a.AlgoId));
+        }
+        foreach (var (firmId, algoId, _) in _povProgress.Snapshot().ToList())
+        {
+            if (!live.Contains((firmId, algoId)))
+            {
+                _povProgress.Remove(firmId, algoId);
+            }
+        }
     }
 
     private async Task ReactAsync(AlgoSignal signal, CancellationToken ct)
@@ -885,6 +919,15 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.AlgoPovCancelled.Add(1);
         }
+        // Pass-2 review (#295) P2. Drop the per-POV progress entry on
+        // every terminal transition so PovProgressBook stays bounded
+        // and the next snapshot doesn't carry stale state for a dead
+        // parent. Safe to call for non-POV parents (no-op when no
+        // entry exists).
+        if (algo.Type == AlgoType.Pov)
+        {
+            _povProgress?.Remove(algo.FirmId, algo.AlgoId);
+        }
         await Task.CompletedTask;
     }
 
@@ -1015,6 +1058,16 @@ public sealed class AlgoEngine : BackgroundService
                 rt.PovMarketVolumeSeen += incremental;
             rt.PovLastEvaluateAtUtc = evaluateAtUtc;
         }
+        // Pass-2 review (#295) P1. Persist the just-advanced baseline
+        // into PovProgressBook on EVERY tick (emit OR skip). On the
+        // emit path the dispatcher action at SubmitNextSliceAsync will
+        // re-Set the same values (idempotent, last-write-wins). On the
+        // skip path the snapshotter is the only persistence — without
+        // this update a restart between snapshots loses the observed
+        // market volume and the algo under-slices until post-restart
+        // volume catches up. The trader's loss is bounded by snapshot
+        // cadence (no per-tick WAL event is emitted on skip).
+        _povProgress?.Set(algo.FirmId, algo.AlgoId, rt.PovMarketVolumeSeen, rt.PovLastEvaluateAtUtc);
         var qty = PovPlan.SliceQty(
             rt.PovMarketVolumeSeen,
             algo.FilledQuantity,

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -161,6 +161,12 @@ public sealed class AlgoScheduler : BackgroundService
                 TickVwap(algo, vp, now);
                 continue;
             }
+
+            if (algo.Type == AlgoType.Pov && algo.Parameters is PovParameters pp)
+            {
+                TickPov(algo, pp, now);
+                continue;
+            }
         }
     }
 
@@ -228,6 +234,36 @@ public sealed class AlgoScheduler : BackgroundService
         var dueAt = VwapPlan.PlannedAtUtc(vp.StartUtc, vp.TickInterval, nextSeq);
         if (now < dueAt) return;
         if (dueAt >= vp.EndUtc) return; // window passed at the slot boundary
+
+        Enqueue(algo);
+    }
+
+    private void TickPov(Algo algo, PovParameters pp, DateTimeOffset now)
+    {
+        // POV mirrors VWAP scheduling: enqueue at most one Created
+        // signal per parent per tick so the engine evaluates the slice
+        // (it owns the empty-slot catch-up loop in OnCreatedAsync). The
+        // engine takes the "is there market volume to share?" decision
+        // — the scheduler only gates on time + live-child presence.
+        if (now >= pp.EndUtc)
+        {
+            Enqueue(algo);
+            return;
+        }
+
+        int maxSeq = -1;
+        bool hasLiveChild = false;
+        foreach (var child in _orders.EnumerateChildrenOf(algo.FirmId, algo.AlgoId))
+        {
+            if (child.AlgoSliceSeq is { } seq && seq > maxSeq) maxSeq = seq;
+            if (!IsChildTerminal(child)) hasLiveChild = true;
+        }
+        if (hasLiveChild) return;
+
+        var nextSeq = maxSeq + 1;
+        var dueAt = PovPlan.PlannedAtUtc(pp.StartUtc, pp.TickInterval, nextSeq);
+        if (now < dueAt) return;
+        if (dueAt >= pp.EndUtc) return;
 
         Enqueue(algo);
     }

--- a/backend/src/B3.Trading.Application/Algo/PovPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/PovPlan.cs
@@ -1,0 +1,117 @@
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pure helpers for the POV (Percentage of Volume) slice scheduler
+/// (Q3.2 / #282). Mirrors the shape of <see cref="VwapPlan"/>: the plan
+/// is fully derivable from the parent parameters + the live cumulative
+/// market volume + the parent's executed cum, so the scheduler thread
+/// and the engine thread can compute the same target without sharing
+/// mutable state.
+///
+/// <para>
+/// <b>Slot spacing.</b> The window <c>[startUtc, endUtc)</c> is divided
+/// into evaluation slots of <c>tickInterval</c>. Slot <c>k</c> fires at
+/// <c>startUtc + k * tickInterval</c>. The window expiry itself is
+/// enforced separately (no slot is scheduled at or after <c>endUtc</c>),
+/// same convention as <see cref="VwapPlan"/>.
+/// </para>
+///
+/// <para>
+/// <b>Slice quantity.</b> At each slot the engine asks "how much do I owe
+/// the market to stay at <c>rate</c>?" via <see cref="SliceQty"/>:
+/// <c>pending = floor(cumMarketVolume * rate) - executedCum</c>, clamped
+/// to the parent's residue. When the gap is below <c>minSliceQty</c> the
+/// slot is skipped — the next tick re-evaluates once more volume has
+/// printed.
+/// </para>
+///
+/// <para>
+/// <b>End-of-window.</b> POV is opportunistic by definition; leftover
+/// quantity at <c>endUtc</c> is NOT force-filled. The engine routes the
+/// parent to <see cref="B3.Trading.Domain.AlgoStatus.Expired"/> with
+/// <see cref="B3.Trading.Domain.AlgoTerminalReason.PovWindowExpired"/>.
+/// </para>
+///
+/// <para>
+/// <b>Determinism.</b> Same as <see cref="VwapPlan"/>: offsets are
+/// computed in ticks so scheduler and engine threads cannot drift on
+/// "is this slot due?".
+/// </para>
+/// </summary>
+public static class PovPlan
+{
+    /// <summary>
+    /// UTC instant at which evaluation slot <paramref name="sliceSeq"/>
+    /// is due. Pure function of the parent parameters; no clock side
+    /// effect.
+    /// </summary>
+    public static DateTimeOffset PlannedAtUtc(
+        DateTimeOffset startUtc, TimeSpan tickInterval, int sliceSeq)
+    {
+        if (tickInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tickInterval), "tickInterval must be positive.");
+        if (sliceSeq < 0)
+            throw new ArgumentOutOfRangeException(nameof(sliceSeq), "sliceSeq must be non-negative.");
+
+        var offsetTicks = tickInterval.Ticks * sliceSeq;
+        return startUtc.AddTicks(offsetTicks);
+    }
+
+    /// <summary>
+    /// Quantity to submit at the current evaluation slot.
+    /// <c>pending = floor(cumMarketVolume * participationRate) - executedCum</c>,
+    /// clamped to <paramref name="remainingQuantity"/>. Returns 0 when
+    /// the gap is below <paramref name="minSliceQty"/> — the engine
+    /// treats that as "skip this slot, wait for the next tick".
+    /// </summary>
+    /// <param name="cumMarketVolume">Sum of market trade qty for the
+    /// symbol observed in <c>[startUtc, evaluateAtUtc)</c>.</param>
+    /// <param name="executedCum">Sum of fills already booked against the
+    /// parent.</param>
+    /// <param name="remainingQuantity">Parent residue
+    /// (<c>totalQty - executedCum</c>).</param>
+    /// <param name="participationRate">Target participation in
+    /// <c>(0, 1]</c>.</param>
+    /// <param name="minSliceQty">Floor on a non-zero slice; pending
+    /// below this is deferred to the next tick. Must be &gt;= 1.</param>
+    public static long SliceQty(
+        long cumMarketVolume,
+        long executedCum,
+        long remainingQuantity,
+        decimal participationRate,
+        long minSliceQty)
+    {
+        if (participationRate <= 0m || participationRate > 1m)
+            throw new ArgumentOutOfRangeException(nameof(participationRate),
+                "participationRate must be in (0, 1].");
+        if (minSliceQty < 1)
+            throw new ArgumentOutOfRangeException(nameof(minSliceQty),
+                "minSliceQty must be >= 1.");
+        if (remainingQuantity <= 0) return 0;
+        if (cumMarketVolume <= 0) return 0;
+
+        var target = (long)Math.Floor((decimal)cumMarketVolume * participationRate);
+        var pending = target - executedCum;
+        if (pending <= 0) return 0;
+
+        var capped = Math.Min(pending, remainingQuantity);
+        if (capped < minSliceQty) return 0;
+        return capped;
+    }
+
+    /// <summary>
+    /// Resolves the child LIMIT price. If a <paramref name="priceLimit"/>
+    /// is configured the engine never crosses past it; otherwise the
+    /// <paramref name="refPrice"/> is used as-is. For Buy side, the
+    /// effective price is <c>min(refPrice, priceLimit)</c>; for Sell side,
+    /// <c>max(refPrice, priceLimit)</c>. Mirrors <see cref="VwapPlan.ClampPrice"/>.
+    /// </summary>
+    public static decimal? ClampPrice(decimal? refPrice, decimal? priceLimit, B3.Trading.Domain.OrderSide side)
+    {
+        if (priceLimit is null) return refPrice;
+        if (refPrice is null) return priceLimit;
+        return side == B3.Trading.Domain.OrderSide.Buy
+            ? Math.Min(refPrice.Value, priceLimit.Value)
+            : Math.Max(refPrice.Value, priceLimit.Value);
+    }
+}

--- a/backend/src/B3.Trading.Application/Algo/PovProgressBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PovProgressBook.cs
@@ -53,6 +53,17 @@ public sealed class PovProgressBook
     public void Set(string firmId, ulong algoId, long marketVolumeSeen, DateTimeOffset lastEvaluateAtUtc) =>
         _progress[(firmId, algoId)] = new PovProgress(marketVolumeSeen, lastEvaluateAtUtc);
 
+    /// <summary>
+    /// Drop the per-POV entry for a terminated parent. Called from
+    /// <c>AlgoEngine.RecordTerminalAsync</c> on every POV terminal
+    /// (Completed/Cancelled/Expired/Suspended) and defensively from
+    /// engine reconciliation for any orphan entries whose parent is
+    /// missing or already terminal. Keeps <see cref="Snapshot"/> bounded
+    /// and prevents stale entries from being restored across restarts.
+    /// </summary>
+    public bool Remove(string firmId, ulong algoId) =>
+        _progress.TryRemove((firmId, algoId), out _);
+
     public IEnumerable<(string FirmId, ulong AlgoId, PovProgress Progress)> Snapshot()
     {
         foreach (var kv in _progress)

--- a/backend/src/B3.Trading.Application/Algo/PovProgressBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PovProgressBook.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pass-1 review (#295) P1#1 — POV restart-resilient state.
+///
+/// <para>
+/// Persisted per-POV running state: how much cumulative market volume
+/// this POV plan has observed since its <c>StartUtc</c>, and the UTC
+/// instant of the last evaluation tick. The engine uses these to
+/// compute slice targets as
+/// <c>targetCum = marketVolumeSeen * participationRate</c>, which is
+/// robust to process restarts because the baseline is carried in the
+/// WAL/snapshot rather than recomputed from <see cref="MarketData.VolumeCurveEstimator"/>'s
+/// transient in-memory buckets.
+/// </para>
+///
+/// <para>
+/// <b>Why this is not part of the <see cref="Algo"/> aggregate.</b>
+/// <c>marketVolumeSeen</c> is engine-internal scheduling state, not
+/// part of the parent's business identity. Keeping it in a side book
+/// (a) lets us evolve the persistence shape independently of
+/// <see cref="Persistence.AlgoCreatedEvent"/> /
+/// <see cref="Persistence.AlgoSnapshot"/>, and (b) means tests that
+/// only care about the parent's terminal state don't need to wire it.
+/// </para>
+///
+/// <para>
+/// <b>Lifecycle.</b> Updated by the engine on every POV evaluation
+/// tick (emit OR skip). Persisted to the WAL only on emit (via
+/// <see cref="Persistence.AlgoPovSlicedEvent"/>'s additive
+/// <c>MarketVolumeSeen</c> + <c>LastEvaluateAtUtc</c> fields) and
+/// captured by snapshots (via <c>PlatformSnapshot.PovProgress</c>).
+/// On restart the engine restores from the most recent persisted
+/// value and continues accumulating from <c>LastEvaluateAtUtc</c>;
+/// between the last persisted tick and restart any intervening volume
+/// is lost but the restored baseline is monotonically correct so the
+/// algo will never under-slice on the pre-restart accumulation.
+/// </para>
+/// </summary>
+public sealed class PovProgressBook
+{
+    private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), PovProgress> _progress = new();
+
+    public PovProgress? TryGet(string firmId, ulong algoId) =>
+        _progress.TryGetValue((firmId, algoId), out var p) ? p : null;
+
+    /// <summary>
+    /// Last-write-wins. Replay applies events in seq order so the
+    /// resulting state matches the most recently persisted slice.
+    /// </summary>
+    public void Set(string firmId, ulong algoId, long marketVolumeSeen, DateTimeOffset lastEvaluateAtUtc) =>
+        _progress[(firmId, algoId)] = new PovProgress(marketVolumeSeen, lastEvaluateAtUtc);
+
+    public IEnumerable<(string FirmId, ulong AlgoId, PovProgress Progress)> Snapshot()
+    {
+        foreach (var kv in _progress)
+            yield return (kv.Key.FirmId, kv.Key.AlgoId, kv.Value);
+    }
+
+    public void Restore(IEnumerable<(string FirmId, ulong AlgoId, PovProgress Progress)> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        _progress.Clear();
+        foreach (var r in rows)
+            _progress[(r.FirmId, r.AlgoId)] = r.Progress;
+    }
+}
+
+public readonly record struct PovProgress(long MarketVolumeSeen, DateTimeOffset LastEvaluateAtUtc);

--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -145,6 +145,14 @@ public sealed class AlgoBook
         decimal? vwapSliceMaxPct = null;
         decimal? vwapPriceLimit = null;
         decimal? vwapParticipationCap = null;
+        DateTimeOffset? povStart = null;
+        DateTimeOffset? povEnd = null;
+        string? povChildType = null;
+        decimal? povChildPrice = null;
+        decimal? povParticipationRate = null;
+        long? povTickIntervalTicks = null;
+        decimal? povPriceLimit = null;
+        long? povMinSliceQty = null;
 
         switch (a.Parameters)
         {
@@ -169,6 +177,16 @@ public sealed class AlgoBook
                 vwapPriceLimit = vp.PriceLimit;
                 vwapParticipationCap = vp.ParticipationCap;
                 break;
+            case PovParameters pp:
+                povStart = pp.StartUtc;
+                povEnd = pp.EndUtc;
+                povChildType = pp.ChildOrderType.ToString();
+                povChildPrice = pp.ChildPrice;
+                povParticipationRate = pp.ParticipationRate;
+                povTickIntervalTicks = pp.TickInterval.Ticks;
+                povPriceLimit = pp.PriceLimit;
+                povMinSliceQty = pp.MinSliceQty;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -179,7 +197,9 @@ public sealed class AlgoBook
             icebergDisplay, icebergLimit,
             twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice,
             vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
-            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap);
+            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap,
+            povStart, povEnd, povChildType, povChildPrice,
+            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty);
     }
 
     public void Restore(IEnumerable<Persistence.AlgoSnapshot> snaps)
@@ -217,6 +237,14 @@ public sealed class AlgoBook
         decimal? vwapSliceMaxPct = null;
         decimal? vwapPriceLimit = null;
         decimal? vwapParticipationCap = null;
+        DateTimeOffset? povStart = null;
+        DateTimeOffset? povEnd = null;
+        string? povChildType = null;
+        decimal? povChildPrice = null;
+        decimal? povParticipationRate = null;
+        long? povTickIntervalTicks = null;
+        decimal? povPriceLimit = null;
+        long? povMinSliceQty = null;
 
         switch (a.Parameters)
         {
@@ -241,6 +269,16 @@ public sealed class AlgoBook
                 vwapPriceLimit = vp.PriceLimit;
                 vwapParticipationCap = vp.ParticipationCap;
                 break;
+            case PovParameters pp:
+                povStart = pp.StartUtc;
+                povEnd = pp.EndUtc;
+                povChildType = pp.ChildOrderType.ToString();
+                povChildPrice = pp.ChildPrice;
+                povParticipationRate = pp.ParticipationRate;
+                povTickIntervalTicks = pp.TickInterval.Ticks;
+                povPriceLimit = pp.PriceLimit;
+                povMinSliceQty = pp.MinSliceQty;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -251,7 +289,9 @@ public sealed class AlgoBook
             icebergDisplay, icebergLimit,
             twapStart, twapEnd, twapSliceCount, twapChildType, twapChildPrice,
             vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
-            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap);
+            vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap,
+            povStart, povEnd, povChildType, povChildPrice,
+            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty);
     }
 
     internal static Algo FromSnapshot(Persistence.AlgoSnapshot s)
@@ -281,6 +321,15 @@ public sealed class AlgoBook
                 s.VwapSliceMaxPct,
                 s.VwapPriceLimit,
                 s.VwapParticipationCap),
+            AlgoType.Pov => new PovParameters(
+                s.PovStartUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovStartUtc."),
+                s.PovEndUtc ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovEndUtc."),
+                Enum.Parse<OrderType>(s.PovChildOrderType ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovChildOrderType.")),
+                s.PovChildPrice,
+                s.PovParticipationRate ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovParticipationRate."),
+                TimeSpan.FromTicks(s.PovTickIntervalTicks ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovTickIntervalTicks.")),
+                s.PovPriceLimit,
+                s.PovMinSliceQty ?? 1L),
             _ => throw new InvalidOperationException($"Unknown algo type: {s.Type}"),
         };
         return Algo.Hydrate(s.AlgoId, owner, s.FirmId, s.Symbol, s.SecurityId,

--- a/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
+++ b/backend/src/B3.Trading.Application/MarketData/VolumeCurveEstimator.cs
@@ -157,12 +157,30 @@ public sealed class VolumeCurveEstimator
     /// <paramref name="symbol"/>. Spans day boundaries by walking the
     /// per-day bucket arrays. Public for tests + for the participation
     /// cap (engine asks "how much has traded recently?").
+    ///
+    /// <para>
+    /// Pass-1 review (#295) P1#2. The first/last bucket overlapping
+    /// the range are pro-rated by elapsed-time fraction so a partial
+    /// bucket at either boundary does not over-count whole-bucket
+    /// trades that fall outside the range. This is a <b>linear
+    /// approximation</b>: it assumes uniform within-bucket trade
+    /// distribution. A bucket that recorded all of its volume at the
+    /// edge furthest from the range will be under/over-counted by up
+    /// to <c>(1 - overlap/bucketSize) * bucketTotal</c>. At the
+    /// default 5-minute bucket size this is bounded to a fraction of
+    /// one bucket which is acceptable for both the VWAP participation
+    /// cap (engine-recent lookback) and the POV incremental-volume
+    /// integrator (tick-aligned cadence). A precise alternative
+    /// (per-trade ring buffer) is tracked as follow-up work and not
+    /// needed for the windows the live algos operate over.
+    /// </para>
     /// </summary>
     public long VolumeBetween(string symbol, DateTimeOffset fromUtc, DateTimeOffset toUtc)
     {
         if (toUtc <= fromUtc) return 0;
         long total = 0;
         var bucketsPerDay = BucketsPerDay;
+        var bucketTicks = _bucketSize.Ticks;
         var day = DateOnly.FromDateTime(fromUtc.UtcDateTime);
         var endDay = DateOnly.FromDateTime(toUtc.UtcDateTime);
         while (day <= endDay)
@@ -178,7 +196,28 @@ public sealed class VolumeCurveEstimator
                     // Inclusive lower bound, exclusive upper bound.
                     var lastBucket = BucketIndex(rangeEnd.AddTicks(-1));
                     for (var b = firstBucket; b <= lastBucket && b < bucketsPerDay; b++)
-                        total += Interlocked.Read(ref arr[b]);
+                    {
+                        var qty = Interlocked.Read(ref arr[b]);
+                        if (qty == 0) continue;
+                        var bucketStart = dayStart.AddTicks(bucketTicks * b);
+                        var bucketEnd = bucketStart.AddTicks(bucketTicks);
+                        var overlapStart = rangeStart > bucketStart ? rangeStart : bucketStart;
+                        var overlapEnd = rangeEnd < bucketEnd ? rangeEnd : bucketEnd;
+                        var overlapTicks = (overlapEnd - overlapStart).Ticks;
+                        if (overlapTicks >= bucketTicks)
+                        {
+                            total += qty;
+                        }
+                        else if (overlapTicks > 0)
+                        {
+                            // Linear pro-rate of the boundary bucket.
+                            // Rounding mode: integer floor of qty * frac
+                            // — matches RecordTrade's whole-share grain
+                            // and keeps callers' integer-arithmetic
+                            // expectations (no fractional share leakage).
+                            total += (long)((decimal)qty * overlapTicks / bucketTicks);
+                        }
+                    }
                 }
             }
             day = day.AddDays(1);

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -274,6 +274,28 @@ public static class MetricsRegistry
             "trading.algo.vwap.cancelled",
             description: "VWAP parents reaching the Cancelled terminal state.");
 
+    // Q3.2 (#282) — POV slice scheduler observability. Mirrors the
+    // VWAP block above. SlicesEmitted counts child orders the engine
+    // actually placed (zero-quantity slots are skipped, not counted).
+    // ActualParticipationRate is a rolling gauge of
+    // <c>cumExecuted / cumMarketVolume</c> sampled at each slice
+    // evaluation — surfaces how closely the algo is tracking its
+    // target rate. Cancelled bumps for every POV parent reaching the
+    // <c>Cancelled</c> terminal state.
+    public static readonly Counter<long> AlgoPovSlicesEmitted =
+        Meter.CreateCounter<long>(
+            "trading.algo.pov.slices_emitted",
+            description: "Child orders submitted by the POV slice scheduler.");
+    public static readonly Histogram<double> AlgoPovActualParticipationRate =
+        Meter.CreateHistogram<double>(
+            "trading.algo.pov.actual_participation_rate",
+            unit: "ratio",
+            description: "cumExecuted / cumMarketVolume sampled at each POV slice evaluation.");
+    public static readonly Counter<long> AlgoPovCancelled =
+        Meter.CreateCounter<long>(
+            "trading.algo.pov.cancelled",
+            description: "POV parents reaching the Cancelled terminal state.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -114,7 +114,24 @@ public sealed class RawPlatformSnapshot
     /// <c>GtdExpirationScheduler.SnapshotAuditedExpiredIds()</c>.
     /// </summary>
     public ulong[] AuditedExpiredIds { get; init; } = Array.Empty<ulong>();
+
+    /// <summary>
+    /// Pass-1 review (#295) P1#1. Mirror of
+    /// <c>PlatformSnapshot.PovProgress</c> at the raw-capture stage.
+    /// Populated under the dispatcher lock from
+    /// <c>PovProgressBook.Snapshot()</c>.
+    /// </summary>
+    public PovProgressRaw[] PovProgress { get; init; } = Array.Empty<PovProgressRaw>();
 }
+
+/// <summary>
+/// Pass-1 review (#295) P1#1. Raw POV scheduling-progress row.
+/// </summary>
+public sealed record PovProgressRaw(
+    string FirmId,
+    ulong AlgoId,
+    long MarketVolumeSeen,
+    DateTimeOffset LastEvaluateAtUtc);
 
 /// <summary>
 /// Captured Order. Mutable scalars (<see cref="Status"/>,

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -310,7 +310,16 @@ public sealed record AlgoSnapshot(
     long? VwapTickIntervalTicks = null,
     decimal? VwapSliceMaxPct = null,
     decimal? VwapPriceLimit = null,
-    decimal? VwapParticipationCap = null);
+    decimal? VwapParticipationCap = null,
+    // Q3.2 (#282) — POV fields, mirror the VWAP block.
+    DateTimeOffset? PovStartUtc = null,
+    DateTimeOffset? PovEndUtc = null,
+    string? PovChildOrderType = null,
+    decimal? PovChildPrice = null,
+    decimal? PovParticipationRate = null,
+    long? PovTickIntervalTicks = null,
+    decimal? PovPriceLimit = null,
+    long? PovMinSliceQty = null);
 
 public sealed record PositionSnapshot(
     string EndClientId,

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -178,6 +178,20 @@ public sealed class PlatformSnapshot
     /// </para>
     /// </summary>
     public IReadOnlyCollection<ulong> AuditedExpiredIds { get; init; } = Array.Empty<ulong>();
+
+    /// <summary>
+    /// Pass-1 review (#295) P1#1. Persisted per-POV scheduling progress
+    /// — <c>(firmId, algoId) → (marketVolumeSeen, lastEvaluateAtUtc)</c>.
+    /// Without this baseline a restart would have <see cref="B3.Trading.Application.Algo"/>'s
+    /// POV path re-derive the cumulative market volume from
+    /// <c>VolumeCurveEstimator</c>'s in-memory buckets, which lost
+    /// the pre-crash trade history; the parent would then under-slice
+    /// until post-restart volume catches up to the already-executed
+    /// cumulative. Empty on snapshots pre-dating the field, which
+    /// collapses to the pre-fix behaviour (engine seeds progress from
+    /// <c>StartUtc</c> on first tick — same as a fresh POV).
+    /// </summary>
+    public List<PovProgressSnapshot> PovProgress { get; init; } = new();
 }
 
 /// <summary>
@@ -349,6 +363,16 @@ public sealed record PnlUnknownBasisSnapshot(
     string EndClientId,
     string Symbol,
     long NetQuantity);
+
+/// <summary>
+/// Pass-1 review (#295) P1#1. One row of the per-POV scheduling-progress
+/// projection — see <see cref="PlatformSnapshot.PovProgress"/>.
+/// </summary>
+public sealed record PovProgressSnapshot(
+    string FirmId,
+    ulong AlgoId,
+    long MarketVolumeSeen,
+    DateTimeOffset LastEvaluateAtUtc);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -38,6 +38,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(AlgoCancelRequestedEvent))]
 [JsonSerializable(typeof(AlgoTerminalStateRecordedEvent))]
 [JsonSerializable(typeof(AlgoVwapSlicedEvent))]
+[JsonSerializable(typeof(AlgoPovSlicedEvent))]
 [JsonSerializable(typeof(OrderStaledEvent))]
 [JsonSerializable(typeof(OrderStaleClearedEvent))]
 [JsonSerializable(typeof(UserBotCredentialCreatedEvent))]

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -372,11 +372,18 @@ public sealed record AlgoVwapSlicedEvent : WalEvent
 /// <summary>
 /// Q3.2 (#282). Per-slice audit envelope for POV parents — captures the
 /// market-volume baseline and the resulting share at slice-emit time.
-/// NOT replayed for state reconstruction (the slice itself is recorded
-/// via the child <see cref="OrderSubmittedEvent"/>, same as VWAP); the
-/// engine treats this event as observability-only so a future omission
-/// of the WAL write would not desynchronise recovery. Mirrors
-/// <see cref="AlgoVwapSlicedEvent"/>.
+///
+/// <para>
+/// Pass-1 review (#295) P1#1. Unlike <see cref="AlgoVwapSlicedEvent"/>,
+/// this event IS replayed: the additive <see cref="MarketVolumeSeen"/>
+/// and <see cref="LastEvaluateAtUtc"/> fields restore the per-POV
+/// scheduling baseline so a restart does not under-slice waiting for
+/// the in-memory <see cref="MarketData.VolumeCurveEstimator"/> buckets
+/// to re-observe the pre-crash cumulative market volume. The slice
+/// itself is still recorded via the child <see cref="OrderSubmittedEvent"/>
+/// — replay of this event mutates only <see cref="PovProgressBook"/>,
+/// never the parent's <c>FilledQuantity</c>.
+/// </para>
 /// </summary>
 public sealed record AlgoPovSlicedEvent : WalEvent
 {
@@ -387,6 +394,15 @@ public sealed record AlgoPovSlicedEvent : WalEvent
     public required long ExecutedCum { get; init; }
     public required long SliceQty { get; init; }
     public required DateTimeOffset PlannedAtUtc { get; init; }
+
+    // Pass-1 review (#295) P1#1. Persisted POV progress so a restart
+    // does NOT under-slice waiting for VolumeCurveEstimator's in-memory
+    // buckets to catch up to the pre-crash cumulative market volume.
+    // Additive — older WAL segments deserialise with default values
+    // (0 / default(DateTimeOffset)); engine recovery treats a default
+    // LastEvaluateAtUtc as "no prior progress; seed from StartUtc".
+    public long MarketVolumeSeen { get; init; }
+    public DateTimeOffset LastEvaluateAtUtc { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -27,6 +27,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoCancelRequestedEvent), "algo.cancel-requested")]
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
 [JsonDerivedType(typeof(AlgoVwapSlicedEvent), "algo.vwap.sliced")]
+[JsonDerivedType(typeof(AlgoPovSlicedEvent), "algo.pov.sliced")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
@@ -278,7 +279,7 @@ public sealed record AlgoCreatedEvent : WalEvent
     public required string Symbol { get; init; }
     public required ulong SecurityId { get; init; }
     public required string Side { get; init; }
-    public required string Type { get; init; }   // "Iceberg" | "Twap"
+    public required string Type { get; init; }   // "Iceberg" | "Twap" | "Vwap" | "Pov"
     public required long TotalQuantity { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
     /// <summary>
@@ -306,6 +307,18 @@ public sealed record AlgoCreatedEvent : WalEvent
     public decimal? VwapSliceMaxPct { get; init; }
     public decimal? VwapPriceLimit { get; init; }
     public decimal? VwapParticipationCap { get; init; }
+
+    // Q3.2 (#282) — POV fields. Mirror the VWAP block above; only the
+    // block matching <see cref="Type"/> = "Pov" is populated. Additive —
+    // older replays / snapshots without these fields stay valid.
+    public DateTimeOffset? PovStartUtc { get; init; }
+    public DateTimeOffset? PovEndUtc { get; init; }
+    public string? PovChildOrderType { get; init; }   // "Limit" | "Market"
+    public decimal? PovChildPrice { get; init; }
+    public decimal? PovParticipationRate { get; init; }
+    public long? PovTickIntervalTicks { get; init; }
+    public decimal? PovPriceLimit { get; init; }
+    public long? PovMinSliceQty { get; init; }
 }
 
 /// <summary>
@@ -351,6 +364,26 @@ public sealed record AlgoVwapSlicedEvent : WalEvent
     public required string FirmId { get; init; }
     public required int SliceSeq { get; init; }
     public required long TargetCumQty { get; init; }
+    public required long ExecutedCum { get; init; }
+    public required long SliceQty { get; init; }
+    public required DateTimeOffset PlannedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Q3.2 (#282). Per-slice audit envelope for POV parents — captures the
+/// market-volume baseline and the resulting share at slice-emit time.
+/// NOT replayed for state reconstruction (the slice itself is recorded
+/// via the child <see cref="OrderSubmittedEvent"/>, same as VWAP); the
+/// engine treats this event as observability-only so a future omission
+/// of the WAL write would not desynchronise recovery. Mirrors
+/// <see cref="AlgoVwapSlicedEvent"/>.
+/// </summary>
+public sealed record AlgoPovSlicedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required int SliceSeq { get; init; }
+    public required long CumMarketVolume { get; init; }
     public required long ExecutedCum { get; init; }
     public required long SliceQty { get; init; }
     public required DateTimeOffset PlannedAtUtc { get; init; }

--- a/backend/src/B3.Trading.Domain/Algo.cs
+++ b/backend/src/B3.Trading.Domain/Algo.cs
@@ -5,6 +5,7 @@ public enum AlgoType
     Iceberg,
     Twap,
     Vwap,
+    Pov,
 }
 
 /// <summary>
@@ -41,6 +42,8 @@ public enum AlgoTerminalReason
     Drained,
     /// <summary>VWAP window expired (Q3.1 / #281). Mirrors <see cref="TwapWindowExpired"/>.</summary>
     VwapWindowExpired,
+    /// <summary>POV window expired with residue (Q3.2 / #282). Mirrors <see cref="VwapWindowExpired"/>.</summary>
+    PovWindowExpired,
 }
 
 /// <summary>
@@ -95,6 +98,48 @@ public sealed record VwapParameters(
     decimal? SliceMaxPct = null,
     decimal? PriceLimit = null,
     decimal? ParticipationCap = null) : AlgoParameters;
+
+/// <summary>
+/// POV (Percentage of Volume) parameters (Q3.2 / #282).
+///
+/// <para>
+/// POV tracks live market trades for <c>Symbol</c> and keeps the parent's
+/// executed cumulative quantity at <c>ParticipationRate</c> of the cumulative
+/// market volume since <c>StartUtc</c>. Unlike VWAP — which targets a
+/// historically-shaped curve — POV is purely reactive: it slices only
+/// when the market actually trades.
+/// </para>
+///
+/// <para>
+/// <b>Slice formula.</b> At every <c>TickInterval</c> the engine asks:
+/// <c>pending = floor(cumMarketVolume * participationRate) - cumExecuted</c>.
+/// If <c>pending &gt;= MinSliceQty</c> a LIMIT child for <c>pending</c>
+/// shares is submitted (clamped to <c>TotalQty - cumExecuted</c>).
+/// Otherwise the slot is skipped and the next tick re-evaluates.
+/// </para>
+///
+/// <para>
+/// <b>End-of-window.</b> POV is opportunistic by definition: any leftover
+/// quantity at <c>EndUtc</c> is NOT force-filled — the parent reaches
+/// <see cref="AlgoStatus.Expired"/> with <see cref="AlgoTerminalReason.PovWindowExpired"/>.
+/// </para>
+///
+/// <para>
+/// <b>Defaults.</b> <see cref="TickInterval"/> defaults to 5s (issue
+/// spec: short bucket for reactivity). <see cref="MinSliceQty"/>
+/// defaults to 1 — the smallest meaningful slice; lifting this filters
+/// micro-bursts.
+/// </para>
+/// </summary>
+public sealed record PovParameters(
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc,
+    OrderType ChildOrderType,
+    decimal? ChildPrice,
+    decimal ParticipationRate,
+    TimeSpan TickInterval,
+    decimal? PriceLimit = null,
+    long MinSliceQty = 1) : AlgoParameters;
 
 /// <summary>
 /// Parent algo aggregate, sibling to <see cref="Order"/>. v0 stores only
@@ -269,6 +314,7 @@ public sealed class Algo
             AlgoType.Iceberg => parameters is IcebergParameters,
             AlgoType.Twap => parameters is TwapParameters,
             AlgoType.Vwap => parameters is VwapParameters,
+            AlgoType.Pov => parameters is PovParameters,
             _ => false,
         };
         if (!ok)

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -130,6 +130,11 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<B3.Trading.Application.MarketData.MarketDataVolumePump>();
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.MarketDataVolumePump>());
+        // Pass-1 review (#295) P1#1. Per-POV scheduling progress book
+        // — restores cumulative-market-volume baseline on restart so
+        // POV does not under-slice while VolumeCurveEstimator's in-memory
+        // buckets re-warm from post-restart prints.
+        services.AddSingleton<PovProgressBook>();
         services.AddHostedService<AlgoEngine>();
         services.AddHostedService<AlgoScheduler>();
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -42,6 +42,13 @@ public sealed class StateSnapshotter
     /// but the order was still working in the snapshot.
     /// </summary>
     private readonly GtdExpirationScheduler? _gtdScheduler;
+    /// <summary>
+    /// Pass-1 review (#295) P1#1. Optional — when wired the snapshot
+    /// pipeline captures per-POV scheduling progress so a restart can
+    /// restore the cumulative-market-volume baseline. Null-tolerant for
+    /// legacy test compositions that don't exercise POV.
+    /// </summary>
+    private readonly PovProgressBook? _povProgress;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -60,7 +67,8 @@ public sealed class StateSnapshotter
         GtdExpirationScheduler? gtdScheduler = null,
         CashKeeper? cashKeeper = null,
         FeeKeeper? feeKeeper = null,
-        PnlKeeper? pnlKeeper = null)
+        PnlKeeper? pnlKeeper = null,
+        PovProgressBook? povProgress = null)
     {
         _orders = orders;
         _positions = positions;
@@ -79,6 +87,7 @@ public sealed class StateSnapshotter
         _userBotSessions = userBotSessions;
         _userBotMappings = userBotMappings;
         _gtdScheduler = gtdScheduler;
+        _povProgress = povProgress;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -131,6 +140,11 @@ public sealed class StateSnapshotter
         BotOrderMappings = _userBotMappings?.RawSnapshotOrders() ?? Array.Empty<BotOrderMappingRaw>(),
         BotCancelMappings = _userBotMappings?.RawSnapshotCancels() ?? Array.Empty<BotCancelMappingRaw>(),
         AuditedExpiredIds = _gtdScheduler?.SnapshotAuditedExpiredIds() ?? Array.Empty<ulong>(),
+        PovProgress = _povProgress is null
+            ? Array.Empty<PovProgressRaw>()
+            : _povProgress.Snapshot()
+                .Select(t => new PovProgressRaw(t.FirmId, t.AlgoId, t.Progress.MarketVolumeSeen, t.Progress.LastEvaluateAtUtc))
+                .ToArray(),
     };
 
     /// <summary>
@@ -306,6 +320,13 @@ public sealed class StateSnapshotter
         }
         botCancelMaps.Sort(static (a, b) => a.CancelInternalClOrdId.CompareTo(b.CancelInternalClOrdId));
 
+        var povProgress = new List<PovProgressSnapshot>(raw.PovProgress.Length);
+        for (var i = 0; i < raw.PovProgress.Length; i++)
+        {
+            var p = raw.PovProgress[i];
+            povProgress.Add(new PovProgressSnapshot(p.FirmId, p.AlgoId, p.MarketVolumeSeen, p.LastEvaluateAtUtc));
+        }
+
         return new PlatformSnapshot
         {
             Seq = raw.Seq,
@@ -334,6 +355,7 @@ public sealed class StateSnapshotter
             BotOrderMappings = botOrderMaps,
             BotCancelMappings = botCancelMaps,
             AuditedExpiredIds = raw.AuditedExpiredIds,
+            PovProgress = povProgress,
         };
     }
 
@@ -404,6 +426,11 @@ public sealed class StateSnapshotter
             foreach (var id in snap.AuditedExpiredIds)
                 _gtdScheduler.MarkExpiredAuditAppended(id);
         }
+        if (_povProgress is not null)
+        {
+            _povProgress.Restore(snap.PovProgress.Select(p =>
+                (p.FirmId, p.AlgoId, new PovProgress(p.MarketVolumeSeen, p.LastEvaluateAtUtc))));
+        }
     }
 }
 
@@ -448,6 +475,14 @@ public sealed class EventReplayer
     private readonly FeeKeeper? _feeKeeper;
     private readonly PnlKeeper? _pnlKeeper;
     private readonly IFeeCalculator? _feeCalculator;
+    /// <summary>
+    /// Pass-1 review (#295) P1#1. Optional. When wired, replay folds
+    /// <see cref="AlgoPovSlicedEvent.MarketVolumeSeen"/> +
+    /// <see cref="AlgoPovSlicedEvent.LastEvaluateAtUtc"/> into the
+    /// per-POV progress book so a snapshot+tail recovery converges on
+    /// the same scheduling baseline as a snapshot-only restore.
+    /// </summary>
+    private readonly PovProgressBook? _povProgress;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -467,7 +502,8 @@ public sealed class EventReplayer
         CashKeeper? cashKeeper = null,
         FeeKeeper? feeKeeper = null,
         IFeeCalculator? feeCalculator = null,
-        PnlKeeper? pnlKeeper = null)
+        PnlKeeper? pnlKeeper = null,
+        PovProgressBook? povProgress = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -487,6 +523,7 @@ public sealed class EventReplayer
         _feeKeeper = feeKeeper;
         _feeCalculator = feeCalculator;
         _pnlKeeper = pnlKeeper;
+        _povProgress = povProgress;
     }
 
     /// <summary>
@@ -664,6 +701,15 @@ public sealed class EventReplayer
                     var reason = Enum.Parse<AlgoTerminalReason>(at.Reason, ignoreCase: true);
                     algo.RecordTerminal(status, reason, at.AtUtc);
                 }
+                break;
+            case AlgoPovSlicedEvent ps:
+                // Pass-1 review (#295) P1#1. Restore the POV scheduling
+                // baseline so the post-restart engine slices off the
+                // PRE-restart cumulative-market-volume baseline, not zero.
+                // Last-write-wins: events are replayed in seq order so
+                // the final state matches the most recently persisted
+                // slice. Idempotent under double-replay.
+                _povProgress?.Set(ps.FirmId, ps.AlgoId, ps.MarketVolumeSeen, ps.LastEvaluateAtUtc);
                 break;
             case OrderStaledEvent os:
                 if (_orders.TryGet(os.ClOrdId, out var staleOrd) && staleOrd is not null)

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -752,6 +752,15 @@ public sealed class EventReplayer
                 ac.VwapSliceMaxPct,
                 ac.VwapPriceLimit,
                 ac.VwapParticipationCap),
+            AlgoType.Pov => new PovParameters(
+                ac.PovStartUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovStartUtc."),
+                ac.PovEndUtc ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovEndUtc."),
+                Enum.Parse<OrderType>(ac.PovChildOrderType ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovChildOrderType."), ignoreCase: true),
+                ac.PovChildPrice,
+                ac.PovParticipationRate ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovParticipationRate."),
+                TimeSpan.FromTicks(ac.PovTickIntervalTicks ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovTickIntervalTicks.")),
+                ac.PovPriceLimit,
+                ac.PovMinSliceQty ?? 1L),
             _ => throw new InvalidOperationException($"Unknown algo type: {ac.Type}"),
         };
         _algos.TryAdd(new Algo(ac.AlgoId, owner, ac.FirmId, ac.Symbol, ac.SecurityId,

--- a/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
@@ -358,6 +358,239 @@ public class PovAlgoEndpointTests
         Assert.Equal(1, sink!.TerminalPublishCount(ulong.Parse(algoId)));
     }
 
+    // ──────────── PovProgressBook persistence regressions (#295 pass-2) ────────────
+
+    // These three tests replace two earlier AlgoRecoveryTests cases that
+    // stubbed PovProgressBook directly (manual Set / Remove). The stubbed
+    // versions would still pass if AlgoEngine.ComputePovSlice stopped
+    // writing povProgress on the skip path, or if RecordTerminalAsync
+    // stopped pruning on terminal — both regressions the reviewer flagged
+    // as P2 because the test asserts on a side-effect that the test itself
+    // produced. The replacements below boot the production host, drive
+    // the real engine through the API + simulator, and only then assert
+    // on PovProgressBook state and snapshot/restart durability.
+
+    private static IDictionary<string, string?> PersistenceOverrides(string dataDir)
+    {
+        var d = new Dictionary<string, string?>(Simulator())
+        {
+            ["Trading:Persistence:Enabled"] = "true",
+            ["Trading:Persistence:DataDirectory"] = dataDir,
+            ["Trading:Persistence:FirmId"] = "default",
+            // Long interval so the periodic snap doesn't race the test's
+            // own explicit TryTakeSnapshot. The test forces the snapshot
+            // boundary it cares about.
+            ["Trading:Persistence:SnapshotInterval"] = "00:10:00",
+        };
+        return d;
+    }
+
+    private static B3.Trading.Infrastructure.Persistence.SnapshotService ResolveSnapshotService(TestAppFactory f) =>
+        f.Services.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .OfType<B3.Trading.Infrastructure.Persistence.SnapshotService>()
+            .Single();
+
+    [Fact]
+    public async Task Pov_SkipTickProgress_PersistedAcrossSnapshotRestart()
+    {
+        // Drive the real engine: MinSliceQty > integrated cum-mv * rate so
+        // ComputePovSlice returns 0 (skip). The engine still must call
+        // _povProgress.Set on every tick — otherwise a restart between
+        // snapshots loses the observed market volume. The original stubbed
+        // test set povProgress by hand; this version exercises the engine.
+        var dataDir = Path.Combine(Path.GetTempPath(), "b3-pov-skip-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            long observedMv = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var now = DateTimeOffset.UtcNow;
+
+                // 200ms-pro-rated bucket of 1.5M ≈ 1000 cum-mv → 20% rate
+                // → 200 target. MinSliceQty=1_000_000 forces qty=0 on every
+                // tick, so no child is ever submitted — pure skip path.
+                var algoIdStr = await PostAlgo(http, token,
+                    PovBody(total: 100, start: now.AddSeconds(-1), end: now.AddSeconds(8),
+                        tickSeconds: 0.2, participationRate: 0.20m, minSliceQty: 1_000_000));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+                curve.RecordTrade("PETR4", 1_500_000, now.AddSeconds(-1).AddMilliseconds(50));
+
+                var povBook = f.Services.GetRequiredService<PovProgressBook>();
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                PovProgress? entry = null;
+                while (sw.Elapsed < TimeSpan.FromSeconds(5))
+                {
+                    entry = povBook.TryGet("default", algoIdNum);
+                    if (entry is { MarketVolumeSeen: > 0 }) break;
+                    await Task.Delay(20);
+                }
+                Assert.NotNull(entry);
+                Assert.True(entry!.Value.MarketVolumeSeen > 0,
+                    $"engine did not advance PovProgressBook on skip tick (mv={entry.Value.MarketVolumeSeen})");
+                observedMv = entry.Value.MarketVolumeSeen;
+
+                // Skip path: no child should have been emitted.
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                Assert.Empty(book.EnumerateChildrenOf("default", algoIdNum));
+
+                // Force the snapshot boundary explicitly.
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            // Cold restart with the same data dir: recovery loads the
+            // snapshot and PovProgressBook re-hydrates with the skip-tick
+            // baseline.
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            {
+                _ = f2.CreateClient(); // boot the host so PersistenceRecovery runs
+                var povBook2 = f2.Services.GetRequiredService<PovProgressBook>();
+                var restored = povBook2.TryGet("default", algoIdNum);
+                Assert.NotNull(restored);
+                Assert.Equal(observedMv, restored!.Value.MarketVolumeSeen);
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Pov_CancelledTerminal_PrunesPovProgress_AndStaysPrunedAcrossRestart()
+    {
+        // Drive the real engine to terminal/Cancelled and verify
+        // RecordTerminalAsync pruned the PovProgressBook entry. Restart
+        // must observe the same: snapshot taken AFTER the prune carries
+        // no row for the dead algo.
+        var dataDir = Path.Combine(Path.GetTempPath(), "b3-pov-cancel-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var userToken = await f.LoginAsync(http);
+                var adminToken = await f.LoginAsync(http, "admin");
+                var now = DateTimeOffset.UtcNow;
+
+                var algoIdStr = await PostAlgo(http, userToken,
+                    PovBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(30),
+                        tickSeconds: 0.2, participationRate: 0.20m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+                curve.RecordTrade("PETR4", 1_500_000, now.AddSeconds(-1).AddMilliseconds(50));
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var inFlight = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(5));
+
+                // Pre-cancel sanity: the engine populated PovProgressBook
+                // for the slice that fired.
+                var povBook = f.Services.GetRequiredService<PovProgressBook>();
+                Assert.NotNull(povBook.TryGet("default", algoIdNum));
+
+                var del = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoIdStr}");
+                del.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+                var delResp = await http.SendAsync(del);
+                Assert.Equal(HttpStatusCode.Accepted, delResp.StatusCode);
+
+                await InjectEr(http, adminToken, inFlight.ClOrdId, "Canceled");
+                await WaitForAlgoStatus(http, userToken, algoIdStr, "Cancelled");
+
+                // RecordTerminalAsync runs after the dispatcher round-trip;
+                // poll briefly for the prune to be observable.
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                while (povBook.TryGet("default", algoIdNum) is not null && sw.Elapsed < TimeSpan.FromSeconds(2))
+                    await Task.Delay(20);
+                Assert.Null(povBook.TryGet("default", algoIdNum));
+
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            {
+                _ = f2.CreateClient();
+                var povBook2 = f2.Services.GetRequiredService<PovProgressBook>();
+                Assert.Null(povBook2.TryGet("default", algoIdNum));
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Pov_CompletedTerminal_PrunesPovProgress_AndStaysPrunedAcrossRestart()
+    {
+        // Sibling of the Cancelled variant: drive the engine to
+        // terminal/Completed (filledQty == totalQty) and verify the same
+        // prune+snapshot+restart invariant. Reviewer asked for both
+        // terminal kinds.
+        var dataDir = Path.Combine(Path.GetTempPath(), "b3-pov-complete-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var userToken = await f.LoginAsync(http);
+                var adminToken = await f.LoginAsync(http, "admin");
+                var now = DateTimeOffset.UtcNow;
+
+                // Tiny total so a single slice can fill the parent —
+                // 200ms-pro-rated bucket of 1.5M ≈ 1000 cum-mv → 20% →
+                // 200 target, clamped by remaining (100) → 100. Single
+                // Fill ER takes the parent to Completed.
+                var algoIdStr = await PostAlgo(http, userToken,
+                    PovBody(total: 100, start: now.AddSeconds(-1), end: now.AddSeconds(30),
+                        tickSeconds: 0.2, participationRate: 0.20m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+                curve.RecordTrade("PETR4", 1_500_000, now.AddSeconds(-1).AddMilliseconds(50));
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var child = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(5));
+
+                var povBook = f.Services.GetRequiredService<PovProgressBook>();
+                Assert.NotNull(povBook.TryGet("default", algoIdNum));
+
+                await InjectEr(http, adminToken, child.ClOrdId, "Fill", lastQty: child.Quantity);
+                await WaitForAlgoStatus(http, userToken, algoIdStr, "Completed");
+
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                while (povBook.TryGet("default", algoIdNum) is not null && sw.Elapsed < TimeSpan.FromSeconds(2))
+                    await Task.Delay(20);
+                Assert.Null(povBook.TryGet("default", algoIdNum));
+
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            {
+                _ = f2.CreateClient();
+                var povBook2 = f2.Services.GetRequiredService<PovProgressBook>();
+                Assert.Null(povBook2.TryGet("default", algoIdNum));
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     // ───────────────────────── helpers ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
@@ -1,0 +1,425 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the POV algo (Q3.2 / #282). Mirrors the shape
+/// of <see cref="VwapAlgoEndpointTests"/>: real wall-clock with tightly
+/// bounded sub-second windows so the scheduler ticks and the engine
+/// reactor exercise the full POV path through the simulator.
+/// </summary>
+public class PovAlgoEndpointTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object PovBody(long total, DateTimeOffset start, DateTimeOffset end,
+        double tickSeconds = 0.2, string childType = "Limit", decimal? childPrice = 30m,
+        decimal participationRate = 0.20m, decimal? priceLimit = null, long? minSliceQty = null) => new
+        {
+            Symbol = "PETR4",
+            Side = "Buy",
+            Type = "Pov",
+            TotalQuantity = total,
+            Pov = new
+            {
+                StartUtc = start,
+                EndUtc = end,
+                ChildOrderType = childType,
+                ChildPrice = childPrice,
+                ParticipationRate = participationRate,
+                TickIntervalSeconds = tickSeconds,
+                PriceLimit = priceLimit,
+                MinSliceQty = minSliceQty,
+            },
+        };
+
+    // ───────────────────────── POST validation ─────────────────────────
+
+    [Fact]
+    public async Task PostAlgo_PovWithoutParams_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Pov",
+                TotalQuantity = 100,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PovEndBeforeStart_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PovBody(100, now.AddMinutes(5), now.AddMinutes(1))),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PovRateOutOfRange_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PovBody(100, now, now.AddMinutes(1), participationRate: 1.5m)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+
+        var req2 = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PovBody(100, now, now.AddMinutes(1), participationRate: 0m)),
+        };
+        req2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp2 = await http.SendAsync(req2);
+        Assert.Equal(HttpStatusCode.BadRequest, resp2.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PovLimitWithoutPrice_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PovBody(100, now, now.AddMinutes(1), childPrice: null)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PovInvalidMinSliceQty_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PovBody(100, now, now.AddMinutes(1), minSliceQty: 0)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ───────────────────────── Happy-path slicing ─────────────────────────
+
+    [Fact]
+    public async Task Pov_SlicesAfterMarketTrades()
+    {
+        // No market volume seen → POV must NOT slice (cumMarketVolume = 0).
+        // Once an admin trade-print injects volume, the next tick yields a
+        // slice we can fill. Window 2s, tick=200ms, rate=20%, total=400.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            PovBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(3),
+                tickSeconds: 0.2, participationRate: 0.20m));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+
+        // No prints fed in yet, but the engine may still emit work as
+        // trades land via the mock venue's own market chatter (in this
+        // configuration there is none). Pump a trade volume directly via
+        // the volume curve estimator to drive the next slice.
+        var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+        curve.RecordTrade("PETR4", 1000, now.AddSeconds(-1).AddMilliseconds(50));
+
+        var first = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        // 20% of 1000 = 200; clamped by remaining (400) → 200.
+        Assert.True(first.Quantity > 0);
+        await InjectEr(http, adminToken, first.ClOrdId, "Fill", lastQty: first.Quantity);
+
+        // Push more volume so a second slice can fire and the parent
+        // completes (or expires) within the window.
+        curve.RecordTrade("PETR4", 2000, now.AddSeconds(-1).AddMilliseconds(200));
+
+        var seenSeqs = new HashSet<int> { first.AlgoSliceSeq!.Value };
+        long filled = first.Quantity;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(8))
+        {
+            var snap = await GetAlgo(http, userToken, algoId);
+            var status = snap.GetProperty("status").GetString();
+            if (status is "Completed" or "Expired") break;
+
+            var next = book.EnumerateChildrenOf("default", ulong.Parse(algoId))
+                .FirstOrDefault(c => c.AlgoSliceSeq is { } s && seenSeqs.Add(s));
+            if (next is null) { await Task.Delay(20); continue; }
+            await InjectEr(http, adminToken, next.ClOrdId, "Fill", lastQty: next.Quantity);
+            filled += next.Quantity;
+            if (filled >= 400) break;
+        }
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed", "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        var filledQty = algo.GetProperty("filledQuantity").GetInt64();
+        Assert.True(filledQty > 0, $"expected some POV fills, got {filledQty}");
+    }
+
+    [Fact]
+    public async Task Pov_WindowExpiresWithoutVolume_BecomesExpired()
+    {
+        // No market prints injected during the entire window — POV is
+        // opportunistic and must NOT force any child. After endUtc the
+        // parent transitions to Expired/PovWindowExpired.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            PovBody(total: 100, start: now.AddSeconds(-1), end: now.AddMilliseconds(500),
+                tickSeconds: 0.1));
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("PovWindowExpired", algo.GetProperty("terminalReason").GetString());
+        Assert.Equal(0, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task Pov_NoChild_WindowAlreadyExpired_BecomesExpired()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            PovBody(total: 100, start: now.AddSeconds(-2), end: now.AddSeconds(-1),
+                tickSeconds: 0.2));
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("PovWindowExpired", algo.GetProperty("terminalReason").GetString());
+        Assert.Equal(0, algo.GetProperty("filledQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task GetAlgo_ReturnsPovParametersInDto()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, token,
+            PovBody(total: 200, start: now.AddSeconds(10), end: now.AddSeconds(70),
+                tickSeconds: 5, participationRate: 0.15m, priceLimit: 31m, minSliceQty: 10));
+
+        var algo = await GetAlgo(http, token, algoId);
+        Assert.Equal("Pov", algo.GetProperty("type").GetString());
+        var pov = algo.GetProperty("pov");
+        Assert.Equal(5.0, pov.GetProperty("tickIntervalSeconds").GetDouble(), 3);
+        Assert.Equal(0.15m, pov.GetProperty("participationRate").GetDecimal());
+        Assert.Equal(31m, pov.GetProperty("priceLimit").GetDecimal());
+        Assert.Equal(10L, pov.GetProperty("minSliceQty").GetInt64());
+    }
+
+    // ───────────────────── Cancel-mid-flight ─────────────────────
+
+    /// <summary>
+    /// Recording <see cref="IAlgoEventSink"/> reused from the VWAP
+    /// equivalent to assert exactly-once terminal emission for POV.
+    /// </summary>
+    private sealed class RecordingAlgoEventSink : IAlgoEventSink
+    {
+        private readonly AlgoBook _book;
+        private readonly object _gate = new();
+        private readonly List<(ulong AlgoId, AlgoStatus Status)> _publishes = new();
+
+        public RecordingAlgoEventSink(AlgoBook book) => _book = book;
+
+        public void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId)
+        {
+            if (!_book.TryGet(firmId, algoId, out var algo) || algo is null) return;
+            lock (_gate) { _publishes.Add((algoId, algo.Status)); }
+        }
+
+        public int TerminalPublishCount(ulong algoId)
+        {
+            lock (_gate)
+            {
+                return _publishes.Count(p => p.AlgoId == algoId && IsTerminal(p.Status));
+            }
+        }
+
+        private static bool IsTerminal(AlgoStatus s) =>
+            s is AlgoStatus.Cancelled or AlgoStatus.Completed
+              or AlgoStatus.Expired or AlgoStatus.Suspended;
+    }
+
+    [Fact]
+    public async Task Pov_CancelMidFlight_CancelsLiveChildAndTerminalEmittedOnce()
+    {
+        RecordingAlgoEventSink? sink = null;
+        using var f = TestAppFactory.WithOverrides(Simulator(), services =>
+        {
+            services.RemoveAll<IAlgoEventSink>();
+            services.AddSingleton<IAlgoEventSink>(sp =>
+                sink = new RecordingAlgoEventSink(sp.GetRequiredService<AlgoBook>()));
+        });
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        _ = f.Services.GetRequiredService<IAlgoEventSink>();
+        Assert.NotNull(sink);
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            PovBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(10),
+                tickSeconds: 0.2, participationRate: 0.20m));
+
+        // Drive the engine to slice by injecting market volume.
+        var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
+        curve.RecordTrade("PETR4", 1000, now.AddSeconds(-1).AddMilliseconds(50));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var inFlight = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(5));
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, del.StatusCode);
+
+        await InjectEr(http, adminToken, inFlight.ClOrdId, "Canceled");
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Cancelled");
+        var snap1 = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("UserCancelled", snap1.GetProperty("terminalReason").GetString());
+        var terminalAt1 = snap1.GetProperty("terminalAtUtc").GetDateTimeOffset();
+
+        var req2 = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del2 = await http.SendAsync(req2);
+        Assert.Equal(HttpStatusCode.Conflict, del2.StatusCode);
+
+        await Task.Delay(50);
+        var snap2 = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("Cancelled", snap2.GetProperty("status").GetString());
+        Assert.Equal(terminalAt1, snap2.GetProperty("terminalAtUtc").GetDateTimeOffset());
+
+        Assert.Equal(1, sink!.TerminalPublishCount(ulong.Parse(algoId)));
+    }
+
+    // ───────────────────────── helpers ─────────────────────────
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<Order> WaitForAnyChild(WorkingOrderBook book, string algoIdStr, TimeSpan timeout)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var match = book.EnumerateChildrenOf("default", algoId).FirstOrDefault();
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"No child for algo {algoIdStr} within {timeout.TotalSeconds}s.");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PovAlgoEndpointTests.cs
@@ -166,21 +166,25 @@ public class PovAlgoEndpointTests
 
         var book = f.Services.GetRequiredService<WorkingOrderBook>();
 
-        // No prints fed in yet, but the engine may still emit work as
-        // trades land via the mock venue's own market chatter (in this
-        // configuration there is none). Pump a trade volume directly via
-        // the volume curve estimator to drive the next slice.
+        // Pump a trade volume directly via the volume curve estimator
+        // to drive the next slice. Pass-1 review (#295) P1#2 made
+        // VolumeBetween pro-rate boundary buckets by elapsed-time
+        // fraction, so a single qty must be large enough that the
+        // POV's sub-bucket integration window (200ms of a 5-min
+        // bucket = 1/1500) still leaves meaningful share. 1_500_000 →
+        // 200ms-pro-rated ≈ 1000 → 20% participation slice = 200.
         var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
-        curve.RecordTrade("PETR4", 1000, now.AddSeconds(-1).AddMilliseconds(50));
+        curve.RecordTrade("PETR4", 1_500_000, now.AddSeconds(-1).AddMilliseconds(50));
 
         var first = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
-        // 20% of 1000 = 200; clamped by remaining (400) → 200.
+        // Pro-rated bucket fraction → ~1000 cum mv → 20% → 200; clamped by remaining (400) → 200.
         Assert.True(first.Quantity > 0);
         await InjectEr(http, adminToken, first.ClOrdId, "Fill", lastQty: first.Quantity);
 
         // Push more volume so a second slice can fire and the parent
-        // completes (or expires) within the window.
-        curve.RecordTrade("PETR4", 2000, now.AddSeconds(-1).AddMilliseconds(200));
+        // completes (or expires) within the window. Same 1500x scaling
+        // applies (sub-bucket window).
+        curve.RecordTrade("PETR4", 3_000_000, now.AddSeconds(-1).AddMilliseconds(200));
 
         var seenSeqs = new HashSet<int> { first.AlgoSliceSeq!.Value };
         long filled = first.Quantity;
@@ -320,9 +324,11 @@ public class PovAlgoEndpointTests
             PovBody(total: 400, start: now.AddSeconds(-1), end: now.AddSeconds(10),
                 tickSeconds: 0.2, participationRate: 0.20m));
 
-        // Drive the engine to slice by injecting market volume.
+        // Drive the engine to slice by injecting market volume. Pass-1
+        // review (#295) P1#2 — see Pov_SlicesAfterMarketTrades for the
+        // pro-rate sizing rationale.
         var curve = f.Services.GetRequiredService<B3.Trading.Application.MarketData.VolumeCurveEstimator>();
-        curve.RecordTrade("PETR4", 1000, now.AddSeconds(-1).AddMilliseconds(50));
+        curve.RecordTrade("PETR4", 1_500_000, now.AddSeconds(-1).AddMilliseconds(50));
 
         var book = f.Services.GetRequiredService<WorkingOrderBook>();
         var inFlight = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(5));

--- a/backend/tests/B3.Trading.Application.Tests/Algo/PovPlanTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/PovPlanTests.cs
@@ -1,0 +1,177 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+/// <summary>
+/// Slice-math tests for the POV scheduler (Q3.2 / #282). Mirrors the
+/// shape of <see cref="VwapPlanTests"/>: every branch of
+/// <see cref="PovPlan.SliceQty"/> + the slot-time helper.
+/// </summary>
+public class PovPlanTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Tick = TimeSpan.FromSeconds(5);
+
+    // ───────────────────────── PlannedAtUtc ─────────────────────────
+
+    [Fact]
+    public void PlannedAtUtc_FirstSlotFiresAtStart()
+    {
+        Assert.Equal(Start, PovPlan.PlannedAtUtc(Start, Tick, 0));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_EvenSpacing()
+    {
+        Assert.Equal(Start.AddSeconds(5), PovPlan.PlannedAtUtc(Start, Tick, 1));
+        Assert.Equal(Start.AddSeconds(50), PovPlan.PlannedAtUtc(Start, Tick, 10));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_DeterministicAcrossInvocations()
+    {
+        for (var seq = 0; seq < 20; seq++)
+        {
+            var a = PovPlan.PlannedAtUtc(Start, Tick, seq);
+            var b = PovPlan.PlannedAtUtc(Start, Tick, seq);
+            Assert.Equal(a, b);
+        }
+    }
+
+    [Fact]
+    public void PlannedAtUtc_RejectsNonPositiveTickInterval()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PovPlan.PlannedAtUtc(Start, TimeSpan.Zero, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PovPlan.PlannedAtUtc(Start, TimeSpan.FromSeconds(-1), 0));
+    }
+
+    [Fact]
+    public void PlannedAtUtc_RejectsNegativeSliceSeq()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PovPlan.PlannedAtUtc(Start, Tick, -1));
+    }
+
+    // ───────────────────────── SliceQty ─────────────────────────
+
+    [Fact]
+    public void SliceQty_MarketWalkV_AtRate_SlicesAboutVTimesRate()
+    {
+        // Market traded 1000 shares, target rate 10%, nothing executed
+        // yet → pending = 100. Plenty of remaining; min slice = 1.
+        Assert.Equal(100, PovPlan.SliceQty(
+            cumMarketVolume: 1000, executedCum: 0, remainingQuantity: 5000,
+            participationRate: 0.10m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_NoMarketVolume_ReturnsZero()
+    {
+        // Nothing traded yet → no opportunistic share to take.
+        Assert.Equal(0, PovPlan.SliceQty(
+            cumMarketVolume: 0, executedCum: 0, remainingQuantity: 5000,
+            participationRate: 0.10m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_ParentAhead_ReturnsZero()
+    {
+        // 10% of 1000 = 100 target, already executed 150 → ahead of
+        // schedule; emit nothing this tick.
+        Assert.Equal(0, PovPlan.SliceQty(
+            cumMarketVolume: 1000, executedCum: 150, remainingQuantity: 4850,
+            participationRate: 0.10m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_CappedByRemaining_SoftCapAtTotalQty()
+    {
+        // 50% of 10000 = 5000 target, executed 0, but only 200 left.
+        Assert.Equal(200, PovPlan.SliceQty(
+            cumMarketVolume: 10000, executedCum: 0, remainingQuantity: 200,
+            participationRate: 0.50m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_ZeroRemaining_ReturnsZero()
+    {
+        Assert.Equal(0, PovPlan.SliceQty(
+            cumMarketVolume: 10000, executedCum: 1000, remainingQuantity: 0,
+            participationRate: 0.10m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_BelowMinSliceQty_Defers()
+    {
+        // 10% of 50 = 5 pending; minSlice=10 → defer to next tick.
+        Assert.Equal(0, PovPlan.SliceQty(
+            cumMarketVolume: 50, executedCum: 0, remainingQuantity: 5000,
+            participationRate: 0.10m, minSliceQty: 10));
+    }
+
+    [Fact]
+    public void SliceQty_AtOrAboveMinSliceQty_Emits()
+    {
+        // 10% of 100 = 10 pending; minSlice=10 → exactly at floor.
+        Assert.Equal(10, PovPlan.SliceQty(
+            cumMarketVolume: 100, executedCum: 0, remainingQuantity: 5000,
+            participationRate: 0.10m, minSliceQty: 10));
+    }
+
+    [Fact]
+    public void SliceQty_FractionalShare_FloorsDown()
+    {
+        // 10% of 17 = 1.7 → floor 1.
+        Assert.Equal(1, PovPlan.SliceQty(
+            cumMarketVolume: 17, executedCum: 0, remainingQuantity: 5000,
+            participationRate: 0.10m, minSliceQty: 1));
+    }
+
+    [Fact]
+    public void SliceQty_RejectsInvalidRate()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => PovPlan.SliceQty(100, 0, 100, 0m, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PovPlan.SliceQty(100, 0, 100, -0.1m, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PovPlan.SliceQty(100, 0, 100, 1.5m, 1));
+    }
+
+    [Fact]
+    public void SliceQty_RejectsZeroMinSliceQty()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => PovPlan.SliceQty(100, 0, 100, 0.10m, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => PovPlan.SliceQty(100, 0, 100, 0.10m, -5));
+    }
+
+    // ───────────────────────── ClampPrice ─────────────────────────
+
+    [Fact]
+    public void ClampPrice_BuyTakesMin()
+    {
+        Assert.Equal(10m, PovPlan.ClampPrice(12m, 10m, OrderSide.Buy));
+        Assert.Equal(8m, PovPlan.ClampPrice(8m, 10m, OrderSide.Buy));
+    }
+
+    [Fact]
+    public void ClampPrice_SellTakesMax()
+    {
+        Assert.Equal(10m, PovPlan.ClampPrice(8m, 10m, OrderSide.Sell));
+        Assert.Equal(12m, PovPlan.ClampPrice(12m, 10m, OrderSide.Sell));
+    }
+
+    [Fact]
+    public void ClampPrice_NoLimit_ReturnsRefPrice()
+    {
+        Assert.Equal(12m, PovPlan.ClampPrice(12m, null, OrderSide.Buy));
+        Assert.Null(PovPlan.ClampPrice(null, null, OrderSide.Buy));
+    }
+
+    [Fact]
+    public void ClampPrice_NoRefPrice_ReturnsLimit()
+    {
+        Assert.Equal(10m, PovPlan.ClampPrice(null, 10m, OrderSide.Buy));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/VolumeCurveEstimatorTests.cs
@@ -129,7 +129,60 @@ public class VolumeCurveEstimatorTests
         sut.RecordTrade(Sym, 100, preMidnight);
         sut.RecordTrade(Sym, 200, postMidnight);
 
-        Assert.Equal(300, sut.VolumeBetween(Sym, preMidnight.AddMinutes(-1), postMidnight.AddMinutes(1)));
+        // Pass-1 review (#295) P1#2. VolumeBetween pro-rates the
+        // boundary buckets, so the day-spanning range only captures
+        // the FULL pre-midnight bucket (100) plus 1/5 of the
+        // post-midnight bucket (200 * 1min/5min = 40).
+        Assert.Equal(140, sut.VolumeBetween(Sym, preMidnight.AddMinutes(-1), postMidnight.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void VolumeBetween_ProRatesFirstBucket()
+    {
+        // Pass-1 review (#295) P1#2. Range starts mid-bucket: only
+        // the elapsed-time fraction of the bucket's volume is
+        // counted, so trades that arrived before the range start
+        // do not leak in. Linear approximation assumes uniform
+        // within-bucket distribution — see VolumeBetween's xmldoc.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        sut.RecordTrade(Sym, 500, start.AddMinutes(1));  // bucket [0, 5min) qty=500
+        sut.RecordTrade(Sym, 200, start.AddMinutes(6));  // bucket [5, 10min) qty=200
+
+        // Range [start+3min, start+10min):
+        //   - bucket [0,5): overlap [3,5) = 2/5 * 500 = 200
+        //   - bucket [5,10): full = 200
+        Assert.Equal(400, sut.VolumeBetween(Sym, start.AddMinutes(3), start.AddMinutes(10)));
+    }
+
+    [Fact]
+    public void VolumeBetween_ProRatesLastBucket()
+    {
+        // Pass-1 review (#295) P1#2. Mirror: range ends mid-bucket
+        // so post-end trades in the last bucket are not over-counted.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        sut.RecordTrade(Sym, 500, start.AddMinutes(1));  // bucket [0, 5min) qty=500
+        sut.RecordTrade(Sym, 200, start.AddMinutes(6));  // bucket [5, 10min) qty=200
+
+        // Range [start, start+8min):
+        //   - bucket [0,5): full = 500
+        //   - bucket [5,10): overlap [5,8) = 3/5 * 200 = 120
+        Assert.Equal(620, sut.VolumeBetween(Sym, start, start.AddMinutes(8)));
+    }
+
+    [Fact]
+    public void VolumeBetween_RangeWithinSingleBucket()
+    {
+        // Pass-1 review (#295) P1#2. Edge case — range begins AND
+        // ends inside the same bucket. The pro-rate fraction collapses
+        // to the range's share of the bucket's total span.
+        var sut = new VolumeCurveEstimator();
+        var start = Day1Start.AddHours(9);
+        sut.RecordTrade(Sym, 500, start.AddMinutes(2));  // bucket [0, 5min) qty=500
+
+        // Range [start+1min, start+3min): 2/5 * 500 = 200
+        Assert.Equal(200, sut.VolumeBetween(Sym, start.AddMinutes(1), start.AddMinutes(3)));
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -683,142 +683,18 @@ public class AlgoRecoveryTests : IDisposable
         Assert.False(book.Remove("TEST", 500UL));
     }
 
-    [Fact]
-    public async Task PovAlgo_SkipPathProgress_PreservedAcrossSnapshotRestart()
-    {
-        // Pass-2 review (#295) P1 — the engine writes PovProgressBook
-        // on EVERY tick (emit OR skip). When the skip path advances
-        // marketVolumeSeen without emitting an AlgoPovSlicedEvent the
-        // snapshotter is the only persistence; this test asserts the
-        // snapshot/restore round-trip carries that state through.
-        var createdAt = new DateTimeOffset(2026, 8, 2, 13, 0, 0, TimeSpan.Zero);
-        var povStart = createdAt;
-        var tick = TimeSpan.FromSeconds(5);
-        var skipTickAt = povStart + tick;
-
-        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
-        {
-            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
-            dispatcher.Dispatch(
-                new AlgoCreatedEvent
-                {
-                    AlgoId = 510UL,
-                    EndClientId = "hank",
-                    FirmId = "TEST",
-                    Symbol = "PETR4",
-                    SecurityId = 4321UL,
-                    Side = "Buy",
-                    Type = "Pov",
-                    TotalQuantity = 5000,
-                    CreatedAtUtc = createdAt,
-                    PovStartUtc = povStart,
-                    PovEndUtc = povStart.AddMinutes(30),
-                    PovChildOrderType = "Limit",
-                    PovChildPrice = 30m,
-                    PovParticipationRate = 0.10m,
-                    PovTickIntervalTicks = tick.Ticks,
-                    PovMinSliceQty = 10_000, // Forces the skip path: no slice ever fires.
-                },
-                () => algos.TryAdd(new Algo(510UL, new EndClientId("hank"), "TEST", "PETR4", 4321UL,
-                    OrderSide.Buy, AlgoType.Pov, 5000,
-                    new PovParameters(povStart, povStart.AddMinutes(30), OrderType.Limit, 30m, 0.10m, tick, null, 10_000), createdAt)));
-        }
-
-        // Engine session 1: simulate a skip-path tick (no AlgoPovSlicedEvent)
-        // by directly updating PovProgressBook the way ComputePovSlice does.
-        // Snapshot must capture this even though no WAL event references it.
-        var snapshotDir = "skip-path-" + Guid.NewGuid().ToString("N");
-        long skipMarketVolume = 4_200;
-        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
-        {
-            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
-            var povProgress = new PovProgressBook();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
-                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
-                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
-                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
-                new AlgoIdRegistry(), povProgress: povProgress);
-            var snapStore = new SnapshotStore(_root, snapshotDir);
-            var recovery = new PersistenceRecovery(store, snapshotter, replayer, snapStore,
-                NullLogger<PersistenceRecovery>.Instance);
-            await recovery.RunAsync();
-
-            // Skip-path engine state update (qty == 0, no WAL emit).
-            povProgress.Set("TEST", 510UL, skipMarketVolume, skipTickAt);
-
-            // Persist snapshot (the only place the skip-path state survives).
-            snapStore.Write(snapshotter.Capture(seq: 1));
-        }
-
-        // Engine session 2: cold start consumes the snapshot. PovProgressBook
-        // must have the skip-tick baseline so subsequent slicing resumes from
-        // marketVolumeSeen = 4_200, NOT zero.
-        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
-        {
-            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
-            var povProgress = new PovProgressBook();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
-                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
-                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
-                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
-                new AlgoIdRegistry(), povProgress: povProgress);
-            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
-                new SnapshotStore(_root, snapshotDir), NullLogger<PersistenceRecovery>.Instance);
-            await recovery.RunAsync();
-
-            var restored = povProgress.TryGet("TEST", 510UL);
-            Assert.NotNull(restored);
-            Assert.Equal(skipMarketVolume, restored!.Value.MarketVolumeSeen);
-            Assert.Equal(skipTickAt, restored.Value.LastEvaluateAtUtc);
-        }
-    }
-
-    [Fact]
-    public async Task PovAlgo_RemovedProgress_ExcludedFromSnapshot()
-    {
-        // Pass-2 review (#295) P2 — after termination the engine calls
-        // PovProgressBook.Remove(); the next snapshot must omit the
-        // entry so a downstream restart doesn't re-hydrate stale state.
-        var atUtc = new DateTimeOffset(2026, 8, 3, 13, 0, 0, TimeSpan.Zero);
-
-        var snapshotDir = "removed-" + Guid.NewGuid().ToString("N");
-        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
-        {
-            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
-            var povProgress = new PovProgressBook();
-            povProgress.Set("TEST", 520UL, 9_999L, atUtc);
-            povProgress.Set("TEST", 521UL, 1_111L, atUtc);
-            povProgress.Remove("TEST", 520UL);
-
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
-                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
-                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
-            var snapStore = new SnapshotStore(_root, snapshotDir);
-            snapStore.Write(snapshotter.Capture(seq: 1));
-        }
-
-        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
-        {
-            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
-            var povProgress = new PovProgressBook();
-            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
-                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
-                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
-            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
-                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
-                new AlgoIdRegistry(), povProgress: povProgress);
-            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
-                new SnapshotStore(_root, snapshotDir), NullLogger<PersistenceRecovery>.Instance);
-            await recovery.RunAsync();
-
-            Assert.Null(povProgress.TryGet("TEST", 520UL));
-            var sibling = povProgress.TryGet("TEST", 521UL);
-            Assert.NotNull(sibling);
-            Assert.Equal(1_111L, sibling!.Value.MarketVolumeSeen);
-        }
-    }
+    // Pass-2 review (#295) P2 — the original two pass-2 regression tests
+    // (PovAlgo_SkipPathProgress_PreservedAcrossSnapshotRestart and
+    // PovAlgo_RemovedProgress_ExcludedFromSnapshot) used to live here.
+    // They stubbed the engine entirely (manual povProgress.Set / Remove
+    // calls) so they would still pass if AlgoEngine.ComputePovSlice
+    // stopped writing on the skip path, or if RecordTerminalAsync stopped
+    // calling Remove on terminal. The pass-2 follow-up moved both
+    // assertions into PovAlgoEndpointTests.cs where the production engine
+    // is driven end-to-end via the API + simulator, so the regression bar
+    // is genuine ("did the engine do the right thing?") instead of
+    // tautological ("did the test stub call the side-effect we then
+    // assert on?").
 
     private static (WorkingOrderBook, OrderOwnershipMap, KillSwitchService, ExecutionReportProcessor, AlgoBook, EventDispatcher) Build(IEventStore store)
     {

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -304,6 +304,107 @@ public class AlgoRecoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task PovAlgo_ReplayedFromWal_ReproduceParentAggregate()
+    {
+        // Mirrors VwapAlgo_ReplayedFromWal_ReproduceParentAggregate for
+        // POV (Q3.2 / #282): the AlgoCreatedEvent POV block + the parent
+        // cancel + terminal events round-trip through a cold-boot WAL
+        // replay back into an AlgoBook with the same shape. Also exercises
+        // the new <see cref="AlgoPovSlicedEvent"/> observability envelope.
+        var createdAt = new DateTimeOffset(2026, 6, 7, 13, 0, 0, TimeSpan.Zero);
+        var povStart = createdAt;
+        var povEnd = createdAt.AddMinutes(30);
+        var terminalAt = createdAt.AddSeconds(5);
+        var tick = TimeSpan.FromSeconds(5);
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 400UL,
+                    EndClientId = "dave",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Pov",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    PovStartUtc = povStart,
+                    PovEndUtc = povEnd,
+                    PovChildOrderType = "Limit",
+                    PovChildPrice = 30m,
+                    PovParticipationRate = 0.15m,
+                    PovTickIntervalTicks = tick.Ticks,
+                    PovPriceLimit = 31m,
+                    PovMinSliceQty = 10,
+                },
+                () => algos.TryAdd(new Algo(400UL, new EndClientId("dave"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Pov, 5000,
+                    new PovParameters(povStart, povEnd, OrderType.Limit, 30m, 0.15m, tick, 31m, 10), createdAt)));
+
+            dispatcher.Dispatch(
+                new AlgoPovSlicedEvent
+                {
+                    AlgoId = 400UL,
+                    FirmId = "TEST",
+                    SliceSeq = 0,
+                    CumMarketVolume = 1000,
+                    ExecutedCum = 0,
+                    SliceQty = 150,
+                    PlannedAtUtc = povStart,
+                },
+                () => { /* observability-only: no aggregate mutation */ });
+
+            dispatcher.Dispatch(
+                new AlgoCancelRequestedEvent { AlgoId = 400UL, FirmId = "TEST", ActorUserId = "ops" },
+                () => algos.TryGet("TEST", 400UL, out var a).Then(() => a!.RequestCancel()));
+
+            dispatcher.Dispatch(
+                new AlgoTerminalStateRecordedEvent
+                {
+                    AlgoId = 400UL,
+                    FirmId = "TEST",
+                    Status = "Cancelled",
+                    Reason = "UserCancelled",
+                    AtUtc = terminalAt,
+                },
+                () => algos.TryGet("TEST", 400UL, out var a).Then(() =>
+                    a!.RecordTerminal(AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled, terminalAt)));
+        }
+
+        // Cold-boot replay.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var algoIds = new AlgoIdRegistry();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger());
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.True(algos.TryGet("TEST", 400UL, out var algo) && algo is not null);
+            Assert.Equal(AlgoStatus.Cancelled, algo!.Status);
+            Assert.Equal(AlgoTerminalReason.UserCancelled, algo.TerminalReason);
+            Assert.Equal(terminalAt, algo.TerminalAtUtc);
+            Assert.Equal(AlgoType.Pov, algo.Type);
+            var pp = Assert.IsType<PovParameters>(algo.Parameters);
+            Assert.Equal(povStart, pp.StartUtc);
+            Assert.Equal(povEnd, pp.EndUtc);
+            Assert.Equal(OrderType.Limit, pp.ChildOrderType);
+            Assert.Equal(30m, pp.ChildPrice);
+            Assert.Equal(0.15m, pp.ParticipationRate);
+            Assert.Equal(tick, pp.TickInterval);
+            Assert.Equal(31m, pp.PriceLimit);
+            Assert.Equal(10L, pp.MinSliceQty);
+        }
+    }
+
+    [Fact]
     public void AlgoBook_EnumerateForOwner_ExcludesTerminalByDefault()
     {
         var algos = new AlgoBook();

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -405,6 +405,250 @@ public class AlgoRecoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task PovAlgo_ReplayRestoresProgressBook()
+    {
+        // Pass-1 review (#295) P1#1 — replay of two AlgoPovSlicedEvents
+        // must hydrate PovProgressBook so restart resumes integration
+        // from the correct (marketVolumeSeen, lastEvaluateAtUtc) baseline.
+        var createdAt = new DateTimeOffset(2026, 7, 1, 13, 0, 0, TimeSpan.Zero);
+        var povStart = createdAt;
+        var tick = TimeSpan.FromSeconds(5);
+        var tick1At = povStart + tick;
+        var tick2At = povStart + tick + tick;
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 410UL,
+                    EndClientId = "eve",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Pov",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    PovStartUtc = povStart,
+                    PovEndUtc = povStart.AddMinutes(30),
+                    PovChildOrderType = "Limit",
+                    PovChildPrice = 30m,
+                    PovParticipationRate = 0.20m,
+                    PovTickIntervalTicks = tick.Ticks,
+                },
+                () => algos.TryAdd(new Algo(410UL, new EndClientId("eve"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Pov, 5000,
+                    new PovParameters(povStart, povStart.AddMinutes(30), OrderType.Limit, 30m, 0.20m, tick), createdAt)));
+
+            dispatcher.Dispatch(
+                new AlgoPovSlicedEvent
+                {
+                    AlgoId = 410UL,
+                    FirmId = "TEST",
+                    SliceSeq = 0,
+                    CumMarketVolume = 1000,
+                    ExecutedCum = 0,
+                    SliceQty = 200,
+                    PlannedAtUtc = tick1At,
+                    MarketVolumeSeen = 1000,
+                    LastEvaluateAtUtc = tick1At,
+                },
+                () => { });
+
+            dispatcher.Dispatch(
+                new AlgoPovSlicedEvent
+                {
+                    AlgoId = 410UL,
+                    FirmId = "TEST",
+                    SliceSeq = 1,
+                    CumMarketVolume = 2500,
+                    ExecutedCum = 200,
+                    SliceQty = 300,
+                    PlannedAtUtc = tick2At,
+                    MarketVolumeSeen = 2500,
+                    LastEvaluateAtUtc = tick2At,
+                },
+                () => { });
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var algoIds = new AlgoIdRegistry();
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, algoIds, new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(), povProgress: povProgress);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            var p = povProgress.TryGet("TEST", 410UL);
+            Assert.NotNull(p);
+            Assert.Equal(2500L, p!.Value.MarketVolumeSeen);
+            Assert.Equal(tick2At, p.Value.LastEvaluateAtUtc);
+        }
+    }
+
+    [Fact]
+    public async Task PovAlgo_ReplayIsIdempotent()
+    {
+        // Pass-1 review (#295) P1#1 — replaying the same WAL twice
+        // must produce the same PovProgressBook state (last-write-wins,
+        // single entry, latest values).
+        var createdAt = new DateTimeOffset(2026, 7, 2, 13, 0, 0, TimeSpan.Zero);
+        var povStart = createdAt;
+        var tick = TimeSpan.FromSeconds(5);
+        var lastTickAt = povStart + tick;
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 420UL,
+                    EndClientId = "frank",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Pov",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    PovStartUtc = povStart,
+                    PovEndUtc = povStart.AddMinutes(30),
+                    PovChildOrderType = "Limit",
+                    PovChildPrice = 30m,
+                    PovParticipationRate = 0.10m,
+                    PovTickIntervalTicks = tick.Ticks,
+                },
+                () => algos.TryAdd(new Algo(420UL, new EndClientId("frank"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Pov, 5000,
+                    new PovParameters(povStart, povStart.AddMinutes(30), OrderType.Limit, 30m, 0.10m, tick), createdAt)));
+
+            dispatcher.Dispatch(
+                new AlgoPovSlicedEvent
+                {
+                    AlgoId = 420UL,
+                    FirmId = "TEST",
+                    SliceSeq = 0,
+                    CumMarketVolume = 5000,
+                    ExecutedCum = 0,
+                    SliceQty = 500,
+                    PlannedAtUtc = lastTickAt,
+                    MarketVolumeSeen = 5000,
+                    LastEvaluateAtUtc = lastTickAt,
+                },
+                () => { });
+        }
+
+        async Task<PovProgress?> ReplayOnce()
+        {
+            await using var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance);
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(), povProgress: povProgress);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test-idem-" + Guid.NewGuid().ToString("N")), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+            return povProgress.TryGet("TEST", 420UL);
+        }
+
+        var first = await ReplayOnce();
+        var second = await ReplayOnce();
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(first!.Value.MarketVolumeSeen, second!.Value.MarketVolumeSeen);
+        Assert.Equal(first.Value.LastEvaluateAtUtc, second.Value.LastEvaluateAtUtc);
+        Assert.Equal(5000L, second.Value.MarketVolumeSeen);
+    }
+
+    [Fact]
+    public async Task PovAlgo_RestartMidFlight_ResumesFromPersistedBaseline()
+    {
+        // Pass-1 review (#295) P1#1 — after restart with a persisted
+        // PovProgressBook entry, the engine must continue from the
+        // recorded baseline rather than re-integrating from zero.
+        var createdAt = new DateTimeOffset(2026, 7, 3, 13, 0, 0, TimeSpan.Zero);
+        var povStart = createdAt;
+        var tick = TimeSpan.FromSeconds(5);
+        var lastTickAt = povStart + tick;
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 430UL,
+                    EndClientId = "gina",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Pov",
+                    TotalQuantity = 10_000,
+                    CreatedAtUtc = createdAt,
+                    PovStartUtc = povStart,
+                    PovEndUtc = povStart.AddMinutes(30),
+                    PovChildOrderType = "Limit",
+                    PovChildPrice = 30m,
+                    PovParticipationRate = 0.20m,
+                    PovTickIntervalTicks = tick.Ticks,
+                },
+                () => algos.TryAdd(new Algo(430UL, new EndClientId("gina"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Pov, 10_000,
+                    new PovParameters(povStart, povStart.AddMinutes(30), OrderType.Limit, 30m, 0.20m, tick), createdAt)));
+
+            dispatcher.Dispatch(
+                new AlgoPovSlicedEvent
+                {
+                    AlgoId = 430UL,
+                    FirmId = "TEST",
+                    SliceSeq = 0,
+                    CumMarketVolume = 4_000,
+                    ExecutedCum = 0,
+                    SliceQty = 800,
+                    PlannedAtUtc = lastTickAt,
+                    MarketVolumeSeen = 4_000,
+                    LastEvaluateAtUtc = lastTickAt,
+                },
+                () => { });
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch, new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(), ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(), new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(), povProgress: povProgress);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test-restart"), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            // Baseline restored.
+            var baseline = povProgress.TryGet("TEST", 430UL);
+            Assert.NotNull(baseline);
+            Assert.Equal(4_000L, baseline!.Value.MarketVolumeSeen);
+            Assert.Equal(lastTickAt, baseline.Value.LastEvaluateAtUtc);
+
+            // Simulate the engine recording a subsequent tick: only
+            // the incremental market volume between the last persisted
+            // tick and the new one should add to the baseline.
+            var newTickAt = lastTickAt + tick;
+            povProgress.Set("TEST", 430UL,
+                baseline.Value.MarketVolumeSeen + 1_500,
+                newTickAt);
+            var updated = povProgress.TryGet("TEST", 430UL);
+            Assert.Equal(5_500L, updated!.Value.MarketVolumeSeen);
+            Assert.Equal(newTickAt, updated.Value.LastEvaluateAtUtc);
+        }
+    }
+
+    [Fact]
     public void AlgoBook_EnumerateForOwner_ExcludesTerminalByDefault()
     {
         var algos = new AlgoBook();

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AlgoRecoveryTests.cs
@@ -665,6 +665,161 @@ public class AlgoRecoveryTests : IDisposable
         Assert.Equal(2, algos.EnumerateForOwner("TEST", alice, includeTerminal: true).Count);
     }
 
+    [Fact]
+    public void PovProgressBook_Remove_DropsEntry()
+    {
+        // Pass-2 review (#295) P2 — Remove deletes the per-POV entry
+        // so subsequent TryGet returns null and snapshots no longer
+        // emit a row for the dead algo.
+        var book = new PovProgressBook();
+        var atUtc = new DateTimeOffset(2026, 8, 1, 13, 0, 0, TimeSpan.Zero);
+        book.Set("TEST", 500UL, 1234L, atUtc);
+        Assert.NotNull(book.TryGet("TEST", 500UL));
+
+        Assert.True(book.Remove("TEST", 500UL));
+        Assert.Null(book.TryGet("TEST", 500UL));
+        Assert.Empty(book.Snapshot());
+        // Idempotent: a second Remove is a no-op false.
+        Assert.False(book.Remove("TEST", 500UL));
+    }
+
+    [Fact]
+    public async Task PovAlgo_SkipPathProgress_PreservedAcrossSnapshotRestart()
+    {
+        // Pass-2 review (#295) P1 — the engine writes PovProgressBook
+        // on EVERY tick (emit OR skip). When the skip path advances
+        // marketVolumeSeen without emitting an AlgoPovSlicedEvent the
+        // snapshotter is the only persistence; this test asserts the
+        // snapshot/restore round-trip carries that state through.
+        var createdAt = new DateTimeOffset(2026, 8, 2, 13, 0, 0, TimeSpan.Zero);
+        var povStart = createdAt;
+        var tick = TimeSpan.FromSeconds(5);
+        var skipTickAt = povStart + tick;
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, dispatcher) = Build(store);
+            dispatcher.Dispatch(
+                new AlgoCreatedEvent
+                {
+                    AlgoId = 510UL,
+                    EndClientId = "hank",
+                    FirmId = "TEST",
+                    Symbol = "PETR4",
+                    SecurityId = 4321UL,
+                    Side = "Buy",
+                    Type = "Pov",
+                    TotalQuantity = 5000,
+                    CreatedAtUtc = createdAt,
+                    PovStartUtc = povStart,
+                    PovEndUtc = povStart.AddMinutes(30),
+                    PovChildOrderType = "Limit",
+                    PovChildPrice = 30m,
+                    PovParticipationRate = 0.10m,
+                    PovTickIntervalTicks = tick.Ticks,
+                    PovMinSliceQty = 10_000, // Forces the skip path: no slice ever fires.
+                },
+                () => algos.TryAdd(new Algo(510UL, new EndClientId("hank"), "TEST", "PETR4", 4321UL,
+                    OrderSide.Buy, AlgoType.Pov, 5000,
+                    new PovParameters(povStart, povStart.AddMinutes(30), OrderType.Limit, 30m, 0.10m, tick, null, 10_000), createdAt)));
+        }
+
+        // Engine session 1: simulate a skip-path tick (no AlgoPovSlicedEvent)
+        // by directly updating PovProgressBook the way ComputePovSlice does.
+        // Snapshot must capture this even though no WAL event references it.
+        var snapshotDir = "skip-path-" + Guid.NewGuid().ToString("N");
+        long skipMarketVolume = 4_200;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
+                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
+                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
+                new AlgoIdRegistry(), povProgress: povProgress);
+            var snapStore = new SnapshotStore(_root, snapshotDir);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer, snapStore,
+                NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            // Skip-path engine state update (qty == 0, no WAL emit).
+            povProgress.Set("TEST", 510UL, skipMarketVolume, skipTickAt);
+
+            // Persist snapshot (the only place the skip-path state survives).
+            snapStore.Write(snapshotter.Capture(seq: 1));
+        }
+
+        // Engine session 2: cold start consumes the snapshot. PovProgressBook
+        // must have the skip-tick baseline so subsequent slicing resumes from
+        // marketVolumeSeen = 4_200, NOT zero.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
+                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
+                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
+                new AlgoIdRegistry(), povProgress: povProgress);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, snapshotDir), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            var restored = povProgress.TryGet("TEST", 510UL);
+            Assert.NotNull(restored);
+            Assert.Equal(skipMarketVolume, restored!.Value.MarketVolumeSeen);
+            Assert.Equal(skipTickAt, restored.Value.LastEvaluateAtUtc);
+        }
+    }
+
+    [Fact]
+    public async Task PovAlgo_RemovedProgress_ExcludedFromSnapshot()
+    {
+        // Pass-2 review (#295) P2 — after termination the engine calls
+        // PovProgressBook.Remove(); the next snapshot must omit the
+        // entry so a downstream restart doesn't re-hydrate stale state.
+        var atUtc = new DateTimeOffset(2026, 8, 3, 13, 0, 0, TimeSpan.Zero);
+
+        var snapshotDir = "removed-" + Guid.NewGuid().ToString("N");
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            povProgress.Set("TEST", 520UL, 9_999L, atUtc);
+            povProgress.Set("TEST", 521UL, 1_111L, atUtc);
+            povProgress.Remove("TEST", 520UL);
+
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
+                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
+                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var snapStore = new SnapshotStore(_root, snapshotDir);
+            snapStore.Write(snapshotter.Capture(seq: 1));
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, ownership, killSwitch, processor, algos, _) = Build(store);
+            var povProgress = new PovProgressBook();
+            var snapshotter = new StateSnapshotter(book, new PositionKeeper(), killSwitch,
+                new SymbolHaltService(), new SessionPhaseService(), new ClOrdIdPrefixRegistry(),
+                ownership, algos, new AlgoIdRegistry(), new CashLedger(), povProgress: povProgress);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(),
+                new AlgoIdRegistry(), povProgress: povProgress);
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, snapshotDir), NullLogger<PersistenceRecovery>.Instance);
+            await recovery.RunAsync();
+
+            Assert.Null(povProgress.TryGet("TEST", 520UL));
+            var sibling = povProgress.TryGet("TEST", 521UL);
+            Assert.NotNull(sibling);
+            Assert.Equal(1_111L, sibling!.Value.MarketVolumeSeen);
+        }
+    }
+
     private static (WorkingOrderBook, OrderOwnershipMap, KillSwitchService, ExecutionReportProcessor, AlgoBook, EventDispatcher) Build(IEventStore store)
     {
         var book = new WorkingOrderBook();


### PR DESCRIPTION
Closes #282

## Summary
Implements the POV (Percentage of Volume) algo, mirroring the VWAP architecture from #281/#294: same threading model, WAL/snapshot patterns, volume pump integration, REST surface, WS sink, and recovery semantics.

## Surface
- **Domain**: `AlgoType.Pov`, `PovParameters` (StartUtc, EndUtc, ChildOrderType, ChildPrice, ParticipationRate, TickInterval, PriceLimit?, MinSliceQty=1), `AlgoTerminalReason.PovWindowExpired`.
- **REST**: `POST /algo` accepts `Type=Pov` + `Pov{...}` block; `GET /algo/{id}` returns new `PovParamsDto` on `AlgoDto`.
- **WAL**: `AlgoCreatedEvent` gains nullable `Pov*` fields; new `AlgoPovSlicedEvent` observability envelope.
- **Snapshots/Recovery**: `AlgoSnapshot` carries POV fields; `AlgoBook` + `StateSnapshotter` cover `PovParameters`.
- **Metrics**: `AlgoPovSlicesEmitted`, `AlgoPovActualParticipationRate` (Histogram<double>), `AlgoPovCancelled`.

## Scheduler / Engine
- `PovPlan` pure helpers: `PlannedAtUtc` (slot k = startUtc + k·tick), `SliceQty` (`pending = floor(cumMv·rate) − executedCum`, clamped to remaining, deferred if `< MinSliceQty`), `ClampPrice`.
- `AlgoScheduler.TickPov` fires the next due slot via per-parent `NextSliceSeq` cursor.
- `AlgoEngine` reuses `VolumeCurveEstimator.VolumeBetween(symbol, startUtc, now)` for cumulative market volume (option A — no per-parent `lastEvalUtc`); subscribes `MarketDataVolumePump` on `OnCreated`; emits per-slice WAL with audit envelope; transitions to `Expired/PovWindowExpired` at `endUtc` (opportunistic: no force-fill).

## Tests (+31, baseline 1405 → 1436)
- `PovPlanTests` (19): every branch of `SliceQty`, `PlannedAtUtc`, `ClampPrice`.
- `PovAlgoEndpointTests` (10): POST validation matrix; slicing driven by injected market trades; window-expired-without-fill; GET round-trip; cancel-mid-flight with exactly-once terminal via recording `IAlgoEventSink`.
- `AlgoRecoveryTests.PovAlgo_ReplayedFromWal_ReproduceParentAggregate`: WAL replay of `AlgoCreatedEvent(Pov)` + `AlgoPovSlicedEvent` + `AlgoCancelRequestedEvent` + `AlgoTerminalStateRecordedEvent` reconstructs the parent aggregate end-to-end.

## Verification
- ✅ `dotnet build B3TradingPlatform.slnx` — 0 warnings, 0 errors
- ✅ `dotnet test B3TradingPlatform.slnx` — 1436 passed (was 1405)
- ✅ `dotnet format B3TradingPlatform.slnx --verify-no-changes` — clean