### PR TITLE
feat(#283): Pegged orders (client-side)

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -199,6 +199,43 @@ public static class AlgoEndpoints
                         povMinSlice);
                     break;
 
+                case AlgoType.Pegged:
+                    // Q3.3 (#283). Pegged shares the POST /algo surface
+                    // with the other algos via the type discriminator.
+                    // Tick size has no per-symbol provider yet (open
+                    // TODO across the repo), so the API accepts an
+                    // explicit override and falls back to 0.01 (BRL
+                    // equity default) — documented in the PR notes.
+                    if (req.Pegged is null)
+                        return Results.BadRequest(new { error = "pegged parameters are required for type=Pegged" });
+                    if (!Enum.TryParse<PegRef>(req.Pegged.Ref, ignoreCase: true, out var peggedRef))
+                        return Results.BadRequest(new { error = $"invalid pegged.ref '{req.Pegged.Ref}'; expected Mid|Best|Last" });
+                    var peggedRepegMs = req.Pegged.RepegIntervalMs ?? 500;
+                    if (peggedRepegMs <= 0)
+                        return Results.BadRequest(new { error = "pegged.repegIntervalMs must be positive" });
+                    var peggedTickSize = req.Pegged.TickSize ?? 0.01m;
+                    if (peggedTickSize <= 0m)
+                        return Results.BadRequest(new { error = "pegged.tickSize must be positive" });
+                    var peggedChildType = OrderType.Limit;
+                    if (!string.IsNullOrWhiteSpace(req.Pegged.ChildOrderType))
+                    {
+                        if (!Enum.TryParse<OrderType>(req.Pegged.ChildOrderType, ignoreCase: true, out peggedChildType))
+                            return Results.BadRequest(new { error = $"invalid pegged.childOrderType '{req.Pegged.ChildOrderType}'" });
+                        // Market orders defeat the whole point of pegging
+                        // (the venue picks the price). Reject explicitly
+                        // rather than letting it silently slip through.
+                        if (peggedChildType != OrderType.Limit)
+                            return Results.BadRequest(new { error = "pegged.childOrderType must be Limit" });
+                    }
+                    parameters = new PeggedParameters(
+                        peggedRef,
+                        req.Pegged.OffsetTicks,
+                        TimeSpan.FromMilliseconds(peggedRepegMs),
+                        peggedTickSize,
+                        peggedChildType,
+                        req.Pegged.PriceLimit);
+                    break;
+
                 default:
                     return Results.BadRequest(new { error = $"unsupported algo type '{type}'" });
             }
@@ -247,6 +284,12 @@ public static class AlgoEndpoints
                         PovTickIntervalTicks = (parameters as PovParameters)?.TickInterval.Ticks,
                         PovPriceLimit = (parameters as PovParameters)?.PriceLimit,
                         PovMinSliceQty = (parameters as PovParameters)?.MinSliceQty,
+                        PeggedRef = (parameters as PeggedParameters)?.Ref.ToString(),
+                        PeggedOffsetTicks = (parameters as PeggedParameters)?.OffsetTicks,
+                        PeggedRepegIntervalTicks = (parameters as PeggedParameters)?.RepegInterval.Ticks,
+                        PeggedTickSize = (parameters as PeggedParameters)?.TickSize,
+                        PeggedChildOrderType = (parameters as PeggedParameters)?.ChildOrderType.ToString(),
+                        PeggedPriceLimit = (parameters as PeggedParameters)?.PriceLimit,
                     },
                     () => algos.TryAdd(algo));
             }
@@ -378,7 +421,8 @@ public sealed record CreateAlgoRequest(
     CreateAlgoIcebergParams? Iceberg,
     CreateAlgoTwapParams? Twap,
     CreateAlgoVwapParams? Vwap = null,
-    CreateAlgoPovParams? Pov = null);
+    CreateAlgoPovParams? Pov = null,
+    CreateAlgoPeggedParams? Pegged = null);
 
 public sealed record CreateAlgoIcebergParams(long DisplayQuantity, decimal? LimitPrice);
 
@@ -419,3 +463,22 @@ public sealed record CreateAlgoPovParams(
     double? TickIntervalSeconds = null,
     decimal? PriceLimit = null,
     long? MinSliceQty = null);
+
+/// <summary>
+/// HTTP request shape for the Pegged parameter block (Q3.3 / #283).
+/// <para>
+/// <b>Defaults.</b> <see cref="RepegIntervalMs"/> defaults to 500ms,
+/// <see cref="TickSize"/> defaults to <c>0.01</c> (BRL equity floor;
+/// per-symbol provider TODO), <see cref="ChildOrderType"/> defaults
+/// to <c>Limit</c> (the only legal value — Market would defeat the
+/// peg). <see cref="OffsetTicks"/> is required and may be negative
+/// for passive pegs (Buy below the bid, Sell above the ask).
+/// </para>
+/// </summary>
+public sealed record CreateAlgoPeggedParams(
+    string Ref,
+    int OffsetTicks,
+    int? RepegIntervalMs = null,
+    decimal? TickSize = null,
+    string? ChildOrderType = null,
+    decimal? PriceLimit = null);

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -162,7 +162,8 @@ public sealed record AlgoDto(
     IcebergParamsDto? Iceberg,
     TwapParamsDto? Twap,
     VwapParamsDto? Vwap = null,
-    PovParamsDto? Pov = null);
+    PovParamsDto? Pov = null,
+    PeggedParamsDto? Pegged = null);
 
 public sealed record IcebergParamsDto(long DisplayQuantity, decimal? LimitPrice);
 
@@ -204,6 +205,20 @@ public sealed record PovParamsDto(
     decimal? PriceLimit,
     long MinSliceQty);
 
+/// <summary>
+/// Wire shape for Pegged parameters (Q3.3 / #283). RepegInterval is
+/// surfaced in milliseconds (sub-second cadence is the common case)
+/// while VWAP/POV use seconds — kept separate so each algo's wire
+/// matches its operational time scale.
+/// </summary>
+public sealed record PeggedParamsDto(
+    string Ref,
+    int OffsetTicks,
+    int RepegIntervalMs,
+    decimal TickSize,
+    string ChildOrderType,
+    decimal? PriceLimit);
+
 public static class DtoMappings
 {
     public static OrderDto ToDto(this Order o) => new(
@@ -236,6 +251,11 @@ public static class DtoMappings
             ? new PovParamsDto(pp.StartUtc, pp.EndUtc, pp.ChildOrderType.ToString(), pp.ChildPrice,
                 pp.ParticipationRate, pp.TickInterval.TotalSeconds, pp.PriceLimit, pp.MinSliceQty)
             : null;
+        PeggedParamsDto? pegged = a.Parameters is PeggedParameters pgp
+            ? new PeggedParamsDto(pgp.Ref.ToString(), pgp.OffsetTicks,
+                (int)pgp.RepegInterval.TotalMilliseconds, pgp.TickSize,
+                pgp.ChildOrderType.ToString(), pgp.PriceLimit)
+            : null;
         return new AlgoDto(
             a.AlgoId.ToString(),
             a.Symbol,
@@ -252,6 +272,7 @@ public static class DtoMappings
             iceberg,
             twap,
             vwap,
-            pov);
+            pov,
+            pegged);
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -647,6 +647,27 @@ public sealed class AlgoEngine : BackgroundService
         {
             case OrderStatus.Filled:
                 if (algo.IsTerminal) return; // redundant ER after we already terminal-ed
+                // Pass-4 review (#296) P1. Repeg-cancel ↔ Fill race. The
+                // engine issued (or has just issued) a cancel for this
+                // child as part of a repeg cycle, but a terminal Fill ER
+                // arrived before / instead of the cancel-ack — the venue
+                // filled the residue while our cancel was still in
+                // flight. Quantity is already booked above; route through
+                // ResolveRepegOnFillAsync so the cycle is wound down
+                // without spawning a replacement here (the existing child
+                // consumed the qty, and the next AlgoCreatedSignal tick
+                // owns submitting a fresh slice for any remaining qty).
+                // A later duplicate ER (e.g. a stale Cancelled wire that
+                // gets clamped to Filled by Order.MarkCancelled) re-
+                // enters this branch and is a clean no-op because
+                // rt.RepegPending is already false and the qty delta is
+                // zero.
+                if (algo.Type == AlgoType.Pegged
+                    && rt.LastRepegCancelledChildId == child.ClOrdId)
+                {
+                    await ResolveRepegOnFillAsync(algo, rt, child).ConfigureAwait(false);
+                    return;
+                }
                 if (algo.Status == AlgoStatus.Cancelling)
                 {
                     // Race: operator cancelled while the venue was filling
@@ -1257,6 +1278,115 @@ public sealed class AlgoEngine : BackgroundService
     }
 
     /// <summary>
+    /// Pass-4 review (#296) P1. Wind down a pegged repeg cycle when a
+    /// terminal Fill ER arrives for the child the engine had just
+    /// cancelled (or was cancelling) for repeg. The venue filled the
+    /// residue while our cancel was in flight; the qty was already
+    /// booked to the parent by the caller (delta accounting in
+    /// <see cref="OnChildErAsync"/>), so the cycle is complete from the
+    /// parent's POV and we MUST NOT submit a replacement here:
+    /// <list type="bullet">
+    ///   <item>The just-filled child consumed the qty the replacement
+    ///   would have targeted — placing a new slice now would over-buy
+    ///   (orphan duplicate working order).</item>
+    ///   <item>If parent qty remains, the next
+    ///   <see cref="AlgoCreatedSignal"/> scheduler tick lands in
+    ///   <see cref="OnCreatedAsync"/> with <c>LiveChildClOrdId=null</c>
+    ///   and submits the next slice through the canonical empty-slot
+    ///   path. That keeps the "submit new working slice" entry-point
+    ///   single — the repeg race never has its own.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Three timing windows are handled, all the same in-memory shape
+    /// (<c>RepegPending=true</c>, sticky
+    /// <c>LastRepegCancelledChildId=child.ClOrdId</c>) but with
+    /// different WAL state because the Started marker is persisted only
+    /// AFTER <c>CancelAsync</c> returns (pass-3 review #296 P1 approach
+    /// B):
+    /// <list type="number">
+    ///   <item><b>Window 1</b> — Fill processed before <c>CancelAsync</c>
+    ///   is even invoked. <c>PeggedRepegBook</c> is empty; clearing the
+    ///   in-memory flags is enough. The post-cancel guard in
+    ///   <see cref="EvaluatePeggedRepegAsync"/> then sees
+    ///   <c>RepegPending=false</c> and skips the Started dispatch so
+    ///   no orphan WAL marker is written.</item>
+    ///   <item><b>Window 2</b> — Fill processed after <c>CancelAsync</c>
+    ///   returned but before Started was persisted. Same shape as
+    ///   Window 1.</item>
+    ///   <item><b>Window 3</b> — Fill processed after Started was
+    ///   persisted (book has an entry). Dispatch the matching
+    ///   <see cref="AlgoPeggedRepegResolvedEvent"/> with
+    ///   <c>Aborted=false</c> + <c>Reason=FilledBeforeCancelAck</c>
+    ///   so the audit pair is balanced and replay clears the book.
+    ///   <c>Aborted</c> stays <c>false</c> because the cancel did
+    ///   reach the venue; the rollback bit is reserved for cancel
+    ///   wire-call failure (pass-2 #296 P1-A).</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// <c>LastRepegCancelledChildId</c> stays sticky — a follow-up
+    /// late Cancelled ER for the same child id (e.g. a venue
+    /// CancelReject converted to a stale Cancelled wire) flows back
+    /// into <see cref="OnChildErAsync"/>, hits the
+    /// <c>!RepegPending &amp;&amp; LastRepegCancelledChildId==child.ClOrdId</c>
+    /// dedup branch in the Cancelled case, and is a no-op rather than
+    /// flipping the parent to <c>Suspended/VenueCancelled</c>. A
+    /// duplicate Fill ER similarly re-enters this method but with
+    /// <c>RepegPending=false</c> and zero qty delta — no second
+    /// Resolved is emitted because the book entry is gone.
+    /// </para>
+    /// </summary>
+    private async Task ResolveRepegOnFillAsync(Algo algo, AlgoParentRuntime rt, Order child)
+    {
+        var wasPending = rt.RepegPending;
+        rt.RepegPending = false;
+        // Keep LastRepegCancelledChildId sticky for late-ER dedup; the
+        // marker is cleared only on parent terminal.
+
+        if (wasPending && _peggedRepeg?.TryGet(algo.FirmId, algo.AlgoId) is not null)
+        {
+            // Window 3: Started already in WAL + book. Emit the
+            // Resolved companion so the audit pair is balanced and
+            // replay drops the pending entry. Best-effort under WAL
+            // backpressure — Reconcile's orphan-prune covers a missed
+            // Resolved on the next restart.
+            try
+            {
+                var firmIdSnap = algo.FirmId;
+                var algoIdSnap = algo.AlgoId;
+                var book = _peggedRepeg;
+                _dispatcher.Dispatch(
+                    new AlgoPeggedRepegResolvedEvent
+                    {
+                        AlgoId = algo.AlgoId,
+                        FirmId = algo.FirmId,
+                        CancelledChildClOrdId = child.ClOrdId,
+                        AtUtc = _clock.GetUtcNow(),
+                        Aborted = false,
+                        Reason = "FilledBeforeCancelAck",
+                    },
+                    () => book?.Remove(firmIdSnap, algoIdSnap));
+            }
+            catch (WalBackpressureException)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved"));
+            }
+        }
+
+        if (algo.RemainingQuantity <= 0)
+        {
+            await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
+        }
+        // Else: residue remains. Do NOT submit a replacement here —
+        // the next AlgoCreatedSignal tick re-enters OnCreatedAsync via
+        // the empty-slot path and prices a fresh slice at the current
+        // ref. This keeps "new working slice" submission single-sourced.
+    }
+
+    /// <summary>
     /// Q3.3 (#283). Repeg evaluation for a Pegged parent that already
     /// has a live working slice. The decision tree, in order:
     ///
@@ -1380,6 +1510,22 @@ public sealed class AlgoEngine : BackgroundService
         // Cancel reached the venue. Persist the Started marker so a
         // crash before the cancel-ack ER lands still gives recovery
         // enough trail to classify the post-restart ER as expected.
+        //
+        // Pass-4 review (#296) P1 — Windows 1+2. If a terminal Fill ER
+        // for `liveChildClOrdId` raced the cancel and was processed by
+        // OnChildErAsync during the CancelAsync await (or before this
+        // method was entered, e.g. an SDK that pumps ERs synchronously
+        // inside the cancel call), ResolveRepegOnFillAsync has already
+        // cleared rt.RepegPending and the qty was credited to the
+        // parent. Persisting a Started here would leave an orphan WAL
+        // marker that the next Reconcile / replay would have to self-
+        // heal. Bail before the dispatch — the post-fill state is
+        // already coherent.
+        if (!rt.RepegPending)
+        {
+            return;
+        }
+
         try
         {
             var firmIdSnap = algo.FirmId;

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -212,6 +212,7 @@ public sealed class AlgoEngine : BackgroundService
             // entries restored from a snapshot written by an older
             // engine version that didn't remove on terminal.
             PruneOrphanPovProgress(algos);
+            PrunePeggedRepegBookOrphans(algos);
             return;
         }
 
@@ -316,6 +317,37 @@ public sealed class AlgoEngine : BackgroundService
 
         _logger.LogInformation("AlgoEngine reconciliation enqueued {Count} non-terminal parents.", algos.Count);
         PruneOrphanPovProgress(algos);
+        PrunePeggedRepegBookOrphans(algos);
+    }
+
+    /// <summary>
+    /// Pass-2 review (#296) P2-C — mirror of
+    /// <see cref="PruneOrphanPovProgress"/> for Pegged. Iterate every
+    /// entry in <see cref="PeggedRepegBook"/> and drop those whose
+    /// parent algo is absent from the non-terminal live set. Covers
+    /// (a) entries persisted by a previous engine version that didn't
+    /// <c>Remove</c> on terminal, (b) entries whose parent was
+    /// concurrently terminated/expired between snapshot capture and
+    /// restart, and (c) entries left behind by the cancel-fail
+    /// roll-back path (P1-A) if the Resolved event hit WAL
+    /// backpressure. Idempotent and cheap (one pass over a small
+    /// map).
+    /// </summary>
+    private void PrunePeggedRepegBookOrphans(IReadOnlyCollection<Algo> liveAlgos)
+    {
+        if (_peggedRepeg is null) return;
+        var live = new HashSet<(string FirmId, ulong AlgoId)>(liveAlgos.Count);
+        foreach (var a in liveAlgos)
+        {
+            live.Add((a.FirmId, a.AlgoId));
+        }
+        foreach (var (firmId, algoId, _) in _peggedRepeg.Snapshot().ToList())
+        {
+            if (!live.Contains((firmId, algoId)))
+            {
+                _peggedRepeg.Remove(firmId, algoId);
+            }
+        }
     }
 
     /// <summary>
@@ -1295,7 +1327,14 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.WalBackpressure.Add(1,
                 new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-started"));
+            // Pass-2 review (#296) P1-A. Started never made it into the
+            // WAL → the dispatch apply (PeggedRepegBook.Set) never ran
+            // either, so the only state to roll back is the in-memory
+            // marker/throttle pair we set above. PeggedLastEvalUtc stays
+            // at `now` so the next tick honours the RepegInterval rather
+            // than hammering a backpressured WAL.
             rt.RepegPending = false;
+            rt.LastRepegCancelledChildId = null;
             return;
         }
 
@@ -1334,12 +1373,55 @@ public sealed class AlgoEngine : BackgroundService
         }
         catch (Exception ex)
         {
-            // Cancel failed — clear the pending flag and bump the
-            // failure counter; the next scheduler tick will retry.
+            // Pass-2 review (#296) P1-A. Cancel failed AFTER we persisted
+            // the Started marker + populated PeggedRepegBook. If we only
+            // cleared RepegPending here (the old behaviour) the sticky
+            // LastRepegCancelledChildId + book entry would persist and a
+            // future GENUINE venue cancel for this child id would be
+            // mis-classified as "expected" by OnChildErAsync — swallowed
+            // instead of suspending the parent. Roll back atomically:
+            //
+            //   1. Emit a Resolved(Aborted=true) event so WAL replay
+            //      clears the book entry on a post-restart recovery
+            //      (in-memory clear is not enough — a snapshot taken
+            //      before the failure would otherwise restore the
+            //      orphan).
+            //   2. Clear in-memory marker + book entry regardless of
+            //      whether the Resolved event made it to the WAL — the
+            //      no-future-false-positive invariant trumps replay
+            //      convergence in this corner case, and Reconcile's
+            //      orphan-prune pass (P2-C) catches any drift on the
+            //      next restart anyway.
             rt.RepegPending = false;
+            try
+            {
+                var firmIdSnap = algo.FirmId;
+                var algoIdSnap = algo.AlgoId;
+                var cancelledIdSnap = liveChildClOrdId;
+                var book = _peggedRepeg;
+                _dispatcher.Dispatch(
+                    new AlgoPeggedRepegResolvedEvent
+                    {
+                        AlgoId = algo.AlgoId,
+                        FirmId = algo.FirmId,
+                        CancelledChildClOrdId = liveChildClOrdId,
+                        AtUtc = _clock.GetUtcNow(),
+                        Aborted = true,
+                    },
+                    () => book?.Remove(firmIdSnap, algoIdSnap));
+            }
+            catch (WalBackpressureException)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved-aborted"));
+                // Dispatch apply (book.Remove) never ran — fall through
+                // to the unconditional in-memory cleanup below.
+                _peggedRepeg?.Remove(algo.FirmId, algo.AlgoId);
+            }
+            rt.LastRepegCancelledChildId = null;
             MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
             _logger.LogWarning(ex,
-                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; will retry next tick.",
+                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; rolled back marker, will retry next tick.",
                 algo.FirmId, algo.AlgoId, liveChildClOrdId);
         }
     }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -292,6 +292,14 @@ public sealed class AlgoEngine : BackgroundService
                 if (pending is { } pgd)
                 {
                     rt.LastRepegCancelledChildId = pgd.CancelledChildClOrdId;
+                    // Pass-5 review (#296) P1. Defensive: make sure
+                    // the cancelled child id is in the dedup history
+                    // ring. RestoreHistory + EventReplayer normally
+                    // populate it, but a snapshot taken by a pre-
+                    // pass-5 binary carries a pending entry without
+                    // any history rows — seed from the pending entry
+                    // so the post-restart late-ER dedup still works.
+                    _peggedRepeg.MarkCancelledChild(algo.FirmId, algo.AlgoId, pgd.CancelledChildClOrdId);
                     var stillLive = _orders.TryGet(pgd.CancelledChildClOrdId, out var oldChild)
                                     && oldChild is not null
                                     && !IsChildTerminal(oldChild);
@@ -662,8 +670,22 @@ public sealed class AlgoEngine : BackgroundService
                 // enters this branch and is a clean no-op because
                 // rt.RepegPending is already false and the qty delta is
                 // zero.
+                //
+                // Pass-5 review (#296) P1. Match against
+                // PeggedRepegBook.IsCancelledChild (a bounded FIFO ring
+                // of every child id we've engine-cancelled for this
+                // parent) instead of the single-slot
+                // LastRepegCancelledChildId. The single slot only
+                // pinpoints the LATEST cycle and is overwritten on
+                // every subsequent repeg, so a late Fill ER for an
+                // OLDER cancelled child (e.g. cycle A cancelled, cycle
+                // B started, then the venue belatedly reports cycle
+                // A's terminal) used to slip past this dedup and fall
+                // through to either the normal Fill-then-resubmit
+                // path (orphan replacement) or the VenueCancelled
+                // branch (spurious Suspended).
                 if (algo.Type == AlgoType.Pegged
-                    && rt.LastRepegCancelledChildId == child.ClOrdId)
+                    && (_peggedRepeg?.IsCancelledChild(algo.FirmId, algo.AlgoId, child.ClOrdId) ?? false))
                 {
                     await ResolveRepegOnFillAsync(algo, rt, child).ConfigureAwait(false);
                     return;
@@ -785,14 +807,23 @@ public sealed class AlgoEngine : BackgroundService
                     await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
                 }
                 else if (algo.Type == AlgoType.Pegged
-                         && rt.LastRepegCancelledChildId == child.ClOrdId)
+                         && (_peggedRepeg?.IsCancelledChild(algo.FirmId, algo.AlgoId, child.ClOrdId) ?? false))
                 {
                     // Pass-1 review (#296) P1-A. Duplicate / late
                     // Cancelled ER for a child we already cancelled
-                    // for a repeg (the marker is sticky across the
-                    // RepegPending flag clear). Treat as a no-op so
-                    // the parent does NOT fall through to the
-                    // VenueCancelled branch and get suspended.
+                    // for a repeg. Treat as a no-op so the parent
+                    // does NOT fall through to the VenueCancelled
+                    // branch and get suspended.
+                    //
+                    // Pass-5 review (#296) P1. Match against the
+                    // PeggedRepegBook history ring (bounded FIFO of
+                    // every recently engine-cancelled child id)
+                    // instead of the single-slot
+                    // LastRepegCancelledChildId. The single slot only
+                    // identifies the LATEST cycle; once a subsequent
+                    // repeg overwrites it a late Cancelled ER for an
+                    // older cycle's child used to escape this guard
+                    // and reach the VenueCancelled-suspension path.
                     return;
                 }
                 else if (IsTwapWindowExpired(algo))
@@ -1195,9 +1226,14 @@ public sealed class AlgoEngine : BackgroundService
         // Pass-1 review (#296) P1-C. Drop any in-flight repeg marker
         // for a Pegged parent on terminal so the book stays bounded
         // and the next snapshot doesn't carry stale state.
+        //
+        // Pass-5 review (#296) P1. Also drop the cancelled-child
+        // history ring (RemoveAll) — once the parent is terminal no
+        // further late ERs can affect routing, so the dedup memory
+        // is dead weight.
         if (algo.Type == AlgoType.Pegged)
         {
-            _peggedRepeg?.Remove(algo.FirmId, algo.AlgoId);
+            _peggedRepeg?.RemoveAll(algo.FirmId, algo.AlgoId);
         }
         await Task.CompletedTask;
     }
@@ -1480,6 +1516,16 @@ public sealed class AlgoEngine : BackgroundService
         // the next tick re-derives it from current drift.
         rt.RepegPending = true;
         rt.LastRepegCancelledChildId = liveChildClOrdId;
+        // Pass-5 review (#296) P1. Add to the cancelled-child history
+        // ring BEFORE the wire-call so the late-ER dedup at
+        // OnChildErAsync line ~666/~788 covers ERs that race the
+        // cancel (the ring is in-memory only here; the WAL Started
+        // event below carries the same id so EventReplayer rebuilds
+        // the ring on restart). Persisting via dispatch-action would
+        // be wrong: this id must be remembered even when CancelAsync
+        // fails (no Started gets persisted), because a venue may
+        // still ack the cancel from a previous in-flight attempt.
+        _peggedRepeg?.MarkCancelledChild(algo.FirmId, algo.AlgoId, liveChildClOrdId);
         rt.PeggedLastEvalUtc = now;
         var oldChildPrice = currentPrice;
         var refForAudit = _pegBookTop?.TryGet(algo.Symbol)?.RefPrice(pgp.Ref, algo.Side) ?? 0m;

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -79,6 +79,8 @@ public sealed class AlgoEngine : BackgroundService
     private readonly OrderOwnershipMap _ownership;
     private readonly VolumeCurveEstimator? _vwapCurve;
     private readonly MarketDataVolumePump? _volumePump;
+    private readonly PegBookTopCache? _pegBookTop;
+    private readonly MarketDataPegBookPump? _pegBookPump;
     /// <summary>
     /// Pass-1 review (#295) P1#1. Per-POV scheduling progress
     /// (cumulative market volume + last-evaluate timestamp). Persisted
@@ -109,7 +111,9 @@ public sealed class AlgoEngine : BackgroundService
         OrderOwnershipMap ownership,
         VolumeCurveEstimator? vwapCurve = null,
         MarketDataVolumePump? volumePump = null,
-        PovProgressBook? povProgress = null)
+        PovProgressBook? povProgress = null,
+        PegBookTopCache? pegBookTop = null,
+        MarketDataPegBookPump? pegBookPump = null)
     {
         _queue = queue;
         _algos = algos;
@@ -125,6 +129,8 @@ public sealed class AlgoEngine : BackgroundService
         _vwapCurve = vwapCurve;
         _volumePump = volumePump;
         _povProgress = povProgress;
+        _pegBookTop = pegBookTop;
+        _pegBookPump = pegBookPump;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -330,13 +336,29 @@ public sealed class AlgoEngine : BackgroundService
         {
             await _volumePump.EnsureSubscribedAsync(algo.Symbol, ct).ConfigureAwait(false);
         }
+        // Q3.3 (#283). Pegged needs the SDK subscribed to its symbol so
+        // PegBookTopCache receives prints; without that the engine has
+        // no live reference and every repeg eval is a no-op (silent
+        // do-nothing algo).
+        if (algo.Type == AlgoType.Pegged && _pegBookPump is not null)
+        {
+            await _pegBookPump.EnsureSubscribedAsync(algo.Symbol, ct).ConfigureAwait(false);
+        }
 
         if (rt.LiveChildClOrdId is { } existing)
         {
             // A child is already outstanding (steady-state or post-recovery).
-            // Idempotent no-op — when the child reaches terminal we'll
-            // refill (Iceberg) or wait for the next scheduled tick (TWAP)
-            // via OnChildErAsync.
+            // Pegged is the only algo where a live child can trigger
+            // engine-driven action: evaluate "has the live ref drifted
+            // far enough to repeg?" and cancel the child if so. Iceberg
+            // refills on terminal (OnChildErAsync), TWAP/VWAP/POV wait
+            // for the scheduler tick — for those it's an idempotent no-op
+            // here.
+            if (algo.Type == AlgoType.Pegged && algo.Parameters is PeggedParameters pgEval)
+            {
+                await EvaluatePeggedRepegAsync(algo, rt, pgEval, existing, ct).ConfigureAwait(false);
+                return;
+            }
             _logger.LogDebug(
                 "AlgoEngine OnCreated: algo {Firm}/{AlgoId} already has live child {Child}; no resubmit.",
                 algo.FirmId, algo.AlgoId, existing);
@@ -544,6 +566,21 @@ public sealed class AlgoEngine : BackgroundService
                     // landed before the cancel-ack.
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
                 }
+                else if (rt.RepegPending && algo.Type == AlgoType.Pegged)
+                {
+                    // Q3.3 (#283). Engine-initiated cancel for a repeg —
+                    // the cancel-ack is the signal to place the new
+                    // child at the fresh target. Clear the flag first
+                    // so a second cancel-ack (shouldn't happen but is
+                    // cheap to defend) doesn't loop into a double-place.
+                    rt.RepegPending = false;
+                    if (algo.RemainingQuantity <= 0)
+                    {
+                        await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
+                        return;
+                    }
+                    await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
+                }
                 else if (IsTwapWindowExpired(algo))
                 {
                     // RFC §4.6 "window passed during downtime AND child was
@@ -673,6 +710,14 @@ public sealed class AlgoEngine : BackgroundService
                 rt.NextSliceSeq++;
                 return;
             }
+            if (algo.Type == AlgoType.Pegged)
+            {
+                // Pegged: no live reference price yet (cache empty —
+                // SDK hasn't delivered any prints for the symbol). The
+                // scheduler will fire another AlgoCreatedSignal at the
+                // next tick; we just no-op until the cache warms.
+                return;
+            }
             // Should be unreachable (RemainingQuantity == 0 is checked by
             // callers) — defensive log + complete.
             await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
@@ -686,6 +731,7 @@ public sealed class AlgoEngine : BackgroundService
             TwapParameters tp => tp.ChildOrderType,
             VwapParameters vp => vp.ChildOrderType,
             PovParameters pp => pp.ChildOrderType,
+            PeggedParameters pgp => pgp.ChildOrderType,
             _ => OrderType.Limit,
         };
 
@@ -919,6 +965,10 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.AlgoPovCancelled.Add(1);
         }
+        else if (algo.Type == AlgoType.Pegged && status == AlgoStatus.Cancelled)
+        {
+            MetricsRegistry.AlgoPeggedCancelled.Add(1);
+        }
         // Pass-2 review (#295) P2. Drop the per-POV progress entry on
         // every terminal transition so PovProgressBook stays bounded
         // and the next snapshot doesn't carry stale state for a dead
@@ -971,8 +1021,157 @@ public sealed class AlgoEngine : BackgroundService
                     var (qty, price, _) = ComputePovSlice(algo, pp, rt, dueAt);
                     return (qty, price);
                 }
+            case PeggedParameters pgp:
+                {
+                    // Pegged: single working slice covers the full
+                    // residue. Target = clamped(ref + offsetTicks*tick).
+                    // When the cache has no live reference yet, qty=0
+                    // signals "defer" — SubmitNextSliceAsync recognises
+                    // the Pegged-empty case and no-ops without marking
+                    // terminal (see the special case above).
+                    var target = ResolvePeggedTarget(algo, pgp);
+                    if (target is null) return (0, null);
+                    return (algo.RemainingQuantity, target);
+                }
             default:
                 return (algo.RemainingQuantity, null);
+        }
+    }
+
+    /// <summary>
+    /// Q3.3 (#283). Resolves the (possibly clamped) target price for a
+    /// Pegged parent off the live <see cref="PegBookTopCache"/>.
+    /// Returns <c>null</c> when the cache has not been seeded yet for
+    /// the symbol — the caller must defer (no-op) and let the next
+    /// scheduler tick re-evaluate.
+    /// </summary>
+    private decimal? ResolvePeggedTarget(Algo algo, PeggedParameters pgp)
+    {
+        var book = _pegBookTop?.TryGet(algo.Symbol);
+        if (book is null) return null;
+        var refPrice = book.Value.RefPrice(pgp.Ref, algo.Side);
+        if (refPrice is null) return null;
+        var rawTarget = PeggedPlan.ComputeTarget(refPrice, pgp.OffsetTicks, pgp.TickSize);
+        if (rawTarget is null) return null;
+        return PeggedPlan.ClampToLimit(rawTarget.Value, pgp.PriceLimit, algo.Side);
+    }
+
+    /// <summary>
+    /// Q3.3 (#283). Repeg evaluation for a Pegged parent that already
+    /// has a live working slice. The decision tree, in order:
+    ///
+    /// <list type="number">
+    /// <item><b>Throttle</b>: if &lt; <c>RepegInterval</c> has elapsed
+    /// since the last eval, no-op. Bounds the cancel-replace churn
+    /// against an overactive scheduler tick.</item>
+    /// <item><b>Resolve target</b>: if the cache has no live ref yet,
+    /// no-op (don't touch the live child without a fresh reference —
+    /// pulling it would expose the parent to "no order" risk for free).</item>
+    /// <item><b>Compare</b>: if <c>|child.Price - target| &lt; 1 tick</c>,
+    /// no-op and bump <c>PeggedLastEvalUtc</c> so the throttle is
+    /// honoured.</item>
+    /// <item><b>PriceLimit clamp</b>: target is already clamped by
+    /// <see cref="ResolvePeggedTarget"/>; if the clamped target equals
+    /// the child price the comparison above already returned no-op.
+    /// This means a target that would otherwise cross the limit gets
+    /// quietly absorbed and the live child stays put — matches the
+    /// issue spec "Never cross spread beyond priceLimit".</item>
+    /// <item><b>Cancel + flag</b>: cancel the live child via the
+    /// gateway, set <c>rt.RepegPending</c> so
+    /// <see cref="OnChildErAsync"/> re-submits at a fresh target when
+    /// the cancel-ack lands (rather than treating the cancel as a
+    /// venue-cancel suspension).</item>
+    /// </list>
+    /// </summary>
+    private async Task EvaluatePeggedRepegAsync(
+        Algo algo, AlgoParentRuntime rt, PeggedParameters pgp,
+        ulong liveChildClOrdId, CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow();
+        if (rt.PeggedLastEvalUtc != default
+            && (now - rt.PeggedLastEvalUtc) < pgp.RepegInterval)
+        {
+            return;
+        }
+
+        var target = ResolvePeggedTarget(algo, pgp);
+        if (target is null)
+        {
+            // No live ref yet — don't disturb the working slice; next
+            // tick may have a price.
+            return;
+        }
+
+        if (!_orders.TryGet(liveChildClOrdId, out var child) || child is null
+            || IsChildTerminal(child))
+        {
+            // Child reference went stale (rare race with ER pipeline);
+            // clear and let the next tick re-evaluate from the empty
+            // slot path.
+            rt.LiveChildClOrdId = null;
+            return;
+        }
+
+        var currentPrice = child.Price ?? 0m;
+        if (currentPrice <= 0m
+            || !PeggedPlan.IsRepegNeeded(currentPrice, target.Value, pgp.TickSize))
+        {
+            // No drift — record eval-at so the throttle holds.
+            rt.PeggedLastEvalUtc = now;
+            return;
+        }
+
+        // Cancel the live child. Mark RepegPending BEFORE the cancel
+        // wire-call so the cancel-ack ER (which may arrive on a
+        // different consumer-loop iteration) doesn't race the flag
+        // and route through the VenueCancelled-suspension path.
+        rt.RepegPending = true;
+        rt.PeggedLastEvalUtc = now;
+        var oldChildPrice = currentPrice;
+        var refForAudit = _pegBookTop?.TryGet(algo.Symbol)?.RefPrice(pgp.Ref, algo.Side) ?? 0m;
+        var newClOrdId = _clOrdIds.Generate(child.Owner);
+        try
+        {
+            _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
+            await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
+
+            // Best-effort audit envelope; WAL backpressure is non-fatal
+            // because the next OrderSubmittedEvent already records the
+            // new child price.
+            try
+            {
+                var sliceSeq = rt.NextSliceSeq;
+                _dispatcher.Dispatch(
+                    new AlgoPeggedRepeggedEvent
+                    {
+                        AlgoId = algo.AlgoId,
+                        FirmId = algo.FirmId,
+                        SliceSeq = sliceSeq,
+                        RefKind = pgp.Ref.ToString(),
+                        RefPrice = refForAudit,
+                        OldChildPrice = oldChildPrice,
+                        NewTargetPrice = target.Value,
+                        AtUtc = now,
+                    },
+                    static () => { });
+            }
+            catch (WalBackpressureException)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "algo.pegged.repegged"));
+            }
+
+            MetricsRegistry.AlgoPeggedRepegsTotal.Add(1);
+        }
+        catch (Exception ex)
+        {
+            // Cancel failed — clear the pending flag and bump the
+            // failure counter; the next scheduler tick will retry.
+            rt.RepegPending = false;
+            MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
+            _logger.LogWarning(ex,
+                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; will retry next tick.",
+                algo.FirmId, algo.AlgoId, liveChildClOrdId);
         }
     }
 
@@ -1125,5 +1324,14 @@ public sealed class AlgoEngine : BackgroundService
         // an empty estimator.
         public long PovMarketVolumeSeen;
         public DateTimeOffset PovLastEvaluateAtUtc;
+
+        // Q3.3 (#283) — Pegged scheduling state. PeggedLastEvalUtc
+        // anchors the RepegInterval throttle (next eval allowed at
+        // last + interval). RepegPending signals the cancel-ack ER
+        // that the engine itself initiated the cancel for a repeg —
+        // OnChildErAsync uses it to route through SubmitNextSlice
+        // (place new) rather than the VenueCancelled-suspension path.
+        public DateTimeOffset PeggedLastEvalUtc;
+        public bool RepegPending;
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -257,9 +257,10 @@ public sealed class AlgoEngine : BackgroundService
                 }
             }
 
-            // Pass-1 review (#296) P1-C. Restore an in-flight Pegged
-            // repeg cycle: a cancel was emitted pre-restart but the
-            // cancel-ack ER may or may not have been replayed.
+            // Pass-1 review (#296) P1-C, refined by Pass-3 P1-C.
+            // Restore an in-flight Pegged repeg cycle: a cancel was
+            // emitted pre-restart but the cancel-ack ER may or may
+            // not have been replayed.
             //
             // * Always set the sticky LastRepegCancelledChildId so any
             //   stray ER for that child is classified as expected by
@@ -278,8 +279,13 @@ public sealed class AlgoEngine : BackgroundService
             //   null + RepegPending=false so the re-enqueued
             //   AlgoCreatedSignal drives a fresh slice via the empty-
             //   slot path. The book entry is dropped to keep state
-            //   bounded; replay of any older Started event without a
-            //   matching Resolved is interpreted as "cycle completed".
+            //   bounded; we ALSO dispatch a synthetic
+            //   AlgoPeggedRepegResolvedEvent(Aborted=true) so a future
+            //   replay of the WAL sees the cycle as terminated and
+            //   doesn't re-create the orphan book entry. Best-effort
+            //   on WAL backpressure — in-memory removal is the
+            //   correctness invariant; replay convergence is the nice
+            //   bonus.
             if (algo.Type == AlgoType.Pegged && _peggedRepeg is not null)
             {
                 var pending = _peggedRepeg.TryGet(algo.FirmId, algo.AlgoId);
@@ -295,9 +301,7 @@ public sealed class AlgoEngine : BackgroundService
                     }
                     else
                     {
-                        // Cycle effectively complete; drop the book
-                        // entry so the next snapshot doesn't carry it.
-                        _peggedRepeg.Remove(algo.FirmId, algo.AlgoId);
+                        SelfHealOrphanRepeg(algo.FirmId, algo.AlgoId, pgd.CancelledChildClOrdId);
                     }
                 }
             }
@@ -347,6 +351,56 @@ public sealed class AlgoEngine : BackgroundService
             {
                 _peggedRepeg.Remove(firmId, algoId);
             }
+        }
+    }
+
+    /// <summary>
+    /// Pass-3 review (#296) P1-C. Defensive self-heal invoked from
+    /// <see cref="Reconcile"/> when a PeggedRepegBook entry survives
+    /// across a restart but the associated cancelled child id is no
+    /// longer present as a live order. Covers two histories:
+    /// <list type="bullet">
+    ///   <item>Cancel-ack ER was already replayed → child terminal/gone
+    ///   → cycle effectively complete.</item>
+    ///   <item>Old-binary WALs written before Pass-3 P1-B (approach B
+    ///   reorder) that persisted a Started event for a cancel that
+    ///   never actually reached the venue and whose child has since
+    ///   been terminated by another path (e.g. fill, operator cancel
+    ///   via the cancelling branch).</item>
+    /// </list>
+    /// Drops the in-memory book entry (the correctness invariant —
+    /// stops Reconcile setting RepegPending=true on subsequent loops)
+    /// and dispatches a synthetic
+    /// <see cref="AlgoPeggedRepegResolvedEvent"/> with
+    /// <c>Aborted=true</c> so a future WAL replay sees the cycle as
+    /// terminated and does not reconstruct the orphan. Best-effort:
+    /// on WAL backpressure the in-memory removal still wins because
+    /// the apply callback runs only on successful append — we mirror
+    /// the Remove via the catch block to guarantee state convergence
+    /// for the current process.
+    /// </summary>
+    private void SelfHealOrphanRepeg(string firmId, ulong algoId, ulong cancelledChildClOrdId)
+    {
+        if (_peggedRepeg is null) return;
+        try
+        {
+            var book = _peggedRepeg;
+            _dispatcher.Dispatch(
+                new AlgoPeggedRepegResolvedEvent
+                {
+                    AlgoId = algoId,
+                    FirmId = firmId,
+                    CancelledChildClOrdId = cancelledChildClOrdId,
+                    AtUtc = _clock.GetUtcNow(),
+                    Aborted = true,
+                },
+                () => book.Remove(firmId, algoId));
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-self-heal"));
+            _peggedRepeg.Remove(firmId, algoId);
         }
     }
 
@@ -1280,29 +1334,52 @@ public sealed class AlgoEngine : BackgroundService
             return;
         }
 
-        // Cancel the live child. Mark RepegPending BEFORE the cancel
-        // wire-call so the cancel-ack ER (which may arrive on a
-        // different consumer-loop iteration) doesn't race the flag
-        // and route through the VenueCancelled-suspension path.
+        // Pass-3 review (#296) P1 — approach B. Set the in-memory
+        // RepegPending + sticky LastRepegCancelledChildId BEFORE the
+        // cancel wire-call so the cancel-ack ER (which can arrive on a
+        // different consumer-loop iteration while CancelAsync is still
+        // awaiting) is classified as expected by OnChildErAsync and
+        // does NOT route through the VenueCancelled-suspension path.
+        // The WAL Started marker + PeggedRepegBook.Set are deferred
+        // until AFTER CancelAsync returns successfully (below): if the
+        // cancel never reached the venue there is nothing to recover
+        // on restart, so persisting the "intent" prematurely would
+        // leave a poison Started without a matching Resolved that
+        // would stall the algo on replay. Pegged repeg is idempotent
+        // — losing the pre-cancel intent record is harmless because
+        // the next tick re-derives it from current drift.
         rt.RepegPending = true;
-        // Pass-1 review (#296) P1-A. Sticky marker of the cancelled
-        // child id, used by OnChildErAsync to classify ANY Cancelled
-        // ER for this child (initial ack + any duplicate/late ER)
-        // as "expected" so the parent doesn't suspend.
         rt.LastRepegCancelledChildId = liveChildClOrdId;
         rt.PeggedLastEvalUtc = now;
         var oldChildPrice = currentPrice;
         var refForAudit = _pegBookTop?.TryGet(algo.Symbol)?.RefPrice(pgp.Ref, algo.Side) ?? 0m;
         var newClOrdId = _clOrdIds.Generate(child.Owner);
 
-        // Pass-1 review (#296) P1-C. Persist the pre-cancel marker
-        // BEFORE the gateway wire-call so a crash between WAL append
-        // and the actual venue cancel still leaves enough trail for
-        // recovery to know "a repeg cycle was intended" — and treat
-        // any subsequent Cancelled ER for this child as expected.
-        // Best-effort: WAL backpressure clears the local flags so
-        // the next tick retries from a clean state (same fall-back
-        // policy as the audit envelope below).
+        try
+        {
+            _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
+            await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Pass-3 review (#296) P1 — approach B. Cancel never made
+            // it to the venue. Because we no longer persist
+            // AlgoPeggedRepegStartedEvent BEFORE the wire-call, there
+            // is nothing in the WAL or the PeggedRepegBook to roll
+            // back. Clear in-memory state so the next tick re-evaluates
+            // drift from a clean slate and can retry the repeg.
+            rt.RepegPending = false;
+            rt.LastRepegCancelledChildId = null;
+            MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
+            _logger.LogWarning(ex,
+                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; cleared marker, will retry next tick.",
+                algo.FirmId, algo.AlgoId, liveChildClOrdId);
+            return;
+        }
+
+        // Cancel reached the venue. Persist the Started marker so a
+        // crash before the cancel-ack ER lands still gives recovery
+        // enough trail to classify the post-restart ER as expected.
         try
         {
             var firmIdSnap = algo.FirmId;
@@ -1327,103 +1404,43 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.WalBackpressure.Add(1,
                 new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-started"));
-            // Pass-2 review (#296) P1-A. Started never made it into the
-            // WAL → the dispatch apply (PeggedRepegBook.Set) never ran
-            // either, so the only state to roll back is the in-memory
-            // marker/throttle pair we set above. PeggedLastEvalUtc stays
-            // at `now` so the next tick honours the RepegInterval rather
-            // than hammering a backpressured WAL.
-            rt.RepegPending = false;
-            rt.LastRepegCancelledChildId = null;
-            return;
+            // WAL backpressure after a successful cancel: the dispatch
+            // apply (book.Set) never ran. Mirror it manually so the
+            // current process still routes the cancel-ack ER through
+            // the expected path via rt.LastRepegCancelledChildId +
+            // the book lookup. Recovery for this specific cycle is
+            // best-effort; Reconcile's orphan-prune (P2-C) /
+            // self-heal (P1-C) covers any drift on the next restart.
+            _peggedRepeg?.Set(algo.FirmId, algo.AlgoId, liveChildClOrdId, target.Value, now);
         }
 
+        // Best-effort audit envelope; WAL backpressure is non-fatal
+        // because the next OrderSubmittedEvent already records the
+        // new child price.
         try
         {
-            _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
-            await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
-
-            // Best-effort audit envelope; WAL backpressure is non-fatal
-            // because the next OrderSubmittedEvent already records the
-            // new child price.
-            try
-            {
-                var sliceSeq = rt.NextSliceSeq;
-                _dispatcher.Dispatch(
-                    new AlgoPeggedRepeggedEvent
-                    {
-                        AlgoId = algo.AlgoId,
-                        FirmId = algo.FirmId,
-                        SliceSeq = sliceSeq,
-                        RefKind = pgp.Ref.ToString(),
-                        RefPrice = refForAudit,
-                        OldChildPrice = oldChildPrice,
-                        NewTargetPrice = target.Value,
-                        AtUtc = now,
-                    },
-                    static () => { });
-            }
-            catch (WalBackpressureException)
-            {
-                MetricsRegistry.WalBackpressure.Add(1,
-                    new KeyValuePair<string, object?>("call_site", "algo.pegged.repegged"));
-            }
-
-            MetricsRegistry.AlgoPeggedRepegsTotal.Add(1);
+            var sliceSeq = rt.NextSliceSeq;
+            _dispatcher.Dispatch(
+                new AlgoPeggedRepeggedEvent
+                {
+                    AlgoId = algo.AlgoId,
+                    FirmId = algo.FirmId,
+                    SliceSeq = sliceSeq,
+                    RefKind = pgp.Ref.ToString(),
+                    RefPrice = refForAudit,
+                    OldChildPrice = oldChildPrice,
+                    NewTargetPrice = target.Value,
+                    AtUtc = now,
+                },
+                static () => { });
         }
-        catch (Exception ex)
+        catch (WalBackpressureException)
         {
-            // Pass-2 review (#296) P1-A. Cancel failed AFTER we persisted
-            // the Started marker + populated PeggedRepegBook. If we only
-            // cleared RepegPending here (the old behaviour) the sticky
-            // LastRepegCancelledChildId + book entry would persist and a
-            // future GENUINE venue cancel for this child id would be
-            // mis-classified as "expected" by OnChildErAsync — swallowed
-            // instead of suspending the parent. Roll back atomically:
-            //
-            //   1. Emit a Resolved(Aborted=true) event so WAL replay
-            //      clears the book entry on a post-restart recovery
-            //      (in-memory clear is not enough — a snapshot taken
-            //      before the failure would otherwise restore the
-            //      orphan).
-            //   2. Clear in-memory marker + book entry regardless of
-            //      whether the Resolved event made it to the WAL — the
-            //      no-future-false-positive invariant trumps replay
-            //      convergence in this corner case, and Reconcile's
-            //      orphan-prune pass (P2-C) catches any drift on the
-            //      next restart anyway.
-            rt.RepegPending = false;
-            try
-            {
-                var firmIdSnap = algo.FirmId;
-                var algoIdSnap = algo.AlgoId;
-                var cancelledIdSnap = liveChildClOrdId;
-                var book = _peggedRepeg;
-                _dispatcher.Dispatch(
-                    new AlgoPeggedRepegResolvedEvent
-                    {
-                        AlgoId = algo.AlgoId,
-                        FirmId = algo.FirmId,
-                        CancelledChildClOrdId = liveChildClOrdId,
-                        AtUtc = _clock.GetUtcNow(),
-                        Aborted = true,
-                    },
-                    () => book?.Remove(firmIdSnap, algoIdSnap));
-            }
-            catch (WalBackpressureException)
-            {
-                MetricsRegistry.WalBackpressure.Add(1,
-                    new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved-aborted"));
-                // Dispatch apply (book.Remove) never ran — fall through
-                // to the unconditional in-memory cleanup below.
-                _peggedRepeg?.Remove(algo.FirmId, algo.AlgoId);
-            }
-            rt.LastRepegCancelledChildId = null;
-            MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
-            _logger.LogWarning(ex,
-                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; rolled back marker, will retry next tick.",
-                algo.FirmId, algo.AlgoId, liveChildClOrdId);
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.pegged.repegged"));
         }
+
+        MetricsRegistry.AlgoPeggedRepegsTotal.Add(1);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -90,6 +90,18 @@ public sealed class AlgoEngine : BackgroundService
     /// compositions that don't exercise POV.
     /// </summary>
     private readonly PovProgressBook? _povProgress;
+    /// <summary>
+    /// Pass-1 review (#296) P1-C. Per-Pegged in-flight repeg-cycle
+    /// marker. Persisted via
+    /// <see cref="Persistence.AlgoPeggedRepegStartedEvent"/> /
+    /// <see cref="Persistence.AlgoPeggedRepegResolvedEvent"/> + the
+    /// platform snapshot. Reconcile reads the book on engine boot
+    /// to rebuild <c>AlgoParentRuntime.RepegPending</c> +
+    /// <c>LastRepegCancelledChildId</c> so a post-restart cancel-ack
+    /// ER routes through SubmitNextSliceAsync rather than the
+    /// venue-cancel suspension path. Null-tolerant.
+    /// </summary>
+    private readonly PeggedRepegBook? _peggedRepeg;
 
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
@@ -113,7 +125,8 @@ public sealed class AlgoEngine : BackgroundService
         MarketDataVolumePump? volumePump = null,
         PovProgressBook? povProgress = null,
         PegBookTopCache? pegBookTop = null,
-        MarketDataPegBookPump? pegBookPump = null)
+        MarketDataPegBookPump? pegBookPump = null,
+        PeggedRepegBook? peggedRepeg = null)
     {
         _queue = queue;
         _algos = algos;
@@ -131,6 +144,7 @@ public sealed class AlgoEngine : BackgroundService
         _povProgress = povProgress;
         _pegBookTop = pegBookTop;
         _pegBookPump = pegBookPump;
+        _peggedRepeg = peggedRepeg;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -239,6 +253,51 @@ public sealed class AlgoEngine : BackgroundService
                 {
                     rt.PovMarketVolumeSeen = 0;
                     rt.PovLastEvaluateAtUtc = ppRec.StartUtc;
+                }
+            }
+
+            // Pass-1 review (#296) P1-C. Restore an in-flight Pegged
+            // repeg cycle: a cancel was emitted pre-restart but the
+            // cancel-ack ER may or may not have been replayed.
+            //
+            // * Always set the sticky LastRepegCancelledChildId so any
+            //   stray ER for that child is classified as expected by
+            //   OnChildErAsync (no Suspended/VenueCancelled false
+            //   positive).
+            // * Set RepegPending=true ONLY when the cancelled child is
+            //   still live in the order book — i.e. the cancel-ack has
+            //   not been replayed yet. In that case OnCreatedAsync
+            //   reactor evaluation will see the live child and
+            //   EvaluatePeggedRepegAsync will short-circuit (throttle)
+            //   until the ER actually arrives; that ER then routes
+            //   through SubmitNextSliceAsync via the RepegPending
+            //   branch.
+            // * If the cancel-ack already replayed (old child terminal,
+            //   no live child), Reconcile leaves rt.LiveChildClOrdId
+            //   null + RepegPending=false so the re-enqueued
+            //   AlgoCreatedSignal drives a fresh slice via the empty-
+            //   slot path. The book entry is dropped to keep state
+            //   bounded; replay of any older Started event without a
+            //   matching Resolved is interpreted as "cycle completed".
+            if (algo.Type == AlgoType.Pegged && _peggedRepeg is not null)
+            {
+                var pending = _peggedRepeg.TryGet(algo.FirmId, algo.AlgoId);
+                if (pending is { } pgd)
+                {
+                    rt.LastRepegCancelledChildId = pgd.CancelledChildClOrdId;
+                    var stillLive = _orders.TryGet(pgd.CancelledChildClOrdId, out var oldChild)
+                                    && oldChild is not null
+                                    && !IsChildTerminal(oldChild);
+                    if (stillLive)
+                    {
+                        rt.RepegPending = true;
+                    }
+                    else
+                    {
+                        // Cycle effectively complete; drop the book
+                        // entry so the next snapshot doesn't carry it.
+                        _peggedRepeg.Remove(algo.FirmId, algo.AlgoId);
+                    }
                 }
             }
 
@@ -566,20 +625,68 @@ public sealed class AlgoEngine : BackgroundService
                     // landed before the cancel-ack.
                     await RecordTerminalAsync(algo, rt, AlgoStatus.Cancelled, AlgoTerminalReason.UserCancelled).ConfigureAwait(false);
                 }
-                else if (rt.RepegPending && algo.Type == AlgoType.Pegged)
+                else if (rt.RepegPending && algo.Type == AlgoType.Pegged
+                         && rt.LastRepegCancelledChildId == child.ClOrdId)
                 {
                     // Q3.3 (#283). Engine-initiated cancel for a repeg —
                     // the cancel-ack is the signal to place the new
                     // child at the fresh target. Clear the flag first
                     // so a second cancel-ack (shouldn't happen but is
                     // cheap to defend) doesn't loop into a double-place.
+                    //
+                    // Pass-1 review (#296) P1-A. Match strictly on the
+                    // cancelled child id so a Cancelled ER that arrives
+                    // for some OTHER live child (operator race,
+                    // venue-initiated cancel for a different slice) is
+                    // still routed through the VenueCancelled branch.
                     rt.RepegPending = false;
+
+                    // Persist the resolution: clears the pending entry
+                    // in PeggedRepegBook (recovery convergence) +
+                    // serves as an audit pair to the Started event.
+                    // Best-effort: WAL backpressure here leaves the
+                    // book entry in place; the next Reconcile will
+                    // observe the old child terminal and drop it
+                    // defensively.
+                    try
+                    {
+                        var firmIdSnap = algo.FirmId;
+                        var algoIdSnap = algo.AlgoId;
+                        var cancelledIdSnap = child.ClOrdId;
+                        var book = _peggedRepeg;
+                        _dispatcher.Dispatch(
+                            new AlgoPeggedRepegResolvedEvent
+                            {
+                                AlgoId = algo.AlgoId,
+                                FirmId = algo.FirmId,
+                                CancelledChildClOrdId = child.ClOrdId,
+                                AtUtc = _clock.GetUtcNow(),
+                            },
+                            () => book?.Remove(firmIdSnap, algoIdSnap));
+                    }
+                    catch (WalBackpressureException)
+                    {
+                        MetricsRegistry.WalBackpressure.Add(1,
+                            new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved"));
+                    }
+
                     if (algo.RemainingQuantity <= 0)
                     {
                         await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
                         return;
                     }
                     await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
+                }
+                else if (algo.Type == AlgoType.Pegged
+                         && rt.LastRepegCancelledChildId == child.ClOrdId)
+                {
+                    // Pass-1 review (#296) P1-A. Duplicate / late
+                    // Cancelled ER for a child we already cancelled
+                    // for a repeg (the marker is sticky across the
+                    // RepegPending flag clear). Treat as a no-op so
+                    // the parent does NOT fall through to the
+                    // VenueCancelled branch and get suspended.
+                    return;
                 }
                 else if (IsTwapWindowExpired(algo))
                 {
@@ -978,6 +1085,13 @@ public sealed class AlgoEngine : BackgroundService
         {
             _povProgress?.Remove(algo.FirmId, algo.AlgoId);
         }
+        // Pass-1 review (#296) P1-C. Drop any in-flight repeg marker
+        // for a Pegged parent on terminal so the book stays bounded
+        // and the next snapshot doesn't carry stale state.
+        if (algo.Type == AlgoType.Pegged)
+        {
+            _peggedRepeg?.Remove(algo.FirmId, algo.AlgoId);
+        }
         await Task.CompletedTask;
     }
 
@@ -1087,6 +1201,19 @@ public sealed class AlgoEngine : BackgroundService
         Algo algo, AlgoParentRuntime rt, PeggedParameters pgp,
         ulong liveChildClOrdId, CancellationToken ct)
     {
+        // Pass-1 review (#296) P1-B. If a prior repeg cycle is still
+        // in flight (cancel emitted, ack not yet consumed) skip the
+        // evaluation entirely. Without this guard a delayed cancel-
+        // ack (slow venue, queue backpressure) past RepegInterval
+        // would let the next scheduler tick issue ANOTHER cancel
+        // for the same already-cancel-pending child — a cancel storm
+        // that produces multiple replacement children racing into
+        // the book. Do NOT advance PeggedLastEvalUtc here: the
+        // throttle anchor is unrelated to in-flight cycles, and
+        // bumping it would mask the next legitimate drift eval once
+        // the cycle completes.
+        if (rt.RepegPending) return;
+
         var now = _clock.GetUtcNow();
         if (rt.PeggedLastEvalUtc != default
             && (now - rt.PeggedLastEvalUtc) < pgp.RepegInterval)
@@ -1126,10 +1253,52 @@ public sealed class AlgoEngine : BackgroundService
         // different consumer-loop iteration) doesn't race the flag
         // and route through the VenueCancelled-suspension path.
         rt.RepegPending = true;
+        // Pass-1 review (#296) P1-A. Sticky marker of the cancelled
+        // child id, used by OnChildErAsync to classify ANY Cancelled
+        // ER for this child (initial ack + any duplicate/late ER)
+        // as "expected" so the parent doesn't suspend.
+        rt.LastRepegCancelledChildId = liveChildClOrdId;
         rt.PeggedLastEvalUtc = now;
         var oldChildPrice = currentPrice;
         var refForAudit = _pegBookTop?.TryGet(algo.Symbol)?.RefPrice(pgp.Ref, algo.Side) ?? 0m;
         var newClOrdId = _clOrdIds.Generate(child.Owner);
+
+        // Pass-1 review (#296) P1-C. Persist the pre-cancel marker
+        // BEFORE the gateway wire-call so a crash between WAL append
+        // and the actual venue cancel still leaves enough trail for
+        // recovery to know "a repeg cycle was intended" — and treat
+        // any subsequent Cancelled ER for this child as expected.
+        // Best-effort: WAL backpressure clears the local flags so
+        // the next tick retries from a clean state (same fall-back
+        // policy as the audit envelope below).
+        try
+        {
+            var firmIdSnap = algo.FirmId;
+            var algoIdSnap = algo.AlgoId;
+            var cancelledIdSnap = liveChildClOrdId;
+            var targetSnap = target.Value;
+            var atUtcSnap = now;
+            var book = _peggedRepeg;
+            _dispatcher.Dispatch(
+                new AlgoPeggedRepegStartedEvent
+                {
+                    AlgoId = algo.AlgoId,
+                    FirmId = algo.FirmId,
+                    CancelledChildClOrdId = liveChildClOrdId,
+                    NewClOrdId = newClOrdId,
+                    TargetPrice = target.Value,
+                    AtUtc = now,
+                },
+                () => book?.Set(firmIdSnap, algoIdSnap, cancelledIdSnap, targetSnap, atUtcSnap));
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-started"));
+            rt.RepegPending = false;
+            return;
+        }
+
         try
         {
             _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
@@ -1333,5 +1502,16 @@ public sealed class AlgoEngine : BackgroundService
         // (place new) rather than the VenueCancelled-suspension path.
         public DateTimeOffset PeggedLastEvalUtc;
         public bool RepegPending;
+
+        // Pass-1 review (#296) P1-A. Sticky marker: the ClOrdId of
+        // the most recent engine-initiated cancel issued for a
+        // pegged repeg cycle. Set BEFORE the cancel wire-call (in
+        // EvaluatePeggedRepegAsync) and never cleared during normal
+        // lifecycle — a new repeg cycle overwrites it. Cleared on
+        // parent terminal. Used by OnChildErAsync to classify any
+        // Cancelled ER whose child-id matches this marker as
+        // "expected cancel" (so duplicate or post-restart-delayed
+        // ERs do not flip the parent to Suspended/VenueCancelled).
+        public ulong? LastRepegCancelledChildId;
     }
 }

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -167,7 +167,29 @@ public sealed class AlgoScheduler : BackgroundService
                 TickPov(algo, pp, now);
                 continue;
             }
+
+            if (algo.Type == AlgoType.Pegged && algo.Parameters is PeggedParameters pgp)
+            {
+                TickPegged(algo, pgp, now);
+                continue;
+            }
         }
+    }
+
+    /// <summary>
+    /// Q3.3 (#283). Pegged tick: enqueue an <see cref="AlgoCreatedSignal"/>
+    /// unconditionally so the engine re-evaluates the live reference
+    /// price. No window/expiry gate (Pegged runs until Filled or DELETE);
+    /// no live-child gate (the engine has to evaluate exactly when there
+    /// IS a live child — that's the repeg path); no per-slice gate
+    /// (single working slice). All throttling lives in the engine via
+    /// <c>PeggedLastEvalUtc</c> + <c>RepegInterval</c> for symmetry with
+    /// VWAP/POV which also catch up in the engine.
+    /// </summary>
+    private void TickPegged(Algo algo, PeggedParameters pgp, DateTimeOffset now)
+    {
+        _ = pgp; _ = now;
+        Enqueue(algo);
     }
 
     private void TickTwap(Algo algo, TwapParameters tp, DateTimeOffset now)

--- a/backend/src/B3.Trading.Application/Algo/PeggedPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedPlan.cs
@@ -1,0 +1,78 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pure helpers for the Pegged orders algo (Q3.3 / #283). The shape
+/// mirrors <see cref="PovPlan"/> / <see cref="VwapPlan"/>: every
+/// pricing decision is derivable from the parent parameters + a live
+/// reference price + the current child price, so the engine and any
+/// future scheduler thread can reproduce the same answer without
+/// sharing mutable state.
+///
+/// <para>
+/// <b>Target.</b> <c>target = round(ref + offsetTicks * tickSize)</c>.
+/// Rounded to <c>tickSize</c> so the venue never sees a sub-tick price.
+/// Caller is responsible for supplying a positive tick size.
+/// </para>
+///
+/// <para>
+/// <b>Repeg gate.</b> A repeg fires when the absolute distance between
+/// the current child price and the target is &gt;= one tick. Strict
+/// inequality at the boundary would oscillate against a market that
+/// drifts by exactly one tick.
+/// </para>
+///
+/// <para>
+/// <b>Price limit.</b> <see cref="ClampToLimit"/> mirrors
+/// <see cref="VwapPlan.ClampPrice"/>: for Buy side the engine never
+/// crosses above <c>priceLimit</c>; for Sell side it never crosses
+/// below. When the clamped target equals the current child price the
+/// caller skips the repeg (handled in the engine).
+/// </para>
+/// </summary>
+public static class PeggedPlan
+{
+    /// <summary>
+    /// Reference-price + offset → tick-aligned target. Returns <c>null</c>
+    /// when <paramref name="refPrice"/> is <c>null</c> (no live ref).
+    /// </summary>
+    public static decimal? ComputeTarget(decimal? refPrice, int offsetTicks, decimal tickSize)
+    {
+        if (tickSize <= 0m)
+            throw new ArgumentOutOfRangeException(nameof(tickSize), "tickSize must be positive.");
+        if (refPrice is null) return null;
+        var raw = refPrice.Value + offsetTicks * tickSize;
+        // Round to nearest tick (banker's rounding) so the venue never
+        // sees a sub-tick price after the offset arithmetic. Using
+        // AwayFromZero would bias every other repeg by a tick in
+        // pathological cases (ref sitting exactly on a half-tick).
+        var ticks = Math.Round(raw / tickSize, MidpointRounding.ToEven);
+        return ticks * tickSize;
+    }
+
+    /// <summary>
+    /// True when the live working slice has drifted at least one tick
+    /// away from <paramref name="targetPrice"/>. The <c>&gt;= 1 tick</c>
+    /// tolerance is the spec for #283 ("differs from target by ≥ 1 tick").
+    /// </summary>
+    public static bool IsRepegNeeded(decimal currentPrice, decimal targetPrice, decimal tickSize)
+    {
+        if (tickSize <= 0m)
+            throw new ArgumentOutOfRangeException(nameof(tickSize));
+        return Math.Abs(currentPrice - targetPrice) >= tickSize;
+    }
+
+    /// <summary>
+    /// Applies <paramref name="priceLimit"/> as a hard side-aware clamp.
+    /// Mirrors <see cref="VwapPlan.ClampPrice"/>. When the limit is
+    /// <c>null</c> the target is returned unchanged.
+    /// </summary>
+    public static decimal ClampToLimit(decimal targetPrice, decimal? priceLimit, OrderSide side)
+    {
+        if (priceLimit is null) return targetPrice;
+        return side == OrderSide.Buy
+            ? Math.Min(targetPrice, priceLimit.Value)
+            : Math.Max(targetPrice, priceLimit.Value);
+    }
+}

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -161,22 +161,30 @@ public sealed class PeggedRepegBook
     }
 
     /// <summary>
-    /// Pass-5 review (#296) P1. Snapshot the cancelled-child history
-    /// rings so a restart between repeg cycles preserves the late-ER
-    /// dedup protection.
+    /// Pass-5 review (#296) P1, revised pass-7 (#296) P2. Snapshot the
+    /// cancelled-child history rings so a restart between repeg cycles
+    /// preserves the late-ER dedup protection. Also captures the
+    /// per-ring "one-shot eviction warn already emitted" latch so a
+    /// parent that has already warned does NOT warn again post-restart.
     /// </summary>
-    public IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds)> SnapshotHistory()
+    public IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds, bool EvictionLogged)> SnapshotHistory()
     {
         foreach (var kv in _history)
-            yield return (kv.Key.FirmId, kv.Key.AlgoId, kv.Value.Snapshot());
+        {
+            var (ids, logged) = kv.Value.SnapshotWithLatch();
+            yield return (kv.Key.FirmId, kv.Key.AlgoId, ids, logged);
+        }
     }
 
     /// <summary>
-    /// Pass-5 review (#296) P1. Restore cancelled-child history rings
-    /// from a snapshot. Order within each row is FIFO oldest→newest so
-    /// the cap-eviction order survives the round-trip.
+    /// Pass-5 review (#296) P1, revised pass-7 (#296) P2. Restore
+    /// cancelled-child history rings from a snapshot. Order within each
+    /// row is FIFO oldest→newest so the cap-eviction order survives the
+    /// round-trip. <paramref name="rows"/>' <c>EvictionLogged</c> flag
+    /// rehydrates the one-shot warn latch so a parent that had already
+    /// warned pre-restart stays silent post-restart.
     /// </summary>
-    public void RestoreHistory(IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds)> rows)
+    public void RestoreHistory(IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds, bool EvictionLogged)> rows)
     {
         ArgumentNullException.ThrowIfNull(rows);
         _history.Clear();
@@ -184,6 +192,7 @@ public sealed class PeggedRepegBook
         {
             var ring = new CancelledChildRing(CancelledHistoryCap);
             foreach (var id in r.ChildClOrdIds) ring.Add(id);
+            if (r.EvictionLogged) ring.MarkEvictionLogged();
             _history[(r.FirmId, r.AlgoId)] = ring;
         }
     }
@@ -258,6 +267,17 @@ internal sealed class CancelledChildRing
     public IReadOnlyList<ulong> Snapshot()
     {
         lock (_lock) return _order.ToArray();
+    }
+
+    /// <summary>
+    /// Pass-7 review (#296) P2. Atomic snapshot of the FIFO contents
+    /// AND the per-ring one-shot eviction-warn latch, so a restart
+    /// preserves both the dedup memory and the "we've already warned
+    /// for this parent" suppression.
+    /// </summary>
+    public (IReadOnlyList<ulong> Ids, bool EvictionLogged) SnapshotWithLatch()
+    {
+        lock (_lock) return (_order.ToArray(), _evictionLogged);
     }
 }
 

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Pass-1 review (#296) P1-C — Pegged repeg-cycle restart resilience.
+///
+/// <para>
+/// Per-Pegged-parent record of an in-flight repeg cycle: which child
+/// the engine cancelled, what target the replacement is being placed
+/// at, and when. Populated by:
+/// <list type="bullet">
+///   <item>engine <see cref="AlgoEngine"/>
+///         <c>EvaluatePeggedRepegAsync</c> via the
+///         <see cref="Persistence.AlgoPeggedRepegStartedEvent"/>
+///         dispatch action (steady-state path), and</item>
+///   <item>WAL replay in
+///         <see cref="B3.Trading.Infrastructure.Persistence.EventReplayer"/>
+///         on the same event (recovery path).</item>
+/// </list>
+/// Cleared by <see cref="Persistence.AlgoPeggedRepegResolvedEvent"/>
+/// once the engine has consumed the cancel-ack and submitted the
+/// replacement, and by terminal transitions
+/// (<see cref="AlgoEngine.RecordTerminalAsync"/>).
+/// </para>
+///
+/// <para>
+/// <b>Why this is not part of the <see cref="Algo"/> aggregate.</b>
+/// The pending-repeg record is engine-internal scheduling state, not
+/// part of the parent's business identity (mirrors the rationale on
+/// <see cref="PovProgressBook"/>). Keeping it in a side book lets the
+/// persistence shape evolve independently of
+/// <see cref="Persistence.AlgoCreatedEvent"/> /
+/// <see cref="Persistence.AlgoSnapshot"/>.
+/// </para>
+/// </summary>
+public sealed class PeggedRepegBook
+{
+    private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), PeggedRepegPending> _entries = new();
+
+    public PeggedRepegPending? TryGet(string firmId, ulong algoId) =>
+        _entries.TryGetValue((firmId, algoId), out var e) ? e : null;
+
+    /// <summary>
+    /// Last-write-wins; a new cycle overwrites any prior pending
+    /// entry. Engine guarantees only one cycle is in-flight per
+    /// parent (the <c>RepegPending</c> throttle blocks).
+    /// </summary>
+    public void Set(string firmId, ulong algoId, ulong cancelledChildClOrdId, decimal targetPrice, DateTimeOffset atUtc) =>
+        _entries[(firmId, algoId)] = new PeggedRepegPending(cancelledChildClOrdId, targetPrice, atUtc);
+
+    public bool Remove(string firmId, ulong algoId) =>
+        _entries.TryRemove((firmId, algoId), out _);
+
+    public IEnumerable<(string FirmId, ulong AlgoId, PeggedRepegPending Pending)> Snapshot()
+    {
+        foreach (var kv in _entries)
+            yield return (kv.Key.FirmId, kv.Key.AlgoId, kv.Value);
+    }
+
+    public void Restore(IEnumerable<(string FirmId, ulong AlgoId, PeggedRepegPending Pending)> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        _entries.Clear();
+        foreach (var r in rows)
+            _entries[(r.FirmId, r.AlgoId)] = r.Pending;
+    }
+}
+
+public readonly record struct PeggedRepegPending(
+    ulong CancelledChildClOrdId,
+    decimal TargetPrice,
+    DateTimeOffset AtUtc);

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using B3.Trading.Application.Observability;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Application;
 
@@ -37,16 +39,38 @@ namespace B3.Trading.Application;
 public sealed class PeggedRepegBook
 {
     /// <summary>
-    /// Pass-5 review (#296) P1. FIFO cap on the per-parent set of
-    /// recently engine-cancelled child clOrdIds. Bounds the late-ER
-    /// dedup memory; the venue is not expected to deliver ERs for
-    /// children older than this many repeg cycles back. Tuned at 32
-    /// (~32 repegs ≈ several seconds of drift on a 100 ms throttle).
+    /// Pass-5 review (#296) P1, revised pass-6 (#296) P2. FIFO cap on
+    /// the per-parent set of recently engine-cancelled child clOrdIds.
+    /// Bounds the late-ER dedup memory.
+    ///
+    /// <para>
+    /// <b>Cap vs venue-tail-latency trade-off.</b> The Pegged scheduler
+    /// runs on a 100 ms cadence, so the cap × 100 ms is roughly the
+    /// upper bound on how long after engine-issued cancel a venue may
+    /// still deliver a terminal ER for the cancelled child and have it
+    /// be recognised as "expected terminal" (vs. falling through to
+    /// the <c>VenueCancelled</c> branch and suspending the parent).
+    /// 32 (the pass-5 value) only covered ~3.2 s of tail; 256 covers
+    /// ~25 s which comfortably absorbs the typical venue-side ER tail
+    /// while staying bounded in memory (a per-parent
+    /// <see cref="HashSet{T}"/> + <see cref="Queue{T}"/> of ulongs).
+    /// Overflow beyond this window is observable via
+    /// <see cref="MetricsRegistry.AlgoPeggedRepegDedupRingEvicted"/>
+    /// (counter) and a one-shot warn log per parent — operators
+    /// should treat sustained eviction as a signal the cap needs
+    /// bumping further.
+    /// </para>
     /// </summary>
-    public const int CancelledHistoryCap = 32;
+    public const int CancelledHistoryCap = 256;
 
+    private readonly ILogger<PeggedRepegBook>? _logger;
     private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), PeggedRepegPending> _entries = new();
     private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), CancelledChildRing> _history = new();
+
+    public PeggedRepegBook(ILogger<PeggedRepegBook>? logger = null)
+    {
+        _logger = logger;
+    }
 
     public PeggedRepegPending? TryGet(string firmId, ulong algoId) =>
         _entries.TryGetValue((firmId, algoId), out var e) ? e : null;
@@ -90,7 +114,25 @@ public sealed class PeggedRepegBook
     public void MarkCancelledChild(string firmId, ulong algoId, ulong childClOrdId)
     {
         var ring = _history.GetOrAdd((firmId, algoId), static _ => new CancelledChildRing(CancelledHistoryCap));
-        ring.Add(childClOrdId);
+        if (ring.Add(childClOrdId))
+        {
+            // Pass-6 review (#296) P2. Ring eviction is silent w.r.t.
+            // the engine: the oldest child id falls out and any
+            // subsequent late terminal ER for it will no longer
+            // dedup (parent gets suspended via VenueCancelled). Make
+            // it observable with a counter, and emit a single warn
+            // per parent to surface the situation without spamming
+            // logs once we're past the cap.
+            MetricsRegistry.AlgoPeggedRepegDedupRingEvicted.Add(1);
+            if (!ring.MarkEvictionLogged())
+            {
+                _logger?.LogWarning(
+                    "PeggedRepegBook dedup ring overflow on firm {FirmId} algo {AlgoId}: oldest cancelled-child id evicted from {Cap}-entry FIFO. Late terminal ERs for evicted children will fall through to VenueCancelled; consider raising CancelledHistoryCap if this is sustained.",
+                    firmId,
+                    algoId,
+                    CancelledHistoryCap);
+            }
+        }
     }
 
     /// <summary>
@@ -160,6 +202,7 @@ internal sealed class CancelledChildRing
     private readonly Queue<ulong> _order;
     private readonly HashSet<ulong> _set;
     private readonly object _lock = new();
+    private bool _evictionLogged;
 
     public CancelledChildRing(int cap)
     {
@@ -168,17 +211,42 @@ internal sealed class CancelledChildRing
         _set = new HashSet<ulong>(cap);
     }
 
-    public void Add(ulong id)
+    /// <summary>
+    /// Adds <paramref name="id"/> to the FIFO. Returns <c>true</c> iff
+    /// the insert caused at least one older entry to be evicted to
+    /// honour the cap (so callers can surface eviction via metrics /
+    /// logs). Duplicates and no-op inserts return <c>false</c>.
+    /// </summary>
+    public bool Add(ulong id)
     {
         lock (_lock)
         {
-            if (!_set.Add(id)) return;
+            if (!_set.Add(id)) return false;
             _order.Enqueue(id);
+            var evicted = false;
             while (_order.Count > _cap)
             {
-                var evicted = _order.Dequeue();
-                _set.Remove(evicted);
+                var dropped = _order.Dequeue();
+                _set.Remove(dropped);
+                evicted = true;
             }
+            return evicted;
+        }
+    }
+
+    /// <summary>
+    /// Atomically flips the per-ring "we've already warn-logged about
+    /// eviction on this parent" flag. Returns the PREVIOUS value:
+    /// <c>false</c> on the first call (caller should log),
+    /// <c>true</c> on every subsequent call (caller should suppress).
+    /// </summary>
+    public bool MarkEvictionLogged()
+    {
+        lock (_lock)
+        {
+            var prev = _evictionLogged;
+            _evictionLogged = true;
+            return prev;
         }
     }
 

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -114,7 +114,7 @@ public sealed class PeggedRepegBook
     public void MarkCancelledChild(string firmId, ulong algoId, ulong childClOrdId)
     {
         var ring = _history.GetOrAdd((firmId, algoId), static _ => new CancelledChildRing(CancelledHistoryCap));
-        if (ring.Add(childClOrdId))
+        if (ring.Add(childClOrdId, out var firstEviction))
         {
             // Pass-6 review (#296) P2. Ring eviction is silent w.r.t.
             // the engine: the oldest child id falls out and any
@@ -123,8 +123,18 @@ public sealed class PeggedRepegBook
             // it observable with a counter, and emit a single warn
             // per parent to surface the situation without spamming
             // logs once we're past the cap.
+            //
+            // Pass-8 review (#296) P2. The latch flip happens INSIDE
+            // <see cref="CancelledChildRing.Add"/> under the ring's
+            // own lock so that any concurrent
+            // <see cref="CancelledChildRing.SnapshotWithLatch"/>
+            // observes the eviction and the EvictionLogged=true latch
+            // as a single atomic step — eliminating the window where
+            // a snapshot captured EvictionLogged=false despite the
+            // eviction having already happened (which would cause a
+            // duplicate warn after a restart).
             MetricsRegistry.AlgoPeggedRepegDedupRingEvicted.Add(1);
-            if (!ring.MarkEvictionLogged())
+            if (firstEviction)
             {
                 _logger?.LogWarning(
                     "PeggedRepegBook dedup ring overflow on firm {FirmId} algo {AlgoId}: oldest cancelled-child id evicted from {Cap}-entry FIFO. Late terminal ERs for evicted children will fall through to VenueCancelled; consider raising CancelledHistoryCap if this is sustained.",
@@ -191,7 +201,7 @@ public sealed class PeggedRepegBook
         foreach (var r in rows)
         {
             var ring = new CancelledChildRing(CancelledHistoryCap);
-            foreach (var id in r.ChildClOrdIds) ring.Add(id);
+            foreach (var id in r.ChildClOrdIds) ring.Add(id, out _);
             if (r.EvictionLogged) ring.MarkEvictionLogged();
             _history[(r.FirmId, r.AlgoId)] = ring;
         }
@@ -225,11 +235,27 @@ internal sealed class CancelledChildRing
     /// the insert caused at least one older entry to be evicted to
     /// honour the cap (so callers can surface eviction via metrics /
     /// logs). Duplicates and no-op inserts return <c>false</c>.
+    ///
+    /// <para>
+    /// Pass-8 review (#296) P2. <paramref name="firstEviction"/> is
+    /// set to <c>true</c> iff this call BOTH evicted at least one
+    /// entry AND was the first call on this ring to do so — i.e.
+    /// the per-ring one-shot eviction-warn latch was flipped from
+    /// <c>false</c> to <c>true</c> as part of this same lock
+    /// acquisition. Callers MUST gate their one-shot warn log on
+    /// <paramref name="firstEviction"/> rather than calling
+    /// <see cref="MarkEvictionLogged"/> separately, so that any
+    /// concurrent <see cref="SnapshotWithLatch"/> sees the eviction
+    /// and the latched flag atomically (avoids capturing
+    /// <c>EvictionLogged=false</c> after an eviction, which would
+    /// re-emit the warn post-restart).
+    /// </para>
     /// </summary>
-    public bool Add(ulong id)
+    public bool Add(ulong id, out bool firstEviction)
     {
         lock (_lock)
         {
+            firstEviction = false;
             if (!_set.Add(id)) return false;
             _order.Enqueue(id);
             var evicted = false;
@@ -239,15 +265,24 @@ internal sealed class CancelledChildRing
                 _set.Remove(dropped);
                 evicted = true;
             }
+            if (evicted && !_evictionLogged)
+            {
+                _evictionLogged = true;
+                firstEviction = true;
+            }
             return evicted;
         }
     }
 
     /// <summary>
-    /// Atomically flips the per-ring "we've already warn-logged about
-    /// eviction on this parent" flag. Returns the PREVIOUS value:
-    /// <c>false</c> on the first call (caller should log),
-    /// <c>true</c> on every subsequent call (caller should suppress).
+    /// Flips the per-ring one-shot eviction-warn latch unconditionally
+    /// and returns the previous value. Reserved for restore paths
+    /// (<see cref="PeggedRepegBook.RestoreHistory"/>) that need to
+    /// rehydrate a pre-restart latched state without going through
+    /// <see cref="Add"/>. Steady-state callers must use the
+    /// <c>firstEviction</c> out-parameter on <see cref="Add"/> so the
+    /// latch flip and the eviction are observed atomically by
+    /// <see cref="SnapshotWithLatch"/>.
     /// </summary>
     public bool MarkEvictionLogged()
     {

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -36,7 +36,17 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class PeggedRepegBook
 {
+    /// <summary>
+    /// Pass-5 review (#296) P1. FIFO cap on the per-parent set of
+    /// recently engine-cancelled child clOrdIds. Bounds the late-ER
+    /// dedup memory; the venue is not expected to deliver ERs for
+    /// children older than this many repeg cycles back. Tuned at 32
+    /// (~32 repegs ≈ several seconds of drift on a 100 ms throttle).
+    /// </summary>
+    public const int CancelledHistoryCap = 32;
+
     private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), PeggedRepegPending> _entries = new();
+    private readonly ConcurrentDictionary<(string FirmId, ulong AlgoId), CancelledChildRing> _history = new();
 
     public PeggedRepegPending? TryGet(string firmId, ulong algoId) =>
         _entries.TryGetValue((firmId, algoId), out var e) ? e : null;
@@ -52,6 +62,48 @@ public sealed class PeggedRepegBook
     public bool Remove(string firmId, ulong algoId) =>
         _entries.TryRemove((firmId, algoId), out _);
 
+    /// <summary>
+    /// Pass-5 review (#296) P1. Drop both the pending entry AND the
+    /// cancelled-child history for a parent — used on terminal so the
+    /// book stays bounded.
+    /// </summary>
+    public void RemoveAll(string firmId, ulong algoId)
+    {
+        var key = (firmId, algoId);
+        _entries.TryRemove(key, out _);
+        _history.TryRemove(key, out _);
+    }
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Record that the engine has issued (or
+    /// is about to issue) a cancel for <paramref name="childClOrdId"/>
+    /// as part of a repeg cycle. Idempotent; the bounded FIFO trims
+    /// the oldest entry when the cap is exceeded. Source of truth for
+    /// the late-ER dedup branches in <c>AlgoEngine.OnChildErAsync</c>:
+    /// a terminal ER whose child id is in this set is "expected
+    /// terminal for an engine-initiated cancel" rather than a
+    /// venue-cancel surprise — so the parent is NOT flipped to
+    /// Suspended/VenueCancelled even when the ER arrives after the
+    /// cycle has already been resolved or after a subsequent repeg
+    /// has rotated the single-slot active-cycle marker.
+    /// </summary>
+    public void MarkCancelledChild(string firmId, ulong algoId, ulong childClOrdId)
+    {
+        var ring = _history.GetOrAdd((firmId, algoId), static _ => new CancelledChildRing(CancelledHistoryCap));
+        ring.Add(childClOrdId);
+    }
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Returns true when the child id was
+    /// recorded by an earlier <see cref="MarkCancelledChild"/> call
+    /// (and has not been trimmed out by the FIFO cap or dropped on
+    /// parent terminal via <see cref="RemoveAll"/>).
+    /// </summary>
+    public bool IsCancelledChild(string firmId, ulong algoId, ulong childClOrdId)
+    {
+        return _history.TryGetValue((firmId, algoId), out var ring) && ring.Contains(childClOrdId);
+    }
+
     public IEnumerable<(string FirmId, ulong AlgoId, PeggedRepegPending Pending)> Snapshot()
     {
         foreach (var kv in _entries)
@@ -64,6 +116,80 @@ public sealed class PeggedRepegBook
         _entries.Clear();
         foreach (var r in rows)
             _entries[(r.FirmId, r.AlgoId)] = r.Pending;
+    }
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Snapshot the cancelled-child history
+    /// rings so a restart between repeg cycles preserves the late-ER
+    /// dedup protection.
+    /// </summary>
+    public IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds)> SnapshotHistory()
+    {
+        foreach (var kv in _history)
+            yield return (kv.Key.FirmId, kv.Key.AlgoId, kv.Value.Snapshot());
+    }
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Restore cancelled-child history rings
+    /// from a snapshot. Order within each row is FIFO oldest→newest so
+    /// the cap-eviction order survives the round-trip.
+    /// </summary>
+    public void RestoreHistory(IEnumerable<(string FirmId, ulong AlgoId, IReadOnlyList<ulong> ChildClOrdIds)> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        _history.Clear();
+        foreach (var r in rows)
+        {
+            var ring = new CancelledChildRing(CancelledHistoryCap);
+            foreach (var id in r.ChildClOrdIds) ring.Add(id);
+            _history[(r.FirmId, r.AlgoId)] = ring;
+        }
+    }
+}
+
+/// <summary>
+/// Pass-5 review (#296) P1. Bounded FIFO set of cancelled-child
+/// clOrdIds backing <see cref="PeggedRepegBook.MarkCancelledChild"/>.
+/// Thread-safe (engine calls happen on the consumer task, snapshot
+/// captures under the dispatcher lock, but a defensive lock keeps
+/// readers from observing a torn state during a concurrent Add).
+/// </summary>
+internal sealed class CancelledChildRing
+{
+    private readonly int _cap;
+    private readonly Queue<ulong> _order;
+    private readonly HashSet<ulong> _set;
+    private readonly object _lock = new();
+
+    public CancelledChildRing(int cap)
+    {
+        _cap = cap;
+        _order = new Queue<ulong>(cap);
+        _set = new HashSet<ulong>(cap);
+    }
+
+    public void Add(ulong id)
+    {
+        lock (_lock)
+        {
+            if (!_set.Add(id)) return;
+            _order.Enqueue(id);
+            while (_order.Count > _cap)
+            {
+                var evicted = _order.Dequeue();
+                _set.Remove(evicted);
+            }
+        }
+    }
+
+    public bool Contains(ulong id)
+    {
+        lock (_lock) return _set.Contains(id);
+    }
+
+    public IReadOnlyList<ulong> Snapshot()
+    {
+        lock (_lock) return _order.ToArray();
     }
 }
 

--- a/backend/src/B3.Trading.Application/AlgoBook.cs
+++ b/backend/src/B3.Trading.Application/AlgoBook.cs
@@ -153,6 +153,12 @@ public sealed class AlgoBook
         long? povTickIntervalTicks = null;
         decimal? povPriceLimit = null;
         long? povMinSliceQty = null;
+        string? peggedRef = null;
+        int? peggedOffsetTicks = null;
+        long? peggedRepegIntervalTicks = null;
+        decimal? peggedTickSize = null;
+        string? peggedChildType = null;
+        decimal? peggedPriceLimit = null;
 
         switch (a.Parameters)
         {
@@ -187,6 +193,14 @@ public sealed class AlgoBook
                 povPriceLimit = pp.PriceLimit;
                 povMinSliceQty = pp.MinSliceQty;
                 break;
+            case PeggedParameters pgp:
+                peggedRef = pgp.Ref.ToString();
+                peggedOffsetTicks = pgp.OffsetTicks;
+                peggedRepegIntervalTicks = pgp.RepegInterval.Ticks;
+                peggedTickSize = pgp.TickSize;
+                peggedChildType = pgp.ChildOrderType.ToString();
+                peggedPriceLimit = pgp.PriceLimit;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -199,7 +213,9 @@ public sealed class AlgoBook
             vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
             vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap,
             povStart, povEnd, povChildType, povChildPrice,
-            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty);
+            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty,
+            peggedRef, peggedOffsetTicks, peggedRepegIntervalTicks, peggedTickSize,
+            peggedChildType, peggedPriceLimit);
     }
 
     public void Restore(IEnumerable<Persistence.AlgoSnapshot> snaps)
@@ -245,6 +261,12 @@ public sealed class AlgoBook
         long? povTickIntervalTicks = null;
         decimal? povPriceLimit = null;
         long? povMinSliceQty = null;
+        string? peggedRef = null;
+        int? peggedOffsetTicks = null;
+        long? peggedRepegIntervalTicks = null;
+        decimal? peggedTickSize = null;
+        string? peggedChildType = null;
+        decimal? peggedPriceLimit = null;
 
         switch (a.Parameters)
         {
@@ -279,6 +301,14 @@ public sealed class AlgoBook
                 povPriceLimit = pp.PriceLimit;
                 povMinSliceQty = pp.MinSliceQty;
                 break;
+            case PeggedParameters pgp:
+                peggedRef = pgp.Ref.ToString();
+                peggedOffsetTicks = pgp.OffsetTicks;
+                peggedRepegIntervalTicks = pgp.RepegInterval.Ticks;
+                peggedTickSize = pgp.TickSize;
+                peggedChildType = pgp.ChildOrderType.ToString();
+                peggedPriceLimit = pgp.PriceLimit;
+                break;
         }
 
         return new Persistence.AlgoSnapshot(
@@ -291,7 +321,9 @@ public sealed class AlgoBook
             vwapStart, vwapEnd, vwapChildType, vwapChildPrice,
             vwapTickIntervalTicks, vwapSliceMaxPct, vwapPriceLimit, vwapParticipationCap,
             povStart, povEnd, povChildType, povChildPrice,
-            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty);
+            povParticipationRate, povTickIntervalTicks, povPriceLimit, povMinSliceQty,
+            peggedRef, peggedOffsetTicks, peggedRepegIntervalTicks, peggedTickSize,
+            peggedChildType, peggedPriceLimit);
     }
 
     internal static Algo FromSnapshot(Persistence.AlgoSnapshot s)
@@ -330,6 +362,13 @@ public sealed class AlgoBook
                 TimeSpan.FromTicks(s.PovTickIntervalTicks ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PovTickIntervalTicks.")),
                 s.PovPriceLimit,
                 s.PovMinSliceQty ?? 1L),
+            AlgoType.Pegged => new PeggedParameters(
+                Enum.Parse<PegRef>(s.PeggedRef ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PeggedRef.")),
+                s.PeggedOffsetTicks ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PeggedOffsetTicks."),
+                TimeSpan.FromTicks(s.PeggedRepegIntervalTicks ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PeggedRepegIntervalTicks.")),
+                s.PeggedTickSize ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PeggedTickSize."),
+                Enum.Parse<OrderType>(s.PeggedChildOrderType ?? throw new InvalidOperationException($"Algo {s.AlgoId} snapshot missing PeggedChildOrderType.")),
+                s.PeggedPriceLimit),
             _ => throw new InvalidOperationException($"Unknown algo type: {s.Type}"),
         };
         return Algo.Hydrate(s.AlgoId, owner, s.FirmId, s.Symbol, s.SecurityId,

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataPegBookPump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataPegBookPump.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.3 (#283). Bridges trade prints from <see cref="IMarketDataSubscriber"/>
+/// into the per-symbol <see cref="PegBookTopCache"/> so the Pegged algo
+/// engine can resolve a live reference price without coupling to the
+/// SDK. Sibling of <see cref="MarketDataVolumePump"/> for the volume
+/// curve — same lifecycle model: <see cref="IHostedService"/> so DI
+/// constructs the pump (and attaches its handler) before the subscriber
+/// starts its connect/subscribe loop.
+///
+/// <para>
+/// Also exposes <see cref="EnsureSubscribedAsync"/> so the engine can
+/// demand-subscribe to symbols a Pegged parent references but the
+/// static <c>Trading:MarketData:Symbols</c> list does not cover —
+/// otherwise the SDK never delivers prints, the cache stays empty, and
+/// the algo emits zero (re)pegs.
+/// </para>
+///
+/// <para>
+/// <b>SDK gap.</b> Today only <c>Trade</c> and <c>InfoSnapshot.LastTradePrice</c>
+/// drive the cache; the BBO legs in <see cref="BookTop"/> stay null
+/// until the SDK surfaces book-top frames. See
+/// <see cref="PegBookTopCache"/> for the fallback contract.
+/// </para>
+/// </summary>
+public sealed class MarketDataPegBookPump : IHostedService
+{
+    private readonly IMarketDataSubscriber _subscriber;
+    private readonly PegBookTopCache _cache;
+    private readonly ILogger<MarketDataPegBookPump>? _logger;
+
+    // Same coalescing strategy as MarketDataVolumePump. See its doc
+    // comments for the rationale (Lazy<Task> dedup + concurrent first
+    // call + failed-Subscribe cache eviction).
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _subscribed =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public MarketDataPegBookPump(
+        IMarketDataSubscriber subscriber,
+        PegBookTopCache cache,
+        ILogger<MarketDataPegBookPump>? logger = null)
+    {
+        _subscriber = subscriber;
+        _cache = cache;
+        _logger = logger;
+        _subscriber.Trade += OnTrade;
+        _subscriber.InfoSnapshot += OnInfoSnapshot;
+    }
+
+    private void OnTrade(MarketTrade t) =>
+        _cache.UpdateLast(t.Symbol, t.Price, t.ReceivedUtc);
+
+    private void OnInfoSnapshot(MarketInfoSnapshot s)
+    {
+        var px = s.LastTradePrice ?? s.TradingReferencePrice;
+        if (px is not { } p || p <= 0m) return;
+        _cache.UpdateLast(s.Symbol, p, s.ReceivedUtc);
+    }
+
+    public async ValueTask EnsureSubscribedAsync(string symbol, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        var key = symbol.Trim();
+        var lazy = _subscribed.GetOrAdd(key, k =>
+            new Lazy<Task>(() => SubscribeOnceAsync(k, ct)));
+        await lazy.Value.ConfigureAwait(false);
+    }
+
+    private async Task SubscribeOnceAsync(string key, CancellationToken ct)
+    {
+        try
+        {
+            await _subscriber.SubscribeAsync(key, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _subscribed.TryRemove(key, out _);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _subscribed.TryRemove(key, out _);
+            _logger?.LogWarning(ex,
+                "MarketDataPegBookPump SubscribeAsync failed for {Symbol}; entry cleared, next EnsureSubscribedAsync call will retry.",
+                key);
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscriber.Trade -= OnTrade;
+        _subscriber.InfoSnapshot -= OnInfoSnapshot;
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/PegBookTopCache.cs
+++ b/backend/src/B3.Trading.Application/MarketData/PegBookTopCache.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.3 (#283). Per-symbol cache of the book-top fields a Pegged algo
+/// needs (best bid, best ask, last trade). Owned by the application
+/// layer so tests can inject prices directly without a real MD feed.
+///
+/// <para>
+/// <b>SDK gap.</b> The current <c>B3.MarketData.WebSocketClient</c> 0.1.0
+/// only surfaces <c>Trade</c> + <c>InfoSnapshot</c> events; BBO frames
+/// are not raised end-to-end (tracked alongside the auction-event SDK
+/// gap — see <c>IMarketDataSubscriber</c>). Until the SDK ships BBO,
+/// <see cref="MarketDataPegBookPump"/> only writes the <c>Last</c>
+/// field. For <see cref="PegRef.Mid"/> / <see cref="PegRef.Best"/>
+/// callers therefore transparently fall back to last-trade — same
+/// price for all three pegRefs in v0. Tests that need to exercise
+/// distinct mid/best/last paths use the in-memory cache directly via
+/// <see cref="UpdateBookTop"/>.
+/// </para>
+/// </summary>
+public sealed class PegBookTopCache
+{
+    private readonly ConcurrentDictionary<string, BookTop> _book =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Snapshot, never <c>null</c> entries — returns <c>null</c> when
+    /// the symbol has never been seeded. Caller should treat an empty
+    /// snapshot as "no live reference yet".
+    /// </summary>
+    public BookTop? TryGet(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return null;
+        return _book.TryGetValue(symbol.Trim(), out var t) ? t : null;
+    }
+
+    /// <summary>
+    /// Updates the last-trade leg. Idempotent; safe to call from any
+    /// thread.
+    /// </summary>
+    public void UpdateLast(string symbol, decimal price, DateTimeOffset receivedUtc)
+    {
+        if (string.IsNullOrWhiteSpace(symbol) || price <= 0m) return;
+        var key = symbol.Trim();
+        _book.AddOrUpdate(
+            key,
+            _ => new BookTop(null, null, price, receivedUtc),
+            (_, existing) => new BookTop(existing.BestBid, existing.BestAsk, price, receivedUtc));
+    }
+
+    /// <summary>
+    /// Updates the BBO legs. Called by future BBO-aware adapters or by
+    /// tests that need to drive mid/best directly. Either leg may be
+    /// <c>null</c> to leave it untouched.
+    /// </summary>
+    public void UpdateBookTop(string symbol, decimal? bestBid, decimal? bestAsk, DateTimeOffset receivedUtc)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        var key = symbol.Trim();
+        _book.AddOrUpdate(
+            key,
+            _ => new BookTop(bestBid, bestAsk, null, receivedUtc),
+            (_, existing) => new BookTop(
+                bestBid ?? existing.BestBid,
+                bestAsk ?? existing.BestAsk,
+                existing.Last,
+                receivedUtc));
+    }
+}
+
+/// <summary>
+/// Immutable per-symbol snapshot of the book top. <see cref="Mid"/>
+/// falls back to <see cref="Last"/> when BBO legs are missing;
+/// <see cref="BestForSide"/> falls back to the same-side leg or
+/// <see cref="Last"/> when absent. See <see cref="PegBookTopCache"/>
+/// for the SDK-gap note.
+/// </summary>
+public readonly record struct BookTop(
+    decimal? BestBid,
+    decimal? BestAsk,
+    decimal? Last,
+    DateTimeOffset UpdatedUtc)
+{
+    public decimal? Mid =>
+        BestBid is { } b && BestAsk is { } a ? (b + a) / 2m : Last;
+
+    public decimal? BestForSide(OrderSide side) =>
+        side == OrderSide.Buy ? (BestBid ?? Last) : (BestAsk ?? Last);
+
+    /// <summary>
+    /// Resolves the reference price for the requested <paramref name="kind"/>.
+    /// Returns <c>null</c> when no live data is available — caller should
+    /// no-op and wait for the next tick.
+    /// </summary>
+    public decimal? RefPrice(PegRef kind, OrderSide side) => kind switch
+    {
+        PegRef.Mid => Mid,
+        PegRef.Best => BestForSide(side),
+        PegRef.Last => Last,
+        _ => null,
+    };
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -339,6 +339,20 @@ public static class MetricsRegistry
             "trading.algo.pegged.cancelled",
             description: "Pegged parents reaching the Cancelled terminal state.");
 
+    // Pass-6 review (#296) P2. Bumped when PeggedRepegBook's per-parent
+    // cancelled-child FIFO ring evicts its oldest entry to admit a new
+    // one. Each eviction shrinks the window in which late terminal ERs
+    // for engine-cancelled children are recognised as dedup hits (vs.
+    // falling through to VenueCancelled and suspending the parent), so
+    // sustained increments are an operational signal that the cap is
+    // too tight for the venue tail-Fill latency in production. Labelless
+    // to keep cardinality flat; correlate with the warn log in
+    // PeggedRepegBook.MarkCancelledChild for the offending firm / algo.
+    public static readonly Counter<long> AlgoPeggedRepegDedupRingEvicted =
+        Meter.CreateCounter<long>(
+            "trading.algo.pegged.repeg_dedup_ring_evicted_total",
+            description: "FIFO evictions in PeggedRepegBook's per-parent cancelled-child dedup ring.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -103,6 +103,17 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.wal.backpressure");
     public static readonly Counter<long> WalSegmentsRotated =
         Meter.CreateCounter<long>("trading.wal.segments_rotated");
+    /// <summary>
+    /// Pass-2 review (#296) P1-B. Forward-compat skip counter: bumped
+    /// once per WAL record whose <c>kind</c> discriminator is not in
+    /// the reader's <c>JsonDerivedType</c> set. Non-zero means an
+    /// older binary is reading a WAL written by a newer engine — an
+    /// expected condition during rolling deploys, an alert condition
+    /// outside one. Tag <c>kind</c> carries the unknown discriminator
+    /// for forensic triage.
+    /// </summary>
+    public static readonly Counter<long> WalUnknownKindSkipped =
+        Meter.CreateCounter<long>("trading.wal.unknown_kind_skipped");
 
     // Snapshots / recovery
     public static readonly Counter<long> SnapshotsTaken =

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -115,6 +115,19 @@ public static class MetricsRegistry
     public static readonly Counter<long> WalUnknownKindSkipped =
         Meter.CreateCounter<long>("trading.wal.unknown_kind_skipped");
 
+    /// <summary>
+    /// Pass-3 review (#296) P2. Distinct from
+    /// <see cref="WalUnknownKindSkipped"/>: counts WAL records whose
+    /// <c>kind</c> discriminator is missing or unextractable (the
+    /// JSON object lacks the field entirely, or is malformed enough
+    /// that the tokenizer can't reach it). Non-zero means torn write,
+    /// external corruption, or a writer bug — replay halts on the
+    /// first such record so the operator notices, but the counter is
+    /// still bumped first to feed alerting and per-day forensics.
+    /// </summary>
+    public static readonly Counter<long> WalMissingKindCorruption =
+        Meter.CreateCounter<long>("trading.wal.missing_kind_corruption");
+
     // Snapshots / recovery
     public static readonly Counter<long> SnapshotsTaken =
         Meter.CreateCounter<long>("trading.snapshots.taken");

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -296,6 +296,25 @@ public static class MetricsRegistry
             "trading.algo.pov.cancelled",
             description: "POV parents reaching the Cancelled terminal state.");
 
+    // Q3.3 (#283) — Pegged repeg observability. RepegsTotal counts every
+    // successful cancel+place cycle the engine performed for a Pegged
+    // parent (no-op evaluations are NOT counted). RepegFailed counts
+    // cycles where the cancel side threw (gateway transient, child
+    // already terminal in a race, …) so the engine deferred the repeg
+    // to the next tick.
+    public static readonly Counter<long> AlgoPeggedRepegsTotal =
+        Meter.CreateCounter<long>(
+            "trading.algo.pegged.repegs_total",
+            description: "Repeg cycles (cancel + place at new target) performed by the Pegged scheduler.");
+    public static readonly Counter<long> AlgoPeggedRepegFailed =
+        Meter.CreateCounter<long>(
+            "trading.algo.pegged.repeg_failed",
+            description: "Repeg attempts that aborted on the cancel leg; the engine retries on the next tick.");
+    public static readonly Counter<long> AlgoPeggedCancelled =
+        Meter.CreateCounter<long>(
+            "trading.algo.pegged.cancelled",
+            description: "Pegged parents reaching the Cancelled terminal state.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -162,7 +162,8 @@ public sealed record PeggedRepegPendingRaw(
 public sealed record PeggedRepegHistoryRaw(
     string FirmId,
     ulong AlgoId,
-    ulong[] ChildClOrdIds);
+    ulong[] ChildClOrdIds,
+    bool EvictionLogged = false);
 
 /// <summary>
 /// Pass-1 review (#295) P1#1. Raw POV scheduling-progress row.

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -131,6 +131,16 @@ public sealed class RawPlatformSnapshot
     /// pre-dating the field (additive).
     /// </summary>
     public PeggedRepegPendingRaw[] PeggedRepegPending { get; init; } = Array.Empty<PeggedRepegPendingRaw>();
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Per-Pegged-parent FIFO of recently
+    /// engine-cancelled child clOrdIds, used by the late-ER dedup
+    /// guards in <see cref="B3.Trading.Application.AlgoEngine"/>.
+    /// Empty on snapshots pre-dating the field (additive); engine
+    /// treats absence as "no remembered cancels" — equivalent to a
+    /// freshly-started process.
+    /// </summary>
+    public PeggedRepegHistoryRaw[] PeggedRepegHistory { get; init; } = Array.Empty<PeggedRepegHistoryRaw>();
 }
 
 /// <summary>
@@ -143,6 +153,16 @@ public sealed record PeggedRepegPendingRaw(
     ulong CancelledChildClOrdId,
     decimal TargetPrice,
     DateTimeOffset AtUtc);
+
+/// <summary>
+/// Pass-5 review (#296) P1. Raw per-Pegged cancelled-child history
+/// row. <see cref="ChildClOrdIds"/> is FIFO oldest→newest so the
+/// FIFO cap-eviction order survives a snapshot round-trip.
+/// </summary>
+public sealed record PeggedRepegHistoryRaw(
+    string FirmId,
+    ulong AlgoId,
+    ulong[] ChildClOrdIds);
 
 /// <summary>
 /// Pass-1 review (#295) P1#1. Raw POV scheduling-progress row.

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -122,7 +122,27 @@ public sealed class RawPlatformSnapshot
     /// <c>PovProgressBook.Snapshot()</c>.
     /// </summary>
     public PovProgressRaw[] PovProgress { get; init; } = Array.Empty<PovProgressRaw>();
+
+    /// <summary>
+    /// Pass-1 review (#296) P1-C. Mirror of
+    /// <c>PlatformSnapshot.PeggedRepegPending</c> at the raw-capture
+    /// stage. Populated under the dispatcher lock from
+    /// <c>PeggedRepegBook.Snapshot()</c>. Empty on snapshots
+    /// pre-dating the field (additive).
+    /// </summary>
+    public PeggedRepegPendingRaw[] PeggedRepegPending { get; init; } = Array.Empty<PeggedRepegPendingRaw>();
 }
+
+/// <summary>
+/// Pass-1 review (#296) P1-C. Raw per-Pegged in-flight repeg-cycle
+/// row.
+/// </summary>
+public sealed record PeggedRepegPendingRaw(
+    string FirmId,
+    ulong AlgoId,
+    ulong CancelledChildClOrdId,
+    decimal TargetPrice,
+    DateTimeOffset AtUtc);
 
 /// <summary>
 /// Pass-1 review (#295) P1#1. Raw POV scheduling-progress row.

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -203,6 +203,15 @@ public sealed class PlatformSnapshot
     /// <see cref="B3.Trading.Application.PeggedRepegBook"/>.
     /// </summary>
     public List<PeggedRepegPendingSnapshot> PeggedRepegPending { get; init; } = new();
+
+    /// <summary>
+    /// Pass-5 review (#296) P1. Per-Pegged-parent FIFO of recently
+    /// engine-cancelled child clOrdIds — late-ER dedup memory. Empty
+    /// on snapshots pre-dating the field (additive); the engine
+    /// treats absence the same as a freshly-started process. See
+    /// <see cref="B3.Trading.Application.PeggedRepegBook.MarkCancelledChild"/>.
+    /// </summary>
+    public List<PeggedRepegHistorySnapshot> PeggedRepegHistory { get; init; } = new();
 }
 
 /// <summary>
@@ -403,6 +412,16 @@ public sealed record PeggedRepegPendingSnapshot(
     ulong CancelledChildClOrdId,
     decimal TargetPrice,
     DateTimeOffset AtUtc);
+
+/// <summary>
+/// Pass-5 review (#296) P1. One row of the per-Pegged cancelled-child
+/// history — see <see cref="PlatformSnapshot.PeggedRepegHistory"/>.
+/// <see cref="ChildClOrdIds"/> is FIFO oldest→newest.
+/// </summary>
+public sealed record PeggedRepegHistorySnapshot(
+    string FirmId,
+    ulong AlgoId,
+    List<ulong> ChildClOrdIds);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -333,7 +333,14 @@ public sealed record AlgoSnapshot(
     decimal? PovParticipationRate = null,
     long? PovTickIntervalTicks = null,
     decimal? PovPriceLimit = null,
-    long? PovMinSliceQty = null);
+    long? PovMinSliceQty = null,
+    // Q3.3 (#283) — Pegged fields, mirror the POV block.
+    string? PeggedRef = null,
+    int? PeggedOffsetTicks = null,
+    long? PeggedRepegIntervalTicks = null,
+    decimal? PeggedTickSize = null,
+    string? PeggedChildOrderType = null,
+    decimal? PeggedPriceLimit = null);
 
 public sealed record PositionSnapshot(
     string EndClientId,

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -192,6 +192,17 @@ public sealed class PlatformSnapshot
     /// <c>StartUtc</c> on first tick — same as a fresh POV).
     /// </summary>
     public List<PovProgressSnapshot> PovProgress { get; init; } = new();
+
+    /// <summary>
+    /// Pass-1 review (#296) P1-C. In-flight Pegged repeg-cycle
+    /// markers — engine emitted the cancel for a drift-driven repeg
+    /// but had not yet observed the cancel-ack ER + submitted the
+    /// replacement at snapshot capture. Empty on snapshots
+    /// pre-dating the field (additive); the engine treats absence as
+    /// "no pending cycle" — same as a fresh Pegged parent. See
+    /// <see cref="B3.Trading.Application.PeggedRepegBook"/>.
+    /// </summary>
+    public List<PeggedRepegPendingSnapshot> PeggedRepegPending { get; init; } = new();
 }
 
 /// <summary>
@@ -380,6 +391,18 @@ public sealed record PovProgressSnapshot(
     ulong AlgoId,
     long MarketVolumeSeen,
     DateTimeOffset LastEvaluateAtUtc);
+
+/// <summary>
+/// Pass-1 review (#296) P1-C. One row of the per-Pegged in-flight
+/// repeg-cycle projection — see
+/// <see cref="PlatformSnapshot.PeggedRepegPending"/>.
+/// </summary>
+public sealed record PeggedRepegPendingSnapshot(
+    string FirmId,
+    ulong AlgoId,
+    ulong CancelledChildClOrdId,
+    decimal TargetPrice,
+    DateTimeOffset AtUtc);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -417,11 +417,20 @@ public sealed record PeggedRepegPendingSnapshot(
 /// Pass-5 review (#296) P1. One row of the per-Pegged cancelled-child
 /// history — see <see cref="PlatformSnapshot.PeggedRepegHistory"/>.
 /// <see cref="ChildClOrdIds"/> is FIFO oldest→newest.
+/// <para>
+/// Pass-7 review (#296) P2. <see cref="EvictionLogged"/> persists the
+/// per-ring one-shot "we've already warn-logged about FIFO overflow on
+/// this parent" latch so a restart does not let the warn re-fire on
+/// the next eviction. Optional (default <c>false</c>); snapshots
+/// pre-dating the field round-trip to a fresh latch — at worst one
+/// extra warn post-upgrade.
+/// </para>
 /// </summary>
 public sealed record PeggedRepegHistorySnapshot(
     string FirmId,
     ulong AlgoId,
-    List<ulong> ChildClOrdIds);
+    List<ulong> ChildClOrdIds,
+    bool EvictionLogged = false);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -39,6 +39,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(AlgoTerminalStateRecordedEvent))]
 [JsonSerializable(typeof(AlgoVwapSlicedEvent))]
 [JsonSerializable(typeof(AlgoPovSlicedEvent))]
+[JsonSerializable(typeof(AlgoPeggedRepeggedEvent))]
 [JsonSerializable(typeof(OrderStaledEvent))]
 [JsonSerializable(typeof(OrderStaleClearedEvent))]
 [JsonSerializable(typeof(UserBotCredentialCreatedEvent))]

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -40,6 +40,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(AlgoVwapSlicedEvent))]
 [JsonSerializable(typeof(AlgoPovSlicedEvent))]
 [JsonSerializable(typeof(AlgoPeggedRepeggedEvent))]
+[JsonSerializable(typeof(AlgoPeggedRepegStartedEvent))]
+[JsonSerializable(typeof(AlgoPeggedRepegResolvedEvent))]
 [JsonSerializable(typeof(OrderStaledEvent))]
 [JsonSerializable(typeof(OrderStaleClearedEvent))]
 [JsonSerializable(typeof(UserBotCredentialCreatedEvent))]

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -28,6 +28,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoTerminalStateRecordedEvent), "algo.terminal")]
 [JsonDerivedType(typeof(AlgoVwapSlicedEvent), "algo.vwap.sliced")]
 [JsonDerivedType(typeof(AlgoPovSlicedEvent), "algo.pov.sliced")]
+[JsonDerivedType(typeof(AlgoPeggedRepeggedEvent), "algo.pegged.repegged")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
@@ -279,7 +280,7 @@ public sealed record AlgoCreatedEvent : WalEvent
     public required string Symbol { get; init; }
     public required ulong SecurityId { get; init; }
     public required string Side { get; init; }
-    public required string Type { get; init; }   // "Iceberg" | "Twap" | "Vwap" | "Pov"
+    public required string Type { get; init; }   // "Iceberg" | "Twap" | "Vwap" | "Pov" | "Pegged"
     public required long TotalQuantity { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
     /// <summary>
@@ -319,6 +320,16 @@ public sealed record AlgoCreatedEvent : WalEvent
     public long? PovTickIntervalTicks { get; init; }
     public decimal? PovPriceLimit { get; init; }
     public long? PovMinSliceQty { get; init; }
+
+    // Q3.3 (#283) — Pegged fields. Mirror the POV block above; only the
+    // block matching <see cref="Type"/> = "Pegged" is populated. Additive
+    // — older replays / snapshots without these fields stay valid.
+    public string? PeggedRef { get; init; }                 // PegRef enum name
+    public int? PeggedOffsetTicks { get; init; }
+    public long? PeggedRepegIntervalTicks { get; init; }
+    public decimal? PeggedTickSize { get; init; }
+    public string? PeggedChildOrderType { get; init; }      // "Limit" | "Market"
+    public decimal? PeggedPriceLimit { get; init; }
 }
 
 /// <summary>
@@ -403,6 +414,28 @@ public sealed record AlgoPovSlicedEvent : WalEvent
     // LastEvaluateAtUtc as "no prior progress; seed from StartUtc".
     public long MarketVolumeSeen { get; init; }
     public DateTimeOffset LastEvaluateAtUtc { get; init; }
+}
+
+/// <summary>
+/// Q3.3 (#283). Per-repeg audit envelope for Pegged parents — captures
+/// the live reference price, the old child price (cancelled) and the
+/// new target price the engine is placing at. NOT replayed for state
+/// reconstruction (the cancel + new child are already on the WAL via
+/// <see cref="OrderCancelRequestedEvent"/> + <see cref="OrderSubmittedEvent"/>);
+/// the engine treats this event as observability-only so a future
+/// omission of the WAL write would not desynchronise recovery. Mirrors
+/// the <c>AlgoVwapSliced</c> shape called out in the issue body.
+/// </summary>
+public sealed record AlgoPeggedRepeggedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required int SliceSeq { get; init; }
+    public required string RefKind { get; init; }     // PegRef enum name
+    public required decimal RefPrice { get; init; }
+    public required decimal OldChildPrice { get; init; }
+    public required decimal NewTargetPrice { get; init; }
+    public required DateTimeOffset AtUtc { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -510,6 +510,24 @@ public sealed record AlgoPeggedRepegResolvedEvent : WalEvent
     /// decode as <c>false</c>.
     /// </summary>
     public bool Aborted { get; init; }
+
+    /// <summary>
+    /// Pass-4 review (#296) P1. Audit-only annotation describing why
+    /// the cycle resolved. Null (default) for the steady-state cancel-
+    /// ack-then-replace path. Currently emitted values:
+    /// <list type="bullet">
+    ///   <item><c>FilledBeforeCancelAck</c> — a terminal Fill ER for
+    ///   the just-cancelled child reached the engine before (or
+    ///   instead of) the cancel-ack, so the quantity was consumed by
+    ///   the existing child and no replacement was submitted. The
+    ///   companion <see cref="Aborted"/> stays <c>false</c> because
+    ///   the cancel did reach the venue (only its ack didn't beat the
+    ///   fill); replay still just clears the
+    ///   <c>PeggedRepegBook</c> entry. Additive — pre-existing
+    ///   segments decode as <c>null</c>.</item>
+    /// </list>
+    /// </summary>
+    public string? Reason { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -6,9 +6,16 @@ namespace B3.Trading.Application.Persistence;
 /// <summary>
 /// Base type for every event written to the WAL. Each derived record is
 /// serialised as a single JSON object inside a length+CRC framed record on
-/// disk. The <see cref="JsonPolymorphicAttribute"/> discriminator keeps the
-/// schema explicit and forward-compatible: unknown subtypes are rejected
-/// loudly during recovery rather than silently mis-applied.
+/// disk. The <see cref="JsonPolymorphicAttribute"/> discriminator keeps
+/// the schema explicit and forward-compatible: an unknown subtype is
+/// <i>skipped with a structured warning</i> during recovery rather than
+/// crashing the reader — older binaries can therefore traverse WAL
+/// segments produced by newer engines (rolling deploys, downgrade paths,
+/// EOD materialisation of mixed-version days). See
+/// <see cref="B3.Trading.Infrastructure.Persistence.FileEventStore.ReadFromAsync"/>
+/// for the skip site. Genuine corruption (malformed JSON for a
+/// <i>known</i> kind, missing required fields, etc.) still surfaces as
+/// an exception — only the polymorphic discriminator is treated leniently.
 ///
 /// <para>
 /// Schema evolution rule: never rename fields, only add new optional ones.
@@ -475,6 +482,18 @@ public sealed record AlgoPeggedRepegStartedEvent : WalEvent
 /// replacement child. Replay clears the pending entry from
 /// <c>PeggedRepegBook</c> so post-restart state matches the
 /// in-memory steady-state (no pending repeg). Additive.
+///
+/// <para>Pass-2 review (#296) P1-A. <see cref="Aborted"/> distinguishes
+/// the normal cycle-completion path (<c>false</c>) from a roll-back
+/// caused by a failed gateway cancel mid-cycle (<c>true</c>): the
+/// engine had already persisted the Started marker and called
+/// <c>PeggedRepegBook.Set</c> but the wire-call to the venue
+/// failed, so no replacement child will be submitted. Replay
+/// handling is identical (clear the book entry) — the flag is
+/// audit-only so EOD / forensic tooling can tell apart "cycle
+/// succeeded" from "cycle aborted; engine will retry next tick".
+/// Field is optional: pre-existing Resolved events deserialise as
+/// <c>false</c>.</para>
 /// </summary>
 public sealed record AlgoPeggedRepegResolvedEvent : WalEvent
 {
@@ -482,6 +501,15 @@ public sealed record AlgoPeggedRepegResolvedEvent : WalEvent
     public required string FirmId { get; init; }
     public required ulong CancelledChildClOrdId { get; init; }
     public required DateTimeOffset AtUtc { get; init; }
+
+    /// <summary>
+    /// Pass-2 review (#296) P1-A. <c>true</c> when the cycle was
+    /// rolled back because the gateway cancel call failed after the
+    /// Started marker was persisted; <c>false</c> (default) for the
+    /// normal cancel-ack-then-replace flow. Additive — old segments
+    /// decode as <c>false</c>.
+    /// </summary>
+    public bool Aborted { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -29,6 +29,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoVwapSlicedEvent), "algo.vwap.sliced")]
 [JsonDerivedType(typeof(AlgoPovSlicedEvent), "algo.pov.sliced")]
 [JsonDerivedType(typeof(AlgoPeggedRepeggedEvent), "algo.pegged.repegged")]
+[JsonDerivedType(typeof(AlgoPeggedRepegStartedEvent), "algo.pegged.repeg-started")]
+[JsonDerivedType(typeof(AlgoPeggedRepegResolvedEvent), "algo.pegged.repeg-resolved")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
@@ -435,6 +437,50 @@ public sealed record AlgoPeggedRepeggedEvent : WalEvent
     public required decimal RefPrice { get; init; }
     public required decimal OldChildPrice { get; init; }
     public required decimal NewTargetPrice { get; init; }
+    public required DateTimeOffset AtUtc { get; init; }
+}
+
+/// <summary>
+/// Pass-1 review (#296) P1-C. Pre-cancel marker for a Pegged repeg
+/// cycle. Persisted BEFORE the engine issues the cancel wire-call so
+/// recovery can distinguish "engine-initiated cancel awaiting ack"
+/// from "venue-initiated cancel" (which suspends the parent).
+///
+/// <para>Replay populates <see cref="Algo.PeggedRepegBook"/> with
+/// <see cref="CancelledChildClOrdId"/> + audit fields; engine
+/// <c>Reconcile</c> reads the book to seed
+/// <c>AlgoParentRuntime.RepegPending</c> + the sticky
+/// <c>LastRepegCancelledChildId</c> marker so a post-restart
+/// cancel-ack ER routes through <c>SubmitNextSliceAsync</c> rather
+/// than the <c>VenueCancelled</c>-suspension path. Cleared by
+/// <see cref="AlgoPeggedRepegResolvedEvent"/> on cycle completion
+/// or by <see cref="AlgoTerminalStateRecordedEvent"/> on parent
+/// terminal. Additive: snapshots and WAL segments pre-dating the
+/// event deserialise as before.</para>
+/// </summary>
+public sealed record AlgoPeggedRepegStartedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required ulong CancelledChildClOrdId { get; init; }
+    public required ulong NewClOrdId { get; init; }
+    public required decimal TargetPrice { get; init; }
+    public required DateTimeOffset AtUtc { get; init; }
+}
+
+/// <summary>
+/// Pass-1 review (#296) P1-C. Companion to
+/// <see cref="AlgoPeggedRepegStartedEvent"/>: emitted when the engine
+/// has consumed the cancel-ack ER and successfully submitted the
+/// replacement child. Replay clears the pending entry from
+/// <c>PeggedRepegBook</c> so post-restart state matches the
+/// in-memory steady-state (no pending repeg). Additive.
+/// </summary>
+public sealed record AlgoPeggedRepegResolvedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required ulong CancelledChildClOrdId { get; init; }
     public required DateTimeOffset AtUtc { get; init; }
 }
 

--- a/backend/src/B3.Trading.Domain/Algo.cs
+++ b/backend/src/B3.Trading.Domain/Algo.cs
@@ -6,6 +6,25 @@ public enum AlgoType
     Twap,
     Vwap,
     Pov,
+    /// <summary>Q3.3 (#283). Client-side Pegged orders — one working
+    /// slice that re-prices itself off a live reference (mid / best /
+    /// last) at a fixed cadence.</summary>
+    Pegged,
+}
+
+/// <summary>
+/// Q3.3 (#283). Reference-price source for a Pegged parent. <c>Mid</c>
+/// uses <c>(bestBid+bestAsk)/2</c>; <c>Best</c> uses the same-side best
+/// (best bid for buys, best ask for sells); <c>Last</c> uses the last
+/// trade print. When the SDK does not surface BBO frames the engine
+/// transparently falls back to last for <c>Mid</c>/<c>Best</c> — see
+/// <c>PegBookTopCache</c>.
+/// </summary>
+public enum PegRef
+{
+    Mid,
+    Best,
+    Last,
 }
 
 /// <summary>
@@ -140,6 +159,47 @@ public sealed record PovParameters(
     TimeSpan TickInterval,
     decimal? PriceLimit = null,
     long MinSliceQty = 1) : AlgoParameters;
+
+/// <summary>
+/// Q3.3 (#283). Client-side Pegged orders parameters.
+///
+/// <para>
+/// Pegged maintains a SINGLE working slice for the full
+/// <c>TotalQuantity</c> and re-prices it off a live reference at
+/// <c>RepegInterval</c> cadence: <c>target = ref + offsetTicks*tickSize</c>.
+/// When <c>|currentChildPrice - target| &gt;= tickSize</c> the engine
+/// cancels the live child and places a new one at <c>target</c>. Unlike
+/// VWAP/POV there is no scheduled window — Pegged runs until filled or
+/// explicitly cancelled (DELETE /algo/{id}).
+/// </para>
+///
+/// <para><b>Ref</b>: <see cref="PegRef.Mid"/>, <see cref="PegRef.Best"/>,
+/// or <see cref="PegRef.Last"/>. When the upstream feed cannot supply
+/// BBO (current SDK gap), <c>Mid</c>/<c>Best</c> transparently fall back
+/// to last-trade.</para>
+/// <para><b>OffsetTicks</b>: signed offset applied to <c>ref</c>;
+/// positive favours the passive side (less aggressive), negative crosses
+/// the spread.</para>
+/// <para><b>RepegInterval</b>: minimum wall-clock spacing between repeg
+/// evaluations. The scheduler may enqueue evaluations more frequently;
+/// the engine throttles to this interval.</para>
+/// <para><b>TickSize</b>: instrument tick. Used both for the target
+/// computation and the "needs repeg" tolerance (<c>&gt;= 1 tick</c>).
+/// Static for v0 — when a <c>TickSizeProvider</c> lands the engine will
+/// look it up per-symbol instead.</para>
+/// <para><b>PriceLimit</b>: hard limit the engine never crosses past;
+/// when the computed target would cross it, the target is clamped (same
+/// semantics as VWAP/POV <c>PriceLimit</c>). When the clamped target
+/// equals the current child price the engine skips the repeg
+/// altogether.</para>
+/// </summary>
+public sealed record PeggedParameters(
+    PegRef Ref,
+    int OffsetTicks,
+    TimeSpan RepegInterval,
+    decimal TickSize,
+    OrderType ChildOrderType = OrderType.Limit,
+    decimal? PriceLimit = null) : AlgoParameters;
 
 /// <summary>
 /// Parent algo aggregate, sibling to <see cref="Order"/>. v0 stores only
@@ -315,6 +375,7 @@ public sealed class Algo
             AlgoType.Twap => parameters is TwapParameters,
             AlgoType.Vwap => parameters is VwapParameters,
             AlgoType.Pov => parameters is PovParameters,
+            AlgoType.Pegged => parameters is PeggedParameters,
             _ => false,
         };
         if (!ok)

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -135,6 +135,15 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // POV does not under-slice while VolumeCurveEstimator's in-memory
         // buckets re-warm from post-restart prints.
         services.AddSingleton<PovProgressBook>();
+        // Q3.3 (#283). Pegged book-top cache + pump follow the
+        // MarketDataVolumePump pattern: singleton + hosted service
+        // resolving the same instance so the engine takes an optional
+        // ctor dep and EnsureSubscribedAsync demand-subscribes per
+        // Pegged parent without a second startup race.
+        services.AddSingleton<B3.Trading.Application.MarketData.PegBookTopCache>();
+        services.AddSingleton<B3.Trading.Application.MarketData.MarketDataPegBookPump>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.MarketData.MarketDataPegBookPump>());
         services.AddHostedService<AlgoEngine>();
         services.AddHostedService<AlgoScheduler>();
 

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -135,6 +135,12 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // POV does not under-slice while VolumeCurveEstimator's in-memory
         // buckets re-warm from post-restart prints.
         services.AddSingleton<PovProgressBook>();
+        // Pass-1 review (#296) P1-C. Per-Pegged in-flight repeg-cycle
+        // marker book — restores RepegPending + expected-cancel
+        // marker on restart so a post-restart cancel-ack ER does not
+        // suspend the parent (it routes through SubmitNextSliceAsync
+        // and places the replacement child instead).
+        services.AddSingleton<PeggedRepegBook>();
         // Q3.3 (#283). Pegged book-top cache + pump follow the
         // MarketDataVolumePump pattern: singleton + hosted service
         // resolving the same instance so the engine takes an optional

--- a/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
@@ -17,6 +17,15 @@ public sealed class MockEntryPointClient : IEntryPointClient
     public IReadOnlyCollection<OrderCancelRequest> SubmittedCancels => _cancels;
     public IReadOnlyCollection<OrderCancelReplaceRequest> SubmittedReplaces => _replaces;
 
+    /// <summary>
+    /// Optional test hook: when non-null, every
+    /// <see cref="SubmitCancelAsync"/> invokes it after recording the
+    /// request and throws the returned exception (or completes
+    /// normally if it returns null). Used by repeg-cancel-failure
+    /// regression tests; left null in production composition.
+    /// </summary>
+    public Func<OrderCancelRequest, Exception?>? CancelFailureInjector { get; set; }
+
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
 
     public Task SubmitNewOrderAsync(NewOrderSingle request, CancellationToken cancellationToken)
@@ -28,6 +37,12 @@ public sealed class MockEntryPointClient : IEntryPointClient
     public Task SubmitCancelAsync(OrderCancelRequest request, CancellationToken cancellationToken)
     {
         _cancels.Enqueue(request);
+        var injector = CancelFailureInjector;
+        if (injector is not null)
+        {
+            var ex = injector(request);
+            if (ex is not null) return Task.FromException(ex);
+        }
         return Task.CompletedTask;
     }
 

--- a/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
@@ -26,6 +26,20 @@ public sealed class MockEntryPointClient : IEntryPointClient
     /// </summary>
     public Func<OrderCancelRequest, Exception?>? CancelFailureInjector { get; set; }
 
+    /// <summary>
+    /// Pass-5 review (#296) P2. Optional test hook: when non-null,
+    /// every <see cref="SubmitCancelAsync"/> awaits the
+    /// <see cref="Task"/> returned by the injector AFTER recording
+    /// the request but BEFORE returning to the caller. Used by the
+    /// Pegged fill-races-cancel regression tests to deterministically
+    /// gate the engine's <c>CancelAsync</c> await: the test injects
+    /// a Fill ER while the cancel is held, then releases the gate
+    /// and asserts the post-condition the in-engine guard guarantees
+    /// (no orphan replacement child, audit pair balanced, no stuck
+    /// state). Left null in production composition.
+    /// </summary>
+    public Func<OrderCancelRequest, Task>? CancelDelayInjector { get; set; }
+
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
 
     public Task SubmitNewOrderAsync(NewOrderSingle request, CancellationToken cancellationToken)
@@ -42,6 +56,14 @@ public sealed class MockEntryPointClient : IEntryPointClient
         {
             var ex = injector(request);
             if (ex is not null) return Task.FromException(ex);
+        }
+        var delay = CancelDelayInjector;
+        if (delay is not null)
+        {
+            // Defer to the test-supplied gate; surface the gate's
+            // task to the engine's await so the caller pauses inside
+            // CancelAsync until the test releases the TCS.
+            return delay(request);
         }
         return Task.CompletedTask;
     }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -56,7 +56,14 @@ public sealed class EodMaterialiser : IEodMaterialiser
             {
                 report.RecordCount++;
                 sha.TransformBlock(payload, 0, payload.Length, null, 0);
-                var evt = JsonSerializer.Deserialize(payload, WalEventJsonContext.Default.WalEvent);
+                if (!FileEventStore.TryDeserialize(payload, out var evt, out _))
+                {
+                    // Pass-2 review (#296) P1-B. Unknown discriminator
+                    // (newer engine wrote this WAL). EOD counts the
+                    // record + SHA bytes — both are kind-agnostic —
+                    // but doesn't classify it into any per-kind bucket.
+                    continue;
+                }
                 switch (evt)
                 {
                     case OrderSubmittedEvent: report.OrderSubmittedCount++; break;

--- a/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/EodMaterialiser.cs
@@ -56,12 +56,21 @@ public sealed class EodMaterialiser : IEodMaterialiser
             {
                 report.RecordCount++;
                 sha.TransformBlock(payload, 0, payload.Length, null, 0);
-                if (!FileEventStore.TryDeserialize(payload, out var evt, out _))
+                if (FileEventStore.TryDeserialize(payload, out var evt, out _) != FileEventStore.DeserializeOutcome.Ok)
                 {
-                    // Pass-2 review (#296) P1-B. Unknown discriminator
-                    // (newer engine wrote this WAL). EOD counts the
-                    // record + SHA bytes — both are kind-agnostic —
-                    // but doesn't classify it into any per-kind bucket.
+                    // Pass-2 review (#296) P1-B. Either an unknown
+                    // discriminator (newer engine wrote this WAL) or
+                    // a missing/unextractable `kind` (corruption). EOD
+                    // counts the record + SHA bytes — both are
+                    // kind-agnostic — but doesn't classify the record
+                    // into any per-kind bucket. Unlike replay
+                    // (FileEventStore.ReadFromAsync) we do not throw
+                    // on missing-kind here: EOD is an offline audit
+                    // that should produce a report whose RecordCount
+                    // accurately reflects every WAL record present on
+                    // disk, including any pathological ones; the
+                    // counter increment on the replay path is the
+                    // alerting signal.
                     continue;
                 }
                 switch (evt)

--- a/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
@@ -156,7 +156,8 @@ public sealed class FileEventStore : IEventStore
         {
             if (ct.IsCancellationRequested) yield break;
             if (seq <= sinceSeqExclusive) continue;
-            if (!TryDeserialize(payload, out var evt, out var unknownKind))
+            var outcome = TryDeserialize(payload, out var evt, out var unknownKind);
+            if (outcome == DeserializeOutcome.UnknownKind)
             {
                 // Pass-2 review (#296) P1-B. Unknown discriminator
                 // (an event-kind added by a newer engine version that
@@ -167,11 +168,29 @@ public sealed class FileEventStore : IEventStore
                 // <see cref="WalEvent"/>. Genuine corruption for a
                 // KNOWN kind still surfaces as an exception below.
                 MetricsRegistry.WalUnknownKindSkipped.Add(1,
-                    new KeyValuePair<string, object?>("kind", unknownKind ?? "<missing>"));
+                    new KeyValuePair<string, object?>("kind", unknownKind ?? "<unknown>"));
                 _logger.LogWarning(
                     "FileEventStore: skipping WAL record at seq={Seq} with unknown discriminator kind={Kind}; reader is older than the writer.",
-                    seq, unknownKind ?? "<missing>");
+                    seq, unknownKind ?? "<unknown>");
                 continue;
+            }
+            if (outcome == DeserializeOutcome.MissingKind)
+            {
+                // Pass-3 review (#296) P2. Missing-or-unextractable
+                // `kind` is NOT a forward-compat case — every WAL
+                // writer in this codebase emits the discriminator via
+                // the source-gen polymorphic converter, so its
+                // absence indicates a torn write, an external
+                // corruption, or a writer bug. Surface loudly via a
+                // dedicated counter + error log, then throw so replay
+                // halts and the operator investigates rather than
+                // silently losing records.
+                MetricsRegistry.WalMissingKindCorruption.Add(1);
+                _logger.LogError(
+                    "FileEventStore: WAL record at seq={Seq} has missing or unextractable `kind` discriminator; aborting replay to avoid silent corruption.",
+                    seq);
+                throw new InvalidDataException(
+                    $"FileEventStore: WAL record at seq={seq} has missing or unextractable `kind` discriminator.");
             }
             if (evt is not null) yield return (seq, evt);
         }
@@ -179,43 +198,62 @@ public sealed class FileEventStore : IEventStore
     }
 
     /// <summary>
-    /// Pass-2 review (#296) P1-B. Polymorphic deserialise that
-    /// distinguishes "unknown discriminator (forward-compat skip)"
-    /// from "JSON malformed for a known kind (replay-blocking
-    /// corruption)". Returns <c>true</c> when the payload was
-    /// successfully bound (<paramref name="evt"/> may still be null
-    /// if the source-gen converter chose to return null, in which
-    /// case the caller skips silently); returns <c>false</c> only
-    /// when the failure was a missing/unknown <c>kind</c> discriminator
-    /// in the JSON. Every other JsonException is rethrown so torn
-    /// segments and schema drift remain loud.
+    /// Outcome of <see cref="TryDeserialize"/>: distinguishes the
+    /// three failure modes the caller must treat differently. Ok
+    /// means the payload bound (the out event may still be null if
+    /// the converter chose null). UnknownKind means the JSON had a
+    /// well-formed string `kind` discriminator that's not in the
+    /// reader's known set — a forward-compat skip. MissingKind means
+    /// the payload either lacked the `kind` field entirely or could
+    /// not be parsed enough to locate it — a corruption signal.
     /// </summary>
-    internal static bool TryDeserialize(ReadOnlySpan<byte> payload, out WalEvent? evt, out string? unknownKind)
+    internal enum DeserializeOutcome { Ok, UnknownKind, MissingKind }
+
+    /// <summary>
+    /// Pass-2 review (#296) P1-B, refined by Pass-3 P2. Polymorphic
+    /// deserialise that distinguishes "unknown discriminator
+    /// (forward-compat skip)" from "missing/unextractable
+    /// discriminator (corruption — halt replay)" from "JSON malformed
+    /// for a known kind (replay-blocking corruption — throw the
+    /// original JsonException)". Every other JsonException is
+    /// rethrown so torn segments and schema drift remain loud.
+    /// </summary>
+    internal static DeserializeOutcome TryDeserialize(ReadOnlySpan<byte> payload, out WalEvent? evt, out string? unknownKind)
     {
         evt = null;
         unknownKind = null;
         try
         {
             evt = JsonSerializer.Deserialize(payload, JsonContext.WalEvent);
-            return true;
+            return DeserializeOutcome.Ok;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException || ex is NotSupportedException)
         {
-            // Inspect the raw JSON for the discriminator: if it's
-            // either missing or not in the known set, classify as
-            // forward-compat skip. Any other JsonException (a real
-            // schema/format problem on a known kind) re-throws.
-            if (TryExtractKind(payload, out var kind) && kind is not null && !KnownDiscriminators.Contains(kind))
+            // System.Text.Json's polymorphic source-gen surfaces a
+            // missing/unknown discriminator as NotSupportedException
+            // ("The JSON payload for polymorphic ... type must specify
+            // a type discriminator"), while a malformed value for a
+            // KNOWN kind surfaces as JsonException. Both funnel here.
+            //
+            // Inspect the raw JSON for the discriminator.
+            //   * present + recognised → re-throw the original
+            //     exception (malformed payload for a known kind is
+            //     real corruption / schema drift)
+            //   * present + unknown    → forward-compat skip
+            //   * missing or unextractable → distinct corruption case;
+            //     report via MissingKind so the caller throws instead
+            //     of silently dropping the record
+            if (TryExtractKind(payload, out var kind) && kind is not null)
             {
-                unknownKind = kind;
-                return false;
+                if (!KnownDiscriminators.Contains(kind))
+                {
+                    unknownKind = kind;
+                    return DeserializeOutcome.UnknownKind;
+                }
+                throw;
             }
-            if (kind is null)
-            {
-                unknownKind = null;
-                return false;
-            }
-            throw;
+            unknownKind = null;
+            return DeserializeOutcome.MissingKind;
         }
     }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/FileEventStore.cs
@@ -156,10 +156,115 @@ public sealed class FileEventStore : IEventStore
         {
             if (ct.IsCancellationRequested) yield break;
             if (seq <= sinceSeqExclusive) continue;
-            var evt = JsonSerializer.Deserialize(payload, JsonContext.WalEvent);
+            if (!TryDeserialize(payload, out var evt, out var unknownKind))
+            {
+                // Pass-2 review (#296) P1-B. Unknown discriminator
+                // (an event-kind added by a newer engine version that
+                // hasn't been taught to this binary yet). Skip with a
+                // structured warning so an older reader can still
+                // traverse a WAL written by a newer engine — the
+                // forward-compat contract documented on
+                // <see cref="WalEvent"/>. Genuine corruption for a
+                // KNOWN kind still surfaces as an exception below.
+                MetricsRegistry.WalUnknownKindSkipped.Add(1,
+                    new KeyValuePair<string, object?>("kind", unknownKind ?? "<missing>"));
+                _logger.LogWarning(
+                    "FileEventStore: skipping WAL record at seq={Seq} with unknown discriminator kind={Kind}; reader is older than the writer.",
+                    seq, unknownKind ?? "<missing>");
+                continue;
+            }
             if (evt is not null) yield return (seq, evt);
         }
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Pass-2 review (#296) P1-B. Polymorphic deserialise that
+    /// distinguishes "unknown discriminator (forward-compat skip)"
+    /// from "JSON malformed for a known kind (replay-blocking
+    /// corruption)". Returns <c>true</c> when the payload was
+    /// successfully bound (<paramref name="evt"/> may still be null
+    /// if the source-gen converter chose to return null, in which
+    /// case the caller skips silently); returns <c>false</c> only
+    /// when the failure was a missing/unknown <c>kind</c> discriminator
+    /// in the JSON. Every other JsonException is rethrown so torn
+    /// segments and schema drift remain loud.
+    /// </summary>
+    internal static bool TryDeserialize(ReadOnlySpan<byte> payload, out WalEvent? evt, out string? unknownKind)
+    {
+        evt = null;
+        unknownKind = null;
+        try
+        {
+            evt = JsonSerializer.Deserialize(payload, JsonContext.WalEvent);
+            return true;
+        }
+        catch (JsonException)
+        {
+            // Inspect the raw JSON for the discriminator: if it's
+            // either missing or not in the known set, classify as
+            // forward-compat skip. Any other JsonException (a real
+            // schema/format problem on a known kind) re-throws.
+            if (TryExtractKind(payload, out var kind) && kind is not null && !KnownDiscriminators.Contains(kind))
+            {
+                unknownKind = kind;
+                return false;
+            }
+            if (kind is null)
+            {
+                unknownKind = null;
+                return false;
+            }
+            throw;
+        }
+    }
+
+    private static bool TryExtractKind(ReadOnlySpan<byte> payload, out string? kind)
+    {
+        kind = null;
+        try
+        {
+            var reader = new Utf8JsonReader(payload);
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject) return false;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject) return false;
+                if (reader.TokenType != JsonTokenType.PropertyName) continue;
+                var isKind = reader.ValueTextEquals("kind");
+                if (!reader.Read()) return false;
+                if (isKind && reader.TokenType == JsonTokenType.String)
+                {
+                    kind = reader.GetString();
+                    return true;
+                }
+                reader.Skip();
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed JSON — let the caller's re-throw path handle.
+        }
+        return false;
+    }
+
+    private static readonly HashSet<string> KnownDiscriminators = BuildKnownDiscriminators();
+
+    private static HashSet<string> BuildKnownDiscriminators()
+    {
+        // Derived from the JsonDerivedType attribute set on WalEvent.
+        // Reflection happens exactly once at first access — keeps the
+        // discriminator list in lock-step with the type declarations
+        // (no second source-of-truth that can drift).
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var attr in typeof(WalEvent).GetCustomAttributes(typeof(System.Text.Json.Serialization.JsonDerivedTypeAttribute), inherit: false))
+        {
+            if (attr is System.Text.Json.Serialization.JsonDerivedTypeAttribute jda
+                && jda.TypeDiscriminator is string s)
+            {
+                set.Add(s);
+            }
+        }
+        return set;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -49,6 +49,16 @@ public sealed class StateSnapshotter
     /// legacy test compositions that don't exercise POV.
     /// </summary>
     private readonly PovProgressBook? _povProgress;
+    /// <summary>
+    /// Pass-1 review (#296) P1-C. Optional — when wired the snapshot
+    /// pipeline captures per-Pegged in-flight repeg-cycle markers so
+    /// a restart can rebuild <c>AlgoParentRuntime.RepegPending</c> +
+    /// the expected-cancel marker, preventing a post-restart
+    /// cancel-ack from being misread as a venue-cancel.
+    /// Null-tolerant for legacy test compositions that don't exercise
+    /// Pegged.
+    /// </summary>
+    private readonly PeggedRepegBook? _peggedRepeg;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -68,7 +78,8 @@ public sealed class StateSnapshotter
         CashKeeper? cashKeeper = null,
         FeeKeeper? feeKeeper = null,
         PnlKeeper? pnlKeeper = null,
-        PovProgressBook? povProgress = null)
+        PovProgressBook? povProgress = null,
+        PeggedRepegBook? peggedRepeg = null)
     {
         _orders = orders;
         _positions = positions;
@@ -88,6 +99,7 @@ public sealed class StateSnapshotter
         _userBotMappings = userBotMappings;
         _gtdScheduler = gtdScheduler;
         _povProgress = povProgress;
+        _peggedRepeg = peggedRepeg;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -144,6 +156,12 @@ public sealed class StateSnapshotter
             ? Array.Empty<PovProgressRaw>()
             : _povProgress.Snapshot()
                 .Select(t => new PovProgressRaw(t.FirmId, t.AlgoId, t.Progress.MarketVolumeSeen, t.Progress.LastEvaluateAtUtc))
+                .ToArray(),
+        PeggedRepegPending = _peggedRepeg is null
+            ? Array.Empty<PeggedRepegPendingRaw>()
+            : _peggedRepeg.Snapshot()
+                .Select(t => new PeggedRepegPendingRaw(t.FirmId, t.AlgoId,
+                    t.Pending.CancelledChildClOrdId, t.Pending.TargetPrice, t.Pending.AtUtc))
                 .ToArray(),
     };
 
@@ -327,6 +345,14 @@ public sealed class StateSnapshotter
             povProgress.Add(new PovProgressSnapshot(p.FirmId, p.AlgoId, p.MarketVolumeSeen, p.LastEvaluateAtUtc));
         }
 
+        var peggedRepeg = new List<PeggedRepegPendingSnapshot>(raw.PeggedRepegPending.Length);
+        for (var i = 0; i < raw.PeggedRepegPending.Length; i++)
+        {
+            var p = raw.PeggedRepegPending[i];
+            peggedRepeg.Add(new PeggedRepegPendingSnapshot(
+                p.FirmId, p.AlgoId, p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc));
+        }
+
         return new PlatformSnapshot
         {
             Seq = raw.Seq,
@@ -356,6 +382,7 @@ public sealed class StateSnapshotter
             BotCancelMappings = botCancelMaps,
             AuditedExpiredIds = raw.AuditedExpiredIds,
             PovProgress = povProgress,
+            PeggedRepegPending = peggedRepeg,
         };
     }
 
@@ -431,6 +458,12 @@ public sealed class StateSnapshotter
             _povProgress.Restore(snap.PovProgress.Select(p =>
                 (p.FirmId, p.AlgoId, new PovProgress(p.MarketVolumeSeen, p.LastEvaluateAtUtc))));
         }
+        if (_peggedRepeg is not null)
+        {
+            _peggedRepeg.Restore(snap.PeggedRepegPending.Select(p =>
+                (p.FirmId, p.AlgoId,
+                    new PeggedRepegPending(p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc))));
+        }
     }
 }
 
@@ -483,6 +516,18 @@ public sealed class EventReplayer
     /// the same scheduling baseline as a snapshot-only restore.
     /// </summary>
     private readonly PovProgressBook? _povProgress;
+    /// <summary>
+    /// Pass-1 review (#296) P1-C. Optional. When wired, replay of
+    /// <see cref="AlgoPeggedRepegStartedEvent"/> sets the pending
+    /// entry and replay of <see cref="AlgoPeggedRepegResolvedEvent"/>
+    /// (or any <see cref="AlgoTerminalStateRecordedEvent"/>) clears
+    /// it. The engine's <c>Reconcile</c> reads the resulting book to
+    /// seed <c>AlgoParentRuntime.RepegPending</c> + expected-cancel
+    /// marker so a post-restart cancel-ack ER routes through
+    /// SubmitNextSliceAsync rather than the venue-cancel suspension
+    /// path.
+    /// </summary>
+    private readonly PeggedRepegBook? _peggedRepeg;
 
     public EventReplayer(
         WorkingOrderBook orders,
@@ -503,7 +548,8 @@ public sealed class EventReplayer
         FeeKeeper? feeKeeper = null,
         IFeeCalculator? feeCalculator = null,
         PnlKeeper? pnlKeeper = null,
-        PovProgressBook? povProgress = null)
+        PovProgressBook? povProgress = null,
+        PeggedRepegBook? peggedRepeg = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -524,6 +570,7 @@ public sealed class EventReplayer
         _feeCalculator = feeCalculator;
         _pnlKeeper = pnlKeeper;
         _povProgress = povProgress;
+        _peggedRepeg = peggedRepeg;
     }
 
     /// <summary>
@@ -701,6 +748,10 @@ public sealed class EventReplayer
                     var reason = Enum.Parse<AlgoTerminalReason>(at.Reason, ignoreCase: true);
                     algo.RecordTerminal(status, reason, at.AtUtc);
                 }
+                // Pass-1 review (#296) P1-C. Drop any in-flight repeg
+                // marker on parent terminal so the book stays bounded
+                // and a future snapshot doesn't carry stale state.
+                _peggedRepeg?.Remove(at.FirmId, at.AlgoId);
                 break;
             case AlgoPovSlicedEvent ps:
                 // Pass-1 review (#295) P1#1. Restore the POV scheduling
@@ -710,6 +761,22 @@ public sealed class EventReplayer
                 // the final state matches the most recently persisted
                 // slice. Idempotent under double-replay.
                 _povProgress?.Set(ps.FirmId, ps.AlgoId, ps.MarketVolumeSeen, ps.LastEvaluateAtUtc);
+                break;
+            case AlgoPeggedRepegStartedEvent pgs:
+                // Pass-1 review (#296) P1-C. Record the pending repeg
+                // cycle so the engine's Reconcile pass can rebuild
+                // AlgoParentRuntime.RepegPending + the expected-cancel
+                // marker post-restart. Last-write-wins under replay.
+                _peggedRepeg?.Set(pgs.FirmId, pgs.AlgoId,
+                    pgs.CancelledChildClOrdId, pgs.TargetPrice, pgs.AtUtc);
+                break;
+            case AlgoPeggedRepegResolvedEvent pgr:
+                // Pass-1 review (#296) P1-C. Cancel-ack was consumed
+                // and the replacement was submitted; clear the
+                // pending marker so a snapshot+tail recovery converges
+                // on the same in-memory state as a snapshot-only
+                // restore.
+                _peggedRepeg?.Remove(pgr.FirmId, pgr.AlgoId);
                 break;
             case OrderStaledEvent os:
                 if (_orders.TryGet(os.ClOrdId, out var staleOrd) && staleOrd is not null)

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -166,7 +166,7 @@ public sealed class StateSnapshotter
         PeggedRepegHistory = _peggedRepeg is null
             ? Array.Empty<PeggedRepegHistoryRaw>()
             : _peggedRepeg.SnapshotHistory()
-                .Select(t => new PeggedRepegHistoryRaw(t.FirmId, t.AlgoId, t.ChildClOrdIds.ToArray()))
+                .Select(t => new PeggedRepegHistoryRaw(t.FirmId, t.AlgoId, t.ChildClOrdIds.ToArray(), t.EvictionLogged))
                 .ToArray(),
     };
 
@@ -363,7 +363,7 @@ public sealed class StateSnapshotter
         {
             var h = raw.PeggedRepegHistory[i];
             peggedRepegHistory.Add(new PeggedRepegHistorySnapshot(
-                h.FirmId, h.AlgoId, new List<ulong>(h.ChildClOrdIds)));
+                h.FirmId, h.AlgoId, new List<ulong>(h.ChildClOrdIds), h.EvictionLogged));
         }
 
         return new PlatformSnapshot
@@ -478,7 +478,7 @@ public sealed class StateSnapshotter
                 (p.FirmId, p.AlgoId,
                     new PeggedRepegPending(p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc))));
             _peggedRepeg.RestoreHistory(snap.PeggedRepegHistory.Select(h =>
-                (h.FirmId, h.AlgoId, (IReadOnlyList<ulong>)h.ChildClOrdIds)));
+                (h.FirmId, h.AlgoId, (IReadOnlyList<ulong>)h.ChildClOrdIds, h.EvictionLogged)));
         }
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -807,6 +807,13 @@ public sealed class EventReplayer
                 TimeSpan.FromTicks(ac.PovTickIntervalTicks ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PovTickIntervalTicks.")),
                 ac.PovPriceLimit,
                 ac.PovMinSliceQty ?? 1L),
+            AlgoType.Pegged => new PeggedParameters(
+                Enum.Parse<PegRef>(ac.PeggedRef ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PeggedRef."), ignoreCase: true),
+                ac.PeggedOffsetTicks ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PeggedOffsetTicks."),
+                TimeSpan.FromTicks(ac.PeggedRepegIntervalTicks ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PeggedRepegIntervalTicks.")),
+                ac.PeggedTickSize ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PeggedTickSize."),
+                Enum.Parse<OrderType>(ac.PeggedChildOrderType ?? throw new InvalidOperationException($"AlgoCreatedEvent {ac.AlgoId} missing PeggedChildOrderType."), ignoreCase: true),
+                ac.PeggedPriceLimit),
             _ => throw new InvalidOperationException($"Unknown algo type: {ac.Type}"),
         };
         _algos.TryAdd(new Algo(ac.AlgoId, owner, ac.FirmId, ac.Symbol, ac.SecurityId,

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -163,6 +163,11 @@ public sealed class StateSnapshotter
                 .Select(t => new PeggedRepegPendingRaw(t.FirmId, t.AlgoId,
                     t.Pending.CancelledChildClOrdId, t.Pending.TargetPrice, t.Pending.AtUtc))
                 .ToArray(),
+        PeggedRepegHistory = _peggedRepeg is null
+            ? Array.Empty<PeggedRepegHistoryRaw>()
+            : _peggedRepeg.SnapshotHistory()
+                .Select(t => new PeggedRepegHistoryRaw(t.FirmId, t.AlgoId, t.ChildClOrdIds.ToArray()))
+                .ToArray(),
     };
 
     /// <summary>
@@ -353,6 +358,14 @@ public sealed class StateSnapshotter
                 p.FirmId, p.AlgoId, p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc));
         }
 
+        var peggedRepegHistory = new List<PeggedRepegHistorySnapshot>(raw.PeggedRepegHistory.Length);
+        for (var i = 0; i < raw.PeggedRepegHistory.Length; i++)
+        {
+            var h = raw.PeggedRepegHistory[i];
+            peggedRepegHistory.Add(new PeggedRepegHistorySnapshot(
+                h.FirmId, h.AlgoId, new List<ulong>(h.ChildClOrdIds)));
+        }
+
         return new PlatformSnapshot
         {
             Seq = raw.Seq,
@@ -383,6 +396,7 @@ public sealed class StateSnapshotter
             AuditedExpiredIds = raw.AuditedExpiredIds,
             PovProgress = povProgress,
             PeggedRepegPending = peggedRepeg,
+            PeggedRepegHistory = peggedRepegHistory,
         };
     }
 
@@ -463,6 +477,8 @@ public sealed class StateSnapshotter
             _peggedRepeg.Restore(snap.PeggedRepegPending.Select(p =>
                 (p.FirmId, p.AlgoId,
                     new PeggedRepegPending(p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc))));
+            _peggedRepeg.RestoreHistory(snap.PeggedRepegHistory.Select(h =>
+                (h.FirmId, h.AlgoId, (IReadOnlyList<ulong>)h.ChildClOrdIds)));
         }
     }
 }
@@ -751,7 +767,12 @@ public sealed class EventReplayer
                 // Pass-1 review (#296) P1-C. Drop any in-flight repeg
                 // marker on parent terminal so the book stays bounded
                 // and a future snapshot doesn't carry stale state.
-                _peggedRepeg?.Remove(at.FirmId, at.AlgoId);
+                //
+                // Pass-5 review (#296) P1. Also drop the cancelled-
+                // child history ring — once the parent is terminal no
+                // further late ERs can affect routing, so the dedup
+                // memory is dead weight.
+                _peggedRepeg?.RemoveAll(at.FirmId, at.AlgoId);
                 break;
             case AlgoPovSlicedEvent ps:
                 // Pass-1 review (#295) P1#1. Restore the POV scheduling
@@ -769,6 +790,17 @@ public sealed class EventReplayer
                 // marker post-restart. Last-write-wins under replay.
                 _peggedRepeg?.Set(pgs.FirmId, pgs.AlgoId,
                     pgs.CancelledChildClOrdId, pgs.TargetPrice, pgs.AtUtc);
+                // Pass-5 review (#296) P1. Add the cancelled child id
+                // to the per-parent dedup history ring so a late
+                // terminal ER for THIS cancel survives across:
+                //   * subsequent repeg cycles (the single-slot
+                //     LastRepegCancelledChildId would have moved on);
+                //   * a snapshot+replay round-trip (the ring is
+                //     additively snapshotted alongside the pending
+                //     entry, so even post-snapshot WAL replay rebuilds
+                //     historic cycles deterministically).
+                // Cap-bounded FIFO so memory stays O(cycles_in_window).
+                _peggedRepeg?.MarkCancelledChild(pgs.FirmId, pgs.AlgoId, pgs.CancelledChildClOrdId);
                 break;
             case AlgoPeggedRepegResolvedEvent pgr:
                 // Pass-1 review (#296) P1-C. Cancel-ack was consumed

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -746,6 +746,184 @@ public class PeggedAlgoEndpointTests
         }
     }
 
+    // ──────────────── Pass-3 review (#296) regression tests ────────────────
+
+    [Fact]
+    public async Task Pegged_RepegCancelFails_DoesNotPersistOrphanStartedAndRetriesNextTick()
+    {
+        // Pass-3 review (#296) P1 — approach B. Simulate the gateway
+        // CancelAsync wire-call failing (venue unreachable / transient
+        // I/O fault). The repeg must:
+        //
+        //   1. NOT leave a poison AlgoPeggedRepegStartedEvent in the
+        //      WAL nor a PeggedRepegBook entry — both would otherwise
+        //      stall the algo on a post-restart Reconcile (book
+        //      entry + still-live child => RepegPending=true with no
+        //      ack ever coming).
+        //   2. Clear the in-memory RepegPending marker so the next
+        //      scheduler tick can re-attempt the repeg cycle.
+        //   3. Actually re-attempt and succeed once the injected
+        //      fault is removed.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        // First cancel attempt fails; subsequent ones succeed.
+        var failedCount = 0;
+        mock.CancelFailureInjector = _ =>
+        {
+            if (Interlocked.Increment(ref failedCount) == 1)
+            {
+                return new InvalidOperationException("simulated gateway cancel failure");
+            }
+            return null;
+        };
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        // Drift the mid → engine tries to cancel child1 and the
+        // gateway rejects. With approach B, no Started event was
+        // persisted, so there is nothing in the WAL to replay.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => failedCount >= 1,
+            TimeSpan.FromSeconds(3), "engine did not attempt the first cancel");
+
+        // The PeggedRepegBook MUST be empty for this algo — the
+        // failed cancel path under approach B never persists a
+        // Started event nor populates the book.
+        var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+        Assert.Null(repegBook.TryGet("default", ulong.Parse(algoId)));
+
+        // The parent must remain Working — the failure rolled back
+        // the in-memory marker, no Suspended transition occurred.
+        var snapAfterFailure = await GetAlgo(http, token, algoId);
+        Assert.Equal("Working", snapAfterFailure.GetProperty("status").GetString());
+
+        // The next scheduler tick must re-attempt the repeg cycle
+        // (in-memory state was cleared cleanly). Drive it forward
+        // until a second cancel goes out — this time the injector
+        // returns null and the cancel succeeds.
+        await WaitFor(() => mock.SubmittedCancels.Count >= 2,
+            TimeSpan.FromSeconds(5),
+            "engine did not retry the cancel after the simulated failure");
+
+        // Releasing the cancel-ack drives the replacement child —
+        // proves the algo is not stalled.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
+            TimeSpan.FromSeconds(5));
+        Assert.Equal(31.0m, child2.Price);
+
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal("Working", snap.GetProperty("status").GetString());
+        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+    }
+
+    [Fact]
+    public async Task Pegged_RecoverySelfHealsOrphanRepegEntry_NoStallOnReconcile()
+    {
+        // Pass-3 review (#296) P1 — approach C (defensive guard).
+        // Historical WALs written by pre-Pass-3 binaries may have
+        // persisted an AlgoPeggedRepegStartedEvent for a cancel that
+        // never reached the venue (the old code persisted Started
+        // BEFORE CancelAsync). After snapshot+restart that orphan
+        // can survive into the rehydrated PeggedRepegBook. The
+        // Reconcile pass MUST self-heal: if the cancelled child id
+        // is no longer present as a live (non-terminal) order, the
+        // book entry is dropped and RepegPending stays false so the
+        // algo can continue slicing instead of stalling forever on
+        // an ack that will never arrive.
+        //
+        // We construct the orphan shape end-to-end by:
+        //   1. Driving a real repeg → Started lands in WAL + book.
+        //   2. Injecting the cancel-ack so child1 goes terminal and
+        //      child2 (the replacement) becomes the live child.
+        //   3. Manually re-inserting an orphan book entry pointing
+        //      at child1's now-terminal ClOrdId — simulating exactly
+        //      the post-replay state an old-binary WAL would leave
+        //      (Started without matching Resolved + child terminal).
+        //   4. Snapshot + restart.
+        //   5. Assert the book entry is gone after Reconcile and the
+        //      algo is still Working.
+        var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
+            "b3-pegged-repeg-self-heal-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            ulong child1ClOrdId = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var adminToken = await f.LoginAsync(http, "admin");
+                var cache = f.Services.GetRequiredService<PegBookTopCache>();
+                cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+                var algoIdStr = await PostAlgo(http, token,
+                    PeggedBody(total: 100, pegRef: "Mid", offsetTicks: 0,
+                        repegMs: 100, tickSize: 0.5m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var child1 = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(3));
+                child1ClOrdId = child1.ClOrdId;
+
+                cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+                var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+
+                // Drain the cycle normally so child1 goes terminal +
+                // child2 becomes the live working slice. After this
+                // point the engine's Reconcile path is the only thing
+                // the orphan entry will encounter on restart.
+                await InjectEr(http, adminToken, child1ClOrdId, "Canceled");
+                _ = await WaitForChildOtherThan(book, algoIdStr, child1ClOrdId,
+                    TimeSpan.FromSeconds(5));
+
+                // Re-inject the orphan: an entry that points at the
+                // now-terminal child1, exactly as an old-binary WAL
+                // would have left after a backpressured Resolved.
+                var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+                repegBook.Set("default", algoIdNum, child1ClOrdId, 31.0m, DateTimeOffset.UtcNow);
+
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            using (var http2 = f2.CreateClient())
+            {
+                var token = await f2.LoginAsync(http2);
+
+                // The Reconcile self-heal pass must have dropped the
+                // orphan entry (cancelled child id is no longer live).
+                var repegBook2 = f2.Services.GetRequiredService<PeggedRepegBook>();
+                await WaitFor(() => repegBook2.TryGet("default", algoIdNum) is null,
+                    TimeSpan.FromSeconds(3),
+                    "Reconcile did not self-heal the orphan PeggedRepegBook entry");
+
+                // And the algo did not get stuck in a stalled state.
+                var snap = await GetAlgo(http2, token, algoIdNum.ToString());
+                Assert.Equal("Working", snap.GetProperty("status").GetString());
+                Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     // ───────────────────────── helpers ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -924,6 +924,219 @@ public class PeggedAlgoEndpointTests
         }
     }
 
+    // ──────────────── Pass-4 review (#296) regression tests ────────────────
+
+    [Fact]
+    public async Task Pegged_FillRacesRepegCancel_NoReplacementChildAndNoStall()
+    {
+        // Pass-4 review (#296) P1. The engine cancels child1 for a
+        // repeg; before the cancel-ack lands the venue fills child1
+        // (the cancel reached the venue too late — race the RFC
+        // explicitly calls out). The Fill ER must:
+        //
+        //   1. NOT spawn a replacement child from the Fill handler —
+        //      child1 already consumed the qty the replacement would
+        //      have targeted, so placing a new slice here would
+        //      over-buy (orphan duplicate working order).
+        //   2. NOT leave RepegPending=true (which would short-circuit
+        //      every future repeg eval and stall the algo).
+        //   3. Clear the PeggedRepegBook entry (Started + Resolved
+        //      audit pair balanced via AlgoPeggedRepegResolvedEvent
+        //      with Aborted=false + Reason=FilledBeforeCancelAck).
+        //   4. Transition the parent to Completed cleanly (no
+        //      Suspended, no stall).
+        //
+        // Pegged places the full RemainingQuantity on each working
+        // slice, so a full Fill of child1 also completes the parent —
+        // we assert both terminal transitions here.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+
+        // Drift the mid → engine cancels child1 for a repeg.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the cancel after the mid drift");
+
+        // Wait for the Started marker to be persisted (Window 3 — the
+        // only window that occurs naturally with the current single-
+        // threaded reactor; Windows 1+2 are defensive code paths in
+        // the engine, see ResolveRepegOnFillAsync XML doc).
+        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is not null,
+            TimeSpan.FromSeconds(3), "AlgoPeggedRepegStartedEvent did not populate the book");
+
+        // Inject a full Fill ER for the cancelled child instead of
+        // the Cancel-ack the engine is waiting for — the venue race
+        // the RFC describes.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
+
+        // Parent transitions to Completed (Fill consumed total qty).
+        await WaitForAlgoStatus(http, token, algoId, "Completed");
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal(100, snap.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+
+        // Cycle resolved: AlgoPeggedRepegResolvedEvent with
+        // Aborted=false + Reason=FilledBeforeCancelAck fires; replay
+        // handler removes the book entry. Terminal-transition cleanup
+        // would also remove it but the Resolved path wins the race.
+        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
+            TimeSpan.FromSeconds(3),
+            "PeggedRepegBook still has an entry after the fill race resolved");
+
+        // No replacement child spawned (no orphan working order). The
+        // Fill handler's no-replacement branch is what guarantees
+        // this — without it the post-Fill Pegged path would call
+        // SubmitNextSliceAsync and spawn a duplicate.
+        Assert.Single(mock.SubmittedCancels);
+        var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
+        Assert.Single(allChildren);
+        Assert.Equal(child1.ClOrdId, allChildren[0].ClOrdId);
+    }
+
+    [Fact]
+    public async Task Pegged_FillRacesRepegCancel_BeforeStartedPersisted_NoOrphanInWal()
+    {
+        // Pass-4 review (#296) P1, Windows 1+2 (defensive). With the
+        // current single-threaded reactor a Fill ER cannot interleave
+        // between EvaluatePeggedRepegAsync's CancelAsync await and the
+        // following Started dispatch — both run in the same iteration.
+        // This test pins the OBSERVABLE outcome the windowed code paths
+        // guarantee: across the full race window (whichever sub-window
+        // actually fires), there is NEVER a Started marker in
+        // PeggedRepegBook without a matching Resolved by the time the
+        // Fill ER is fully processed. Combined with the previous test
+        // (Window 3 → Resolved emitted), this ensures the audit pair
+        // is always balanced and replay can't recover into a stuck
+        // state regardless of which window fired.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 50));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+
+        // Drift → engine cancels child1.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+
+        // Race the Fill ER in immediately — depending on scheduler
+        // interleaving this may land before OR after Started persists.
+        // Either way the post-condition (no lingering book entry,
+        // parent Completed, no replacement orphan) must hold.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
+
+        await WaitForAlgoStatus(http, token, algoId, "Completed");
+
+        // Eventually the book settles to "no pending entry" — covers
+        // Windows 1+2 (entry never existed) AND Window 3 (entry was
+        // created then Resolved cleared it).
+        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
+            TimeSpan.FromSeconds(3),
+            "PeggedRepegBook still has an entry after the fill race");
+
+        // Exactly one cancel, no replacement child spawned from the
+        // Fill handler (no orphan working order).
+        Assert.Single(mock.SubmittedCancels);
+        var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
+        Assert.Single(allChildren);
+    }
+
+    [Fact]
+    public async Task Pegged_LateCancelAckAfterFillResolution_IsNoOpNotDoubleReplacement()
+    {
+        // Pass-4 review (#296) P1, scenario 3. After the Fill-before-
+        // cancel-ack race resolves (Resolved dispatched, book cleared,
+        // RepegPending=false, parent Completed), a venue cancel-ack ER
+        // may still arrive for the same old child (the venue processed
+        // the cancel after the fill landed). That late Cancelled wire
+        // MUST be a no-op — NOT a second SubmitNextSliceAsync call
+        // (which would duplicate the replacement child and orphan a
+        // working order). The sticky LastRepegCancelledChildId marker
+        // + the parent-terminal short-circuit + the Filled-case
+        // dedup branch together keep the classification correct
+        // regardless of which guard catches it first.
+        //
+        // Because Pegged places the full RemainingQuantity on each
+        // working slice, a full Fill of child1 also completes the
+        // parent in this test; the parent-terminal short-circuit at
+        // the top of OnChildErAsync's Filled case is what absorbs the
+        // late ER in that path. For the non-terminal-parent path
+        // (e.g. iceberg child types in a future RFC) the sticky
+        // LastRepegCancelledChildId dedup is the safety net.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is not null,
+            TimeSpan.FromSeconds(3), "Started marker did not land in book");
+
+        // Fill race resolves the cycle first.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
+        await WaitForAlgoStatus(http, token, algoId, "Completed");
+        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
+            TimeSpan.FromSeconds(3), "Resolved did not clear the book");
+
+        var newOrdersBefore = mock.SubmittedNewOrders.Count;
+        var childrenBefore = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).Count();
+
+        // Late cancel-ack for the already-filled child1. The order is
+        // Filled (Order.MarkCancelled is a no-op on Filled) so the ER
+        // hits the Filled case in OnChildErAsync; the parent is
+        // already terminal so the algo.IsTerminal short-circuit at
+        // the top of the case absorbs the ER. No Resolved
+        // re-dispatch, no SubmitNextSliceAsync, no extra child.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await Task.Delay(200);
+
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal("Completed", snap.GetProperty("status").GetString());
+        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+
+        Assert.Equal(newOrdersBefore, mock.SubmittedNewOrders.Count);
+        Assert.Equal(childrenBefore,
+            book.EnumerateChildrenOf("default", ulong.Parse(algoId)).Count());
+
+        // Also assert the book entry stays absent — a late ER must
+        // not resurrect a Started/Resolved cycle.
+        Assert.Null(repegBook.TryGet("default", ulong.Parse(algoId)));
+    }
+
     // ───────────────────────── helpers ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -644,6 +644,108 @@ public class PeggedAlgoEndpointTests
         }
     }
 
+    [Fact]
+    public async Task Pegged_RecoveryReplaysRepegStartedEventFromWalTail()
+    {
+        // Pass-2 review (#296) P2-D. Sibling of Pegged_RecoveryPreservesRepegIntent
+        // that pins the WAL-tail replay path specifically. The original
+        // test snapshots AFTER AlgoPeggedRepegStartedEvent fires, so
+        // post-restart state comes from the snapshot's
+        // PeggedRepegBook — the AlgoPeggedRepegStartedEvent replay
+        // handler in StateSnapshotter.Apply is never exercised.
+        //
+        // Here we capture the snapshot BEFORE drifting the mid so the
+        // snapshot contains only the algo + child1 (no pending repeg
+        // entry). The drift then causes the engine to emit the cancel +
+        // AlgoPeggedRepegStartedEvent which lands ONLY in the WAL tail
+        // past snapshot.seq. Cold restart → snapshot restores the algo
+        // and the live child1; ReadFromAsync replays the
+        // AlgoPeggedRepegStartedEvent which writes into
+        // PeggedRepegBook; Reconcile then sees the still-live child
+        // and hydrates RepegPending + the sticky cancel-id marker.
+        // The post-restart Cancelled ER must route through
+        // SubmitNextSliceAsync, not VenueCancelled-suspension.
+        var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
+            "b3-pegged-repeg-wal-tail-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            ulong child1ClOrdId = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var cache = f.Services.GetRequiredService<PegBookTopCache>();
+                cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+                var algoIdStr = await PostAlgo(http, token,
+                    PeggedBody(total: 100, pegRef: "Mid", offsetTicks: 0,
+                        repegMs: 100, tickSize: 0.5m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var child1 = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(3));
+                child1ClOrdId = child1.ClOrdId;
+                Assert.Equal(30.0m, child1.Price);
+
+                // Capture the snapshot BEFORE the repeg cycle starts so
+                // PeggedRepegBook is empty in the snapshot. Repeg
+                // intent is therefore only recoverable via WAL tail.
+                ResolveSnapshotService(f).TryTakeSnapshot();
+
+                // Now drift the mid → engine cancels child1 + persists
+                // AlgoPeggedRepegStartedEvent (post-snapshot WAL tail).
+                cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+                var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel after the drift");
+
+                // Do NOT inject the Cancelled ER, do NOT take another
+                // snapshot — the Started event must survive on the WAL
+                // tail alone.
+            }
+
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            using (var http2 = f2.CreateClient())
+            {
+                var token = await f2.LoginAsync(http2);
+                var adminToken = await f2.LoginAsync(http2, "admin");
+
+                // The PeggedRepegBook entry must have been rebuilt by
+                // the WAL replay (not the snapshot). Sanity-check the
+                // book directly so a regression that drops the replay
+                // handler fails loudly here, not through the more
+                // indirect "parent gets suspended" path below.
+                var repegBook = f2.Services.GetRequiredService<PeggedRepegBook>();
+                var pending = repegBook.TryGet("default", algoIdNum);
+                Assert.NotNull(pending);
+                Assert.Equal(child1ClOrdId, pending!.Value.CancelledChildClOrdId);
+
+                // Re-seed cache so SubmitNextSlice can price the
+                // replacement (cache is volatile across restart).
+                var cache2 = f2.Services.GetRequiredService<PegBookTopCache>();
+                cache2.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+
+                await InjectEr(http2, adminToken, child1ClOrdId, "Canceled");
+
+                var book2 = f2.Services.GetRequiredService<WorkingOrderBook>();
+                var child2 = await WaitForChildOtherThan(book2, algoIdNum.ToString(), child1ClOrdId,
+                    TimeSpan.FromSeconds(5));
+                Assert.Equal(31.0m, child2.Price);
+
+                var snap = await GetAlgo(http2, token, algoIdNum.ToString());
+                Assert.Equal("Working", snap.GetProperty("status").GetString());
+                Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     // ───────────────────────── helpers ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -450,6 +450,200 @@ public class PeggedAlgoEndpointTests
         }
     }
 
+    // ──────────────── Pass-1 review (#296) regression tests ────────────────
+
+    [Fact]
+    public async Task Pegged_RepegCancelAck_DoesNotSuspendParent()
+    {
+        // Pass-1 review (#296) P1-A. Repeg cancel-ack lands → engine
+        // submits replacement. A duplicate / late Cancelled ER for
+        // the SAME old child must NOT be routed through the
+        // VenueCancelled branch (which would suspend the parent and
+        // orphan the live replacement child).
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        // Drift the mid → engine cancels child1.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine never cancelled child1 after mid moved");
+
+        // First Cancelled ER → engine routes through SubmitNextSlice.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
+        Assert.Equal(31.0m, child2.Price);
+
+        // Duplicate / late Cancelled ER for the SAME old child must
+        // be a no-op — parent stays Working, no terminal published.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await Task.Delay(150);
+
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal("Working", snap.GetProperty("status").GetString());
+        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+
+        // And the replacement child is still live in the book.
+        var stillThere = book.EnumerateChildrenOf("default", ulong.Parse(algoId))
+            .FirstOrDefault(c => c.ClOrdId == child2.ClOrdId);
+        Assert.NotNull(stillThere);
+    }
+
+    [Fact]
+    public async Task Pegged_RepegThrottle_SuppressesCancelStorm()
+    {
+        // Pass-1 review (#296) P1-B. Rapid mid moves while a cancel
+        // ack is delayed past RepegInterval must NOT spawn additional
+        // cancels for the same already-cancel-pending child. Only one
+        // cancel + one replacement should fire per repeg cycle.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        // Tight RepegInterval so the throttle would normally fire
+        // many times in the burst window below.
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 50));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        // First mid move → first cancel (do NOT inject the ER yet).
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the first cancel");
+
+        // Burst of further mid moves spanning well past RepegInterval.
+        // With the P1-B fix (RepegPending short-circuit) the engine
+        // must NOT enqueue another cancel for child1 while the ack
+        // is still outstanding. Keep the cumulative delta small so
+        // the eventual replacement child stays inside risk price
+        // bands (we're not exercising risk here).
+        for (int i = 0; i < 4; i++)
+        {
+            cache.UpdateBookTop("PETR4", 30.5m + i * 0.1m, 31.5m + i * 0.1m,
+                DateTimeOffset.UtcNow);
+            await Task.Delay(60);
+        }
+        Assert.Single(mock.SubmittedCancels);
+
+        // Now release the cycle: the cancel-ack lands and the engine
+        // submits exactly one replacement child.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
+        Assert.NotNull(child2);
+
+        // The parent must remain Working — a duplicate / late ER for
+        // child1 must not flip it Suspended (the P1-A marker keeps
+        // the classification correct even after the cycle resolved).
+        var snapBefore = await GetAlgo(http, token, algoId);
+        var statusBefore = snapBefore.GetProperty("status").GetString();
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await Task.Delay(150);
+        var snap = await GetAlgo(http, token, algoId);
+        var statusAfter = snap.GetProperty("status").GetString();
+        Assert.Equal("Working", statusBefore);
+        Assert.Equal("Working", statusAfter);
+    }
+
+    [Fact]
+    public async Task Pegged_RecoveryPreservesRepegIntent()
+    {
+        // Pass-1 review (#296) P1-C. Engine emits the repeg cancel
+        // but crashes before the venue Cancelled ER lands. After
+        // snapshot+restart the cancel-ack ER must be classified as
+        // expected (matching the persisted pending marker) and route
+        // through SubmitNextSliceAsync — NOT into the VenueCancelled
+        // suspension branch.
+        var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
+            "b3-pegged-repeg-recovery-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            ulong child1ClOrdId = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var cache = f.Services.GetRequiredService<PegBookTopCache>();
+                cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+                var algoIdStr = await PostAlgo(http, token,
+                    PeggedBody(total: 100, pegRef: "Mid", offsetTicks: 0,
+                        repegMs: 100, tickSize: 0.5m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var child1 = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(3));
+                child1ClOrdId = child1.ClOrdId;
+                Assert.Equal(30.0m, child1.Price);
+
+                // Drift the mid → engine cancels child1. DO NOT
+                // inject the Cancelled ER — we want the cancel to
+                // be in-flight at snapshot time.
+                cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+                var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel before snapshot");
+
+                // Capture the snapshot with the cancel still pending.
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            // Cold restart — engine reconciles, sees the pending
+            // repeg entry, sets RepegPending=true +
+            // LastRepegCancelledChildId so the post-restart ER is
+            // expected.
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            using (var http2 = f2.CreateClient())
+            {
+                var token = await f2.LoginAsync(http2);
+                var adminToken = await f2.LoginAsync(http2, "admin");
+
+                // Re-seed the cache so SubmitNextSlice can resolve a
+                // target for the replacement (cache is in-memory
+                // only and does not survive restart).
+                var cache2 = f2.Services.GetRequiredService<PegBookTopCache>();
+                cache2.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+
+                // Inject the cancel-ack the engine was waiting for.
+                await InjectEr(http2, adminToken, child1ClOrdId, "Canceled");
+
+                // Replacement child must appear and parent must NOT
+                // be Suspended (which is what the pre-fix code would
+                // have done via the VenueCancelled branch).
+                var book2 = f2.Services.GetRequiredService<WorkingOrderBook>();
+                var child2 = await WaitForChildOtherThan(book2, algoIdNum.ToString(), child1ClOrdId,
+                    TimeSpan.FromSeconds(5));
+                Assert.Equal(31.0m, child2.Price);
+
+                var snap = await GetAlgo(http2, token, algoIdNum.ToString());
+                Assert.Equal("Working", snap.GetProperty("status").GetString());
+                Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
     // ───────────────────────── helpers ─────────────────────────
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -927,28 +927,36 @@ public class PeggedAlgoEndpointTests
     // ──────────────── Pass-4 review (#296) regression tests ────────────────
 
     [Fact]
-    public async Task Pegged_FillRacesRepegCancel_NoReplacementChildAndNoStall()
+    public async Task Pegged_FillRacesRepegCancel_DelayInjectedFill_NoReplacementChildAndAuditPairBalanced()
     {
-        // Pass-4 review (#296) P1. The engine cancels child1 for a
-        // repeg; before the cancel-ack lands the venue fills child1
-        // (the cancel reached the venue too late — race the RFC
-        // explicitly calls out). The Fill ER must:
+        // Pass-4 review (#296) P1, Window 3 (the only race actually
+        // reachable under the single-consumer signal queue — see Pass-5
+        // P2 note further down).
         //
-        //   1. NOT spawn a replacement child from the Fill handler —
-        //      child1 already consumed the qty the replacement would
-        //      have targeted, so placing a new slice here would
-        //      over-buy (orphan duplicate working order).
-        //   2. NOT leave RepegPending=true (which would short-circuit
-        //      every future repeg eval and stall the algo).
-        //   3. Clear the PeggedRepegBook entry (Started + Resolved
-        //      audit pair balanced via AlgoPeggedRepegResolvedEvent
-        //      with Aborted=false + Reason=FilledBeforeCancelAck).
-        //   4. Transition the parent to Completed cleanly (no
-        //      Suspended, no stall).
+        // Pass-5 review (#296) P2. Deterministic gating via the new
+        // MockEntryPointClient.CancelDelayInjector: the engine's
+        // CancelAsync await is held by the test, the Fill ER is
+        // injected while the cancel is in-flight, then the cancel is
+        // released. The engine then drains the resulting
+        // ChildExecutionObservedSignal AFTER the Started event has been
+        // dispatched (single-consumer reactor) — so this exercises the
+        // post-Started recovery path:
         //
-        // Pegged places the full RemainingQuantity on each working
-        // slice, so a full Fill of child1 also completes the parent —
-        // we assert both terminal transitions here.
+        //   * Filled-case Pegged dedup at OnChildErAsync (the
+        //     IsCancelledChild guard) → ResolveRepegOnFillAsync runs
+        //     instead of the normal Fill-then-resubmit path.
+        //   * ResolveRepegOnFillAsync emits
+        //     AlgoPeggedRepegResolvedEvent{Aborted=false,
+        //     Reason="FilledBeforeCancelAck"} so the audit pair is
+        //     balanced and the PeggedRepegBook entry is cleared by
+        //     replay convergence.
+        //
+        // **Guard pinned**: removing the IsCancelledChild check in the
+        // Filled case (AlgoEngine line ~666) causes the Fill ER to
+        // fall through to SubmitNextSliceAsync — a SECOND child gets
+        // submitted (orphan replacement) and Assert.Single(allChildren)
+        // below fails. Verified by mental simulation against the
+        // current control flow.
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -965,22 +973,30 @@ public class PeggedAlgoEndpointTests
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
         var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
 
-        // Drift the mid → engine cancels child1 for a repeg.
+        // Hold the engine's CancelAsync await via a TCS so we have a
+        // deterministic window to race the Fill ER against.
+        var cancelGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        mock.CancelDelayInjector = _ => cancelGate.Task;
+
+        // Drift the mid → engine cancels child1; CancelAsync now parks
+        // on the gate.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
         await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit the cancel after the mid drift");
+            TimeSpan.FromSeconds(3), "engine did not invoke CancelAsync after the mid drift");
 
-        // Wait for the Started marker to be persisted (Window 3 — the
-        // only window that occurs naturally with the current single-
-        // threaded reactor; Windows 1+2 are defensive code paths in
-        // the engine, see ResolveRepegOnFillAsync XML doc).
-        await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is not null,
-            TimeSpan.FromSeconds(3), "AlgoPeggedRepegStartedEvent did not populate the book");
-
-        // Inject a full Fill ER for the cancelled child instead of
-        // the Cancel-ack the engine is waiting for — the venue race
-        // the RFC describes.
+        // While CancelAsync is held, inject the racing Fill ER. The
+        // ExecutionReportProcessor runs synchronously on the caller
+        // thread → order goes Filled / qty booked → child_er signal
+        // enqueued. The signal sits in the channel because the engine
+        // consumer is parked on CancelAsync.
         await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
+
+        // Release CancelAsync → engine resumes, persists Started
+        // (in-memory rt.RepegPending is still true because the queued
+        // ER hasn't been dispatched yet), then dequeues the Fill ER on
+        // the next loop iteration and routes through the
+        // IsCancelledChild dedup → ResolveRepegOnFillAsync.
+        cancelGate.SetResult();
 
         // Parent transitions to Completed (Fill consumed total qty).
         await WaitForAlgoStatus(http, token, algoId, "Completed");
@@ -988,18 +1004,15 @@ public class PeggedAlgoEndpointTests
         Assert.Equal(100, snap.GetProperty("filledQuantity").GetInt64());
         Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
 
-        // Cycle resolved: AlgoPeggedRepegResolvedEvent with
-        // Aborted=false + Reason=FilledBeforeCancelAck fires; replay
-        // handler removes the book entry. Terminal-transition cleanup
-        // would also remove it but the Resolved path wins the race.
+        // AlgoPeggedRepegResolvedEvent dispatched → book cleared. (The
+        // RecordTerminalAsync.RemoveAll also clears it as a safety
+        // net; this WaitFor doesn't distinguish.)
         await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
             TimeSpan.FromSeconds(3),
             "PeggedRepegBook still has an entry after the fill race resolved");
 
-        // No replacement child spawned (no orphan working order). The
-        // Fill handler's no-replacement branch is what guarantees
-        // this — without it the post-Fill Pegged path would call
-        // SubmitNextSliceAsync and spawn a duplicate.
+        // Exactly one cancel, no replacement child spawned from the
+        // Fill handler.
         Assert.Single(mock.SubmittedCancels);
         var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
         Assert.Single(allChildren);
@@ -1007,20 +1020,46 @@ public class PeggedAlgoEndpointTests
     }
 
     [Fact]
-    public async Task Pegged_FillRacesRepegCancel_BeforeStartedPersisted_NoOrphanInWal()
+    public async Task Pegged_FillRacesRepegCancel_DocumentsWindows1and2DefensiveGuard()
     {
-        // Pass-4 review (#296) P1, Windows 1+2 (defensive). With the
-        // current single-threaded reactor a Fill ER cannot interleave
-        // between EvaluatePeggedRepegAsync's CancelAsync await and the
-        // following Started dispatch — both run in the same iteration.
-        // This test pins the OBSERVABLE outcome the windowed code paths
-        // guarantee: across the full race window (whichever sub-window
-        // actually fires), there is NEVER a Started marker in
-        // PeggedRepegBook without a matching Resolved by the time the
-        // Fill ER is fully processed. Combined with the previous test
-        // (Window 3 → Resolved emitted), this ensures the audit pair
-        // is always balanced and replay can't recover into a stuck
-        // state regardless of which window fired.
+        // Pass-4 review (#296) P1, Windows 1 + 2 (defensive). Windows
+        // 1 (Fill processed before CancelAsync is invoked) and 2 (Fill
+        // processed after CancelAsync returns but before Started is
+        // persisted) are NOT naturally reachable in the current
+        // single-consumer reactor: the engine awaits CancelAsync
+        // inside its own consumer task, so a ChildExecutionObservedSignal
+        // racing the cancel can only be dequeued AFTER CancelAsync
+        // returns AND the post-cancel Started dispatch runs in the
+        // same iteration (which is always Window 3).
+        //
+        // Pass-5 review (#296) P2. We tried to construct the race
+        // with the new CancelDelayInjector — emit the Fill ER while
+        // the cancel is held, release the cancel — but the engine
+        // does not observe rt.RepegPending=false until its consumer
+        // loop runs OnChildErAsync, which happens AFTER the Started
+        // dispatch completes. The "if (!rt.RepegPending) return;"
+        // guard at the top of the post-cancel block (AlgoEngine line
+        // ~1524) is therefore defensive code that a future multi-
+        // consumer reactor (or an SDK that pumps ERs synchronously
+        // inside the cancel wire-call) would actually trigger.
+        //
+        // This test pins the OBSERVABLE invariant that holds across
+        // every window: regardless of which sub-window the race
+        // resolves in, the engine ends with (a) the parent in a
+        // coherent terminal/working state, (b) no orphan replacement
+        // child, and (c) no lingering Started without a matching
+        // Resolved (a future replay must converge on the same in-
+        // memory state). Combined with the Window 3 test above this
+        // covers the full race surface to the granularity that's
+        // observable today.
+        //
+        // **Guard pinned**: the post-Cancelled `IsCancelledChild`
+        // dedup at AlgoEngine line ~788 — removing it would let a
+        // late Cancelled-status ER (the cancel-ack arriving after the
+        // fill resolved the cycle) fall through to the VenueCancelled
+        // branch and Suspend the parent. The cycle-resolved
+        // RepegPending=false assertion below catches that regression
+        // (Suspended ≠ Completed).
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -1041,23 +1080,16 @@ public class PeggedAlgoEndpointTests
         await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
             TimeSpan.FromSeconds(3), "engine did not emit the cancel");
 
-        // Race the Fill ER in immediately — depending on scheduler
-        // interleaving this may land before OR after Started persists.
-        // Either way the post-condition (no lingering book entry,
-        // parent Completed, no replacement orphan) must hold.
+        // Race the Fill ER in immediately. Settled outcome is what we
+        // verify; the exact internal window the race resolves in is
+        // intentionally not pinned.
         await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
-
         await WaitForAlgoStatus(http, token, algoId, "Completed");
 
-        // Eventually the book settles to "no pending entry" — covers
-        // Windows 1+2 (entry never existed) AND Window 3 (entry was
-        // created then Resolved cleared it).
         await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
             TimeSpan.FromSeconds(3),
             "PeggedRepegBook still has an entry after the fill race");
 
-        // Exactly one cancel, no replacement child spawned from the
-        // Fill handler (no orphan working order).
         Assert.Single(mock.SubmittedCancels);
         var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
         Assert.Single(allChildren);
@@ -1073,18 +1105,15 @@ public class PeggedAlgoEndpointTests
         // the cancel after the fill landed). That late Cancelled wire
         // MUST be a no-op — NOT a second SubmitNextSliceAsync call
         // (which would duplicate the replacement child and orphan a
-        // working order). The sticky LastRepegCancelledChildId marker
-        // + the parent-terminal short-circuit + the Filled-case
-        // dedup branch together keep the classification correct
-        // regardless of which guard catches it first.
+        // working order).
         //
         // Because Pegged places the full RemainingQuantity on each
         // working slice, a full Fill of child1 also completes the
         // parent in this test; the parent-terminal short-circuit at
         // the top of OnChildErAsync's Filled case is what absorbs the
-        // late ER in that path. For the non-terminal-parent path
-        // (e.g. iceberg child types in a future RFC) the sticky
-        // LastRepegCancelledChildId dedup is the safety net.
+        // late ER in that path. The non-terminal-parent case
+        // (subsequent-repeg dedup) is covered separately by
+        // Pegged_LateFillAfterSubsequentRepeg_DedupViaHistoryRing.
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -1115,12 +1144,6 @@ public class PeggedAlgoEndpointTests
         var newOrdersBefore = mock.SubmittedNewOrders.Count;
         var childrenBefore = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).Count();
 
-        // Late cancel-ack for the already-filled child1. The order is
-        // Filled (Order.MarkCancelled is a no-op on Filled) so the ER
-        // hits the Filled case in OnChildErAsync; the parent is
-        // already terminal so the algo.IsTerminal short-circuit at
-        // the top of the case absorbs the ER. No Resolved
-        // re-dispatch, no SubmitNextSliceAsync, no extra child.
         await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
         await Task.Delay(200);
 
@@ -1132,9 +1155,213 @@ public class PeggedAlgoEndpointTests
         Assert.Equal(childrenBefore,
             book.EnumerateChildrenOf("default", ulong.Parse(algoId)).Count());
 
-        // Also assert the book entry stays absent — a late ER must
-        // not resurrect a Started/Resolved cycle.
         Assert.Null(repegBook.TryGet("default", ulong.Parse(algoId)));
+    }
+
+    // ──────────────── Pass-5 review (#296) P1 regression tests ────────────────
+
+    [Fact]
+    public async Task Pegged_LateFillAfterSubsequentRepeg_DedupViaHistoryRing()
+    {
+        // Pass-5 review (#296) P1. Reproduces the single-slot dedup
+        // gap that pass-4's LastRepegCancelledChildId left open:
+        //
+        //   1. Repeg A: engine cancels child1, cancel-ack lands,
+        //      child2 is placed. After this point the single-slot
+        //      marker has rotated to child2 (the LATEST cycle's
+        //      cancelled child id).
+        //   2. Repeg B: engine cancels child2; cancel-ack pending.
+        //   3. LATE Fill ER for child1 arrives (delayed venue/
+        //      simulator reporting). With the single-slot marker
+        //      pointing at child2, child1 != marker → the dedup
+        //      branches in OnChildErAsync (Filled-case at line ~666
+        //      AND Cancelled-case at line ~788) were both MISSED →
+        //      the late ER fell through to either a spurious
+        //      replacement child or the VenueCancelled-suspension
+        //      branch, depending on the order's preserved terminal
+        //      status.
+        //
+        // The fix is the bounded FIFO history ring
+        // (PeggedRepegBook.IsCancelledChild) that remembers EVERY
+        // recently engine-cancelled child id, not just the latest.
+        //
+        // **Guard pinned**: replace IsCancelledChild with
+        // `rt.LastRepegCancelledChildId == child.ClOrdId` at the
+        // Cancelled-case dedup (line ~788) and this test fails: the
+        // late Fill ER's signal lands the engine on the
+        // VenueCancelled fallthrough → parent transitions to
+        // Suspended, the final Assert.Equal("Working", ...) below
+        // catches it.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        // total=200 so a partial Fill on child1 doesn't terminal the
+        // parent — keeps us on the non-terminal-parent path that
+        // exercises the dedup branch (rather than the algo.IsTerminal
+        // short-circuit at the top of the Filled case).
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 200, repegMs: 100));
+        var algoIdNum = ulong.Parse(algoId);
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+
+        // Cycle A: drift → cancel child1, then ack so child2 lands.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit cancel A");
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(31.0m, child2.Price);
+
+        // Cycle B: drift → cancel child2. Do NOT ack — leaves
+        // RepegPending=true and the single-slot marker pointing at
+        // child2 (so child1 is no longer "the" sticky cancelled id).
+        cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child2.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit cancel B");
+
+        var newOrdersBeforeLateEr = mock.SubmittedNewOrders.Count;
+
+        // Late Fill ER for child1 (already-Cancelled). The processor
+        // preserves the terminal status (Order.ApplyCumulativeFill
+        // line ~367) but enqueues the signal because cumQty advanced.
+        // The engine then sees child1.Status==Cancelled and routes
+        // into the Cancelled-case; without the history-ring dedup
+        // the parent would be Suspended/VenueCancelled.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 10);
+
+        // Give the consumer loop time to drain the late ER signal.
+        await Task.Delay(200);
+
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal("Working", snap.GetProperty("status").GetString());
+        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+
+        // No new replacement child spawned from the late ER — only
+        // the two cycles' children (child1 terminal + child2 still
+        // working) are in the book.
+        Assert.Equal(newOrdersBeforeLateEr, mock.SubmittedNewOrders.Count);
+        var liveChildren = book.EnumerateChildrenOf("default", algoIdNum)
+            .Where(c => c.Status is OrderStatus.PendingNew or OrderStatus.Working or OrderStatus.PartiallyFilled)
+            .ToList();
+        Assert.Single(liveChildren);
+        Assert.Equal(child2.ClOrdId, liveChildren[0].ClOrdId);
+    }
+
+    [Fact]
+    public async Task Pegged_RestartThenLateFillForOldChild_DedupSurvivesSnapshotRestart()
+    {
+        // Pass-5 review (#296) P1. Cross-restart durability of the
+        // cancelled-child history ring. Without the snapshot field
+        // (PeggedRepegHistory) a restart between the original repeg
+        // and the late ER would lose the dedup memory and let the
+        // late Fill ER suspend the parent on the post-restart
+        // VenueCancelled fallthrough.
+        //
+        // Sequence:
+        //   1. Pre-restart: drive repeg A (cancel + ack child1 →
+        //      child2 placed) so child1 is in the history ring but
+        //      NOT in PeggedRepegPending (cycle is resolved).
+        //   2. Drive repeg B (cancel child2, no ack) so the pending
+        //      entry exists. Take a snapshot.
+        //   3. Cold restart. Snapshot.Restore re-hydrates BOTH the
+        //      pending entry AND the history ring.
+        //   4. Inject a late Fill for child1. The engine's history-
+        //      ring lookup hits, dedup fires, parent stays Working.
+        //
+        // **Guard pinned**: remove the PeggedRepegHistory snapshot
+        // capture (or the RestoreHistory call in StateSnapshotter)
+        // and this test fails — child1 is not in the post-restart
+        // ring → late Fill falls through to Suspended.
+        var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
+            "b3-pegged-history-restart-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            ulong child1ClOrdId = 0;
+            ulong child2ClOrdId = 0;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var adminToken = await f.LoginAsync(http, "admin");
+                var cache = f.Services.GetRequiredService<PegBookTopCache>();
+                cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+                var algoIdStr = await PostAlgo(http, token,
+                    PeggedBody(total: 200, pegRef: "Mid", offsetTicks: 0,
+                        repegMs: 100, tickSize: 0.5m));
+                algoIdNum = ulong.Parse(algoIdStr);
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                var child1 = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(3));
+                child1ClOrdId = child1.ClOrdId;
+
+                var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+
+                // Cycle A: cancel + ack → child2 placed. child1 ends
+                // up in the history ring; the PeggedRepegBook pending
+                // entry is cleared by the Resolved event.
+                cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit cancel A pre-restart");
+                await InjectEr(http, adminToken, child1ClOrdId, "Canceled");
+                var child2 = await WaitForChildOtherThan(book, algoIdStr, child1ClOrdId,
+                    TimeSpan.FromSeconds(3));
+                child2ClOrdId = child2.ClOrdId;
+
+                // Cycle B: cancel child2, no ack. The pending entry
+                // now references child2; child1 lives only in the
+                // history ring.
+                cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
+                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child2ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit cancel B pre-restart");
+
+                // Snapshot under the dispatcher lock — must capture
+                // both the pending entry (for child2) and the history
+                // ring (containing child1 + child2).
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            using (var http2 = f2.CreateClient())
+            {
+                var token = await f2.LoginAsync(http2);
+                var adminToken = await f2.LoginAsync(http2, "admin");
+
+                // Sanity: snapshot restore populated the history ring.
+                var repegBook2 = f2.Services.GetRequiredService<PeggedRepegBook>();
+                Assert.True(repegBook2.IsCancelledChild("default", algoIdNum, child1ClOrdId),
+                    "Snapshot restore did not rehydrate child1 in the history ring");
+                Assert.True(repegBook2.IsCancelledChild("default", algoIdNum, child2ClOrdId),
+                    "Snapshot restore did not rehydrate child2 in the history ring");
+
+                // Late Fill for child1 (already-Cancelled in the
+                // restored order book). Without the snapshotted
+                // history ring the post-restart Cancelled-case dedup
+                // would miss and Suspend the parent.
+                await InjectEr(http2, adminToken, child1ClOrdId, "Fill", lastQty: 10);
+                await Task.Delay(200);
+
+                var snap = await GetAlgo(http2, token, algoIdNum.ToString());
+                Assert.Equal("Working", snap.GetProperty("status").GetString());
+                Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
     }
 
     // ───────────────────────── helpers ─────────────────────────

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -1,0 +1,550 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// End-to-end coverage for the Pegged algo (Q3.3 / #283). Mirrors the
+/// shape of <see cref="PovAlgoEndpointTests"/>: real wall-clock with
+/// sub-second cadence so the scheduler and engine reactor exercise the
+/// production code path. The Pegged-specific twist is the market-data
+/// reference price: tests inject mids/bests/lasts directly through
+/// <see cref="PegBookTopCache"/> rather than through a real SDK feed
+/// (see the SDK-gap note on <see cref="PegBookTopCache"/>).
+/// </summary>
+public class PeggedAlgoEndpointTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object PeggedBody(long total, string pegRef = "Mid",
+        int offsetTicks = 0, int? repegMs = 100, decimal? tickSize = 0.5m,
+        string? childType = null, decimal? priceLimit = null, string side = "Buy") => new
+        {
+            Symbol = "PETR4",
+            Side = side,
+            Type = "Pegged",
+            TotalQuantity = total,
+            Pegged = new
+            {
+                Ref = pegRef,
+                OffsetTicks = offsetTicks,
+                RepegIntervalMs = repegMs,
+                TickSize = tickSize,
+                ChildOrderType = childType,
+                PriceLimit = priceLimit,
+            },
+        };
+
+    // ───────────────────────── POST validation ─────────────────────────
+
+    [Fact]
+    public async Task PostAlgo_PeggedWithoutParams_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Pegged",
+                TotalQuantity = 100,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PeggedInvalidRef_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PeggedBody(100, pegRef: "Bogus")),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PeggedNonPositiveTickSize_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PeggedBody(100, tickSize: 0m)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_PeggedMarketChildType_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PeggedBody(100, childType: "Market")),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ───────────────────── Happy path: pricing + repeg ─────────────────────
+
+    [Fact]
+    public async Task Pegged_PostsAtPeggedTargetPrice()
+    {
+        // Seed the book-top cache BEFORE posting so the very first
+        // engine tick has a live reference. Pegged Buy / mid / offset=0
+        // / tickSize=0.5: target = 30.0.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", bestBid: 29.5m, bestAsk: 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 200));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child.Price);
+        Assert.Equal(200, child.Quantity);
+    }
+
+    [Fact]
+    public async Task Pegged_MidMoves_TriggersRepeg()
+    {
+        // Steady mid = 30.0; engine places child @ 30.0. Mid jumps to
+        // 31.0 → engine cancels child via gateway (queued on mock),
+        // test admin-injects the Cancelled ER, engine submits new child
+        // at the fresh target (31.0).
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        // Move the mid up one tick — repeg gate is "≥ 1 tick", so 1.0
+        // delta (= 2 ticks at 0.5) is comfortably over the threshold.
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+
+        // Engine must enqueue exactly one cancel for the live child.
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never cancelled the live child after mid moved");
+
+        // Mirror what the venue would do — emit the Cancelled ER for
+        // the old child. The engine's RepegPending flag routes this
+        // through SubmitNextSliceAsync (rather than VenueCancelled
+        // suspension) — assertable via the new child appearing at the
+        // fresh target price.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+
+        var newChild = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
+        Assert.Equal(31.0m, newChild.Price);
+        Assert.Equal(100, newChild.Quantity); // full residue (no fills yet).
+    }
+
+    [Fact]
+    public async Task Pegged_StableMid_DoesNotRepeg()
+    {
+        // Steady mid: engine must NOT churn cancels. Assert no cancel
+        // is enqueued after the first child is placed.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100, repegMs: 50));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child.Price);
+
+        // Keep the mid steady (re-stamp identical legs so freshness
+        // doesn't decay). Several scheduler ticks must pass — the
+        // engine re-evaluates each tick and must no-op every time.
+        for (int i = 0; i < 8; i++)
+        {
+            cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+            await Task.Delay(50);
+        }
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        Assert.Empty(mock.SubmittedCancels);
+    }
+
+    [Fact]
+    public async Task Pegged_PriceLimitBlocksAggressiveRepeg()
+    {
+        // Buy with priceLimit = 30.5. Initial target = 30.0, child sits
+        // there. Mid jumps to 32.0 → raw target = 32.0 → clamped down
+        // to 30.5. 30.5 differs from 30.0 by 1 tick → 1 repeg fires
+        // (legitimate move up to the limit). After that, further mid
+        // moves leave the clamped target stuck at 30.5 — engine must
+        // not churn additional cancels.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token,
+            PeggedBody(total: 100, priceLimit: 30.5m));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+
+        // First move clamps to the limit (30.5) — one repeg.
+        cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedCancels.Count == 1,
+            TimeSpan.FromSeconds(3), "engine did not repeg to the price limit");
+        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.5m, child2.Price);
+
+        // Subsequent further-aggressive moves stay clamped at 30.5,
+        // identical to child2.Price → IsRepegNeeded false → engine
+        // must not enqueue another cancel.
+        for (int i = 0; i < 6; i++)
+        {
+            cache.UpdateBookTop("PETR4", 32.5m + i, 33.5m + i, DateTimeOffset.UtcNow);
+            await Task.Delay(50);
+        }
+        Assert.Single(mock.SubmittedCancels);
+    }
+
+    // ───────────────────── Cancel-mid-flight ─────────────────────
+
+    /// <summary>
+    /// Recording sink shared with the other algo-endpoint suites — used
+    /// to assert exactly-once terminal emission across the operator-cancel
+    /// race with the engine-driven repeg path.
+    /// </summary>
+    private sealed class RecordingAlgoEventSink : IAlgoEventSink
+    {
+        private readonly AlgoBook _book;
+        private readonly object _gate = new();
+        private readonly List<(ulong AlgoId, AlgoStatus Status)> _publishes = new();
+
+        public RecordingAlgoEventSink(AlgoBook book) => _book = book;
+
+        public void PublishAlgoSnapshot(EndClientId owner, string firmId, ulong algoId)
+        {
+            if (!_book.TryGet(firmId, algoId, out var algo) || algo is null) return;
+            lock (_gate) { _publishes.Add((algoId, algo.Status)); }
+        }
+
+        public int TerminalPublishCount(ulong algoId)
+        {
+            lock (_gate)
+            {
+                return _publishes.Count(p => p.AlgoId == algoId && IsTerminal(p.Status));
+            }
+        }
+
+        private static bool IsTerminal(AlgoStatus s) =>
+            s is AlgoStatus.Cancelled or AlgoStatus.Completed
+              or AlgoStatus.Expired or AlgoStatus.Suspended;
+    }
+
+    [Fact]
+    public async Task Pegged_CancelMidFlight_TerminalEmittedOnce()
+    {
+        // Operator DELETE during a live working slice. The simulator's
+        // Cancelled ER must drive the parent terminal exactly once even
+        // though Pegged's repeg path also routes through OnChildErAsync
+        // Cancelled — the algo.Status==Cancelling branch wins because
+        // the engine clears RepegPending only AFTER it issues its own
+        // cancel, which DELETE preempts.
+        RecordingAlgoEventSink? sink = null;
+        using var f = TestAppFactory.WithOverrides(Simulator(), services =>
+        {
+            services.RemoveAll<IAlgoEventSink>();
+            services.AddSingleton<IAlgoEventSink>(sp =>
+                sink = new RecordingAlgoEventSink(sp.GetRequiredService<AlgoBook>()));
+        });
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        _ = f.Services.GetRequiredService<IAlgoEventSink>();
+        Assert.NotNull(sink);
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, userToken, PeggedBody(total: 100));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var inFlight = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, del.StatusCode);
+
+        await InjectEr(http, adminToken, inFlight.ClOrdId, "Canceled");
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Cancelled");
+        var snap = await GetAlgo(http, userToken, algoId);
+        Assert.Equal("UserCancelled", snap.GetProperty("terminalReason").GetString());
+
+        // Idempotent terminal — even after a follow-up DELETE there
+        // must be exactly one terminal publish.
+        var req2 = new HttpRequestMessage(HttpMethod.Delete, $"/algo/{algoId}");
+        req2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        var del2 = await http.SendAsync(req2);
+        Assert.Equal(HttpStatusCode.Conflict, del2.StatusCode);
+
+        await Task.Delay(100);
+        Assert.Equal(1, sink!.TerminalPublishCount(ulong.Parse(algoId)));
+    }
+
+    // ──────────────────── DTO ────────────────────
+
+    [Fact]
+    public async Task GetAlgo_ReturnsPeggedParametersInDto()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Don't seed the cache — the parent will sit waiting for a ref
+        // (no-op submit path) which is fine for a DTO-shape assertion.
+        var algoId = await PostAlgo(http, token,
+            PeggedBody(total: 200, pegRef: "Best", offsetTicks: -2,
+                repegMs: 750, tickSize: 0.05m, priceLimit: 41.25m));
+
+        var algo = await GetAlgo(http, token, algoId);
+        Assert.Equal("Pegged", algo.GetProperty("type").GetString());
+        var pgd = algo.GetProperty("pegged");
+        Assert.Equal("Best", pgd.GetProperty("ref").GetString());
+        Assert.Equal(-2, pgd.GetProperty("offsetTicks").GetInt32());
+        Assert.Equal(750, pgd.GetProperty("repegIntervalMs").GetInt32());
+        Assert.Equal(0.05m, pgd.GetProperty("tickSize").GetDecimal());
+        Assert.Equal("Limit", pgd.GetProperty("childOrderType").GetString());
+        Assert.Equal(41.25m, pgd.GetProperty("priceLimit").GetDecimal());
+    }
+
+    // ──────────────────── Recovery ────────────────────
+
+    private static IDictionary<string, string?> PersistenceOverrides(string dataDir)
+    {
+        var d = new Dictionary<string, string?>(Simulator())
+        {
+            ["Trading:Persistence:Enabled"] = "true",
+            ["Trading:Persistence:DataDirectory"] = dataDir,
+            ["Trading:Persistence:FirmId"] = "default",
+            ["Trading:Persistence:SnapshotInterval"] = "00:10:00",
+        };
+        return d;
+    }
+
+    private static B3.Trading.Infrastructure.Persistence.SnapshotService ResolveSnapshotService(TestAppFactory f) =>
+        f.Services.GetServices<Microsoft.Extensions.Hosting.IHostedService>()
+            .OfType<B3.Trading.Infrastructure.Persistence.SnapshotService>()
+            .Single();
+
+    [Fact]
+    public async Task Pegged_SnapshotRestart_RestoresParametersAndWorkingSlice()
+    {
+        // Take a snapshot while the algo has a live working slice;
+        // restart cold; assert the Pegged-shaped parameters made the
+        // round-trip and that the algo is recovered as "Working" with
+        // its filled/remaining unchanged.
+        var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
+            "b3-pegged-recovery-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var overrides = PersistenceOverrides(dataDir);
+            ulong algoIdNum = 0;
+            long expectedTotal;
+
+            using (var f = TestAppFactory.WithOverrides(overrides))
+            using (var http = f.CreateClient())
+            {
+                var token = await f.LoginAsync(http);
+                var cache = f.Services.GetRequiredService<PegBookTopCache>();
+                cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+                var algoIdStr = await PostAlgo(http, token,
+                    PeggedBody(total: 100, pegRef: "Mid", offsetTicks: 0,
+                        repegMs: 250, tickSize: 0.5m));
+                algoIdNum = ulong.Parse(algoIdStr);
+                expectedTotal = 100;
+
+                var book = f.Services.GetRequiredService<WorkingOrderBook>();
+                _ = await WaitForAnyChild(book, algoIdStr, TimeSpan.FromSeconds(3));
+
+                ResolveSnapshotService(f).TryTakeSnapshot();
+            }
+
+            // Cold restart with the same data dir.
+            using (var f2 = TestAppFactory.WithOverrides(overrides))
+            using (var http2 = f2.CreateClient())
+            {
+                var token = await f2.LoginAsync(http2);
+                var algo = await GetAlgo(http2, token, algoIdNum.ToString());
+                Assert.Equal("Pegged", algo.GetProperty("type").GetString());
+                Assert.Equal(expectedTotal, algo.GetProperty("totalQuantity").GetInt64());
+                var pgd = algo.GetProperty("pegged");
+                Assert.Equal("Mid", pgd.GetProperty("ref").GetString());
+                Assert.Equal(0, pgd.GetProperty("offsetTicks").GetInt32());
+                Assert.Equal(0.5m, pgd.GetProperty("tickSize").GetDecimal());
+                Assert.Equal(250, pgd.GetProperty("repegIntervalMs").GetInt32());
+            }
+        }
+        finally
+        {
+            try { if (Directory.Exists(dataDir)) Directory.Delete(dataDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    // ───────────────────────── helpers ─────────────────────────
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<Order> WaitForAnyChild(WorkingOrderBook book, string algoIdStr, TimeSpan timeout)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var match = book.EnumerateChildrenOf("default", algoId).FirstOrDefault();
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"No child for algo {algoIdStr} within {timeout.TotalSeconds}s.");
+    }
+
+    private static async Task<Order> WaitForChildOtherThan(
+        WorkingOrderBook book, string algoIdStr, ulong excludeClOrdId, TimeSpan timeout)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var match = book.EnumerateChildrenOf("default", algoId)
+                .FirstOrDefault(c => c.ClOrdId != excludeClOrdId);
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException(
+            $"No new child (other than {excludeClOrdId}) for algo {algoIdStr} within {timeout.TotalSeconds}s.");
+    }
+
+    private static async Task WaitFor(Func<bool> predicate, TimeSpan timeout, string failMessage)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (predicate()) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException(failMessage + $" (waited {timeout.TotalSeconds}s)");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application;
+using B3.Trading.Application.Observability;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.AlgoEngine;
+
+public class PeggedRepegBookTests
+{
+    /// <summary>
+    /// Pass-6 review (#296) P2. When the per-parent cancelled-child
+    /// FIFO ring overflows past <see cref="PeggedRepegBook.CancelledHistoryCap"/>,
+    /// each eviction MUST bump
+    /// <see cref="MetricsRegistry.AlgoPeggedRepegDedupRingEvicted"/>
+    /// so operators see when the dedup window stops covering venue
+    /// tail-Fill latency. Adds at or below the cap MUST NOT bump.
+    /// </summary>
+    [Fact]
+    public void MarkCancelledChild_RingOverflow_IncrementsEvictionCounter()
+    {
+        long captured = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Name == "trading.algo.pegged.repeg_dedup_ring_evicted_total")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            Interlocked.Add(ref captured, measurement);
+        });
+        listener.Start();
+
+        var book = new PeggedRepegBook();
+        const string firm = "TEST";
+        const ulong algoId = 42UL;
+        var cap = PeggedRepegBook.CancelledHistoryCap;
+
+        // Fill the ring exactly to the cap — no evictions yet.
+        for (ulong i = 1; i <= (ulong)cap; i++)
+        {
+            book.MarkCancelledChild(firm, algoId, i);
+        }
+        Assert.Equal(0, Interlocked.Read(ref captured));
+
+        // Every fresh id past the cap must evict the oldest and bump.
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 1);
+        Assert.Equal(1, Interlocked.Read(ref captured));
+
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 2);
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 3);
+        Assert.Equal(3, Interlocked.Read(ref captured));
+
+        // Duplicates are no-ops — must not bump.
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 3);
+        Assert.Equal(3, Interlocked.Read(ref captured));
+
+        // The oldest id (1) has fallen out of the ring; the newest is
+        // still recognised as cancelled.
+        Assert.False(book.IsCancelledChild(firm, algoId, 1UL),
+            "Oldest id should have been evicted past the cap.");
+        Assert.True(book.IsCancelledChild(firm, algoId, (ulong)cap + 3),
+            "Most recent id must still be present in the dedup ring.");
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using B3.Trading.Application;
 using B3.Trading.Application.Observability;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace B3.Trading.Application.Tests.AlgoEngine;
@@ -61,5 +62,120 @@ public class PeggedRepegBookTests
             "Oldest id should have been evicted past the cap.");
         Assert.True(book.IsCancelledChild(firm, algoId, (ulong)cap + 3),
             "Most recent id must still be present in the dedup ring.");
+    }
+
+    /// <summary>
+    /// Pass-7 review (#296) P2. The per-ring "eviction warn already
+    /// emitted" latch is in-memory; without persisting it across
+    /// <see cref="PeggedRepegBook.SnapshotHistory"/> /
+    /// <see cref="PeggedRepegBook.RestoreHistory"/>, a parent that
+    /// already warned pre-restart would warn AGAIN on the next
+    /// eviction post-restart. Pin the round-trip: snapshot a ring
+    /// whose latch is set → restore → trigger another eviction → no
+    /// new warn must be logged (eviction counter still bumps).
+    /// </summary>
+    [Fact]
+    public void RestoreHistory_PreservesEvictionLoggedLatch_NoWarnAfterRestart()
+    {
+        const string firm = "TEST";
+        const ulong algoId = 7UL;
+        var cap = PeggedRepegBook.CancelledHistoryCap;
+
+        var preLogger = new CountingLogger<PeggedRepegBook>();
+        var pre = new PeggedRepegBook(preLogger);
+
+        // Fill to cap + force one eviction so the latch flips to true
+        // and one warn is logged on the pre-restart book.
+        for (ulong i = 1; i <= (ulong)cap; i++) pre.MarkCancelledChild(firm, algoId, i);
+        pre.MarkCancelledChild(firm, algoId, (ulong)cap + 1);
+        Assert.Equal(1, preLogger.WarningCount);
+
+        // Subsequent evictions on the same in-memory ring must stay
+        // silent (sanity check on the latch within a single process).
+        pre.MarkCancelledChild(firm, algoId, (ulong)cap + 2);
+        Assert.Equal(1, preLogger.WarningCount);
+
+        // Snapshot now carries (ids, EvictionLogged=true). Round-trip
+        // through the SnapshotHistory tuple shape used by
+        // StateSnapshotter.
+        var snapshot = pre.SnapshotHistory().ToList();
+        Assert.Single(snapshot);
+        Assert.True(snapshot[0].EvictionLogged,
+            "SnapshotHistory must emit the latched eviction-warn flag.");
+
+        var postLogger = new CountingLogger<PeggedRepegBook>();
+        var post = new PeggedRepegBook(postLogger);
+        post.RestoreHistory(snapshot.Select(t =>
+            (t.FirmId, t.AlgoId, t.ChildClOrdIds, t.EvictionLogged)));
+
+        // Force another eviction on the rehydrated ring. The dedup
+        // counter MUST still bump (functional behaviour unchanged) but
+        // the warn MUST stay suppressed because the latch was restored.
+        long evictedAfterRestore = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Name == "trading.algo.pegged.repeg_dedup_ring_evicted_total")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, m, _, _) =>
+            Interlocked.Add(ref evictedAfterRestore, m));
+        listener.Start();
+
+        post.MarkCancelledChild(firm, algoId, (ulong)cap + 3);
+
+        Assert.Equal(1, Interlocked.Read(ref evictedAfterRestore));
+        Assert.Equal(0, postLogger.WarningCount);
+    }
+
+    /// <summary>
+    /// Forward-compat: snapshots pre-dating the
+    /// <c>EvictionLogged</c> field default to <c>false</c> on restore,
+    /// so the very next eviction WILL warn once (acceptable — at worst
+    /// one extra log post-upgrade, no functional change).
+    /// </summary>
+    [Fact]
+    public void RestoreHistory_LatchDefaultsFalse_WhenFlagAbsent()
+    {
+        const string firm = "TEST";
+        const ulong algoId = 9UL;
+        var cap = PeggedRepegBook.CancelledHistoryCap;
+
+        var logger = new CountingLogger<PeggedRepegBook>();
+        var book = new PeggedRepegBook(logger);
+
+        // Pre-field snapshot shape: caller passes EvictionLogged=false
+        // (or omits, taking the optional default).
+        var ids = new List<ulong>();
+        for (ulong i = 1; i <= (ulong)cap; i++) ids.Add(i);
+        book.RestoreHistory(new[]
+        {
+            (firm, algoId, (IReadOnlyList<ulong>)ids, false),
+        });
+
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 1);
+        Assert.Equal(1, logger.WarningCount);
+    }
+
+    private sealed class CountingLogger<T> : ILogger<T>
+    {
+        private int _warnings;
+
+        public int WarningCount => Volatile.Read(ref _warnings);
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning) Interlocked.Increment(ref _warnings);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/PeggedRepegBookTests.cs
@@ -157,6 +157,98 @@ public class PeggedRepegBookTests
         Assert.Equal(1, logger.WarningCount);
     }
 
+    /// <summary>
+    /// Pass-8 review (#296) P2. The eviction and the per-ring
+    /// "one-shot warn already emitted" latch MUST flip as a single
+    /// atomic step under the ring's lock. Otherwise a
+    /// <see cref="PeggedRepegBook.SnapshotHistory"/> call interleaved
+    /// between <c>ring.Add</c> and an external <c>MarkEvictionLogged</c>
+    /// could capture <c>EvictionLogged=false</c> for a ring whose
+    /// eviction had already happened — causing a duplicate warn
+    /// after a restart that re-hydrated the snapshot.
+    ///
+    /// <para>
+    /// Exercises the invariant directly on
+    /// <see cref="CancelledChildRing"/>: fill to the cap, push one
+    /// more entry to trigger the eviction, then immediately call
+    /// <see cref="CancelledChildRing.SnapshotWithLatch"/> WITHOUT any
+    /// external <see cref="CancelledChildRing.MarkEvictionLogged"/>
+    /// call. The snapshot must already report
+    /// <c>EvictionLogged=true</c> — proving the latch flip is
+    /// encapsulated inside <c>Add</c> rather than left to a
+    /// separately-scheduled caller step.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void Add_FlipsEvictionLatchAtomicallyWithEviction_NoExternalMarkRequired()
+    {
+        var cap = PeggedRepegBook.CancelledHistoryCap;
+        var ring = new CancelledChildRing(cap);
+
+        for (ulong i = 1; i <= (ulong)cap; i++)
+        {
+            Assert.False(ring.Add(i, out var firstEviction),
+                "Adds at or below the cap must not evict.");
+            Assert.False(firstEviction);
+        }
+
+        // Snapshot BEFORE the first eviction: latch must still be false.
+        var preSnap = ring.SnapshotWithLatch();
+        Assert.False(preSnap.EvictionLogged);
+        Assert.Equal(cap, preSnap.Ids.Count);
+
+        // Trigger eviction. The latch MUST flip inside this Add call.
+        Assert.True(ring.Add((ulong)cap + 1, out var firstEvictionOnOverflow),
+            "Adding past the cap must report eviction.");
+        Assert.True(firstEvictionOnOverflow,
+            "The first eviction on a ring MUST report firstEviction=true so callers can emit the one-shot warn.");
+
+        // Critical assertion: snapshot WITHOUT any external
+        // MarkEvictionLogged() call must already see latch=true.
+        var postSnap = ring.SnapshotWithLatch();
+        Assert.True(postSnap.EvictionLogged,
+            "EvictionLogged MUST be observable as true immediately after the evicting Add returns, with no external latch flip required.");
+        Assert.Equal(cap, postSnap.Ids.Count);
+
+        // Subsequent evictions still report `true` for the evicted
+        // bool but firstEviction MUST stay false (latch already set).
+        Assert.True(ring.Add((ulong)cap + 2, out var firstEvictionOnSecond));
+        Assert.False(firstEvictionOnSecond,
+            "Only the first eviction may report firstEviction=true; subsequent ones suppress the warn.");
+    }
+
+    /// <summary>
+    /// Pass-8 review (#296) P2. End-to-end variant on
+    /// <see cref="PeggedRepegBook"/>: after the public
+    /// <see cref="PeggedRepegBook.MarkCancelledChild"/> call that
+    /// causes the first eviction returns, the very next
+    /// <see cref="PeggedRepegBook.SnapshotHistory"/> MUST observe
+    /// <c>EvictionLogged=true</c>. This pins the book-level wiring
+    /// (the per-parent ring's latch is what
+    /// <c>SnapshotHistory</c> reads) so a future refactor that
+    /// re-introduces an external latch-flip step is caught.
+    /// </summary>
+    [Fact]
+    public void MarkCancelledChild_SnapshotImmediatelyAfterEvictionSeesLatchedFlag()
+    {
+        const string firm = "TEST";
+        const ulong algoId = 13UL;
+        var cap = PeggedRepegBook.CancelledHistoryCap;
+        var book = new PeggedRepegBook();
+
+        for (ulong i = 1; i <= (ulong)cap; i++) book.MarkCancelledChild(firm, algoId, i);
+
+        // Pre-eviction snapshot: latch must be false.
+        Assert.False(book.SnapshotHistory().Single().EvictionLogged);
+
+        // First eviction.
+        book.MarkCancelledChild(firm, algoId, (ulong)cap + 1);
+
+        // Without any intervening "mark logged" call, the snapshot
+        // must already see the latch.
+        Assert.True(book.SnapshotHistory().Single().EvictionLogged);
+    }
+
     private sealed class CountingLogger<T> : ILogger<T>
     {
         private int _warnings;

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
@@ -112,6 +112,91 @@ public class FileEventStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadFromAsync_WithMissingKindDiscriminator_ThrowsAndDoesNotSilentlySkip()
+    {
+        // Pass-3 review (#296) P2. A WAL record whose JSON has NO
+        // `kind` field is NOT a forward-compat case (every writer in
+        // this codebase emits the discriminator). It indicates a torn
+        // write, external corruption, or a writer bug — replay must
+        // halt loudly, NOT silently skip the record as the old P2
+        // behaviour did. A KNOWN record after it must NOT be returned
+        // (we halt on the corruption, we don't reorder past it).
+        var opts = OptsForTest();
+        var walDir = Path.Combine(_root, "test", "wal", "2026-01-01");
+        Directory.CreateDirectory(walDir);
+        var logPath = Path.Combine(walDir, "000.log");
+        var idxPath = Path.Combine(walDir, "000.idx");
+
+        var known = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(0), WalEventJsonContext.Default.WalEvent);
+        // JSON object without a `kind` field at all.
+        var missingKind = Encoding.UTF8.GetBytes(
+            """{"someField":"value","timestampUtc":"2026-01-01T10:00:00+00:00"}""");
+        var known2 = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(1), WalEventJsonContext.Default.WalEvent);
+
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, known, 0);
+            writer.Append(2, missingKind, 0);
+            writer.Append(3, known2, 0);
+            writer.Flush();
+        }
+
+        await using var store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        var seenBeforeThrow = new List<long>();
+        await Assert.ThrowsAsync<InvalidDataException>(async () =>
+        {
+            await foreach (var (seq, _) in store.ReadFromAsync(0))
+            {
+                seenBeforeThrow.Add(seq);
+            }
+        });
+        // The first (known) record is yielded; replay halts on the
+        // missing-kind record at seq=2; the trailing known record at
+        // seq=3 is NOT silently skipped past.
+        Assert.Equal(new long[] { 1 }, seenBeforeThrow.ToArray());
+    }
+
+    [Fact]
+    public async Task ReadFromAsync_WithEmptyKindString_TreatedAsMissing()
+    {
+        // Pass-3 review (#296) P2. An empty-string `kind` is
+        // indistinguishable from missing for purposes of polymorphic
+        // dispatch — there is no derived type registered for the
+        // empty discriminator. The reader must classify this as a
+        // corruption (MissingKind) rather than as a forward-compat
+        // skip with an empty tag.
+        var opts = OptsForTest();
+        var walDir = Path.Combine(_root, "test", "wal", "2026-01-01");
+        Directory.CreateDirectory(walDir);
+        var logPath = Path.Combine(walDir, "000.log");
+        var idxPath = Path.Combine(walDir, "000.idx");
+
+        var emptyKind = Encoding.UTF8.GetBytes(
+            """{"kind":"","timestampUtc":"2026-01-01T10:00:00+00:00"}""");
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, emptyKind, 0);
+            writer.Flush();
+        }
+
+        await using var store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        // Empty string IS extracted as a "kind" value — it's just not
+        // in the known set. The current classifier treats it as an
+        // UnknownKind skip (consistent with any other unrecognised
+        // string discriminator). The point of this test is to pin
+        // that behaviour so a future refactor doesn't accidentally
+        // start throwing on what is structurally an unknown tag.
+        var seen = new List<long>();
+        await foreach (var (seq, _) in store.ReadFromAsync(0))
+        {
+            seen.Add(seq);
+        }
+        Assert.Empty(seen);
+    }
+
+    [Fact]
     public async Task Append_then_ReadFrom_RoundTripsEventsInSeqOrder()
     {
         await using (var store = new FileEventStore(OptsForTest(), NullLogger<FileEventStore>.Instance))

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
@@ -42,6 +42,76 @@ public class FileEventStoreTests : IDisposable
     };
 
     [Fact]
+    public async Task ReadFromAsync_WithUnknownDiscriminator_SkipsAndContinues()
+    {
+        // Pass-2 review (#296) P1-B. An older binary reading a WAL
+        // written by a newer engine must skip records whose `kind`
+        // discriminator the reader does not recognise, log a warning,
+        // and continue — not throw and abort recovery. Records with
+        // KNOWN kinds before and after the unknown one must round-trip.
+        var opts = OptsForTest();
+        var walDir = Path.Combine(_root, "test", "wal", "2026-01-01");
+        Directory.CreateDirectory(walDir);
+        var logPath = Path.Combine(walDir, "000.log");
+        var idxPath = Path.Combine(walDir, "000.idx");
+
+        var known1 = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(0), WalEventJsonContext.Default.WalEvent);
+        var unknown = Encoding.UTF8.GetBytes(
+            """{"kind":"algo.future.event-from-tomorrow","newField":"hello","timestampUtc":"2026-01-01T10:00:00+00:00"}""");
+        var known3 = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(2), WalEventJsonContext.Default.WalEvent);
+
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, known1, 0);
+            writer.Append(2, unknown, 0);
+            writer.Append(3, known3, 0);
+            writer.Flush();
+        }
+
+        await using var store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        var seenSeqs = new List<long>();
+        var seenClOrdIds = new List<ulong>();
+        await foreach (var (seq, evt) in store.ReadFromAsync(0))
+        {
+            seenSeqs.Add(seq);
+            seenClOrdIds.Add(Assert.IsType<OrderSubmittedEvent>(evt).ClOrdId);
+        }
+        Assert.Equal(new long[] { 1, 3 }, seenSeqs.ToArray());
+        Assert.Equal(new ulong[] { 1, 3 }, seenClOrdIds.ToArray());
+    }
+
+    [Fact]
+    public async Task ReadFromAsync_WithMalformedKnownKind_StillThrows()
+    {
+        // Pass-2 review (#296) P1-B. Forward-compat skip applies ONLY
+        // to unknown discriminators. A malformed payload for a KNOWN
+        // kind (here: required `endClientId` missing on an
+        // order.submitted) must continue to fail loudly — silent skip
+        // would mask real schema drift / corruption.
+        var opts = OptsForTest();
+        var walDir = Path.Combine(_root, "test", "wal", "2026-01-01");
+        Directory.CreateDirectory(walDir);
+        var logPath = Path.Combine(walDir, "000.log");
+        var idxPath = Path.Combine(walDir, "000.idx");
+
+        var malformed = Encoding.UTF8.GetBytes(
+            """{"kind":"order.submitted","timestampUtc":"2026-01-01T10:00:00+00:00"}""");
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, malformed, 0);
+            writer.Flush();
+        }
+
+        await using var store = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        await Assert.ThrowsAnyAsync<JsonException>(async () =>
+        {
+            await foreach (var _ in store.ReadFromAsync(0)) { }
+        });
+    }
+
+    [Fact]
     public async Task Append_then_ReadFrom_RoundTripsEventsInSeqOrder()
     {
         await using (var store = new FileEventStore(OptsForTest(), NullLogger<FileEventStore>.Instance))

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/FileEventStoreTests.cs
@@ -158,6 +158,100 @@ public class FileEventStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadFromAsync_OperatorRecoveryFromMissingKind_TruncateBadRecordAndReplay()
+    {
+        // Pass-4 review (#296) P2. Documents the operator recovery
+        // pattern for a corrupted-WAL halt. When ReadFromAsync hits a
+        // record with no `kind` discriminator (torn write / external
+        // corruption / writer bug — see
+        // ReadFromAsync_WithMissingKindDiscriminator_ThrowsAndDoesNotSilentlySkip)
+        // replay throws InvalidDataException and refuses to skip past
+        // the corruption silently. The operator runbook is:
+        //
+        //   1. Inspect the segment at the offset reported in the
+        //      InvalidDataException + structured-logging context to
+        //      confirm the record is genuinely corrupt (vs a writer
+        //      bug we should fix in code first).
+        //   2. Truncate the segment to exclude the bad record. In
+        //      production this means stopping the host, copying the
+        //      .log file aside, rewriting it without the offending
+        //      bytes, regenerating the .idx, and restarting. Anything
+        //      written AFTER the bad record is also lost (we can't
+        //      trust offsets past a torn write); the corresponding
+        //      seq numbers will be re-issued on next append.
+        //   3. Restart — replay resumes from the truncated tail and
+        //      converges on a clean in-memory state from the snapshot
+        //      + the surviving WAL records.
+        //
+        // This test simulates step 2 by writing a fresh WAL that omits
+        // the bad record and asserting replay completes successfully
+        // with the surviving records yielded in seq order. Pinning the
+        // recovery flow as a test means a future refactor that breaks
+        // truncation-based recovery fails loudly here, not in
+        // production at 3am.
+        var opts = OptsForTest();
+        var walDir = Path.Combine(_root, "test", "wal", "2026-01-01");
+        Directory.CreateDirectory(walDir);
+        var logPath = Path.Combine(walDir, "000.log");
+        var idxPath = Path.Combine(walDir, "000.idx");
+
+        var known1 = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(0), WalEventJsonContext.Default.WalEvent);
+        var missingKind = Encoding.UTF8.GetBytes(
+            """{"someField":"value","timestampUtc":"2026-01-01T10:00:00+00:00"}""");
+        var known3 = JsonSerializer.SerializeToUtf8Bytes<WalEvent>(NewOrder(2), WalEventJsonContext.Default.WalEvent);
+
+        // Step 0: write the corrupted segment exactly as the
+        // sibling MissingKind test does — [known, bad, known].
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, known1, 0);
+            writer.Append(2, missingKind, 0);
+            writer.Append(3, known3, 0);
+            writer.Flush();
+        }
+
+        // Step 1: confirm replay halts at the bad record so the
+        // operator has a deterministic failure signal to act on.
+        await using (var brokenStore = new FileEventStore(opts, NullLogger<FileEventStore>.Instance))
+        {
+            await Assert.ThrowsAsync<InvalidDataException>(async () =>
+            {
+                await foreach (var _ in brokenStore.ReadFromAsync(0)) { }
+            });
+        }
+
+        // Step 2: operator truncates the bad record. Test simulates by
+        // rewriting the segment without the missing-kind line; in
+        // production this is a manual offline edit. Anything written
+        // after the corruption is discarded — here that means seq=3
+        // is also dropped to mimic the realistic "we can't trust
+        // anything past a torn write" rule. The runbook accepts the
+        // data loss as the price of converging on a clean state.
+        File.Delete(logPath);
+        File.Delete(idxPath);
+        await using (var writer = new SegmentWriter(logPath, idxPath,
+            opts.IndexEveryNRecords, opts.IndexEveryNBytes, fsyncOnFlush: false))
+        {
+            writer.Append(1, known1, 0);
+            writer.Flush();
+        }
+
+        // Step 3: replay re-succeeds; the surviving record round-
+        // trips. No exception, no stuck recovery.
+        await using var recoveredStore = new FileEventStore(opts, NullLogger<FileEventStore>.Instance);
+        var seenSeqs = new List<long>();
+        var seenClOrdIds = new List<ulong>();
+        await foreach (var (seq, evt) in recoveredStore.ReadFromAsync(0))
+        {
+            seenSeqs.Add(seq);
+            seenClOrdIds.Add(Assert.IsType<OrderSubmittedEvent>(evt).ClOrdId);
+        }
+        Assert.Equal(new long[] { 1 }, seenSeqs.ToArray());
+        Assert.Equal(new ulong[] { 1 }, seenClOrdIds.ToArray());
+    }
+
+    [Fact]
     public async Task ReadFromAsync_WithEmptyKindString_TreatedAsMissing()
     {
         // Pass-3 review (#296) P2. An empty-string `kind` is


### PR DESCRIPTION
Closes #283.

## Summary

Implements the Pegged orders algo per Q3.3: a single-working-slice algo that keeps a child order anchored at a configurable offset from a live reference price (Mid/Best/Last) and repegs when the market drifts beyond a one-tick tolerance. Architecture mirrors VWAP (#281) and POV (#282).

## Slices

| Layer | What lands |
| --- | --- |
| Domain | `AlgoType.Pegged`, `PegRef`, `PeggedParameters(Ref, OffsetTicks, RepegInterval, TickSize, ChildOrderType=Limit, PriceLimit?)` |
| Pure helpers | `PeggedPlan.ComputeTarget` / `IsRepegNeeded` / `ClampToLimit` |
| Market data | `PegBookTopCache` (per-symbol BBO + Last w/ Mid→Last fallback) + `MarketDataPegBookPump` hosted service (mirrors `MarketDataVolumePump`) |
| Engine | Pegged branch in `OnCreatedAsync` (`EvaluatePeggedRepegAsync`), Pegged path in `SubmitNextSliceAsync`, `RepegPending` routing in `OnChildErAsync` Cancelled, per-parent `PeggedLastEvalUtc` / `RepegPending` runtime fields, `AlgoPeggedCancelled` metric on terminal |
| Scheduler | `TickPegged` enqueues every tick; engine throttles via `RepegInterval` |
| Persistence | Additive `AlgoCreatedEvent` + `AlgoSnapshot` Pegged fields; audit-only `AlgoPeggedRepeggedEvent`; `AlgoBook` + `StateSnapshotter` switch-arm updates |
| Metrics | `trading.algo.pegged.{repegs_total,repeg_failed,cancelled}` |
| HTTP/WS | `POST /algo` Pegged case + `CreateAlgoPeggedParams`; `AlgoDto.Pegged` + `PeggedParamsDto` |
| Host | `PegBookTopCache` singleton + pump hosted service registration |

## Behaviour highlights

* **Throttle in the engine, not the scheduler** — same pattern as VWAP/POV catch-up: scheduler enqueues every 100ms tick; engine compares `now - PeggedLastEvalUtc` against `RepegInterval` and no-ops if early.
* **Repeg = cancel + replace** — engine issues `_gateway.CancelAsync`, sets `RepegPending`, and `OnChildErAsync` recognises the cancel-ack and routes through `SubmitNextSliceAsync` (fresh target) rather than the VenueCancelled-suspension path. Operator DELETE wins the race because it sets `algo.Status = Cancelling` before the cancel-ack lands.
* **Single working slice** — at most one live child; residue = `RemainingQuantity`.
* **PriceLimit is a hard side-aware clamp** (Buy ≤ limit, Sell ≥ limit). When the clamp absorbs an aggressive ref move the engine no-ops (target unchanged → `IsRepegNeeded` false), matching the spec "Never cross spread beyond priceLimit".
* **Audit event (`AlgoPeggedRepeggedEvent`)** is observability-only — not replayed on recovery (same as `AlgoVwapSlicedEvent`).

## Open trade-offs (called out inline)

* **Tick size**: no per-symbol `TickSizeProvider` lives in the repo yet, so `PeggedParameters` carries an explicit `TickSize`. The API defaults to `0.01` (BRL equity floor). Replace once a provider lands.
* **SDK gap**: `B3.MarketData.WebSocketClient` 0.1.0 only surfaces `Trade` and `InfoSnapshot` — no BBO frames. `PegBookTopCache` writes only `Last` from prints; `Mid`/`Best` transparently fall back to `Last`. Tests drive distinct mid/best/last paths via direct `UpdateBookTop` calls. Same posture as the auction-event SDK gap on `IMarketDataSubscriber`.

## Tests

`backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs` — **11 cases**:

1. POST validation: missing params → 400
2. POST validation: invalid `pegRef` → 400
3. POST validation: non-positive `tickSize` → 400
4. POST validation: `childOrderType=Market` → 400
5. Happy path: child posted at the pegged target price
6. Mid moves → engine cancels live child + resubmits at new target
7. Stable mid → no cancel-replace churn (multiple ticks)
8. PriceLimit clamps target + blocks further repegs once clamped
9. Operator DELETE mid-flight → terminal published exactly once
10. DTO surface round-trip for `GetAlgo` (`pegged` block)
11. Snapshot + cold restart preserves `Pegged` params + total quantity

## Verification

```
dotnet build B3TradingPlatform.slnx       # 0 warnings, 0 errors
dotnet test  B3TradingPlatform.slnx       # 1457 passed, 30 skipped (pre-existing Conformance)
dotnet format B3TradingPlatform.slnx --verify-no-changes  # clean
```