### PR TITLE
feat(#284): iceberg display-qty (native MaxFloor)

### DIFF
--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -700,6 +700,15 @@ public static class HistoryEndpoints
         public long LastSeq;
         public DateTimeOffset LastTs;
 
+        // Q3.4 (#284) — native iceberg / reserve display fields, mirrored
+        // onto the projection so /orders/history is not blind to the
+        // distinction between iceberg and full-disclosure orders. Null on
+        // legacy WAL rows that pre-date the additive fields on
+        // OrderSubmittedEvent — matches the no-reserve semantics those
+        // submissions actually carried (forward-compat with replay).
+        public long? DisplayQty;
+        public string? DisplayResetPolicy;
+
         public static OrderProjection FromSubmit(long seq, OrderSubmittedEvent o) => new()
         {
             ClOrdId = o.ClOrdId,
@@ -712,6 +721,8 @@ public static class HistoryEndpoints
             TimeInForce = o.TimeInForce,
             StopPrice = o.StopPrice,
             GoodTillDate = o.GoodTillDate,
+            DisplayQty = o.DisplayQty,
+            DisplayResetPolicy = o.DisplayResetPolicy,
             LeavesQuantity = o.Quantity,
             CumulativeQuantity = 0,
             Status = OrderStatus.PendingNew,
@@ -754,6 +765,22 @@ public static class HistoryEndpoints
                 ? (rr.RequestedGoodTillDate ?? original?.GoodTillDate)
                 : null;
 
+            // Q3.4 (#284). Iceberg display fields are inherited from the
+            // ORIGINAL projection on cancel-replace — the modify pipeline
+            // does not (yet) expose a way to alter DisplayQty / policy,
+            // so OrderReplaceRequestedEvent currently carries no explicit
+            // override. Mirror Order.HydrateReplacement's clamp semantics
+            // so the projection reflects what the venue actually sees:
+            // if the operator shrinks the order quantity below the
+            // visible portion, clamp DisplayQty down to NewQuantity.
+            // (When a future modify-pipeline slice adds explicit overrides
+            // on OrderReplaceRequestedEvent, prefer those here; today
+            // there is no source other than the original projection.)
+            long? effDisplayQty = original?.DisplayQty;
+            string? effDisplayPolicy = original?.DisplayResetPolicy;
+            if (effDisplayQty.HasValue && effDisplayQty.Value > rr.NewQuantity)
+                effDisplayQty = rr.NewQuantity;
+
             return new OrderProjection
             {
                 ClOrdId = rr.NewClOrdId,
@@ -766,6 +793,8 @@ public static class HistoryEndpoints
                 TimeInForce = effTif,
                 StopPrice = effStop,
                 GoodTillDate = effGtd,
+                DisplayQty = effDisplayQty,
+                DisplayResetPolicy = effDisplayPolicy,
                 LeavesQuantity = rr.NewQuantity,
                 CumulativeQuantity = 0,
                 Status = OrderStatus.PendingNew,
@@ -1028,7 +1057,9 @@ public static class HistoryEndpoints
             StaleReason,
             StaledAtUtc,
             CreatedAtUtc,
-            LastTs);
+            LastTs,
+            DisplayQty,
+            DisplayResetPolicy);
     }
 
     private sealed record ExecutionProjection(
@@ -1108,7 +1139,18 @@ public sealed record OrderHistoryItemDto(
     string? StaleReason,
     DateTimeOffset? StaledAtUtc,
     DateTimeOffset CreatedAtUtc,
-    DateTimeOffset LastUpdatedAtUtc);
+    DateTimeOffset LastUpdatedAtUtc,
+    /// <summary>Q3.4 (#284). Native iceberg / reserve display quantity at
+    /// submit (or, on a cancel-replace row, inherited from the predecessor
+    /// and clamped to NewQuantity per Order.HydrateReplacement). Null =
+    /// full disclosure / no reserve, including legacy WAL rows that
+    /// pre-date the additive WAL field.</summary>
+    long? DisplayQty = null,
+    /// <summary>Q3.4 (#284). Refresh policy enum name (<c>"Always" |
+    /// "OnPartialFill" | "Never"</c>); null iff <see cref="DisplayQty"/>
+    /// is null. Today only <c>"Always"</c> is accepted at intake (SDK
+    /// limitation — see #298).</summary>
+    string? DisplayResetPolicy = null);
 
 /// <summary>Q2.1 (#268). Wire shape for one row of <c>GET /executions/history</c>.</summary>
 public sealed record ExecutionHistoryItemDto(

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -42,6 +42,22 @@ public static class OrdersEndpoints
                 && !Enum.TryParse<TimeInForce>(req.TimeInForce, ignoreCase: true, out tif))
                 return Results.BadRequest(new { error = $"invalid timeInForce '{req.TimeInForce}'" });
 
+            // Q3.4 (#284). Parse the optional iceberg display-qty reset
+            // policy enum the same way as TIF (case-insensitive string)
+            // — the host does not register JsonStringEnumConverter so a
+            // numeric form would otherwise be required. Reject malformed
+            // before the submit pipeline so the bad request never enters
+            // the WAL. The DisplayQty risk check (0 < DisplayQty <= Quantity)
+            // is enforced by Domain.Order's ctor and surfaces as BadRequest
+            // from OrderSubmissionService.
+            DisplayResetPolicy? displayPolicy = null;
+            if (!string.IsNullOrWhiteSpace(req.DisplayResetPolicy))
+            {
+                if (!Enum.TryParse<DisplayResetPolicy>(req.DisplayResetPolicy, ignoreCase: true, out var parsedPolicy))
+                    return Results.BadRequest(new { error = $"invalid displayResetPolicy '{req.DisplayResetPolicy}'" });
+                displayPolicy = parsedPolicy;
+            }
+
             // SecurityId resolution: explicit non-zero in the payload
             // wins (preserves the conformance contract). Otherwise look
             // up the directory by symbol — that is the path the trader
@@ -59,7 +75,9 @@ public static class OrdersEndpoints
                 req.Quantity, req.Price, OrderSubmissionSource.Manual,
                 TimeInForce: tif,
                 StopPrice: req.StopPrice,
-                GoodTillDate: req.GoodTillDate), ct);
+                GoodTillDate: req.GoodTillDate,
+                DisplayQty: req.DisplayQty,
+                DisplayResetPolicy: displayPolicy), ct);
 
             return result.Kind switch
             {
@@ -210,7 +228,17 @@ public sealed record SubmitOrderRequest(
     /// <summary>Q1.1 (#253). Required for <c>StopLoss</c>/<c>StopLimit</c>.</summary>
     decimal? StopPrice = null,
     /// <summary>Q1.1 (#253). Required when <c>TimeInForce == "GTD"</c>.</summary>
-    DateTimeOffset? GoodTillDate = null);
+    DateTimeOffset? GoodTillDate = null,
+    /// <summary>Q3.4 (#284). Native iceberg / reserve display quantity. Null
+    /// = full disclosure. Validated as <c>0 &lt; DisplayQty &lt;= Quantity</c>
+    /// by the submit pipeline.</summary>
+    long? DisplayQty = null,
+    /// <summary>Q3.4 (#284). Refresh policy for the visible portion of an
+    /// iceberg order. Accepts case-insensitive <see cref="Domain.DisplayResetPolicy"/>
+    /// name (<c>"Always" | "OnPartialFill" | "Never"</c>). Defaults to <c>Always</c>
+    /// when <c>DisplayQty</c> is set and this field is null. Must be null when
+    /// <c>DisplayQty</c> is null.</summary>
+    string? DisplayResetPolicy = null);
 
 public sealed record ModifyOrderRequest(
     long Quantity,

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -50,11 +50,29 @@ public static class OrdersEndpoints
             // the WAL. The DisplayQty risk check (0 < DisplayQty <= Quantity)
             // is enforced by Domain.Order's ctor and surfaces as BadRequest
             // from OrderSubmissionService.
+            //
+            // Pass-1 review (#297, follow-up #298). The B3.EntryPoint.Client
+            // SDK 0.14.3 exposes only MaxFloor on NewOrderRequest — there is
+            // no refresh-policy field — so any policy other than Always
+            // would silently default to Always at the venue, breaking the
+            // Never contract entirely. Reject OnPartialFill / Never at the
+            // REST boundary (and again in OrderSubmissionService as a
+            // defensive risk check covering non-REST callers) until the SDK
+            // exposes the field. The Domain enum + WAL/snapshot fields are
+            // intentionally retained so this gate can be lifted with a
+            // one-line gateway change later (see #298).
             DisplayResetPolicy? displayPolicy = null;
             if (!string.IsNullOrWhiteSpace(req.DisplayResetPolicy))
             {
                 if (!Enum.TryParse<DisplayResetPolicy>(req.DisplayResetPolicy, ignoreCase: true, out var parsedPolicy))
                     return Results.BadRequest(new { error = $"invalid displayResetPolicy '{req.DisplayResetPolicy}'" });
+                if (parsedPolicy != DisplayResetPolicy.Always)
+                    return Results.BadRequest(new
+                    {
+                        error =
+                            $"displayResetPolicy={parsedPolicy} is not supported by the current entrypoint SDK; " +
+                            "supported: Always. Track issue #298.",
+                    });
                 displayPolicy = parsedPolicy;
             }
 

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -111,7 +111,13 @@ public sealed record OrderDto(
     /// <summary>Q1.1 (#253). Trigger price for StopLoss/StopLimit; null otherwise.</summary>
     decimal? StopPrice = null,
     /// <summary>Q1.1 (#253). Expiry timestamp for GTD; null otherwise.</summary>
-    DateTimeOffset? GoodTillDate = null);
+    DateTimeOffset? GoodTillDate = null,
+    /// <summary>Q3.4 (#284). Native iceberg / reserve display quantity; null for full disclosure.</summary>
+    long? DisplayQty = null,
+    /// <summary>Q3.4 (#284). Refresh policy for the visible portion of an iceberg order;
+    /// null iff <see cref="DisplayQty"/> is null. Today only <c>"Always"</c> is accepted
+    /// at intake (SDK limitation — see #298).</summary>
+    string? DisplayResetPolicy = null);
 
 public sealed record PositionDto(
     string Symbol,
@@ -226,7 +232,8 @@ public static class DtoMappings
         o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
         o.ParentAlgoId?.ToString(), o.AlgoSliceSeq,
         o.IsStale, o.StaleReason, o.StaledAtUtc,
-        o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate);
+        o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate,
+        o.DisplayQty, o.DisplayResetPolicy?.ToString());
 
     public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
 

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -94,6 +94,19 @@ public sealed class OrderSubmissionService
         if (string.IsNullOrWhiteSpace(req.Symbol))
             return OrderSubmissionResult.BadRequest("symbol is required");
 
+        // Q3.4 (#284) — pass-1 review (#297) follow-up #298. Defensive
+        // gate covering non-REST callers (algo engine, FIXP bot intake):
+        // the B3.EntryPoint.Client SDK 0.14.3 has no refresh-policy
+        // field, so any iceberg whose policy is not Always would be
+        // silently downgraded to Always on the wire. Reject here so the
+        // semantic discrepancy never enters the WAL. The Domain enum
+        // (DisplayResetPolicy.Always/OnPartialFill/Never) is retained
+        // so this guard can be lifted once the SDK exposes the field.
+        if (req.DisplayResetPolicy is { } drp && drp != Domain.DisplayResetPolicy.Always)
+            return OrderSubmissionResult.BadRequest(
+                $"displayResetPolicy={drp} is not supported by the current entrypoint SDK; " +
+                "supported: Always. Track issue #298.");
+
         var clOrdId = _clOrdIds.Generate(req.Owner);
         // #108 — DuplicateClOrdID defensive guard. The registry's
         // per-end-client counter is allocated atomically, so two

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -122,7 +122,8 @@ public sealed class OrderSubmissionService
                 clOrdId, req.Owner, req.Symbol, req.SecurityId, req.Side, req.Type,
                 req.Quantity, req.Price, req.FirmId,
                 parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq,
-                timeInForce: req.TimeInForce, stopPrice: req.StopPrice, goodTillDate: req.GoodTillDate);
+                timeInForce: req.TimeInForce, stopPrice: req.StopPrice, goodTillDate: req.GoodTillDate,
+                displayQty: req.DisplayQty, displayResetPolicy: req.DisplayResetPolicy);
         }
         catch (ArgumentException ex)
         {
@@ -165,6 +166,8 @@ public sealed class OrderSubmissionService
                     TimeInForce = req.TimeInForce.ToString(),
                     StopPrice = req.StopPrice,
                     GoodTillDate = req.GoodTillDate,
+                    DisplayQty = order.DisplayQty,
+                    DisplayResetPolicy = order.DisplayResetPolicy?.ToString(),
                 },
                 () =>
                 {
@@ -316,7 +319,20 @@ public sealed record OrderSubmissionRequest(
     int? AlgoSliceSeq = null,
     TimeInForce TimeInForce = TimeInForce.Day,
     decimal? StopPrice = null,
-    DateTimeOffset? GoodTillDate = null)
+    DateTimeOffset? GoodTillDate = null,
+    /// <summary>
+    /// Q3.4 (#284). Native iceberg / reserve display quantity. Null
+    /// = full disclosure (no reserve). Validated by
+    /// <see cref="Order"/>'s constructor: <c>0 &lt; DisplayQty &lt;= Quantity</c>.
+    /// </summary>
+    long? DisplayQty = null,
+    /// <summary>
+    /// Q3.4 (#284). Refresh policy for the visible portion of an
+    /// iceberg order. Null iff <see cref="DisplayQty"/> is null;
+    /// otherwise defaults to
+    /// <see cref="Domain.DisplayResetPolicy.Always"/>.
+    /// </summary>
+    DisplayResetPolicy? DisplayResetPolicy = null)
 {
     /// <summary>
     /// Sub-issue #171 (E). When non-null, the request originates from

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -307,6 +307,21 @@ public sealed record OrderSnapshot(
     /// Older snapshots default to <c>null</c>.
     /// </summary>
     public DateTimeOffset? GoodTillDate { get; init; }
+
+    /// <summary>
+    /// Q3.4 (#284). Native iceberg / reserve display quantity at
+    /// submit time. Null = full disclosure. Older snapshots default
+    /// to <c>null</c>.
+    /// </summary>
+    public long? DisplayQty { get; init; }
+
+    /// <summary>
+    /// Q3.4 (#284). Refresh policy for the visible portion of an
+    /// iceberg order, stored as the enum name. Null iff
+    /// <see cref="DisplayQty"/> is null. Older snapshots default
+    /// to <c>null</c>.
+    /// </summary>
+    public string? DisplayResetPolicy { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -121,6 +121,25 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// they carried.
     /// </summary>
     public DateTimeOffset? GoodTillDate { get; init; }
+
+    /// <summary>
+    /// Q3.4 (#284). Native iceberg / reserve display quantity. Null
+    /// = full disclosure (no reserve). Older WAL segments without
+    /// the field deserialise as <c>null</c>, matching the
+    /// no-reserve semantics they actually carried.
+    /// </summary>
+    public long? DisplayQty { get; init; }
+
+    /// <summary>
+    /// Q3.4 (#284). Refresh policy for the visible portion of an
+    /// iceberg order. Stored as the enum name to keep the wire
+    /// format stable across future renumberings of
+    /// <see cref="Domain.DisplayResetPolicy"/>. Null iff
+    /// <see cref="DisplayQty"/> is null; otherwise one of
+    /// <c>"Always" | "OnPartialFill" | "Never"</c>. Older WAL
+    /// segments without the field deserialise as <c>null</c>.
+    /// </summary>
+    public string? DisplayResetPolicy { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -210,6 +210,8 @@ public sealed class WorkingOrderBook
                 TimeInForce = o.TimeInForce.ToString(),
                 StopPrice = o.StopPrice,
                 GoodTillDate = o.GoodTillDate,
+                DisplayQty = o.DisplayQty,
+                DisplayResetPolicy = o.DisplayResetPolicy?.ToString(),
             };
         }
     }
@@ -257,11 +259,18 @@ public sealed class WorkingOrderBook
             // OrderSnapshot record's init default, so a missing field
             // round-trips through Enum.Parse cleanly.
             var tif = Enum.Parse<TimeInForce>(s.TimeInForce);
+            // Q3.4 (#284): older snapshots default both display fields
+            // to null (no reserve); new snapshots round-trip the enum
+            // name through Enum.Parse cleanly.
+            DisplayResetPolicy? policy = s.DisplayResetPolicy is { } dpName
+                ? Enum.Parse<DisplayResetPolicy>(dpName)
+                : (DisplayResetPolicy?)null;
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId,
                 s.ParentAlgoId, s.AlgoSliceSeq,
                 isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc,
-                timeInForce: tif, stopPrice: s.StopPrice, goodTillDate: s.GoodTillDate);
+                timeInForce: tif, stopPrice: s.StopPrice, goodTillDate: s.GoodTillDate,
+                displayQty: s.DisplayQty, displayResetPolicy: policy);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -104,6 +104,32 @@ public enum SessionPhase
     AfterHours,
 }
 
+/// <summary>
+/// Q3.4 (#284). Policy that drives whether/how the venue refreshes
+/// the visible portion (display qty) of an iceberg/reserve order
+/// after a fill. Applies only when <see cref="Order.DisplayQty"/>
+/// is set (full-disclosure orders have no reserve to refresh).
+///
+/// <para>The B3 EntryPoint SDK 0.14.3 does not expose a refresh-policy
+/// flag on <c>NewOrderRequest</c> — only <c>MaxFloor</c> (the initial
+/// visible qty). Until the SDK plumbs a per-order policy, every
+/// iceberg submission inherits the venue's default refresh semantics
+/// (currently <see cref="Always"/> on B3). The enum is retained on
+/// the platform side so the trader's intent is recorded in the WAL /
+/// snapshot and surfaced through the REST/UI surface; the value is
+/// informational/local-only on the wire (see TODO in
+/// <c>B3EntryPointClientGateway.SubmitAsync</c>).</para>
+/// </summary>
+public enum DisplayResetPolicy
+{
+    /// <summary>Every fill refreshes display back to <see cref="Order.DisplayQty"/>. Most common iceberg semantics; matches the venue default.</summary>
+    Always,
+    /// <summary>Refresh only on partial fills; on full-display fills don't refresh and let the book consume the next slice naturally.</summary>
+    OnPartialFill,
+    /// <summary>No refresh; once visible qty is consumed it stays at 0 (one-shot peek into the reserve).</summary>
+    Never,
+}
+
 public enum OrderStatus
 {
     PendingNew,
@@ -153,7 +179,9 @@ public sealed class Order
         int? algoSliceSeq = null,
         TimeInForce timeInForce = TimeInForce.Day,
         decimal? stopPrice = null,
-        DateTimeOffset? goodTillDate = null)
+        DateTimeOffset? goodTillDate = null,
+        long? displayQty = null,
+        DisplayResetPolicy? displayResetPolicy = null)
     {
         if (clOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(clOrdId), "ClOrdID cannot be zero (reserved as null sentinel by EntryPoint).");
@@ -189,6 +217,34 @@ public sealed class Order
                 $"GoodTillDate must be null when TimeInForce == {timeInForce} (only GTD carries an expiry).",
                 nameof(goodTillDate));
 
+        // Q3.4 (#284). Iceberg / reserve display-qty invariants.
+        // displayQty=null → full disclosure (no reserve); a non-null
+        // value MUST be strictly positive and not exceed total order
+        // quantity (a "reserve" larger than the order is nonsensical;
+        // an equal value is identical to no reserve and is allowed
+        // only for symmetry with the validation message). Policy is
+        // null iff displayQty is null; when displayQty is set without
+        // an explicit policy we default to Always — the most common
+        // iceberg semantic and the venue default.
+        if (displayQty.HasValue)
+        {
+            if (displayQty.Value <= 0)
+                throw new ArgumentException(
+                    "DisplayQty must be positive when set (use null for full disclosure / no reserve).",
+                    nameof(displayQty));
+            if (displayQty.Value > quantity)
+                throw new ArgumentException(
+                    $"DisplayQty ({displayQty.Value}) must not exceed order Quantity ({quantity}).",
+                    nameof(displayQty));
+            displayResetPolicy ??= B3.Trading.Domain.DisplayResetPolicy.Always;
+        }
+        else if (displayResetPolicy.HasValue)
+        {
+            throw new ArgumentException(
+                "DisplayResetPolicy must be null when DisplayQty is null (full-disclosure orders have no reserve to refresh).",
+                nameof(displayResetPolicy));
+        }
+
         ClOrdId = clOrdId;
         Owner = owner;
         Symbol = symbol;
@@ -203,6 +259,8 @@ public sealed class Order
         TimeInForce = timeInForce;
         StopPrice = stopPrice;
         GoodTillDate = goodTillDate;
+        DisplayQty = displayQty;
+        DisplayResetPolicy = displayResetPolicy;
         LeavesQuantity = quantity;
         Status = OrderStatus.PendingNew;
     }
@@ -251,6 +309,34 @@ public sealed class Order
     /// an already-elapsed timestamp so recovery is total.
     /// </summary>
     public DateTimeOffset? GoodTillDate { get; }
+
+    /// <summary>
+    /// Q3.4 (#284). Native iceberg / reserve display quantity — the
+    /// visible portion the venue exposes on the public book on
+    /// submit. <c>null</c> = full disclosure (no reserve / no
+    /// iceberg behaviour). When set, must satisfy
+    /// <c>0 &lt; DisplayQty &lt;= Quantity</c> (enforced by the
+    /// constructor). Distinct from the client-emulated
+    /// <c>IcebergAlgo</c> / <c>IcebergParameters</c>, which slices
+    /// at the algo layer; this field rides on a plain
+    /// <see cref="Order"/> and is plumbed natively via the SDK's
+    /// <c>MaxFloor</c> field — the venue itself drains the hidden
+    /// reserve and refreshes the visible portion per
+    /// <see cref="DisplayResetPolicy"/>.
+    /// </summary>
+    public long? DisplayQty { get; }
+
+    /// <summary>
+    /// Q3.4 (#284). Refresh semantics for the visible portion of an
+    /// iceberg order. <c>null</c> iff <see cref="DisplayQty"/> is
+    /// <c>null</c>; otherwise defaults to
+    /// <see cref="B3.Trading.Domain.DisplayResetPolicy.Always"/>.
+    /// See the enum for the per-value semantics — and for why this
+    /// is currently informational/local-only on the SDK wire (the
+    /// B3 EntryPoint 0.14.3 <c>NewOrderRequest</c> does not expose
+    /// a refresh-policy flag; the venue defaults to <c>Always</c>).
+    /// </summary>
+    public DisplayResetPolicy? DisplayResetPolicy { get; }
 
     public long LeavesQuantity { get; private set; }
     public long CumulativeQuantity { get; private set; }
@@ -427,10 +513,12 @@ public sealed class Order
         bool isStale = false, string? staleReason = null, DateTimeOffset? staledAtUtc = null,
         TimeInForce timeInForce = TimeInForce.Day,
         decimal? stopPrice = null,
-        DateTimeOffset? goodTillDate = null)
+        DateTimeOffset? goodTillDate = null,
+        long? displayQty = null,
+        DisplayResetPolicy? displayResetPolicy = null)
     {
         var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq,
-            timeInForce, stopPrice, goodTillDate);
+            timeInForce, stopPrice, goodTillDate, displayQty, displayResetPolicy);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;
@@ -500,6 +588,18 @@ public sealed class Order
             ? OrderStatus.Filled
             : (erCumulative > 0 ? OrderStatus.PartiallyFilled : OrderStatus.Working);
 
+        // Q3.4 (#284). Iceberg display fields are inherited from the
+        // original on cancel-replace — the modify pipeline does not
+        // currently expose a way to alter DisplayQty / policy. If the
+        // operator shrinks the order quantity below the original
+        // visible portion, clamp DisplayQty to the new quantity so
+        // the ctor invariant (DisplayQty &lt;= Quantity) still holds.
+        // A future modify-pipeline slice can plumb explicit overrides.
+        long? effDisplayQty = original.DisplayQty;
+        DisplayResetPolicy? effPolicy = original.DisplayResetPolicy;
+        if (effDisplayQty.HasValue && effDisplayQty.Value > newQuantity)
+            effDisplayQty = newQuantity;
+
         return Hydrate(
             clOrdId: newClOrdId,
             owner: original.Owner,
@@ -522,7 +622,9 @@ public sealed class Order
             // always inherited from the original.
             timeInForce: effTif,
             stopPrice: effStop,
-            goodTillDate: effGtd);
+            goodTillDate: effGtd,
+            displayQty: effDisplayQty,
+            displayResetPolicy: effPolicy);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -162,7 +162,23 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = new UpModels.NewOrderRequest
+        var req = BuildNewOrderRequest(order);
+
+        return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
+            ct => _client.SubmitAsync(req, ct), cancellationToken);
+    }
+
+    /// <summary>
+    /// Q3.4 (#284). Extracted from <see cref="SubmitAsync"/> so the
+    /// outbound <c>NewOrderRequest</c> mapping can be pinned by unit
+    /// tests without standing up a real <c>EntryPointClient</c>. Pure
+    /// function: every field is read from the domain
+    /// <see cref="Order"/> exactly once and there are no side effects.
+    /// </summary>
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        return new UpModels.NewOrderRequest
         {
             ClOrdID = new UpModels.ClOrdID(order.ClOrdId),
             SecurityId = order.SecurityId,
@@ -173,10 +189,22 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             OrderQty = (ulong)order.Quantity,
             TimeInForce = MapTimeInForce(order.TimeInForce),
             ExpireDate = order.GoodTillDate,
+            // Q3.4 (#284). Native iceberg / reserve display qty maps
+            // straight to the SDK's MaxFloor (FIX standard for "max
+            // visible qty"). Domain.Order's ctor already validated
+            // 0 < DisplayQty <= Quantity, so the cast is safe.
+            // TODO(#284): DisplayResetPolicy is NOT plumbed to the SDK —
+            // B3.EntryPoint.Client 0.14.3 NewOrderRequest exposes no
+            // refresh-policy flag, so every iceberg currently inherits
+            // the venue default (Always). When the SDK exposes the
+            // field, set it here from order.DisplayResetPolicy and
+            // extend the mapping test. Until then the policy is
+            // informational/local-only (recorded on the WAL +
+            // snapshot + REST/UI surface so the trader's intent is
+            // preserved) and a venue that only supports Always will
+            // silently behave as Always for OnPartialFill / Never.
+            MaxFloor = order.DisplayQty is { } dq ? (ulong)dq : (ulong?)null,
         };
-
-        return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
-            ct => _client.SubmitAsync(req, ct), cancellationToken);
     }
 
     public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken cancellationToken)
@@ -237,6 +265,17 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             OrderQty = (ulong)newQuantity,
             TimeInForce = MapTimeInForce(effTif),
             ExpireDate = effGtd,
+            // Q3.4 (#284). The modify pipeline does not currently
+            // expose a way to alter the iceberg DisplayQty / policy,
+            // so the replace inherits the original's visible portion
+            // (clamped to newQuantity by HydrateReplacement when the
+            // new order qty would otherwise be < DisplayQty). Same
+            // SDK caveat as SubmitAsync: only MaxFloor is wired;
+            // DisplayResetPolicy is local-only until the SDK plumbs
+            // it.
+            MaxFloor = original.DisplayQty is { } odq
+                ? (ulong)Math.Min(odq, newQuantity)
+                : (ulong?)null,
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -193,16 +193,17 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // straight to the SDK's MaxFloor (FIX standard for "max
             // visible qty"). Domain.Order's ctor already validated
             // 0 < DisplayQty <= Quantity, so the cast is safe.
-            // TODO(#284): DisplayResetPolicy is NOT plumbed to the SDK —
+            // TODO(#298): DisplayResetPolicy is NOT plumbed to the SDK —
             // B3.EntryPoint.Client 0.14.3 NewOrderRequest exposes no
-            // refresh-policy flag, so every iceberg currently inherits
-            // the venue default (Always). When the SDK exposes the
-            // field, set it here from order.DisplayResetPolicy and
-            // extend the mapping test. Until then the policy is
-            // informational/local-only (recorded on the WAL +
-            // snapshot + REST/UI surface so the trader's intent is
-            // preserved) and a venue that only supports Always will
-            // silently behave as Always for OnPartialFill / Never.
+            // refresh-policy flag. To avoid the venue silently defaulting
+            // to Always (which would break the OnPartialFill / Never
+            // contracts), the REST + risk validation boundary REJECTS
+            // any policy other than Always (see #297 pass-1 fix).
+            // Therefore only Always-policy icebergs can reach this point,
+            // so MaxFloor alone faithfully expresses the trader's intent.
+            // When B3.EntryPoint.Client exposes a refresh-policy field,
+            // wire order.DisplayResetPolicy here and drop the validation
+            // guard in OrdersEndpoints.cs + OrderSubmissionService.cs.
             MaxFloor = order.DisplayQty is { } dq ? (ulong)dq : (ulong?)null,
         };
     }
@@ -271,8 +272,9 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // (clamped to newQuantity by HydrateReplacement when the
             // new order qty would otherwise be < DisplayQty). Same
             // SDK caveat as SubmitAsync: only MaxFloor is wired;
-            // DisplayResetPolicy is local-only until the SDK plumbs
-            // it.
+            // DisplayResetPolicy ride-along is gated behind the
+            // REST/risk validation that only accepts Always today
+            // (see #298), so passing MaxFloor alone is faithful.
             MaxFloor = original.DisplayQty is { } odq
                 ? (ulong)Math.Min(odq, newQuantity)
                 : (ulong?)null,

--- a/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
@@ -37,7 +37,12 @@ public sealed class EntryPointClientGateway : IExchangeGateway
             order.Type == OrderType.Limit ? EpOrderType.Limit : EpOrderType.Market,
             order.Quantity,
             order.Price,
-            _firmId);
+            _firmId,
+            // Q3.4 (#284). Plumb DisplayQty as MaxFloor through the
+            // mock seam so tests can pin wire mapping. The real SDK
+            // path in B3EntryPointClientGateway maps the same field
+            // to UpModels.NewOrderRequest.MaxFloor.
+            MaxFloor: order.DisplayQty);
 
         return _client.SubmitNewOrderAsync(req, cancellationToken);
     }
@@ -70,7 +75,14 @@ public sealed class EntryPointClientGateway : IExchangeGateway
             new OrderCancelReplaceRequest(
                 original.ClOrdId, newClOrdId, original.SecurityId,
                 original.Side == OrderSide.Buy ? EpSide.Buy : EpSide.Sell,
-                newQuantity, newPrice, _firmId),
+                newQuantity, newPrice, _firmId,
+                // Q3.4 (#284). Replace inherits the original's visible
+                // portion (clamped to newQuantity when the new order qty
+                // would otherwise be < DisplayQty), mirroring the real
+                // SDK path in B3EntryPointClientGateway.CancelReplaceAsync.
+                MaxFloor: original.DisplayQty is { } odq
+                    ? Math.Min(odq, newQuantity)
+                    : (long?)null),
             cancellationToken);
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
@@ -54,7 +54,15 @@ public sealed record NewOrderSingle(
     EpOrderType Type,
     long Quantity,
     decimal? Price,
-    string FirmId);
+    string FirmId,
+    /// <summary>Q3.4 (#284). Native iceberg / reserve display qty (FIX MaxFloor).
+    /// Null means full disclosure (no reserve). Set by
+    /// <see cref="EntryPointClientGateway"/> from the domain order's
+    /// <c>DisplayQty</c>. The real SDK path (<c>B3EntryPointClientGateway</c>)
+    /// already wires MaxFloor on the upstream <c>NewOrderRequest</c>; this
+    /// field plumbs the same intent through the mock seam so tests can
+    /// assert wire mapping without standing up the real client.</summary>
+    long? MaxFloor = null);
 
 public sealed record OrderCancelRequest(
     ulong ClOrdId,
@@ -70,7 +78,12 @@ public sealed record OrderCancelReplaceRequest(
     EpSide Side,
     long NewQuantity,
     decimal? NewPrice,
-    string FirmId);
+    string FirmId,
+    /// <summary>Q3.4 (#284). Native iceberg / reserve display qty (FIX MaxFloor)
+    /// inherited from the original order, clamped to <c>NewQuantity</c> when the
+    /// replace shrinks the order below the original visible portion. Null when
+    /// the original was a full-disclosure order.</summary>
+    long? MaxFloor = null);
 
 /// <summary>
 /// ExecutionReport surfaced by the wire to the platform. <see cref="OrigClOrdId"/>

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -209,6 +209,8 @@ public sealed class StateSnapshotter
                 TimeInForce = o.TimeInForce.ToString(),
                 StopPrice = o.StopPrice,
                 GoodTillDate = o.GoodTillDate,
+                DisplayQty = o.DisplayQty,
+                DisplayResetPolicy = o.DisplayResetPolicy?.ToString(),
             });
         }
 
@@ -622,9 +624,16 @@ public sealed class EventReplayer
                 // the OrderSubmittedEvent record's init default, so a
                 // missing field round-trips through Enum.Parse cleanly.
                 var tif = Enum.Parse<TimeInForce>(o.TimeInForce, ignoreCase: true);
+                // Q3.4 (#284) — older WAL segments default DisplayQty /
+                // DisplayResetPolicy to null (no reserve), so a missing
+                // payload round-trips as a full-disclosure order.
+                DisplayResetPolicy? policy = o.DisplayResetPolicy is { } dpName
+                    ? Enum.Parse<DisplayResetPolicy>(dpName, ignoreCase: true)
+                    : (DisplayResetPolicy?)null;
                 _orders.TryAdd(new Order(o.ClOrdId, owner, o.Symbol, o.SecurityId, side, type,
                     o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq,
-                    timeInForce: tif, stopPrice: o.StopPrice, goodTillDate: o.GoodTillDate));
+                    timeInForce: tif, stopPrice: o.StopPrice, goodTillDate: o.GoodTillDate,
+                    displayQty: o.DisplayQty, displayResetPolicy: policy));
                 _ownership.Register(o.ClOrdId, owner);
                 // #157: advance the ClOrdID registry watermark so the next
                 // live Generate(owner) cannot re-allocate this ID.

--- a/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/HistoryEndpointTests.cs
@@ -1399,6 +1399,137 @@ public class HistoryEndpointTests : IDisposable
         return new HistoryPage(items, nextCursor);
     }
 
+    [Fact]
+    public async Task OrdersHistory_IcebergOrder_SurfacesDisplayFieldsOnInitialAndReplaceRows()
+    {
+        // Pass-2 review (#297) P2 regression. Before the fix, OrderProjection
+        // / OrderHistoryItemDto carried no DisplayQty or DisplayResetPolicy,
+        // so /orders/history made iceberg orders indistinguishable from
+        // full-disclosure orders. Live GET /orders + WS were fixed in
+        // pass-1; this test guards the historical projection path.
+        //
+        // Flow exercised:
+        //   1. POST /orders with DisplayQty=25, Policy=Always (qty=100)
+        //   2. Drive to Working + partial fill (4@30)
+        //   3. PUT /orders/{id} shrinking quantity to 15 → replacement
+        //      ClOrdID inherits DisplayQty but it MUST be clamped to 15
+        //      (mirroring Order.HydrateReplacement's clamp semantics so
+        //      the projection matches what the venue actually sees via
+        //      the gateway's MaxFloor send on cancel-replace).
+        //   4. GET /orders/history exposes DisplayQty + Policy on the
+        //      original row AND the replacement row.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var origClOrdIdStr = await SubmitIcebergOrder(
+            http, token, qty: 100, price: 30m, displayQty: 25, policy: "Always");
+        var origClOrdId = ulong.Parse(origClOrdIdStr);
+
+        // New ack so the modify pipeline accepts the subsequent replace.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origClOrdId,
+            Type = "New",
+        });
+
+        // Optional partial fill (mirrors the spec's "optional partial fill"
+        // step) — proves the projection still carries the iceberg fields
+        // through ApplyEr accumulation, not just the initial FromSubmit.
+        await InjectEr(http, adminToken, new
+        {
+            ClOrdId = origClOrdId,
+            Type = "PartialFill",
+            LastQty = 4L,
+            LastPx = 30m,
+        });
+
+        // Quantity-shrink replace down to 15. The clamp branch in
+        // OrderProjection.FromReplace must drop DisplayQty 25 → 15.
+        var modifyReq = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origClOrdIdStr}")
+        {
+            Content = JsonContent.Create(new { Quantity = 15L, Price = 30m }),
+        };
+        modifyReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modifyResp = await http.SendAsync(modifyReq);
+        Assert.Equal(HttpStatusCode.Accepted, modifyResp.StatusCode);
+        var modifyBody = await modifyResp.Content.ReadFromJsonAsync<JsonElement>();
+        var newClOrdId = ulong.Parse(modifyBody.GetProperty("clOrdId").GetString()!);
+
+        var mock = (B3.Trading.Infrastructure.MockEntryPointClient)
+            f.Services.GetRequiredService<B3.Trading.Infrastructure.IEntryPointClient>();
+        mock.EmitExecutionReport(new B3.Trading.Infrastructure.ExecutionReportEnvelope(
+            ClOrdId: newClOrdId,
+            ExecType: B3.Trading.Infrastructure.EpExecType.Replaced,
+            LeavesQuantity: 15,
+            CumulativeQuantity: 0,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: null,
+            OrigClOrdId: origClOrdId));
+
+        var page = await GetOrdersHistory(http, token);
+        var byId = page.Items.ToDictionary(
+            o => o.GetProperty("clOrdId").GetString()!,
+            o => o,
+            StringComparer.Ordinal);
+
+        var orig = byId[origClOrdIdStr];
+        Assert.Equal(25L, orig.GetProperty("displayQty").GetInt64());
+        Assert.Equal("Always", orig.GetProperty("displayResetPolicy").GetString());
+
+        var replacement = byId[newClOrdId.ToString()];
+        // Inherited + clamped: original DisplayQty=25 > NewQuantity=15
+        // → projection must report 15 to match the venue-side MaxFloor.
+        Assert.Equal(15L, replacement.GetProperty("displayQty").GetInt64());
+        Assert.Equal("Always", replacement.GetProperty("displayResetPolicy").GetString());
+    }
+
+    [Fact]
+    public async Task OrdersHistory_NonIcebergOrder_LeavesDisplayFieldsNull()
+    {
+        // Forward-compat / negative case: a plain limit order (no
+        // DisplayQty on submit, no DisplayQty on legacy WAL replays)
+        // must surface null for both display fields. Guards against a
+        // future regression that defaults DisplayQty to e.g. order.Quantity.
+        using var f = TestAppFactory.WithOverrides(Overrides());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var clOrdId = await SubmitOrder(http, token, qty: 10, price: 30m);
+
+        var page = await GetOrdersHistory(http, token);
+        var item = page.Items.Single(o => o.GetProperty("clOrdId").GetString() == clOrdId);
+        Assert.Equal(JsonValueKind.Null, item.GetProperty("displayQty").ValueKind);
+        Assert.Equal(JsonValueKind.Null, item.GetProperty("displayResetPolicy").ValueKind);
+    }
+
+    private static async Task<string> SubmitIcebergOrder(
+        HttpClient http, string token, int qty, decimal price,
+        long displayQty, string policy, string symbol = "PETR4")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = symbol,
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+                DisplayQty = displayQty,
+                DisplayResetPolicy = policy,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return body.GetProperty("clOrdId").GetString()!;
+    }
+
     private static async Task<string> SubmitOrder(
         HttpClient http, string token, int qty, decimal price, string symbol = "PETR4")
     {

--- a/backend/tests/B3.Trading.Api.Tests/OrdersIcebergEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersIcebergEndpointTests.cs
@@ -1,6 +1,10 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
 using B3.Trading.Domain;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +29,7 @@ public class OrdersIcebergEndpointTests
         var token = await f.LoginAsync(http);
 
         var resp = await PostIceberg(http, token, qty: 100, price: 30m,
-            displayQty: 10, policy: "OnPartialFill");
+            displayQty: 10, policy: "Always");
         Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
         var ack = await resp.Content.ReadFromJsonAsync<OrderAck>();
         Assert.NotNull(ack);
@@ -33,7 +37,33 @@ public class OrdersIcebergEndpointTests
         var book = f.Services.GetRequiredService<WorkingOrderBook>();
         Assert.True(book.TryGet(ulong.Parse(ack!.ClOrdId), out var order));
         Assert.Equal(10L, order!.DisplayQty);
-        Assert.Equal(DisplayResetPolicy.OnPartialFill, order.DisplayResetPolicy);
+        Assert.Equal(DisplayResetPolicy.Always, order.DisplayResetPolicy);
+    }
+
+    [Theory]
+    [InlineData("OnPartialFill")]
+    [InlineData("Never")]
+    [InlineData("onPartialFill")]
+    [InlineData("never")]
+    public async Task POST_orders_UnsupportedPolicy_RejectedAtBoundary(string policy)
+    {
+        // Pass-1 review (#297, follow-up #298). B3.EntryPoint.Client
+        // 0.14.3 has no refresh-policy field, so accepting anything other
+        // than Always would silently downgrade at the venue and break the
+        // Never contract. The REST boundary MUST reject before allocating
+        // a ClOrdID / appending to the WAL.
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var resp = await PostIceberg(http, token, qty: 100, price: 30m, displayQty: 10, policy: policy);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<ErrorBody>();
+        Assert.NotNull(body);
+        Assert.Contains("not supported by the current entrypoint SDK", body!.Error);
+        Assert.Contains("Always", body.Error);
+        Assert.Contains("#298", body.Error);
     }
 
     [Fact]
@@ -88,6 +118,63 @@ public class OrdersIcebergEndpointTests
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<ErrorBody>();
         Assert.Contains("invalid displayResetPolicy", body!.Error);
+    }
+
+    [Fact]
+    public async Task GET_orders_AndWsSnapshot_SurfaceDisplayFields()
+    {
+        // Pass-1 review (#297) P2. OrderDto.ToDto must expose the
+        // persisted DisplayQty + DisplayResetPolicy so REST GET /orders
+        // and WS orders.me snapshots surface the iceberg state — the
+        // trader's intent that is already on the WAL must also be
+        // visible to operators and dashboards.
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var submit = await PostIceberg(http, token, qty: 100, price: 30m, displayQty: 25, policy: "Always");
+        Assert.Equal(HttpStatusCode.Accepted, submit.StatusCode);
+
+        // 1) REST GET /orders surfaces the fields.
+        var get = new HttpRequestMessage(HttpMethod.Get, "/orders/");
+        get.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var listResp = await http.SendAsync(get);
+        Assert.Equal(HttpStatusCode.OK, listResp.StatusCode);
+        var list = await listResp.Content.ReadFromJsonAsync<JsonElement>();
+        var dto = list.EnumerateArray().Single();
+        Assert.Equal(25L, dto.GetProperty("displayQty").GetInt64());
+        Assert.Equal("Always", dto.GetProperty("displayResetPolicy").GetString());
+
+        // 2) WS orders.me snapshot surfaces the fields too.
+        var wsClient = f.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(f.Server.BaseAddress) { Scheme = "ws", Path = "/ws", Query = $"access_token={token}" }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var ws = await wsClient.ConnectAsync(uri, cts.Token);
+
+        var subscribe = JsonSerializer.SerializeToUtf8Bytes(
+            new { type = "subscribe", channels = new[] { Channels.OrdersMe } },
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        await ws.SendAsync(subscribe, WebSocketMessageType.Text, true, cts.Token);
+
+        var snap = await ReadWsJsonAsync(ws, cts.Token);
+        Assert.Equal("snapshot", snap.GetProperty("type").GetString());
+        Assert.Equal(Channels.OrdersMe, snap.GetProperty("channel").GetString());
+        var order = snap.GetProperty("data").EnumerateArray().Single();
+        Assert.Equal(25L, order.GetProperty("displayQty").GetInt64());
+        Assert.Equal("Always", order.GetProperty("displayResetPolicy").GetString());
+    }
+
+    private static async Task<JsonElement> ReadWsJsonAsync(WebSocket ws, CancellationToken ct)
+    {
+        var buf = new byte[16 * 1024];
+        var sb = new StringBuilder();
+        WebSocketReceiveResult res;
+        do
+        {
+            res = await ws.ReceiveAsync(buf, ct);
+            sb.Append(Encoding.UTF8.GetString(buf, 0, res.Count));
+        } while (!res.EndOfMessage);
+        return JsonSerializer.Deserialize<JsonElement>(sb.ToString());
     }
 
     private static async Task<HttpResponseMessage> PostIceberg(

--- a/backend/tests/B3.Trading.Api.Tests/OrdersIcebergEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersIcebergEndpointTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q3.4 (#284). REST surface for the native iceberg / reserve
+/// display-qty fields on <c>POST /orders</c>. Asserts both the
+/// happy-path accept (display fields land on the WorkingOrderBook
+/// intact) and the validation rejections — DisplayQty &gt; Quantity
+/// and DisplayQty &lt;= 0 must come back as 4xx before the WAL
+/// append, so a malformed iceberg never enters recovery.
+/// </summary>
+public class OrdersIcebergEndpointTests
+{
+    [Fact]
+    public async Task POST_orders_WithDisplayQty_AcceptsAndPersistsFields()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var resp = await PostIceberg(http, token, qty: 100, price: 30m,
+            displayQty: 10, policy: "OnPartialFill");
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var ack = await resp.Content.ReadFromJsonAsync<OrderAck>();
+        Assert.NotNull(ack);
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        Assert.True(book.TryGet(ulong.Parse(ack!.ClOrdId), out var order));
+        Assert.Equal(10L, order!.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.OnPartialFill, order.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public async Task POST_orders_DisplayQtyDefaultsToAlwaysPolicy()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // No explicit policy field on the request body — the
+        // pipeline must default to Always when DisplayQty is set.
+        var resp = await PostIceberg(http, token, qty: 200, price: 30m, displayQty: 50, policy: null);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var ack = await resp.Content.ReadFromJsonAsync<OrderAck>();
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        Assert.True(book.TryGet(ulong.Parse(ack!.ClOrdId), out var order));
+        Assert.Equal(50L, order!.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.Always, order.DisplayResetPolicy);
+    }
+
+    [Theory]
+    [InlineData(0, "DisplayQty must be positive")]
+    [InlineData(-5, "DisplayQty must be positive")]
+    [InlineData(150, "must not exceed order Quantity")]
+    public async Task POST_orders_InvalidDisplayQty_RejectedAsAccepted_WithRiskRejection(long badDisplayQty, string expectedFragment)
+    {
+        // The Domain.Order ctor invariant surfaces as BadRequest from
+        // OrderSubmissionService, which the endpoint maps to 400.
+        // (Note: zero/negative values are caught by the ctor before
+        // the WAL append — same path as the other Q1.1 cross-field
+        // validations.)
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var resp = await PostIceberg(http, token, qty: 100, price: 30m, displayQty: badDisplayQty, policy: "Always");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<ErrorBody>();
+        Assert.NotNull(body);
+        Assert.Contains(expectedFragment, body!.Error);
+    }
+
+    [Fact]
+    public async Task POST_orders_InvalidPolicyString_ReturnsBadRequest()
+    {
+        using var f = new TestAppFactory();
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var resp = await PostIceberg(http, token, qty: 100, price: 30m, displayQty: 10, policy: "Sometimes");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<ErrorBody>();
+        Assert.Contains("invalid displayResetPolicy", body!.Error);
+    }
+
+    private static async Task<HttpResponseMessage> PostIceberg(
+        HttpClient http, string token, int qty, decimal price, long displayQty, string? policy)
+    {
+        var payload = policy is null
+            ? (object)new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+                DisplayQty = displayQty,
+            }
+            : new
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321UL,
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = qty,
+                Price = price,
+                DisplayQty = displayQty,
+                DisplayResetPolicy = policy,
+            };
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason);
+    private sealed record ErrorBody(string Error);
+}

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -49,4 +49,40 @@ public class B3EntryPointClientGatewayMapTests
         Assert.Throws<ArgumentOutOfRangeException>(
             () => B3EntryPointClientGateway.MapTimeInForce((TimeInForce)999));
     }
+
+    [Fact]
+    public void BuildNewOrderRequest_PlainOrder_LeavesMaxFloorNull()
+    {
+        // Q3.4 (#284). Full-disclosure (no reserve) orders must not
+        // accidentally populate MaxFloor — a non-null value would
+        // cause the venue to expose only a slice of the order on the
+        // public book.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM-A");
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
+
+        Assert.Null(req.MaxFloor);
+        Assert.Equal(100UL, req.OrderQty);
+    }
+
+    [Theory]
+    [InlineData(10L, 100L)]
+    [InlineData(1L, 1L)]
+    [InlineData(50L, 50L)]
+    public void BuildNewOrderRequest_Iceberg_MapsDisplayQtyToMaxFloor(long displayQty, long quantity)
+    {
+        // Q3.4 (#284). Native iceberg path: DisplayQty → MaxFloor on
+        // the SDK request. Pin both bounds (min=1, equal-to-qty) to
+        // detect any future ulong-cast regression.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            quantity, 30m, "FIRM-A",
+            displayQty: displayQty, displayResetPolicy: DisplayResetPolicy.Always);
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
+
+        Assert.Equal((ulong)displayQty, req.MaxFloor);
+        Assert.Equal((ulong)quantity, req.OrderQty);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -27,6 +27,28 @@ public class EntryPointGatewayAndRouterTests
         Assert.Equal(EpOrderType.Limit, sent.Type);
         Assert.Equal(50, sent.Quantity);
         Assert.Equal(31.25m, sent.Price);
+        // Q3.4 (#284). Plain (no-reserve) orders must not surface a
+        // MaxFloor on the wire — a non-null value would cause the
+        // venue to expose only a slice of the order.
+        Assert.Null(sent.MaxFloor);
+    }
+
+    [Fact]
+    public async Task Gateway_Submit_Iceberg_ForwardsDisplayQtyAsMaxFloor()
+    {
+        // Q3.4 (#284) pass-1 (#297). Pin DisplayQty → MaxFloor wire
+        // mapping through the IEntryPointClient seam (the real SDK
+        // path is pinned by B3EntryPointClientGatewayMapTests).
+        var client = new MockEntryPointClient();
+        var gateway = new EntryPointClientGateway(client, "FIRM-A");
+        var order = new Order(42UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A", displayQty: 10, displayResetPolicy: DisplayResetPolicy.Always);
+
+        await gateway.SubmitAsync(order, CancellationToken.None);
+
+        var sent = Assert.Single(client.SubmittedNewOrders);
+        Assert.Equal(10L, sent.MaxFloor);
+        Assert.Equal(100, sent.Quantity);
     }
 
     [Fact]
@@ -44,6 +66,31 @@ public class EntryPointGatewayAndRouterTests
         Assert.Equal(4321UL, sent.SecurityId);
         Assert.Equal(EpSide.Buy, sent.Side);
         Assert.Equal(200, sent.NewQuantity);
+        // Q3.4 (#284). Plain (no-reserve) replace must not surface MaxFloor.
+        Assert.Null(sent.MaxFloor);
+    }
+
+    [Fact]
+    public async Task Gateway_CancelReplace_Iceberg_InheritsAndClampsMaxFloor()
+    {
+        // Q3.4 (#284) pass-1 (#297). Replace inherits the original's
+        // visible portion (MaxFloor). When the new order qty shrinks
+        // below the original DisplayQty, MaxFloor must clamp to the
+        // new qty so the venue invariant (MaxFloor <= OrderQty) holds.
+        var client = new MockEntryPointClient();
+        var gateway = new EntryPointClientGateway(client, "FIRM-A");
+        var original = new Order(100UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A", displayQty: 50, displayResetPolicy: DisplayResetPolicy.Always);
+
+        // 1) Replace grows the qty — MaxFloor stays at the original 50.
+        await gateway.CancelReplaceAsync(original, 101UL, 200, 30m, null, null, null, CancellationToken.None);
+        var grown = client.SubmittedReplaces.Last();
+        Assert.Equal(50L, grown.MaxFloor);
+
+        // 2) Replace shrinks below DisplayQty — MaxFloor clamps to newQty.
+        await gateway.CancelReplaceAsync(original, 102UL, 20, 30m, null, null, null, CancellationToken.None);
+        var shrunk = client.SubmittedReplaces.Last();
+        Assert.Equal(20L, shrunk.MaxFloor);
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/Orders/IcebergDisplayQtySubmitTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Orders/IcebergDisplayQtySubmitTests.cs
@@ -1,0 +1,205 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Orders;
+
+/// <summary>
+/// Q3.4 (#284). End-to-end behaviour for the native iceberg /
+/// reserve display-qty path: the submit pipeline must forward
+/// <c>DisplayQty</c> + <c>DisplayResetPolicy</c> to the gateway
+/// boundary intact, fills must accumulate as on a plain order (the
+/// venue handles the display refresh server-side — there is no
+/// client-side slicing the way <c>IcebergAlgo</c> does), and
+/// validation must reject the invalid (qty, displayQty) pairs
+/// called out in the issue before the WAL append.
+/// </summary>
+public class IcebergDisplayQtySubmitTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    [Fact]
+    public async Task SubmitIceberg_ForwardsMaxFloorAndPolicy_AndFillsAccumulate()
+    {
+        var h = new Harness();
+
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 30m,
+            DisplayQty: 10,
+            DisplayResetPolicy: DisplayResetPolicy.Always);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+        var submitted = Assert.Single(h.Gateway.SubmittedOrders);
+        // The gateway boundary is what the SDK adapter reads from when
+        // building NewOrderRequest.MaxFloor — pinning the domain Order
+        // there is the strongest assertion the application layer can
+        // make without spinning the real EntryPoint client.
+        Assert.Equal(10L, submitted.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.Always, submitted.DisplayResetPolicy);
+
+        // Drive a sequence of ERs simulating the venue draining the
+        // hidden reserve in 10-lot slices. Because the venue handles
+        // the display refresh server-side, the platform sees plain
+        // cumulative-quantity advances; LeavesQuantity / Status must
+        // still reach the terminal Filled state at 100.
+        var clOrdId = result.ClOrdId;
+        long[] cumulativeSteps = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        long expectedLastQty = 10;
+        foreach (var cum in cumulativeSteps)
+        {
+            var kind = cum == 100 ? ExecKind.Fill : ExecKind.PartialFill;
+            h.Processor.Apply(clOrdId, kind, leaves: 100 - cum, cumQty: cum, lastQty: expectedLastQty, lastPx: 30m, rejectReason: null);
+        }
+
+        Assert.True(h.Book.TryGet(clOrdId, out var order));
+        Assert.NotNull(order);
+        Assert.Equal(OrderStatus.Filled, order!.Status);
+        Assert.Equal(0, order.LeavesQuantity);
+        Assert.Equal(100, order.CumulativeQuantity);
+        // The display fields are immutable post-submit: they describe
+        // the venue contract, not in-flight state.
+        Assert.Equal(10L, order.DisplayQty);
+    }
+
+    [Fact]
+    public async Task SubmitIceberg_NeverPolicy_StillRoundTripsToGateway()
+    {
+        // SDK-limitation note (see TODO in B3EntryPointClientGateway):
+        // the SDK does not currently plumb the refresh policy, so on
+        // the wire `Never` collapses to the venue default (Always).
+        // What the platform CAN guarantee end-to-end is that the
+        // trader's chosen policy is preserved on the domain Order,
+        // recorded on the WAL (Application.Tests.Persistence
+        // .OrderDisplayQtyBackCompatTests), and visible to operators
+        // via the REST/UI surface.
+        var h = new Harness();
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 50, Price: 30m,
+            DisplayQty: 5,
+            DisplayResetPolicy: DisplayResetPolicy.Never);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+        var submitted = Assert.Single(h.Gateway.SubmittedOrders);
+        Assert.Equal(DisplayResetPolicy.Never, submitted.DisplayResetPolicy);
+    }
+
+    [Theory]
+    [InlineData(0, "DisplayQty must be positive")]
+    [InlineData(-5, "DisplayQty must be positive")]
+    [InlineData(101, "must not exceed order Quantity")]
+    public async Task SubmitIceberg_InvalidDisplayQty_Rejected(long badDisplayQty, string expectedFragment)
+    {
+        var h = new Harness();
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 30m,
+            DisplayQty: badDisplayQty,
+            DisplayResetPolicy: DisplayResetPolicy.Always);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+
+        Assert.Equal(OrderSubmissionResultKind.BadRequest, result.Kind);
+        Assert.NotNull(result.Reason);
+        Assert.Contains(expectedFragment, result.Reason);
+        Assert.Empty(h.Gateway.SubmittedOrders);
+    }
+
+    [Fact]
+    public async Task SubmitIceberg_Snapshot_PreservesDisplayFieldsAcrossRestart()
+    {
+        // Snapshot capture + restore round-trip with an in-flight
+        // iceberg order. After hydration, the rebuilt order must
+        // carry the same DisplayQty / policy so the operator sees
+        // the same iceberg state and a future cancel-replace can
+        // inherit the visible-portion semantics correctly.
+        var h = new Harness();
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 30m,
+            DisplayQty: 10,
+            DisplayResetPolicy: DisplayResetPolicy.OnPartialFill);
+        var submitResult = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+
+        // Advance fills 30/100 so the snapshot captures non-trivial
+        // leaves/cum alongside the display fields.
+        h.Processor.Apply(submitResult.ClOrdId, ExecKind.PartialFill, leaves: 70, cumQty: 30, lastQty: 30, lastPx: 30m, rejectReason: null);
+
+        var captured = h.Book.Snapshot().ToList();
+
+        var fresh = new WorkingOrderBook();
+        fresh.Restore(captured);
+
+        Assert.True(fresh.TryGet(submitResult.ClOrdId, out var restored));
+        Assert.NotNull(restored);
+        Assert.Equal(10L, restored!.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.OnPartialFill, restored.DisplayResetPolicy);
+        Assert.Equal(70, restored.LeavesQuantity);
+        Assert.Equal(30, restored.CumulativeQuantity);
+        Assert.Equal(OrderStatus.PartiallyFilled, restored.Status);
+    }
+
+    private sealed class Harness
+    {
+        public WorkingOrderBook Book { get; } = new();
+        public OrderOwnershipMap Ownership { get; } = new();
+        public ClOrdIdPrefixRegistry ClOrdIds { get; } = new();
+        public NullEventStore Store { get; } = new();
+        public EventDispatcher Dispatcher { get; }
+        public RecordingGateway Gateway { get; } = new();
+        public PositionKeeper Positions { get; } = new();
+        public NoOpExecutionEventSink Sink { get; } = new();
+        public RiskPipeline Risk { get; } = new(Array.Empty<IRiskCheck>());
+        public NoOpMarginProvider Margin { get; } = new();
+        public CompositeRiskAccountant Accountant { get; } = new(Array.Empty<IRiskAccountant>());
+        public NeverDrainingGate Drain { get; } = new();
+        public OrderSubmissionService Submitter { get; }
+        public ExecutionReportProcessor Processor { get; }
+
+        public Harness()
+        {
+            Dispatcher = new EventDispatcher(Store);
+            Submitter = new OrderSubmissionService(
+                ClOrdIds, Ownership, Book, Gateway, Sink, Risk, Margin, Accountant,
+                Dispatcher, Drain, NullLogger<OrderSubmissionService>.Instance);
+            Processor = new ExecutionReportProcessor(
+                Ownership, Book, Positions, Sink, Margin,
+                NullLogger<ExecutionReportProcessor>.Instance);
+        }
+    }
+
+    private sealed class RecordingGateway : IExchangeGateway
+    {
+        public List<Order> SubmittedOrders { get; } = new();
+        public Task SubmitAsync(Order order, CancellationToken ct)
+        {
+            SubmittedOrders.Add(order);
+            return Task.CompletedTask;
+        }
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice,
+            DateTimeOffset? requestedGoodTillDate, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class NeverDrainingGate : IDrainGate
+    {
+        public bool IsDraining => false;
+    }
+
+    private sealed class NoOpExecutionEventSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Orders/IcebergDisplayQtySubmitTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Orders/IcebergDisplayQtySubmitTests.cs
@@ -69,29 +69,33 @@ public class IcebergDisplayQtySubmitTests
         Assert.Equal(10L, order.DisplayQty);
     }
 
-    [Fact]
-    public async Task SubmitIceberg_NeverPolicy_StillRoundTripsToGateway()
+    [Theory]
+    [InlineData(DisplayResetPolicy.OnPartialFill)]
+    [InlineData(DisplayResetPolicy.Never)]
+    public async Task SubmitIceberg_UnsupportedPolicy_RejectedBeforeWal(DisplayResetPolicy unsupported)
     {
-        // SDK-limitation note (see TODO in B3EntryPointClientGateway):
-        // the SDK does not currently plumb the refresh policy, so on
-        // the wire `Never` collapses to the venue default (Always).
-        // What the platform CAN guarantee end-to-end is that the
-        // trader's chosen policy is preserved on the domain Order,
-        // recorded on the WAL (Application.Tests.Persistence
-        // .OrderDisplayQtyBackCompatTests), and visible to operators
-        // via the REST/UI surface.
+        // Pass-1 review (#297, follow-up #298). B3.EntryPoint.Client
+        // 0.14.3 has no refresh-policy field, so any policy other than
+        // Always would silently downgrade at the venue and break the
+        // Never contract entirely. The submit pipeline must reject
+        // (defensive — same guard is also in OrdersEndpoints) so
+        // non-REST callers (algo engine, FIXP bot intake) cannot
+        // sneak the unsupported value past the WAL append either.
         var h = new Harness();
         var req = new OrderSubmissionRequest(
             Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
             Quantity: 50, Price: 30m,
             DisplayQty: 5,
-            DisplayResetPolicy: DisplayResetPolicy.Never);
+            DisplayResetPolicy: unsupported);
 
         var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
 
-        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
-        var submitted = Assert.Single(h.Gateway.SubmittedOrders);
-        Assert.Equal(DisplayResetPolicy.Never, submitted.DisplayResetPolicy);
+        Assert.Equal(OrderSubmissionResultKind.BadRequest, result.Kind);
+        Assert.NotNull(result.Reason);
+        Assert.Contains("not supported by the current entrypoint SDK", result.Reason);
+        Assert.Contains("Always", result.Reason);
+        Assert.Contains("#298", result.Reason);
+        Assert.Empty(h.Gateway.SubmittedOrders);
     }
 
     [Theory]
@@ -128,7 +132,7 @@ public class IcebergDisplayQtySubmitTests
             Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
             Quantity: 100, Price: 30m,
             DisplayQty: 10,
-            DisplayResetPolicy: DisplayResetPolicy.OnPartialFill);
+            DisplayResetPolicy: DisplayResetPolicy.Always);
         var submitResult = await h.Submitter.SubmitAsync(req, CancellationToken.None);
 
         // Advance fills 30/100 so the snapshot captures non-trivial
@@ -143,7 +147,7 @@ public class IcebergDisplayQtySubmitTests
         Assert.True(fresh.TryGet(submitResult.ClOrdId, out var restored));
         Assert.NotNull(restored);
         Assert.Equal(10L, restored!.DisplayQty);
-        Assert.Equal(DisplayResetPolicy.OnPartialFill, restored.DisplayResetPolicy);
+        Assert.Equal(DisplayResetPolicy.Always, restored.DisplayResetPolicy);
         Assert.Equal(70, restored.LeavesQuantity);
         Assert.Equal(30, restored.CumulativeQuantity);
         Assert.Equal(OrderStatus.PartiallyFilled, restored.Status);

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/OrderDisplayQtyBackCompatTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/OrderDisplayQtyBackCompatTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using B3.Trading.Application.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Q3.4 (#284). Pins additive evolution of
+/// <see cref="OrderSubmittedEvent"/> and <see cref="OrderSnapshot"/>
+/// for the native iceberg display-qty fields. WAL segments and
+/// snapshot files written before this slice (no <c>DisplayQty</c>
+/// or <c>DisplayResetPolicy</c>) must hydrate cleanly as
+/// full-disclosure / no-reserve orders — the semantics they
+/// actually carried.
+/// </summary>
+public class OrderDisplayQtyBackCompatTests
+{
+    private static readonly JsonSerializerOptions Opts = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void OrderSubmittedEvent_OldPayload_DisplayFieldsDefaultToNull()
+    {
+        const string oldJson = """
+        {
+          "TimestampUtc": "2024-06-15T12:34:56.789+00:00",
+          "ClOrdId": 42,
+          "EndClientId": "alice",
+          "FirmId": "default",
+          "Symbol": "PETR4",
+          "SecurityId": 4321,
+          "Side": "Buy",
+          "Type": "Limit",
+          "Quantity": 100,
+          "Price": 30.5,
+          "TimeInForce": "Day"
+        }
+        """;
+
+        var ev = JsonSerializer.Deserialize<OrderSubmittedEvent>(oldJson, Opts);
+
+        Assert.NotNull(ev);
+        Assert.Null(ev!.DisplayQty);
+        Assert.Null(ev.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public void OrderSubmittedEvent_NewPayload_RoundTripsDisplayFields()
+    {
+        var ev = new OrderSubmittedEvent
+        {
+            TimestampUtc = DateTimeOffset.UtcNow,
+            ClOrdId = 1UL,
+            EndClientId = "alice",
+            FirmId = "default",
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 100,
+            Price = 30.5m,
+            TimeInForce = "Day",
+            DisplayQty = 10,
+            DisplayResetPolicy = "OnPartialFill",
+        };
+
+        var json = JsonSerializer.Serialize(ev, Opts);
+        var rt = JsonSerializer.Deserialize<OrderSubmittedEvent>(json, Opts)!;
+
+        Assert.Equal(10L, rt.DisplayQty);
+        Assert.Equal("OnPartialFill", rt.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public void OrderSnapshot_OldPayload_DisplayFieldsDefaultToNull()
+    {
+        const string oldJson = """
+        {
+          "ClOrdId": 7,
+          "EndClientId": "alice",
+          "Symbol": "PETR4",
+          "SecurityId": 4321,
+          "Side": "Buy",
+          "Type": "Limit",
+          "Quantity": 100,
+          "Price": 30.5,
+          "LeavesQuantity": 100,
+          "CumulativeQuantity": 0,
+          "Status": "Working"
+        }
+        """;
+
+        var snap = JsonSerializer.Deserialize<OrderSnapshot>(oldJson, Opts);
+
+        Assert.NotNull(snap);
+        Assert.Null(snap!.DisplayQty);
+        Assert.Null(snap.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public void OrderSnapshot_NewPayload_RoundTripsDisplayFields()
+    {
+        var snap = new OrderSnapshot(
+            7UL, "alice", "PETR4", 4321UL, "Buy", "Limit",
+            100, 30.5m, 100, 0, "Working")
+        {
+            DisplayQty = 25,
+            DisplayResetPolicy = "Never",
+        };
+
+        var json = JsonSerializer.Serialize(snap, Opts);
+        var rt = JsonSerializer.Deserialize<OrderSnapshot>(json, Opts)!;
+
+        Assert.Equal(25L, rt.DisplayQty);
+        Assert.Equal("Never", rt.DisplayResetPolicy);
+    }
+}

--- a/backend/tests/B3.Trading.Domain.Tests/OrderDisplayQtyValidationTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderDisplayQtyValidationTests.cs
@@ -1,0 +1,123 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+/// <summary>
+/// Q3.4 (#284). Domain-level invariants for the native iceberg /
+/// reserve display-qty fields on <see cref="Order"/>. The ctor is
+/// the single chokepoint for both live submits and replay
+/// hydration; rejecting a malformed (DisplayQty, DisplayResetPolicy)
+/// pair here means no risk-pipeline, gateway, or recovery path can
+/// reconstitute an illegal iceberg order.
+/// </summary>
+public class OrderDisplayQtyValidationTests
+{
+    private static readonly EndClientId Owner = new("alice");
+
+    private static Order Build(long? displayQty = null, DisplayResetPolicy? policy = null, long quantity = 100) =>
+        new(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, quantity, 30m,
+            displayQty: displayQty, displayResetPolicy: policy);
+
+    [Fact]
+    public void NoDisplayQty_IsFullDisclosure_NullPolicy()
+    {
+        var o = Build();
+
+        Assert.Null(o.DisplayQty);
+        Assert.Null(o.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public void DisplayQty_DefaultsPolicy_ToAlways()
+    {
+        var o = Build(displayQty: 10);
+
+        Assert.Equal(10, o.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.Always, o.DisplayResetPolicy);
+    }
+
+    [Theory]
+    [InlineData(DisplayResetPolicy.Always)]
+    [InlineData(DisplayResetPolicy.OnPartialFill)]
+    [InlineData(DisplayResetPolicy.Never)]
+    public void DisplayQty_PreservesExplicitPolicy(DisplayResetPolicy policy)
+    {
+        var o = Build(displayQty: 10, policy: policy);
+
+        Assert.Equal(policy, o.DisplayResetPolicy);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void DisplayQty_NonPositive_Rejected(long bad)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Build(displayQty: bad));
+        Assert.Contains("DisplayQty must be positive", ex.Message);
+    }
+
+    [Fact]
+    public void DisplayQty_GreaterThanQuantity_Rejected()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Build(displayQty: 101, quantity: 100));
+        Assert.Contains("must not exceed order Quantity", ex.Message);
+    }
+
+    [Fact]
+    public void DisplayQty_EqualToQuantity_Allowed()
+    {
+        // Edge case — equivalent to no reserve, but accepted so the
+        // wire mapping stays trivial (MaxFloor = OrderQty) and the
+        // trader can express "show everything explicitly".
+        var o = Build(displayQty: 100, quantity: 100);
+        Assert.Equal(100, o.DisplayQty);
+    }
+
+    [Fact]
+    public void Policy_WithoutDisplayQty_Rejected()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Build(policy: DisplayResetPolicy.Always));
+        Assert.Contains("DisplayResetPolicy must be null when DisplayQty is null", ex.Message);
+    }
+
+    [Fact]
+    public void Hydrate_RoundTripsDisplayFields()
+    {
+        var o = Order.Hydrate(
+            1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            quantity: 100, price: 30m, leaves: 90, cumQty: 10, status: OrderStatus.PartiallyFilled,
+            displayQty: 10, displayResetPolicy: DisplayResetPolicy.Never);
+
+        Assert.Equal(10, o.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.Never, o.DisplayResetPolicy);
+        Assert.Equal(90, o.LeavesQuantity);
+        Assert.Equal(10, o.CumulativeQuantity);
+    }
+
+    [Fact]
+    public void HydrateReplacement_InheritsDisplayFields()
+    {
+        var original = Build(displayQty: 10, policy: DisplayResetPolicy.OnPartialFill, quantity: 100);
+
+        var replacement = Order.HydrateReplacement(
+            original, newClOrdId: 2UL, newQuantity: 80, newPrice: 31m, erLeaves: 80, erCumulative: 0);
+
+        Assert.Equal(10, replacement.DisplayQty);
+        Assert.Equal(DisplayResetPolicy.OnPartialFill, replacement.DisplayResetPolicy);
+    }
+
+    [Fact]
+    public void HydrateReplacement_ClampsDisplayQtyWhenNewQtyShrinks()
+    {
+        // If the operator shrinks the order qty below the original
+        // visible portion, the replacement's DisplayQty must be
+        // clamped — otherwise the ctor invariant (DQ <= Quantity)
+        // would throw and recovery would be poisoned.
+        var original = Build(displayQty: 50, policy: DisplayResetPolicy.Always, quantity: 100);
+
+        var replacement = Order.HydrateReplacement(
+            original, newClOrdId: 2UL, newQuantity: 20, newPrice: 31m, erLeaves: 20, erCumulative: 0);
+
+        Assert.Equal(20, replacement.DisplayQty);
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -158,6 +158,25 @@
             <span>Good-till-date</span>
             <input id="ticket-good-till-date" type="datetime-local" />
           </label>
+          <!-- Q3.4 (#284). Native iceberg / reserve display-qty. Leave
+               Display qty empty for full disclosure (no reserve). When
+               set, must satisfy 0 < Display qty <= Quantity; the
+               backend enforces this and returns 400 otherwise. The
+               Reset policy applies only when Display qty is set. -->
+          <div class="row-two">
+            <label>
+              <span>Display qty</span>
+              <input id="ticket-display-qty" type="number" min="1" step="1" placeholder="(no reserve)" />
+            </label>
+            <label>
+              <span>Reset policy</span>
+              <select id="ticket-display-reset-policy">
+                <option value="Always">Always</option>
+                <option value="OnPartialFill">OnPartialFill</option>
+                <option value="Never">Never</option>
+              </select>
+            </label>
+          </div>
           <p id="ticket-tif-hint" class="field-hint" role="status" aria-live="polite" hidden></p>
           <p id="ticket-rules-hint" class="field-hint" aria-live="polite">lot 100 · tick 0.01</p>
           <p id="ticket-validation" class="field-hint hint-warn" role="status" aria-live="polite" hidden></p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -161,8 +161,13 @@
           <!-- Q3.4 (#284). Native iceberg / reserve display-qty. Leave
                Display qty empty for full disclosure (no reserve). When
                set, must satisfy 0 < Display qty <= Quantity; the
-               backend enforces this and returns 400 otherwise. The
-               Reset policy applies only when Display qty is set. -->
+               backend enforces this and returns 400 otherwise.
+               Pass-1 review (#297) follow-up #298: the entrypoint SDK
+               does not yet expose a refresh-policy field, so today only
+               "Always" is accepted at intake — OnPartialFill / Never
+               would be rejected with 400. The dropdown is kept so the
+               UI shape is forward-compatible; extra options can be
+               re-added when #298 lands. -->
           <div class="row-two">
             <label>
               <span>Display qty</span>
@@ -172,8 +177,6 @@
               <span>Reset policy</span>
               <select id="ticket-display-reset-policy">
                 <option value="Always">Always</option>
-                <option value="OnPartialFill">OnPartialFill</option>
-                <option value="Never">Never</option>
               </select>
             </label>
           </div>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -731,6 +731,18 @@ export function bindUi() {
       stopPrice:    stopHidden || !stopPriceEl || stopPriceEl.value === "" ? null : Number(stopPriceEl.value),
       goodTillDate: gtdHidden  || !gtdEl       || gtdEl.value       === "" ? null : new Date(gtdEl.value).toISOString(),
     };
+    // Q3.4 (#284). Native iceberg / reserve display-qty. An empty
+    // Display qty input means full disclosure (no reserve) — we
+    // omit both display fields from the payload so the backend
+    // defaults kick in (null = no reserve). When the trader fills
+    // it in, send the policy too; the backend defaults to Always
+    // when the policy is omitted on a display-qty submit.
+    const displayQtyEl = $("ticket-display-qty");
+    const displayPolicyEl = $("ticket-display-reset-policy");
+    if (displayQtyEl && displayQtyEl.value !== "") {
+      payload.displayQty = Number(displayQtyEl.value);
+      payload.displayResetPolicy = displayPolicyEl ? displayPolicyEl.value : "Always";
+    }
     onSubmitOrder(payload);
   });
 
@@ -1118,6 +1130,11 @@ export function clearTicket() {
   // ticket starts clean.
   const sp = $("ticket-stop-price");  if (sp) sp.value = "";
   const gtd = $("ticket-good-till-date"); if (gtd) gtd.value = "";
+  // Q3.4 (#284). Reset the iceberg display-qty input; leave the
+  // reset-policy select on its default ("Always") since it's
+  // inert when display qty is empty.
+  const dq = $("ticket-display-qty"); if (dq) dq.value = "";
+  const dp = $("ticket-display-reset-policy"); if (dp) dp.value = "Always";
   syncTicketRules();
   refreshTicketValidation();
 }


### PR DESCRIPTION
Closes #284.

## What

Native iceberg / reserve order support on plain orders via new
`DisplayQty` (long?) + `DisplayResetPolicy` (enum: Always /
OnPartialFill / Never) fields. Distinct from the existing
client-emulated `IcebergAlgo` — these fields ride straight on the
order to the venue.

## Wire mapping

`DisplayQty` → `NewOrderRequest.MaxFloor` /
`ReplaceOrderRequest.MaxFloor` (FIX-standard "max visible qty").
Confirmed via reflection against `B3.EntryPoint.Client` 0.14.3:
both request types expose `Nullable<UInt64> MaxFloor`.

**Reset-policy plumbing — SDK gap.** No field for a refresh /
disclose-on-fill policy exists anywhere in `B3.EntryPoint.Client`
0.14.3 (verified by exhaustive strings dump of the DLL — no
`Policy`, `Reset`, `Refresh`, `Display`, `Disclose` members).
The venue effectively applies its default behaviour. We therefore
accept and persist the policy informationally (recovery, audit,
UI) and leave a prominent `TODO(#284)` at the gateway boundary
that flips on the field the moment the SDK exposes it. No upstream
issue is being filed here — the gap is documented in the gateway
and surfaced in this PR. A future SDK update is a drop-in change.

## Surface changes

- **Domain:** `Order.DisplayQty`, `Order.DisplayResetPolicy`
  with ctor validation (`0 < DisplayQty <= Quantity`, policy
  cannot be set without DisplayQty, auto-defaults to Always).
  Hydrate / HydrateReplacement propagate and clamp.
- **Persistence:** Additive nullable fields on
  `OrderSubmittedEvent` and `OrderSnapshot`. Null = legacy
  no-reserve order; old WAL segments + snapshots replay unchanged
  (covered by new back-compat tests).
- **Gateway:** `B3EntryPointClientGateway` maps DisplayQty →
  MaxFloor on submit and cancel/replace (clamped to new quantity).
- **API:** `POST /orders` accepts `displayQty` +
  `displayResetPolicy` (string, case-insensitive; 400 on bad value).
- **UI:** Ticket gains "Display qty" + "Reset policy" inputs;
  empty Display qty omits both fields (full disclosure, back-compat).

## Tests

~21 new tests across:
- Domain ctor / Hydrate validation (13)
- Persistence WAL/snapshot back-compat round-trip (4)
- Application end-to-end submit (gateway-boundary Order carries
  fields, fills accumulate to Filled, snapshot+restore preserves
  display fields, BadRequest on invalid display qty)
- API endpoint (display fields persist, Always default, validation
  rejections, invalid policy string → 400)
- Gateway map tests pin `BuildNewOrderRequest` MaxFloor mapping (4)

Totals: Domain 81, Application 920, Api 353, EntryPointListener
134, SimulatorBot 23 — 0 failures. Frontend tests 264 — 0 failures.
`dotnet format --verify-no-changes` clean.