### PR TITLE
feat(#285): algo modify (cancel-replace) API + WAL + metrics

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -371,7 +371,15 @@ public static class AlgoEndpoints
                 return Results.Conflict(new { error = $"algo {id} is cancelling" });
             }
 
-            var reason = string.IsNullOrWhiteSpace(req.Reason) ? "operator" : req.Reason.Trim();
+            var reason = ModifyAlgoRequest.NormalizeReason(req.Reason);
+            if (reason is null)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid_reason",
+                    detail = $"reason must be one of: {string.Join(", ", ModifyAlgoRequest.AllowedReasons)}",
+                });
+            }
             if (!signals.TryEnqueue(new AlgoModifyRequestedSignal
             {
                 FirmId = firm,
@@ -577,4 +585,36 @@ public sealed record ModifyAlgoRequest(
     long? NewQuantity = null,
     decimal? NewPrice = null,
     ulong? ChildClOrdId = null,
-    string? Reason = null);
+    string? Reason = null)
+{
+    // Pass-1 review (#299) P2-A. Reason flows into a metric tag, so it
+    // MUST be a closed enum to avoid unbounded cardinality from
+    // arbitrary operator strings. Audit (AlgoChildModifiedEvent) still
+    // records the normalised value verbatim — same identifier, just
+    // constrained. Defaults to OperatorModify when omitted; anything
+    // outside this allowlist is rejected at the endpoint with 400.
+    public static readonly IReadOnlyList<string> AllowedReasons = new[]
+    {
+        "OperatorModify",
+        "AlgoInternal",
+        "Reconciliation",
+    };
+
+    /// <summary>
+    /// Trims and case-insensitively matches <paramref name="raw"/> against
+    /// <see cref="AllowedReasons"/>. Returns the canonical-cased value on
+    /// match, the default (<c>OperatorModify</c>) on null/whitespace, or
+    /// <c>null</c> when the input does not match any allowed reason.
+    /// </summary>
+    public static string? NormalizeReason(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return AllowedReasons[0];
+        var trimmed = raw.Trim();
+        foreach (var allowed in AllowedReasons)
+        {
+            if (string.Equals(trimmed, allowed, StringComparison.OrdinalIgnoreCase))
+                return allowed;
+        }
+        return null;
+    }
+}

--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -317,6 +317,86 @@ public static class AlgoEndpoints
             });
         });
 
+        // Q3.5 (#285). Operator-driven cancel-replace (modify) of a
+        // live algo child. Mirrors the cancel endpoint's auth /
+        // ownership / drain semantics; the modify intent is enqueued
+        // on the engine signal queue and applied on the consumer
+        // thread so per-parent serialisation is preserved (the same
+        // reactor that submits new slices also dispatches modifies,
+        // so an in-flight repeg and an operator modify can't race
+        // each other into a double cancel-replace).
+        group.MapPost("/{algoId}/modify", (
+            string algoId,
+            ModifyAlgoRequest? req,
+            HttpContext ctx,
+            EndClientRegistry registry,
+            AlgoBook algos,
+            DrainState drain,
+            IAlgoSignalQueue signals) =>
+        {
+            if (drain.IsDraining)
+            {
+                MetricsRegistry.DrainRejections.Add(1,
+                    new KeyValuePair<string, object?>("route", "POST /algo/modify"));
+                return Results.Json(
+                    new { error = "service draining" },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            if (!ulong.TryParse(algoId, out var id) || id == 0)
+                return Results.NotFound();
+            if (req is null)
+                return Results.BadRequest(new { error = "request body required" });
+            if (req.NewQuantity is null && req.NewPrice is null)
+                return Results.BadRequest(new { error = "at least one of newQuantity or newPrice must be set" });
+            if (req.NewQuantity is { } q && q <= 0)
+                return Results.BadRequest(new { error = "newQuantity must be positive" });
+
+            var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
+            if (!algos.TryGet(firm, id, out var algo) || algo is null || algo.Owner != owner)
+                return Results.NotFound();
+            if (algo.IsTerminal)
+            {
+                MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                    new KeyValuePair<string, object?>("algoType", algo.Type.ToString().ToLowerInvariant()),
+                    new KeyValuePair<string, object?>("reason", "algo_terminal"));
+                return Results.Conflict(new { error = $"algo {id} is already terminal in {algo.Status}" });
+            }
+            if (algo.Status == AlgoStatus.Cancelling)
+            {
+                MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                    new KeyValuePair<string, object?>("algoType", algo.Type.ToString().ToLowerInvariant()),
+                    new KeyValuePair<string, object?>("reason", "algo_cancelling"));
+                return Results.Conflict(new { error = $"algo {id} is cancelling" });
+            }
+
+            var reason = string.IsNullOrWhiteSpace(req.Reason) ? "operator" : req.Reason.Trim();
+            if (!signals.TryEnqueue(new AlgoModifyRequestedSignal
+            {
+                FirmId = firm,
+                AlgoId = id,
+                TargetChildClOrdId = req.ChildClOrdId,
+                NewQuantity = req.NewQuantity,
+                NewPrice = req.NewPrice,
+                Reason = reason,
+            }))
+            {
+                MetricsRegistry.AlgoSignalsDropped.Add(1,
+                    new KeyValuePair<string, object?>("kind", "modify_requested"));
+                return Results.Json(
+                    new { error = "engine busy (signal queue full)" },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            return Results.Accepted($"/algo/{id}", new
+            {
+                AlgoId = id.ToString(),
+                Status = algo.Status.ToString(),
+                Reason = reason,
+            });
+        });
+
         group.MapDelete("/{algoId}", (
             string algoId,
             HttpContext ctx,
@@ -482,3 +562,19 @@ public sealed record CreateAlgoPeggedParams(
     decimal? TickSize = null,
     string? ChildOrderType = null,
     decimal? PriceLimit = null);
+
+/// <summary>
+/// Q3.5 (#285). Body for <c>POST /algo/{id}/modify</c>. At least one
+/// of <see cref="NewQuantity"/> / <see cref="NewPrice"/> must be set;
+/// the engine inherits the omitted side from the live child.
+/// <see cref="ChildClOrdId"/> is optional — when null the engine
+/// targets the parent's current live child (the common case).
+/// <see cref="Reason"/> is folded into metrics + the
+/// <c>AlgoChildModifiedEvent</c> audit envelope; defaults to
+/// <c>operator</c> when omitted.
+/// </summary>
+public sealed record ModifyAlgoRequest(
+    long? NewQuantity = null,
+    decimal? NewPrice = null,
+    ulong? ChildClOrdId = null,
+    string? Reason = null);

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -659,9 +659,14 @@ public sealed class AlgoEngine : BackgroundService
         // and seed the new child's booked-cum baseline from the venue's
         // echoed cum so the next Fill ER for the new child computes a
         // correct delta. The OLD child has already been MarkReplaced'd
-        // by the processor (Replaced ⇒ terminal) and its
-        // ChildBookedCum entry is left in place — Reconcile rebuilds it
-        // from the order book, and it's bounded per-parent.
+        // by the processor (Replaced ⇒ terminal); its ChildBookedCum
+        // entry is NOT pruned synchronously — a late stray ER for OLD
+        // could still arrive and we must keep the prior booked-cum so
+        // its delta computation yields 0 (rather than re-booking the
+        // OLD cum from a missing-key default of 0). Pass-2 review
+        // (#299) P2 caps that bookkeeping by enqueueing OLD into a
+        // bounded FIFO; once the FIFO overflows (cap=8) the eldest
+        // retired slot is evicted from ChildBookedCum.
         if (_replacements is not null
             && rt.LiveChildClOrdId is { } oldLive
             && oldLive != child.ClOrdId
@@ -672,6 +677,7 @@ public sealed class AlgoEngine : BackgroundService
         {
             rt.LiveChildClOrdId = child.ClOrdId;
             rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
+            rt.RetireChildSlot(oldLive);
             // Fall through so any erCum > prior booked OLD cum that the
             // venue carried over (e.g. a fill landed at venue strictly
             // between our last OLD-child ER and the Replaced ack) is NOT
@@ -2084,12 +2090,36 @@ public sealed class AlgoEngine : BackgroundService
     /// snapshotted) — recovery rebuilds it from the order book on engine
     /// start. Not thread-safe; only the single consumer task touches it.
     /// </summary>
-    private sealed class AlgoParentRuntime
+    internal sealed class AlgoParentRuntime
     {
         public ulong? LiveChildClOrdId;
         public int NextSliceSeq;
         public int RetryAttempts;
         public Dictionary<ulong, long> ChildBookedCum { get; } = new();
+
+        // Pass-2 review (#299) P2. Bounded FIFO of retired (replaced)
+        // child ClOrdIds for this parent. On adoption of a replacement
+        // child via OnChildErAsync, the OLD child id is enqueued here;
+        // when the queue overflows <see cref="RetiredChildSlotsCap"/>,
+        // the eldest id is dequeued AND its row removed from
+        // <see cref="ChildBookedCum"/>. We keep the booked-cum row for
+        // recently-retired slots so a late stray ER for that OLD id
+        // (e.g. a duplicate Cancelled ack the venue emits post-replace)
+        // computes delta = childCum - prevBooked == 0 instead of being
+        // re-booked from a missing-key default of 0. Cap mirrors the
+        // <c>CancelledChildRing</c> sizing pattern from PR #296.
+        private const int RetiredChildSlotsCap = 8;
+        public Queue<ulong> RetiredChildSlots { get; } = new(RetiredChildSlotsCap);
+
+        public void RetireChildSlot(ulong oldChildClOrdId)
+        {
+            RetiredChildSlots.Enqueue(oldChildClOrdId);
+            while (RetiredChildSlots.Count > RetiredChildSlotsCap)
+            {
+                var evicted = RetiredChildSlots.Dequeue();
+                ChildBookedCum.Remove(evicted);
+            }
+        }
 
         // Pass-1 review (#295) P1#1. POV scheduling state. Initialised
         // to (0, default) so the first tick treats StartUtc as the

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -115,6 +116,22 @@ public sealed class AlgoEngine : BackgroundService
     /// </summary>
     private readonly PendingReplacementRegistry? _replacements;
 
+    /// <summary>
+    /// Pass-3 review (#299) P1. Risk pipeline + replace-margin coordinator
+    /// for the engine-driven modify path. Mirrors
+    /// <see cref="OrderModifyService"/>'s pre-trade gates so an operator
+    /// or engine-driven cancel-replace that would push a Buy past
+    /// available cash (or trip any other pre-trade rule) is rejected
+    /// BEFORE the gateway dispatch — closing the bypass identified in
+    /// pass-3 where the algo modify path went straight from validation
+    /// to gateway with no risk check or margin reserve. Both are
+    /// optional only to keep test compositions (which don't wire the
+    /// full risk pipeline) buildable; production composition always
+    /// supplies them via DI alongside <see cref="_replacements"/>.
+    /// </summary>
+    private readonly RiskPipeline? _risk;
+    private readonly IReplaceMarginCoordinator? _replaceMargin;
+
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
     // convenient — no concurrent writers exist in v0.
@@ -139,7 +156,9 @@ public sealed class AlgoEngine : BackgroundService
         PegBookTopCache? pegBookTop = null,
         MarketDataPegBookPump? pegBookPump = null,
         PeggedRepegBook? peggedRepeg = null,
-        PendingReplacementRegistry? replacements = null)
+        PendingReplacementRegistry? replacements = null,
+        RiskPipeline? risk = null,
+        IReplaceMarginCoordinator? replaceMargin = null)
     {
         _queue = queue;
         _algos = algos;
@@ -159,6 +178,8 @@ public sealed class AlgoEngine : BackgroundService
         _pegBookPump = pegBookPump;
         _peggedRepeg = peggedRepeg;
         _replacements = replacements;
+        _risk = risk;
+        _replaceMargin = replaceMargin;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -677,7 +698,27 @@ public sealed class AlgoEngine : BackgroundService
         {
             rt.LiveChildClOrdId = child.ClOrdId;
             rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
-            rt.RetireChildSlot(oldLive);
+            var evicted = rt.RetireChildSlot(oldLive, out var firstRetiredEviction);
+            if (evicted > 0)
+            {
+                // Pass-3 review (#299) P2. Mirror PR #296's
+                // CancelledChildRing observability — silent FIFO
+                // eviction is a class of "you can't rely on this
+                // ChildBookedCum row being there if a late stray ER
+                // arrives for the OLD id". Always bump the counter so
+                // dashboards can spot sustained eviction churn; emit a
+                // single per-parent warn the first time to surface the
+                // condition without log spam thereafter.
+                var algoTypeEvictTag = algo.Type.ToString().ToLowerInvariant();
+                MetricsRegistry.AlgoModifyRetiredChildEvictedTotal.Add(evicted,
+                    new KeyValuePair<string, object?>("algoType", algoTypeEvictTag));
+                if (firstRetiredEviction)
+                {
+                    _logger.LogWarning(
+                        "AlgoEngine retired-child FIFO overflow on algo {Firm}/{AlgoId} (cap={Cap}): oldest ChildBookedCum row evicted. Late stray ERs for evicted child ids will fall through to a missing-key default of 0 booked cum.",
+                        algo.FirmId, algo.AlgoId, 8);
+                }
+            }
             // Fall through so any erCum > prior booked OLD cum that the
             // venue carried over (e.g. a fill landed at venue strictly
             // between our last OLD-child ER and the Replaced ack) is NOT
@@ -1036,17 +1077,21 @@ public sealed class AlgoEngine : BackgroundService
     /// venue, preserving book priority on B3 (priority-up keeps
     /// queue position on price-improving Sells / Buys; qty-down
     /// keeps it as well). Mirrors <see cref="OrderModifyService"/>'s
-    /// plumbing — allocates a new ClOrdID, registers the intent in
+    /// plumbing — allocates a new ClOrdID, runs the same pre-trade
+    /// risk pipeline + margin Prepare (delta-only reservation under
+    /// the new ClOrdID), registers the intent in
     /// <see cref="PendingReplacementRegistry"/> so the Replaced ack
     /// hydrates the new child into the book, writes the
     /// <see cref="OrderReplaceRequestedEvent"/> + audit
     /// <see cref="AlgoChildModifiedEvent"/>, then dispatches to the
-    /// gateway. The engine bypasses the risk / margin pipelines
-    /// (children were already risk-cleared at submit time; residue
-    /// shrinks only via fills, never via modify since we reject
-    /// newQty &lt;= cum above), keeping the algo retrofit path
-    /// behaviourally identical to the existing cancel + place path
-    /// it replaces.
+    /// gateway. Pass-3 review (#299) P1 added the risk + margin
+    /// gates: without them a Buy child could be price/qty-modified
+    /// beyond available cash (CommitReplace on the venue ack only
+    /// rebalances; it does not reject). The gates run BEFORE the
+    /// WAL append + gateway dispatch so a rejection emits no
+    /// <see cref="AlgoChildModifiedEvent"/> and no wire-call —
+    /// only the <c>algo.modify_rejected_total</c> counter with
+    /// reason=<c>risk_rejected</c> / <c>margin_rejected</c>.
     /// </summary>
     private async Task<bool> TryReplaceChildAsync(
         Algo algo, AlgoParentRuntime rt, Order child,
@@ -1074,6 +1119,72 @@ public sealed class AlgoEngine : BackgroundService
         }
 
         var newClOrdId = _clOrdIds.Generate(child.Owner);
+
+        // Pass-3 review (#299) P1. Run the same pre-trade gates the
+        // operator-driven plain-order modify pipeline applies in
+        // <see cref="OrderModifyService.ModifyAsync"/> — pre-trade
+        // risk evaluation (projecting the new qty/price under the
+        // replace context) followed by margin Prepare (delta-only
+        // reservation under the new ClOrdID). Without this, a Buy
+        // child could be price/qty-modified beyond available cash
+        // and the venue ack would land in CommitReplace which only
+        // re-balances; it does not reject. Inputs mirror the
+        // OrderModifyService block: ReplaceOriginalClOrdId set so
+        // NoNakedShortCheck projects the swap; EffectiveLeavesQty
+        // = newQty - cum (already validated > 0 by the caller); TIF
+        // / Stop / GTD are inherited from the original (the algo
+        // modify path does not surface them as overrides).
+        var effectiveLeaves = newQuantity - child.CumulativeQuantity;
+        if (_risk is not null)
+        {
+            var riskCtx = new RiskContext(
+                child.Owner, child.FirmId, child.Symbol, child.Side, child.Type,
+                newQuantity, newPrice,
+                ReplaceOriginalClOrdId: child.ClOrdId,
+                EffectiveLeavesQuantity: effectiveLeaves,
+                TimeInForce: child.TimeInForce,
+                StopPrice: child.StopPrice,
+                GoodTillDate: child.GoodTillDate);
+            var riskDecision = _risk.Evaluate(riskCtx);
+            if (!riskDecision.Approved)
+            {
+                MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                    new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                    new KeyValuePair<string, object?>("reason", "risk_rejected"));
+                _logger.LogInformation(
+                    "AlgoEngine modify rejected by risk for algo {Firm}/{AlgoId} child {Child}: {Reason}",
+                    algo.FirmId, algo.AlgoId, child.ClOrdId, riskDecision.Reason);
+                return false;
+            }
+        }
+
+        // Margin Prepare: reserve only the upsize delta. The coordinator
+        // no-ops on sells / markets / non-positive notionals; the
+        // gating predicate mirrors OrderModifyService so the algo and
+        // plain-order modify paths agree on which orders consume cash.
+        var newRemainingNotional = (child.Side == OrderSide.Buy
+                                    && child.Type.IsMarginBearing()
+                                    && newPrice is { } px)
+            ? px * effectiveLeaves
+            : 0m;
+        var marginPrepared = false;
+        if (_replaceMargin is not null)
+        {
+            var marginDecision = await _replaceMargin.PrepareReplaceAsync(
+                child.ClOrdId, newClOrdId, child.Owner, newRemainingNotional, ct).ConfigureAwait(false);
+            if (!marginDecision.Approved)
+            {
+                MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                    new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                    new KeyValuePair<string, object?>("reason", "margin_rejected"));
+                _logger.LogInformation(
+                    "AlgoEngine modify rejected by margin coordinator for algo {Firm}/{AlgoId} child {Child}: {Reason}",
+                    algo.FirmId, algo.AlgoId, child.ClOrdId, marginDecision.Reason);
+                return false;
+            }
+            marginPrepared = true;
+        }
+
         var intent = new OrderReplacementIntent(
             OriginalClOrdId: child.ClOrdId,
             NewClOrdId: newClOrdId,
@@ -1120,6 +1231,12 @@ public sealed class AlgoEngine : BackgroundService
             MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
                 new KeyValuePair<string, object?>("algoType", algoTypeTag),
                 new KeyValuePair<string, object?>("reason", "wal_backpressure"));
+            // Pass-3 review (#299) P1. Roll back the margin Prepare —
+            // the intent never made it to the registry, so a future
+            // ER cannot drive CommitReplace. Holding the reserve would
+            // leak permanently.
+            if (marginPrepared)
+                _replaceMargin!.AbortReplace(newClOrdId);
             return false;
         }
 
@@ -1156,6 +1273,21 @@ public sealed class AlgoEngine : BackgroundService
             _logger.LogWarning(ex,
                 "AlgoEngine modify gateway dispatch ambiguous for algo {Firm}/{AlgoId} child {Child}; intent retained for late Replaced ER.",
                 algo.FirmId, algo.AlgoId, child.ClOrdId);
+            // Pass-3 review (#299) P1. Release the upsize-delta margin
+            // reservation we prepared above. The PendingReplacementRegistry
+            // intent is deliberately KEPT (P1-B ambiguous-send window —
+            // venue may have already accepted), but holding the margin
+            // reserve indefinitely on a likely-failed send is the worse
+            // failure mode: if the venue did NOT accept the reserve
+            // leaks until the parent terminates. If the venue DID
+            // accept, CommitReplace will still run on the late Replaced
+            // ER and (with no Prepare-side transient entry) will adjust
+            // _reserved against the original's tracked notional; the
+            // accounting converges, only the upsize headroom safety
+            // check is temporarily relaxed for the in-flight window —
+            // an acceptable trade-off vs. permanently leaking the hold.
+            if (marginPrepared)
+                _replaceMargin!.AbortReplace(newClOrdId);
             return false;
         }
 
@@ -2111,15 +2243,55 @@ public sealed class AlgoEngine : BackgroundService
         private const int RetiredChildSlotsCap = 8;
         public Queue<ulong> RetiredChildSlots { get; } = new(RetiredChildSlotsCap);
 
-        public void RetireChildSlot(ulong oldChildClOrdId)
+        // Pass-3 review (#299) P2. One-shot warn latch mirroring the
+        // <see cref="CancelledChildRing"/> pattern from PR #296 pass-7
+        // / pass-8: emit a single warn on the FIRST eviction so an
+        // operator notices that ChildBookedCum rows are now being
+        // forgotten faster than late stray ERs may arrive, without
+        // spamming logs once we're past the cap. Set atomically by
+        // <see cref="RetireChildSlot"/> in the same step that drops the
+        // row, so a concurrent reader cannot observe the eviction
+        // without also observing <c>RetiredEvictionLogged=true</c>.
+        // AlgoParentRuntime is deliberately not snapshotted (recovery
+        // rebuilds it from the order book) so this latch resets on
+        // restart — acceptable: a post-restart warn just re-arms the
+        // operator's attention with no duplicate-spam risk because
+        // restarts are rare and the warn is per-parent.
+        public bool RetiredEvictionLogged;
+
+        /// <summary>
+        /// Enqueue <paramref name="oldChildClOrdId"/> into the retired
+        /// FIFO; if the cap is exceeded, dequeue the eldest, drop its
+        /// <see cref="ChildBookedCum"/> row, and set
+        /// <paramref name="firstEviction"/> to <c>true</c> iff this is
+        /// the FIRST eviction observed on this parent (latch flip).
+        /// Returns the count of rows evicted by this call (0 when
+        /// below cap, 1 in the steady-state overflow case).
+        /// </summary>
+        public int RetireChildSlot(ulong oldChildClOrdId, out bool firstEviction)
         {
+            firstEviction = false;
             RetiredChildSlots.Enqueue(oldChildClOrdId);
+            var evictedCount = 0;
             while (RetiredChildSlots.Count > RetiredChildSlotsCap)
             {
                 var evicted = RetiredChildSlots.Dequeue();
                 ChildBookedCum.Remove(evicted);
+                evictedCount++;
+                if (!RetiredEvictionLogged)
+                {
+                    RetiredEvictionLogged = true;
+                    firstEviction = true;
+                }
             }
+            return evictedCount;
         }
+
+        // Legacy signature retained for the AlgoParentRuntimeTests
+        // direct-construction surface — delegates to the two-arg
+        // variant and discards the eviction observability hooks.
+        public void RetireChildSlot(ulong oldChildClOrdId) =>
+            RetireChildSlot(oldChildClOrdId, out _);
 
         // Pass-1 review (#295) P1#1. POV scheduling state. Initialised
         // to (0, default) so the first tick treats StartUtc as the

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -103,6 +103,18 @@ public sealed class AlgoEngine : BackgroundService
     /// </summary>
     private readonly PeggedRepegBook? _peggedRepeg;
 
+    /// <summary>
+    /// Q3.5 (#285). In-flight cancel-replace intents for child orders
+    /// the engine has modified. Same registry the manual modify
+    /// pipeline (<see cref="OrderModifyService"/>) populates — the
+    /// ER processor consumes from it on the Replaced ack to hydrate
+    /// the new child Order in the book. Optional only to keep the
+    /// test composition (which builds the engine without the full
+    /// modify pipeline) buildable; production composition always
+    /// supplies it.
+    /// </summary>
+    private readonly PendingReplacementRegistry? _replacements;
+
     // Per-parent runtime state. Owned by the consumer task; the
     // ConcurrentDictionary is only used because TryAdd/TryGetValue are
     // convenient — no concurrent writers exist in v0.
@@ -126,7 +138,8 @@ public sealed class AlgoEngine : BackgroundService
         PovProgressBook? povProgress = null,
         PegBookTopCache? pegBookTop = null,
         MarketDataPegBookPump? pegBookPump = null,
-        PeggedRepegBook? peggedRepeg = null)
+        PeggedRepegBook? peggedRepeg = null,
+        PendingReplacementRegistry? replacements = null)
     {
         _queue = queue;
         _algos = algos;
@@ -145,6 +158,7 @@ public sealed class AlgoEngine : BackgroundService
         _pegBookTop = pegBookTop;
         _pegBookPump = pegBookPump;
         _peggedRepeg = peggedRepeg;
+        _replacements = replacements;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -466,6 +480,9 @@ public sealed class AlgoEngine : BackgroundService
                 break;
             case AlgoCancelRequestedSignal:
                 await OnCancelRequestedAsync(algo, rt, ct).ConfigureAwait(false);
+                break;
+            case AlgoModifyRequestedSignal mod:
+                await OnModifyRequestedAsync(algo, rt, mod, ct).ConfigureAwait(false);
                 break;
             default:
                 _logger.LogWarning("AlgoEngine ignoring unknown signal type {Type}.", signal.GetType().Name);
@@ -891,6 +908,256 @@ public sealed class AlgoEngine : BackgroundService
         algo.Type == AlgoType.Pov
         && algo.Parameters is PovParameters pp
         && _clock.GetUtcNow() >= pp.EndUtc;
+
+    /// <summary>
+    /// Q3.5 (#285). Operator-driven cancel-replace of an algo child.
+    /// Resolves the target child (explicit id from the signal, else
+    /// the parent's <c>LiveChildClOrdId</c>), validates terminal /
+    /// modify-below-filled invariants on the consumer thread, then
+    /// delegates the wire-call + WAL plumbing to
+    /// <see cref="TryReplaceChildAsync"/>. Race semantics: if the
+    /// target child has reached terminal between API accept and
+    /// reactor pick-up the modify is rejected gracefully (metric +
+    /// log) and the operator can retry — never applied to the
+    /// replacement that the engine may have already submitted in a
+    /// subsequent Pegged repeg cycle.
+    /// </summary>
+    private async Task OnModifyRequestedAsync(
+        Algo algo, AlgoParentRuntime rt, AlgoModifyRequestedSignal sig, CancellationToken ct)
+    {
+        var algoTypeTag = algo.Type.ToString().ToLowerInvariant();
+        if (algo.IsTerminal)
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "algo_terminal"));
+            _logger.LogDebug(
+                "AlgoEngine modify rejected: algo {Firm}/{AlgoId} is terminal ({Status}).",
+                algo.FirmId, algo.AlgoId, algo.Status);
+            return;
+        }
+        if (algo.Status == AlgoStatus.Cancelling)
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "algo_cancelling"));
+            return;
+        }
+
+        var targetChildClOrdId = sig.TargetChildClOrdId ?? rt.LiveChildClOrdId;
+        if (targetChildClOrdId is not { } childClOrdId || childClOrdId == 0)
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "no_live_child"));
+            return;
+        }
+
+        if (!_orders.TryGet(childClOrdId, out var child) || child is null)
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "child_not_found"));
+            return;
+        }
+        if (child.ParentAlgoId != algo.AlgoId)
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "child_not_owned"));
+            return;
+        }
+        if (IsChildTerminal(child))
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "child_terminal"));
+            return;
+        }
+
+        var newQty = sig.NewQuantity ?? child.Quantity;
+        var newPrice = sig.NewPrice ?? child.Price;
+        if (newQty <= child.CumulativeQuantity)
+        {
+            // Modify-to-invalid: residue would go non-positive. Surface
+            // as a metric — the API layer can't reject this cleanly
+            // because the cum is observed on the consumer thread.
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "qty_below_filled"));
+            return;
+        }
+
+        await TryReplaceChildAsync(algo, rt, child, newQty, newPrice, sig.Reason, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Q3.5 (#285). Shared helper: turn a "modify this live child"
+    /// intent into a gateway cancel-replace dispatched against the
+    /// venue, preserving book priority on B3 (priority-up keeps
+    /// queue position on price-improving Sells / Buys; qty-down
+    /// keeps it as well). Mirrors <see cref="OrderModifyService"/>'s
+    /// plumbing — allocates a new ClOrdID, registers the intent in
+    /// <see cref="PendingReplacementRegistry"/> so the Replaced ack
+    /// hydrates the new child into the book, writes the
+    /// <see cref="OrderReplaceRequestedEvent"/> + audit
+    /// <see cref="AlgoChildModifiedEvent"/>, then dispatches to the
+    /// gateway. The engine bypasses the risk / margin pipelines
+    /// (children were already risk-cleared at submit time; residue
+    /// shrinks only via fills, never via modify since we reject
+    /// newQty &lt;= cum above), keeping the algo retrofit path
+    /// behaviourally identical to the existing cancel + place path
+    /// it replaces.
+    /// </summary>
+    private async Task<bool> TryReplaceChildAsync(
+        Algo algo, AlgoParentRuntime rt, Order child,
+        long newQuantity, decimal? newPrice, string reason, CancellationToken ct)
+    {
+        var algoTypeTag = algo.Type.ToString().ToLowerInvariant();
+        if (_replacements is null)
+        {
+            // Defensive: the test composition that omits the registry
+            // also omits the modify path. Surface as a metric so a
+            // misconfigured composition is observable instead of silently
+            // skipping the retrofit.
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "registry_unavailable"));
+            return false;
+        }
+
+        if (_replacements.IsOriginalInFlight(child.ClOrdId))
+        {
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "already_in_flight"));
+            return false;
+        }
+
+        var newClOrdId = _clOrdIds.Generate(child.Owner);
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: child.ClOrdId,
+            NewClOrdId: newClOrdId,
+            Owner: child.Owner,
+            Symbol: child.Symbol,
+            SecurityId: child.SecurityId,
+            Side: child.Side,
+            Type: child.Type,
+            NewQuantity: newQuantity,
+            NewPrice: newPrice,
+            FirmId: child.FirmId,
+            ParentAlgoId: child.ParentAlgoId,
+            AlgoSliceSeq: child.AlgoSliceSeq);
+
+        var atUtc = _clock.GetUtcNow();
+        try
+        {
+            _dispatcher.Dispatch(
+                new OrderReplaceRequestedEvent
+                {
+                    OriginalClOrdId = child.ClOrdId,
+                    NewClOrdId = newClOrdId,
+                    EndClientId = child.Owner.Value,
+                    FirmId = child.FirmId,
+                    Symbol = child.Symbol,
+                    SecurityId = child.SecurityId,
+                    Side = child.Side.ToString(),
+                    Type = child.Type.ToString(),
+                    NewQuantity = newQuantity,
+                    NewPrice = newPrice,
+                    ParentAlgoId = child.ParentAlgoId,
+                    AlgoSliceSeq = child.AlgoSliceSeq,
+                },
+                () =>
+                {
+                    _replacements.TryAdd(intent);
+                    _ownership.RegisterReplaceLink(child.ClOrdId, newClOrdId);
+                });
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.modify"));
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "wal_backpressure"));
+            return false;
+        }
+
+        try
+        {
+            await _gateway.CancelReplaceAsync(
+                child, newClOrdId, newQuantity, newPrice,
+                requestedTimeInForce: null, requestedStopPrice: null, requestedGoodTillDate: null,
+                ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Roll back: drop the intent + log. Original child stays
+            // live; the operator can retry. No synthetic Rejected ER is
+            // emitted (the algo engine is not the order-event source —
+            // OrderModifyService does that for human-driven modifies
+            // because it owns the response semantics; the engine path
+            // surfaces the failure via the metric below + log).
+            _replacements.TryConsume(newClOrdId, out _);
+            MetricsRegistry.OrdersGatewayFailed.Add(1,
+                new KeyValuePair<string, object?>("path", "algo.modify"));
+            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag),
+                new KeyValuePair<string, object?>("reason", "gateway_failed"));
+            _logger.LogWarning(ex,
+                "AlgoEngine modify gateway dispatch failed for algo {Firm}/{AlgoId} child {Child}; rolled back.",
+                algo.FirmId, algo.AlgoId, child.ClOrdId);
+            return false;
+        }
+
+        // Best-effort audit envelope — observability-only, not
+        // replayed (the OrderReplaceRequestedEvent above is the
+        // durable record). WAL backpressure here is non-fatal.
+        try
+        {
+            var algoIdSnap = algo.AlgoId;
+            var firmIdSnap = algo.FirmId;
+            var oldIdSnap = child.ClOrdId;
+            var newIdSnap = newClOrdId;
+            var atUtcSnap = atUtc;
+            var reasonSnap = reason;
+            var qtySnap = newQuantity;
+            var priceSnap = newPrice;
+            _dispatcher.Dispatch(
+                new AlgoChildModifiedEvent
+                {
+                    AlgoId = algoIdSnap,
+                    FirmId = firmIdSnap,
+                    OldChildClOrdId = oldIdSnap,
+                    NewChildClOrdId = newIdSnap,
+                    NewQuantity = qtySnap,
+                    NewPrice = priceSnap,
+                    Reason = reasonSnap,
+                    AtUtc = atUtcSnap,
+                },
+                static () => { });
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "algo.child.modified"));
+        }
+
+        MetricsRegistry.AlgoChildModifiesTotal.Add(1,
+            new KeyValuePair<string, object?>("algoType", algoTypeTag),
+            new KeyValuePair<string, object?>("reason", reason));
+
+        // Re-target the live-child slot to the replacement id. The
+        // ER processor's Replaced ack will hydrate the new Order in
+        // the book under newClOrdId and fan out a
+        // ChildExecutionObservedSignal — by then rt.LiveChildClOrdId
+        // already matches, so OnChildErAsync's non-terminal early-
+        // return path runs as expected.
+        rt.LiveChildClOrdId = newClOrdId;
+        rt.ChildBookedCum[newClOrdId] = child.CumulativeQuantity;
+        return true;
+    }
 
     private async Task OnCancelRequestedAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
     {
@@ -1753,6 +2020,7 @@ public sealed class AlgoEngine : BackgroundService
         AlgoCreatedSignal => "created",
         AlgoCancelRequestedSignal => "cancel_requested",
         ChildExecutionObservedSignal => "child_er",
+        AlgoModifyRequestedSignal => "modify_requested",
         _ => "unknown",
     };
 
@@ -1761,6 +2029,7 @@ public sealed class AlgoEngine : BackgroundService
         AlgoCreatedSignal c => c.AlgoId,
         AlgoCancelRequestedSignal c => c.AlgoId,
         ChildExecutionObservedSignal c => c.AlgoId,
+        AlgoModifyRequestedSignal c => c.AlgoId,
         _ => 0,
     };
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1300,7 +1300,43 @@ public sealed class AlgoEngine : BackgroundService
             // reservation. The cash invariant is preserved either
             // way.
             if (marginPrepared)
-                _replacements.MarkAmbiguousMarginHeld(newClOrdId);
+            {
+                // Pass-5 review (#299) P1. Persist the ambiguous-held
+                // state via a dedicated WAL event so a crash between
+                // here and the next snapshot cannot lose the flag.
+                // Replay re-calls PrepareReplaceAsync to re-establish
+                // the held reservation and re-marks the registry entry
+                // with the same HeldAtUtc stamp the pre-crash sweep
+                // would have aged from. On success the in-memory mark
+                // also runs (inside the apply callback) so steady-state
+                // behaviour is unchanged. WAL backpressure here is
+                // best-effort logged — if the event cannot be appended
+                // we fall back to the pre-pass-5 in-memory-only mark so
+                // the live TTL sweep still bounds the leak.
+                var heldAt = _clock.GetUtcNow();
+                try
+                {
+                    _dispatcher.Dispatch(
+                        new OrderReplaceAmbiguousMarginHeldEvent
+                        {
+                            NewClOrdId = newClOrdId,
+                            OriginalClOrdId = child.ClOrdId,
+                            EndClientId = child.Owner.Value,
+                            NewRemainingNotional = newRemainingNotional,
+                            HeldAtUtc = heldAt,
+                        },
+                        () => _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt));
+                }
+                catch (WalBackpressureException walEx)
+                {
+                    MetricsRegistry.WalBackpressure.Add(1,
+                        new KeyValuePair<string, object?>("call_site", "algo.modify.ambiguous-held"));
+                    _logger.LogWarning(walEx,
+                        "AlgoEngine could not persist ambiguous-margin-held event for new ClOrdID {NewClOrdId}; live in-memory mark still applied (post-restart recovery would not re-establish this reservation).",
+                        newClOrdId);
+                    _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt);
+                }
+            }
             return false;
         }
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -648,6 +648,39 @@ public sealed class AlgoEngine : BackgroundService
             return;
         }
 
+        // Pass-1 review (#299) P1-A. First observation of a replacement
+        // child — adopt it here (NOT eagerly at modify-dispatch time) so
+        // any Fill ER for the OLD child that arrived between dispatch and
+        // the Replaced ack got booked against the OLD child's slot above
+        // without re-targeting the parent. The Replaced ER's
+        // ApplyReplaceAccepted has just hydrated `child` under the new
+        // ClOrdID (status Working / PartiallyFilled / Filled depending on
+        // erCum vs newQty) and dispatched this signal; we re-target now
+        // and seed the new child's booked-cum baseline from the venue's
+        // echoed cum so the next Fill ER for the new child computes a
+        // correct delta. The OLD child has already been MarkReplaced'd
+        // by the processor (Replaced ⇒ terminal) and its
+        // ChildBookedCum entry is left in place — Reconcile rebuilds it
+        // from the order book, and it's bounded per-parent.
+        if (_replacements is not null
+            && rt.LiveChildClOrdId is { } oldLive
+            && oldLive != child.ClOrdId
+            && child.ParentAlgoId == algo.AlgoId
+            && !rt.ChildBookedCum.ContainsKey(child.ClOrdId)
+            && _ownership.TryResolveOrig(child.ClOrdId, out var origOfNew)
+            && origOfNew == oldLive)
+        {
+            rt.LiveChildClOrdId = child.ClOrdId;
+            rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
+            // Fall through so any erCum > prior booked OLD cum that the
+            // venue carried over (e.g. a fill landed at venue strictly
+            // between our last OLD-child ER and the Replaced ack) is NOT
+            // double-booked: the seed above made delta == 0 in the
+            // accounting block below. Any later Fill ER for the new
+            // ClOrdID advances cum monotonically against this seeded
+            // baseline.
+        }
+
         // Book the cum-quantity delta. Child orders deliver fills via
         // ApplyCumulativeFill so child.CumulativeQuantity is monotonic;
         // we just diff against the last value we credited to the parent.
@@ -1093,20 +1126,29 @@ public sealed class AlgoEngine : BackgroundService
         }
         catch (Exception ex)
         {
-            // Roll back: drop the intent + log. Original child stays
-            // live; the operator can retry. No synthetic Rejected ER is
-            // emitted (the algo engine is not the order-event source —
-            // OrderModifyService does that for human-driven modifies
-            // because it owns the response semantics; the engine path
-            // surfaces the failure via the metric below + log).
-            _replacements.TryConsume(newClOrdId, out _);
+            // Pass-1 review (#299) P1-B. Send-failure is AMBIGUOUS: the
+            // venue may have already accepted the cancel-replace (network
+            // jitter, write succeeded but ack timed out). If we drop the
+            // intent here and a Replaced ER arrives later, it bypasses
+            // the PendingReplacementRegistry intercept and is silently
+            // ignored — the new ClOrdID never appears in the book and
+            // the parent's child pointer stays on the OLD child forever.
+            //
+            // Instead: KEEP the intent and ownership link in place so a
+            // late Replaced ER still resolves correctly. The parent
+            // pointer was deliberately NOT re-targeted yet (see P1-A
+            // adoption-on-Replaced), so the OLD child remains the live
+            // slot and any in-flight fills on it are booked normally.
+            // Operator surfaces this through the dedicated
+            // modify_send_ambiguous counter; the algo-rejected counter
+            // is NOT incremented because we cannot tell yet whether the
+            // modify will eventually succeed.
             MetricsRegistry.OrdersGatewayFailed.Add(1,
                 new KeyValuePair<string, object?>("path", "algo.modify"));
-            MetricsRegistry.AlgoModifyRejectedTotal.Add(1,
-                new KeyValuePair<string, object?>("algoType", algoTypeTag),
-                new KeyValuePair<string, object?>("reason", "gateway_failed"));
+            MetricsRegistry.AlgoModifySendAmbiguous.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoTypeTag));
             _logger.LogWarning(ex,
-                "AlgoEngine modify gateway dispatch failed for algo {Firm}/{AlgoId} child {Child}; rolled back.",
+                "AlgoEngine modify gateway dispatch ambiguous for algo {Firm}/{AlgoId} child {Child}; intent retained for late Replaced ER.",
                 algo.FirmId, algo.AlgoId, child.ClOrdId);
             return false;
         }
@@ -1148,14 +1190,18 @@ public sealed class AlgoEngine : BackgroundService
             new KeyValuePair<string, object?>("algoType", algoTypeTag),
             new KeyValuePair<string, object?>("reason", reason));
 
-        // Re-target the live-child slot to the replacement id. The
-        // ER processor's Replaced ack will hydrate the new Order in
-        // the book under newClOrdId and fan out a
-        // ChildExecutionObservedSignal — by then rt.LiveChildClOrdId
-        // already matches, so OnChildErAsync's non-terminal early-
-        // return path runs as expected.
-        rt.LiveChildClOrdId = newClOrdId;
-        rt.ChildBookedCum[newClOrdId] = child.CumulativeQuantity;
+        // Pass-1 review (#299) P1-A. Do NOT re-target rt.LiveChildClOrdId
+        // here — the venue has not yet acknowledged the cancel-replace.
+        // Re-targeting before the Replaced ER arrives creates a window in
+        // which a Fill ER for the OLD child would book against an
+        // already-rebound parent slot AND when the Replaced ER finally
+        // arrived the replacement's seeded cum would re-book the same
+        // fill, double-counting it on the parent. The adoption now
+        // happens in OnChildErAsync the first time the engine observes
+        // the new ClOrdID (i.e. on the ChildExecutionObservedSignal
+        // emitted by ApplyReplaceAccepted), at which point the new
+        // child's CumulativeQuantity is the venue's authoritative carry-
+        // over baseline.
         return true;
     }
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1325,7 +1325,7 @@ public sealed class AlgoEngine : BackgroundService
                             NewRemainingNotional = newRemainingNotional,
                             HeldAtUtc = heldAt,
                         },
-                        () => _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt));
+                        () => _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt, newRemainingNotional));
                 }
                 catch (WalBackpressureException walEx)
                 {
@@ -1334,7 +1334,7 @@ public sealed class AlgoEngine : BackgroundService
                     _logger.LogWarning(walEx,
                         "AlgoEngine could not persist ambiguous-margin-held event for new ClOrdID {NewClOrdId}; live in-memory mark still applied (post-restart recovery would not re-establish this reservation).",
                         newClOrdId);
-                    _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt);
+                    _replacements.MarkAmbiguousMarginHeld(newClOrdId, heldAt, newRemainingNotional);
                 }
             }
             return false;

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1220,7 +1220,10 @@ public sealed class AlgoEngine : BackgroundService
                 },
                 () =>
                 {
-                    _replacements.TryAdd(intent);
+                    // Pass-4 review (#299) P1. Stamp the registry entry
+                    // with the current clock so the AlgoScheduler TTL
+                    // sweep can bound any ambiguous-send leak below.
+                    _replacements.TryAdd(intent, _clock.GetUtcNow());
                     _ownership.RegisterReplaceLink(child.ClOrdId, newClOrdId);
                 });
         }
@@ -1273,21 +1276,31 @@ public sealed class AlgoEngine : BackgroundService
             _logger.LogWarning(ex,
                 "AlgoEngine modify gateway dispatch ambiguous for algo {Firm}/{AlgoId} child {Child}; intent retained for late Replaced ER.",
                 algo.FirmId, algo.AlgoId, child.ClOrdId);
-            // Pass-3 review (#299) P1. Release the upsize-delta margin
-            // reservation we prepared above. The PendingReplacementRegistry
-            // intent is deliberately KEPT (P1-B ambiguous-send window —
-            // venue may have already accepted), but holding the margin
-            // reserve indefinitely on a likely-failed send is the worse
-            // failure mode: if the venue did NOT accept the reserve
-            // leaks until the parent terminates. If the venue DID
-            // accept, CommitReplace will still run on the late Replaced
-            // ER and (with no Prepare-side transient entry) will adjust
-            // _reserved against the original's tracked notional; the
-            // accounting converges, only the upsize headroom safety
-            // check is temporarily relaxed for the in-flight window —
-            // an acceptable trade-off vs. permanently leaking the hold.
+            // Pass-4 review (#299) P1. KEEP the margin reservation —
+            // do NOT call AbortReplace. Pass-3 freed the upsize delta
+            // here on the theory that holding it indefinitely was the
+            // worse failure mode; that left a window in which another
+            // order could consume the freed headroom before a late
+            // Replaced ER arrived, then CommitReplace would silently
+            // re-add the delta on top, pushing reserved exposure above
+            // the owner's cash cap. The pass-4 fix instead tags the
+            // intent as "ambiguous margin held" so the AlgoScheduler
+            // TTL sweep (see <see cref="AlgoScheduler.SweepAmbiguousReplaceIntents"/>)
+            // bounds the leak: if no Replaced/Rejected/Canceled ER
+            // arrives within
+            // <c>RiskOptions.Margin.AmbiguousReplaceTtl</c>, the
+            // reservation is released and the
+            // <c>algo.modify_ambiguous_intent_expired_total</c>
+            // counter bumps so operators can correlate with the
+            // dashboards. CommitReplace on a late Replaced ER stays
+            // a no-op for the upsize delta (the transient entry is
+            // still present), and a Canceled ER for the orig (venue
+            // dropped the replace) routes through the ER processor's
+            // new TryConsumeByOriginal arm which also releases the
+            // reservation. The cash invariant is preserved either
+            // way.
             if (marginPrepared)
-                _replaceMargin!.AbortReplace(newClOrdId);
+                _replacements.MarkAmbiguousMarginHeld(newClOrdId);
             return false;
         }
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoScheduler.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Application;
 
@@ -68,14 +70,26 @@ public sealed class AlgoScheduler : BackgroundService
     private readonly TimeProvider _clock;
     private readonly TimeSpan _tickInterval;
     private readonly ILogger<AlgoScheduler> _logger;
+    // Pass-4 review (#299) P1. Ambiguous-send replace reservation
+    // sweep dependencies. Both optional — test compositions that
+    // exercise the scheduler without the modify pipeline must
+    // continue to compile. Production composition always supplies
+    // both via DI alongside the registry itself.
+    private readonly PendingReplacementRegistry? _replacements;
+    private readonly IReplaceMarginCoordinator? _replaceMargin;
+    private readonly IOptionsMonitor<RiskOptions>? _riskOptions;
 
     public AlgoScheduler(
         AlgoBook algos,
         WorkingOrderBook orders,
         IAlgoSignalQueue signals,
         TimeProvider clock,
-        ILogger<AlgoScheduler> logger)
-        : this(algos, orders, signals, clock, DefaultTickInterval, logger)
+        ILogger<AlgoScheduler> logger,
+        PendingReplacementRegistry? replacements = null,
+        IReplaceMarginCoordinator? replaceMargin = null,
+        IOptionsMonitor<RiskOptions>? riskOptions = null)
+        : this(algos, orders, signals, clock, DefaultTickInterval, logger,
+               replacements, replaceMargin, riskOptions)
     {
     }
 
@@ -89,7 +103,10 @@ public sealed class AlgoScheduler : BackgroundService
         IAlgoSignalQueue signals,
         TimeProvider clock,
         TimeSpan tickInterval,
-        ILogger<AlgoScheduler> logger)
+        ILogger<AlgoScheduler> logger,
+        PendingReplacementRegistry? replacements = null,
+        IReplaceMarginCoordinator? replaceMargin = null,
+        IOptionsMonitor<RiskOptions>? riskOptions = null)
     {
         if (tickInterval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(tickInterval));
@@ -99,6 +116,9 @@ public sealed class AlgoScheduler : BackgroundService
         _clock = clock;
         _tickInterval = tickInterval;
         _logger = logger;
+        _replacements = replacements;
+        _replaceMargin = replaceMargin;
+        _riskOptions = riskOptions;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -144,6 +164,13 @@ public sealed class AlgoScheduler : BackgroundService
     public void Tick()
     {
         var now = _clock.GetUtcNow();
+        // Pass-4 review (#299) P1. Reap any ambiguous-send replace
+        // intents whose held margin reservation has aged past TTL.
+        // Cheap no-op when no entries are in the ambiguous state
+        // (the common case): the sweep iterates the registry but
+        // only acts on entries explicitly flagged via
+        // MarkAmbiguousMarginHeld.
+        SweepAmbiguousReplaceIntents(now);
         var algos = _algos.EnumerateAll(includeTerminal: false);
         foreach (var algo in algos)
         {
@@ -299,6 +326,53 @@ public sealed class AlgoScheduler : BackgroundService
             _logger.LogWarning(
                 "AlgoScheduler dropped signal for {Firm}/{AlgoId} (queue full).",
                 algo.FirmId, algo.AlgoId);
+        }
+    }
+
+    /// <summary>
+    /// Pass-4 review (#299) P1. Release any margin reservation tied
+    /// to a replace intent that's been pending past
+    /// <see cref="MarginOptions.AmbiguousReplaceTtl"/> after the
+    /// AlgoEngine intentionally retained both intent + reserve on
+    /// an ambiguous gateway dispatch failure. Each released entry
+    /// bumps <c>algo.modify_ambiguous_intent_expired_total</c>
+    /// tagged with the parent's algoType (looked up by ParentAlgoId
+    /// + FirmId; falls back to "unknown" when the parent is no
+    /// longer in the book). Public for the unit test that drives
+    /// the sweep deterministically without spinning the timer.
+    /// </summary>
+    public void SweepAmbiguousReplaceIntents(DateTimeOffset now)
+    {
+        if (_replacements is null || _replaceMargin is null || _riskOptions is null)
+            return;
+        var ttl = _riskOptions.CurrentValue.Margin.AmbiguousReplaceTtl;
+        if (ttl <= TimeSpan.Zero) return;
+
+        var expired = _replacements.SweepExpiredAmbiguous(now, ttl);
+        if (expired.Count == 0) return;
+
+        foreach (var intent in expired)
+        {
+            _replaceMargin.AbortReplace(intent.NewClOrdId);
+
+            // Best-effort algoType tag: ParentAlgoId is null for
+            // operator-driven plain-order modifies (those don't
+            // currently flow through this AlgoEngine ambiguous path,
+            // but tolerate the absence anyway).
+            var algoType = "unknown";
+            if (intent.ParentAlgoId is { } parentId
+                && !string.IsNullOrEmpty(intent.FirmId)
+                && _algos.TryGet(intent.FirmId, parentId, out var parent)
+                && parent is not null)
+            {
+                algoType = parent.Type.ToString().ToLowerInvariant();
+            }
+            MetricsRegistry.AlgoModifyAmbiguousIntentExpiredTotal.Add(1,
+                new KeyValuePair<string, object?>("algoType", algoType));
+
+            _logger.LogWarning(
+                "AlgoScheduler released ambiguous-send replace reservation for new ClOrdID {NewClOrdId} (orig {OrigClOrdId}, owner {Owner}, algoType {AlgoType}); intent expired past TTL {TtlSeconds}s.",
+                intent.NewClOrdId, intent.OriginalClOrdId, intent.Owner.Value, algoType, ttl.TotalSeconds);
         }
     }
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoSignal.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoSignal.cs
@@ -44,3 +44,30 @@ public sealed record ChildExecutionObservedSignal : AlgoSignal
     public required ulong AlgoId { get; init; }
     public required ulong ChildClOrdId { get; init; }
 }
+
+/// <summary>
+/// Q3.5 (#285). An operator (or, in the future, an in-engine
+/// scheduler) requested a cancel-replace of a live child of the
+/// algo. The signal carries the requested overrides only — the
+/// engine resolves the actual target child by the parent's
+/// <c>LiveChildClOrdId</c> when <see cref="TargetChildClOrdId"/>
+/// is null, validates terminal/qty invariants on the consumer
+/// thread, and dispatches via <c>IExchangeGateway.CancelReplaceAsync</c>.
+/// At least one of <see cref="NewQuantity"/> / <see cref="NewPrice"/>
+/// must be set; the engine inherits the omitted side from the
+/// live child.
+/// </summary>
+public sealed record AlgoModifyRequestedSignal : AlgoSignal
+{
+    public required ulong AlgoId { get; init; }
+    public ulong? TargetChildClOrdId { get; init; }
+    public long? NewQuantity { get; init; }
+    public decimal? NewPrice { get; init; }
+
+    /// <summary>
+    /// Human-readable driver — surfaces as a metric tag and as the
+    /// <c>reason</c> field on <see cref="Persistence.AlgoChildModifiedEvent"/>.
+    /// Use short lowercase identifiers (<c>operator</c>, <c>pegged_repeg</c>).
+    /// </summary>
+    public required string Reason { get; init; }
+}

--- a/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
+++ b/backend/src/B3.Trading.Application/B3.Trading.Application.csproj
@@ -20,6 +20,7 @@
     <InternalsVisibleTo Include="B3.Trading.Infrastructure" />
     <InternalsVisibleTo Include="B3.Trading.EntryPointListener" />
     <InternalsVisibleTo Include="B3.Trading.Application.Tests" />
+    <InternalsVisibleTo Include="B3.Trading.Api.Tests" />
     <InternalsVisibleTo Include="B3.Trading.EntryPointListener.Tests" />
     <InternalsVisibleTo Include="B3.Trading.Benchmarks" />
   </ItemGroup>

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -477,6 +477,27 @@ public sealed class ExecutionReportProcessor
                 }
                 order.MarkCancelled();
                 _margin.OnExecution(lookupId, kind, 0);
+                // Pass-4 review (#299) P1. If a pass-1 ambiguous-send
+                // left a still-held replace intent keyed by THIS orig
+                // (because the gateway dispatch threw post-Prepare),
+                // and the venue ultimately Canceled the orig (i.e.
+                // dropped both the orig and the never-acked
+                // replacement), we must release the held upsize-delta
+                // reservation NOW — otherwise it sits until the TTL
+                // sweep fires. Clearing the intent here also prevents
+                // a stray late ER (under the never-created new
+                // ClOrdID) from being misinterpreted as a replace
+                // confirmation. Safe to call regardless of whether
+                // an intent existed; no-op when none did.
+                if (_replacements is not null
+                    && _replacements.TryConsumeByOriginal(lookupId, out var canceledOrigIntent, out _)
+                    && canceledOrigIntent is not null)
+                {
+                    _replaceMargin?.AbortReplace(canceledOrigIntent.NewClOrdId);
+                    _logger.LogInformation(
+                        "event=order.replace.dropped_on_orig_cancel newClOrdId={NewClOrdId} origClOrdId={OrigClOrdId} owner={Owner} symbol={Symbol}; releasing held upsize-delta reservation.",
+                        canceledOrigIntent.NewClOrdId, canceledOrigIntent.OriginalClOrdId, canceledOrigIntent.Owner.Value, canceledOrigIntent.Symbol);
+                }
                 break;
             case ExecKind.Rejected:
                 if (order.Status is OrderStatus.Rejected or OrderStatus.Filled or OrderStatus.PartiallyFilled or OrderStatus.Cancelled or OrderStatus.Replaced)

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -707,11 +707,33 @@ public sealed class ExecutionReportProcessor
         //    them. The cum/leaves on the new Order exists so subsequent
         //    fill ERs (now arriving under newClOrdID) advance from the
         //    correct baseline.
+        //
+        // Pass-2 review (#299) P1. Translators default missing CumQty
+        // to 0 (B3EntryPointClientGateway OrderModified arm, simulator
+        // /admin/simulator/er Replaced arm). If the venue/sim sends a
+        // Replaced ER with stale or zero CumQty AFTER the original
+        // accumulated fills, hydrating the replacement with that low
+        // baseline causes the very next Fill ER for the new ClOrdID to
+        // be diffed against an under-seeded prevBooked in the algo
+        // engine and re-book the original's prior fills against the
+        // parent. Clamp the seed cum upward to the original's cum and
+        // adjust leaves down so the (cum + leaves == newQty) invariant
+        // holds across the seam.
+        var seedCum = erCum;
+        var seedLeaves = erLeaves;
+        if (seedCum < origOrder.CumulativeQuantity)
+        {
+            _logger.LogWarning(
+                "Replaced ER for new ClOrdID {NewClOrdId} carried stale CumQty={ErCum} below original CumQty={OrigCum}; clamping to original to avoid re-booking prior fills.",
+                newClOrdId, erCum, origOrder.CumulativeQuantity);
+            seedCum = origOrder.CumulativeQuantity;
+            seedLeaves = Math.Max(0L, intent.NewQuantity - seedCum);
+        }
         Order newOrder;
         try
         {
             newOrder = Order.HydrateReplacement(
-                origOrder, newClOrdId, intent.NewQuantity, intent.NewPrice, erLeaves, erCum,
+                origOrder, newClOrdId, intent.NewQuantity, intent.NewPrice, seedLeaves, seedCum,
                 intent.RequestedTimeInForce, intent.RequestedStopPrice, intent.RequestedGoodTillDate);
         }
         catch (Exception ex)
@@ -743,11 +765,15 @@ public sealed class ExecutionReportProcessor
         //    For Buy + margin-bearing type (Limit / StopLimit /
         //    MarketWithLeftover) + cash, that's intent.NewPrice * leaves;
         //    everything else is zero (the coordinator no-ops on 0).
+        //    Pass-2 review (#299) P1: use the clamped seedLeaves so the
+        //    margin reservation matches the order book's leaves after
+        //    the cum-stale clamp above (avoids over-reserving margin
+        //    for residue that has already filled at the venue).
         var confirmedRemaining = (intent.Side == OrderSide.Buy
                                   && intent.Type.IsMarginBearing()
                                   && intent.NewPrice is { } px
-                                  && erLeaves > 0)
-            ? px * erLeaves
+                                  && seedLeaves > 0)
+            ? px * seedLeaves
             : 0m;
         _replaceMargin?.CommitReplace(intent.OriginalClOrdId, newClOrdId, confirmedRemaining);
 

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -380,6 +380,19 @@ public static class MetricsRegistry
             "trading.algo.modify_send_ambiguous_total",
             description: "Algo modify gateway dispatches that threw post-WAL but may have been accepted by the venue (intent preserved for late Replaced ER resolution).");
 
+    // Pass-3 review (#299) P2. Per-parent retired-child FIFO eviction
+    // counter. Mirrors PR #296's CancelledChildRing observability —
+    // each eviction means a row was forgotten from
+    // <c>AlgoParentRuntime.ChildBookedCum</c>, so a late stray ER for
+    // the evicted OLD child id would no longer find its prior booked
+    // cum and would re-book from a missing-key default of 0. Tagged by
+    // algoType so dashboards can spot sustained eviction churn on
+    // (e.g.) Pegged repegs vs. operator-driven modifies.
+    public static readonly Counter<long> AlgoModifyRetiredChildEvictedTotal =
+        Meter.CreateCounter<long>(
+            "trading.algo.modify_retired_child_evicted_total",
+            description: "Algo retired-child FIFO entries evicted when the per-parent ChildBookedCum bookkeeping cap is exceeded.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -367,6 +367,19 @@ public static class MetricsRegistry
             "trading.algo.modify_rejected_total",
             description: "Algo modify requests rejected before reaching the gateway (terminal algo, terminal child, invalid qty, …).");
 
+    // Pass-1 review (#299) P1-B. The gateway dispatch for an algo modify
+    // raised an exception, but the venue may have already accepted the
+    // cancel-replace (network jitter / ambiguous send). The engine
+    // intentionally keeps the PendingReplacementRegistry intent in place
+    // so a late Replaced ER still resolves correctly; this counter makes
+    // the ambiguity observable so operators can correlate with the
+    // dashboards and confirm convergence (or absence of) via the eventual
+    // ER. Tagged by algoType only — reason is never user-supplied here.
+    public static readonly Counter<long> AlgoModifySendAmbiguous =
+        Meter.CreateCounter<long>(
+            "trading.algo.modify_send_ambiguous_total",
+            description: "Algo modify gateway dispatches that threw post-WAL but may have been accepted by the venue (intent preserved for late Replaced ER resolution).");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -393,6 +393,21 @@ public static class MetricsRegistry
             "trading.algo.modify_retired_child_evicted_total",
             description: "Algo retired-child FIFO entries evicted when the per-parent ChildBookedCum bookkeeping cap is exceeded.");
 
+    // Pass-4 review (#299) P1. The AlgoScheduler sweep released an
+    // ambiguous-send replace reservation whose intent had been
+    // pending past <c>RiskOptions.Margin.AmbiguousReplaceTtl</c>
+    // without a Replaced/Rejected ER. Each bump corresponds to one
+    // upsize-delta reservation reclaimed back into the owner's
+    // available cash — i.e. a trader temporarily lost (then
+    // recovered) access to that headroom. Tagged by algoType so
+    // dashboards distinguish operator-driven Pegged repegs from
+    // VWAP/POV nudges (or "unknown" when the algo is no longer in
+    // the book at sweep time).
+    public static readonly Counter<long> AlgoModifyAmbiguousIntentExpiredTotal =
+        Meter.CreateCounter<long>(
+            "trading.algo.modify_ambiguous_intent_expired_total",
+            description: "Ambiguous-send replace intents expired by the AlgoScheduler TTL sweep; held margin reservation released.");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -353,6 +353,20 @@ public static class MetricsRegistry
             "trading.algo.pegged.repeg_dedup_ring_evicted_total",
             description: "FIFO evictions in PeggedRepegBook's per-parent cancelled-child dedup ring.");
 
+    // Q3.5 (#285). Algo modify (cancel-replace) API. Tagged by
+    // algoType so we can distinguish operator-driven Pegged repegs
+    // from VWAP/POV price-nudges (when those algos retrofit). Reason
+    // is the human-readable driver — "operator" (POST /algo/{id}/modify)
+    // or "pegged_repeg" (internal Pegged price-drift retrofit).
+    public static readonly Counter<long> AlgoChildModifiesTotal =
+        Meter.CreateCounter<long>(
+            "trading.algo.child_modifies_total",
+            description: "Algo child cancel-replace (modify) cycles dispatched to the gateway.");
+    public static readonly Counter<long> AlgoModifyRejectedTotal =
+        Meter.CreateCounter<long>(
+            "trading.algo.modify_rejected_total",
+            description: "Algo modify requests rejected before reaching the gateway (terminal algo, terminal child, invalid qty, …).");
+
     /// <summary>
     /// 1 when the host booted with <c>Trading:Exchange:AllowErInjection=true</c>
     /// (admin-gated <c>POST /admin/simulator/er</c> is mapped). Set once at

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -55,6 +55,15 @@ public sealed class PendingReplacementRegistry
         // so post-restart replay rebuilds the same TTL deadline the
         // pre-crash sweep would have observed.
         public DateTimeOffset? AmbiguousAt { get; set; }
+        // Pass-6 review (#299) P1. Captured from the AlgoEngine modify
+        // path when the entry is flagged ambiguous; persisted in the
+        // <c>OrderReplaceAmbiguousMarginHeldEvent</c> AND in
+        // <c>RawPlatformSnapshot.PendingReplacements</c> so post-restart
+        // recovery — whether driven by WAL tail or by a snapshot whose
+        // Seq is past the ambiguous mark — can re-invoke
+        // <see cref="Risk.IReplaceMarginCoordinator.PrepareReplaceAsync"/>
+        // with the same value the pre-crash dispatch used.
+        public decimal NewRemainingNotional { get; set; }
         public Entry(OrderReplacementIntent intent, DateTimeOffset createdAt)
         {
             Intent = intent;
@@ -209,11 +218,24 @@ public sealed class PendingReplacementRegistry
     /// </para>
     /// </summary>
     public bool MarkAmbiguousMarginHeld(ulong newClOrdId, DateTimeOffset ambiguousAt)
+        => MarkAmbiguousMarginHeld(newClOrdId, ambiguousAt, newRemainingNotional: 0m);
+
+    /// <summary>
+    /// Pass-6 review (#299) P1 overload. Captures the upsize-delta-
+    /// bearing new remaining notional alongside the ambiguous flag so
+    /// a snapshot taken after the ambiguous mark can be projected into
+    /// <c>RawPlatformSnapshot.PendingReplacements</c> AND a restore can
+    /// re-invoke <c>PrepareReplaceAsync</c> with the same value the
+    /// pre-crash dispatch used.
+    /// </summary>
+    public bool MarkAmbiguousMarginHeld(
+        ulong newClOrdId, DateTimeOffset ambiguousAt, decimal newRemainingNotional)
     {
         if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
         {
             found.AmbiguousMarginHeld = true;
             found.AmbiguousAt = ambiguousAt;
+            found.NewRemainingNotional = newRemainingNotional;
             // Pass-5 review (#299) P2. Add to the ambiguous-only
             // index that the sweep enumerates. TryAdd is idempotent
             // — a second mark on the same entry is a no-op here.
@@ -295,6 +317,68 @@ public sealed class PendingReplacementRegistry
     internal int CountForTesting => _byNewClOrdId.Count;
 
     /// <summary>
+    /// Pass-6 review (#299) P1. Lock-side snapshot of every in-flight
+    /// entry — both plain in-flight and ambiguous-margin-held — for
+    /// projection into <c>RawPlatformSnapshot.PendingReplacements</c>.
+    /// The returned tuples carry every piece of state the post-restart
+    /// <c>StateSnapshotter.Restore</c> needs to re-hydrate the entry
+    /// AND (for ambiguous-flagged entries) re-invoke
+    /// <c>IReplaceMarginCoordinator.PrepareReplaceAsync</c>.
+    /// </summary>
+    public IReadOnlyList<PendingReplacementEntrySnapshot> Snapshot()
+    {
+        var pairs = _byNewClOrdId.ToArray();
+        if (pairs.Length == 0) return Array.Empty<PendingReplacementEntrySnapshot>();
+        var snaps = new PendingReplacementEntrySnapshot[pairs.Length];
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            var e = pairs[i].Value;
+            snaps[i] = new PendingReplacementEntrySnapshot(
+                Intent: e.Intent,
+                CreatedAt: e.CreatedAt,
+                AmbiguousMarginHeld: e.AmbiguousMarginHeld,
+                AmbiguousAt: e.AmbiguousAt,
+                NewRemainingNotional: e.NewRemainingNotional);
+        }
+        return snaps;
+    }
+
+    /// <summary>
+    /// Pass-6 review (#299) P1. Restores the registry from a
+    /// snapshot. Wipes any prior state — restore happens before the
+    /// WAL tail replay, which itself only re-adds entries the
+    /// snapshot didn't carry. Caller is responsible for re-invoking
+    /// <c>IReplaceMarginCoordinator.PrepareReplaceAsync</c> for every
+    /// restored entry whose <see cref="PendingReplacementEntrySnapshot.AmbiguousMarginHeld"/>
+    /// is set — see <c>StateSnapshotter.Restore</c>.
+    /// </summary>
+    public void Restore(IEnumerable<PendingReplacementEntrySnapshot> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        _byNewClOrdId.Clear();
+        _byOriginalClOrdId.Clear();
+        _ambiguous.Clear();
+        foreach (var s in entries)
+        {
+            var entry = new Entry(s.Intent, s.CreatedAt)
+            {
+                AmbiguousMarginHeld = s.AmbiguousMarginHeld,
+                AmbiguousAt = s.AmbiguousAt,
+                NewRemainingNotional = s.NewRemainingNotional,
+            };
+            if (!_byOriginalClOrdId.TryAdd(s.Intent.OriginalClOrdId, s.Intent.NewClOrdId))
+                continue;
+            if (!_byNewClOrdId.TryAdd(s.Intent.NewClOrdId, entry))
+            {
+                _byOriginalClOrdId.TryRemove(s.Intent.OriginalClOrdId, out _);
+                continue;
+            }
+            if (s.AmbiguousMarginHeld)
+                _ambiguous.TryAdd(s.Intent.NewClOrdId, 0);
+        }
+    }
+
+    /// <summary>
     /// Pass-5 review (#299) P2 test hook. Number of registry entries
     /// the most recent <see cref="SweepExpiredAmbiguous"/> invocation
     /// inspected. Used by the unit test that asserts the sweep cost
@@ -338,3 +422,19 @@ public sealed record OrderReplacementIntent(
     TimeInForce? RequestedTimeInForce = null,
     decimal? RequestedStopPrice = null,
     DateTimeOffset? RequestedGoodTillDate = null);
+
+/// <summary>
+/// Pass-6 review (#299) P1. Lock-side projection of one
+/// <see cref="PendingReplacementRegistry"/> entry — both plain in-flight
+/// and ambiguous-margin-held entries are captured. Travels via
+/// <c>RawPlatformSnapshot.PendingReplacements</c> →
+/// <c>PlatformSnapshot.PendingReplacements</c> so a snapshot taken
+/// AFTER an ambiguous mark survives recovery even when the WAL tail
+/// starts past the matching <c>OrderReplaceAmbiguousMarginHeldEvent</c>.
+/// </summary>
+public sealed record PendingReplacementEntrySnapshot(
+    OrderReplacementIntent Intent,
+    DateTimeOffset CreatedAt,
+    bool AmbiguousMarginHeld,
+    DateTimeOffset? AmbiguousAt,
+    decimal NewRemainingNotional);

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -26,7 +26,36 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class PendingReplacementRegistry
 {
-    private readonly ConcurrentDictionary<ulong, OrderReplacementIntent> _byNewClOrdId = new();
+    // Internal entry wrapper: carries the public intent plus
+    // bookkeeping metadata needed by the pass-4 (#299) P1 ambiguous-
+    // send margin convergence path (see SweepExpiredAmbiguous +
+    // MarkAmbiguousMarginHeld below). The public OrderReplacementIntent
+    // record is intentionally NOT extended — its shape is captured
+    // verbatim into OrderReplaceRequestedEvent for WAL replay and
+    // existing tests construct it positionally; widening the record
+    // would ripple unnecessarily.
+    private sealed class Entry
+    {
+        public OrderReplacementIntent Intent { get; }
+        public DateTimeOffset CreatedAt { get; }
+        // Pass-4 review (#299) P1. Set when the gateway dispatch
+        // threw AFTER the margin coordinator's PrepareReplace
+        // succeeded AND the intent was registered. The reservation
+        // under <see cref="OrderReplacementIntent.NewClOrdId"/> is
+        // left in place (rather than aborted) so a late Replaced ER
+        // can converge through CommitReplace without re-checking
+        // capacity — but it must be released by the sweep if no ER
+        // arrives within the configured TTL, otherwise the upsize
+        // delta leaks until the parent terminates.
+        public bool AmbiguousMarginHeld { get; set; }
+        public Entry(OrderReplacementIntent intent, DateTimeOffset createdAt)
+        {
+            Intent = intent;
+            CreatedAt = createdAt;
+        }
+    }
+
+    private readonly ConcurrentDictionary<ulong, Entry> _byNewClOrdId = new();
     // Secondary index: original ClOrdID → new ClOrdID. Enforces the
     // "one in-flight modify per original" guard (slice 4).
     private readonly ConcurrentDictionary<ulong, ulong> _byOriginalClOrdId = new();
@@ -39,7 +68,16 @@ public sealed class PendingReplacementRegistry
     /// (the slice-4 guard) — exactly one pending modify per original
     /// order at any time.
     /// </summary>
-    public bool TryAdd(OrderReplacementIntent intent)
+    public bool TryAdd(OrderReplacementIntent intent) => TryAdd(intent, default);
+
+    /// <summary>
+    /// Pass-4 review (#299) P1 overload. Same as <see cref="TryAdd(OrderReplacementIntent)"/>
+    /// but stamps <paramref name="createdAt"/> on the entry so the
+    /// ambiguous-margin sweep (<see cref="SweepExpiredAmbiguous"/>)
+    /// can release reservations whose intent has been pending too
+    /// long without a Replaced/Rejected ER.
+    /// </summary>
+    public bool TryAdd(OrderReplacementIntent intent, DateTimeOffset createdAt)
     {
         ArgumentNullException.ThrowIfNull(intent);
         // Reserve the orig slot first; if successful, claim the new
@@ -48,7 +86,7 @@ public sealed class PendingReplacementRegistry
         // back the orig reservation.
         if (!_byOriginalClOrdId.TryAdd(intent.OriginalClOrdId, intent.NewClOrdId))
             return false;
-        if (!_byNewClOrdId.TryAdd(intent.NewClOrdId, intent))
+        if (!_byNewClOrdId.TryAdd(intent.NewClOrdId, new Entry(intent, createdAt)))
         {
             _byOriginalClOrdId.TryRemove(intent.OriginalClOrdId, out _);
             return false;
@@ -65,11 +103,36 @@ public sealed class PendingReplacementRegistry
     {
         if (_byNewClOrdId.TryRemove(newClOrdId, out var found))
         {
-            _byOriginalClOrdId.TryRemove(found.OriginalClOrdId, out _);
-            intent = found;
+            _byOriginalClOrdId.TryRemove(found.Intent.OriginalClOrdId, out _);
+            intent = found.Intent;
             return true;
         }
         intent = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Pass-4 review (#299) P1. Consume the pending intent (if any)
+    /// keyed by <paramref name="originalClOrdId"/>. Returns the
+    /// intent on success along with <paramref name="ambiguousMarginHeld"/>
+    /// so the caller (ER processor on a Canceled ER for the orig)
+    /// can release the still-held margin reservation when the venue
+    /// effectively dropped the cancel-replace.
+    /// </summary>
+    public bool TryConsumeByOriginal(
+        ulong originalClOrdId,
+        out OrderReplacementIntent? intent,
+        out bool ambiguousMarginHeld)
+    {
+        if (_byOriginalClOrdId.TryRemove(originalClOrdId, out var newId)
+            && _byNewClOrdId.TryRemove(newId, out var found))
+        {
+            intent = found.Intent;
+            ambiguousMarginHeld = found.AmbiguousMarginHeld;
+            return true;
+        }
+        intent = null;
+        ambiguousMarginHeld = false;
         return false;
     }
 
@@ -82,7 +145,7 @@ public sealed class PendingReplacementRegistry
     {
         if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
         {
-            intent = found;
+            intent = found.Intent;
             return true;
         }
         intent = null;
@@ -98,6 +161,62 @@ public sealed class PendingReplacementRegistry
     /// </summary>
     public bool IsOriginalInFlight(ulong originalClOrdId) =>
         _byOriginalClOrdId.ContainsKey(originalClOrdId);
+
+    /// <summary>
+    /// Pass-4 review (#299) P1. Mark the entry under
+    /// <paramref name="newClOrdId"/> as having a still-held margin
+    /// reservation. Called by the AlgoEngine modify path AFTER an
+    /// ambiguous gateway dispatch failure — the intent is kept in
+    /// place so a late Replaced ER can converge, but the reservation
+    /// will leak indefinitely if no ER ever arrives. The sweep below
+    /// uses this flag to bound the leak via TTL. Returns <c>false</c>
+    /// when no entry exists (e.g. the intent was already consumed
+    /// by a racing ER between dispatch failure and this call).
+    /// </summary>
+    public bool MarkAmbiguousMarginHeld(ulong newClOrdId)
+    {
+        if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
+        {
+            found.AmbiguousMarginHeld = true;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Pass-4 review (#299) P1. Remove + return every entry whose
+    /// <see cref="Entry.AmbiguousMarginHeld"/> flag is set AND whose
+    /// <see cref="Entry.CreatedAt"/> is older than
+    /// <paramref name="now"/> minus <paramref name="ttl"/>. Caller
+    /// (the AlgoScheduler sweep) is responsible for calling
+    /// <see cref="Risk.IReplaceMarginCoordinator.AbortReplace"/> for
+    /// each returned intent and bumping the expired-counter metric.
+    /// Entries without the ambiguous flag (the normal in-flight state)
+    /// are NEVER reaped — a long-lived modify on a slow venue is
+    /// legitimate.
+    /// </summary>
+    public IReadOnlyList<OrderReplacementIntent> SweepExpiredAmbiguous(
+        DateTimeOffset now, TimeSpan ttl)
+    {
+        if (ttl <= TimeSpan.Zero) return Array.Empty<OrderReplacementIntent>();
+        List<OrderReplacementIntent>? expired = null;
+        var cutoff = now - ttl;
+        foreach (var kvp in _byNewClOrdId)
+        {
+            var entry = kvp.Value;
+            if (!entry.AmbiguousMarginHeld) continue;
+            if (entry.CreatedAt > cutoff) continue;
+            // Atomic remove guarded by the secondary index so a
+            // racing TryConsume(newClOrdId) wins cleanly (only one
+            // side will observe the entry as removable).
+            if (_byNewClOrdId.TryRemove(kvp.Key, out var found))
+            {
+                _byOriginalClOrdId.TryRemove(found.Intent.OriginalClOrdId, out _);
+                (expired ??= new List<OrderReplacementIntent>()).Add(found.Intent);
+            }
+        }
+        return (IReadOnlyList<OrderReplacementIntent>?)expired ?? Array.Empty<OrderReplacementIntent>();
+    }
 
     /// <summary>Test/observability helper.</summary>
     internal int CountForTesting => _byNewClOrdId.Count;

--- a/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
+++ b/backend/src/B3.Trading.Application/PendingReplacementRegistry.cs
@@ -48,6 +48,13 @@ public sealed class PendingReplacementRegistry
         // arrives within the configured TTL, otherwise the upsize
         // delta leaks until the parent terminates.
         public bool AmbiguousMarginHeld { get; set; }
+        // Pass-5 review (#299) P1. Wall-clock at which the entry was
+        // marked ambiguous. Used by the TTL sweep as the age anchor
+        // (vs. CreatedAt which lags from intent registration); also
+        // persisted in <c>OrderReplaceAmbiguousMarginHeldEvent</c>
+        // so post-restart replay rebuilds the same TTL deadline the
+        // pre-crash sweep would have observed.
+        public DateTimeOffset? AmbiguousAt { get; set; }
         public Entry(OrderReplacementIntent intent, DateTimeOffset createdAt)
         {
             Intent = intent;
@@ -59,6 +66,23 @@ public sealed class PendingReplacementRegistry
     // Secondary index: original ClOrdID → new ClOrdID. Enforces the
     // "one in-flight modify per original" guard (slice 4).
     private readonly ConcurrentDictionary<ulong, ulong> _byOriginalClOrdId = new();
+    // Pass-5 review (#299) P2. Tertiary index: new ClOrdIDs whose
+    // entry is flagged <see cref="Entry.AmbiguousMarginHeld"/>. The
+    // TTL sweep enumerates THIS set rather than the full registry so
+    // its cost is O(ambiguous) — typically zero — instead of O(all
+    // pending modifies). Membership is maintained in lock-step with
+    // <see cref="MarkAmbiguousMarginHeld(ulong, DateTimeOffset)"/>
+    // (add) and every consume/expire site (remove). The set uses
+    // <c>byte</c> as the value type because <c>ConcurrentDictionary</c>
+    // has no <c>ConcurrentHashSet</c> equivalent in BCL; the value
+    // is never read.
+    private readonly ConcurrentDictionary<ulong, byte> _ambiguous = new();
+    // Pass-5 review (#299) P2 test hook. Counts the number of
+    // registry entries the most recent <see cref="SweepExpiredAmbiguous"/>
+    // call inspected. Exposed via the internal helper below so the
+    // unit test can assert the sweep enumerates O(ambiguous), not
+    // O(all). Reset at the top of every sweep.
+    private long _lastSweepInspectedCount;
 
     /// <summary>
     /// Records an in-flight modify. Returns <c>false</c> when an intent
@@ -104,6 +128,7 @@ public sealed class PendingReplacementRegistry
         if (_byNewClOrdId.TryRemove(newClOrdId, out var found))
         {
             _byOriginalClOrdId.TryRemove(found.Intent.OriginalClOrdId, out _);
+            _ambiguous.TryRemove(newClOrdId, out _);
             intent = found.Intent;
             return true;
         }
@@ -127,6 +152,7 @@ public sealed class PendingReplacementRegistry
         if (_byOriginalClOrdId.TryRemove(originalClOrdId, out var newId)
             && _byNewClOrdId.TryRemove(newId, out var found))
         {
+            _ambiguous.TryRemove(newId, out _);
             intent = found.Intent;
             ambiguousMarginHeld = found.AmbiguousMarginHeld;
             return true;
@@ -172,46 +198,93 @@ public sealed class PendingReplacementRegistry
     /// uses this flag to bound the leak via TTL. Returns <c>false</c>
     /// when no entry exists (e.g. the intent was already consumed
     /// by a racing ER between dispatch failure and this call).
+    /// <para>
+    /// Pass-5 review (#299) P1. The <paramref name="ambiguousAt"/>
+    /// timestamp is captured on the entry AND persisted via the
+    /// matching <c>OrderReplaceAmbiguousMarginHeldEvent</c> so a
+    /// post-restart replay re-hydrates the same TTL deadline the
+    /// pre-crash sweep would have observed. Pass the engine clock's
+    /// current value; the sweep below ages from this stamp, not
+    /// from <see cref="Entry.CreatedAt"/>.
+    /// </para>
     /// </summary>
-    public bool MarkAmbiguousMarginHeld(ulong newClOrdId)
+    public bool MarkAmbiguousMarginHeld(ulong newClOrdId, DateTimeOffset ambiguousAt)
     {
         if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
         {
             found.AmbiguousMarginHeld = true;
+            found.AmbiguousAt = ambiguousAt;
+            // Pass-5 review (#299) P2. Add to the ambiguous-only
+            // index that the sweep enumerates. TryAdd is idempotent
+            // — a second mark on the same entry is a no-op here.
+            _ambiguous.TryAdd(newClOrdId, 0);
             return true;
         }
         return false;
     }
 
     /// <summary>
+    /// Back-compat overload used by tests written before pass-5
+    /// introduced the explicit <c>AmbiguousAt</c> anchor. Anchors the
+    /// TTL to the entry's <see cref="Entry.CreatedAt"/> stamp (the
+    /// pre-pass-5 sweep semantics). Production callers MUST use the
+    /// timestamped overload so the WAL event and entry agree on the
+    /// TTL anchor.
+    /// </summary>
+    public bool MarkAmbiguousMarginHeld(ulong newClOrdId)
+    {
+        if (_byNewClOrdId.TryGetValue(newClOrdId, out var found))
+            return MarkAmbiguousMarginHeld(newClOrdId, found.CreatedAt);
+        return false;
+    }
+
+    /// <summary>
     /// Pass-4 review (#299) P1. Remove + return every entry whose
     /// <see cref="Entry.AmbiguousMarginHeld"/> flag is set AND whose
-    /// <see cref="Entry.CreatedAt"/> is older than
-    /// <paramref name="now"/> minus <paramref name="ttl"/>. Caller
-    /// (the AlgoScheduler sweep) is responsible for calling
+    /// <see cref="Entry.AmbiguousAt"/> is older than <paramref name="now"/>
+    /// minus <paramref name="ttl"/>. Caller (the AlgoScheduler sweep)
+    /// is responsible for calling
     /// <see cref="Risk.IReplaceMarginCoordinator.AbortReplace"/> for
     /// each returned intent and bumping the expired-counter metric.
     /// Entries without the ambiguous flag (the normal in-flight state)
     /// are NEVER reaped — a long-lived modify on a slow venue is
     /// legitimate.
+    /// <para>
+    /// Pass-5 review (#299) P2. Iterates the dedicated ambiguous-only
+    /// index (<c>_ambiguous</c>) instead of the full <c>_byNewClOrdId</c>
+    /// map. Cost is O(ambiguous entries) — almost always zero in
+    /// steady state — versus the previous O(all pending modifies).
+    /// </para>
     /// </summary>
     public IReadOnlyList<OrderReplacementIntent> SweepExpiredAmbiguous(
         DateTimeOffset now, TimeSpan ttl)
     {
+        Interlocked.Exchange(ref _lastSweepInspectedCount, 0);
         if (ttl <= TimeSpan.Zero) return Array.Empty<OrderReplacementIntent>();
+        if (_ambiguous.IsEmpty) return Array.Empty<OrderReplacementIntent>();
         List<OrderReplacementIntent>? expired = null;
         var cutoff = now - ttl;
-        foreach (var kvp in _byNewClOrdId)
+        foreach (var kvp in _ambiguous)
         {
-            var entry = kvp.Value;
+            Interlocked.Increment(ref _lastSweepInspectedCount);
+            if (!_byNewClOrdId.TryGetValue(kvp.Key, out var entry))
+            {
+                // Index entry survived its primary — defensive cleanup.
+                _ambiguous.TryRemove(kvp.Key, out _);
+                continue;
+            }
             if (!entry.AmbiguousMarginHeld) continue;
-            if (entry.CreatedAt > cutoff) continue;
+            // Use AmbiguousAt as the age anchor (falls back to
+            // CreatedAt for legacy entries that pre-date pass-5).
+            var anchor = entry.AmbiguousAt ?? entry.CreatedAt;
+            if (anchor > cutoff) continue;
             // Atomic remove guarded by the secondary index so a
             // racing TryConsume(newClOrdId) wins cleanly (only one
             // side will observe the entry as removable).
             if (_byNewClOrdId.TryRemove(kvp.Key, out var found))
             {
                 _byOriginalClOrdId.TryRemove(found.Intent.OriginalClOrdId, out _);
+                _ambiguous.TryRemove(kvp.Key, out _);
                 (expired ??= new List<OrderReplacementIntent>()).Add(found.Intent);
             }
         }
@@ -220,6 +293,22 @@ public sealed class PendingReplacementRegistry
 
     /// <summary>Test/observability helper.</summary>
     internal int CountForTesting => _byNewClOrdId.Count;
+
+    /// <summary>
+    /// Pass-5 review (#299) P2 test hook. Number of registry entries
+    /// the most recent <see cref="SweepExpiredAmbiguous"/> invocation
+    /// inspected. Used by the unit test that asserts the sweep cost
+    /// scales with the ambiguous-flagged count, not the total
+    /// pending-modify count.
+    /// </summary>
+    internal long LastSweepInspectedCountForTesting =>
+        Interlocked.Read(ref _lastSweepInspectedCount);
+
+    /// <summary>
+    /// Pass-5 review (#299) P2 test hook. Number of entries in the
+    /// dedicated ambiguous-only index.
+    /// </summary>
+    internal int AmbiguousCountForTesting => _ambiguous.Count;
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -141,6 +141,21 @@ public sealed class RawPlatformSnapshot
     /// freshly-started process.
     /// </summary>
     public PeggedRepegHistoryRaw[] PeggedRepegHistory { get; init; } = Array.Empty<PeggedRepegHistoryRaw>();
+
+    /// <summary>
+    /// Pass-6 review (#299) P1. Mirror of
+    /// <c>PlatformSnapshot.PendingReplacements</c> at the raw-capture
+    /// stage. Carries every <see cref="PendingReplacementRegistry"/>
+    /// entry — including its <see cref="PendingReplacementRaw.AmbiguousMarginHeld"/>
+    /// flag, <see cref="PendingReplacementRaw.AmbiguousAt"/>, and
+    /// <see cref="PendingReplacementRaw.NewRemainingNotional"/> — so a
+    /// snapshot taken AFTER an ambiguous mark survives recovery even
+    /// when the WAL tail starts past the matching
+    /// <c>OrderReplaceAmbiguousMarginHeldEvent</c>. Empty on snapshots
+    /// pre-dating the field (additive — legacy snapshots restore as a
+    /// no-op, matching pre-pass-6 behaviour).
+    /// </summary>
+    public PendingReplacementRaw[] PendingReplacements { get; init; } = Array.Empty<PendingReplacementRaw>();
 }
 
 /// <summary>
@@ -274,3 +289,31 @@ public readonly record struct ClOrdIdRegistryRaw(long NextPrefix, ClOrdIdCounter
     public static ClOrdIdRegistryRaw Empty { get; } =
         new(0L, Array.Empty<ClOrdIdCounterRaw>());
 }
+
+/// <summary>
+/// Pass-6 review (#299) P1. Raw lock-side capture of one
+/// <see cref="B3.Trading.Application.PendingReplacementRegistry"/>
+/// entry. Mirrors <see cref="B3.Trading.Application.PendingReplacementEntrySnapshot"/>
+/// 1:1 — the two layers are deliberately distinct so the raw-capture
+/// shape can evolve independently of the persisted DTO if needed.
+/// </summary>
+public readonly record struct PendingReplacementRaw(
+    ulong OriginalClOrdId,
+    ulong NewClOrdId,
+    string OwnerEndClientId,
+    string Symbol,
+    ulong SecurityId,
+    OrderSide Side,
+    OrderType Type,
+    long NewQuantity,
+    decimal? NewPrice,
+    string FirmId,
+    ulong? ParentAlgoId,
+    int? AlgoSliceSeq,
+    TimeInForce? RequestedTimeInForce,
+    decimal? RequestedStopPrice,
+    DateTimeOffset? RequestedGoodTillDate,
+    DateTimeOffset CreatedAtUtc,
+    bool AmbiguousMarginHeld,
+    DateTimeOffset? AmbiguousAtUtc,
+    decimal NewRemainingNotional);

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -212,6 +212,23 @@ public sealed class PlatformSnapshot
     /// <see cref="B3.Trading.Application.PeggedRepegBook.MarkCancelledChild"/>.
     /// </summary>
     public List<PeggedRepegHistorySnapshot> PeggedRepegHistory { get; init; } = new();
+
+    /// <summary>
+    /// Pass-6 review (#299) P1. Persisted in-flight cancel-replace
+    /// registry — every <see cref="B3.Trading.Application.PendingReplacementRegistry"/>
+    /// entry, including the ambiguous-margin-held flag,
+    /// <c>HeldAtUtc</c>, and <c>NewRemainingNotional</c>. Required so a
+    /// periodic snapshot taken AFTER an
+    /// <see cref="OrderReplaceAmbiguousMarginHeldEvent"/> survives
+    /// recovery whose WAL tail starts past that event — without this,
+    /// the post-restart sweep would have no ambiguous entry and a late
+    /// Replaced/Rejected ER would miss the registry path entirely
+    /// (over-allocation invariant break). Empty on snapshots
+    /// pre-dating the field (additive); the restore path treats
+    /// absence as "no in-flight modifies — same as a freshly-started
+    /// process".
+    /// </summary>
+    public List<PendingReplacementSnapshot> PendingReplacements { get; init; } = new();
 }
 
 /// <summary>
@@ -446,6 +463,37 @@ public sealed record PeggedRepegHistorySnapshot(
     ulong AlgoId,
     List<ulong> ChildClOrdIds,
     bool EvictionLogged = false);
+
+/// <summary>
+/// Pass-6 review (#299) P1. Persisted shape of one
+/// <see cref="B3.Trading.Application.PendingReplacementRegistry"/>
+/// entry — see <see cref="PlatformSnapshot.PendingReplacements"/>.
+/// Carries every field the restore path needs to re-hydrate the
+/// in-flight intent AND (when <see cref="AmbiguousMarginHeld"/> is
+/// <c>true</c>) re-invoke
+/// <c>IReplaceMarginCoordinator.PrepareReplaceAsync</c> with the
+/// same value the pre-crash dispatch used.
+/// </summary>
+public sealed record PendingReplacementSnapshot(
+    ulong OriginalClOrdId,
+    ulong NewClOrdId,
+    string OwnerEndClientId,
+    string Symbol,
+    ulong SecurityId,
+    string Side,
+    string Type,
+    long NewQuantity,
+    decimal? NewPrice,
+    string FirmId,
+    ulong? ParentAlgoId,
+    int? AlgoSliceSeq,
+    string? RequestedTimeInForce,
+    decimal? RequestedStopPrice,
+    DateTimeOffset? RequestedGoodTillDate,
+    DateTimeOffset CreatedAtUtc,
+    bool AmbiguousMarginHeld,
+    DateTimeOffset? AmbiguousAtUtc,
+    decimal NewRemainingNotional);
 
 public sealed class ClOrdIdRegistrySnapshot
 {

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -26,6 +26,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
 [JsonDerivedType(typeof(OrderSubmittedEvent), "order.submitted")]
 [JsonDerivedType(typeof(OrderReplaceRequestedEvent), "order.replace-requested")]
+[JsonDerivedType(typeof(OrderReplaceAmbiguousMarginHeldEvent), "order.replace-ambiguous-margin-held")]
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
 [JsonDerivedType(typeof(SymbolHaltToggledEvent), "symbol-halt.toggled")]
@@ -220,6 +221,63 @@ public sealed record OrderReplaceRequestedEvent : WalEvent
     public string? RequestedTimeInForce { get; init; }
     public decimal? RequestedStopPrice { get; init; }
     public DateTimeOffset? RequestedGoodTillDate { get; init; }
+}
+
+/// <summary>
+/// Pass-5 review (#299) P1. Recorded the moment the modify pipeline
+/// observes an AMBIGUOUS gateway dispatch failure (an exception
+/// thrown by <c>IEntryPointClient.CancelReplaceAsync</c> after the
+/// margin coordinator's <c>PrepareReplaceAsync</c> succeeded AND the
+/// intent was registered). The transient margin reservation under
+/// <see cref="NewClOrdId"/> is intentionally KEPT — the venue may
+/// still send a Replaced ER, in which case <c>CommitReplace</c>
+/// converges without re-checking capacity. The
+/// <see cref="PendingReplacementRegistry"/> entry is flagged so the
+/// AlgoScheduler's TTL sweep can bound the leak if no terminal ER
+/// ever arrives.
+///
+/// <para>
+/// <b>Why a WAL event (vs. snapshot-only).</b> The held flag must be
+/// durable across a crash that lands BETWEEN the intent's matching
+/// <see cref="OrderReplaceRequestedEvent"/> and the next periodic
+/// snapshot, otherwise replay re-hydrates the intent without the
+/// flag, the TTL sweep never reaps it, and a late Replaced ER drives
+/// <c>CommitReplace</c> against a freed-on-restart reservation —
+/// breaking the over-allocation invariant. <see cref="EventReplayer"/>
+/// re-calls <c>PrepareReplaceAsync</c> on this event to re-establish
+/// the transient reservation, and re-marks the registry entry with
+/// the persisted <see cref="HeldAtUtc"/> so the post-restart sweep
+/// converges on the same TTL deadline the pre-crash sweep would
+/// have observed.
+/// </para>
+///
+/// <para>
+/// <b>Additive payload.</b> Older binaries skip unknown discriminators
+/// with a structured warning (see <see cref="WalEvent"/>'s schema
+/// evolution rule), so segments produced with this event remain
+/// safely readable by pre-pass-5 readers.
+/// </para>
+/// </summary>
+public sealed record OrderReplaceAmbiguousMarginHeldEvent : WalEvent
+{
+    public required ulong NewClOrdId { get; init; }
+    public required ulong OriginalClOrdId { get; init; }
+    public required string EndClientId { get; init; }
+    /// <summary>
+    /// The upsize-delta-bearing remaining notional the modify
+    /// pipeline passed to <c>PrepareReplaceAsync</c>. Replay
+    /// re-invokes the coordinator with the same value to re-establish
+    /// the held reservation; zero/negative implies a downsize or
+    /// non-margin-bearing order (replay still re-runs Prepare so the
+    /// transient entry is recreated for a future Commit/Abort).
+    /// </summary>
+    public required decimal NewRemainingNotional { get; init; }
+    /// <summary>
+    /// Wall-clock at which the engine observed the ambiguous send.
+    /// The TTL sweep ages from this stamp post-restart so a crash
+    /// inside the TTL window doesn't reset the deadline.
+    /// </summary>
+    public required DateTimeOffset HeldAtUtc { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -38,6 +38,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(AlgoPeggedRepeggedEvent), "algo.pegged.repegged")]
 [JsonDerivedType(typeof(AlgoPeggedRepegStartedEvent), "algo.pegged.repeg-started")]
 [JsonDerivedType(typeof(AlgoPeggedRepegResolvedEvent), "algo.pegged.repeg-resolved")]
+[JsonDerivedType(typeof(AlgoChildModifiedEvent), "algo.child.modified")]
 [JsonDerivedType(typeof(OrderStaledEvent), "order.staled")]
 [JsonDerivedType(typeof(OrderStaleClearedEvent), "order.stale-cleared")]
 [JsonDerivedType(typeof(UserBotCredentialCreatedEvent), "userbot.cred.created")]
@@ -547,6 +548,29 @@ public sealed record AlgoPeggedRepegResolvedEvent : WalEvent
     /// </list>
     /// </summary>
     public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Q3.5 (#285). Audit envelope for an algo child cancel-replace
+/// (modify) — captures the old and new ClOrdIDs plus the requested
+/// quantity/price overrides and the human-readable reason
+/// (<c>operator</c>, <c>pegged_repeg</c>, …). NOT replayed for state
+/// reconstruction: the actual cancel-replace is already on the WAL
+/// via the companion <see cref="OrderReplaceRequestedEvent"/>; this
+/// event exists so EOD / forensic tooling can correlate "engine
+/// modified a child" back to the algo that drove it without joining
+/// across multiple events.
+/// </summary>
+public sealed record AlgoChildModifiedEvent : WalEvent
+{
+    public required ulong AlgoId { get; init; }
+    public required string FirmId { get; init; }
+    public required ulong OldChildClOrdId { get; init; }
+    public required ulong NewChildClOrdId { get; init; }
+    public long? NewQuantity { get; init; }
+    public decimal? NewPrice { get; init; }
+    public required string Reason { get; init; }
+    public required DateTimeOffset AtUtc { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -115,6 +115,26 @@ public sealed class MarginOptions
     public bool Enabled { get; set; }
 
     /// <summary>
+    /// Pass-4 review (#299) P1. Bounded TTL for ambiguous-send
+    /// replace reservations held under a
+    /// <see cref="B3.Trading.Application.PendingReplacementRegistry"/>
+    /// entry whose gateway dispatch threw post-Prepare. The intent
+    /// is intentionally kept so a late Replaced ER can converge
+    /// through <see cref="IReplaceMarginCoordinator.CommitReplace"/>
+    /// without re-checking capacity (the upsize delta is already
+    /// reserved). If no terminal ER arrives within this window, the
+    /// reservation must be released or it leaks until the parent
+    /// order terminates — and any concurrent order can NOT consume
+    /// the held headroom in the meantime, so the cap is preserved
+    /// strictly but the trader temporarily loses access to the
+    /// upsize delta. 30s matches the typical venue ER round-trip
+    /// upper bound on B3 (single-digit seconds is normal; a 30s
+    /// silence indicates a real loss, not a slow ack). Tuneable via
+    /// <c>Trading:Risk:Margin:AmbiguousReplaceTtl</c>.
+    /// </summary>
+    public TimeSpan AmbiguousReplaceTtl { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Per-end-client opening balance (in the single accounting
     /// currency v2 assumes). Missing entries are treated as zero, so
     /// unrecognized end-clients cannot place buy orders when margin

--- a/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
@@ -71,8 +71,26 @@ public sealed class MockEntryPointClient : IEntryPointClient
     public Task SubmitCancelReplaceAsync(OrderCancelReplaceRequest request, CancellationToken cancellationToken)
     {
         _replaces.Enqueue(request);
+        var injector = ReplaceFailureInjector;
+        if (injector is not null)
+        {
+            var ex = injector(request);
+            if (ex is not null) return Task.FromException(ex);
+        }
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Pass-1 review (#299) P1-B. Optional test hook: when non-null,
+    /// every <see cref="SubmitCancelReplaceAsync"/> invokes it after
+    /// recording the request and throws the returned exception (or
+    /// completes normally if it returns null). Mirrors
+    /// <see cref="CancelFailureInjector"/>; used by the algo-modify
+    /// send-failure regression test to simulate an ambiguous send
+    /// (the request was recorded — and may have been accepted by the
+    /// venue — but the SDK reports failure to the caller).
+    /// </summary>
+    public Func<OrderCancelReplaceRequest, Exception?>? ReplaceFailureInjector { get; set; }
 
     /// <summary>
     /// Test/host hook to push an ER through the exchange-side event.

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -59,6 +59,21 @@ public sealed class StateSnapshotter
     /// Pegged.
     /// </summary>
     private readonly PeggedRepegBook? _peggedRepeg;
+    /// <summary>
+    /// Pass-6 review (#299) P1. Optional. When wired the snapshot
+    /// pipeline captures every <see cref="PendingReplacementRegistry"/>
+    /// entry (including the ambiguous-margin-held flag) so a
+    /// snapshot taken AFTER an <c>OrderReplaceAmbiguousMarginHeldEvent</c>
+    /// survives recovery whose WAL tail starts past that event. The
+    /// restore path additionally re-invokes
+    /// <see cref="IReplaceMarginCoordinator.PrepareReplaceAsync"/>
+    /// (when <see cref="_replaceMargin"/> is wired) for every restored
+    /// entry whose <c>AmbiguousMarginHeld</c> flag is set — mirroring
+    /// the WAL-replay branch added in pass-5 so the post-restart sweep
+    /// has both the registry entry and the held reservation.
+    /// </summary>
+    private readonly PendingReplacementRegistry? _replacements;
+    private readonly IReplaceMarginCoordinator? _replaceMargin;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -79,7 +94,9 @@ public sealed class StateSnapshotter
         FeeKeeper? feeKeeper = null,
         PnlKeeper? pnlKeeper = null,
         PovProgressBook? povProgress = null,
-        PeggedRepegBook? peggedRepeg = null)
+        PeggedRepegBook? peggedRepeg = null,
+        PendingReplacementRegistry? replacements = null,
+        IReplaceMarginCoordinator? replaceMargin = null)
     {
         _orders = orders;
         _positions = positions;
@@ -100,6 +117,8 @@ public sealed class StateSnapshotter
         _gtdScheduler = gtdScheduler;
         _povProgress = povProgress;
         _peggedRepeg = peggedRepeg;
+        _replacements = replacements;
+        _replaceMargin = replaceMargin;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -167,6 +186,30 @@ public sealed class StateSnapshotter
             ? Array.Empty<PeggedRepegHistoryRaw>()
             : _peggedRepeg.SnapshotHistory()
                 .Select(t => new PeggedRepegHistoryRaw(t.FirmId, t.AlgoId, t.ChildClOrdIds.ToArray(), t.EvictionLogged))
+                .ToArray(),
+        PendingReplacements = _replacements is null
+            ? Array.Empty<PendingReplacementRaw>()
+            : _replacements.Snapshot()
+                .Select(s => new PendingReplacementRaw(
+                    OriginalClOrdId: s.Intent.OriginalClOrdId,
+                    NewClOrdId: s.Intent.NewClOrdId,
+                    OwnerEndClientId: s.Intent.Owner.Value,
+                    Symbol: s.Intent.Symbol,
+                    SecurityId: s.Intent.SecurityId,
+                    Side: s.Intent.Side,
+                    Type: s.Intent.Type,
+                    NewQuantity: s.Intent.NewQuantity,
+                    NewPrice: s.Intent.NewPrice,
+                    FirmId: s.Intent.FirmId,
+                    ParentAlgoId: s.Intent.ParentAlgoId,
+                    AlgoSliceSeq: s.Intent.AlgoSliceSeq,
+                    RequestedTimeInForce: s.Intent.RequestedTimeInForce,
+                    RequestedStopPrice: s.Intent.RequestedStopPrice,
+                    RequestedGoodTillDate: s.Intent.RequestedGoodTillDate,
+                    CreatedAtUtc: s.CreatedAt,
+                    AmbiguousMarginHeld: s.AmbiguousMarginHeld,
+                    AmbiguousAtUtc: s.AmbiguousAt,
+                    NewRemainingNotional: s.NewRemainingNotional))
                 .ToArray(),
     };
 
@@ -368,6 +411,33 @@ public sealed class StateSnapshotter
                 h.FirmId, h.AlgoId, new List<ulong>(h.ChildClOrdIds), h.EvictionLogged));
         }
 
+        var pendingReplacements = new List<PendingReplacementSnapshot>(raw.PendingReplacements.Length);
+        for (var i = 0; i < raw.PendingReplacements.Length; i++)
+        {
+            var r = raw.PendingReplacements[i];
+            pendingReplacements.Add(new PendingReplacementSnapshot(
+                OriginalClOrdId: r.OriginalClOrdId,
+                NewClOrdId: r.NewClOrdId,
+                OwnerEndClientId: r.OwnerEndClientId,
+                Symbol: r.Symbol,
+                SecurityId: r.SecurityId,
+                Side: r.Side.ToString(),
+                Type: r.Type.ToString(),
+                NewQuantity: r.NewQuantity,
+                NewPrice: r.NewPrice,
+                FirmId: r.FirmId,
+                ParentAlgoId: r.ParentAlgoId,
+                AlgoSliceSeq: r.AlgoSliceSeq,
+                RequestedTimeInForce: r.RequestedTimeInForce?.ToString(),
+                RequestedStopPrice: r.RequestedStopPrice,
+                RequestedGoodTillDate: r.RequestedGoodTillDate,
+                CreatedAtUtc: r.CreatedAtUtc,
+                AmbiguousMarginHeld: r.AmbiguousMarginHeld,
+                AmbiguousAtUtc: r.AmbiguousAtUtc,
+                NewRemainingNotional: r.NewRemainingNotional));
+        }
+        pendingReplacements.Sort(static (a, b) => a.NewClOrdId.CompareTo(b.NewClOrdId));
+
         return new PlatformSnapshot
         {
             Seq = raw.Seq,
@@ -399,6 +469,7 @@ public sealed class StateSnapshotter
             PovProgress = povProgress,
             PeggedRepegPending = peggedRepeg,
             PeggedRepegHistory = peggedRepegHistory,
+            PendingReplacements = pendingReplacements,
         };
     }
 
@@ -481,6 +552,81 @@ public sealed class StateSnapshotter
                     new PeggedRepegPending(p.CancelledChildClOrdId, p.TargetPrice, p.AtUtc))));
             _peggedRepeg.RestoreHistory(snap.PeggedRepegHistory.Select(h =>
                 (h.FirmId, h.AlgoId, (IReadOnlyList<ulong>)h.ChildClOrdIds, h.EvictionLogged)));
+        }
+        // Pass-6 review (#299) P1. Re-hydrate the in-flight cancel-
+        // replace registry from the persisted snapshot and — for
+        // every entry whose ambiguous-margin-held flag was set at
+        // capture time — re-invoke PrepareReplaceAsync to re-establish
+        // the held upsize-delta reservation the pre-crash dispatch
+        // left in place. Mirrors the WAL-replay branch added in
+        // pass-5 (OrderReplaceAmbiguousMarginHeldEvent) so a
+        // snapshot whose Seq is past the ambiguous mark recovers
+        // identically to a WAL-tail-only recovery. Also re-registers
+        // the ownership replace-link so a late Replaced/Rejected ER
+        // on the new ClOrdID resolves correctly through the
+        // processor's replace-side branch. Restore happens BEFORE
+        // WAL replay; replay's OrderReplaceRequestedEvent /
+        // OrderReplaceAmbiguousMarginHeldEvent branches are
+        // idempotent under TryAdd / Mark — duplicate replay (entry
+        // already in the snapshot) becomes a benign no-op.
+        if (_replacements is not null && snap.PendingReplacements is { Count: > 0 })
+        {
+            var entries = new List<PendingReplacementEntrySnapshot>(snap.PendingReplacements.Count);
+            foreach (var p in snap.PendingReplacements)
+            {
+                var intent = new OrderReplacementIntent(
+                    OriginalClOrdId: p.OriginalClOrdId,
+                    NewClOrdId: p.NewClOrdId,
+                    Owner: new EndClientId(p.OwnerEndClientId),
+                    Symbol: p.Symbol,
+                    SecurityId: p.SecurityId,
+                    Side: Enum.Parse<OrderSide>(p.Side, ignoreCase: true),
+                    Type: Enum.Parse<OrderType>(p.Type, ignoreCase: true),
+                    NewQuantity: p.NewQuantity,
+                    NewPrice: p.NewPrice,
+                    FirmId: p.FirmId,
+                    ParentAlgoId: p.ParentAlgoId,
+                    AlgoSliceSeq: p.AlgoSliceSeq,
+                    RequestedTimeInForce: p.RequestedTimeInForce is { } tif
+                        ? Enum.Parse<TimeInForce>(tif, ignoreCase: true)
+                        : (TimeInForce?)null,
+                    RequestedStopPrice: p.RequestedStopPrice,
+                    RequestedGoodTillDate: p.RequestedGoodTillDate);
+                entries.Add(new PendingReplacementEntrySnapshot(
+                    Intent: intent,
+                    CreatedAt: p.CreatedAtUtc,
+                    AmbiguousMarginHeld: p.AmbiguousMarginHeld,
+                    AmbiguousAt: p.AmbiguousAtUtc,
+                    NewRemainingNotional: p.NewRemainingNotional));
+            }
+            _replacements.Restore(entries);
+            foreach (var p in snap.PendingReplacements)
+            {
+                // Snapshot restore runs BEFORE WAL replay, but the
+                // ownership map was already restored above from
+                // snap.Ownership. The orig SHOULD be present
+                // (snapshot was taken while orig was working); if
+                // not (terminal ER landed in the same window and the
+                // orig was evicted from the ownership map by some
+                // future cleanup), the replace-link registration
+                // would throw — skip defensively, mirroring the
+                // WAL-replay branch's `TryResolve(...)` guard.
+                if (!_ownership.TryResolve(p.OriginalClOrdId, out _)) continue;
+                _ownership.RegisterReplaceLink(p.OriginalClOrdId, p.NewClOrdId);
+                if (p.AmbiguousMarginHeld && _replaceMargin is not null)
+                {
+                    // Synchronous under ReserveOnSubmitMarginProvider —
+                    // same GetAwaiter().GetResult() shape as the
+                    // EventReplayer's pass-5 branch.
+                    _replaceMargin.PrepareReplaceAsync(
+                        p.OriginalClOrdId,
+                        p.NewClOrdId,
+                        new EndClientId(p.OwnerEndClientId),
+                        p.NewRemainingNotional,
+                        CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                }
+            }
         }
     }
 }
@@ -745,7 +891,7 @@ public sealed class EventReplayer
                         CancellationToken.None)
                         .GetAwaiter().GetResult();
                 }
-                _replacements?.MarkAmbiguousMarginHeld(amh.NewClOrdId, amh.HeldAtUtc);
+                _replacements?.MarkAmbiguousMarginHeld(amh.NewClOrdId, amh.HeldAtUtc, amh.NewRemainingNotional);
                 break;
             case ExecutionReportReceivedEvent er:
                 if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -504,6 +504,7 @@ public sealed class EventReplayer
     private readonly ClOrdIdPrefixRegistry _clOrdIds;
     private readonly AlgoIdRegistry _algoIds;
     private readonly PendingReplacementRegistry? _replacements;
+    private readonly IReplaceMarginCoordinator? _replaceMargin;
     private readonly InMemoryUserBotCredentialRegistry? _userBotCredentials;
     private readonly InMemoryUserBotSessionRegistry? _userBotSessions;
     private readonly IUserBotOrderMappingRegistry? _userBotMappings;
@@ -567,7 +568,17 @@ public sealed class EventReplayer
         IFeeCalculator? feeCalculator = null,
         PnlKeeper? pnlKeeper = null,
         PovProgressBook? povProgress = null,
-        PeggedRepegBook? peggedRepeg = null)
+        PeggedRepegBook? peggedRepeg = null,
+        // Pass-5 review (#299) P1. Optional. When wired, replay of
+        // <see cref="OrderReplaceAmbiguousMarginHeldEvent"/> re-calls
+        // <c>PrepareReplaceAsync</c> to re-establish the held upsize-
+        // delta reservation a pre-crash modify left in place after an
+        // ambiguous gateway dispatch. Without this hook, capacity
+        // would return on restart and a late Replaced ER would either
+        // double-add (if Prepare ran again) or land in the
+        // "neither side has owner" branch of <c>CommitReplace</c> —
+        // both break the over-allocation invariant.
+        IReplaceMarginCoordinator? replaceMargin = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -589,6 +600,7 @@ public sealed class EventReplayer
         _pnlKeeper = pnlKeeper;
         _povProgress = povProgress;
         _peggedRepeg = peggedRepeg;
+        _replaceMargin = replaceMargin;
     }
 
     /// <summary>
@@ -705,6 +717,35 @@ public sealed class EventReplayer
                 // must advance the watermark even if the replacement
                 // intent itself wasn't re-registered (orig already gone).
                 _clOrdIds.AdvanceCounterTo(new EndClientId(rr.EndClientId), rr.NewClOrdId);
+                break;
+            case OrderReplaceAmbiguousMarginHeldEvent amh:
+                // Pass-5 review (#299) P1. Re-establish the held
+                // margin reservation a pre-crash modify left in
+                // place after an ambiguous gateway dispatch, and
+                // re-mark the corresponding PendingReplacementRegistry
+                // entry so the AlgoScheduler's TTL sweep ages from
+                // the same wall-clock the pre-crash sweep would
+                // have observed. Both hooks are optional — legacy
+                // test compositions that omit the margin coordinator
+                // or the replacement registry simply skip the side
+                // they didn't wire (the other side still applies).
+                if (_replaceMargin is not null)
+                {
+                    // PrepareReplaceAsync's production implementation
+                    // (ReserveOnSubmitMarginProvider) is synchronous
+                    // under a lock and returns a completed task — the
+                    // GetAwaiter().GetResult() shape matches every
+                    // other sync replay site here and avoids forcing
+                    // the snapshotter call chain to be async.
+                    _replaceMargin.PrepareReplaceAsync(
+                        amh.OriginalClOrdId,
+                        amh.NewClOrdId,
+                        new EndClientId(amh.EndClientId),
+                        amh.NewRemainingNotional,
+                        CancellationToken.None)
+                        .GetAwaiter().GetResult();
+                }
+                _replacements?.MarkAmbiguousMarginHeld(amh.NewClOrdId, amh.HeldAtUtc);
                 break;
             case ExecutionReportReceivedEvent er:
                 if (Enum.TryParse<ExecKind>(er.ExecKind, ignoreCase: true, out var kind))

--- a/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
+++ b/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
@@ -39,7 +39,15 @@ public static class SimulatorEndpoint
         // lookup is keyed on the new ClOrdID, but the new Order is
         // hydrated under that new id only if OrigClOrdID resolves to an
         // existing original — caller must supply it.
-        ulong? OrigClOrdId = null);
+        ulong? OrigClOrdId = null,
+        // Pass-1 review (#299) P1-A. Optional cumulative-quantity echo
+        // for Type==Replaced — the venue's view of how much of the
+        // original order had been filled at replace-acceptance time. The
+        // processor seeds the replacement Order's CumulativeQuantity
+        // from this value so subsequent fills advance from the correct
+        // baseline. Defaults to 0 (no carry-over) for back-compat with
+        // tests that exercise the "modify before any fill" path.
+        long? CumQty = null);
 
     /// <summary>
     /// Maps <c>POST /admin/simulator/er</c> under the admin authorization
@@ -84,7 +92,7 @@ public static class SimulatorEndpoint
             if ((req.OrigClOrdId ?? 0UL) == 0UL)
                 return Results.BadRequest(new { error = "missing_origClOrdId", detail = "origClOrdId is required for type=Replaced." });
             var leavesR = req.LastQty ?? 0L;
-            var cumR = 0L;
+            var cumR = req.CumQty ?? 0L;
             var envR = new ExecutionReportEnvelope(
                 ClOrdId: req.ClOrdId,
                 ExecType: EpExecType.Replaced,

--- a/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
+++ b/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
@@ -31,7 +31,15 @@ public static class SimulatorEndpoint
         string Type,
         long? LastQty,
         decimal? LastPx,
-        string? RejectReason);
+        string? RejectReason,
+        // Q3.5 (#285). Required when Type==Replaced — the engine's
+        // cancel-replace flow allocates a brand-new ClOrdID for the
+        // replacement and the venue echoes the original as OrigClOrdID
+        // on the Replaced ack. The processor's PendingReplacementRegistry
+        // lookup is keyed on the new ClOrdID, but the new Order is
+        // hydrated under that new id only if OrigClOrdID resolves to an
+        // existing original — caller must supply it.
+        ulong? OrigClOrdId = null);
 
     /// <summary>
     /// Maps <c>POST /admin/simulator/er</c> under the admin authorization
@@ -63,8 +71,38 @@ public static class SimulatorEndpoint
         if (!Enum.TryParse<EpExecType>(req.Type, ignoreCase: true, out var execType))
             return Results.BadRequest(new { error = "invalid_type", detail = $"unknown ExecType '{req.Type}'" });
 
+        // Q3.5 (#285). Replaced ER lookup is keyed on the NEW
+        // ClOrdID via PendingReplacementRegistry; the new order is
+        // not in WorkingOrderBook yet (it's hydrated by
+        // ApplyReplaceAccepted from the intent). Skip the
+        // pre-flight book lookup for this exec type — leaves / cum
+        // come from the request body (the venue echoes them on the
+        // wire) and we rely on the processor to validate against
+        // the intent and the original order.
         if (execType == EpExecType.Replaced)
-            return Results.BadRequest(new { error = "unsupported_type", detail = "Replaced is out of v0 scope; future RFC will define semantics." });
+        {
+            if ((req.OrigClOrdId ?? 0UL) == 0UL)
+                return Results.BadRequest(new { error = "missing_origClOrdId", detail = "origClOrdId is required for type=Replaced." });
+            var leavesR = req.LastQty ?? 0L;
+            var cumR = 0L;
+            var envR = new ExecutionReportEnvelope(
+                ClOrdId: req.ClOrdId,
+                ExecType: EpExecType.Replaced,
+                LeavesQuantity: leavesR,
+                CumulativeQuantity: cumR,
+                LastQuantity: 0,
+                LastPrice: 0m,
+                RejectReason: null,
+                OrigClOrdId: req.OrigClOrdId!.Value);
+            mock.EmitExecutionReport(envR);
+            return Results.Accepted(value: new
+            {
+                clOrdId = req.ClOrdId,
+                execType = EpExecType.Replaced.ToString(),
+                origClOrdId = req.OrigClOrdId.Value,
+                leavesQuantity = leavesR,
+            });
+        }
 
         if (!book.TryGet(req.ClOrdId, out var order) || order is null)
             return Results.NotFound(new { error = "unknown_clOrdId", clOrdId = req.ClOrdId });

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -403,6 +403,87 @@ public class AlgoModifyEndpointTests
         Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
     }
 
+    [Fact]
+    public async Task Modify_ReplacedErWithStaleZeroCum_ClampsBaselineToOriginal()
+    {
+        // Pass-2 review (#299) P1. Translators in
+        // B3EntryPointClientGateway (OrderModified arm) and
+        // SimulatorEndpoint (/admin/simulator/er Replaced arm) default
+        // missing CumQty to 0. If the OLD child had prior fills (e.g.
+        // partial fill of 30) and the venue / simulator drives a
+        // Replaced ER with erCum=0, hydrating the replacement with
+        // baseline cum=0 caused the next Fill ER for the NEW child id
+        // to compute its delta against an under-seeded prevBooked,
+        // re-booking the OLD child's 30 against the parent.
+        //
+        // Fix: ExecutionReportProcessor.ApplyReplaceAccepted clamps
+        // seedCum upward to origOrder.CumulativeQuantity (and adjusts
+        // seedLeaves) before HydrateReplacement, so the engine adopts
+        // the new child at the correct cum baseline and subsequent
+        // Fill ERs advance from there.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var oldChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        // Partial fill of 30 on the OLD child BEFORE the modify dispatch.
+        await InjectEr(http, adminToken, oldChild.ClOrdId, "PartialFill",
+            lastQty: 30, lastPx: 30.0m);
+        await Task.Delay(150);
+        var algoBefore = await GetAlgo(http, token, algoId);
+        Assert.Equal(30L, algoBefore.GetProperty("filledQuantity").GetInt64());
+
+        // Operator modify: keep quantity unchanged (100) but bump price.
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == oldChild.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never dispatched CancelReplace");
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == oldChild.ClOrdId);
+
+        // Venue Replaced ER with the legacy stale CumQty=0 default.
+        // Without the clamp this would seed the new child at cum=0 and
+        // the next Fill ER (cum=50) would book delta=50 on the parent
+        // on top of the already-booked 30 (parent.FilledQuantity=80).
+        // With the clamp the new child is seeded at cum=30, leaves=70,
+        // so the Fill ER's cum=50 books delta=20 → parent cum=50.
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity,
+            cumQty: 0);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, oldChild.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+        Assert.Equal(30L, newChild.CumulativeQuantity);
+        Assert.Equal(70L, newChild.LeavesQuantity);
+
+        // Drive a Fill ER for the NEW child taking total cum to 50.
+        await InjectEr(http, adminToken, newChild.ClOrdId, "PartialFill",
+            lastQty: 20, lastPx: 30.5m);
+        await Task.Delay(150);
+
+        var algoAfter = await GetAlgo(http, token, algoId);
+        Assert.Equal(50L, algoAfter.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal(50L, algoAfter.GetProperty("remainingQuantity").GetInt64());
+    }
+
     // ───────────────────────── Helpers ─────────────────────────
 
     private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -1,0 +1,353 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q3.5 (#285). End-to-end coverage for the operator algo modify
+/// (cancel-replace) endpoint. The endpoint enqueues an
+/// <c>AlgoModifyRequestedSignal</c> onto the engine reactor; the engine
+/// resolves the live child, validates qty/price against the current
+/// cumulative fills, dispatches <c>OrderReplaceRequestedEvent</c>, and
+/// then issues <c>IExchangeGateway.CancelReplaceAsync</c>. The mock
+/// records the wire request in <c>SubmittedReplaces</c>; tests inject a
+/// <c>Replaced</c> ER through the simulator to drive the convergence
+/// path in <c>ExecutionReportProcessor.ApplyReplaceAccepted</c>.
+/// </summary>
+public class AlgoModifyEndpointTests
+{
+    private static IDictionary<string, string?> Simulator() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+        };
+
+    private static object PeggedBody(long total) => new
+    {
+        Symbol = "PETR4",
+        Side = "Buy",
+        Type = "Pegged",
+        TotalQuantity = total,
+        Pegged = new
+        {
+            Ref = "Mid",
+            OffsetTicks = 0,
+            RepegIntervalMs = 100,
+            TickSize = 0.5m,
+        },
+    };
+
+    // ───────────────────────── Validation ─────────────────────────
+
+    [Fact]
+    public async Task Modify_UnknownAlgo_Returns404()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/9999999/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.0m }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Modify_MissingBothFields_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Use a real algoId so we hit the validator before the ownership
+        // / not-found short circuit. The pegged book-top seed lets the
+        // POST succeed deterministically.
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { Reason = "no-op" }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Modify_NonPositiveQuantity_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewQuantity = 0 }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Modify_TerminalAlgo_Returns409()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        // Drive the algo to Filled (terminal) so the modify is rejected.
+        await InjectEr(http, adminToken, child.ClOrdId, "Fill", lastQty: 100);
+        await WaitForAlgoStatus(http, token, algoId, "Completed", "Filled");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 31.0m }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    // ───────────────────────── Happy path ─────────────────────────
+
+    [Fact]
+    public async Task Modify_LiveChild_IssuesReplaceAndConverges()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child1.Price);
+
+        // Operator modify: bump the limit one tick up. Quantity stays.
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m, Reason = "test-op" }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+        // Engine must have issued exactly one cancel-replace targeting
+        // the live child (not a plain CancelAsync — that's the whole
+        // point of Q3.5).
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r =>
+                r.OriginalClOrdId == child1.ClOrdId
+                && r.NewPrice == 30.5m
+                && r.NewQuantity == child1.Quantity),
+            TimeSpan.FromSeconds(3),
+            "engine never issued CancelReplace for the operator modify");
+
+        var replace = mock.SubmittedReplaces.Single(r =>
+            r.OriginalClOrdId == child1.ClOrdId);
+
+        // Drive the venue ack — Replaced ER for the new ClOrdID with
+        // OrigClOrdID echoing the original. The processor will hydrate
+        // the new child into the book and re-emit
+        // ChildExecutionObservedSignal so the engine retargets cleanly.
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(30.5m, newChild.Price);
+        Assert.Equal(100, newChild.Quantity);
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+    }
+
+    [Fact]
+    public async Task Modify_QuantityBelowFilled_Rejected()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(200));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        // Partial fill: cum=120, leaves=80.
+        await InjectEr(http, adminToken, child.ClOrdId, "PartialFill",
+            lastQty: 120, lastPx: 30.0m);
+
+        // Wait until the engine has consumed the partial-fill ER so
+        // RecomputeCumQty has propagated; the easiest signal is the
+        // child Quantity reflecting the unchanged total (cum is on
+        // the parent runtime, not the child Quantity, so just sleep
+        // briefly to let the consumer loop drain).
+        await Task.Delay(150);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            // newQty=100 is below cum=120 → engine rejects.
+            Content = JsonContent.Create(new { NewQuantity = 100 }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        // Endpoint accepts (validation is per-engine); engine rejects
+        // asynchronously and bumps the rejected counter. Either way
+        // no CancelReplace is issued to the wire.
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+        await Task.Delay(300);
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        Assert.DoesNotContain(mock.SubmittedReplaces,
+            r => r.OriginalClOrdId == child.ClOrdId);
+    }
+
+    // ───────────────────────── Helpers ─────────────────────────
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<HttpResponseMessage> InjectEr(
+        HttpClient http, string adminToken, ulong childClOrdId,
+        string type, long? lastQty = null, decimal lastPx = 30m)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = childClOrdId,
+                Type = type,
+                LastQty = lastQty,
+                LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<HttpResponseMessage> InjectReplacedEr(
+        HttpClient http, string adminToken, ulong newClOrdId, ulong origClOrdId, long leavesQuantity)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = newClOrdId,
+                Type = "Replaced",
+                // LastQty is repurposed as "leavesQuantity" hint for the
+                // Replaced injector arm (no Last fill on a replace ack).
+                LastQty = leavesQuantity,
+                OrigClOrdId = origClOrdId,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    private static async Task<Order> WaitForAnyChild(WorkingOrderBook book, string algoIdStr, TimeSpan timeout)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var match = book.EnumerateChildrenOf("default", algoId).FirstOrDefault();
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException($"No child for algo {algoIdStr} within {timeout.TotalSeconds}s.");
+    }
+
+    private static async Task<Order> WaitForChildOtherThan(
+        WorkingOrderBook book, string algoIdStr, ulong excludeClOrdId, TimeSpan timeout)
+    {
+        var algoId = ulong.Parse(algoIdStr);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            var match = book.EnumerateChildrenOf("default", algoId)
+                .FirstOrDefault(c => c.ClOrdId != excludeClOrdId);
+            if (match is not null) return match;
+            await Task.Delay(10);
+        }
+        throw new TimeoutException(
+            $"No new child (other than {excludeClOrdId}) for algo {algoIdStr} within {timeout.TotalSeconds}s.");
+    }
+
+    private static async Task WaitFor(Func<bool> predicate, TimeSpan timeout, string failMessage)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (predicate()) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException(failMessage + $" (waited {timeout.TotalSeconds}s)");
+    }
+
+    private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? last = null;
+        while (sw.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var resp = await http.SendAsync(req);
+            resp.EnsureSuccessStatusCode();
+            var algo = await resp.Content.ReadFromJsonAsync<JsonElement>();
+            last = algo.GetProperty("status").GetString();
+            if (anyOf.Contains(last)) return;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -484,6 +484,268 @@ public class AlgoModifyEndpointTests
         Assert.Equal(50L, algoAfter.GetProperty("remainingQuantity").GetInt64());
     }
 
+    // ───────────── Pass-3 review (#299) regressions ─────────────
+
+    [Fact]
+    public async Task Modify_BuyChildPastAvailableCash_RejectedByMargin_NoGatewayCall()
+    {
+        // Pass-3 review (#299) P1. The algo modify path must run the
+        // same pre-trade risk pipeline + margin Prepare gates the
+        // operator-driven plain-order modify pipeline applies. Before
+        // the fix the engine went straight from validation to gateway
+        // dispatch and CommitReplace on the venue ack only rebalanced
+        // — a Buy child could be price-modified past available cash
+        // with no rejection. After the fix: pre-Prepare reject → no
+        // CancelReplace on the wire, no AlgoChildModifiedEvent
+        // emitted, and algo.modify_rejected_total{reason=margin_rejected}
+        // bumps. (We assert the margin reason specifically — risk
+        // pipeline + margin coordinator are wired in order; an upsize
+        // past available cash trips the coordinator, not the pipeline.)
+        var overrides = new Dictionary<string, string?>(Simulator())
+        {
+            ["Trading:Risk:Margin:Enabled"] = "true",
+            // Exactly enough for the initial 100@30=3000 reservation;
+            // any upsize delta on a subsequent modify must trip the
+            // coordinator (delta > available=0).
+            [$"Trading:Risk:Margin:Initial:{TestAppFactory.TestUser}"] = "3000",
+            // Push other limits high so margin is the only gate that
+            // could plausibly reject the modify.
+            ["Trading:Risk:Default:MaxNotional"] = "999999999",
+        };
+        using var f = TestAppFactory.WithOverrides(overrides);
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        long rejectedByMargin = 0;
+        long childModifies = 0;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Name == "trading.algo.modify_rejected_total"
+                || instrument.Name == "trading.algo.child_modifies_total")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((inst, measurement, tags, _) =>
+        {
+            if (inst.Name == "trading.algo.modify_rejected_total")
+            {
+                string? reason = null;
+                foreach (var t in tags)
+                    if (t.Key == "reason") reason = t.Value as string;
+                if (reason == "margin_rejected")
+                    Interlocked.Add(ref rejectedByMargin, measurement);
+            }
+            else if (inst.Name == "trading.algo.child_modifies_total")
+            {
+                Interlocked.Add(ref childModifies, measurement);
+            }
+        });
+        listener.Start();
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        Assert.Equal(30.0m, child.Price);
+
+        // Operator modify: bump price one tick up → upsize delta of
+        // 100 * 0.5 = 50 cash. Available is 0 (initial 3000 already
+        // reserved against the original child). Margin coordinator
+        // must reject; no CancelReplace must hit the wire.
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var preReplaces = mock.SubmittedReplaces.Count;
+
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        // Endpoint accepts (validation is per-engine async); engine
+        // rejects on the consumer task.
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        await Task.Delay(300);
+
+        // No CancelReplace dispatched to the gateway for this child.
+        Assert.Equal(preReplaces, mock.SubmittedReplaces.Count);
+        Assert.DoesNotContain(mock.SubmittedReplaces,
+            r => r.OriginalClOrdId == child.ClOrdId);
+
+        // Margin-reason rejection observed; no child-modify success
+        // counter bump (which would have implied an
+        // AlgoChildModifiedEvent emit).
+        listener.RecordObservableInstruments();
+        Assert.True(Interlocked.Read(ref rejectedByMargin) >= 1,
+            "expected algo.modify_rejected_total{reason=margin_rejected} to bump at least once");
+        Assert.Equal(0, Interlocked.Read(ref childModifies));
+    }
+
+    [Fact]
+    public async Task Modify_WithinRisk_StillSucceeds_HappyPathRegression()
+    {
+        // Pass-3 review (#299) P1. The risk + margin gates added to
+        // the algo modify path must NOT regress the within-budget
+        // happy path: a modify that stays inside the operator's cash
+        // headroom and inside all risk limits must still produce a
+        // gateway CancelReplace and converge on the Replaced ER. This
+        // mirrors Modify_LiveChild_IssuesReplaceAndConverges but with
+        // margin explicitly enabled and a generous balance to prove
+        // the new gates pass on the green path.
+        var overrides = new Dictionary<string, string?>(Simulator())
+        {
+            ["Trading:Risk:Margin:Enabled"] = "true",
+            [$"Trading:Risk:Margin:Initial:{TestAppFactory.TestUser}"] = "1000000",
+            ["Trading:Risk:Default:MaxNotional"] = "999999999",
+        };
+        using var f = TestAppFactory.WithOverrides(overrides);
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var oldChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == oldChild.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never dispatched CancelReplace on within-budget modify");
+
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == oldChild.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, oldChild.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(30.5m, newChild.Price);
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+    }
+
+    [Fact]
+    public async Task Modify_RepeatedAdoptions_OverflowRetiredFifo_BumpsEvictionCounter()
+    {
+        // Pass-3 review (#299) P2. Mirror PR #296's CancelledChildRing
+        // observability for the retired-child FIFO. The FIFO caps the
+        // per-parent ChildBookedCum bookkeeping at 8 retired entries
+        // (rationale lives on AlgoParentRuntime.RetiredChildSlotsCap);
+        // each adoption past the cap evicts the eldest entry and MUST
+        // bump trading.algo.modify_retired_child_evicted_total so
+        // dashboards see sustained churn. We drive 9 successive
+        // operator-modify-then-Replaced-ER cycles on the same parent
+        // — the 9th adoption is the first to push the queue past cap
+        // and trigger an eviction.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        long evicted = 0;
+        string? evictedAlgoType = null;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (instrument, ml) =>
+        {
+            if (instrument.Name == "trading.algo.modify_retired_child_evicted_total")
+                ml.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            foreach (var t in tags)
+                if (t.Key == "algoType") evictedAlgoType = t.Value as string;
+            Interlocked.Add(ref evicted, measurement);
+        });
+        listener.Start();
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var liveChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+
+        // Drive 9 modify→Replaced cycles. Bump NewQuantity to keep each
+        // modify operative without pushing past the default
+        // PriceCollarPercent=10 around the 30.0 reference price (which
+        // would only allow a few price ticks before tripping the
+        // collar — quantity-bump is the safe lever here).
+        for (int cycle = 0; cycle < 9; cycle++)
+        {
+            var newQty = 101 + cycle; // 101, 102, ..., 109
+            var preReplaceCount = mock.SubmittedReplaces.Count;
+            var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+            {
+                Content = JsonContent.Create(new { NewQuantity = newQty }),
+            };
+            modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var modResp = await http.SendAsync(modReq);
+            Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+            await WaitFor(
+                () => mock.SubmittedReplaces.Count > preReplaceCount
+                      && mock.SubmittedReplaces.Last().OriginalClOrdId == liveChild.ClOrdId,
+                TimeSpan.FromSeconds(3),
+                $"cycle {cycle}: engine did not dispatch CancelReplace for child {liveChild.ClOrdId}");
+            var replace = mock.SubmittedReplaces.Last();
+
+            await InjectReplacedEr(http, adminToken,
+                newClOrdId: replace.NewClOrdId,
+                origClOrdId: replace.OriginalClOrdId,
+                leavesQuantity: newQty);
+
+            // Wait for the new child to materialise in the book under
+            // the expected ClOrdID. The generic WaitForChildOtherThan
+            // would return any non-matching child (and prior cycles'
+            // Replaced-terminal children stay in the book), so we
+            // target the specific id from this cycle's replace
+            // intent to keep the loop deterministic across N>1 cycles.
+            var expectedNewId = replace.NewClOrdId;
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            Order? hydrated = null;
+            while (sw.Elapsed < TimeSpan.FromSeconds(3))
+            {
+                if (book.TryGet(expectedNewId, out var maybe) && maybe is not null)
+                {
+                    hydrated = maybe;
+                    break;
+                }
+                await Task.Delay(10);
+            }
+            Assert.NotNull(hydrated);
+            liveChild = hydrated!;
+            // Allow the engine consumer task to process the
+            // ChildExecutionObservedSignal that ApplyReplaceAccepted
+            // fans out — that's where RetireChildSlot runs. Without
+            // this brief delay the next cycle's modify can race the
+            // adoption (still-in-flight intent for the OLD id).
+            await Task.Delay(50);
+        }
+
+        // 9 adoptions on the same parent = 9 retired-child enqueues;
+        // cap=8 ⇒ exactly 1 eviction; the algoType tag is the lowercased
+        // AlgoType enum value (matches the algo.modify_rejected_total
+        // taxonomy already in use).
+        listener.RecordObservableInstruments();
+        Assert.Equal(1L, Interlocked.Read(ref evicted));
+        Assert.Equal("pegged", evictedAlgoType);
+    }
+
     // ───────────────────────── Helpers ─────────────────────────
 
     private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -156,7 +156,7 @@ public class AlgoModifyEndpointTests
         // Operator modify: bump the limit one tick up. Quantity stays.
         var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
         {
-            Content = JsonContent.Create(new { NewPrice = 30.5m, Reason = "test-op" }),
+            Content = JsonContent.Create(new { NewPrice = 30.5m, Reason = "OperatorModify" }),
         };
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var resp = await http.SendAsync(req);
@@ -237,7 +237,182 @@ public class AlgoModifyEndpointTests
             r => r.OriginalClOrdId == child.ClOrdId);
     }
 
+    [Fact]
+    public async Task Modify_InvalidReason_Returns400()
+    {
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            // Pass-1 review (#299) P2-A. Reason becomes a metric tag, so
+            // only the closed allowlist is accepted. An arbitrary
+            // operator string must be rejected at validation time.
+            Content = JsonContent.Create(new { NewPrice = 30.5m, Reason = "free-form-reason" }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // ────────────── Pass-1 review (#299) regressions ──────────────
+
+    [Fact]
+    public async Task Modify_FillOnOldChildBeforeReplacedEr_NoDoubleCounting()
+    {
+        // Pass-1 review (#299) P1-A. With the pre-fix code the engine
+        // re-targeted rt.LiveChildClOrdId to the new ClOrdID at
+        // dispatch time AND seeded ChildBookedCum[new] = old.Cum, so a
+        // Fill ER for the OLD child landing in the in-flight window
+        // booked the fill twice on the parent (once via the OLD child
+        // delta, once via the replacement's seeded cum carry-over on
+        // the next ER for the new child). The fix defers adoption to
+        // the actual Replaced-ER observation; parent.FilledQuantity
+        // must reflect exactly one fill.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var oldChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        // Operator modify in flight — engine writes WAL + registers
+        // intent + dispatches CancelReplace, but does NOT yet move
+        // rt.LiveChildClOrdId off the OLD child.
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        // Wait for the CancelReplace wire-call so the intent is
+        // registered before we drive the Replaced ER. The fill MUST
+        // land for the OLD child id BEFORE the Replaced ER hydrates
+        // the replacement — that is the race we're regression-testing.
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == oldChild.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never dispatched CancelReplace");
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == oldChild.ClOrdId);
+
+        // Partial fill of 30 on the OLD child while the replace is
+        // still in flight. The engine's child-ER path books delta=30
+        // against the OLD child slot (parent.FilledQuantity=30).
+        await InjectEr(http, adminToken, oldChild.ClOrdId, "PartialFill",
+            lastQty: 30, lastPx: 30.0m);
+        await Task.Delay(150);
+        var algoMid = await GetAlgo(http, token, algoId);
+        Assert.Equal(30L, algoMid.GetProperty("filledQuantity").GetInt64());
+
+        // Venue Replaced ER, carrying erCum=30 (venue echoes the OLD
+        // child's cum). Processor hydrates the new child with
+        // CumulativeQuantity=30, leaves=70, and fans out a
+        // ChildExecutionObservedSignal for the new ClOrdID; the engine
+        // adopts the replacement and seeds its booked-cum baseline so
+        // the carry-over is NOT re-booked.
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: 70,
+            cumQty: 30);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, oldChild.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+        Assert.Equal(30L, newChild.CumulativeQuantity);
+
+        // Settle, then assert parent cum still equals the single
+        // observed fill — no double-counting.
+        await Task.Delay(150);
+        var algoAfter = await GetAlgo(http, token, algoId);
+        Assert.Equal(30L, algoAfter.GetProperty("filledQuantity").GetInt64());
+        Assert.Equal(70L, algoAfter.GetProperty("remainingQuantity").GetInt64());
+    }
+
+    [Fact]
+    public async Task Modify_GatewayThrowsButVenueAccepted_LateReplacedErIsHonoured()
+    {
+        // Pass-1 review (#299) P1-B. CancelReplaceAsync exception is
+        // semantically AMBIGUOUS — the venue may already have accepted
+        // the request. The fix keeps the PendingReplacementRegistry
+        // intent + ownership link in place so a late Replaced ER still
+        // resolves correctly through the early intercept; previously
+        // the intent was rolled back, the Replaced ER bypassed the
+        // registry and the new child was silently dropped.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        // Arm the mock to throw on the cancel-replace dispatch BUT
+        // still enqueue the request first (mirrors a real ambiguous
+        // send — wire write succeeded, ack timed out / errored).
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        mock.ReplaceFailureInjector = _ => new InvalidOperationException("simulated SDK ambiguous send");
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var oldChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == oldChild.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never dispatched CancelReplace");
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == oldChild.ClOrdId);
+
+        // Disarm so any further dispatches don't trip the injector.
+        mock.ReplaceFailureInjector = null;
+
+        // Drive the late Replaced ER (venue had actually accepted the
+        // request before timing out). With the fix the intent is still
+        // registered, so the processor's early intercept fires, the
+        // new child is hydrated, and the engine adopts it as the live
+        // slot on the resulting ChildExecutionObservedSignal.
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, oldChild.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(30.5m, newChild.Price);
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+    }
+
     // ───────────────────────── Helpers ─────────────────────────
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
 
     private static async Task<string> PostAlgo(HttpClient http, string token, object body)
     {
@@ -273,7 +448,8 @@ public class AlgoModifyEndpointTests
     }
 
     private static async Task<HttpResponseMessage> InjectReplacedEr(
-        HttpClient http, string adminToken, ulong newClOrdId, ulong origClOrdId, long leavesQuantity)
+        HttpClient http, string adminToken, ulong newClOrdId, ulong origClOrdId, long leavesQuantity,
+        long? cumQty = null)
     {
         var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
         {
@@ -285,6 +461,7 @@ public class AlgoModifyEndpointTests
                 // Replaced injector arm (no Last fill on a replace ack).
                 LastQty = leavesQuantity,
                 OrigClOrdId = origClOrdId,
+                CumQty = cumQty,
             }),
         };
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -746,6 +746,138 @@ public class AlgoModifyEndpointTests
         Assert.Equal("pegged", evictedAlgoType);
     }
 
+    // ───── Pass-4 review (#299) P1 — ambiguous-send margin convergence ─────
+
+    [Fact]
+    public async Task Modify_GatewayThrowsButMarginEnabled_HoldsReservation_LateReplacedConvergesWithoutDoubleAdd_AndCompetingOrderRejectedForMargin()
+    {
+        // Pass-4 review (#299) P1. The pass-3 fix freed the upsize
+        // delta on an ambiguous gateway dispatch failure under the
+        // theory that holding it indefinitely was worse than the
+        // accounting drift. That created a window in which a
+        // competing order could consume the freed headroom; then a
+        // late Replaced ER would land in CommitReplace which adds
+        // the delta back on top of the already-reserved competing
+        // notional, pushing reserved exposure above the owner's
+        // cash cap.
+        //
+        // The pass-4 fix keeps the reservation tied to the intent:
+        //   - on ambiguous send, mark the entry as
+        //     AmbiguousMarginHeld but DO NOT call AbortReplace;
+        //   - on a late Replaced ER, CommitReplace converges
+        //     against the existing transient entry (no double-add);
+        //   - a competing order placed in the window between
+        //     ambiguous send and late ER must be rejected for
+        //     margin because the held delta is still counted.
+        //
+        // This test exercises all three.
+        var overrides = new Dictionary<string, string?>(Simulator())
+        {
+            ["Trading:Risk:Margin:Enabled"] = "true",
+            // Initial 100 @ 30 = 3000 reserved; modify to 30.5 needs
+            // delta = 50; cap of 3050 leaves NO headroom for the
+            // competing order's 1 @ 30 = 30 below.
+            [$"Trading:Risk:Margin:Initial:{TestAppFactory.TestUser}"] = "3050",
+            ["Trading:Risk:Default:MaxNotional"] = "999999999",
+        };
+        using var f = TestAppFactory.WithOverrides(overrides);
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        mock.ReplaceFailureInjector = _ => new InvalidOperationException("simulated SDK ambiguous send");
+
+        var algoId = await PostAlgo(http, token, PeggedBody(100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var oldChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        // Snapshot the reserved figure on the original alone (3000).
+        // The submit path reserves margin BEFORE dispatching the New
+        // event, so by the time the child is in the book + Working
+        // the reservation is normally in place — but the algo-engine
+        // consumer that originated the submit runs on a separate
+        // task, so the visible-in-book vs. visible-in-ledger orderings
+        // can briefly lag in either direction under CI load. Wait
+        // for convergence before asserting the baseline.
+        var margin = (B3.Trading.Application.Risk.ReserveOnSubmitMarginProvider)
+            f.Services.GetRequiredService<B3.Trading.Application.Risk.IReplaceMarginCoordinator>();
+        await WaitFor(
+            () => margin.ReservedForTesting(TestAppFactory.TestUser) == 3000m,
+            TimeSpan.FromSeconds(3),
+            $"expected reserved=3000m baseline, got {margin.ReservedForTesting(TestAppFactory.TestUser)}");
+
+        var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
+        {
+            Content = JsonContent.Create(new { NewPrice = 30.5m }),
+        };
+        modReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var modResp = await http.SendAsync(modReq);
+        Assert.Equal(HttpStatusCode.Accepted, modResp.StatusCode);
+
+        await WaitFor(
+            () => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == oldChild.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never dispatched CancelReplace");
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == oldChild.ClOrdId);
+        mock.ReplaceFailureInjector = null;
+
+        // Reservation MUST still hold the upsize delta of 50 (the
+        // pass-3 behaviour would have released it back to 3000).
+        // Give the engine consumer a beat to finish processing the
+        // ambiguous-failure arm.
+        await WaitFor(
+            () => margin.ReservedForTesting(TestAppFactory.TestUser) == 3050m,
+            TimeSpan.FromSeconds(3),
+            $"expected reserved=3050m post-ambiguous, got {margin.ReservedForTesting(TestAppFactory.TestUser)}");
+
+        // A competing order trying to consume the freed delta MUST
+        // be rejected for margin. /orders accepts the request with
+        // 202 and validates asynchronously (mirrors the existing
+        // pass-3 test's posture), so we assert on the ledger side:
+        // reserved must NOT increase above 3050 after the submission
+        // attempt — if margin had been freed back to 3000 by an
+        // erroneous AbortReplace, the 30-notional competing order
+        // would slot into the headroom and bump reserved to 3030.
+        var orderReq = new HttpRequestMessage(HttpMethod.Post, "/orders/")
+        {
+            Content = JsonContent.Create(new
+            {
+                Symbol = "PETR4",
+                Side = "Buy",
+                Type = "Limit",
+                Quantity = 1,
+                Price = 30.0m,
+            }),
+        };
+        orderReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        await http.SendAsync(orderReq);
+        // Give the submit pipeline a beat to attempt the reservation.
+        await Task.Delay(200);
+        Assert.Equal(3050m, margin.ReservedForTesting(TestAppFactory.TestUser));
+
+        // Now drive the late Replaced ER. CommitReplace must consume
+        // the existing transient delta — no double-add: reserved
+        // stays at 3050 (newRemainingNotional = 30.5 * 100 = 3050).
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
+
+        var newChild = await WaitForChildOtherThan(book, algoId, oldChild.ClOrdId,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
+        Assert.Equal(30.5m, newChild.Price);
+
+        await WaitFor(
+            () => margin.ReservedForTesting(TestAppFactory.TestUser) == 3050m,
+            TimeSpan.FromSeconds(3),
+            $"expected reserved=3050m post-Replaced (no double-add), got {margin.ReservedForTesting(TestAppFactory.TestUser)}");
+    }
+
     // ───────────────────────── Helpers ─────────────────────────
 
     private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoParentRuntimeTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoParentRuntimeTests.cs
@@ -1,0 +1,70 @@
+using AlgoParentRuntime = B3.Trading.Application.AlgoEngine.AlgoParentRuntime;
+
+namespace B3.Trading.Application.Tests.AlgoEngineTests;
+
+/// <summary>
+/// Pass-2 review (#299) P2. Targeted coverage for
+/// <c>AlgoParentRuntime.RetireChildSlot</c> — the bounded FIFO that
+/// caps <c>ChildBookedCum</c> growth across repeated modifies on the
+/// same live parent. Mirrors the <c>CancelledChildRing</c> sizing
+/// pattern from PR #296 (cap=8). Without the cap, each successful
+/// modify left an orphan row in <c>ChildBookedCum</c> indefinitely;
+/// the cap evicts the eldest retired slot AND drops its
+/// <c>ChildBookedCum</c> row when overflowed, while keeping recent
+/// retired slots so late stray ERs for them compute a zero delta
+/// instead of re-booking from a missing-key default of 0.
+/// </summary>
+public class AlgoParentRuntimeTests
+{
+    [Fact]
+    public void RetireChildSlot_BoundsChildBookedCumAtCap()
+    {
+        var rt = new AlgoParentRuntime();
+
+        // Simulate 10 successive modify-then-adoption cycles on the same
+        // parent. Each cycle hydrates a new child slot in ChildBookedCum
+        // (mirroring OnChildErAsync's `rt.ChildBookedCum[child.ClOrdId] =
+        // child.CumulativeQuantity` seed) and retires the OLD slot.
+        for (ulong childId = 1; childId <= 10; childId++)
+        {
+            rt.ChildBookedCum[childId] = 0;
+            if (childId > 1)
+                rt.RetireChildSlot(childId - 1);
+        }
+
+        // Cap=8 retired entries + 1 live (the 10th, never retired) = 9.
+        Assert.Equal(9, rt.ChildBookedCum.Count);
+        Assert.Equal(8, rt.RetiredChildSlots.Count);
+
+        // The eldest retired id (1) is evicted from BOTH the FIFO and
+        // ChildBookedCum on the 10th retire (which pushed the queue
+        // from 8 → 9, exceeding the cap by one).
+        Assert.False(rt.ChildBookedCum.ContainsKey(1UL));
+        Assert.DoesNotContain(1UL, rt.RetiredChildSlots);
+
+        // The 8 most-recently-retired ids (2..9) plus the live slot (10)
+        // remain accessible — a late stray ER for any retired id can
+        // still compute delta = cum - prevBooked == 0 against the row.
+        for (ulong stillPresent = 2; stillPresent <= 10; stillPresent++)
+            Assert.True(rt.ChildBookedCum.ContainsKey(stillPresent),
+                $"ChildBookedCum should still contain recently-retired/live id {stillPresent}.");
+    }
+
+    [Fact]
+    public void RetireChildSlot_BelowCap_DoesNotEvict()
+    {
+        var rt = new AlgoParentRuntime();
+        for (ulong childId = 1; childId <= 4; childId++)
+        {
+            rt.ChildBookedCum[childId] = 0;
+            if (childId > 1)
+                rt.RetireChildSlot(childId - 1);
+        }
+
+        // 3 retired + 1 live = 4 rows; nothing evicted (cap=8).
+        Assert.Equal(4, rt.ChildBookedCum.Count);
+        Assert.Equal(3, rt.RetiredChildSlots.Count);
+        for (ulong id = 1; id <= 4; id++)
+            Assert.True(rt.ChildBookedCum.ContainsKey(id));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoParentRuntimeTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoParentRuntimeTests.cs
@@ -67,4 +67,41 @@ public class AlgoParentRuntimeTests
         for (ulong id = 1; id <= 4; id++)
             Assert.True(rt.ChildBookedCum.ContainsKey(id));
     }
+
+    [Fact]
+    public void RetireChildSlot_FirstEvictionFlipsLatchOnce()
+    {
+        // Pass-3 review (#299) P2. The one-shot warn latch flips on the
+        // FIRST eviction (transitions the queue from cap → cap+1) and
+        // stays latched on subsequent evictions so callers can emit a
+        // single warn per parent without log spam.
+        var rt = new AlgoParentRuntime();
+
+        // Fill the FIFO up to the cap (8 retired entries). The 9th
+        // enqueue is the first that pushes past cap and evicts.
+        for (ulong childId = 1; childId <= 8; childId++)
+        {
+            rt.ChildBookedCum[childId] = 0;
+            rt.RetireChildSlot(childId, out var first0);
+            Assert.False(first0);
+        }
+        Assert.False(rt.RetiredEvictionLogged);
+
+        // 9th retire: queue grows to 9, the eldest (id=1) is evicted
+        // → first eviction returns true exactly once.
+        rt.ChildBookedCum[9UL] = 0;
+        var evicted1 = rt.RetireChildSlot(9UL, out var firstOverflow);
+        Assert.Equal(1, evicted1);
+        Assert.True(firstOverflow);
+        Assert.True(rt.RetiredEvictionLogged);
+        Assert.False(rt.ChildBookedCum.ContainsKey(1UL));
+
+        // 10th retire: still overflowing — eviction happens but latch
+        // stays armed; the firstEviction out-param must NOT re-arm.
+        rt.ChildBookedCum[10UL] = 0;
+        var evicted2 = rt.RetireChildSlot(10UL, out var firstAgain);
+        Assert.Equal(1, evicted2);
+        Assert.False(firstAgain);
+        Assert.True(rt.RetiredEvictionLogged);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -192,5 +194,111 @@ public class AlgoSchedulerTests
         algos.TryAdd(NewTwap(1, sliceCount: 4));
         scheduler.Tick();
         Assert.Single(Drain(queue));
+    }
+
+    // ───────── Pass-4 review (#299) P1 — ambiguous-send TTL sweep ─────────
+
+    [Fact]
+    public async Task SweepAmbiguousReplaceIntents_ExpiredEntry_ReleasesReservationAndBumpsMetric()
+    {
+        // Pass-4 review (#299) P1. Approach A+TTL convergence: an
+        // AlgoEngine modify whose gateway dispatch threw post-Prepare
+        // intentionally KEEPS the upsize-delta reservation +
+        // PendingReplacementRegistry intent so a late Replaced ER can
+        // converge without re-checking capacity. If no terminal ER
+        // arrives within RiskOptions.Margin.AmbiguousReplaceTtl, the
+        // AlgoScheduler sweep MUST release the reservation (or it
+        // leaks until the parent terminates) and bump
+        // algo.modify_ambiguous_intent_expired_total.
+        var algos = new AlgoBook();
+        var orders = new WorkingOrderBook();
+        var queue = new AlgoSignalQueue();
+        var clock = new MutableClock(Start);
+
+        // Owner with a known cash baseline; original 100 @ 30 = 3000
+        // reserved on submit; modify upsizes price to 30.5 = 3050,
+        // delta = 50 reserved at Prepare and held thereafter.
+        var risk = new RiskOptions();
+        risk.Margin.Enabled = true;
+        risk.Margin.AmbiguousReplaceTtl = TimeSpan.FromSeconds(30);
+#pragma warning disable CS0618 // Initial is the transition fallback used by the unit-test composition.
+        risk.Margin.Initial["alice"] = 10_000m;
+#pragma warning restore CS0618
+        var monitor = new StaticOptionsMonitor<RiskOptions>(risk);
+        var margin = new ReserveOnSubmitMarginProvider(monitor,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        var reg = new PendingReplacementRegistry();
+
+        // Seed the original reservation as the submit path would have done.
+        var bought = await margin.TryReserveAsync(
+            clOrdId: 100UL,
+            new RiskContext(new EndClientId("alice"), Firm, "PETR4",
+                OrderSide.Buy, OrderType.Limit, 100, 30m),
+            CancellationToken.None);
+        Assert.True(bought.Approved);
+        Assert.Equal(3000m, margin.ReservedForTesting("alice"));
+
+        // Prepare a replace upsize to 30.5 (delta = 50). The transient
+        // entry under newClOrdId=200 holds the delta; _reserved=3050.
+        var prep = await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(
+            originalClOrdId: 100UL, newClOrdId: 200UL,
+            owner: new EndClientId("alice"),
+            newRemainingNotional: 3050m,
+            CancellationToken.None);
+        Assert.True(prep.Approved);
+        Assert.Equal(3050m, margin.ReservedForTesting("alice"));
+
+        // Simulate the pass-1 ambiguous-send: intent registered with
+        // a known CreatedAt, then the gateway dispatch threw and the
+        // engine marked the entry as still holding margin.
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: 100UL, NewClOrdId: 200UL,
+            Owner: new EndClientId("alice"),
+            Symbol: "PETR4", SecurityId: 4321UL,
+            Side: OrderSide.Buy, Type: OrderType.Limit,
+            NewQuantity: 100, NewPrice: 30.5m, FirmId: Firm,
+            ParentAlgoId: null, AlgoSliceSeq: null);
+        Assert.True(reg.TryAdd(intent, clock.GetUtcNow()));
+        Assert.True(reg.MarkAmbiguousMarginHeld(200UL));
+
+        var scheduler = new AlgoScheduler(algos, orders, queue, clock,
+            AlgoScheduler.DefaultTickInterval,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<AlgoScheduler>.Instance,
+            replacements: reg,
+            replaceMargin: margin,
+            riskOptions: monitor);
+
+        // Within TTL: sweep does nothing.
+        scheduler.SweepAmbiguousReplaceIntents(clock.GetUtcNow().AddSeconds(10));
+        Assert.True(reg.IsOriginalInFlight(100UL));
+        Assert.Equal(3050m, margin.ReservedForTesting("alice"));
+
+        // Past TTL: sweep releases the reservation + clears the intent.
+        long expiredCount = 0;
+        string? expiredAlgoType = null;
+        using var listener = new System.Diagnostics.Metrics.MeterListener();
+        listener.InstrumentPublished = (inst, ml) =>
+        {
+            if (inst.Name == "trading.algo.modify_ambiguous_intent_expired_total")
+                ml.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<long>((_, m, tags, _) =>
+        {
+            foreach (var t in tags)
+                if (t.Key == "algoType") expiredAlgoType = t.Value as string;
+            Interlocked.Add(ref expiredCount, m);
+        });
+        listener.Start();
+
+        scheduler.SweepAmbiguousReplaceIntents(clock.GetUtcNow().AddSeconds(31));
+
+        Assert.False(reg.IsOriginalInFlight(100UL));
+        // Released: _reserved drops back to the original 3000m.
+        Assert.Equal(3000m, margin.ReservedForTesting("alice"));
+        listener.RecordObservableInstruments();
+        Assert.Equal(1, Interlocked.Read(ref expiredCount));
+        // ParentAlgoId is null in this synthetic test, so the tag
+        // falls back to "unknown" (covered by the lookup branch).
+        Assert.Equal("unknown", expiredAlgoType);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/AlgoSchedulerTests.cs
@@ -301,4 +301,94 @@ public class AlgoSchedulerTests
         // falls back to "unknown" (covered by the lookup branch).
         Assert.Equal("unknown", expiredAlgoType);
     }
+
+    // ───────── Pass-5 review (#299) P2 — sweep iterates ambiguous-only index ─────────
+
+    [Fact]
+    public void SweepExpiredAmbiguous_OnlyInspectsAmbiguousEntries_NotEntireRegistry()
+    {
+        // Pass-5 review (#299) P2. The pre-pass-5 sweep enumerated
+        // ConcurrentDictionary<ulong, Entry> in full every 100ms
+        // tick, even though virtually every entry was a normal in-
+        // flight modify (AmbiguousMarginHeld=false). Pass-5 indexes
+        // the ambiguous-flagged subset separately so the sweep is
+        // O(ambiguous) — typically zero — instead of O(all pending
+        // modifies). This test asserts the inspection count tracked
+        // by the registry never exceeds the ambiguous subset, no
+        // matter how many normal entries coexist.
+        var reg = new PendingReplacementRegistry();
+        var now = new DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+
+        // 1000 normal in-flight modifies; the sweep MUST NOT enumerate any.
+        for (ulong i = 1; i <= 1000; i++)
+        {
+            var intent = new OrderReplacementIntent(
+                OriginalClOrdId: i, NewClOrdId: 100_000 + i,
+                Owner: new EndClientId("alice"),
+                Symbol: "PETR4", SecurityId: 4321UL,
+                Side: OrderSide.Buy, Type: OrderType.Limit,
+                NewQuantity: 10, NewPrice: 30m, FirmId: Firm,
+                ParentAlgoId: null, AlgoSliceSeq: null);
+            Assert.True(reg.TryAdd(intent, now));
+        }
+
+        // 3 ambiguous entries, all already past TTL.
+        var ambiguousIds = new ulong[] { 200_001, 200_002, 200_003 };
+        for (var i = 0; i < ambiguousIds.Length; i++)
+        {
+            var ambiguousNew = ambiguousIds[i];
+            var intent = new OrderReplacementIntent(
+                OriginalClOrdId: 9_000UL + (ulong)i, NewClOrdId: ambiguousNew,
+                Owner: new EndClientId("alice"),
+                Symbol: "PETR4", SecurityId: 4321UL,
+                Side: OrderSide.Buy, Type: OrderType.Limit,
+                NewQuantity: 10, NewPrice: 30m, FirmId: Firm,
+                ParentAlgoId: null, AlgoSliceSeq: null);
+            Assert.True(reg.TryAdd(intent, now));
+            Assert.True(reg.MarkAmbiguousMarginHeld(ambiguousNew, now));
+        }
+
+        Assert.Equal(1003, reg.CountForTesting);
+        Assert.Equal(3, reg.AmbiguousCountForTesting);
+
+        var expired = reg.SweepExpiredAmbiguous(now.AddMinutes(5), TimeSpan.FromMinutes(1));
+
+        // Sweep must have inspected ONLY the 3 ambiguous entries —
+        // not the 1000 normal ones. If a future refactor reverts to
+        // iterating _byNewClOrdId, this count jumps to 1003 and the
+        // assertion fails. Mirrors the pass-2/pass-3 lesson: the
+        // test must FAIL if the optimisation is removed.
+        Assert.Equal(3L, reg.LastSweepInspectedCountForTesting);
+        Assert.Equal(3, expired.Count);
+        // The 1000 normal entries are NOT consumed by the sweep —
+        // they remain in the registry as long-lived legitimate
+        // in-flight modifies.
+        Assert.Equal(1000, reg.CountForTesting);
+        Assert.Equal(0, reg.AmbiguousCountForTesting);
+    }
+
+    [Fact]
+    public void SweepExpiredAmbiguous_EmptyAmbiguousIndex_IsZeroCostNoOp()
+    {
+        // No ambiguous entries, even if many normal entries: sweep
+        // exits immediately and inspects zero entries.
+        var reg = new PendingReplacementRegistry();
+        var now = new DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+        for (ulong i = 1; i <= 500; i++)
+        {
+            var intent = new OrderReplacementIntent(
+                OriginalClOrdId: i, NewClOrdId: 100_000 + i,
+                Owner: new EndClientId("alice"),
+                Symbol: "PETR4", SecurityId: 4321UL,
+                Side: OrderSide.Buy, Type: OrderType.Limit,
+                NewQuantity: 10, NewPrice: 30m, FirmId: Firm,
+                ParentAlgoId: null, AlgoSliceSeq: null);
+            Assert.True(reg.TryAdd(intent, now));
+        }
+
+        var expired = reg.SweepExpiredAmbiguous(now.AddMinutes(5), TimeSpan.FromMinutes(1));
+
+        Assert.Empty(expired);
+        Assert.Equal(0L, reg.LastSweepInspectedCountForTesting);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1183,4 +1183,52 @@ public class OrderModifyMarginAndProcessorTests
 
         Assert.Equal(600m, margin.ReservedForTesting("alice"));
     }
+
+    // ───── Pass-4 review (#299) P1 — Canceled ER for orig clears ambiguous intent ─────
+
+    [Fact]
+    public async Task Processor_CancelledOrigWithPendingReplaceIntent_ReleasesHeldReservationAndClearsIntent()
+    {
+        // Pass-4 review (#299) P1. Scenario: AlgoEngine modify
+        // dispatched ambiguous (gateway threw), so the engine KEEPS
+        // both the PendingReplacementRegistry intent AND the held
+        // upsize-delta margin reservation. The venue ultimately
+        // emits a Cancelled ER for the ORIG (i.e. the venue
+        // accepted the cancel half of the cancel-replace but
+        // dropped the replacement — or never registered the
+        // replacement at all). The ER processor must now release
+        // the still-held upsize delta + clear the pending intent
+        // so a stray late ER under the never-created new ClOrdID
+        // is not misinterpreted as a replace confirmation.
+        var (proc, ownership, book, reg, margin, _) = BuildProcessor();
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        book.TryAdd(orig);
+        orig.MarkWorking();
+        ownership.Register(1UL, owner);
+        Assert.True((await margin.TryReserveAsync(1UL, BuyCtx("alice", 30m, 100), default)).Approved);
+        Assert.Equal(3000m, margin.ReservedForTesting("alice"));
+
+        // Pass-1 ambiguous-send state: intent in the registry +
+        // Prepare-held upsize delta + AmbiguousMarginHeld marker.
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30.5m), DateTimeOffset.UtcNow));
+        Assert.True((await ((IReplaceMarginCoordinator)margin).PrepareReplaceAsync(
+            1UL, 2UL, owner, 3050m, default)).Approved);
+        Assert.True(reg.MarkAmbiguousMarginHeld(2UL));
+        Assert.Equal(3050m, margin.ReservedForTesting("alice"));
+
+        // Venue Cancelled the orig — the cancel-replace's "replace"
+        // half never materialised. Drive a Canceled ER for the orig.
+        proc.Apply(1UL, ExecKind.Canceled, leaves: 0, cumQty: 0,
+                   lastQty: 0, lastPx: 0m, rejectReason: null);
+
+        // Original transitioned + upsize delta released back to 0.
+        Assert.Equal(OrderStatus.Cancelled, orig.Status);
+        Assert.Equal(0m, margin.ReservedForTesting("alice"));
+        // Intent cleared from both the new-ClOrdID and orig indexes,
+        // so neither a stray ER nor a follow-up modify on the same
+        // orig is blocked by phantom in-flight state.
+        Assert.False(reg.TryGet(2UL, out _));
+        Assert.False(reg.IsOriginalInFlight(1UL));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1319,4 +1319,145 @@ public class OrderModifyMarginAndProcessorTests
         // because reserved stayed at 0. That's the regression the
         // test guards against.
     }
+
+    // ─────────── Pass-6 review (#299) P1 — snapshot capture/restore re-establishes held reservation ───────────
+
+    [Fact]
+    public async Task StateSnapshotter_CaptureRestore_AmbiguousMarginHeldEntry_ReEstablishesReservation_BlocksCompetingOrderPostRestart()
+    {
+        // Pass-6 review (#299) P1. The pass-5 fix made the held
+        // reservation durable via OrderReplaceAmbiguousMarginHeldEvent
+        // so a snapshot-less / WAL-tail-only recovery could re-call
+        // PrepareReplaceAsync. But CaptureRaw never projected the
+        // PendingReplacementRegistry into the persisted snapshot:
+        // when the periodic snapshotter ran AFTER the ambiguous mark
+        // its Seq advanced past the OrderReplaceAmbiguousMarginHeldEvent,
+        // recovery loaded the snapshot and started its WAL read past
+        // that event, the snapshot didn't carry the entry, and so the
+        // post-restart sweep had no ambiguous entry at all — a late
+        // Replaced/Rejected ER missed the registry path and the
+        // reservation leaked (or worse, was returned to free capacity
+        // by a competing order winning the race).
+        //
+        // The pass-6 fix persists every PendingReplacementRegistry
+        // entry — including the AmbiguousMarginHeld flag + HeldAtUtc +
+        // NewRemainingNotional — in the snapshot, AND re-invokes
+        // PrepareReplaceAsync on restore for every ambiguous-flagged
+        // entry. This test exercises the snapshot path end-to-end
+        // (no WAL replay) and asserts the same over-allocation
+        // invariant the pass-5 WAL-replay test guards.
+        //
+        // Owner cap = 3050; original Buy 100 @ 30 (3000); modify
+        // requests 100 @ 30.5 → new notional 3050 (upsize delta 50).
+        // After the ambiguous send, the upsize delta is held under
+        // the new ClOrdID alongside the still-reserved original
+        // 3000 — total 3050 = full cap. Post-restart we only model
+        // the held NEW-side reservation (the original reservation,
+        // like every plain OrderSubmittedEvent reservation, is NOT
+        // durable across restart per the documented semantics —
+        // only the ambiguous-held slot is). So the new-side
+        // re-reservation alone must consume 3050 of the 3050 cap.
+
+        // ── Pre-crash world ──
+        var pre = new TestWorld(initial: 3050m);
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM");
+        pre.Book.TryAdd(orig);
+        orig.MarkWorking();
+        pre.Ownership.Register(1UL, owner);
+        Assert.True((await pre.Margin.TryReserveAsync(1UL, BuyCtx("alice", 30m, 100), default)).Approved);
+        Assert.True(pre.Replacements.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30.5m),
+            createdAt: new DateTimeOffset(2026, 1, 1, 8, 59, 0, TimeSpan.Zero)));
+        Assert.True((await ((IReplaceMarginCoordinator)pre.Margin).PrepareReplaceAsync(
+            1UL, 2UL, owner, 3050m, default)).Approved);
+        var heldAt = new DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+        Assert.True(pre.Replacements.MarkAmbiguousMarginHeld(2UL, heldAt, newRemainingNotional: 3050m));
+
+        // Periodic snapshot captured AFTER the ambiguous mark.
+        var snap = pre.Snapshotter.Capture(seq: 42L);
+
+        // Sanity: snapshot carries the entry (the bug pre-pass-6 was
+        // exactly that this list was empty).
+        Assert.Single(snap.PendingReplacements);
+        var persisted = snap.PendingReplacements[0];
+        Assert.Equal(2UL, persisted.NewClOrdId);
+        Assert.True(persisted.AmbiguousMarginHeld);
+        Assert.Equal(heldAt, persisted.AmbiguousAtUtc);
+        Assert.Equal(3050m, persisted.NewRemainingNotional);
+
+        // ── Crash + restart ── fresh world (clean ownership map,
+        // empty book, zero-reservation margin provider, empty
+        // registry). No WAL tail; recovery is snapshot-only.
+        var post = new TestWorld(initial: 3050m);
+        Assert.Equal(0m, post.Margin.ReservedForTesting("alice"));
+        post.Snapshotter.Restore(snap);
+
+        // Reservation re-established to the full held delta — exactly
+        // what the pre-crash dispatch had reserved under the new
+        // ClOrdID — and the registry entry is back in the ambiguous
+        // state so the post-restart TTL sweep ages from the same
+        // wall-clock the pre-crash sweep would have observed.
+        Assert.Equal(3050m, post.Margin.ReservedForTesting("alice"));
+        Assert.Equal(1, post.Replacements.AmbiguousCountForTesting);
+        Assert.True(post.Replacements.TryGet(2UL, out var rehydrated));
+        Assert.NotNull(rehydrated);
+        Assert.Equal(1UL, rehydrated!.OriginalClOrdId);
+
+        // A competing order trying to grab the (would-be-free)
+        // capacity MUST be rejected.
+        var competing = await post.Margin.TryReserveAsync(
+            clOrdId: 99UL,
+            new RiskContext(owner, "FIRM", "PETR4",
+                OrderSide.Buy, OrderType.Limit, 1, 30.0m),
+            CancellationToken.None);
+        Assert.False(competing.Approved);
+
+        // Late Replaced ER under the new ClOrdID converges through
+        // the registry path: CommitReplace finalises the reservation
+        // at the venue-confirmed leaves (100 @ 30.5 = 3050) so the
+        // owner stays fully reserved. Without the snapshot
+        // re-hydration above this branch would land in the
+        // "no intent" fallback and silently drop the held delta.
+        var processor = new ExecutionReportProcessor(
+            post.Ownership, post.Book, new PositionKeeper(), new CaptureSink(), post.Margin,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null, cash: null,
+            replacements: post.Replacements, replaceMargin: post.Margin);
+        processor.Apply(2UL, ExecKind.Replaced, leaves: 100, cumQty: 0, lastQty: 0,
+                        lastPx: 0m, rejectReason: null, origClOrdId: 1UL);
+        Assert.Equal(3050m, post.Margin.ReservedForTesting("alice"));
+        Assert.False(post.Replacements.TryGet(2UL, out _));
+
+        // Regression guard: if the snapshot capture or the restore
+        // re-hydration is removed (the pre-pass-6 bug), the snapshot
+        // would carry no entry, post.Restore would no-op, reserved
+        // would stay at 0, competing would be Approved, and the
+        // Replaced ER would land outside the registry path. Every
+        // assertion above flips — exactly the snapshot-tail
+        // recovery hole pass-6 closes.
+    }
+
+    private sealed class TestWorld
+    {
+        public OrderOwnershipMap Ownership { get; } = new();
+        public WorkingOrderBook Book { get; } = new();
+        public PositionKeeper Positions { get; } = new();
+        public ReserveOnSubmitMarginProvider Margin { get; }
+        public PendingReplacementRegistry Replacements { get; } = new();
+        public StateSnapshotter Snapshotter { get; }
+
+        public TestWorld(decimal initial)
+        {
+            var opts = new RiskOptions();
+            opts.Margin.Enabled = true;
+            opts.Margin.Initial["alice"] = initial;
+            var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+            Margin = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+            Snapshotter = new StateSnapshotter(
+                Book, Positions, new KillSwitchService(), new SymbolHaltService(), new SessionPhaseService(),
+                new ClOrdIdPrefixRegistry(), Ownership, new AlgoBook(), new AlgoIdRegistry(), new CashLedger(),
+                replacements: Replacements,
+                replaceMargin: Margin);
+        }
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1231,4 +1231,92 @@ public class OrderModifyMarginAndProcessorTests
         Assert.False(reg.TryGet(2UL, out _));
         Assert.False(reg.IsOriginalInFlight(1UL));
     }
+
+    // ─────────── Pass-5 review (#299) P1 — restart re-establishes held reservation ───────────
+
+    [Fact]
+    public async Task EventReplayer_AmbiguousMarginHeldEvent_ReEstablishesReservation_BlocksCompetingOrderPostRestart()
+    {
+        // Pass-5 review (#299) P1. The pass-4 fix kept the upsize-
+        // delta margin reservation tied to the in-memory ambiguous-
+        // held flag so a late Replaced ER could converge without
+        // breaking the over-allocation invariant. But the flag lived
+        // ONLY in memory: a crash between the OrderReplaceRequestedEvent
+        // append and the next periodic snapshot lost it, replay re-
+        // added the intent without the flag (so the TTL sweep never
+        // reaped it), and capacity returned post-restart while the
+        // venue might still send Replaced — at which point
+        // CommitReplace landed in the "neither side has owner" branch
+        // and dropped the reservation entirely, or (after Prepare ran
+        // again) double-added it.
+        //
+        // Pass-5 fixes the durability hole with a dedicated WAL event
+        // that the EventReplayer translates back into both the
+        // PrepareReplaceAsync re-reservation and the in-memory flag
+        // mark. This test exercises the replay path directly and
+        // asserts that a competing order placed POST-replay cannot
+        // consume the held capacity — i.e. the over-allocation
+        // invariant is preserved across the crash.
+        //
+        // Owner cap = 3050 (matches the pass-4 endpoint test); held
+        // delta = full new notional of 3050 because the original's
+        // pre-crash reservation is NOT replayed (per the documented
+        // "reservations are not durable across restart" semantics of
+        // OrderSubmittedEvent — only the held ambiguous slot is).
+        var (_, ownership, book, reg, margin, _) = BuildProcessor(initial: 3050m);
+        var processor = new ExecutionReportProcessor(
+            ownership, book, new PositionKeeper(), new CaptureSink(), margin,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null, cash: null,
+            replacements: reg, replaceMargin: margin);
+
+        // POST-RESTART world: nothing reserved yet. The intent has
+        // been re-registered by replay of the OrderReplaceRequestedEvent
+        // (mirror that shape here directly).
+        var heldAt = new DateTimeOffset(2026, 1, 1, 9, 0, 0, TimeSpan.Zero);
+        Assert.True(reg.TryAdd(BuyLimitIntent(1UL, 2UL, "alice", 100, 30.5m), heldAt));
+        Assert.Equal(0m, margin.ReservedForTesting("alice"));
+
+        var replayer = new EventReplayer(book, ownership,
+            new KillSwitchService(), new SymbolHaltService(), new SessionPhaseService(),
+            processor, new AlgoBook(),
+            new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(),
+            replacements: reg,
+            replaceMargin: margin);
+
+        // Replay the durable ambiguous-held event.
+        replayer.Apply(new OrderReplaceAmbiguousMarginHeldEvent
+        {
+            NewClOrdId = 2UL,
+            OriginalClOrdId = 1UL,
+            EndClientId = "alice",
+            NewRemainingNotional = 3050m,
+            HeldAtUtc = heldAt,
+        });
+
+        // Reservation re-established to the full held delta (3050) —
+        // exactly the value that would have been held pre-crash.
+        Assert.Equal(3050m, margin.ReservedForTesting("alice"));
+
+        // A competing order trying to grab the freed capacity MUST
+        // be rejected: only 0 of the 3050 cap is available.
+        var owner = new EndClientId("alice");
+        var competing = await margin.TryReserveAsync(
+            clOrdId: 99UL,
+            new RiskContext(owner, "FIRM", "PETR4",
+                OrderSide.Buy, OrderType.Limit, 1, 30.0m),
+            CancellationToken.None);
+        Assert.False(competing.Approved);
+
+        // The intent is back in the ambiguous-held state so the
+        // post-restart TTL sweep can converge on the same deadline
+        // the pre-crash sweep would have observed.
+        Assert.Equal(1, reg.AmbiguousCountForTesting);
+
+        // Sanity: if the persistence is REMOVED (i.e. the replay
+        // case branch goes away, simulating pre-pass-5 behaviour),
+        // this assertion flips — competing would be approved
+        // because reserved stayed at 0. That's the regression the
+        // test guards against.
+    }
 }


### PR DESCRIPTION
Closes #285 (operator endpoint deliverable).

## Summary
Adds an operator-driven cancel-replace endpoint for live algo children, replacing the previous cancel+place pattern with a single `CancelReplaceAsync` flow that preserves the venue's time-priority on the order book.

## Surface
- `POST /algo/{id}/modify` — owner-only (mirrors DELETE auth), enqueues an `AlgoModifyRequestedSignal` onto the engine reactor. Body: `{ newQuantity?, newPrice?, childClOrdId?, reason? }`. At least one of `newQuantity`/`newPrice` is required.
  - **404** on unknown / cross-owner.
  - **409** on terminal / cancelling algos.
  - **400** on missing both fields or non-positive qty.
  - **503** when draining or signal queue full.
  - **202** `{ algoId, status, reason }` on accept.
- New WAL event `AlgoChildModifiedEvent` (additive, discriminator `algo.child.modified`).
- New metrics `trading.algo.child_modifies_total` and `trading.algo.modify_rejected_total`, tagged `algoType` + `reason`.

## Engine
`AlgoEngine` takes an optional `PendingReplacementRegistry` (DI singleton already registered) and routes the new signal through `OnModifyRequestedAsync`. `TryReplaceChildAsync` mirrors the dispatcher / registry / ownership plumbing in `OrderModifyService` so the `ExecutionReportProcessor` Replaced-ack intercept hydrates the replacement order under the new ClOrdID while preserving `ParentAlgoId` / `AlgoSliceSeq`. Re-targets `rt.LiveChildClOrdId` to the new id before returning so the inbound non-terminal `ChildExecutionObservedSignal` is a no-op.

### Race semantics (modify-during-fill)
Resolved on the consumer thread. If `newQuantity ≤ cum` at consume time the modify is rejected gracefully (reason `qty_below_filled`); the operator can retry against the residue. Reject taxonomy (metric tag values): `algo_terminal`, `algo_cancelling`, `no_live_child`, `child_not_found`, `child_not_owned`, `child_terminal`, `qty_below_filled`, `registry_unavailable`, `already_in_flight`, `wal_backpressure`, `gateway_failed`.

## Simulator
`SimulatorEndpoint` now accepts `Type=Replaced` with an `OrigClOrdId` field so integration tests can drive the convergence path through the existing ER injection surface.

## Tests
6 new tests in `AlgoModifyEndpointTests.cs`:
- 404 on unknown algo.
- 400 on missing both fields.
- 400 on non-positive quantity.
- 409 on terminal algo.
- Happy path: `POST /algo/{id}/modify` → engine emits `CancelReplaceAsync` (`SubmittedReplaces`) → `Replaced` ER injection → new child appears in book at new price under the new ClOrdID.
- Race: `newQuantity ≤ cum` → no wire CancelReplace issued.

**Full suite**: 1,527 passed / 0 failed / 30 skipped (conformance suite is config-gated). `dotnet format --verify-no-changes` clean.

## Scope deferral
The Pegged repeg internal retrofit (swapping `_gateway.CancelAsync` inside `EvaluatePeggedRepegAsync` for `CancelReplaceAsync`) is intentionally deferred. The `RepegPending` / `LastRepegCancelledChildId` / `PeggedRepegBook` state machine + WAL Started/Resolved sequencing in `OnChildErAsync` is tightly coupled to the Cancelled-ER path and the ~22 existing pegged tests assert `SubmittedCancels` semantics. Shipping that retrofit alongside this PR would balloon the diff and risk regressing the existing repeg recovery / orphan-prune correctness; it will land as a focused follow-up. The operator endpoint already lets external orchestration drive cancel-replace semantics on Pegged children today. VWAP/POV similarly deferred — none have an internal repeg loop today, so the deferral is no-op for them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

## Pass-1 review follow-ups

Addressed in commit on top of this PR (see [6ec2ffa](../commit/6ec2ffa)):

- **P1-A** Premature parent re-target / double-book on Fill before Replaced. Adoption is now deferred to the actual Replaced-ER observation (in `OnChildErAsync`), so a Fill ER for the OLD child during the in-flight window books exactly once. New regression test `Modify_FillOnOldChildBeforeReplacedEr_NoDoubleCounting`.
- **P1-B** Send-failure path no longer consumes the `PendingReplacementRegistry` intent — a late `Replaced` ER after an ambiguous `CancelReplaceAsync` exception is still resolved correctly. Surfaced via new counter `trading.algo.modify_send_ambiguous_total` (tagged by `algoType` only). New regression test `Modify_GatewayThrowsButVenueAccepted_LateReplacedErIsHonoured`. The `gateway_failed` reject reason is retired (the path is ambiguous, not a definitive reject).
- **P2-A** `reason` is now constrained to a closed allowlist at the REST boundary (`OperatorModify`, `AlgoInternal`, `Reconciliation`) so it cannot blow up metric-tag cardinality. Unknown values return 400. The audit `AlgoChildModifiedEvent` still records the normalised value verbatim. New regression test `Modify_InvalidReason_Returns400`.
- **P2-B** Pegged retrofit deferred — tracked in **#300**.

Updated suite: **1,530 passed / 0 failed / 30 skipped**.
