### PR TITLE
feat(#301): sub-account model (master-broker)

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -112,6 +112,17 @@ public static class AuthEndpoints
             // when known (so P&L doesn't show a fake gain/loss); zero is
             // a fine fallback (matches the dogfood overlay's choice for
             // symbols without a configured ref price).
+            //
+            // PR #316 P1. Signup seeds intentionally land in
+            // <see cref="PositionKeeper.DefaultFirmId"/> because
+            // <see cref="PositionSeedOptions"/> has no firm field (signup
+            // is firm-agnostic — the seed is the "every user starts here"
+            // overlay, not a per-firm prefund). A signup that races a
+            // firm-scoped fill on the same JWT sub stays partitioned:
+            // the fill lands in the user's actual firm bucket, the seed
+            // sits in default and surfaces only to clients that
+            // authenticate without a firm claim. Adding a per-firm seed
+            // config is tracked as a follow-up (out of scope here).
             foreach (var (symbol, qty) in SignupSeedPositions)
             {
                 refPrice.TryGet(symbol, out var avgPx);

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -192,10 +192,12 @@ public static class OrdersEndpoints
             }
 
             var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
             var result = await modifier.ModifyAsync(
                 new OrderModifyRequest(
                     owner, clOrdIdU, req.Quantity, req.Price,
-                    tif, req.StopPrice, req.GoodTillDate),
+                    tif, req.StopPrice, req.GoodTillDate,
+                    FirmId: firm),
                 ct);
 
             return result.Kind switch
@@ -241,10 +243,14 @@ public static class OrdersEndpoints
                 return Results.NotFound();
 
             var owner = ResolveOwner(ctx, registry);
+            var firm = ResolveFirm(ctx);
             // Sub-issue #171 (E): REST cancels now go through the WAL-
             // durable OrderCancelRequestedEvent path (RFC §4.6 / §4.8).
             // botOrigin is null — REST is not a bot session.
-            var result = await canceller.CancelAsync(owner, clOrdIdU, ct);
+            // PR #316 P1 — pass firm so the service rejects (as
+            // NotFound) cancels that target an order owned by a
+            // different firm, matching GET /orders scoping.
+            var result = await canceller.CancelAsync(owner, clOrdIdU, ct, firmId: firm);
             return result.Kind switch
             {
                 OrderCancelResultKind.Accepted => Results.NoContent(),

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -18,7 +18,10 @@ public static class OrdersEndpoints
         group.MapGet("/", (HttpContext ctx, WorkingOrderBook book, EndClientRegistry registry) =>
         {
             var owner = ResolveOwner(ctx, registry);
-            var orders = book.ForEndClient(owner).Select(o => o.ToDto());
+            var firm = ResolveFirm(ctx);
+            // PR #316 P1. Scope by firm so the same JWT sub registered
+            // in two firms doesn't see the other firm's orders.
+            var orders = book.ForEndClientAndFirm(firm, owner).Select(o => o.ToDto());
             return Results.Ok(orders);
         });
 

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -83,6 +83,15 @@ public static class OrdersEndpoints
             // caller's firm. Active-status is checked again inside
             // SubAccountLimitsCheck under the dispatcher lock — this
             // is a fast-fail before any WAL write happens.
+            //
+            // PR review #301 P2: distinguish the two rejection cases
+            // with structured reasons so clients and metrics can tell
+            // "unknown id" apart from "operator-disabled".
+            //   * sub_account_not_registered — never seen this id
+            //     for this firm (or it was created under a different
+            //     firm and the caller's claim mismatches);
+            //   * sub_account_deactivated   — registered but soft-
+            //     deleted via DELETE /sub-accounts.
             SubAccountId? subAccount = null;
             if (!string.IsNullOrWhiteSpace(req.SubAccountId))
             {
@@ -91,10 +100,18 @@ public static class OrdersEndpoints
                 {
                     return Results.BadRequest(new { error = $"invalid subAccountId: {ex.Message}" });
                 }
-                if (!subAccounts.IsActive(ResolveFirm(ctx), subAccount.Value))
+                var firmForLookup = ResolveFirm(ctx);
+                if (!subAccounts.TryGet(firmForLookup, subAccount.Value, out var entry))
                     return Results.BadRequest(new
                     {
-                        error = $"sub-account '{subAccount.Value}' is not registered or has been deactivated for firm",
+                        error = $"sub-account '{subAccount.Value}' is not registered for firm",
+                        reason = "sub_account_not_registered",
+                    });
+                if (!entry.Active)
+                    return Results.BadRequest(new
+                    {
+                        error = $"sub-account '{subAccount.Value}' has been deactivated for firm",
+                        reason = "sub_account_deactivated",
                     });
             }
 
@@ -283,9 +300,10 @@ public sealed record SubmitOrderRequest(
     /// <summary>Q4.1 (#301). Optional sub-account bucket the order is
     /// booked against. Must satisfy <see cref="B3.Trading.Domain.SubAccountId"/>
     /// validation (1-64 chars, alphanumerics + <c>._-</c>); rejected with
-    /// HTTP 400 if invalid, with HTTP 422 (<c>sub_account_limit_exceeded</c>)
-    /// if the sub-account exists but is deactivated. <c>null</c> retains
-    /// pre-#301 master-only behaviour.</summary>
+    /// HTTP 400 if invalid (<c>reason: "sub_account_not_registered"</c>
+    /// when unknown, <c>reason: "sub_account_deactivated"</c> when
+    /// soft-deleted). <c>null</c> retains pre-#301 master-only
+    /// behaviour.</summary>
     string? SubAccountId = null);
 
 public sealed record ModifyOrderRequest(

--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -28,6 +28,7 @@ public static class OrdersEndpoints
             EndClientRegistry registry,
             OrderSubmissionService submitter,
             SymbolDirectory symbols,
+            SubAccountsRegistry subAccounts,
             CancellationToken ct) =>
         {
             if (!Enum.TryParse<OrderSide>(req.Side, ignoreCase: true, out var side))
@@ -76,6 +77,27 @@ public static class OrdersEndpoints
                 displayPolicy = parsedPolicy;
             }
 
+            // Q4.1 (#301). Parse the optional sub-account hint, validate
+            // the id (1-64 chars, alphanumerics + ._-) via the value-type
+            // constructor, and confirm it exists and is active for the
+            // caller's firm. Active-status is checked again inside
+            // SubAccountLimitsCheck under the dispatcher lock — this
+            // is a fast-fail before any WAL write happens.
+            SubAccountId? subAccount = null;
+            if (!string.IsNullOrWhiteSpace(req.SubAccountId))
+            {
+                try { subAccount = new SubAccountId(req.SubAccountId); }
+                catch (ArgumentException ex)
+                {
+                    return Results.BadRequest(new { error = $"invalid subAccountId: {ex.Message}" });
+                }
+                if (!subAccounts.IsActive(ResolveFirm(ctx), subAccount.Value))
+                    return Results.BadRequest(new
+                    {
+                        error = $"sub-account '{subAccount.Value}' is not registered or has been deactivated for firm",
+                    });
+            }
+
             // SecurityId resolution: explicit non-zero in the payload
             // wins (preserves the conformance contract). Otherwise look
             // up the directory by symbol — that is the path the trader
@@ -95,7 +117,8 @@ public static class OrdersEndpoints
                 StopPrice: req.StopPrice,
                 GoodTillDate: req.GoodTillDate,
                 DisplayQty: req.DisplayQty,
-                DisplayResetPolicy: displayPolicy), ct);
+                DisplayResetPolicy: displayPolicy,
+                SubAccountId: subAccount), ct);
 
             return result.Kind switch
             {
@@ -256,7 +279,14 @@ public sealed record SubmitOrderRequest(
     /// name (<c>"Always" | "OnPartialFill" | "Never"</c>). Defaults to <c>Always</c>
     /// when <c>DisplayQty</c> is set and this field is null. Must be null when
     /// <c>DisplayQty</c> is null.</summary>
-    string? DisplayResetPolicy = null);
+    string? DisplayResetPolicy = null,
+    /// <summary>Q4.1 (#301). Optional sub-account bucket the order is
+    /// booked against. Must satisfy <see cref="B3.Trading.Domain.SubAccountId"/>
+    /// validation (1-64 chars, alphanumerics + <c>._-</c>); rejected with
+    /// HTTP 400 if invalid, with HTTP 422 (<c>sub_account_limit_exceeded</c>)
+    /// if the sub-account exists but is deactivated. <c>null</c> retains
+    /// pre-#301 master-only behaviour.</summary>
+    string? SubAccountId = null);
 
 public sealed record ModifyOrderRequest(
     long Quantity,

--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -85,7 +85,8 @@ public static class PnlEndpoints
                 return Results.Ok(new PnlTodayDto(realized,
                     Array.Empty<PnlUnrealizedEntry>(), total, 0m));
             }
-            var snap = PnlProjection.Build(owner, pnl, positions, refPrice);
+            var legacyFirm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+            var snap = PnlProjection.Build(owner, legacyFirm, pnl, positions, refPrice);
             return Results.Ok(snap);
         });
 
@@ -132,30 +133,33 @@ public static class PnlProjection
         PnlKeeper pnl,
         PositionKeeper positions,
         IReferencePrice refPrice,
+        DateOnly? day = null) =>
+        Build(owner, PnlKeeper.DefaultFirmId, pnl, positions, refPrice, day);
+
+    /// <summary>
+    /// PR #316 P1. Firm-scoped overload. The same JWT <c>sub</c>
+    /// registered in two firms must see only positions, basis, and
+    /// realized totals booked under <paramref name="firmId"/>. Master
+    /// keepers are firm-keyed since #316; the legacy 2-arg overload
+    /// above delegates to <see cref="PnlKeeper.DefaultFirmId"/> for
+    /// callers that have not yet been threaded.
+    /// </summary>
+    public static PnlTodayDto Build(
+        EndClientId owner,
+        string firmId,
+        PnlKeeper pnl,
+        PositionKeeper positions,
+        IReferencePrice refPrice,
         DateOnly? day = null)
     {
         var d = day ?? DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
 
-        // Unrealized: one row per OPEN position with a live ref price.
-        // Symbols whose ref-price lookup misses are omitted (rather
-        // than reported as 0) so the total stays honest.
-        //
-        // Pass-4 review (#278) P1#2. Unknown-basis legacy positions
-        // (seeded from pre-#271 snapshots whose AverageEntryPrice was
-        // zero) carry no usable basis: Position.AverageEntryPrice is
-        // either 0 or some polluted value, so a naive
-        // (refPrice - avg) * qty would publish phantom unrealized
-        // P&L. Skip them entirely — the position simply doesn't
-        // appear in the unrealized array until the legacy leg goes
-        // flat and a real basis is established by a fresh fill (see
-        // PnlKeeper.ApplyFillToAvgCost). The realized side is
-        // unaffected (those rows come from PnlKeeper.ForEndClientDay).
         var unrealized = new List<PnlUnrealizedEntry>();
         decimal totalUnrealized = 0m;
-        foreach (var p in positions.ForEndClient(owner))
+        foreach (var p in positions.ForEndClientAndFirm(firmId, owner))
         {
             if (p.NetQuantity == 0) continue;
-            if (pnl.GetUnknownBasisQty(owner.Value, p.Symbol) != 0) continue;
+            if (pnl.GetUnknownBasisQty(firmId, owner.Value, p.Symbol) != 0) continue;
             if (!refPrice.TryGet(p.Symbol, out var px)) continue;
             var value = p.NetQuantity >= 0
                 ? (px - p.AverageEntryPrice) * p.NetQuantity
@@ -164,12 +168,9 @@ public static class PnlProjection
             totalUnrealized += value;
         }
 
-        // Realized: every symbol with a non-zero realized total for
-        // the day, including symbols whose position has since closed
-        // out (no current position row).
         var realized = new List<PnlRealizedEntry>();
         decimal totalRealized = 0m;
-        foreach (var (symbol, value) in pnl.ForEndClientDay(owner.Value, d))
+        foreach (var (symbol, value) in pnl.ForEndClientDay(firmId, owner.Value, d))
         {
             if (value == 0m) continue;
             realized.Add(new PnlRealizedEntry(symbol, value));

--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -76,7 +76,7 @@ public static class PnlEndpoints
                 var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
                 var realized = new List<PnlRealizedEntry>();
                 decimal total = 0m;
-                foreach (var (symbol, value) in subPnl.ForSubAccountDay(owner.Value, saId, day))
+                foreach (var (symbol, value) in subPnl.ForSubAccountDay(firm, owner.Value, saId, day))
                 {
                     if (value == 0m) continue;
                     realized.Add(new PnlRealizedEntry(symbol, value));

--- a/backend/src/B3.Trading.Api/PnlEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PnlEndpoints.cs
@@ -47,12 +47,44 @@ public static class PnlEndpoints
             EndClientRegistry registry,
             PnlKeeper pnl,
             PositionKeeper positions,
-            IReferencePrice refPrice) =>
+            SubAccountPnlKeeper subPnl,
+            SubAccountsRegistry subAccounts,
+            IReferencePrice refPrice,
+            string? subAccount) =>
         {
             var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
                       ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
             var owner = registry.Register(sub);
             Application.Observability.MetricsRegistry.PnlEndpointRequests.Add(1);
+            // Q4.1 (#301). With ?subAccount=X the response is restricted
+            // to the per-sub-account realized totals; the unrealized
+            // side is intentionally empty because per-sub-account
+            // avg-cost basis is not tracked in this slice (see PR
+            // body — deferred to a follow-up). Without the filter the
+            // legacy master-aggregate projection is returned.
+            if (!string.IsNullOrWhiteSpace(subAccount))
+            {
+                SubAccountId saId;
+                try { saId = new SubAccountId(subAccount); }
+                catch (ArgumentException ex)
+                {
+                    return Results.BadRequest(new { error = $"invalid subAccount: {ex.Message}" });
+                }
+                var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+                if (!subAccounts.TryGet(firm, saId.Value, out _))
+                    return Results.BadRequest(new { error = $"sub-account '{saId.Value}' is not registered for firm" });
+                var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+                var realized = new List<PnlRealizedEntry>();
+                decimal total = 0m;
+                foreach (var (symbol, value) in subPnl.ForSubAccountDay(owner.Value, saId, day))
+                {
+                    if (value == 0m) continue;
+                    realized.Add(new PnlRealizedEntry(symbol, value));
+                    total += value;
+                }
+                return Results.Ok(new PnlTodayDto(realized,
+                    Array.Empty<PnlUnrealizedEntry>(), total, 0m));
+            }
             var snap = PnlProjection.Build(owner, pnl, positions, refPrice);
             return Results.Ok(snap);
         });

--- a/backend/src/B3.Trading.Api/PositionsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PositionsEndpoints.cs
@@ -39,7 +39,7 @@ public static class PositionsEndpoints
                 var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
                 if (!subAccounts.TryGet(firm, saId.Value, out _))
                     return Results.BadRequest(new { error = $"sub-account '{saId.Value}' is not registered for firm" });
-                var view = subPositions.ForSubAccount(owner, saId)
+                var view = subPositions.ForSubAccount(firm, owner, saId)
                     .Where(p => p.NetQuantity != 0)
                     .Select(p => p.ToDto(saId));
                 return Results.Ok(view);

--- a/backend/src/B3.Trading.Api/PositionsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PositionsEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
+using B3.Trading.Domain;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -12,13 +13,39 @@ public static class PositionsEndpoints
 {
     public static IEndpointRouteBuilder MapPositions(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/positions", [Authorize] (HttpContext ctx, EndClientRegistry registry, PositionKeeper positions) =>
+        app.MapGet("/positions", [Authorize] (
+            HttpContext ctx,
+            EndClientRegistry registry,
+            PositionKeeper positions,
+            SubAccountPositionKeeper subPositions,
+            SubAccountsRegistry subAccounts,
+            string? subAccount) =>
         {
             var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
                       ?? throw new InvalidOperationException("Authenticated request missing sub claim.");
             var owner = registry.Register(sub);
-            var view = positions.ForEndClient(owner).Select(p => p.ToDto());
-            return Results.Ok(view);
+            // Q4.1 (#301). When ?subAccount=X is supplied, validate the
+            // id and return only that bucket. Without the filter the
+            // legacy master-aggregate view is returned (sum across
+            // sub-accounts + untagged) — pre-#301 wire shape preserved.
+            if (!string.IsNullOrWhiteSpace(subAccount))
+            {
+                SubAccountId saId;
+                try { saId = new SubAccountId(subAccount); }
+                catch (ArgumentException ex)
+                {
+                    return Results.BadRequest(new { error = $"invalid subAccount: {ex.Message}" });
+                }
+                var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+                if (!subAccounts.TryGet(firm, saId.Value, out _))
+                    return Results.BadRequest(new { error = $"sub-account '{saId.Value}' is not registered for firm" });
+                var view = subPositions.ForSubAccount(owner, saId)
+                    .Where(p => p.NetQuantity != 0)
+                    .Select(p => p.ToDto(saId));
+                return Results.Ok(view);
+            }
+            var legacy = positions.ForEndClient(owner).Select(p => p.ToDto());
+            return Results.Ok(legacy);
         });
 
         return app;

--- a/backend/src/B3.Trading.Api/PositionsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/PositionsEndpoints.cs
@@ -44,7 +44,12 @@ public static class PositionsEndpoints
                     .Select(p => p.ToDto(saId));
                 return Results.Ok(view);
             }
-            var legacy = positions.ForEndClient(owner).Select(p => p.ToDto());
+            var legacyFirm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+            // PR #316 P1. Firm-scope the unfiltered view so the same
+            // JWT sub registered in two firms doesn't see the other
+            // firm's positions (the master keeper bucket is keyed by
+            // firmId since #316).
+            var legacy = positions.ForEndClientAndFirm(legacyFirm, owner).Select(p => p.ToDto());
             return Results.Ok(legacy);
         });
 

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -134,7 +134,7 @@ public static class StatementEndpoints
             wal.Add(entry);
         }
 
-        return StatementProjection.Build(owner, day, wal, livePositionsSnapshot);
+        return StatementProjection.Build(owner, day, firmId, wal, livePositionsSnapshot);
     }
 
     private static void EmitDayTradeMetric(DailyStatementDto dto)

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Security.Claims;
 using System.Text;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Api;
 
@@ -32,6 +34,16 @@ namespace B3.Trading.Api;
 /// </summary>
 public static class StatementEndpoints
 {
+    // PR #316 P2 (review). One-shot warn dedupe set for the master-
+    // bucket avg-cost basis degraded path: per-process, per
+    // (firmId, ownerEndClient, symbol) tuple. The condition signals
+    // an invariant violation after P1's legacy-snapshot backfill,
+    // so we log once and lean on the
+    // statement.master_avg_basis_degraded_total counter for
+    // sustained surfaces.
+    private static readonly ConcurrentDictionary<(string Firm, string Owner, string Symbol), byte>
+        s_masterAvgDegradedWarned = new();
+
     public static IEndpointRouteBuilder MapStatement(this IEndpointRouteBuilder app)
     {
         app.MapGet("/statement/{dayKey?}", [Authorize] async (
@@ -43,6 +55,7 @@ public static class StatementEndpoints
             SubAccountPnlKeeper subAccountPnl,
             SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
+            ILoggerFactory loggerFactory,
             string? dayKey,
             string? subAccount,
             CancellationToken ct) =>
@@ -55,7 +68,7 @@ public static class StatementEndpoints
                 return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "json"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, subFilter, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, loggerFactory, subFilter, ct);
             EmitDayTradeMetric(dto);
             return Results.Ok(dto);
         });
@@ -69,6 +82,7 @@ public static class StatementEndpoints
             SubAccountPnlKeeper subAccountPnl,
             SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
+            ILoggerFactory loggerFactory,
             string dayKey,
             string? subAccount,
             CancellationToken ct) =>
@@ -81,7 +95,7 @@ public static class StatementEndpoints
                 return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "csv"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, subFilter, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, loggerFactory, subFilter, ct);
             EmitDayTradeMetric(dto);
             var bytes = RenderCsv(dto);
             return Results.File(
@@ -96,7 +110,7 @@ public static class StatementEndpoints
     private static async Task<DailyStatementDto> BuildAsync(
         EndClientId owner, string firmId, DateOnly day, IEventStore store, PositionKeeper positions,
         SubAccountPositionKeeper subPositions, SubAccountPnlKeeper subAccountPnl,
-        EventDispatcher dispatcher, string? subAccountFilter, CancellationToken ct)
+        EventDispatcher dispatcher, ILoggerFactory loggerFactory, string? subAccountFilter, CancellationToken ct)
     {
         var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
         var isToday = day == today;
@@ -190,21 +204,8 @@ public static class StatementEndpoints
             //         fill mirrors into the master keeper).
             var symbols = new HashSet<string>(aggregateBySymbol.Keys, StringComparer.Ordinal);
             foreach (var sym in subSumBySymbol.Keys) symbols.Add(sym);
-            var masterRows = new List<PositionRowDto>(symbols.Count);
-            foreach (var symbol in symbols)
-            {
-                var aggQty = aggregateBySymbol.TryGetValue(symbol, out var agg) ? agg.Qty : 0;
-                var subSum = subSumBySymbol.TryGetValue(symbol, out var s) ? s : 0;
-                var masterQty = aggQty - subSum;
-                if (masterQty == 0) continue;
-                var bucket = subAccountPnl.GetBucketAvgCost(firmId, owner.Value, subAccount: null, symbol);
-                var masterAvg = bucket is not null && bucket.NetQuantity == masterQty
-                    ? bucket.AvgPrice
-                    : agg.Avg;
-                masterRows.Add(new PositionRowDto(symbol, masterQty, masterAvg, null));
-            }
-            masterRows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
-            capturedSeedFallback = masterRows;
+            capturedSeedFallback = BuildMasterBucketRows(
+                firmId, owner, symbols, aggregateBySymbol, subSumBySymbol, subAccountPnl, loggerFactory);
         });
         var snapshotSeq = capturedSeq;
         var livePositionsSnapshot = capturedPositions;
@@ -254,6 +255,72 @@ public static class StatementEndpoints
         if (dto.IrDayTrade.PerSymbol.Count > 0)
             Application.Observability.MetricsRegistry.StatementDayTradeDetected.Add(1);
     }
+
+    /// <summary>
+    /// PR #316 P1.1 / P2 (review). Build the live MASTER-bucket
+    /// snapshot rows used by the daily-statement projection. Each
+    /// row's quantity is <c>aggregate − sumSub</c> (the master-only
+    /// invariant). The avg-cost comes from the per-bucket basis
+    /// store; when that's missing or its recorded qty disagrees with
+    /// <c>aggregate − sumSub</c>, the row is emitted with
+    /// <c>AvgPrice = 0m</c> (fail-closed "unknown basis" semantic)
+    /// instead of falling back to the polluted aggregate avg, and
+    /// <c>statement.master_avg_basis_degraded_total</c> is incremented.
+    /// Post-#316 P1 backfill this degraded branch should never fire
+    /// in production — when it does, it signals an invariant
+    /// violation surfaced by the counter + a one-shot warn per
+    /// (firm, owner, symbol) per process.
+    /// </summary>
+    internal static IReadOnlyList<PositionRowDto> BuildMasterBucketRows(
+        string firmId,
+        EndClientId owner,
+        IEnumerable<string> symbols,
+        IReadOnlyDictionary<string, (long Qty, decimal Avg)> aggregateBySymbol,
+        IReadOnlyDictionary<string, long> subSumBySymbol,
+        SubAccountPnlKeeper subAccountPnl,
+        ILoggerFactory? loggerFactory)
+    {
+        var masterRows = new List<PositionRowDto>();
+        foreach (var symbol in symbols)
+        {
+            var aggQty = aggregateBySymbol.TryGetValue(symbol, out var agg) ? agg.Qty : 0;
+            var subSum = subSumBySymbol.TryGetValue(symbol, out var s) ? s : 0;
+            var masterQty = aggQty - subSum;
+            if (masterQty == 0) continue;
+            var bucket = subAccountPnl.GetBucketAvgCost(firmId, owner.Value, subAccount: null, symbol);
+            decimal masterAvg;
+            if (bucket is not null && bucket.NetQuantity == masterQty)
+            {
+                masterAvg = bucket.AvgPrice;
+            }
+            else
+            {
+                Application.Observability.MetricsRegistry.StatementMasterAvgBasisDegraded.Add(1);
+                if (loggerFactory is not null
+                    && s_masterAvgDegradedWarned.TryAdd((firmId, owner.Value, symbol), 0))
+                {
+                    loggerFactory
+                        .CreateLogger(typeof(StatementEndpoints).FullName!)
+                        .LogWarning(
+                            "Statement master-bucket avg-cost basis degraded for firm={FirmId} owner={Owner} symbol={Symbol}: bucket={BucketPresent} bucketQty={BucketQty} masterQty={MasterQty}. Emitting AvgPrice=0 (post-#316 P1 backfill this signals an invariant violation).",
+                            firmId, owner.Value, symbol,
+                            bucket is not null, bucket?.NetQuantity ?? 0L, masterQty);
+                }
+                masterAvg = 0m;
+            }
+            masterRows.Add(new PositionRowDto(symbol, masterQty, masterAvg, null));
+        }
+        masterRows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+        return masterRows;
+    }
+
+    /// <summary>
+    /// Test-only: drops the one-shot warn dedupe so a test asserting
+    /// the warn-once contract can observe it without inter-test
+    /// pollution from a sibling test that already tripped the dedupe.
+    /// </summary>
+    internal static void ResetMasterAvgDegradedWarnDedupeForTesting() =>
+        s_masterAvgDegradedWarned.Clear();
 
     private static bool TryResolveDay(string? raw, out DateOnly day, out IResult? error)
     {

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -126,17 +126,21 @@ public static class StatementEndpoints
         // existing snapshot fast-path.
         long capturedSeq = 0;
         IReadOnlyList<PositionRowDto>? capturedPositions = null;
+        IReadOnlyList<PositionRowDto>? capturedSeedFallback = null;
         dispatcher.RunExclusive(() =>
         {
             capturedSeq = store.CurrentSeq;
             if (!isToday) return;
             if (subAccountFilter is not null) return;
-            // Only take the master snapshot when the owner has no
-            // per-sub-account positions in this firm; otherwise we fall
-            // through to WAL replay which can bucket correctly.
-            var anySub = false;
-            foreach (var _ in subPositions.EnumerateForOwner(firmId, owner)) { anySub = true; break; }
-            if (anySub) return;
+            // Snapshot the live master keeper rows. If the owner has
+            // no per-sub-account positions in this firm we use the
+            // snapshot verbatim (fast pre-#301 path). Otherwise we
+            // pass it as a seed-fallback so the WAL-replay path can
+            // re-inject any startup-seeded master positions (per
+            // PR #316 P2 — TradingHostStartup applies seeds straight
+            // to PositionKeeper, never via WAL, so plain WAL replay
+            // would silently drop them whenever a sub-account row
+            // forces us off the snapshot fast-path).
             var rows = new List<PositionRowDto>();
             foreach (var p in positions.ForEndClientAndFirm(firmId, owner))
             {
@@ -144,10 +148,17 @@ public static class StatementEndpoints
                 rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
             }
             rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
-            capturedPositions = rows;
+
+            var anySub = false;
+            foreach (var _ in subPositions.EnumerateForOwner(firmId, owner)) { anySub = true; break; }
+            if (anySub)
+                capturedSeedFallback = rows;
+            else
+                capturedPositions = rows;
         });
         var snapshotSeq = capturedSeq;
         var livePositionsSnapshot = capturedPositions;
+        var liveMasterSeedFallback = capturedSeedFallback;
 
         // Drain the writer AFTER taking the dispatcher snapshot so
         // every entry with seq <= snapshotSeq is durable and visible
@@ -162,7 +173,7 @@ public static class StatementEndpoints
             wal.Add(entry);
         }
 
-        return StatementProjection.Build(owner, day, firmId, wal, livePositionsSnapshot, subAccountFilter);
+        return StatementProjection.Build(owner, day, firmId, wal, livePositionsSnapshot, subAccountFilter, liveMasterSeedFallback);
     }
 
     private static bool TryResolveSubAccount(

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -46,9 +46,10 @@ public static class StatementEndpoints
             if (!TryResolveDay(dayKey, out var day, out var error))
                 return error!;
             var owner = ResolveOwner(ctx, registry);
+            var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "json"));
-            var dto = await BuildAsync(owner, day, store, positions, dispatcher, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, dispatcher, ct);
             EmitDayTradeMetric(dto);
             return Results.Ok(dto);
         });
@@ -65,9 +66,10 @@ public static class StatementEndpoints
             if (!TryResolveDay(dayKey, out var day, out var error))
                 return error!;
             var owner = ResolveOwner(ctx, registry);
+            var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "csv"));
-            var dto = await BuildAsync(owner, day, store, positions, dispatcher, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, dispatcher, ct);
             EmitDayTradeMetric(dto);
             var bytes = RenderCsv(dto);
             return Results.File(
@@ -80,7 +82,7 @@ public static class StatementEndpoints
     }
 
     private static async Task<DailyStatementDto> BuildAsync(
-        EndClientId owner, DateOnly day, IEventStore store, PositionKeeper positions,
+        EndClientId owner, string firmId, DateOnly day, IEventStore store, PositionKeeper positions,
         EventDispatcher dispatcher, CancellationToken ct)
     {
         var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
@@ -108,7 +110,7 @@ public static class StatementEndpoints
             capturedSeq = store.CurrentSeq;
             if (!isToday) return;
             var rows = new List<PositionRowDto>();
-            foreach (var p in positions.ForEndClient(owner))
+            foreach (var p in positions.ForEndClientAndFirm(firmId, owner))
             {
                 if (p.NetQuantity == 0) continue;
                 rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -39,17 +39,22 @@ public static class StatementEndpoints
             EndClientRegistry registry,
             IEventStore store,
             PositionKeeper positions,
+            SubAccountPositionKeeper subPositions,
+            SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
             string? dayKey,
+            string? subAccount,
             CancellationToken ct) =>
         {
             if (!TryResolveDay(dayKey, out var day, out var error))
                 return error!;
             var owner = ResolveOwner(ctx, registry);
             var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+            if (!TryResolveSubAccount(subAccount, firm, subAccounts, out var subFilter, out var subError))
+                return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "json"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, dispatcher, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, dispatcher, subFilter, ct);
             EmitDayTradeMetric(dto);
             return Results.Ok(dto);
         });
@@ -59,17 +64,22 @@ public static class StatementEndpoints
             EndClientRegistry registry,
             IEventStore store,
             PositionKeeper positions,
+            SubAccountPositionKeeper subPositions,
+            SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
             string dayKey,
+            string? subAccount,
             CancellationToken ct) =>
         {
             if (!TryResolveDay(dayKey, out var day, out var error))
                 return error!;
             var owner = ResolveOwner(ctx, registry);
             var firm = ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default";
+            if (!TryResolveSubAccount(subAccount, firm, subAccounts, out var subFilter, out var subError))
+                return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "csv"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, dispatcher, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, dispatcher, subFilter, ct);
             EmitDayTradeMetric(dto);
             var bytes = RenderCsv(dto);
             return Results.File(
@@ -83,7 +93,7 @@ public static class StatementEndpoints
 
     private static async Task<DailyStatementDto> BuildAsync(
         EndClientId owner, string firmId, DateOnly day, IEventStore store, PositionKeeper positions,
-        EventDispatcher dispatcher, CancellationToken ct)
+        SubAccountPositionKeeper subPositions, EventDispatcher dispatcher, string? subAccountFilter, CancellationToken ct)
     {
         var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
         var isToday = day == today;
@@ -103,12 +113,30 @@ public static class StatementEndpoints
         // pure WAL so we skip the keeper snapshot there. The exclusive
         // section stays tiny — no I/O — and the WAL scan + projection
         // run after we exit the lock.
+        //
+        // PR #316 P2.2. When the caller requested a per-sub-account
+        // view (or when any per-sub-account rows exist for this
+        // owner+firm), we cannot reuse the master-aggregate live
+        // snapshot — it would either double-count (master == sum of
+        // sub-buckets + null bucket) or be missing the per-bucket
+        // breakdown the projection needs. The projection then derives
+        // positions from the WAL replay (already firm- and bucket-
+        // scoped), which is correct but slower; the common pre-#301
+        // path (no sub-accounts in play, no filter) keeps the
+        // existing snapshot fast-path.
         long capturedSeq = 0;
         IReadOnlyList<PositionRowDto>? capturedPositions = null;
         dispatcher.RunExclusive(() =>
         {
             capturedSeq = store.CurrentSeq;
             if (!isToday) return;
+            if (subAccountFilter is not null) return;
+            // Only take the master snapshot when the owner has no
+            // per-sub-account positions in this firm; otherwise we fall
+            // through to WAL replay which can bucket correctly.
+            var anySub = false;
+            foreach (var _ in subPositions.EnumerateForOwner(firmId, owner)) { anySub = true; break; }
+            if (anySub) return;
             var rows = new List<PositionRowDto>();
             foreach (var p in positions.ForEndClientAndFirm(firmId, owner))
             {
@@ -134,7 +162,30 @@ public static class StatementEndpoints
             wal.Add(entry);
         }
 
-        return StatementProjection.Build(owner, day, firmId, wal, livePositionsSnapshot);
+        return StatementProjection.Build(owner, day, firmId, wal, livePositionsSnapshot, subAccountFilter);
+    }
+
+    private static bool TryResolveSubAccount(
+        string? raw, string firmId, SubAccountsRegistry subAccounts,
+        out string? subAccountFilter, out IResult? error)
+    {
+        error = null;
+        subAccountFilter = null;
+        if (string.IsNullOrWhiteSpace(raw)) return true;
+        SubAccountId saId;
+        try { saId = new SubAccountId(raw); }
+        catch (ArgumentException ex)
+        {
+            error = Results.BadRequest(new { error = $"invalid subAccount: {ex.Message}" });
+            return false;
+        }
+        if (!subAccounts.TryGet(firmId, saId.Value, out _))
+        {
+            error = Results.BadRequest(new { error = $"sub-account '{saId.Value}' is not registered for firm" });
+            return false;
+        }
+        subAccountFilter = saId.Value;
+        return true;
     }
 
     private static void EmitDayTradeMetric(DailyStatementDto dto)
@@ -183,13 +234,14 @@ public static class StatementEndpoints
         var sb = new StringBuilder(1024);
 
         WriteSectionHeader(sb, "positions");
-        sb.Append("symbol,netQty,avgPrice\r\n");
+        sb.Append("symbol,netQty,avgPrice,subAccount\r\n");
         foreach (var p in dto.Positions)
-            sb.Append(Csv(p.Symbol)).Append(',').Append(Num(p.NetQty)).Append(',').Append(Num(p.AvgPrice)).Append("\r\n");
+            sb.Append(Csv(p.Symbol)).Append(',').Append(Num(p.NetQty)).Append(',').Append(Num(p.AvgPrice))
+              .Append(',').Append(Csv(p.SubAccountId ?? string.Empty)).Append("\r\n");
         sb.Append("\r\n");
 
         WriteSectionHeader(sb, "fills");
-        sb.Append("executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc\r\n");
+        sb.Append("executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc,subAccount\r\n");
         foreach (var f in dto.Fills)
         {
             sb.Append(Csv(f.ExecutionId)).Append(',')
@@ -199,7 +251,8 @@ public static class StatementEndpoints
               .Append(Csv(f.Side)).Append(',')
               .Append(Num(f.Quantity)).Append(',')
               .Append(Num(f.Price)).Append(',')
-              .Append(f.TimestampUtc.ToString("O", CultureInfo.InvariantCulture))
+              .Append(f.TimestampUtc.ToString("O", CultureInfo.InvariantCulture)).Append(',')
+              .Append(Csv(f.SubAccountId ?? string.Empty))
               .Append("\r\n");
         }
         sb.Append("\r\n");

--- a/backend/src/B3.Trading.Api/StatementEndpoints.cs
+++ b/backend/src/B3.Trading.Api/StatementEndpoints.cs
@@ -40,6 +40,7 @@ public static class StatementEndpoints
             IEventStore store,
             PositionKeeper positions,
             SubAccountPositionKeeper subPositions,
+            SubAccountPnlKeeper subAccountPnl,
             SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
             string? dayKey,
@@ -54,7 +55,7 @@ public static class StatementEndpoints
                 return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "json"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, dispatcher, subFilter, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, subFilter, ct);
             EmitDayTradeMetric(dto);
             return Results.Ok(dto);
         });
@@ -65,6 +66,7 @@ public static class StatementEndpoints
             IEventStore store,
             PositionKeeper positions,
             SubAccountPositionKeeper subPositions,
+            SubAccountPnlKeeper subAccountPnl,
             SubAccountsRegistry subAccounts,
             EventDispatcher dispatcher,
             string dayKey,
@@ -79,7 +81,7 @@ public static class StatementEndpoints
                 return subError!;
             Application.Observability.MetricsRegistry.StatementEndpointRequests.Add(
                 1, new KeyValuePair<string, object?>("format", "csv"));
-            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, dispatcher, subFilter, ct);
+            var dto = await BuildAsync(owner, firm, day, store, positions, subPositions, subAccountPnl, dispatcher, subFilter, ct);
             EmitDayTradeMetric(dto);
             var bytes = RenderCsv(dto);
             return Results.File(
@@ -93,7 +95,8 @@ public static class StatementEndpoints
 
     private static async Task<DailyStatementDto> BuildAsync(
         EndClientId owner, string firmId, DateOnly day, IEventStore store, PositionKeeper positions,
-        SubAccountPositionKeeper subPositions, EventDispatcher dispatcher, string? subAccountFilter, CancellationToken ct)
+        SubAccountPositionKeeper subPositions, SubAccountPnlKeeper subAccountPnl,
+        EventDispatcher dispatcher, string? subAccountFilter, CancellationToken ct)
     {
         var today = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
         var isToday = day == today;
@@ -114,16 +117,16 @@ public static class StatementEndpoints
         // section stays tiny — no I/O — and the WAL scan + projection
         // run after we exit the lock.
         //
-        // PR #316 P2.2. When the caller requested a per-sub-account
+        // PR #316 P2.2 / P1.1. When the caller requested a per-sub-account
         // view (or when any per-sub-account rows exist for this
         // owner+firm), we cannot reuse the master-aggregate live
-        // snapshot — it would either double-count (master == sum of
-        // sub-buckets + null bucket) or be missing the per-bucket
-        // breakdown the projection needs. The projection then derives
-        // positions from the WAL replay (already firm- and bucket-
-        // scoped), which is correct but slower; the common pre-#301
-        // path (no sub-accounts in play, no filter) keeps the
-        // existing snapshot fast-path.
+        // snapshot — it would double-count (master == sum of
+        // sub-buckets + null bucket) and its avg-cost is polluted by
+        // sub-bucket fills. The projection derives sub-bucket rows
+        // from the WAL replay (already firm- and bucket-scoped); we
+        // pass a master-bucket-only snapshot built from the bucket
+        // store (qty = aggregate − sumSub, avg = bucket basis) so
+        // the master row reflects ONLY master-bucket history.
         long capturedSeq = 0;
         IReadOnlyList<PositionRowDto>? capturedPositions = null;
         IReadOnlyList<PositionRowDto>? capturedSeedFallback = null;
@@ -132,29 +135,76 @@ public static class StatementEndpoints
             capturedSeq = store.CurrentSeq;
             if (!isToday) return;
             if (subAccountFilter is not null) return;
-            // Snapshot the live master keeper rows. If the owner has
-            // no per-sub-account positions in this firm we use the
-            // snapshot verbatim (fast pre-#301 path). Otherwise we
-            // pass it as a seed-fallback so the WAL-replay path can
-            // re-inject any startup-seeded master positions (per
-            // PR #316 P2 — TradingHostStartup applies seeds straight
-            // to PositionKeeper, never via WAL, so plain WAL replay
-            // would silently drop them whenever a sub-account row
-            // forces us off the snapshot fast-path).
-            var rows = new List<PositionRowDto>();
+
+            var anySub = false;
+            // Aggregate (qty, avg) keyed by symbol from the master
+            // keeper — used as the avg-cost fallback when the bucket
+            // store has no master-bucket basis (pure no-sub-account
+            // case, or pre-#316 host with seeds applied without a
+            // SubAccountPnlKeeper wire).
+            var aggregateBySymbol = new Dictionary<string, (long Qty, decimal Avg)>(StringComparer.Ordinal);
             foreach (var p in positions.ForEndClientAndFirm(firmId, owner))
             {
                 if (p.NetQuantity == 0) continue;
-                rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+                aggregateBySymbol[p.Symbol] = (p.NetQuantity, p.AverageEntryPrice);
             }
-            rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
 
-            var anySub = false;
-            foreach (var _ in subPositions.EnumerateForOwner(firmId, owner)) { anySub = true; break; }
-            if (anySub)
-                capturedSeedFallback = rows;
-            else
+            // Sum sub-bucket quantities per symbol. Doubles as the
+            // anySub probe — non-empty enumeration means we cannot
+            // use the master-aggregate snapshot fast-path.
+            var subSumBySymbol = new Dictionary<string, long>(StringComparer.Ordinal);
+            foreach (var (_, position) in subPositions.EnumerateForOwner(firmId, owner))
+            {
+                if (position.NetQuantity == 0) continue;
+                anySub = true;
+                subSumBySymbol[position.Symbol] = subSumBySymbol.TryGetValue(position.Symbol, out var prior)
+                    ? prior + position.NetQuantity
+                    : position.NetQuantity;
+            }
+
+            if (!anySub)
+            {
+                var rows = new List<PositionRowDto>(aggregateBySymbol.Count);
+                foreach (var kv in aggregateBySymbol)
+                    rows.Add(new PositionRowDto(kv.Key, kv.Value.Qty, kv.Value.Avg));
+                rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
                 capturedPositions = rows;
+                return;
+            }
+
+            // PR #316 P1.1. Build the live MASTER-bucket snapshot:
+            //   qty = aggregate − sumSub  (invariant tracked by the
+            //         bucket store under per-bucket basis)
+            //   avg = bucket-store master basis when present (the
+            //         authoritative master-only avg cost — set on
+            //         seed at host startup and advanced by every
+            //         master fill); aggregate avg only as a last
+            //         resort for legacy hosts that pre-date the
+            //         bucket-basis seed (no sub activity could have
+            //         polluted the aggregate avg in that case
+            //         because we already know anySub is true ⇒
+            //         degraded mode, but the row still has SOME avg
+            //         so downstream renderers don't NaN). Symbols
+            //         only present in sub-buckets but not in the
+            //         aggregate snapshot can't happen (every sub
+            //         fill mirrors into the master keeper).
+            var symbols = new HashSet<string>(aggregateBySymbol.Keys, StringComparer.Ordinal);
+            foreach (var sym in subSumBySymbol.Keys) symbols.Add(sym);
+            var masterRows = new List<PositionRowDto>(symbols.Count);
+            foreach (var symbol in symbols)
+            {
+                var aggQty = aggregateBySymbol.TryGetValue(symbol, out var agg) ? agg.Qty : 0;
+                var subSum = subSumBySymbol.TryGetValue(symbol, out var s) ? s : 0;
+                var masterQty = aggQty - subSum;
+                if (masterQty == 0) continue;
+                var bucket = subAccountPnl.GetBucketAvgCost(firmId, owner.Value, subAccount: null, symbol);
+                var masterAvg = bucket is not null && bucket.NetQuantity == masterQty
+                    ? bucket.AvgPrice
+                    : agg.Avg;
+                masterRows.Add(new PositionRowDto(symbol, masterQty, masterAvg, null));
+            }
+            masterRows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+            capturedSeedFallback = masterRows;
         });
         var snapshotSeq = capturedSeq;
         var livePositionsSnapshot = capturedPositions;

--- a/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
@@ -1,0 +1,121 @@
+using System.Security.Claims;
+using B3.Trading.Api.Auth;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// Q4.1 (#301). REST surface for the sub-account master-broker /
+/// sub-account model. <c>GET</c> is open to any authenticated caller
+/// (trader UIs need the list to populate the dropdown), <c>POST</c>
+/// and <c>DELETE</c> require the <c>admin</c> policy — the spec
+/// reserves sub-account lifecycle to operators. Every mutation
+/// appends a WAL event so a snapshot+tail recovery converges on
+/// identical registry state.
+/// </summary>
+public static class SubAccountsEndpoints
+{
+    public static IEndpointRouteBuilder MapSubAccounts(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/sub-accounts").RequireAuthorization();
+
+        group.MapGet("/", (HttpContext ctx, SubAccountsRegistry registry, bool? includeDeactivated) =>
+        {
+            var firm = ResolveFirm(ctx);
+            var rows = registry.ListForFirm(firm);
+            if (includeDeactivated is not true)
+                rows = rows.Where(r => r.Active).ToList();
+            return Results.Ok(rows.Select(r => new SubAccountDto(
+                r.Id, r.DisplayName, r.Active)));
+        });
+
+        var admin = app.MapGroup("/sub-accounts").RequireAuthorization("admin");
+
+        admin.MapPost("/", (
+            SubAccountCreateRequest? req,
+            HttpContext ctx,
+            SubAccountsRegistry registry,
+            EventDispatcher dispatcher) =>
+        {
+            if (req is null) return Results.BadRequest(new { error = "missing body" });
+            SubAccountId id;
+            try { id = new SubAccountId(req.Id); }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            var firm = ResolveFirm(ctx);
+            var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            try
+            {
+                dispatcher.Dispatch(
+                    new SubAccountCreatedEvent
+                    {
+                        FirmId = firm,
+                        Id = id.Value,
+                        DisplayName = req.DisplayName,
+                        ActorUserId = actor,
+                    },
+                    () => registry.ApplyCreated(firm, id.Value, req.DisplayName));
+                return Results.Created($"/sub-accounts/{id.Value}",
+                    new SubAccountDto(id.Value, req.DisplayName, Active: true));
+            }
+            catch (WalBackpressureException ex)
+            {
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+        });
+
+        admin.MapDelete("/{id}", (
+            string id,
+            HttpContext ctx,
+            SubAccountsRegistry registry,
+            EventDispatcher dispatcher) =>
+        {
+            SubAccountId sub;
+            try { sub = new SubAccountId(id); }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+            var firm = ResolveFirm(ctx);
+            if (!registry.TryGet(firm, sub.Value, out _))
+                return Results.NotFound(new { error = $"sub-account '{sub.Value}' not found for firm" });
+            var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            try
+            {
+                dispatcher.Dispatch(
+                    new SubAccountDeactivatedEvent
+                    {
+                        FirmId = firm,
+                        Id = sub.Value,
+                        ActorUserId = actor,
+                    },
+                    () => registry.ApplyDeactivated(firm, sub.Value));
+                return Results.NoContent();
+            }
+            catch (WalBackpressureException ex)
+            {
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+        });
+
+        return app;
+    }
+
+    private static string ResolveFirm(HttpContext ctx) =>
+        ctx.User.FindFirstValue(JwtIssuer.FirmClaim) ?? "default";
+}
+
+public sealed record SubAccountCreateRequest(string Id, string? DisplayName = null);
+
+public sealed record SubAccountDto(string Id, string? DisplayName, bool Active);

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -117,12 +117,20 @@ public sealed record OrderDto(
     /// <summary>Q3.4 (#284). Refresh policy for the visible portion of an iceberg order;
     /// null iff <see cref="DisplayQty"/> is null. Today only <c>"Always"</c> is accepted
     /// at intake (SDK limitation — see #298).</summary>
-    string? DisplayResetPolicy = null);
+    string? DisplayResetPolicy = null,
+    /// <summary>Q4.1 (#301). Sub-account bucket this order is booked
+    /// against. Null = master bucket (legacy / non-sub-account flow).</summary>
+    string? SubAccountId = null);
 
 public sealed record PositionDto(
     string Symbol,
     long NetQuantity,
-    decimal AverageEntryPrice);
+    decimal AverageEntryPrice,
+    /// <summary>Q4.1 (#301). Sub-account this row belongs to. Null on
+    /// the master-aggregate row (sum across all sub-accounts plus the
+    /// untagged bucket) returned when the caller did not pass
+    /// <c>?subAccount=X</c>.</summary>
+    string? SubAccountId = null);
 
 /// <summary>
 /// Wire shape for <c>GET /balance</c>. Slice 1 of #107 exposes only
@@ -233,9 +241,13 @@ public static class DtoMappings
         o.ParentAlgoId?.ToString(), o.AlgoSliceSeq,
         o.IsStale, o.StaleReason, o.StaledAtUtc,
         o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate,
-        o.DisplayQty, o.DisplayResetPolicy?.ToString());
+        o.DisplayQty, o.DisplayResetPolicy?.ToString(),
+        o.SubAccountId?.Value);
 
     public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
+
+    public static PositionDto ToDto(this Position p, SubAccountId? subAccount) =>
+        new(p.Symbol, p.NetQuantity, p.AverageEntryPrice, subAccount?.Value);
 
     public static ExecutionDto ToDto(this ExecutionEvent ev) => new(
         ev.ClOrdId.ToString(), ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),

--- a/backend/src/B3.Trading.Api/WebSockets/PnlRefPriceFanOut.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/PnlRefPriceFanOut.cs
@@ -174,19 +174,24 @@ public sealed class PnlRefPriceFanOut : IHostedService, IAsyncDisposable
             }
         }
 
-        var holders = _positions.ForSymbol(symbol);
+        var holders = _positions.ForSymbolWithFirm(symbol);
         if (holders.Count == 0) return;
 
-        // Distinct owners (a symbol position is per-(owner, symbol) so
-        // already distinct per row, but we set-deduplicate defensively).
-        var seenOwners = new HashSet<EndClientId>();
+        // PR #316 P1. Snapshot is firm-scoped; ForSymbolWithFirm yields
+        // one row per (firmId, position) so a JWT sub registered in
+        // two firms gets one publish per firm with the matching
+        // bucket's basis + realized totals — and the firm-aware
+        // Publish overload filters delivery to the WS sessions that
+        // actually authenticated under that firm.
+        var seenOwnerFirms = new HashSet<(string FirmId, EndClientId Owner)>();
         var publishCount = 0;
-        foreach (var p in holders)
+        foreach (var (firmId, p) in holders)
         {
-            if (!seenOwners.Add(p.Owner)) continue;
+            var key = (firmId, p.Owner);
+            if (!seenOwnerFirms.Add(key)) continue;
             if (_subs.CountFor(p.Owner) == 0) continue;
-            var snap = PnlProjection.Build(p.Owner, _pnl, _positions, _refPriceLookup);
-            _subs.Publish(p.Owner, Channels.PnlMe, snap);
+            var snap = PnlProjection.Build(p.Owner, firmId, _pnl, _positions, _refPriceLookup);
+            _subs.Publish(p.Owner, firmId, Channels.PnlMe, snap);
             publishCount++;
         }
 

--- a/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
@@ -86,12 +86,12 @@ public sealed class SubscriptionManager
 
             object? data = channel switch
             {
-                Channels.OrdersMe => _orders.ForEndClient(client.Owner).Select(o => o.ToDto()).ToArray(),
-                Channels.PositionsMe => _positions.ForEndClient(client.Owner).Select(p => p.ToDto()).ToArray(),
+                Channels.OrdersMe => _orders.ForEndClientAndFirm(client.FirmId, client.Owner).Select(o => o.ToDto()).ToArray(),
+                Channels.PositionsMe => _positions.ForEndClientAndFirm(client.FirmId, client.Owner).Select(p => p.ToDto()).ToArray(),
                 Channels.ExecutionsMe => Array.Empty<ExecutionDto>(), // no historical exec log in v1
                 Channels.AlgoMe => _algos.EnumerateForOwner(client.FirmId, client.Owner).Select(a => a.ToDto()).ToArray(),
                 Channels.PnlMe => (_pnl is not null && _refPrice is not null)
-                    ? PnlProjection.Build(client.Owner, _pnl, _positions, _refPrice)
+                    ? PnlProjection.Build(client.Owner, client.FirmId, _pnl, _positions, _refPrice)
                     : null,
                 _ => null,
             };
@@ -102,9 +102,25 @@ public sealed class SubscriptionManager
 
     /// <summary>
     /// Fan out <paramref name="payload"/> as a delta on <paramref name="channel"/>
-    /// to every subscribed client of <paramref name="owner"/>.
+    /// to every subscribed client of <paramref name="owner"/>. Legacy
+    /// overload — fans out to ALL subscribed clients of the owner
+    /// regardless of firm. New owner-keyed publish sites (orders.me /
+    /// positions.me / executions.me / pnl.me) should call the
+    /// firm-aware overload to avoid cross-firm leakage when the same
+    /// JWT <c>sub</c> is registered in multiple firms.
     /// </summary>
-    public void Publish(EndClientId owner, string channel, object payload)
+    public void Publish(EndClientId owner, string channel, object payload) =>
+        Publish(owner, firmId: null, channel, payload);
+
+    /// <summary>
+    /// PR #316 P1. Firm-scoped fan-out. Delivers <paramref name="payload"/>
+    /// only to subscribed clients whose <see cref="SubscribedClient.FirmId"/>
+    /// matches <paramref name="firmId"/>. A <c>null</c> firm preserves
+    /// the legacy behaviour (no filter) — kept so the public channel
+    /// path and any not-yet-threaded caller still work, but every
+    /// owner-keyed business publish should pass a concrete firmId.
+    /// </summary>
+    public void Publish(EndClientId owner, string? firmId, string channel, object payload)
     {
         if (!_byOwner.TryGetValue(owner, out var clients) || clients.IsEmpty)
             return;
@@ -114,6 +130,8 @@ public sealed class SubscriptionManager
             foreach (var client in clients)
             {
                 if (!client.IsSubscribed(channel) || client.MarkedForDisconnect)
+                    continue;
+                if (firmId is not null && !string.Equals(client.FirmId, firmId, StringComparison.OrdinalIgnoreCase))
                     continue;
                 var seq = client.NextSeq(channel);
                 if (seq < 0)

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketAlgoEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketAlgoEventSink.cs
@@ -26,6 +26,6 @@ public sealed class WebSocketAlgoEventSink : IAlgoEventSink
             return;
         if (!_algos.TryGet(firmId, algoId, out var algo) || algo is null)
             return;
-        _subs.Publish(owner, Channels.AlgoMe, algo.ToDto());
+        _subs.Publish(owner, firmId, Channels.AlgoMe, algo.ToDto());
     }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
@@ -142,30 +142,29 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         if (_subs.CountFor(ev.Owner) == 0)
             return;
 
+        // PR #316 P1. Firm-scope every owner-keyed fan-out so the
+        // same JWT sub registered in two firms doesn't see the other
+        // firm's executions/orders/positions/pnl on its WS session.
+        var firmId = ev.FirmId;
+
         // executions.me — every ER becomes an execution event.
-        _subs.Publish(ev.Owner, Channels.ExecutionsMe, ev.ToDto());
+        _subs.Publish(ev.Owner, firmId, Channels.ExecutionsMe, ev.ToDto());
 
         // orders.me — current order state after mutation.
         if (_orders.TryGet(ev.ClOrdId, out var order) && order is not null)
-            _subs.Publish(ev.Owner, Channels.OrdersMe, order.ToDto());
+            _subs.Publish(ev.Owner, firmId, Channels.OrdersMe, order.ToDto());
 
         // positions.me — only fills affect positions.
         if (ev.Kind is ExecKind.Fill or ExecKind.PartialFill && ev.LastQuantity > 0)
         {
-            var position = _positions.GetOrCreate(ev.Owner, ev.Symbol);
-            _subs.Publish(ev.Owner, Channels.PositionsMe, position.ToDto());
+            var positionFirm = firmId ?? PnlKeeper.DefaultFirmId;
+            var position = _positions.GetOrCreate(positionFirm, ev.Owner, ev.Symbol);
+            _subs.Publish(ev.Owner, firmId, Channels.PositionsMe, position.ToDto());
 
-            // Q2.4 (#271). pnl.me — fills move both the realized
-            // bucket (via PnlKeeper) and unrealized (via the new
-            // avg-cost basis). Re-project the whole snapshot so
-            // subscribers can swap it in atomically. Note we project
-            // OFF the dispatcher path (this drain is async and
-            // ordered with positions.me — guaranteeing pnl reflects
-            // the same fill the position update reports).
             if (_pnl is not null && _refPrice is not null)
             {
-                var pnlSnap = PnlProjection.Build(ev.Owner, _pnl, _positions, _refPrice);
-                _subs.Publish(ev.Owner, Channels.PnlMe, pnlSnap);
+                var pnlSnap = PnlProjection.Build(ev.Owner, positionFirm, _pnl, _positions, _refPrice);
+                _subs.Publish(ev.Owner, firmId, Channels.PnlMe, pnlSnap);
             }
         }
     }

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -418,22 +418,26 @@ public sealed class ExecutionReportProcessor
                             // — registering them would only inflate
                             // the FinalizeReplay materialisation count.
                             //
-                            // PR #316 P2. (preFillQty, preFillAvg) is
+                            // PR #316 P1.2. (preFillQty, preFillAvg) is
                             // the BUCKET-of-the-fill's pre-fill state
                             // (master vs sub), so the would-realize
                             // gate and synth payload match what live
-                            // would emit. The synth materialises into
-                            // the aggregate keeper only; the
-                            // sub-bucket realized total is rebuilt
-                            // when the durable RealizedPnlEvent is
-                            // replayed (EventReplayer routes it via
-                            // _subAccountPnl.Add).
+                            // would emit. The synth carries the
+                            // originating SubAccountId so FinalizeReplay
+                            // can fold the materialised delta into the
+                            // per-bucket realised total in
+                            // SubAccountPnlKeeper as well — without
+                            // this, a sub-bucket realised delta whose
+                            // RealizedPnlEvent did not survive the
+                            // ER-then-crash window would leak into the
+                            // aggregate keeper only.
                             var wouldRealize = PnlKeeper.ComputeRealizedDelta(preFillQty, preFillAvg, order.Side, delta, lastPx);
                             if (wouldRealize != 0m)
                             {
                                 _pnlKeeper.RegisterPendingReplaySynth(
                                     order.FirmId, executionIdPnl, owner.Value, order.Symbol, order.Side,
-                                    delta, lastPx, nowUtcPnl, preFillQty, preFillAvg);
+                                    delta, lastPx, nowUtcPnl, preFillQty, preFillAvg,
+                                    order.SubAccountId?.Value);
                             }
                             // Still advance the basis tracker on replay
                             // — the durable event Apply path uses

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -254,10 +254,10 @@ public sealed class ExecutionReportProcessor
                     decimal preFillAvg = 0m;
                     if (_pnlKeeper is not null)
                     {
-                        var avg = _pnlKeeper.GetAvgCost(owner.Value, order.Symbol);
+                        var avg = _pnlKeeper.GetAvgCost(order.FirmId, owner.Value, order.Symbol);
                         if (avg is not null) { preFillQty = avg.NetQuantity; preFillAvg = avg.AvgPrice; }
                     }
-                    _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
+                    _positions.ApplyFill(order.FirmId, owner, order.Symbol, order.Side, delta, lastPx);
                     // Q4.1 (#301). Sub-account-tagged fills are also
                     // booked into the parallel sub-account keeper so a
                     // ?subAccount=X filter on GET /positions can read
@@ -407,14 +407,14 @@ public sealed class ExecutionReportProcessor
                             if (wouldRealize != 0m)
                             {
                                 _pnlKeeper.RegisterPendingReplaySynth(
-                                    executionIdPnl, owner.Value, order.Symbol, order.Side,
+                                    order.FirmId, executionIdPnl, owner.Value, order.Symbol, order.Side,
                                     delta, lastPx, nowUtcPnl, preFillQty, preFillAvg);
                             }
                             // Still advance the basis tracker on replay
                             // — the durable event Apply path uses
                             // RunningTotal directly, so basis is purely
                             // in-memory state used for live computation.
-                            _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            _pnlKeeper.ApplyFillToAvgCost(order.FirmId, owner.Value, order.Symbol, order.Side, delta, lastPx);
                         }
                         else
                         {
@@ -445,10 +445,10 @@ public sealed class ExecutionReportProcessor
                             // serialisation is sufficient because all
                             // live ER processing flows through it.
                             var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
-                            var realized = _pnlKeeper.ApplyFillToAvgCost(owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            var realized = _pnlKeeper.ApplyFillToAvgCost(order.FirmId, owner.Value, order.Symbol, order.Side, delta, lastPx);
                             if (realized != 0m)
                             {
-                                var prevTotal = _pnlKeeper.GetDayRealized(owner.Value, order.Symbol, dayKey);
+                                var prevTotal = _pnlKeeper.GetDayRealized(order.FirmId, owner.Value, order.Symbol, dayKey);
                                 var running = prevTotal + realized;
                                 var pnlEvt = new Persistence.RealizedPnlEvent
                                 {
@@ -460,16 +460,16 @@ public sealed class ExecutionReportProcessor
                                     DeltaRealized = realized,
                                     RunningTotal = running,
                                     TimestampUtc = nowUtcPnl,
-                                    // Q4.1 (#301). Tag the WAL event with
-                                    // the order's sub-account so replay
-                                    // can fan out to SubAccountPnlKeeper
-                                    // without depending on the WorkingOrderBook
-                                    // having been restored first. FirmId
-                                    // is carried alongside so the
-                                    // fan-out is firm-scoped (PR review
-                                    // #301 P1).
+                                    // PR #316 P1. Firm namespace for owner-keyed
+                                    // PnL fan-out. Always populated from the order
+                                    // (no longer conditional on SubAccountId) so a
+                                    // snapshot+tail recovery routes the realized
+                                    // delta into the correct firm bucket — required
+                                    // so the same JWT sub registered in two firms
+                                    // doesn't see cross-firm realized leaking on
+                                    // GET /pnl/today or pnl.me.
                                     SubAccountId = order.SubAccountId?.Value,
-                                    FirmId = order.SubAccountId is null ? null : order.FirmId,
+                                    FirmId = order.FirmId,
                                 };
                                 var keeperPnl = _pnlKeeper;
                                 var subPnl = _subAccountPnl;
@@ -608,7 +608,8 @@ public sealed class ExecutionReportProcessor
             lastPx,
             rejectReason,
             DateTimeOffset.UtcNow,
-            isNativeStp);
+            isNativeStp,
+            order.FirmId);
         // RFC §5.2 (F2). Capture-then-fan-out path: the dispatcher walks
         // the writer and TryWrites into every per-sink channel while still
         // under the dispatcher lock so subscribers observe events in WAL
@@ -685,7 +686,8 @@ public sealed class ExecutionReportProcessor
             LastPrice: 0m,
             RejectReason: rejectReason,
             TimestampUtc: DateTimeOffset.UtcNow,
-            IsNativeStp: false);
+            IsNativeStp: false,
+            FirmId: intent.FirmId);
         if (fanOut is not null)
         {
             fanOut.Add(rejectedEv, Persistence.ExecutionFanOutTargets.BotRouter);
@@ -746,7 +748,8 @@ public sealed class ExecutionReportProcessor
             0m,
             null,
             DateTimeOffset.UtcNow,
-            false);
+            false,
+            intent.FirmId);
         if (fanOut is not null)
         {
             fanOut.Add(origEv);
@@ -850,7 +853,8 @@ public sealed class ExecutionReportProcessor
             erLastPx,
             null,
             DateTimeOffset.UtcNow,
-            false);
+            false,
+            intent.FirmId);
         if (fanOut is not null)
         {
             fanOut.Add(newEv);

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -39,6 +39,8 @@ public sealed class ExecutionReportProcessor
     private readonly IFeeCalculator? _feeCalculator;
     private readonly FeeKeeper? _feeKeeper;
     private readonly PnlKeeper? _pnlKeeper;
+    private readonly SubAccountPositionKeeper? _subAccountPositions;
+    private readonly SubAccountPnlKeeper? _subAccountPnl;
     private readonly Persistence.EventDispatcher? _dispatcher;
     private readonly PendingReplacementRegistry? _replacements;
     private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
@@ -61,7 +63,9 @@ public sealed class ExecutionReportProcessor
         IFeeCalculator? feeCalculator = null,
         FeeKeeper? feeKeeper = null,
         Persistence.EventDispatcher? dispatcher = null,
-        PnlKeeper? pnlKeeper = null)
+        PnlKeeper? pnlKeeper = null,
+        SubAccountPositionKeeper? subAccountPositions = null,
+        SubAccountPnlKeeper? subAccountPnl = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -79,6 +83,8 @@ public sealed class ExecutionReportProcessor
         _feeKeeper = feeKeeper;
         _dispatcher = dispatcher;
         _pnlKeeper = pnlKeeper;
+        _subAccountPositions = subAccountPositions;
+        _subAccountPnl = subAccountPnl;
     }
 
     /// <summary>
@@ -252,6 +258,14 @@ public sealed class ExecutionReportProcessor
                         if (avg is not null) { preFillQty = avg.NetQuantity; preFillAvg = avg.AvgPrice; }
                     }
                     _positions.ApplyFill(owner, order.Symbol, order.Side, delta, lastPx);
+                    // Q4.1 (#301). Sub-account-tagged fills are also
+                    // booked into the parallel sub-account keeper so a
+                    // ?subAccount=X filter on GET /positions can read
+                    // a segregated row. The master keeper above sees
+                    // every fill (sub-account-null + sub-account-tagged)
+                    // so the aggregate view is naturally preserved.
+                    if (order.SubAccountId is { } sa)
+                        _subAccountPositions?.ApplyFill(owner, sa, order.Symbol, order.Side, delta, lastPx);
                     // Book the cash leg of the fill on the same delta as
                     // the position. Buys debit, Sells credit; T+0 settle.
                     // Null when the host hasn't wired CashLedger yet
@@ -443,11 +457,24 @@ public sealed class ExecutionReportProcessor
                                     DeltaRealized = realized,
                                     RunningTotal = running,
                                     TimestampUtc = nowUtcPnl,
+                                    // Q4.1 (#301). Tag the WAL event with
+                                    // the order's sub-account so replay
+                                    // can fan out to SubAccountPnlKeeper
+                                    // without depending on the WorkingOrderBook
+                                    // having been restored first.
+                                    SubAccountId = order.SubAccountId?.Value,
                                 };
                                 var keeperPnl = _pnlKeeper;
+                                var subPnl = _subAccountPnl;
+                                var subTag = order.SubAccountId;
                                 try
                                 {
-                                    _dispatcher.Dispatch(pnlEvt, () => keeperPnl.Apply(pnlEvt));
+                                    _dispatcher.Dispatch(pnlEvt, () =>
+                                    {
+                                        keeperPnl.Apply(pnlEvt);
+                                        if (subTag is { } saInner)
+                                            subPnl?.Add(owner.Value, saInner, order.Symbol, dayKey, realized);
+                                    });
                                     MetricsRegistry.PnlRealizedAppended.Add(1);
                                 }
                                 catch (Persistence.WalBackpressureException)
@@ -458,6 +485,8 @@ public sealed class ExecutionReportProcessor
                                         "Dropping RealizedPnlEvent for {ClOrdId} on WAL backpressure; applying realized pnl directly to keeper.",
                                         lookupId);
                                     keeperPnl.Apply(pnlEvt);
+                                    if (subTag is { } saInner2)
+                                        subPnl?.Add(owner.Value, saInner2, order.Symbol, dayKey, realized);
                                 }
                             }
                         }

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -264,8 +264,11 @@ public sealed class ExecutionReportProcessor
                     // a segregated row. The master keeper above sees
                     // every fill (sub-account-null + sub-account-tagged)
                     // so the aggregate view is naturally preserved.
+                    // FirmId is forwarded so the same login under two
+                    // firms with the same sub-account id stays
+                    // segregated (PR review #301 P1).
                     if (order.SubAccountId is { } sa)
-                        _subAccountPositions?.ApplyFill(owner, sa, order.Symbol, order.Side, delta, lastPx);
+                        _subAccountPositions?.ApplyFill(order.FirmId, owner, sa, order.Symbol, order.Side, delta, lastPx);
                     // Book the cash leg of the fill on the same delta as
                     // the position. Buys debit, Sells credit; T+0 settle.
                     // Null when the host hasn't wired CashLedger yet
@@ -461,19 +464,24 @@ public sealed class ExecutionReportProcessor
                                     // the order's sub-account so replay
                                     // can fan out to SubAccountPnlKeeper
                                     // without depending on the WorkingOrderBook
-                                    // having been restored first.
+                                    // having been restored first. FirmId
+                                    // is carried alongside so the
+                                    // fan-out is firm-scoped (PR review
+                                    // #301 P1).
                                     SubAccountId = order.SubAccountId?.Value,
+                                    FirmId = order.SubAccountId is null ? null : order.FirmId,
                                 };
                                 var keeperPnl = _pnlKeeper;
                                 var subPnl = _subAccountPnl;
                                 var subTag = order.SubAccountId;
+                                var firmTag = order.FirmId;
                                 try
                                 {
                                     _dispatcher.Dispatch(pnlEvt, () =>
                                     {
                                         keeperPnl.Apply(pnlEvt);
                                         if (subTag is { } saInner)
-                                            subPnl?.Add(owner.Value, saInner, order.Symbol, dayKey, realized);
+                                            subPnl?.Add(firmTag, owner.Value, saInner, order.Symbol, dayKey, realized);
                                     });
                                     MetricsRegistry.PnlRealizedAppended.Add(1);
                                 }
@@ -486,7 +494,7 @@ public sealed class ExecutionReportProcessor
                                         lookupId);
                                     keeperPnl.Apply(pnlEvt);
                                     if (subTag is { } saInner2)
-                                        subPnl?.Add(owner.Value, saInner2, order.Symbol, dayKey, realized);
+                                        subPnl?.Add(firmTag, owner.Value, saInner2, order.Symbol, dayKey, realized);
                                 }
                             }
                         }

--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -245,14 +245,28 @@ public sealed class ExecutionReportProcessor
                     }
                     // Q2.4 (#271). Capture the pre-fill avg-cost basis
                     // BEFORE _positions.ApplyFill mutates it — realized
-                    // delta is computed off the pre-fill state. We read
-                    // off PnlKeeper's parallel basis tracker (kept in
-                    // lockstep with PositionKeeper via
-                    // ApplyFillToAvgCost below) so the snapshot/restore
-                    // path is independent of PositionKeeper.
+                    // delta is computed off the pre-fill state.
+                    //
+                    // PR #316 P2. The basis we read here must be the
+                    // BUCKET-of-the-fill's basis (master when
+                    // SubAccountId is null, else the sub-bucket), NOT
+                    // the aggregate _pnlKeeper basis — otherwise a
+                    // sub-account fill that offsets a position held in
+                    // the master bucket realises against the master's
+                    // avg cost and the spec's "P&L segregated" contract
+                    // is broken. Falls back to the aggregate keeper
+                    // only when _subAccountPnl is not wired (test
+                    // contexts that haven't been migrated), which
+                    // collapses to the original aggregate behaviour
+                    // for the no-sub-account case.
                     long preFillQty = 0;
                     decimal preFillAvg = 0m;
-                    if (_pnlKeeper is not null)
+                    if (_subAccountPnl is not null)
+                    {
+                        var bucket = _subAccountPnl.GetBucketAvgCost(order.FirmId, owner.Value, order.SubAccountId, order.Symbol);
+                        if (bucket is not null) { preFillQty = bucket.NetQuantity; preFillAvg = bucket.AvgPrice; }
+                    }
+                    else if (_pnlKeeper is not null)
                     {
                         var avg = _pnlKeeper.GetAvgCost(order.FirmId, owner.Value, order.Symbol);
                         if (avg is not null) { preFillQty = avg.NetQuantity; preFillAvg = avg.AvgPrice; }
@@ -403,6 +417,17 @@ public sealed class ExecutionReportProcessor
                             // mode, so they have nothing to reconcile
                             // — registering them would only inflate
                             // the FinalizeReplay materialisation count.
+                            //
+                            // PR #316 P2. (preFillQty, preFillAvg) is
+                            // the BUCKET-of-the-fill's pre-fill state
+                            // (master vs sub), so the would-realize
+                            // gate and synth payload match what live
+                            // would emit. The synth materialises into
+                            // the aggregate keeper only; the
+                            // sub-bucket realized total is rebuilt
+                            // when the durable RealizedPnlEvent is
+                            // replayed (EventReplayer routes it via
+                            // _subAccountPnl.Add).
                             var wouldRealize = PnlKeeper.ComputeRealizedDelta(preFillQty, preFillAvg, order.Side, delta, lastPx);
                             if (wouldRealize != 0m)
                             {
@@ -414,7 +439,13 @@ public sealed class ExecutionReportProcessor
                             // — the durable event Apply path uses
                             // RunningTotal directly, so basis is purely
                             // in-memory state used for live computation.
+                            // PR #316 P2. Aggregate basis stays in
+                            // lockstep with PositionKeeper; bucket
+                            // basis is advanced separately so a future
+                            // live close after replay uses the right
+                            // segregated basis.
                             _pnlKeeper.ApplyFillToAvgCost(order.FirmId, owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            _subAccountPnl?.ApplyBucketFill(order.FirmId, owner.Value, order.SubAccountId, order.Symbol, order.Side, delta, lastPx);
                         }
                         else
                         {
@@ -445,7 +476,29 @@ public sealed class ExecutionReportProcessor
                             // serialisation is sufficient because all
                             // live ER processing flows through it.
                             var dayKey = DateOnly.FromDateTime(nowUtcPnl.UtcDateTime);
-                            var realized = _pnlKeeper.ApplyFillToAvgCost(order.FirmId, owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            // PR #316 P2. The aggregate keeper still
+                            // advances its basis (consumed by legacy
+                            // statement paths, the live snapshot
+                            // mirror, and the no-sub-account fallback
+                            // pre-fill read above), but its returned
+                            // delta is NOT the event source. The
+                            // authoritative realized delta is computed
+                            // against the bucket-of-the-fill's own
+                            // basis via the sub-account keeper — so a
+                            // sub-bucket close against an aggregate
+                            // position dominated by the master bucket
+                            // realises against the SUB's basis, not
+                            // the master's, satisfying the
+                            // "fill in sub-account A increments only
+                            // A's P&L" contract. When _subAccountPnl
+                            // is not wired (legacy test contexts) we
+                            // fall back to the aggregate delta so
+                            // pre-#316 ER processor tests keep
+                            // passing unchanged.
+                            var aggregateRealized = _pnlKeeper.ApplyFillToAvgCost(order.FirmId, owner.Value, order.Symbol, order.Side, delta, lastPx);
+                            var realized = _subAccountPnl is not null
+                                ? _subAccountPnl.ApplyBucketFill(order.FirmId, owner.Value, order.SubAccountId, order.Symbol, order.Side, delta, lastPx)
+                                : aggregateRealized;
                             if (realized != 0m)
                             {
                                 var prevTotal = _pnlKeeper.GetDayRealized(order.FirmId, owner.Value, order.Symbol, dayKey);

--- a/backend/src/B3.Trading.Application/IExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Application/IExecutionEventSink.cs
@@ -31,7 +31,8 @@ public sealed record ExecutionEvent(
     decimal LastPrice,
     string? RejectReason,
     DateTimeOffset TimestampUtc,
-    bool IsNativeStp = false);
+    bool IsNativeStp = false,
+    string? FirmId = null);
 
 public sealed class NoOpExecutionEventSink : IExecutionEventSink
 {

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -175,6 +175,19 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.statement.endpoint_requests");
     public static readonly Counter<long> StatementDayTradeDetected =
         Meter.CreateCounter<long>("trading.statement.day_trade_detected");
+    // PR #316 P2 (review). Bumped per (firmId, owner, symbol) row each
+    // time the daily-statement projection had to render a master-bucket
+    // row whose per-bucket avg-cost basis is absent OR whose recorded
+    // qty disagrees with (aggregate − sumSub). Post-#316 P1 backfill
+    // (StateSnapshotter.Restore → SubAccountPnlKeeper.SeedBucketBasisFromLegacyPositions)
+    // closes the legacy-snapshot gap, so a non-zero count after the
+    // P1 backfill ships indicates an invariant violation (a bucket-
+    // basis row was lost mid-process or never established). When the
+    // counter fires the projection emits AvgPrice = 0 (fail-closed
+    // "unknown basis" semantic) instead of the previous fallback to
+    // the polluted aggregate avg.
+    public static readonly Counter<long> StatementMasterAvgBasisDegraded =
+        Meter.CreateCounter<long>("trading.statement.master_avg_basis_degraded_total");
     // Pass-1 review (#278) P1#1. Bumped once per (endClient, symbol)
     // row when StateSnapshotter restores a legacy snapshot whose
     // PnlAvgCost block is empty but Positions has rows — the avg-cost

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -180,14 +180,35 @@ public static class MetricsRegistry
     // row whose per-bucket avg-cost basis is absent OR whose recorded
     // qty disagrees with (aggregate − sumSub). Post-#316 P1 backfill
     // (StateSnapshotter.Restore → SubAccountPnlKeeper.SeedBucketBasisFromLegacyPositions)
-    // closes the legacy-snapshot gap, so a non-zero count after the
-    // P1 backfill ships indicates an invariant violation (a bucket-
-    // basis row was lost mid-process or never established). When the
-    // counter fires the projection emits AvgPrice = 0 (fail-closed
-    // "unknown basis" semantic) instead of the previous fallback to
-    // the polluted aggregate avg.
+    // closes the legacy-snapshot gap for the master-only case; when
+    // sub positions exist alongside an absent SubAccountPnlBasis block
+    // the master basis is intentionally NOT seeded (the aggregate row
+    // is polluted — see SubAccountMasterBasisUnrecoverable below) and
+    // this counter fires together with the unrecoverable counter until
+    // a fresh master fill re-establishes basis. Any other non-zero
+    // count after the P1 backfill ships indicates an invariant
+    // violation (a bucket-basis row was lost mid-process or never
+    // established). When the counter fires the projection emits
+    // AvgPrice = 0 (fail-closed "unknown basis" semantic) instead of
+    // the previous fallback to the polluted aggregate avg.
     public static readonly Counter<long> StatementMasterAvgBasisDegraded =
         Meter.CreateCounter<long>("trading.statement.master_avg_basis_degraded_total");
+    // PR #316 P1 (review). Bumped once per (firmId, owner, symbol) row
+    // when StateSnapshotter.Restore observes a legacy snapshot whose
+    // SubAccountPnlBasis block is absent for a master bucket AND the
+    // same (firm, owner, symbol) carries non-zero sub-account positions.
+    // The aggregate PlatformSnapshot.Positions row in that case is the
+    // SUM of master + every sub bucket and its AverageEntryPrice is a
+    // cross-bucket weighted average — seeding the master bucket from it
+    // would import sibling-bucket basis as master-only history. The
+    // backfill leaves master unseeded; the statement endpoint's
+    // fail-closed path (master_avg_basis_degraded_total + AvgPrice=0)
+    // surfaces the gap to operators until a fresh master fill
+    // re-establishes basis. A non-zero count indicates a snapshot was
+    // written without the SubAccountPnlBasis block while sub-account
+    // activity was already live — investigate the snapshot writer.
+    public static readonly Counter<long> SubAccountMasterBasisUnrecoverable =
+        Meter.CreateCounter<long>("trading.subaccount.master_basis_unrecoverable_total");
     // Pass-1 review (#278) P1#1. Bumped once per (endClient, symbol)
     // row when StateSnapshotter restores a legacy snapshot whose
     // PnlAvgCost block is empty but Positions has rows — the avg-cost

--- a/backend/src/B3.Trading.Application/OrderCancelService.cs
+++ b/backend/src/B3.Trading.Application/OrderCancelService.cs
@@ -61,13 +61,19 @@ public sealed class OrderCancelService
         EndClientId owner,
         ulong originalClOrdId,
         CancellationToken ct,
-        BotOrigin? botOrigin = null)
+        BotOrigin? botOrigin = null,
+        string? firmId = null)
     {
         ArgumentNullException.ThrowIfNull(owner);
 
         if (!_book.TryGet(originalClOrdId, out var order) || order is null)
             return OrderCancelResult.NotFound;
         if (order.Owner != owner)
+            return OrderCancelResult.NotFound;
+        // PR #316 P1. Reject cross-firm cancels (same posture as
+        // modify and read paths) — return NotFound so existence is
+        // not leaked across the firm boundary.
+        if (firmId is not null && !string.Equals(order.FirmId, firmId, StringComparison.Ordinal))
             return OrderCancelResult.NotFound;
         if (order.IsStale)
             return OrderCancelResult.Stale(order.StaleReason ?? "stale");

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -207,6 +207,12 @@ public sealed class OrderModifyService
             // surface as BadRequest (400) before any WAL append.
             return OrderModifyResult.BadRequest(ex.Message);
         }
+        // PR #316 P1. Forward the original's SubAccountId (the
+        // replacement inherits it — see Order.cs ctor) so
+        // SubAccountLimitsCheck enforces per-(firm, sub-account)
+        // position/notional/open-order caps AND rejects modifies
+        // targeting a deactivated sub-account. Without this the
+        // check no-ops on null and the sub-account gate is bypassed.
         var riskCtx = new RiskContext(
             req.Owner, orig.FirmId, orig.Symbol, orig.Side, orig.Type,
             req.NewQuantity, req.NewPrice,
@@ -214,7 +220,8 @@ public sealed class OrderModifyService
             EffectiveLeavesQuantity: effectiveLeaves,
             TimeInForce: effTif,
             StopPrice: effStop,
-            GoodTillDate: effGtd);
+            GoodTillDate: effGtd,
+            SubAccountId: orig.SubAccountId);
 
         var decision = _risk.Evaluate(riskCtx);
         if (!decision.Approved)

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -110,6 +110,13 @@ public sealed class OrderModifyService
         if (orig.Owner != req.Owner)
             return OrderModifyResult.NotFound; // do not leak existence cross-owner
 
+        // PR #316 P1. Reject cross-firm modifies — a JWT sub
+        // registered in two firms knowing a ClOrdId from another
+        // firm must not be able to mutate it. Treated as NotFound
+        // (same as cross-owner) so existence is not leaked.
+        if (req.FirmId is not null && !string.Equals(orig.FirmId, req.FirmId, StringComparison.Ordinal))
+            return OrderModifyResult.NotFound;
+
         if (orig.Status is OrderStatus.Filled or OrderStatus.Cancelled
             or OrderStatus.Rejected or OrderStatus.Replaced)
         {
@@ -365,7 +372,17 @@ public sealed record OrderModifyRequest(
     decimal? NewPrice,
     TimeInForce? NewTimeInForce = null,
     decimal? NewStopPrice = null,
-    DateTimeOffset? NewGoodTillDate = null);
+    DateTimeOffset? NewGoodTillDate = null,
+    /// <summary>
+    /// PR #316 P1. Caller's firm scope. When non-null, the service
+    /// rejects (as NotFound) modifies whose original order belongs
+    /// to a different firm — same isolation guard as
+    /// <c>OrdersEndpoints</c>' GET path. Optional for back-compat
+    /// with internal callers (algo engine, GTD scheduler) that
+    /// already operate on a known order; user-facing transports
+    /// (REST, FIXP) must populate it.
+    /// </summary>
+    string? FirmId = null);
 
 /// <summary>
 /// Outcome of <see cref="OrderModifyService.ModifyAsync"/>. The

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -322,7 +322,8 @@ public sealed class OrderModifyService
                 LeavesQuantity: 0, CumulativeQuantity: 0,
                 LastQuantity: 0, LastPrice: 0m,
                 RejectReason: "gateway_unavailable",
-                TimestampUtc: DateTimeOffset.UtcNow));
+                TimestampUtc: DateTimeOffset.UtcNow,
+                FirmId: orig.FirmId));
             return OrderModifyResult.GatewayFailed(newClOrdId, ex);
         }
 

--- a/backend/src/B3.Trading.Application/OrderStalenessService.cs
+++ b/backend/src/B3.Trading.Application/OrderStalenessService.cs
@@ -207,7 +207,8 @@ public sealed class OrderStalenessService
                 LastQuantity: 0,
                 LastPrice: 0m,
                 RejectReason: reason,
-                TimestampUtc: atUtc));
+                TimestampUtc: atUtc,
+                FirmId: order.FirmId));
         }
         catch
         {

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -301,7 +301,7 @@ public sealed class OrderSubmissionService
                     _sink.Publish(new ExecutionEvent(
                         order.Owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
                         order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
-                        reason, DateTimeOffset.UtcNow));
+                        reason, DateTimeOffset.UtcNow, IsNativeStp: false, FirmId: order.FirmId));
                 });
         }
         catch (WalBackpressureException)
@@ -310,7 +310,7 @@ public sealed class OrderSubmissionService
             _sink.Publish(new ExecutionEvent(
                 order.Owner, order.ClOrdId, order.Symbol, order.Side, order.Status, ExecKind.Rejected,
                 order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
-                reason, DateTimeOffset.UtcNow));
+                reason, DateTimeOffset.UtcNow, IsNativeStp: false, FirmId: order.FirmId));
         }
     }
 }

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -136,7 +136,8 @@ public sealed class OrderSubmissionService
                 req.Quantity, req.Price, req.FirmId,
                 parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq,
                 timeInForce: req.TimeInForce, stopPrice: req.StopPrice, goodTillDate: req.GoodTillDate,
-                displayQty: req.DisplayQty, displayResetPolicy: req.DisplayResetPolicy);
+                displayQty: req.DisplayQty, displayResetPolicy: req.DisplayResetPolicy,
+                subAccountId: req.SubAccountId);
         }
         catch (ArgumentException ex)
         {
@@ -181,6 +182,7 @@ public sealed class OrderSubmissionService
                     GoodTillDate = req.GoodTillDate,
                     DisplayQty = order.DisplayQty,
                     DisplayResetPolicy = order.DisplayResetPolicy?.ToString(),
+                    SubAccountId = order.SubAccountId?.Value,
                 },
                 () =>
                 {
@@ -228,7 +230,8 @@ public sealed class OrderSubmissionService
             req.Owner, req.FirmId, req.Symbol, req.Side, req.Type, req.Quantity, req.Price,
             TimeInForce: req.TimeInForce,
             StopPrice: req.StopPrice,
-            GoodTillDate: req.GoodTillDate);
+            GoodTillDate: req.GoodTillDate,
+            SubAccountId: req.SubAccountId);
         var decision = _risk.Evaluate(riskCtx);
         var marginReserved = false;
         if (decision.Approved)
@@ -345,7 +348,16 @@ public sealed record OrderSubmissionRequest(
     /// otherwise defaults to
     /// <see cref="Domain.DisplayResetPolicy.Always"/>.
     /// </summary>
-    DisplayResetPolicy? DisplayResetPolicy = null)
+    DisplayResetPolicy? DisplayResetPolicy = null,
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket the order is booked
+    /// against. <c>null</c> = master bucket (every legacy caller).
+    /// When non-null, the submit pipeline records the id on the WAL,
+    /// the order, the per-sub-account position keeper, and runs the
+    /// per-sub-account risk gates ON TOP OF the existing master ones
+    /// — reject-on-either-fail (see <c>SubAccountLimitsCheck</c>).
+    /// </summary>
+    SubAccountId? SubAccountId = null)
 {
     /// <summary>
     /// Sub-issue #171 (E). When non-null, the request originates from

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -156,6 +156,27 @@ public sealed class RawPlatformSnapshot
     /// no-op, matching pre-pass-6 behaviour).
     /// </summary>
     public PendingReplacementRaw[] PendingReplacements { get; init; } = Array.Empty<PendingReplacementRaw>();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-firm registry of sub-accounts. Empty on
+    /// snapshots pre-dating the field (additive); rebuilt entirely
+    /// from <c>SubAccountCreatedEvent</c> / <c>SubAccountDeactivatedEvent</c>
+    /// replay in that case.
+    /// </summary>
+    public IReadOnlyList<SubAccountSnapshot> SubAccounts { get; init; } =
+        Array.Empty<SubAccountSnapshot>();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-(end-client, sub-account, symbol) net positions.
+    /// </summary>
+    public IReadOnlyList<SubAccountPositionSnapshot> SubAccountPositions { get; init; } =
+        Array.Empty<SubAccountPositionSnapshot>();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-(end-client, sub-account, symbol, day) realized P&amp;L totals.
+    /// </summary>
+    public IReadOnlyList<SubAccountPnlSnapshot> SubAccountPnl { get; init; } =
+        Array.Empty<SubAccountPnlSnapshot>();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -244,7 +244,9 @@ public readonly record struct PositionRaw(
     string EndClientId,
     string Symbol,
     long NetQuantity,
-    decimal AverageEntryPrice);
+    decimal AverageEntryPrice,
+    // PR #316 P1. Firm dimension on owner-keyed state.
+    string FirmId = "DEFAULT");
 
 public readonly record struct OwnershipRaw(ulong ClOrdId, string EndClientId);
 
@@ -272,14 +274,26 @@ public readonly record struct FeeKeeperRaw(string EndClientId, DateOnly Day, dec
 /// Q2.4 (#271). Raw lock-side capture of one (end-client, symbol, day)
 /// realized-P&amp;L bucket from <see cref="B3.Trading.Application.PnlKeeper"/>.
 /// </summary>
-public readonly record struct PnlRealizedRaw(string EndClientId, string Symbol, DateOnly Day, decimal Realized);
+public readonly record struct PnlRealizedRaw(
+    string EndClientId,
+    string Symbol,
+    DateOnly Day,
+    decimal Realized,
+    // PR #316 P1. Firm dimension on owner-keyed state.
+    string FirmId = "DEFAULT");
 
 /// <summary>
 /// Q2.4 (#271). Raw lock-side capture of one (end-client, symbol)
 /// avg-cost basis row tracked by <see cref="B3.Trading.Application.PnlKeeper"/>
 /// in parallel with <see cref="B3.Trading.Application.PositionKeeper"/>.
 /// </summary>
-public readonly record struct PnlAvgCostRaw(string EndClientId, string Symbol, long NetQuantity, decimal AvgPrice);
+public readonly record struct PnlAvgCostRaw(
+    string EndClientId,
+    string Symbol,
+    long NetQuantity,
+    decimal AvgPrice,
+    // PR #316 P1. Firm dimension on owner-keyed state.
+    string FirmId = "DEFAULT");
 
 /// <summary>
 /// Pass-3 review (#278) P1. Raw lock-side capture of one
@@ -288,7 +302,12 @@ public readonly record struct PnlAvgCostRaw(string EndClientId, string Symbol, l
 /// snapshot rehydration. Persisting this set keeps a snapshot+tail
 /// recovery from re-creating the phantom-P&amp;L bug on every restart.
 /// </summary>
-public readonly record struct PnlUnknownBasisRaw(string EndClientId, string Symbol, long NetQuantity);
+public readonly record struct PnlUnknownBasisRaw(
+    string EndClientId,
+    string Symbol,
+    long NetQuantity,
+    // PR #316 P1. Firm dimension on owner-keyed state.
+    string FirmId = "DEFAULT");
 
 public readonly record struct ClOrdIdCounterRaw(string EndClientId, ulong PrefixIdx, long Counter);
 

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -177,6 +177,13 @@ public sealed class RawPlatformSnapshot
     /// </summary>
     public IReadOnlyList<SubAccountPnlSnapshot> SubAccountPnl { get; init; } =
         Array.Empty<SubAccountPnlSnapshot>();
+
+    /// <summary>
+    /// PR #316 P2. Per-bucket avg-cost basis rows from
+    /// <see cref="B3.Trading.Application.SubAccountPnlKeeper"/>.
+    /// </summary>
+    public IReadOnlyList<SubAccountPnlBasisSnapshot> SubAccountPnlBasis { get; init; } =
+        Array.Empty<SubAccountPnlBasisSnapshot>();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -565,11 +565,18 @@ public sealed record SessionPhaseOverrideSnapshot(string Symbol, string Phase);
 public sealed record SubAccountSnapshot(string FirmId, string Id, string? DisplayName, bool Active);
 
 /// <summary>
-/// Q4.1 (#301). One <c>(EndClientId, SubAccountId, Symbol) → net
-/// quantity + avg price</c> row from
+/// Q4.1 (#301). One <c>(FirmId, EndClientId, SubAccountId, Symbol) →
+/// net quantity + avg price</c> row from
 /// <see cref="B3.Trading.Application.SubAccountPositionKeeper"/>.
+///
+/// <para>
+/// <b>Migration note.</b> <see cref="FirmId"/> is additive and
+/// non-nullable. The DTO type is new in Q4.1 (#301) — no production
+/// snapshots predate it, so there are no legacy records to migrate.
+/// </para>
 /// </summary>
 public sealed record SubAccountPositionSnapshot(
+    string FirmId,
     string EndClientId,
     string SubAccountId,
     string Symbol,
@@ -577,11 +584,19 @@ public sealed record SubAccountPositionSnapshot(
     decimal AverageEntryPrice);
 
 /// <summary>
-/// Q4.1 (#301). One <c>(EndClientId, SubAccountId, Symbol, Day) →
-/// realized total</c> row from
+/// Q4.1 (#301). One <c>(FirmId, EndClientId, SubAccountId, Symbol,
+/// Day) → realized total</c> row from
 /// <see cref="B3.Trading.Application.SubAccountPnlKeeper"/>.
+///
+/// <para>
+/// <b>Migration note.</b> Same shape concern as
+/// <see cref="SubAccountPositionSnapshot"/>: <see cref="FirmId"/> is
+/// additive non-nullable on a type new in Q4.1, no pre-merge data
+/// exists.
+/// </para>
 /// </summary>
 public sealed record SubAccountPnlSnapshot(
+    string FirmId,
     string EndClientId,
     string SubAccountId,
     string Symbol,

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -430,7 +430,12 @@ public sealed record PositionSnapshot(
     string EndClientId,
     string Symbol,
     long NetQuantity,
-    decimal AverageEntryPrice);
+    decimal AverageEntryPrice,
+    // PR #316 P1. Firm dimension on owner-keyed state. Defaults to
+    // "default" so older snapshots and test-only call sites that
+    // construct PositionSnapshot positionally still round-trip; the
+    // firm-aware code paths overwrite this with the real firm.
+    string FirmId = "DEFAULT");
 
 public sealed record CashBalanceSnapshot(
     string EndClientId,
@@ -444,7 +449,10 @@ public sealed record PnlAvgCostSnapshot(
     string EndClientId,
     string Symbol,
     long NetQuantity,
-    decimal AvgPrice);
+    decimal AvgPrice,
+    // PR #316 P1. Firm dimension on owner-keyed state. Defaults to
+    // "default" so older snapshots hydrate as a single legacy bucket.
+    string FirmId = "DEFAULT");
 
 /// <summary>
 /// Pass-3 review (#278) P1. Persisted "unknown basis" qty row —
@@ -453,7 +461,10 @@ public sealed record PnlAvgCostSnapshot(
 public sealed record PnlUnknownBasisSnapshot(
     string EndClientId,
     string Symbol,
-    long NetQuantity);
+    long NetQuantity,
+    // PR #316 P1. Firm dimension on owner-keyed state. Defaults to
+    // "default" so older snapshots hydrate as a single legacy bucket.
+    string FirmId = "DEFAULT");
 
 /// <summary>
 /// Pass-1 review (#295) P1#1. One row of the per-POV scheduling-progress

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -253,6 +253,14 @@ public sealed class PlatformSnapshot
     /// pre-dating the field.
     /// </summary>
     public List<SubAccountPnlSnapshot> SubAccountPnl { get; init; } = new();
+
+    /// <summary>
+    /// PR #316 P2. Per-bucket avg-cost basis rows powering
+    /// <see cref="B3.Trading.Application.SubAccountPnlKeeper.ApplyBucketFill"/>.
+    /// Empty on snapshots predating the field — legacy hydrates to an
+    /// empty basis map (best-effort, see record doc).
+    /// </summary>
+    public List<SubAccountPnlBasisSnapshot> SubAccountPnlBasis { get; init; } = new();
 }
 
 /// <summary>
@@ -613,3 +621,24 @@ public sealed record SubAccountPnlSnapshot(
     string Symbol,
     DateOnly Day,
     decimal RealizedTotal);
+
+/// <summary>
+/// PR #316 P2. One row of the per-bucket avg-cost basis projected
+/// by <see cref="B3.Trading.Application.SubAccountPnlKeeper"/>.
+/// <see cref="SubAccountId"/> is
+/// <see cref="B3.Trading.Application.SubAccountPnlKeeper.MasterBucketKey"/>
+/// (empty string) for the MASTER bucket (fills with no sub-account
+/// tag) and a real sub-account id otherwise. Persisted alongside
+/// <see cref="SubAccountPnlSnapshot"/> so a snapshot+tail recovery
+/// preserves bucket-level basis. Additive on snapshots predating
+/// the field; legacy hydrates to an empty basis map (best-effort
+/// recovery — see <c>SubAccountPnlKeeper.SnapshotBasis</c> for the
+/// recovery semantics).
+/// </summary>
+public sealed record SubAccountPnlBasisSnapshot(
+    string FirmId,
+    string EndClientId,
+    string SubAccountId,
+    string Symbol,
+    long NetQuantity,
+    decimal AvgPrice);

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -229,6 +229,30 @@ public sealed class PlatformSnapshot
     /// process".
     /// </summary>
     public List<PendingReplacementSnapshot> PendingReplacements { get; init; } = new();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-firm registry of known sub-accounts (active
+    /// + soft-deleted). Empty on snapshots pre-dating the field;
+    /// rebuilt entirely from <see cref="SubAccountCreatedEvent"/> /
+    /// <see cref="SubAccountDeactivatedEvent"/> replay in that case.
+    /// </summary>
+    public List<SubAccountSnapshot> SubAccounts { get; init; } = new();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-(end-client, sub-account, symbol) net
+    /// positions for sub-account-tagged fills. The master aggregate
+    /// continues to live in <see cref="Positions"/> (sub-account-null
+    /// and sub-account-tagged fills both folded). Empty on snapshots
+    /// pre-dating the field.
+    /// </summary>
+    public List<SubAccountPositionSnapshot> SubAccountPositions { get; init; } = new();
+
+    /// <summary>
+    /// Q4.1 (#301). Per-(end-client, sub-account, symbol, day)
+    /// realized-P&amp;L running totals. Empty on snapshots
+    /// pre-dating the field.
+    /// </summary>
+    public List<SubAccountPnlSnapshot> SubAccountPnl { get; init; } = new();
 }
 
 /// <summary>
@@ -339,6 +363,14 @@ public sealed record OrderSnapshot(
     /// to <c>null</c>.
     /// </summary>
     public string? DisplayResetPolicy { get; init; }
+
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket the order was booked
+    /// against at submit time. Null = master bucket. Older snapshots
+    /// without the field hydrate as null, matching the pre-#301
+    /// semantics they actually carried.
+    /// </summary>
+    public string? SubAccountId { get; init; }
 }
 
 /// <summary>
@@ -522,3 +554,36 @@ public sealed record AlgoIdCounterSnapshot(string FirmId, long Counter);
 /// enum name for forward-compat across reorderings.
 /// </summary>
 public sealed record SessionPhaseOverrideSnapshot(string Symbol, string Phase);
+
+/// <summary>
+/// Q4.1 (#301). One per-firm row of the
+/// <see cref="B3.Trading.Application.SubAccountsRegistry"/>.
+/// <see cref="Active"/> = false means soft-deleted: orders still
+/// resolve historically, but the submit pipeline rejects new ones
+/// (the registry's <c>IsActive</c> gate fails).
+/// </summary>
+public sealed record SubAccountSnapshot(string FirmId, string Id, string? DisplayName, bool Active);
+
+/// <summary>
+/// Q4.1 (#301). One <c>(EndClientId, SubAccountId, Symbol) → net
+/// quantity + avg price</c> row from
+/// <see cref="B3.Trading.Application.SubAccountPositionKeeper"/>.
+/// </summary>
+public sealed record SubAccountPositionSnapshot(
+    string EndClientId,
+    string SubAccountId,
+    string Symbol,
+    long NetQuantity,
+    decimal AverageEntryPrice);
+
+/// <summary>
+/// Q4.1 (#301). One <c>(EndClientId, SubAccountId, Symbol, Day) →
+/// realized total</c> row from
+/// <see cref="B3.Trading.Application.SubAccountPnlKeeper"/>.
+/// </summary>
+public sealed record SubAccountPnlSnapshot(
+    string EndClientId,
+    string SubAccountId,
+    string Symbol,
+    DateOnly Day,
+    decimal RealizedTotal);

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -54,6 +54,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(CashLedgerEvent))]
 [JsonSerializable(typeof(FeeAccruedEvent))]
 [JsonSerializable(typeof(RealizedPnlEvent))]
+[JsonSerializable(typeof(SubAccountCreatedEvent))]
+[JsonSerializable(typeof(SubAccountDeactivatedEvent))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -52,6 +52,8 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(CashLedgerEvent), "cash.ledger")]
 [JsonDerivedType(typeof(FeeAccruedEvent), "fee.accrued")]
 [JsonDerivedType(typeof(RealizedPnlEvent), "pnl.realized")]
+[JsonDerivedType(typeof(SubAccountCreatedEvent), "sub-account.created")]
+[JsonDerivedType(typeof(SubAccountDeactivatedEvent), "sub-account.deactivated")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -142,6 +144,17 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// segments without the field deserialise as <c>null</c>.
     /// </summary>
     public string? DisplayResetPolicy { get; init; }
+
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket. <c>null</c> = master
+    /// bucket — every legacy WAL segment deserialises with this field
+    /// missing, which maps to <c>null</c>, which is the only value
+    /// the platform produced before this slice. Validated through
+    /// <see cref="Domain.SubAccountId"/>'s constructor on replay so a
+    /// corrupted id surfaces as a deserialisation error rather than
+    /// silently poisoning the sub-account books.
+    /// </summary>
+    public string? SubAccountId { get; init; }
 }
 
 /// <summary>
@@ -370,6 +383,14 @@ public sealed record AlgoCreatedEvent : WalEvent
     public required string Type { get; init; }   // "Iceberg" | "Twap" | "Vwap" | "Pov" | "Pegged"
     public required long TotalQuantity { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
+
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket. Inherited by every
+    /// child <see cref="OrderSubmittedEvent"/> the engine produces
+    /// for this parent. <c>null</c> = master bucket (pre-#301
+    /// semantics — every legacy AlgoCreated row).
+    /// </summary>
+    public string? SubAccountId { get; init; }
     /// <summary>
     /// Iceberg-only: visible slice quantity. Mutually exclusive with
     /// the Twap fields below. Validated by the engine, not the WAL —
@@ -873,6 +894,11 @@ public sealed record FeeAccruedEvent : WalEvent
     public required decimal Emolumentos { get; init; }
     public required decimal Liquidacao { get; init; }
     public required decimal Total { get; init; }
+
+    /// <summary>Q4.1 (#301). Optional sub-account bucket; inherited
+    /// from the originating order. Legacy rows hydrate as <c>null</c>
+    /// (master).</summary>
+    public string? SubAccountId { get; init; }
 }
 
 /// <summary>
@@ -941,4 +967,40 @@ public sealed record RealizedPnlEvent : WalEvent
     /// avg-cost calculation in the keeper has drifted between runs.
     /// </summary>
     public required decimal RunningTotal { get; init; }
+
+    /// <summary>Q4.1 (#301). Optional sub-account bucket; inherited
+    /// from the originating order. Legacy rows hydrate as <c>null</c>
+    /// (master).</summary>
+    public string? SubAccountId { get; init; }
+}
+
+/// <summary>
+/// Q4.1 (#301). Recorded when a new sub-account is registered for a
+/// firm via <c>POST /sub-accounts</c>. The
+/// <c>SubAccountsRegistry</c> rehydrates the in-memory set on
+/// recovery by replaying this event family (CREATE / DEACTIVATE).
+/// Sub-accounts are namespaced per-firm: <c>(FirmId, Id)</c> is the
+/// uniqueness key.
+/// </summary>
+public sealed record SubAccountCreatedEvent : WalEvent
+{
+    public required string FirmId { get; init; }
+    public required string Id { get; init; }
+    public string? DisplayName { get; init; }
+    public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Q4.1 (#301). Soft-delete companion to
+/// <see cref="SubAccountCreatedEvent"/>. The registry marks the
+/// matching entry inactive; history endpoints continue to surface
+/// the id, but the submit pipeline rejects new orders against it
+/// (the registry returns <c>false</c> from <c>IsActive</c>).
+/// Re-issuing a CREATE for the same id revives it.
+/// </summary>
+public sealed record SubAccountDeactivatedEvent : WalEvent
+{
+    public required string FirmId { get; init; }
+    public required string Id { get; init; }
+    public string? ActorUserId { get; init; }
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -972,6 +972,19 @@ public sealed record RealizedPnlEvent : WalEvent
     /// from the originating order. Legacy rows hydrate as <c>null</c>
     /// (master).</summary>
     public string? SubAccountId { get; init; }
+
+    /// <summary>
+    /// Q4.1 (#301). Firm namespace for sub-account fan-out. Required
+    /// whenever <see cref="SubAccountId"/> is set so the replayer can
+    /// route the delta into the firm-scoped
+    /// <see cref="B3.Trading.Application.SubAccountPnlKeeper"/> without
+    /// depending on the <see cref="B3.Trading.Application.WorkingOrderBook"/>
+    /// having been restored first. Pre-#301 WAL segments and
+    /// post-#301 master-bucket rows (no <c>SubAccountId</c>) hydrate
+    /// this as <c>null</c>; the fan-out is short-circuited in those
+    /// cases.
+    /// </summary>
+    public string? FirmId { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -92,7 +92,7 @@ public sealed class PnlKeeper
     private readonly record struct PendingReplaySynth(
         string FirmId, string EndClientId, string Symbol, OrderSide Side,
         long FillQuantity, decimal FillPrice, DateTimeOffset TimestampUtc,
-        long PreFillQuantity, decimal PreFillAvgPrice);
+        long PreFillQuantity, decimal PreFillAvgPrice, string? SubAccountId);
 
     public sealed record AvgCostState(long NetQuantity, decimal AvgPrice);
 
@@ -341,18 +341,37 @@ public sealed class PnlKeeper
         OrderSide side, long fillQuantity, decimal fillPrice,
         DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice) =>
         RegisterPendingReplaySynth(DefaultFirmId, executionId, endClientId, symbol,
-            side, fillQuantity, fillPrice, timestampUtc, preFillQuantity, preFillAvgPrice);
+            side, fillQuantity, fillPrice, timestampUtc, preFillQuantity, preFillAvgPrice, subAccountId: null);
 
     public void RegisterPendingReplaySynth(
         string firmId, string executionId, string endClientId, string symbol,
         OrderSide side, long fillQuantity, decimal fillPrice,
-        DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice)
+        DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice) =>
+        RegisterPendingReplaySynth(firmId, executionId, endClientId, symbol,
+            side, fillQuantity, fillPrice, timestampUtc, preFillQuantity, preFillAvgPrice, subAccountId: null);
+
+    /// <summary>
+    /// PR #316 P1.2. Overload that carries the originating
+    /// <see cref="SubAccountId"/> through to <see cref="FinalizeReplay"/>
+    /// so the materialised delta can be folded into the per-bucket
+    /// realised total in <see cref="SubAccountPnlKeeper"/>. Without
+    /// this, a sub-account fill whose <see cref="RealizedPnlEvent"/>
+    /// did not survive the ER-then-crash window would leak its realised
+    /// delta into the aggregate keeper only — the per-bucket total
+    /// (which is what <c>?subAccount=A</c> reads) would silently drift
+    /// from the live path.
+    /// </summary>
+    public void RegisterPendingReplaySynth(
+        string firmId, string executionId, string endClientId, string symbol,
+        OrderSide side, long fillQuantity, decimal fillPrice,
+        DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice,
+        string? subAccountId)
     {
         ArgumentNullException.ThrowIfNull(executionId);
         if (_seenExecutionIds.ContainsKey(executionId)) return;
         _pendingReplaySynths.TryAdd(executionId,
             new PendingReplaySynth(Norm(firmId), endClientId, symbol, side, fillQuantity, fillPrice,
-                timestampUtc, preFillQuantity, preFillAvgPrice));
+                timestampUtc, preFillQuantity, preFillAvgPrice, subAccountId));
     }
 
     /// <summary>
@@ -362,8 +381,19 @@ public sealed class PnlKeeper
     /// using the pre-fill snapshot captured at registration time so the
     /// outcome is deterministic from position state. Increments
     /// <c>pnl.replay_synth{reconciled=false}</c> per materialised row.
+    ///
+    /// <para>
+    /// PR #316 P1.2. When <paramref name="subAccountPnl"/> is wired,
+    /// each materialised delta whose <see cref="PendingReplaySynth.SubAccountId"/>
+    /// is non-null is ALSO folded into the per-bucket realised total
+    /// so the sub-account view matches the live path. Aggregate-only
+    /// callers (test fixtures using the no-argument overload below)
+    /// retain the original behaviour.
+    /// </para>
     /// </summary>
-    public int FinalizeReplay()
+    public int FinalizeReplay() => FinalizeReplay(subAccountPnl: null);
+
+    public int FinalizeReplay(SubAccountPnlKeeper? subAccountPnl)
     {
         if (_pendingReplaySynths.IsEmpty) return 0;
         var materialised = 0;
@@ -377,6 +407,8 @@ public sealed class PnlKeeper
                 var day = DateOnly.FromDateTime(p.TimestampUtc.UtcDateTime);
                 var key = (p.FirmId, p.EndClientId, p.Symbol, day);
                 _realizedByDay.AddOrUpdate(key, delta, (_, current) => current + delta);
+                if (subAccountPnl is not null && p.SubAccountId is { } sa)
+                    subAccountPnl.Add(p.FirmId, p.EndClientId, new SubAccountId(sa), p.Symbol, day, delta);
             }
             Observability.MetricsRegistry.PnlReplaySynth.Add(1,
                 new KeyValuePair<string, object?>("reconciled", false));

--- a/backend/src/B3.Trading.Application/PnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/PnlKeeper.cs
@@ -37,77 +37,115 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class PnlKeeper
 {
-    /// <summary>Per-(end-client, symbol, day) cumulative realized total.</summary>
-    private readonly ConcurrentDictionary<(string EndClient, string Symbol, DateOnly Day), decimal> _realizedByDay = new();
+    /// <summary>
+    /// PR #316 P1. Sentinel firm id used when a call site has not yet
+    /// been migrated to the firm-aware API (legacy overloads, snapshots
+    /// pre-dating the firm dimension on owner-keyed state).
+    /// </summary>
+    /// <summary>
+    /// Sentinel firm bucket. Matches <see cref="PositionKeeper.DefaultFirmId"/>
+    /// (PR #316 P1) so legacy WAL events and snapshot DTOs lacking a
+    /// firm tag converge on the same bucket as the master keepers.
+    /// </summary>
+    public const string DefaultFirmId = "DEFAULT";
 
     /// <summary>
-    /// Per-(end-client, symbol) avg-cost basis: tracked here in PARALLEL
+    /// PR #316 P1. Case-insensitive normalisation at the keeper boundary
+    /// (see <see cref="PositionKeeper.NormalizeFirmId"/> for rationale).
+    /// </summary>
+    internal static string Norm(string firmId) =>
+        string.IsNullOrEmpty(firmId) ? DefaultFirmId : firmId.ToUpperInvariant();
+
+    /// <summary>Per-(firm, end-client, symbol, day) cumulative realized total.</summary>
+    private readonly ConcurrentDictionary<(string FirmId, string EndClient, string Symbol, DateOnly Day), decimal> _realizedByDay = new();
+
+    /// <summary>
+    /// Per-(firm, end-client, symbol) avg-cost basis: tracked here in PARALLEL
     /// to <see cref="PositionKeeper"/> so a P&amp;L-only snapshot+restore
     /// path (no <see cref="PositionKeeper"/> rehydration) round-trips. In
     /// production both keepers receive every fill and stay in lockstep;
     /// the parallel track defends against a future refactor that splits
     /// the snapshots.
     /// </summary>
-    private readonly ConcurrentDictionary<(string EndClient, string Symbol), AvgCostState> _avgCost = new();
+    private readonly ConcurrentDictionary<(string FirmId, string EndClient, string Symbol), AvgCostState> _avgCost = new();
 
     /// <summary>
-    /// Pass-3 review (#278) P1. Per-(end-client, symbol) net quantity
+    /// Pass-3 review (#278) P1. Per-(firm, end-client, symbol) net quantity
     /// for positions whose basis is UNKNOWN — i.e. seeded from a legacy
     /// <see cref="PositionSnapshot"/> row whose <c>AverageEntryPrice</c>
     /// was zero (pre-#271 snapshot format). Keys here are mutually
     /// exclusive with <see cref="_avgCost"/>: a key in this set has no
-    /// usable avg-price, so <see cref="ApplyFillToAvgCost"/> realises
-    /// 0 for any fill against it (no phantom P&amp;L from an invented
-    /// basis); fills only adjust the unknown qty until the position
-    /// goes flat (entry removed → next fresh fill establishes a real
-    /// basis via the normal opening path) or flips through zero (the
-    /// closing portion realises 0; the residual opens fresh at the
-    /// fill price as a real basis — matching the standard avg-cost
+    /// usable avg-price, so <see cref="ApplyFillToAvgCost(string, string, string, OrderSide, long, decimal)"/>
+    /// realises 0 for any fill against it (no phantom P&amp;L from an
+    /// invented basis); fills only adjust the unknown qty until the
+    /// position goes flat (entry removed → next fresh fill establishes
+    /// a real basis via the normal opening path) or flips through zero
+    /// (the closing portion realises 0; the residual opens fresh at
+    /// the fill price as a real basis — matching the standard avg-cost
     /// convention for sign flips on a known basis).
     /// </summary>
-    private readonly ConcurrentDictionary<(string EndClient, string Symbol), long> _unknownBasisQty = new();
+    private readonly ConcurrentDictionary<(string FirmId, string EndClient, string Symbol), long> _unknownBasisQty = new();
 
     private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
     private readonly ConcurrentDictionary<string, PendingReplaySynth> _pendingReplaySynths = new();
 
     private readonly record struct PendingReplaySynth(
-        string EndClientId, string Symbol, OrderSide Side,
+        string FirmId, string EndClientId, string Symbol, OrderSide Side,
         long FillQuantity, decimal FillPrice, DateTimeOffset TimestampUtc,
         long PreFillQuantity, decimal PreFillAvgPrice);
 
     public sealed record AvgCostState(long NetQuantity, decimal AvgPrice);
 
-    public decimal GetDayRealized(string endClient, string symbol, DateOnly day) =>
-        _realizedByDay.TryGetValue((endClient, symbol, day), out var v) ? v : 0m;
+    // --- Firm-aware public surface (PR #316 P1) ----------------------
 
-    /// <summary>Sum of realized totals across every (symbol, day) for the end-client on the given day.</summary>
-    public decimal GetDayRealizedTotal(string endClient, DateOnly day)
+    public decimal GetDayRealized(string firmId, string endClient, string symbol, DateOnly day) =>
+        _realizedByDay.TryGetValue((Norm(firmId), endClient, symbol, day), out var v) ? v : 0m;
+
+    /// <summary>Sum of realized totals across every (symbol, day) for the (firm, end-client) on the given day.</summary>
+    public decimal GetDayRealizedTotal(string firmId, string endClient, DateOnly day)
     {
+        var norm = Norm(firmId);
         var sum = 0m;
         foreach (var kv in _realizedByDay)
-            if (kv.Key.EndClient == endClient && kv.Key.Day == day) sum += kv.Value;
+            if (kv.Key.EndClient == endClient && kv.Key.Day == day
+                && string.Equals(kv.Key.FirmId, norm, StringComparison.Ordinal))
+                sum += kv.Value;
         return sum;
     }
 
-    public IEnumerable<(string Symbol, decimal Realized)> ForEndClientDay(string endClient, DateOnly day)
+    public IEnumerable<(string Symbol, decimal Realized)> ForEndClientDay(string firmId, string endClient, DateOnly day)
     {
+        var norm = Norm(firmId);
         foreach (var kv in _realizedByDay)
-            if (kv.Key.EndClient == endClient && kv.Key.Day == day)
+            if (kv.Key.EndClient == endClient && kv.Key.Day == day
+                && string.Equals(kv.Key.FirmId, norm, StringComparison.Ordinal))
                 yield return (kv.Key.Symbol, kv.Value);
     }
 
-    public AvgCostState? GetAvgCost(string endClient, string symbol) =>
-        _avgCost.TryGetValue((endClient, symbol), out var s) ? s : null;
+    public AvgCostState? GetAvgCost(string firmId, string endClient, string symbol) =>
+        _avgCost.TryGetValue((Norm(firmId), endClient, symbol), out var s) ? s : null;
 
-    /// <summary>
-    /// Pass-3 review (#278) P1. Returns the net quantity carried as
-    /// "unknown basis" for the given key, or 0 when the key has either
-    /// a known basis or no position at all. Exposed for tests and for
-    /// observability — production code paths route through
-    /// <see cref="ApplyFillToAvgCost"/>.
-    /// </summary>
+    public long GetUnknownBasisQty(string firmId, string endClient, string symbol) =>
+        _unknownBasisQty.TryGetValue((Norm(firmId), endClient, symbol), out var q) ? q : 0;
+
+    // --- Legacy (no-firm) overloads — delegate to DefaultFirmId.
+    // Preserves test-host compatibility and any call site we haven't
+    // migrated yet. Owner-scoped REST/WS read paths MUST use the
+    // firm-aware variants above to avoid cross-firm leaks.
+    public decimal GetDayRealized(string endClient, string symbol, DateOnly day) =>
+        GetDayRealized(DefaultFirmId, endClient, symbol, day);
+
+    public decimal GetDayRealizedTotal(string endClient, DateOnly day) =>
+        GetDayRealizedTotal(DefaultFirmId, endClient, day);
+
+    public IEnumerable<(string Symbol, decimal Realized)> ForEndClientDay(string endClient, DateOnly day) =>
+        ForEndClientDay(DefaultFirmId, endClient, day);
+
+    public AvgCostState? GetAvgCost(string endClient, string symbol) =>
+        GetAvgCost(DefaultFirmId, endClient, symbol);
+
     public long GetUnknownBasisQty(string endClient, string symbol) =>
-        _unknownBasisQty.TryGetValue((endClient, symbol), out var q) ? q : 0;
+        GetUnknownBasisQty(DefaultFirmId, endClient, symbol);
 
     /// <summary>
     /// Pure avg-cost realized-delta calculator. Public so the ER processor
@@ -152,7 +190,12 @@ public sealed class PnlKeeper
                 new KeyValuePair<string, object?>("reconciled", true));
         }
         if (!_seenExecutionIds.TryAdd(evt.ExecutionId, 0)) return false;
-        var key = (evt.EndClientId, evt.Symbol, evt.DayKey);
+        // PR #316 P1. Legacy WAL events (pre-firm-dimension) carry a
+        // null FirmId — they hydrate into the DefaultFirmId bucket so
+        // a snapshot+tail recovery built off old segments lands in the
+        // same legacy slice the no-firm Restore path produces.
+        var firmId = Norm(evt.FirmId ?? DefaultFirmId);
+        var key = (firmId, evt.EndClientId, evt.Symbol, evt.DayKey);
         // Use the persisted RunningTotal as authoritative — see record
         // doc-comment. A re-projection from the in-memory delta would
         // race a snapshot+tail recovery whose snapshot already baked in
@@ -186,10 +229,14 @@ public sealed class PnlKeeper
     /// processing flows through it.
     /// </para>
     /// </summary>
-    public decimal ApplyFillToAvgCost(string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice)
+    public decimal ApplyFillToAvgCost(string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice) =>
+        ApplyFillToAvgCost(DefaultFirmId, endClient, symbol, side, fillQuantity, fillPrice);
+
+    public decimal ApplyFillToAvgCost(string firmId, string endClient, string symbol, OrderSide side, long fillQuantity, decimal fillPrice)
     {
         if (fillQuantity <= 0) return 0m;
-        var key = (endClient, symbol);
+        var normFirm = Norm(firmId);
+        var key = (normFirm, endClient, symbol);
 
         // Pass-3 review (#278) P1. Unknown-basis path: legacy snapshot
         // seeded a quantity but no usable avg price, so we cannot
@@ -292,12 +339,19 @@ public sealed class PnlKeeper
     public void RegisterPendingReplaySynth(
         string executionId, string endClientId, string symbol,
         OrderSide side, long fillQuantity, decimal fillPrice,
+        DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice) =>
+        RegisterPendingReplaySynth(DefaultFirmId, executionId, endClientId, symbol,
+            side, fillQuantity, fillPrice, timestampUtc, preFillQuantity, preFillAvgPrice);
+
+    public void RegisterPendingReplaySynth(
+        string firmId, string executionId, string endClientId, string symbol,
+        OrderSide side, long fillQuantity, decimal fillPrice,
         DateTimeOffset timestampUtc, long preFillQuantity, decimal preFillAvgPrice)
     {
         ArgumentNullException.ThrowIfNull(executionId);
         if (_seenExecutionIds.ContainsKey(executionId)) return;
         _pendingReplaySynths.TryAdd(executionId,
-            new PendingReplaySynth(endClientId, symbol, side, fillQuantity, fillPrice,
+            new PendingReplaySynth(Norm(firmId), endClientId, symbol, side, fillQuantity, fillPrice,
                 timestampUtc, preFillQuantity, preFillAvgPrice));
     }
 
@@ -321,7 +375,7 @@ public sealed class PnlKeeper
             if (delta != 0m)
             {
                 var day = DateOnly.FromDateTime(p.TimestampUtc.UtcDateTime);
-                var key = (p.EndClientId, p.Symbol, day);
+                var key = (p.FirmId, p.EndClientId, p.Symbol, day);
                 _realizedByDay.AddOrUpdate(key, delta, (_, current) => current + delta);
             }
             Observability.MetricsRegistry.PnlReplaySynth.Add(1,
@@ -343,7 +397,7 @@ public sealed class PnlKeeper
         for (var i = 0; i < pairs.Length; i++)
         {
             if (pairs[i].Value == 0m) continue;
-            buf[n++] = new PnlRealizedRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Key.Day, pairs[i].Value);
+            buf[n++] = new PnlRealizedRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Key.Day, pairs[i].Value, pairs[i].Key.FirmId);
         }
         if (n == buf.Length) return buf;
         var trimmed = new PnlRealizedRaw[n];
@@ -362,7 +416,7 @@ public sealed class PnlKeeper
         {
             var v = pairs[i].Value;
             if (v.NetQuantity == 0) continue;
-            buf[n++] = new PnlAvgCostRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, v.NetQuantity, v.AvgPrice);
+            buf[n++] = new PnlAvgCostRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, v.NetQuantity, v.AvgPrice, pairs[i].Key.FirmId);
         }
         if (n == buf.Length) return buf;
         var trimmed = new PnlAvgCostRaw[n];
@@ -386,7 +440,7 @@ public sealed class PnlKeeper
         for (var i = 0; i < pairs.Length; i++)
         {
             if (pairs[i].Value == 0) continue;
-            buf[n++] = new PnlUnknownBasisRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Value);
+            buf[n++] = new PnlUnknownBasisRaw(pairs[i].Key.EndClient, pairs[i].Key.Symbol, pairs[i].Value, pairs[i].Key.FirmId);
         }
         if (n == buf.Length) return buf;
         var trimmed = new PnlUnknownBasisRaw[n];
@@ -423,15 +477,21 @@ public sealed class PnlKeeper
         _seenExecutionIds.Clear();
         foreach (var kv in realizedByKey)
         {
-            if (!TryParseRealizedKey(kv.Key, out var ec, out var sym, out var day)) continue;
-            _realizedByDay[(ec, sym, day)] = kv.Value;
+            if (!TryParseRealizedKey(kv.Key, out var firmId, out var ec, out var sym, out var day)) continue;
+            _realizedByDay[(Norm(firmId), ec, sym, day)] = kv.Value;
         }
         foreach (var row in avgCostRows)
-            _avgCost[(row.EndClientId, row.Symbol)] = new AvgCostState(row.NetQuantity, row.AvgPrice);
+        {
+            var firmId = Norm(row.FirmId);
+            _avgCost[(firmId, row.EndClientId, row.Symbol)] = new AvgCostState(row.NetQuantity, row.AvgPrice);
+        }
         if (unknownBasisRows is not null)
             foreach (var row in unknownBasisRows)
                 if (row.NetQuantity != 0)
-                    _unknownBasisQty[(row.EndClientId, row.Symbol)] = row.NetQuantity;
+                {
+                    var firmId = Norm(row.FirmId);
+                    _unknownBasisQty[(firmId, row.EndClientId, row.Symbol)] = row.NetQuantity;
+                }
         // Pass-4 review (#278) P2#3. Enforce mutual exclusivity
         // between _avgCost and _unknownBasisQty after restore. The
         // live keeper holds these collections strictly disjoint by
@@ -512,12 +572,14 @@ public sealed class PnlKeeper
             if (p.AverageEntryPrice <= 0m)
             {
                 Observability.MetricsRegistry.PnlLegacySnapshotBasisSkippedZero.Add(1);
-                var unknownKey = (p.EndClientId, p.Symbol);
+                var firmId = Norm(p.FirmId);
+                var unknownKey = (firmId, p.EndClientId, p.Symbol);
                 if (!_avgCost.ContainsKey(unknownKey))
                     _unknownBasisQty.TryAdd(unknownKey, p.NetQuantity);
                 continue;
             }
-            var key = (p.EndClientId, p.Symbol);
+            var keyFirmId = Norm(p.FirmId);
+            var key = (keyFirmId, p.EndClientId, p.Symbol);
             if (_avgCost.ContainsKey(key)) continue;
             if (_avgCost.TryAdd(key, new AvgCostState(p.NetQuantity, p.AverageEntryPrice)))
             {
@@ -530,25 +592,48 @@ public sealed class PnlKeeper
 
     /// <summary>
     /// Composite key serialisation for the snapshot's
-    /// <c>Dictionary&lt;string, decimal&gt;</c> shape. Format:
-    /// <c>{endClient}|{symbol}|{yyyy-MM-dd}</c>.
+    /// <c>Dictionary&lt;string, decimal&gt;</c> shape. New format:
+    /// <c>{firmId}|{endClient}|{symbol}|{yyyy-MM-dd}</c>. The legacy
+    /// 3-segment format (<c>{endClient}|{symbol}|{yyyy-MM-dd}</c>) is
+    /// still accepted by <see cref="TryParseRealizedKey(string, out string, out string, out string, out DateOnly)"/>
+    /// and parses as <see cref="DefaultFirmId"/>.
     /// </summary>
-    public static string FormatRealizedKey(string endClient, string symbol, DateOnly day) =>
-        endClient + "|" + symbol + "|" + day.ToString("yyyy-MM-dd");
+    public static string FormatRealizedKey(string firmId, string endClient, string symbol, DateOnly day) =>
+        Norm(firmId) + "|" + endClient + "|" + symbol + "|" + day.ToString("yyyy-MM-dd");
 
-    public static bool TryParseRealizedKey(string key, out string endClient, out string symbol, out DateOnly day)
+    /// <summary>Legacy helper — formats as the default-firm bucket.</summary>
+    public static string FormatRealizedKey(string endClient, string symbol, DateOnly day) =>
+        FormatRealizedKey(DefaultFirmId, endClient, symbol, day);
+
+    public static bool TryParseRealizedKey(string key, out string firmId, out string endClient, out string symbol, out DateOnly day)
     {
+        firmId = DefaultFirmId;
         endClient = string.Empty;
         symbol = string.Empty;
         day = default;
         if (string.IsNullOrEmpty(key)) return false;
-        var lastPipe = key.LastIndexOf('|');
-        if (lastPipe <= 0 || lastPipe == key.Length - 1) return false;
-        if (!DateOnly.TryParseExact(key.AsSpan(lastPipe + 1), "yyyy-MM-dd", out day)) return false;
-        var firstPipe = key.IndexOf('|');
-        if (firstPipe <= 0 || firstPipe == lastPipe) return false;
-        endClient = key.Substring(0, firstPipe);
-        symbol = key.Substring(firstPipe + 1, lastPipe - firstPipe - 1);
-        return true;
+        var parts = key.Split('|');
+        if (parts.Length == 3)
+        {
+            // Legacy (pre-PR #316) format. Hydrates as DefaultFirmId.
+            if (!DateOnly.TryParseExact(parts[2], "yyyy-MM-dd", out day)) return false;
+            if (parts[0].Length == 0 || parts[1].Length == 0) return false;
+            endClient = parts[0];
+            symbol = parts[1];
+            return true;
+        }
+        if (parts.Length == 4)
+        {
+            if (!DateOnly.TryParseExact(parts[3], "yyyy-MM-dd", out day)) return false;
+            if (parts[0].Length == 0 || parts[1].Length == 0 || parts[2].Length == 0) return false;
+            firmId = parts[0];
+            endClient = parts[1];
+            symbol = parts[2];
+            return true;
+        }
+        return false;
     }
+
+    public static bool TryParseRealizedKey(string key, out string endClient, out string symbol, out DateOnly day) =>
+        TryParseRealizedKey(key, out _, out endClient, out symbol, out day);
 }

--- a/backend/src/B3.Trading.Application/PositionKeeper.cs
+++ b/backend/src/B3.Trading.Application/PositionKeeper.cs
@@ -4,15 +4,57 @@ using B3.Trading.Domain;
 namespace B3.Trading.Application;
 
 /// <summary>
-/// Cumulative position keeper, derived from ExecutionReport fills. Per-end-client,
-/// per-symbol. Ephemeral in v1; rebuilt from ER replay on (re)connect.
+/// Cumulative position keeper, derived from ExecutionReport fills. Per-firm,
+/// per-end-client, per-symbol. Ephemeral in v1; rebuilt from ER replay on
+/// (re)connect.
+///
+/// <para>
+/// PR #316 P1. Adds the firm dimension to the internal key so the same JWT
+/// <c>sub</c> (which becomes <see cref="EndClientId"/>) registered under
+/// multiple firms (FIRM01, FIRM02) does NOT collide into a single per-symbol
+/// row. The owner-scoped REST/WS read paths use the new
+/// <see cref="ForEndClientAndFirm"/> variant to return only the caller's
+/// firm slice. Legacy <c>ApplyFill(owner, …)</c> / <c>GetOrCreate(owner, …)</c>
+/// / <c>SeedIfAbsent(owner, …)</c> overloads remain (delegating to
+/// <see cref="DefaultFirmId"/>) so test compatibility and the
+/// <c>PositionSeedOptions</c> startup seed (which does not carry firm) keep
+/// working — the seed goes into the default-firm bucket and is read by the
+/// default-firm code paths.
+/// </para>
 /// </summary>
 public sealed class PositionKeeper
 {
-    private readonly ConcurrentDictionary<(EndClientId Owner, string Symbol), Position> _positions = new();
+    /// <summary>
+    /// PR #316 P1. Sentinel firm id used when a call site has not yet been
+    /// migrated to the firm-aware API (legacy overloads, position seed from
+    /// configuration, older snapshot rows that pre-date the firm dimension).
+    /// </summary>
+    /// <summary>
+    /// Sentinel firm bucket used by the legacy no-firm overloads and
+    /// by the snapshot DTO defaults (PR #316 P1 back-compat). Matches
+    /// <see cref="B3.Trading.Domain.Order"/>'s ctor default so tests
+    /// and any unfirmed call site converge on the same bucket.
+    /// </summary>
+    public const string DefaultFirmId = "DEFAULT";
+
+    /// <summary>
+    /// PR #316 P1. Firm ids in this codebase are treated case-insensitively
+    /// at the keeper boundary: <c>JwtIssuer</c> emits <c>"default"</c> while
+    /// <see cref="Domain.Order"/>'s ctor default is <c>"DEFAULT"</c>, and
+    /// operator-supplied firm codes (FIRM01 vs firm01) must not split the
+    /// same logical bucket. Every <c>firmId</c> parameter is normalised
+    /// before it touches the dict key so all variants converge.
+    /// </summary>
+    internal static string NormalizeFirmId(string firmId) =>
+        string.IsNullOrEmpty(firmId) ? DefaultFirmId : firmId.ToUpperInvariant();
+
+    private readonly ConcurrentDictionary<(string FirmId, EndClientId Owner, string Symbol), Position> _positions = new();
 
     public Position GetOrCreate(EndClientId owner, string symbol) =>
-        _positions.GetOrAdd((owner, symbol), key => new Position(key.Owner, key.Symbol));
+        GetOrCreate(DefaultFirmId, owner, symbol);
+
+    public Position GetOrCreate(string firmId, EndClientId owner, string symbol) =>
+        _positions.GetOrAdd((NormalizeFirmId(firmId), owner, symbol), key => new Position(key.Owner, key.Symbol));
 
     /// <summary>
     /// Insert a starting position iff one is not already tracked for
@@ -21,27 +63,57 @@ public sealed class PositionKeeper
     /// existing position (from snapshot/WAL replay or a prior fill)
     /// already occupies the slot. Idempotent and thread-safe.
     /// </summary>
-    public bool SeedIfAbsent(EndClientId owner, string symbol, long netQuantity, decimal averageEntryPrice)
+    public bool SeedIfAbsent(EndClientId owner, string symbol, long netQuantity, decimal averageEntryPrice) =>
+        SeedIfAbsent(DefaultFirmId, owner, symbol, netQuantity, averageEntryPrice);
+
+    public bool SeedIfAbsent(string firmId, EndClientId owner, string symbol, long netQuantity, decimal averageEntryPrice)
     {
         var seeded = Position.Hydrate(owner, symbol, netQuantity, averageEntryPrice);
-        return _positions.TryAdd((owner, symbol), seeded);
+        return _positions.TryAdd((NormalizeFirmId(firmId), owner, symbol), seeded);
     }
 
-    public void ApplyFill(EndClientId owner, string symbol, OrderSide side, long quantity, decimal price)
+    public void ApplyFill(EndClientId owner, string symbol, OrderSide side, long quantity, decimal price) =>
+        ApplyFill(DefaultFirmId, owner, symbol, side, quantity, price);
+
+    public void ApplyFill(string firmId, EndClientId owner, string symbol, OrderSide side, long quantity, decimal price)
     {
-        var position = GetOrCreate(owner, symbol);
+        var position = GetOrCreate(firmId, owner, symbol);
         lock (position)
         {
             position.ApplyFill(side, quantity, price);
         }
     }
 
+    /// <summary>
+    /// Returns positions for <paramref name="owner"/> across ALL firms.
+    /// Preserved as legacy behaviour for callers we haven't migrated to
+    /// the firm-aware API; owner-scoped REST/WS read paths MUST use
+    /// <see cref="ForEndClientAndFirm"/> to avoid leaking cross-firm rows.
+    /// </summary>
     public IReadOnlyCollection<Position> ForEndClient(EndClientId owner)
     {
         var list = new List<Position>();
         foreach (var kv in _positions)
         {
             if (kv.Key.Owner == owner)
+                list.Add(kv.Value);
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// PR #316 P1. Returns positions for <paramref name="owner"/> filtered
+    /// to <paramref name="firmId"/>. Used by /positions, /pnl, /statement
+    /// and the WS owner-scoped snapshot path so an end-client registered
+    /// under multiple firms only sees the caller's firm slice.
+    /// </summary>
+    public IReadOnlyCollection<Position> ForEndClientAndFirm(string firmId, EndClientId owner)
+    {
+        var norm = NormalizeFirmId(firmId);
+        var list = new List<Position>();
+        foreach (var kv in _positions)
+        {
+            if (kv.Key.Owner == owner && string.Equals(kv.Key.FirmId, norm, StringComparison.Ordinal))
                 list.Add(kv.Value);
         }
         return list;
@@ -67,6 +139,26 @@ public sealed class PositionKeeper
         return list;
     }
 
+    /// <summary>
+    /// PR #316 P1. Same as <see cref="ForSymbol"/> but also returns the
+    /// firmId for each row so per-(owner, firm) fan-out (e.g.
+    /// <c>PnlRefPriceFanOut</c>) can publish a snapshot built from each
+    /// client's own firm slice — required after the keeper grew the firm
+    /// dimension, since the same owner can now appear in multiple firms
+    /// for the same symbol.
+    /// </summary>
+    public IReadOnlyList<(string FirmId, Position Position)> ForSymbolWithFirm(string symbol)
+    {
+        if (string.IsNullOrEmpty(symbol)) return Array.Empty<(string, Position)>();
+        var list = new List<(string, Position)>();
+        foreach (var kv in _positions)
+        {
+            if (kv.Key.Symbol == symbol && kv.Value.NetQuantity != 0)
+                list.Add((kv.Key.FirmId, kv.Value));
+        }
+        return list;
+    }
+
     public IEnumerable<Persistence.PositionSnapshot> Snapshot()
     {
         foreach (var kv in _positions)
@@ -77,7 +169,8 @@ public sealed class PositionKeeper
             if (kv.Value.NetQuantity == 0) continue;
             yield return new Persistence.PositionSnapshot(
                 kv.Key.Owner.Value, kv.Key.Symbol,
-                kv.Value.NetQuantity, kv.Value.AverageEntryPrice);
+                kv.Value.NetQuantity, kv.Value.AverageEntryPrice,
+                kv.Key.FirmId);
         }
     }
 
@@ -100,7 +193,8 @@ public sealed class PositionKeeper
             if (p.NetQuantity == 0) continue;
             buf[n++] = new Persistence.PositionRaw(
                 pairs[i].Key.Owner.Value, pairs[i].Key.Symbol,
-                p.NetQuantity, p.AverageEntryPrice);
+                p.NetQuantity, p.AverageEntryPrice,
+                pairs[i].Key.FirmId);
         }
         if (n == buf.Length) return buf;
         var trimmed = new Persistence.PositionRaw[n];
@@ -115,7 +209,9 @@ public sealed class PositionKeeper
         foreach (var s in snaps)
         {
             var owner = new EndClientId(s.EndClientId);
-            _positions[(owner, s.Symbol)] = Position.Hydrate(owner, s.Symbol, s.NetQuantity, s.AverageEntryPrice);
+            var firmId = NormalizeFirmId(s.FirmId);
+            _positions[(firmId, owner, s.Symbol)] =
+                Position.Hydrate(owner, s.Symbol, s.NetQuantity, s.AverageEntryPrice);
         }
     }
 }

--- a/backend/src/B3.Trading.Application/PositionSeedOptions.cs
+++ b/backend/src/B3.Trading.Application/PositionSeedOptions.cs
@@ -31,6 +31,17 @@ public sealed class PositionSeed
     public string Symbol { get; set; } = string.Empty;
 
     /// <summary>
+    /// PR #316 P2. Optional firm bucket. When unset (legacy config) the
+    /// seed lands in <see cref="PositionKeeper.DefaultFirmId"/>, which
+    /// is invisible to real-mode users authenticated under FIRM01 / FIRM02
+    /// — every multi-firm deployment must populate this explicitly. The
+    /// startup seeder logs a one-shot warning if any seed lacks
+    /// <see cref="Firm"/> while more than one firm is configured under
+    /// <c>Trading:Auth:Users</c>.
+    /// </summary>
+    public string? Firm { get; set; }
+
+    /// <summary>
     /// Net quantity. Positive = long (the only useful seed today, since
     /// the naked-short gate cares about the long side); negative values
     /// are accepted by <see cref="PositionKeeper"/> but no current risk

--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxOpenOrdersCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxOpenOrdersCheck.cs
@@ -46,7 +46,10 @@ public sealed class MaxOpenOrdersCheck : IRiskCheck
         if (!cap.HasValue) return RiskDecision.Approve;
 
         // The current order is already in the book — see XML doc.
-        var openIncludingSelf = _book.CountOpenForOwner(ctx.Owner);
+        // PR #316 P2.1. Cap is resolved per-(firm, end-client) so the
+        // counter must also be firm-scoped: a FIRM02 order under the
+        // same JWT sub must not consume the FIRM01 quota.
+        var openIncludingSelf = _book.CountOpenForOwnerAndFirm(ctx.FirmId, ctx.Owner);
         if (openIncludingSelf > cap.Value)
             return RiskDecision.Reject(
                 $"open orders {openIncludingSelf - 1} would exceed cap {cap.Value} for {ctx.Owner.Value}");

--- a/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/NoNakedShortCheck.cs
@@ -61,8 +61,8 @@ public sealed class NoNakedShortCheck : IRiskCheck
             opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.AllowShortSell);
         if (allow == true) return RiskDecision.Approve;
 
-        var currentLong = _positions.GetOrCreate(ctx.Owner, ctx.Symbol).NetQuantity;
-        var openSellLeaves = _orders.SumOpenSellLeavesForSymbol(ctx.Owner, ctx.Symbol);
+        var currentLong = _positions.GetOrCreate(ctx.FirmId, ctx.Owner, ctx.Symbol).NetQuantity;
+        var openSellLeaves = _orders.SumOpenSellLeavesForSymbolAndFirm(ctx.FirmId, ctx.Owner, ctx.Symbol);
 
         // Modify (cancel-replace) projection — slice 3 of #122. The
         // original order is still in the book until the venue's

--- a/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PositionLimitCheck.cs
@@ -23,7 +23,7 @@ public sealed class PositionLimitCheck : IRiskCheck
         var limit = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.PositionLimit);
         if (!limit.HasValue) return RiskDecision.Approve;
 
-        var current = _positions.GetOrCreate(ctx.Owner, ctx.Symbol).NetQuantity;
+        var current = _positions.GetOrCreate(ctx.FirmId, ctx.Owner, ctx.Symbol).NetQuantity;
         var signed = ctx.Side == OrderSide.Buy ? ctx.Quantity : -ctx.Quantity;
         var projected = Math.Abs(current + signed);
         if (projected > limit.Value)

--- a/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
@@ -90,7 +90,13 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
         if (allow == true) return RiskDecision.Approve;
 
         var oppositeSide = ctx.Side == OrderSide.Buy ? OrderSide.Sell : OrderSide.Buy;
-        foreach (var existing in _orders.ForEndClient(ctx.Owner))
+        // PR #316 P2: scope the contra-order scan to the caller's firm
+        // so an opposite-side working order in FIRM02 cannot reject a
+        // FIRM01 order from the same JWT sub. Self-trading is a venue-
+        // session concern (the matching engine groups orders by firm
+        // session, not by end-client), so cross-firm pairs of the same
+        // owner can never wash-trade through this platform.
+        foreach (var existing in _orders.ForEndClientAndFirm(ctx.FirmId, ctx.Owner))
         {
             if (existing.Side != oppositeSide) continue;
             if (!string.Equals(existing.Symbol, ctx.Symbol, StringComparison.Ordinal)) continue;

--- a/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
@@ -1,0 +1,98 @@
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// Q4.1 (#301). Per-(firm, sub-account) risk gate. Rejects when the
+/// proposed order would push the sub-account-scoped open-order count,
+/// net position, or notional past the cap configured in
+/// <see cref="SubAccountRiskOptions"/>; also rejects any submit
+/// targeting a soft-deleted sub-account.
+///
+/// <para>
+/// <b>Ordering.</b> Runs at <see cref="Order"/> 175 — between
+/// <see cref="MaxOpenOrdersCheck"/> (170) and
+/// <see cref="PositionLimitCheck"/> (200). The master caps fire
+/// first so a sub-account submit that breaches the master ceiling
+/// is rejected with the legacy reason; sub-account-specific caps
+/// then narrow further.
+/// </para>
+///
+/// <para>
+/// <b>Skip path.</b> When <see cref="RiskContext.SubAccountId"/> is
+/// <c>null</c> the check is a complete no-op — master-bucket
+/// submissions are evaluated solely by the legacy gates, preserving
+/// pre-#301 behaviour exactly.
+/// </para>
+/// </summary>
+public sealed class SubAccountLimitsCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<SubAccountRiskOptions> _options;
+    private readonly WorkingOrderBook _book;
+    private readonly SubAccountPositionKeeper _positions;
+    private readonly SubAccountsRegistry _registry;
+
+    public SubAccountLimitsCheck(
+        IOptionsMonitor<SubAccountRiskOptions> options,
+        WorkingOrderBook book,
+        SubAccountPositionKeeper positions,
+        SubAccountsRegistry registry)
+    {
+        _options = options;
+        _book = book;
+        _positions = positions;
+        _registry = registry;
+    }
+
+    public int Order => 175;
+    public string Name => "sub_account_limits";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.SubAccountId is not { } sub) return RiskDecision.Approve;
+
+        if (_registry.TryGet(ctx.FirmId, sub.Value, out var entry) && !entry.Active)
+            return RiskDecision.Reject(
+                $"sub_account_limit_exceeded: sub-account {ctx.FirmId}:{sub.Value} is deactivated");
+
+        var limits = _options.CurrentValue.Resolve(ctx.FirmId, sub.Value);
+        if (limits is null) return RiskDecision.Approve;
+
+        if (limits.MaxOpenOrders is { } maxOpen)
+        {
+            // The current order is already in the book by the time
+            // risk runs — match the MaxOpenOrdersCheck convention.
+            var openIncludingSelf = _book.CountOpenForOwnerAndSubAccount(ctx.Owner, sub);
+            if (openIncludingSelf > maxOpen)
+                return RiskDecision.Reject(
+                    $"sub_account_limit_exceeded: open orders {openIncludingSelf - 1} would exceed sub-account cap {maxOpen} for {ctx.FirmId}:{sub.Value}");
+        }
+
+        if (limits.PositionLimit is { } posCap)
+        {
+            var pos = _positions.GetOrCreate(ctx.Owner, sub, ctx.Symbol);
+            long projectedNet;
+            lock (pos)
+            {
+                projectedNet = ctx.Side == OrderSide.Buy
+                    ? pos.NetQuantity + ctx.Quantity
+                    : pos.NetQuantity - ctx.Quantity;
+            }
+            if (Math.Abs(projectedNet) > posCap)
+                return RiskDecision.Reject(
+                    $"sub_account_limit_exceeded: projected position {projectedNet} would exceed sub-account cap ±{posCap} for {ctx.FirmId}:{sub.Value} on {ctx.Symbol}");
+        }
+
+        if (limits.MaxNotional is { } notCap && ctx.Type == OrderType.Limit && ctx.Price is { } price)
+        {
+            var notional = price * ctx.Quantity;
+            if (notional > notCap)
+                return RiskDecision.Reject(
+                    $"sub_account_limit_exceeded: notional {notional} would exceed sub-account cap {notCap} for {ctx.FirmId}:{sub.Value}");
+        }
+
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
@@ -49,13 +49,25 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
     public int Order => 175;
     public string Name => "sub_account_limits";
 
+    /// <summary>
+    /// Q4.1 (#301). Distinct reason emitted when the targeted
+    /// sub-account is registered-then-deactivated. Kept separate
+    /// from <c>sub_account_limit_exceeded</c> (actual cap breach)
+    /// so observability / client UX can differentiate "you're hard
+    /// stopped" from "your knob is too tight". The REST surface
+    /// mirrors the same string in its structured error
+    /// (<see cref="B3.Trading.Api"/>).
+    /// </summary>
+    public const string DeactivatedReason = "sub_account_deactivated";
+    public const string LimitExceededPrefix = "sub_account_limit_exceeded";
+
     public RiskDecision Check(RiskContext ctx)
     {
         if (ctx.SubAccountId is not { } sub) return RiskDecision.Approve;
 
         if (_registry.TryGet(ctx.FirmId, sub.Value, out var entry) && !entry.Active)
             return RiskDecision.Reject(
-                $"sub_account_limit_exceeded: sub-account {ctx.FirmId}:{sub.Value} is deactivated");
+                $"{DeactivatedReason}: sub-account {ctx.FirmId}:{sub.Value} is deactivated");
 
         var limits = _options.CurrentValue.Resolve(ctx.FirmId, sub.Value);
         if (limits is null) return RiskDecision.Approve;
@@ -64,15 +76,15 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
         {
             // The current order is already in the book by the time
             // risk runs — match the MaxOpenOrdersCheck convention.
-            var openIncludingSelf = _book.CountOpenForOwnerAndSubAccount(ctx.Owner, sub);
+            var openIncludingSelf = _book.CountOpenForOwnerAndSubAccount(ctx.FirmId, ctx.Owner, sub);
             if (openIncludingSelf > maxOpen)
                 return RiskDecision.Reject(
-                    $"sub_account_limit_exceeded: open orders {openIncludingSelf - 1} would exceed sub-account cap {maxOpen} for {ctx.FirmId}:{sub.Value}");
+                    $"{LimitExceededPrefix}: open orders {openIncludingSelf - 1} would exceed sub-account cap {maxOpen} for {ctx.FirmId}:{sub.Value}");
         }
 
         if (limits.PositionLimit is { } posCap)
         {
-            var pos = _positions.GetOrCreate(ctx.Owner, sub, ctx.Symbol);
+            var pos = _positions.GetOrCreate(ctx.FirmId, ctx.Owner, sub, ctx.Symbol);
             long projectedNet;
             lock (pos)
             {
@@ -82,7 +94,7 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
             }
             if (Math.Abs(projectedNet) > posCap)
                 return RiskDecision.Reject(
-                    $"sub_account_limit_exceeded: projected position {projectedNet} would exceed sub-account cap ±{posCap} for {ctx.FirmId}:{sub.Value} on {ctx.Symbol}");
+                    $"{LimitExceededPrefix}: projected position {projectedNet} would exceed sub-account cap ±{posCap} for {ctx.FirmId}:{sub.Value} on {ctx.Symbol}");
         }
 
         if (limits.MaxNotional is { } notCap && ctx.Type == OrderType.Limit && ctx.Price is { } price)
@@ -90,7 +102,7 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
             var notional = price * ctx.Quantity;
             if (notional > notCap)
                 return RiskDecision.Reject(
-                    $"sub_account_limit_exceeded: notional {notional} would exceed sub-account cap {notCap} for {ctx.FirmId}:{sub.Value}");
+                    $"{LimitExceededPrefix}: notional {notional} would exceed sub-account cap {notCap} for {ctx.FirmId}:{sub.Value}");
         }
 
         return RiskDecision.Approve;

--- a/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
@@ -37,7 +37,14 @@ public sealed record RiskContext(
     // with the original positional arguments.
     TimeInForce TimeInForce = TimeInForce.Day,
     decimal? StopPrice = null,
-    DateTimeOffset? GoodTillDate = null);
+    DateTimeOffset? GoodTillDate = null,
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket the order is booked
+    /// against. Forwarded to <c>SubAccountLimitsCheck</c> so the
+    /// per-(firm, subAccount) caps are applied alongside the master
+    /// caps. <c>null</c> means master-only (legacy semantics).
+    /// </summary>
+    SubAccountId? SubAccountId = null);
 
 public sealed record RiskDecision(bool Approved, string? Reason)
 {

--- a/backend/src/B3.Trading.Application/Risk/SubAccountRiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/SubAccountRiskOptions.cs
@@ -1,0 +1,106 @@
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Q4.1 (#301). Per-(firm, subAccountId) risk caps applied IN
+/// ADDITION TO the existing master caps in <see cref="RiskOptions"/>.
+/// The pipeline rejects the submit if EITHER bucket fails — master
+/// limits still always apply globally; sub-account limits are a
+/// per-segregated-bucket extra gate.
+///
+/// <para>
+/// <b>Config shape.</b> Bound from <c>Trading:Risk:SubAccount</c>:
+/// <code>
+/// {
+///   "PerFirm": {
+///     "FIRM01": {
+///       "PerSubAccount": {
+///         "tradingdesk": { "MaxOpenOrders": 50, "PositionLimit": 100000, "MaxNotional": 5000000 }
+///       },
+///       "Default": { "MaxOpenOrders": 25 }
+///     }
+///   }
+/// }
+/// </code>
+/// Resolution: per-(firm, sub-account) → per-firm default → null
+/// (no sub-account cap; only master gates apply). A missing key at
+/// every level collapses to "no cap" — the check is a no-op for
+/// firms / sub-accounts that have not been configured.
+/// </para>
+///
+/// <para>
+/// <b>Reason taxonomy.</b> Rejections from
+/// <see cref="Checks.SubAccountLimitsCheck"/> use the
+/// <c>sub_account_limit_exceeded</c> reason prefix so a metric / log
+/// scan can distinguish them from the master-side rejections.
+/// </para>
+/// </summary>
+public sealed class SubAccountRiskOptions
+{
+    public const string SectionName = "Trading:Risk:SubAccount";
+
+    public Dictionary<string, FirmSubAccountRiskOptions> PerFirm { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves the effective <see cref="SubAccountRiskLimits"/> for
+    /// <paramref name="firmId"/> / <paramref name="subAccountId"/>.
+    /// Returns <c>null</c> when no per-firm configuration exists for
+    /// the firm at all — the check is then a complete no-op (master
+    /// limits still apply via the existing pipeline).
+    /// </summary>
+    public SubAccountRiskLimits? Resolve(string firmId, string subAccountId)
+    {
+        if (string.IsNullOrWhiteSpace(firmId) || string.IsNullOrWhiteSpace(subAccountId))
+            return null;
+        if (!PerFirm.TryGetValue(firmId, out var firm)) return null;
+        if (firm.PerSubAccount.TryGetValue(subAccountId, out var explicitCap))
+            return Merge(explicitCap, firm.Default);
+        return firm.Default;
+    }
+
+    private static SubAccountRiskLimits Merge(SubAccountRiskLimits primary, SubAccountRiskLimits? fallback) =>
+        fallback is null
+            ? primary
+            : new SubAccountRiskLimits
+            {
+                MaxOpenOrders = primary.MaxOpenOrders ?? fallback.MaxOpenOrders,
+                PositionLimit = primary.PositionLimit ?? fallback.PositionLimit,
+                MaxNotional = primary.MaxNotional ?? fallback.MaxNotional,
+            };
+}
+
+public sealed class FirmSubAccountRiskOptions
+{
+    public Dictionary<string, SubAccountRiskLimits> PerSubAccount { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public SubAccountRiskLimits? Default { get; set; }
+}
+
+public sealed class SubAccountRiskLimits
+{
+    /// <summary>
+    /// Cap on simultaneous non-terminal orders for the sub-account
+    /// (PendingNew / Working / PartiallyFilled). Mirrors the master
+    /// <see cref="RiskLimits.MaxOpenOrders"/> but scoped to the
+    /// per-sub-account secondary index on
+    /// <see cref="WorkingOrderBook"/>.
+    /// </summary>
+    public int? MaxOpenOrders { get; set; }
+
+    /// <summary>
+    /// Cap on the absolute net position within the sub-account on
+    /// the order's symbol. Computed exactly like the master
+    /// <see cref="RiskLimits.PositionLimit"/>, but against
+    /// <see cref="SubAccountPositionKeeper"/>'s row.
+    /// </summary>
+    public long? PositionLimit { get; set; }
+
+    /// <summary>
+    /// Cap on the new order's notional (<c>price × quantity</c>) for
+    /// sub-account-tagged Limit orders. Market orders skip — there
+    /// is no price to evaluate, exactly like
+    /// <see cref="RiskLimits.MaxNotional"/>.
+    /// </summary>
+    public decimal? MaxNotional { get; set; }
+}

--- a/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/GtdExpirationScheduler.cs
@@ -616,7 +616,8 @@ public sealed class GtdExpirationScheduler : IHostedService, IDisposable
                     LastQuantity: 0,
                     LastPrice: 0m,
                     RejectReason: ReasonGtd,
-                    TimestampUtc: originalGtd));
+                    TimestampUtc: originalGtd,
+                    FirmId: order.FirmId));
             }
             catch (Exception ex)
             {

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -74,7 +74,8 @@ public static class StatementProjection
         string firmId,
         IReadOnlyList<(long Seq, WalEvent Event)> walEventsAllTime,
         IReadOnlyList<PositionRowDto>? livePositionsSnapshot,
-        string? subAccountFilter = null)
+        string? subAccountFilter = null,
+        IReadOnlyList<PositionRowDto>? liveMasterSeedFallback = null)
     {
         ArgumentNullException.ThrowIfNull(walEventsAllTime);
         ArgumentException.ThrowIfNullOrEmpty(firmId);
@@ -217,6 +218,48 @@ public static class StatementProjection
         else
         {
             positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId, subAccountFilter);
+
+            // PR #316 P2. Today's unfiltered statement falls into this
+            // WAL-replay branch the moment any sub-account row exists
+            // for (firm, owner) — the live master snapshot would
+            // double-count, so we cannot reuse it verbatim. But WAL
+            // replay misses any positions seeded directly into
+            // PositionKeeper at host startup (TradingHostStartup applies
+            // seeds straight to the keeper, never via WAL). To recover
+            // them, the caller passes the live master snapshot through
+            // <paramref name="liveMasterSeedFallback"/>: for every
+            // symbol present there but absent from the WAL-projected
+            // master bucket we inject the live row as a master-bucket
+            // entry (SubAccountId=null). Symbols already projected from
+            // WAL keep their WAL-derived qty/avg untouched (so today's
+            // master fills are not overwritten by the seed). Only used
+            // for unfiltered queries — a sub-account-scoped statement
+            // must never see master-bucket seeds.
+            if (liveMasterSeedFallback is not null && subAccountFilter is null && liveMasterSeedFallback.Count > 0)
+            {
+                var masterPresent = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var p in positions)
+                    if (p.SubAccountId is null) masterPresent.Add(p.Symbol);
+
+                List<PositionRowDto>? merged = null;
+                foreach (var seed in liveMasterSeedFallback)
+                {
+                    if (seed.NetQty == 0) continue;
+                    if (masterPresent.Contains(seed.Symbol)) continue;
+                    merged ??= new List<PositionRowDto>(positions);
+                    merged.Add(new PositionRowDto(seed.Symbol, seed.NetQty, seed.AvgPrice, null));
+                }
+                if (merged is not null)
+                {
+                    merged.Sort(static (a, b) =>
+                    {
+                        var bySym = string.CompareOrdinal(a.Symbol, b.Symbol);
+                        if (bySym != 0) return bySym;
+                        return string.CompareOrdinal(a.SubAccountId ?? "", b.SubAccountId ?? "");
+                    });
+                    positions = merged;
+                }
+            }
         }
 
         // ----------------- IR day-trade pre-calc -----------------

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -73,7 +73,8 @@ public static class StatementProjection
         DateOnly dayKey,
         string firmId,
         IReadOnlyList<(long Seq, WalEvent Event)> walEventsAllTime,
-        IReadOnlyList<PositionRowDto>? livePositionsSnapshot)
+        IReadOnlyList<PositionRowDto>? livePositionsSnapshot,
+        string? subAccountFilter = null)
     {
         ArgumentNullException.ThrowIfNull(walEventsAllTime);
         ArgumentException.ThrowIfNullOrEmpty(firmId);
@@ -91,8 +92,14 @@ public static class StatementProjection
         // for owner X under FIRM01 leaks rows from the same owner login
         // active under FIRM02. Legacy WAL rows without a firm tag are
         // treated as PositionKeeper.DefaultFirmId, matching the
-        // back-compat convention used elsewhere.
-        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)>();
+        // back-compat convention used elsewhere. PR #316 P2.2: the
+        // metadata also carries the originating SubAccountId so the
+        // projection can tag fills/positions per-bucket and so the
+        // optional <paramref name="subAccountFilter"/> can be enforced
+        // on fees / realized PnL (FeeAccruedEvent has no SubAccountId
+        // discriminator beyond the originating submit — same hop the
+        // FirmId filter takes).
+        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side, string FirmId, string? SubAccountId)>();
         var fills = new List<FillRowDto>();
         var feesByType = new Dictionary<string, decimal>(StringComparer.Ordinal);
         decimal realizedGross = 0m;
@@ -103,16 +110,21 @@ public static class StatementProjection
             {
                 case OrderSubmittedEvent o:
                     ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol, o.Side,
-                        PositionKeeper.NormalizeFirmId(o.FirmId));
+                        PositionKeeper.NormalizeFirmId(o.FirmId), o.SubAccountId);
                     break;
 
                 case OrderReplaceRequestedEvent rr:
                     // A replace creates a brand-new ClOrdID that becomes
                     // its own working order; subsequent fill ERs arrive
                     // under it, so register ownership for the new ID
-                    // too.
+                    // too. Inherit SubAccountId from the original
+                    // submit (OrderReplaceRequestedEvent does not carry
+                    // it — Order.HydrateReplacement does the same).
+                    var inheritedSub = ownerByClOrdId.TryGetValue(rr.OriginalClOrdId, out var origMeta)
+                        ? origMeta.SubAccountId
+                        : null;
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side,
-                        PositionKeeper.NormalizeFirmId(rr.FirmId));
+                        PositionKeeper.NormalizeFirmId(rr.FirmId), inheritedSub);
                     break;
 
                 case ExecutionReportReceivedEvent er:
@@ -122,6 +134,8 @@ public static class StatementProjection
                     if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) break;
                     if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) break;
                     if (!string.Equals(meta.FirmId, normFirm, StringComparison.Ordinal)) break;
+                    if (subAccountFilter is not null &&
+                        !string.Equals(meta.SubAccountId, subAccountFilter, StringComparison.Ordinal)) break;
                     fills.Add(new FillRowDto(
                         ExecutionId: $"{er.ClOrdId}:{er.CumulativeQuantity}",
                         ClOrdId: er.ClOrdId.ToString(),
@@ -130,7 +144,8 @@ public static class StatementProjection
                         Side: meta.Side,
                         Quantity: er.LastQuantity,
                         Price: er.LastPrice,
-                        TimestampUtc: er.TimestampUtc));
+                        TimestampUtc: er.TimestampUtc,
+                        SubAccountId: meta.SubAccountId));
                     break;
 
                 case FeeAccruedEvent fee:
@@ -141,6 +156,16 @@ public static class StatementProjection
                     // whose originating Submit pre-dates this map fall
                     // back to DefaultFirmId.
                     if (!ResolveFirm(ownerByClOrdId, fee.ClOrdId, normFirm)) break;
+                    // PR #316 P2.2. Sub-account filter is resolved via
+                    // the same ownership map (FeeAccruedEvent carries
+                    // SubAccountId since #301; fall back to the map for
+                    // legacy rows).
+                    if (subAccountFilter is not null)
+                    {
+                        var feeSub = fee.SubAccountId
+                            ?? (ownerByClOrdId.TryGetValue(fee.ClOrdId, out var feeMeta) ? feeMeta.SubAccountId : null);
+                        if (!string.Equals(feeSub, subAccountFilter, StringComparison.Ordinal)) break;
+                    }
                     AddFee(feesByType, "brokerage", fee.Brokerage);
                     AddFee(feesByType, "emolumentos", fee.Emolumentos);
                     AddFee(feesByType, "liquidacao", fee.Liquidacao);
@@ -160,6 +185,12 @@ public static class StatementProjection
                             : PositionKeeper.DefaultFirmId)
                         : PositionKeeper.NormalizeFirmId(pnl.FirmId);
                     if (!string.Equals(pnlFirm, normFirm, StringComparison.Ordinal)) break;
+                    if (subAccountFilter is not null)
+                    {
+                        var pnlSub = pnl.SubAccountId
+                            ?? (ownerByClOrdId.TryGetValue(pnl.ClOrdId, out var pnlMeta2) ? pnlMeta2.SubAccountId : null);
+                        if (!string.Equals(pnlSub, subAccountFilter, StringComparison.Ordinal)) break;
+                    }
                     realizedGross += pnl.DeltaRealized;
                     break;
             }
@@ -177,11 +208,15 @@ public static class StatementProjection
         IReadOnlyList<PositionRowDto> positions;
         if (livePositionsSnapshot is not null)
         {
-            positions = livePositionsSnapshot;
+            positions = subAccountFilter is null
+                ? livePositionsSnapshot
+                : livePositionsSnapshot
+                    .Where(p => string.Equals(p.SubAccountId, subAccountFilter, StringComparison.Ordinal))
+                    .ToList();
         }
         else
         {
-            positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId);
+            positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId, subAccountFilter);
         }
 
         // ----------------- IR day-trade pre-calc -----------------
@@ -204,7 +239,7 @@ public static class StatementProjection
     }
 
     private static bool ResolveFirm(
-        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)> map,
+        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId, string? SubAccountId)> map,
         ulong clOrdId,
         string targetFirm)
     {
@@ -217,7 +252,8 @@ public static class StatementProjection
         string firmId,
         DateTimeOffset dayEnd,
         IReadOnlyList<(long Seq, WalEvent Event)> wal,
-        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)> ownerByClOrdId)
+        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId, string? SubAccountId)> ownerByClOrdId,
+        string? subAccountFilter)
     {
         // Replay every fill ER from genesis up to (but not including)
         // dayEnd. Cumulative net qty + avg price is computed via a
@@ -225,8 +261,18 @@ public static class StatementProjection
         // semantics (including the flip-past-zero reset). PR #316 P2:
         // replay is firm-scoped so the historical positions read back
         // through ForEndClientAndFirm match what the live keeper would
-        // return for the same (owner, firm) bucket.
-        var keeper = new PositionKeeper();
+        // return for the same (owner, firm) bucket. PR #316 P2.2:
+        // bucket by SubAccountId (string?) so each sub-account
+        // (including the null "master" bucket) gets its own avg-cost
+        // computation; rows are then emitted tagged. When
+        // <paramref name="subAccountFilter"/> is set we only project
+        // the matching bucket — every other fill is skipped at
+        // ingestion so a sub-account A statement never sees
+        // sub-account B's lots.
+        // Use a sentinel for the null/master bucket so we can use a
+        // non-nullable string key.
+        const string MasterBucketKey = "\0master";
+        var keepers = new Dictionary<string, PositionKeeper>(StringComparer.Ordinal);
         foreach (var (_, evt) in wal)
         {
             if (evt is not ExecutionReportReceivedEvent er) continue;
@@ -236,18 +282,37 @@ public static class StatementProjection
             if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) continue;
             if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) continue;
             if (!string.Equals(meta.FirmId, firmId, StringComparison.Ordinal)) continue;
+            if (subAccountFilter is not null &&
+                !string.Equals(meta.SubAccountId, subAccountFilter, StringComparison.Ordinal)) continue;
             if (!Enum.TryParse<OrderSide>(meta.Side, ignoreCase: true, out var side)) continue;
             if (er.LastQuantity <= 0) continue;
+            var bucketKey = meta.SubAccountId ?? MasterBucketKey;
+            if (!keepers.TryGetValue(bucketKey, out var keeper))
+            {
+                keeper = new PositionKeeper();
+                keepers[bucketKey] = keeper;
+            }
             keeper.ApplyFill(firmId, owner, meta.Symbol, side, er.LastQuantity, er.LastPrice);
         }
 
         var rows = new List<PositionRowDto>();
-        foreach (var p in keeper.ForEndClientAndFirm(firmId, owner))
+        foreach (var bucket in keepers)
         {
-            if (p.NetQuantity == 0) continue;
-            rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+            var subTag = bucket.Key == MasterBucketKey ? null : bucket.Key;
+            foreach (var p in bucket.Value.ForEndClientAndFirm(firmId, owner))
+            {
+                if (p.NetQuantity == 0) continue;
+                rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice, subTag));
+            }
         }
-        rows.Sort(static (a, b) => string.CompareOrdinal(a.Symbol, b.Symbol));
+        // Stable order: by symbol, then by sub-account (null bucket
+        // first to match the legacy single-row shape).
+        rows.Sort(static (a, b) =>
+        {
+            var bySym = string.CompareOrdinal(a.Symbol, b.Symbol);
+            if (bySym != 0) return bySym;
+            return string.CompareOrdinal(a.SubAccountId ?? "", b.SubAccountId ?? "");
+        });
         return rows;
     }
 
@@ -356,7 +421,7 @@ public sealed record DailyStatementDto(
     PnlSummaryDto Pnl,
     IrDayTradeDto IrDayTrade);
 
-public sealed record PositionRowDto(string Symbol, long NetQty, decimal AvgPrice);
+public sealed record PositionRowDto(string Symbol, long NetQty, decimal AvgPrice, string? SubAccountId = null);
 
 public sealed record FillRowDto(
     string ExecutionId,
@@ -366,7 +431,8 @@ public sealed record FillRowDto(
     string Side,
     long Quantity,
     decimal Price,
-    DateTimeOffset TimestampUtc);
+    DateTimeOffset TimestampUtc,
+    string? SubAccountId = null);
 
 public sealed record FeeRowDto(string FeeType, decimal Total);
 

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -219,46 +219,35 @@ public static class StatementProjection
         {
             positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId, subAccountFilter);
 
-            // PR #316 P2. Today's unfiltered statement falls into this
-            // WAL-replay branch the moment any sub-account row exists
-            // for (firm, owner) — the live master snapshot would
-            // double-count, so we cannot reuse it verbatim. But WAL
-            // replay misses any positions seeded directly into
-            // PositionKeeper at host startup (TradingHostStartup applies
-            // seeds straight to the keeper, never via WAL). To recover
-            // them, the caller passes the live master snapshot through
-            // <paramref name="liveMasterSeedFallback"/>: for every
-            // symbol present there but absent from the WAL-projected
-            // master bucket we inject the live row as a master-bucket
-            // entry (SubAccountId=null). Symbols already projected from
-            // WAL keep their WAL-derived qty/avg untouched (so today's
-            // master fills are not overwritten by the seed). Only used
-            // for unfiltered queries — a sub-account-scoped statement
-            // must never see master-bucket seeds.
-            if (liveMasterSeedFallback is not null && subAccountFilter is null && liveMasterSeedFallback.Count > 0)
+            // PR #316 P2. Today's unfiltered statement falls into
+            // this WAL-replay branch the moment any sub-account row
+            // exists for (firm, owner) — the live master snapshot
+            // would double-count, so we cannot reuse it verbatim.
+            // But the WAL replay misses positions seeded directly
+            // into PositionKeeper at host startup (TradingHostStartup
+            // applies seeds straight to the keeper, never via WAL).
+            //
+            // The live master keeper aggregates everything:
+            //   liveAggregate(sym) = seedOpening + sumOfAllFills(sym)
+            // where sumOfAllFills includes BOTH master-bucket and
+            // sub-bucket fills (each fill touches the master keeper
+            // AND the sub-account keeper). The WAL replay above
+            // projects per-bucket positions (master + each sub),
+            // each starting from zero. So:
+            //   masterLogicalQty(sym) = liveAggregate(sym)
+            //                         - sum_subBuckets(walProjected(sym))
+            // This is the seed's contribution PLUS any same-day
+            // master-bucket fills, with sub-bucket activity removed.
+            // We replace any WAL-projected master row for the symbol
+            // with this corrected row, while keeping all sub-bucket
+            // rows from the WAL projection untouched. Symbols whose
+            // master-logical quantity is zero are dropped.
+            //
+            // Only applied for unfiltered queries — a sub-account-
+            // scoped statement must never see the master bucket.
+            if (liveMasterSeedFallback is not null && subAccountFilter is null)
             {
-                var masterPresent = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var p in positions)
-                    if (p.SubAccountId is null) masterPresent.Add(p.Symbol);
-
-                List<PositionRowDto>? merged = null;
-                foreach (var seed in liveMasterSeedFallback)
-                {
-                    if (seed.NetQty == 0) continue;
-                    if (masterPresent.Contains(seed.Symbol)) continue;
-                    merged ??= new List<PositionRowDto>(positions);
-                    merged.Add(new PositionRowDto(seed.Symbol, seed.NetQty, seed.AvgPrice, null));
-                }
-                if (merged is not null)
-                {
-                    merged.Sort(static (a, b) =>
-                    {
-                        var bySym = string.CompareOrdinal(a.Symbol, b.Symbol);
-                        if (bySym != 0) return bySym;
-                        return string.CompareOrdinal(a.SubAccountId ?? "", b.SubAccountId ?? "");
-                    });
-                    positions = merged;
-                }
+                positions = MergeMasterWithSeedFallback(positions, liveMasterSeedFallback);
             }
         }
 
@@ -357,6 +346,88 @@ public static class StatementProjection
             return string.CompareOrdinal(a.SubAccountId ?? "", b.SubAccountId ?? "");
         });
         return rows;
+    }
+
+    /// <summary>
+    /// PR #316 P2 — approach (b). Replace the WAL-projected master
+    /// rows with rows derived from the live master keeper snapshot
+    /// minus the sum of WAL-projected sub-bucket quantities for the
+    /// same symbol. This preserves the seeded opening position while
+    /// avoiding the double-count that would occur from naively
+    /// merging the aggregate seed alongside sub-bucket WAL rows
+    /// (the seed already includes every sub-bucket fill because
+    /// fills update BOTH the per-sub keeper AND the master keeper).
+    ///
+    /// <para>
+    /// Algorithm:
+    /// </para>
+    /// <list type="number">
+    ///   <item>Sum WAL sub-bucket NetQty per symbol.</item>
+    ///   <item>Carry every WAL sub-bucket row through unchanged.</item>
+    ///   <item>For every symbol present in the live snapshot, emit a
+    ///   master row with
+    ///   <c>masterQty = liveAggregate - sumSubBucketWalQty</c> and
+    ///   <c>avgPrice = liveAggregate avg</c>. Drop when masterQty is
+    ///   zero.</item>
+    ///   <item>For symbols with a WAL master row but absent from the
+    ///   live snapshot (live aggregate netted to zero), keep the
+    ///   WAL master row as-is so non-trivial intra-day master
+    ///   positions are still visible.</item>
+    /// </list>
+    /// </summary>
+    private static IReadOnlyList<PositionRowDto> MergeMasterWithSeedFallback(
+        IReadOnlyList<PositionRowDto> walRows,
+        IReadOnlyList<PositionRowDto> liveMasterSeedFallback)
+    {
+        var subSumBySymbol = new Dictionary<string, long>(StringComparer.Ordinal);
+        var subRows = new List<PositionRowDto>();
+        var walMasterBySymbol = new Dictionary<string, PositionRowDto>(StringComparer.Ordinal);
+        foreach (var row in walRows)
+        {
+            if (row.SubAccountId is null)
+            {
+                walMasterBySymbol[row.Symbol] = row;
+            }
+            else
+            {
+                subRows.Add(row);
+                subSumBySymbol[row.Symbol] = subSumBySymbol.TryGetValue(row.Symbol, out var prior)
+                    ? prior + row.NetQty
+                    : row.NetQty;
+            }
+        }
+
+        var merged = new List<PositionRowDto>(subRows.Count + liveMasterSeedFallback.Count);
+        merged.AddRange(subRows);
+
+        var liveSymbols = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var live in liveMasterSeedFallback)
+        {
+            if (live.SubAccountId is not null) continue; // defensive: snapshot is master-only
+            liveSymbols.Add(live.Symbol);
+            var subSum = subSumBySymbol.TryGetValue(live.Symbol, out var s) ? s : 0;
+            var masterQty = live.NetQty - subSum;
+            if (masterQty == 0) continue;
+            merged.Add(new PositionRowDto(live.Symbol, masterQty, live.AvgPrice, null));
+        }
+
+        // Preserve WAL master rows for symbols whose live aggregate
+        // netted to zero (and thus dropped out of the snapshot). The
+        // formula above cannot reconstruct them without the live
+        // anchor, but their WAL projection is self-consistent.
+        foreach (var kv in walMasterBySymbol)
+        {
+            if (liveSymbols.Contains(kv.Key)) continue;
+            merged.Add(kv.Value);
+        }
+
+        merged.Sort(static (a, b) =>
+        {
+            var bySym = string.CompareOrdinal(a.Symbol, b.Symbol);
+            if (bySym != 0) return bySym;
+            return string.CompareOrdinal(a.SubAccountId ?? "", b.SubAccountId ?? "");
+        });
+        return merged;
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -219,29 +219,19 @@ public static class StatementProjection
         {
             positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId, subAccountFilter);
 
-            // PR #316 P2. Today's unfiltered statement falls into
+            // PR #316 P1.1. Today's unfiltered statement falls into
             // this WAL-replay branch the moment any sub-account row
-            // exists for (firm, owner) — the live master snapshot
-            // would double-count, so we cannot reuse it verbatim.
-            // But the WAL replay misses positions seeded directly
-            // into PositionKeeper at host startup (TradingHostStartup
-            // applies seeds straight to the keeper, never via WAL).
-            //
-            // The live master keeper aggregates everything:
-            //   liveAggregate(sym) = seedOpening + sumOfAllFills(sym)
-            // where sumOfAllFills includes BOTH master-bucket and
-            // sub-bucket fills (each fill touches the master keeper
-            // AND the sub-account keeper). The WAL replay above
-            // projects per-bucket positions (master + each sub),
-            // each starting from zero. So:
-            //   masterLogicalQty(sym) = liveAggregate(sym)
-            //                         - sum_subBuckets(walProjected(sym))
-            // This is the seed's contribution PLUS any same-day
-            // master-bucket fills, with sub-bucket activity removed.
-            // We replace any WAL-projected master row for the symbol
-            // with this corrected row, while keeping all sub-bucket
-            // rows from the WAL projection untouched. Symbols whose
-            // master-logical quantity is zero are dropped.
+            // exists for (firm, owner) — the live master-aggregate
+            // snapshot would double-count and its avg-cost would be
+            // polluted by sub fills. The caller now passes the live
+            // MASTER-bucket snapshot (qty + avg sourced from the
+            // bucket-aware store: qty = aggregate − sumSub,
+            // avg = bucket-store master basis), so the merge below
+            // can drop any WAL master row (the snapshot supersedes
+            // it) and just emit (sub rows from WAL) ∪ (master rows
+            // from snapshot). Under per-bucket basis the invariant
+            // master = aggregate − sumSub is tracked exactly by the
+            // bucket store, so no subtraction in the merge.
             //
             // Only applied for unfiltered queries — a sub-account-
             // scoped statement must never see the master bucket.
@@ -349,107 +339,35 @@ public static class StatementProjection
     }
 
     /// <summary>
-    /// PR #316 P2 — approach (b). Replace the WAL-projected master
-    /// rows with rows derived from the live master keeper snapshot
-    /// minus the sum of WAL-projected sub-bucket quantities for the
-    /// same symbol. This preserves the seeded opening position while
-    /// avoiding the double-count that would occur from naively
-    /// merging the aggregate seed alongside sub-bucket WAL rows
-    /// (the seed already includes every sub-bucket fill because
-    /// fills update BOTH the per-sub keeper AND the master keeper).
-    ///
-    /// <para>
-    /// Algorithm:
-    /// </para>
-    /// <list type="number">
-    ///   <item>Sum WAL sub-bucket NetQty per symbol.</item>
-    ///   <item>Carry every WAL sub-bucket row through unchanged.</item>
-    ///   <item>For every symbol present in the live snapshot, emit a
-    ///   master row with
-    ///   <c>masterQty = liveAggregate - sumSubBucketWalQty</c> and
-    ///   <c>avgPrice = liveAggregate avg</c>. Drop when masterQty is
-    ///   zero.</item>
-    ///   <item>For symbols ABSENT from the live snapshot but with
-    ///   WAL sub-bucket activity, the live aggregate has netted to
-    ///   exactly zero. The invariant
-    ///   <c>master = liveAggregate - sumSub</c> still applies with
-    ///   <c>liveAggregate = 0</c>, so we synthesize a master row at
-    ///   <c>-sumSub</c> (dropping any raw WAL master row for the
-    ///   same symbol — it would double-count). Average price is
-    ///   set to <c>0m</c> because we no longer have a live anchor
-    ///   to reconstruct it and the raw WAL master avg only reflects
-    ///   today's master fills (not the seed contribution baked into
-    ///   <c>-sumSub</c>); surfacing it would be misleading.</item>
-    ///   <item>For symbols with a WAL master row but absent from the
-    ///   live snapshot AND no sub-bucket activity, keep the WAL
-    ///   master row as-is — its avg-cost is meaningful and the
-    ///   invariant degenerates to <c>master = walMaster</c>.</item>
-    /// </list>
+    /// PR #316 P1.1. Merge WAL-projected per-bucket position rows with
+    /// the caller's live MASTER-bucket snapshot. Under per-bucket
+    /// avg-cost basis (#316 P2) the invariant
+    /// <c>master = aggregate - sumSub</c> is exactly tracked by the
+    /// bucket store; the caller pre-computes it (qty + avg) and we
+    /// just emit those master rows alongside every WAL sub-bucket row.
+    /// WAL master rows are dropped — the live master snapshot is the
+    /// single source of truth for the master bucket because (a) it
+    /// already includes any host-startup seed (TradingHostStartup
+    /// applies seeds straight to PositionKeeper + the bucket basis,
+    /// never via WAL) and (b) its avg-cost was sourced from the
+    /// bucket-aware store and so is not polluted by sub-bucket fills.
     /// </summary>
     private static IReadOnlyList<PositionRowDto> MergeMasterWithSeedFallback(
         IReadOnlyList<PositionRowDto> walRows,
         IReadOnlyList<PositionRowDto> liveMasterSeedFallback)
     {
-        var subSumBySymbol = new Dictionary<string, long>(StringComparer.Ordinal);
-        var subRows = new List<PositionRowDto>();
-        var walMasterBySymbol = new Dictionary<string, PositionRowDto>(StringComparer.Ordinal);
+        var merged = new List<PositionRowDto>(walRows.Count + liveMasterSeedFallback.Count);
         foreach (var row in walRows)
         {
-            if (row.SubAccountId is null)
-            {
-                walMasterBySymbol[row.Symbol] = row;
-            }
-            else
-            {
-                subRows.Add(row);
-                subSumBySymbol[row.Symbol] = subSumBySymbol.TryGetValue(row.Symbol, out var prior)
-                    ? prior + row.NetQty
-                    : row.NetQty;
-            }
+            if (row.SubAccountId is null) continue;
+            merged.Add(row);
         }
 
-        var merged = new List<PositionRowDto>(subRows.Count + liveMasterSeedFallback.Count);
-        merged.AddRange(subRows);
-
-        var liveSymbols = new HashSet<string>(StringComparer.Ordinal);
         foreach (var live in liveMasterSeedFallback)
         {
             if (live.SubAccountId is not null) continue; // defensive: snapshot is master-only
-            liveSymbols.Add(live.Symbol);
-            var subSum = subSumBySymbol.TryGetValue(live.Symbol, out var s) ? s : 0;
-            var masterQty = live.NetQty - subSum;
-            if (masterQty == 0) continue;
-            merged.Add(new PositionRowDto(live.Symbol, masterQty, live.AvgPrice, null));
-        }
-
-        // For symbols absent from the live snapshot, the live
-        // aggregate netted to zero. Two sub-cases:
-        //   (a) Sub-bucket WAL activity exists → the invariant
-        //       master = liveAggregate - sumSub still holds with
-        //       liveAggregate = 0, so synthesize master = -sumSub.
-        //       Any raw WAL master row for the same symbol is
-        //       dropped — adding it would double-count the seed
-        //       that already cancelled inside the live aggregate.
-        //       AvgPrice is zeroed: we have no live anchor to
-        //       reconstruct it, and the WAL master avg only
-        //       describes today's master fills (omits the seed),
-        //       so surfacing it would mislead.
-        //   (b) No sub activity → preserve the raw WAL master row
-        //       (its avg-cost is self-consistent and the formula
-        //       degenerates to master = walMaster).
-        foreach (var kv in subSumBySymbol)
-        {
-            if (liveSymbols.Contains(kv.Key)) continue;
-            var masterQty = -kv.Value;
-            if (masterQty == 0) continue;
-            merged.Add(new PositionRowDto(kv.Key, masterQty, 0m, null));
-        }
-
-        foreach (var kv in walMasterBySymbol)
-        {
-            if (liveSymbols.Contains(kv.Key)) continue;
-            if (subSumBySymbol.ContainsKey(kv.Key)) continue;
-            merged.Add(kv.Value);
+            if (live.NetQty == 0) continue;
+            merged.Add(new PositionRowDto(live.Symbol, live.NetQty, live.AvgPrice, null));
         }
 
         merged.Sort(static (a, b) =>

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -369,10 +369,21 @@ public static class StatementProjection
     ///   <c>masterQty = liveAggregate - sumSubBucketWalQty</c> and
     ///   <c>avgPrice = liveAggregate avg</c>. Drop when masterQty is
     ///   zero.</item>
+    ///   <item>For symbols ABSENT from the live snapshot but with
+    ///   WAL sub-bucket activity, the live aggregate has netted to
+    ///   exactly zero. The invariant
+    ///   <c>master = liveAggregate - sumSub</c> still applies with
+    ///   <c>liveAggregate = 0</c>, so we synthesize a master row at
+    ///   <c>-sumSub</c> (dropping any raw WAL master row for the
+    ///   same symbol — it would double-count). Average price is
+    ///   set to <c>0m</c> because we no longer have a live anchor
+    ///   to reconstruct it and the raw WAL master avg only reflects
+    ///   today's master fills (not the seed contribution baked into
+    ///   <c>-sumSub</c>); surfacing it would be misleading.</item>
     ///   <item>For symbols with a WAL master row but absent from the
-    ///   live snapshot (live aggregate netted to zero), keep the
-    ///   WAL master row as-is so non-trivial intra-day master
-    ///   positions are still visible.</item>
+    ///   live snapshot AND no sub-bucket activity, keep the WAL
+    ///   master row as-is — its avg-cost is meaningful and the
+    ///   invariant degenerates to <c>master = walMaster</c>.</item>
     /// </list>
     /// </summary>
     private static IReadOnlyList<PositionRowDto> MergeMasterWithSeedFallback(
@@ -411,13 +422,33 @@ public static class StatementProjection
             merged.Add(new PositionRowDto(live.Symbol, masterQty, live.AvgPrice, null));
         }
 
-        // Preserve WAL master rows for symbols whose live aggregate
-        // netted to zero (and thus dropped out of the snapshot). The
-        // formula above cannot reconstruct them without the live
-        // anchor, but their WAL projection is self-consistent.
+        // For symbols absent from the live snapshot, the live
+        // aggregate netted to zero. Two sub-cases:
+        //   (a) Sub-bucket WAL activity exists → the invariant
+        //       master = liveAggregate - sumSub still holds with
+        //       liveAggregate = 0, so synthesize master = -sumSub.
+        //       Any raw WAL master row for the same symbol is
+        //       dropped — adding it would double-count the seed
+        //       that already cancelled inside the live aggregate.
+        //       AvgPrice is zeroed: we have no live anchor to
+        //       reconstruct it, and the WAL master avg only
+        //       describes today's master fills (omits the seed),
+        //       so surfacing it would mislead.
+        //   (b) No sub activity → preserve the raw WAL master row
+        //       (its avg-cost is self-consistent and the formula
+        //       degenerates to master = walMaster).
+        foreach (var kv in subSumBySymbol)
+        {
+            if (liveSymbols.Contains(kv.Key)) continue;
+            var masterQty = -kv.Value;
+            if (masterQty == 0) continue;
+            merged.Add(new PositionRowDto(kv.Key, masterQty, 0m, null));
+        }
+
         foreach (var kv in walMasterBySymbol)
         {
             if (liveSymbols.Contains(kv.Key)) continue;
+            if (subSumBySymbol.ContainsKey(kv.Key)) continue;
             merged.Add(kv.Value);
         }
 

--- a/backend/src/B3.Trading.Application/StatementProjection.cs
+++ b/backend/src/B3.Trading.Application/StatementProjection.cs
@@ -54,12 +54,16 @@ public static class StatementProjection
     /// Build the statement DTO for <paramref name="owner"/> on
     /// <paramref name="dayKey"/> from the WAL events in
     /// <paramref name="walEventsAllTime"/> (already filtered to the day, but
-    /// re-filtered defensively below). When
+    /// re-filtered defensively below). <paramref name="firmId"/> scopes
+    /// every projection slice (fills, fees, realized PnL, position
+    /// replay) to the caller's firm so the same JWT <c>sub</c> active
+    /// in multiple firms does not bleed rows across them. When
     /// <paramref name="livePositionsSnapshot"/> is non-null it is used
     /// verbatim as the positions snapshot (already sorted and
-    /// zero-quantity-filtered by the caller); otherwise positions are
-    /// projected from <paramref name="walEventsAllTime"/> up to the end
-    /// of <paramref name="dayKey"/>. The caller is responsible for
+    /// zero-quantity-filtered by the caller, and already firm-scoped);
+    /// otherwise positions are projected from
+    /// <paramref name="walEventsAllTime"/> up to the end of
+    /// <paramref name="dayKey"/>. The caller is responsible for
     /// capturing the snapshot atomically with the WAL upper-bound used
     /// to bound <paramref name="walEventsAllTime"/> (today path takes
     /// both under <see cref="Persistence.EventDispatcher.RunExclusive(System.Action)"/>).
@@ -67,22 +71,28 @@ public static class StatementProjection
     public static DailyStatementDto Build(
         EndClientId owner,
         DateOnly dayKey,
+        string firmId,
         IReadOnlyList<(long Seq, WalEvent Event)> walEventsAllTime,
         IReadOnlyList<PositionRowDto>? livePositionsSnapshot)
     {
         ArgumentNullException.ThrowIfNull(walEventsAllTime);
+        ArgumentException.ThrowIfNullOrEmpty(firmId);
 
+        var normFirm = PositionKeeper.NormalizeFirmId(firmId);
         var dayStart = new DateTimeOffset(dayKey.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
         var dayEnd = dayStart.AddDays(1);
 
         // ----------------- fills + ownership side-table -----------------
-        // ER events carry no owner/symbol; resubstitute them from the
-        // matching OrderSubmittedEvent. This mirrors HistoryEndpoints'
-        // ownerByClOrdId map but without the cancel/replace fallback
-        // complexity: for a daily statement we only care about Fill /
-        // PartialFill ERs, which always land on the original ClOrdID
-        // and never on a cancel-side or replace-side one.
-        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side)>();
+        // ER events carry no owner/symbol/firm; resubstitute them from
+        // the matching OrderSubmittedEvent (or OrderReplaceRequestedEvent).
+        // PR #316 P2: we also track the originating FirmId so all
+        // downstream filters (fills, fees, realized PnL, position replay)
+        // can scope to the caller's firm — without this the statement
+        // for owner X under FIRM01 leaks rows from the same owner login
+        // active under FIRM02. Legacy WAL rows without a firm tag are
+        // treated as PositionKeeper.DefaultFirmId, matching the
+        // back-compat convention used elsewhere.
+        var ownerByClOrdId = new Dictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)>();
         var fills = new List<FillRowDto>();
         var feesByType = new Dictionary<string, decimal>(StringComparer.Ordinal);
         decimal realizedGross = 0m;
@@ -92,7 +102,8 @@ public static class StatementProjection
             switch (evt)
             {
                 case OrderSubmittedEvent o:
-                    ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol, o.Side);
+                    ownerByClOrdId[o.ClOrdId] = (o.EndClientId, o.Symbol, o.Side,
+                        PositionKeeper.NormalizeFirmId(o.FirmId));
                     break;
 
                 case OrderReplaceRequestedEvent rr:
@@ -100,7 +111,8 @@ public static class StatementProjection
                     // its own working order; subsequent fill ERs arrive
                     // under it, so register ownership for the new ID
                     // too.
-                    ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
+                    ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side,
+                        PositionKeeper.NormalizeFirmId(rr.FirmId));
                     break;
 
                 case ExecutionReportReceivedEvent er:
@@ -109,6 +121,7 @@ public static class StatementProjection
                     if (kind is not (ExecKind.Fill or ExecKind.PartialFill)) break;
                     if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) break;
                     if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) break;
+                    if (!string.Equals(meta.FirmId, normFirm, StringComparison.Ordinal)) break;
                     fills.Add(new FillRowDto(
                         ExecutionId: $"{er.ClOrdId}:{er.CumulativeQuantity}",
                         ClOrdId: er.ClOrdId.ToString(),
@@ -123,6 +136,11 @@ public static class StatementProjection
                 case FeeAccruedEvent fee:
                     if (fee.TimestampUtc < dayStart || fee.TimestampUtc >= dayEnd) break;
                     if (!string.Equals(fee.EndClientId, owner.Value, StringComparison.Ordinal)) break;
+                    // FeeAccruedEvent does not carry FirmId; resolve via
+                    // the submit-side ownership map. Legacy fee rows
+                    // whose originating Submit pre-dates this map fall
+                    // back to DefaultFirmId.
+                    if (!ResolveFirm(ownerByClOrdId, fee.ClOrdId, normFirm)) break;
                     AddFee(feesByType, "brokerage", fee.Brokerage);
                     AddFee(feesByType, "emolumentos", fee.Emolumentos);
                     AddFee(feesByType, "liquidacao", fee.Liquidacao);
@@ -132,6 +150,16 @@ public static class StatementProjection
                     if (pnl.TimestampUtc < dayStart || pnl.TimestampUtc >= dayEnd) break;
                     if (!string.Equals(pnl.EndClientId, owner.Value, StringComparison.Ordinal)) break;
                     if (pnl.DayKey != dayKey) break;
+                    // RealizedPnlEvent.FirmId is nullable on legacy WAL
+                    // rows; treat null as DefaultFirmId, but prefer the
+                    // ownership-map firm when the explicit field is
+                    // absent so a complete WAL still routes correctly.
+                    var pnlFirm = pnl.FirmId is null
+                        ? (ownerByClOrdId.TryGetValue(pnl.ClOrdId, out var pnlMeta)
+                            ? pnlMeta.FirmId
+                            : PositionKeeper.DefaultFirmId)
+                        : PositionKeeper.NormalizeFirmId(pnl.FirmId);
+                    if (!string.Equals(pnlFirm, normFirm, StringComparison.Ordinal)) break;
                     realizedGross += pnl.DeltaRealized;
                     break;
             }
@@ -153,7 +181,7 @@ public static class StatementProjection
         }
         else
         {
-            positions = ProjectPositionsFromWal(owner, dayEnd, walEventsAllTime, ownerByClOrdId);
+            positions = ProjectPositionsFromWal(owner, normFirm, dayEnd, walEventsAllTime, ownerByClOrdId);
         }
 
         // ----------------- IR day-trade pre-calc -----------------
@@ -175,16 +203,29 @@ public static class StatementProjection
         bag[key] = bag.TryGetValue(key, out var prior) ? prior + value : value;
     }
 
+    private static bool ResolveFirm(
+        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)> map,
+        ulong clOrdId,
+        string targetFirm)
+    {
+        var firm = map.TryGetValue(clOrdId, out var meta) ? meta.FirmId : PositionKeeper.DefaultFirmId;
+        return string.Equals(firm, targetFirm, StringComparison.Ordinal);
+    }
+
     private static IReadOnlyList<PositionRowDto> ProjectPositionsFromWal(
         EndClientId owner,
+        string firmId,
         DateTimeOffset dayEnd,
         IReadOnlyList<(long Seq, WalEvent Event)> wal,
-        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side)> ownerByClOrdId)
+        IReadOnlyDictionary<ulong, (string Owner, string Symbol, string Side, string FirmId)> ownerByClOrdId)
     {
         // Replay every fill ER from genesis up to (but not including)
         // dayEnd. Cumulative net qty + avg price is computed via a
         // throwaway PositionKeeper so we share the exact ApplyFill
-        // semantics (including the flip-past-zero reset).
+        // semantics (including the flip-past-zero reset). PR #316 P2:
+        // replay is firm-scoped so the historical positions read back
+        // through ForEndClientAndFirm match what the live keeper would
+        // return for the same (owner, firm) bucket.
         var keeper = new PositionKeeper();
         foreach (var (_, evt) in wal)
         {
@@ -194,13 +235,14 @@ public static class StatementProjection
             if (kind is not (ExecKind.Fill or ExecKind.PartialFill)) continue;
             if (!ownerByClOrdId.TryGetValue(er.ClOrdId, out var meta)) continue;
             if (!string.Equals(meta.Owner, owner.Value, StringComparison.Ordinal)) continue;
+            if (!string.Equals(meta.FirmId, firmId, StringComparison.Ordinal)) continue;
             if (!Enum.TryParse<OrderSide>(meta.Side, ignoreCase: true, out var side)) continue;
             if (er.LastQuantity <= 0) continue;
-            keeper.ApplyFill(owner, meta.Symbol, side, er.LastQuantity, er.LastPrice);
+            keeper.ApplyFill(firmId, owner, meta.Symbol, side, er.LastQuantity, er.LastPrice);
         }
 
         var rows = new List<PositionRowDto>();
-        foreach (var p in keeper.ForEndClient(owner))
+        foreach (var p in keeper.ForEndClientAndFirm(firmId, owner))
         {
             if (p.NetQuantity == 0) continue;
             rows.Add(new PositionRowDto(p.Symbol, p.NetQuantity, p.AverageEntryPrice));

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -136,6 +136,77 @@ public sealed class SubAccountPnlKeeper
         return _bucketAvgCost.TryAdd(key, new PnlKeeper.AvgCostState(signedQuantity, avgPrice));
     }
 
+    /// <summary>
+    /// PR #316 P1 (review). Backfill the per-bucket avg-cost basis from a
+    /// legacy snapshot whose <see cref="Persistence.PlatformSnapshot.SubAccountPnlBasis"/>
+    /// block is empty or incomplete (pre-#316 snapshots have positions
+    /// but no bucket basis at all; partial snapshots may carry basis
+    /// for some buckets but not others). Without this seed, the first
+    /// closing fill on a restored master/sub bucket whose basis is
+    /// absent goes through <see cref="ApplyBucketFill"/>, hits the
+    /// "missing basis" branch, treats the close as a FRESH open, and
+    /// emits realized P&amp;L = 0 — even though the live (pre-restart)
+    /// keeper would have computed the realized delta against the
+    /// existing avg-cost basis. The aggregate <see cref="PnlKeeper"/>
+    /// already has its own legacy backfill
+    /// (<c>SeedAvgCostFromLegacyPositions</c>), but the ER processor
+    /// wires its return value as the authoritative event source for
+    /// the sub-keeper only when the sub-keeper is unwired — so once
+    /// the sub-keeper exists, only its own backfilled basis is
+    /// consulted on the close.
+    ///
+    /// <para>
+    /// Mirrors <see cref="PnlKeeper.SeedAvgCostFromLegacyPositions"/>:
+    /// idempotent (never overwrites an entry that <see cref="Restore"/>
+    /// loaded from <see cref="Persistence.SubAccountPnlBasisSnapshot"/>),
+    /// skips zero-quantity rows, and skips degenerate zero-avg rows
+    /// (the basis cannot be recovered; opening a leg at zero would
+    /// realise phantom P&amp;L on the first close — same treatment as
+    /// the aggregate keeper's pass-3 fix).
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Seed-price caveat.</b> The master bucket basis is seeded
+    /// from the aggregate <see cref="Persistence.PositionSnapshot"/>'s
+    /// <c>AverageEntryPrice</c> (best available — when there's no sub
+    /// activity yet, aggregate == master). Sub-bucket basis is seeded
+    /// from its own <see cref="Persistence.SubAccountPositionSnapshot.AverageEntryPrice"/>;
+    /// when the sub-position snapshot pre-dates per-bucket basis
+    /// tracking (zero avg), the row is skipped — there's no per-bucket
+    /// history to recover and seeding from the aggregate avg would
+    /// import pollution from sibling buckets. After at least one
+    /// snapshot is taken post-recovery, <see cref="SnapshotBasis"/>
+    /// includes the seeded buckets and subsequent recoveries hydrate
+    /// them directly without going through this path.
+    /// </para>
+    /// </summary>
+    /// <returns>The number of (bucket, symbol) rows seeded.</returns>
+    public int SeedBucketBasisFromLegacyPositions(
+        IEnumerable<Persistence.PositionSnapshot> masterPositions,
+        IEnumerable<Persistence.SubAccountPositionSnapshot> subPositions)
+    {
+        ArgumentNullException.ThrowIfNull(masterPositions);
+        ArgumentNullException.ThrowIfNull(subPositions);
+        var seeded = 0;
+        foreach (var p in masterPositions)
+        {
+            if (p.NetQuantity == 0) continue;
+            if (p.AverageEntryPrice <= 0m) continue;
+            var key = (p.FirmId, p.EndClientId, MasterBucketKey, p.Symbol);
+            if (_bucketAvgCost.TryAdd(key, new PnlKeeper.AvgCostState(p.NetQuantity, p.AverageEntryPrice)))
+                seeded++;
+        }
+        foreach (var p in subPositions)
+        {
+            if (p.NetQuantity == 0) continue;
+            if (p.AverageEntryPrice <= 0m) continue;
+            var key = (p.FirmId, p.EndClientId, p.SubAccountId, p.Symbol);
+            if (_bucketAvgCost.TryAdd(key, new PnlKeeper.AvgCostState(p.NetQuantity, p.AverageEntryPrice)))
+                seeded++;
+        }
+        return seeded;
+    }
+
     public decimal ApplyBucketFill(
         string firmId, string endClient, SubAccountId? subAccount, string symbol,
         OrderSide side, long fillQuantity, decimal fillPrice)

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -23,8 +23,38 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class SubAccountPnlKeeper
 {
+    /// <summary>
+    /// PR #316 P2. Sentinel sub-account key for the MASTER bucket
+    /// (fills with <c>SubAccountId == null</c>). Master bucket basis
+    /// is tracked alongside per-sub bucket basis in
+    /// <see cref="_bucketAvgCost"/> so realized-PnL on a master fill
+    /// is computed against master-only history, not the aggregate
+    /// position. Empty string is safe — <see cref="SubAccountId"/>
+    /// rejects empty/whitespace at construction.
+    /// </summary>
+    public const string MasterBucketKey = "";
+
     private readonly ConcurrentDictionary<(string FirmId, string EndClient, string SubAccount, string Symbol, DateOnly Day), decimal>
         _realized = new();
+
+    /// <summary>
+    /// PR #316 P2. Per-bucket avg-cost basis keyed by
+    /// <c>(FirmId, EndClient, SubAccount, Symbol)</c> where
+    /// <c>SubAccount</c> is <see cref="MasterBucketKey"/> for master
+    /// fills. Each bucket realises P&amp;L against its OWN basis: a
+    /// sub-account fill that offsets the aggregate position (because
+    /// master is long) realises 0 if the sub-bucket itself has no
+    /// prior position — it opens a fresh leg in the sub-bucket. The
+    /// master bucket's basis is updated only by
+    /// <c>SubAccountId == null</c> fills, so sub activity never
+    /// pollutes master avg-cost. The aggregate
+    /// <see cref="PnlKeeper"/> still tracks the all-fills basis for
+    /// statement / legacy snapshot paths (its returned realized delta
+    /// is no longer the authoritative event source, see
+    /// <c>ExecutionReportProcessor.OnFill</c>).
+    /// </summary>
+    private readonly ConcurrentDictionary<(string FirmId, string EndClient, string SubAccount, string Symbol), PnlKeeper.AvgCostState>
+        _bucketAvgCost = new();
 
     /// <summary>
     /// Adds <paramref name="delta"/> to the (firm, owner, subAccount,
@@ -49,6 +79,61 @@ public sealed class SubAccountPnlKeeper
 
     public decimal GetDayRealized(string firmId, string endClient, SubAccountId subAccount, string symbol, DateOnly day) =>
         _realized.TryGetValue((firmId, endClient, subAccount.Value, symbol, day), out var v) ? v : 0m;
+
+    /// <summary>
+    /// PR #316 P2. Reads the (firm, owner, bucket, symbol) avg-cost
+    /// basis. Pass <c>null</c> for <paramref name="subAccount"/> to
+    /// query the master bucket. Returns <c>null</c> for an unseen
+    /// bucket (flat position; no basis yet).
+    /// </summary>
+    public PnlKeeper.AvgCostState? GetBucketAvgCost(string firmId, string endClient, SubAccountId? subAccount, string symbol)
+    {
+        var key = (firmId, endClient, subAccount?.Value ?? MasterBucketKey, symbol);
+        return _bucketAvgCost.TryGetValue(key, out var s) ? s : null;
+    }
+
+    /// <summary>
+    /// PR #316 P2. Live-path entry point used by
+    /// <c>ExecutionReportProcessor</c>: computes the realized delta
+    /// for <paramref name="subAccount"/>'s bucket (master when null)
+    /// against THAT BUCKET's avg-cost basis — never against the
+    /// aggregate. Then advances the bucket basis using the same
+    /// projection rules as <see cref="PnlKeeper.ProjectAvgCost"/>:
+    /// same-side fills grow the average, opposing-side closes don't
+    /// move avg until flip-through-zero, and a sign flip resets avg
+    /// to the fill price.
+    ///
+    /// <para>
+    /// Returns <c>0</c> for opening fills (the leg has no prior
+    /// basis), same-side adds, and the no-position case — matching
+    /// <see cref="PnlKeeper.ComputeRealizedDelta"/>. Caller is
+    /// expected to gate the <c>RealizedPnlEvent</c> emission on a
+    /// non-zero return.
+    /// </para>
+    /// </summary>
+    public decimal ApplyBucketFill(
+        string firmId, string endClient, SubAccountId? subAccount, string symbol,
+        OrderSide side, long fillQuantity, decimal fillPrice)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(endClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        if (fillQuantity <= 0) return 0m;
+        var key = (firmId, endClient, subAccount?.Value ?? MasterBucketKey, symbol);
+        if (!_bucketAvgCost.TryGetValue(key, out var current))
+        {
+            var signed = side == OrderSide.Buy ? fillQuantity : -fillQuantity;
+            _bucketAvgCost[key] = new PnlKeeper.AvgCostState(signed, fillPrice);
+            return 0m;
+        }
+        var realized = PnlKeeper.ComputeRealizedDelta(current.NetQuantity, current.AvgPrice, side, fillQuantity, fillPrice);
+        var projected = PnlKeeper.ProjectAvgCost(current, side, fillQuantity, fillPrice);
+        if (projected.NetQuantity == 0)
+            _bucketAvgCost.TryRemove(key, out _);
+        else
+            _bucketAvgCost[key] = projected;
+        return realized;
+    }
 
     public IEnumerable<(string Symbol, decimal Realized)> ForSubAccountDay(string firmId, string endClient, SubAccountId subAccount, DateOnly day)
     {
@@ -75,11 +160,59 @@ public sealed class SubAccountPnlKeeper
         return arr;
     }
 
+    /// <summary>
+    /// PR #316 P2. Lock-side capture of per-bucket avg-cost rows.
+    /// Persisted additively alongside <see cref="Snapshot"/> so a
+    /// snapshot+tail recovery preserves bucket-level basis (and
+    /// therefore bucket-level realized correctness on the first
+    /// post-restore closing fill). Legacy snapshots without this
+    /// block hydrate to an empty basis map; the next fill on each
+    /// bucket establishes a fresh basis at the fill price — best-
+    /// effort recovery consistent with the pre-#316 (aggregate-only)
+    /// behaviour for the no-sub-account case and benign for the
+    /// new-in-this-PR sub-account case (no pre-merge data exists).
+    /// </summary>
+    public Persistence.SubAccountPnlBasisSnapshot[] SnapshotBasis()
+    {
+        var pairs = _bucketAvgCost.ToArray();
+        if (pairs.Length == 0) return Array.Empty<Persistence.SubAccountPnlBasisSnapshot>();
+        var buf = new Persistence.SubAccountPnlBasisSnapshot[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            var v = pairs[i].Value;
+            if (v.NetQuantity == 0) continue;
+            buf[n++] = new Persistence.SubAccountPnlBasisSnapshot(
+                pairs[i].Key.FirmId, pairs[i].Key.EndClient, pairs[i].Key.SubAccount,
+                pairs[i].Key.Symbol, v.NetQuantity, v.AvgPrice);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new Persistence.SubAccountPnlBasisSnapshot[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
     public void Restore(IEnumerable<Persistence.SubAccountPnlSnapshot> snaps)
+        => Restore(snaps, basis: null);
+
+    /// <summary>
+    /// PR #316 P2. Restore with bucket basis. <paramref name="basis"/>
+    /// is optional for backwards-compat with pre-#316 snapshots and
+    /// legacy test fixtures.
+    /// </summary>
+    public void Restore(
+        IEnumerable<Persistence.SubAccountPnlSnapshot> snaps,
+        IEnumerable<Persistence.SubAccountPnlBasisSnapshot>? basis)
     {
         ArgumentNullException.ThrowIfNull(snaps);
         _realized.Clear();
+        _bucketAvgCost.Clear();
         foreach (var s in snaps)
             _realized[(s.FirmId, s.EndClientId, s.SubAccountId, s.Symbol, s.Day)] = s.RealizedTotal;
+        if (basis is not null)
+            foreach (var b in basis)
+                if (b.NetQuantity != 0)
+                    _bucketAvgCost[(b.FirmId, b.EndClientId, b.SubAccountId, b.Symbol)] =
+                        new PnlKeeper.AvgCostState(b.NetQuantity, b.AvgPrice);
     }
 }

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q4.1 (#301). Parallel realized-P&amp;L store keyed by
+/// <c>(EndClientId, SubAccountId, Symbol, Day)</c> for sub-account
+/// segregation. Fed by <see cref="ExecutionReportProcessor"/>
+/// alongside the master <see cref="PnlKeeper"/> whenever the
+/// originating order carries a non-null
+/// <see cref="SubAccountId"/>; the master keeper continues to
+/// receive every fill (sub-account-null and sub-account-tagged
+/// alike) so that endpoint reads without a filter naturally show
+/// the aggregate.
+/// </summary>
+public sealed class SubAccountPnlKeeper
+{
+    private readonly ConcurrentDictionary<(string EndClient, string SubAccount, string Symbol, DateOnly Day), decimal>
+        _realized = new();
+
+    /// <summary>
+    /// Adds <paramref name="delta"/> to the (owner, subAccount,
+    /// symbol, day) bucket. Idempotence is the caller's
+    /// responsibility — the master <see cref="PnlKeeper"/> already
+    /// dedupes on <see cref="Persistence.RealizedPnlEvent.ExecutionId"/>
+    /// and gates its sub-account peer behind the same gate, so a
+    /// double-apply here would require a double-apply on the master
+    /// keeper too. Tracking a second seen-set would add storage for
+    /// no marginal protection.
+    /// </summary>
+    public void Add(string endClient, SubAccountId subAccount, string symbol, DateOnly day, decimal delta)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        ArgumentNullException.ThrowIfNull(subAccount);
+        _realized.AddOrUpdate((endClient, subAccount.Value, symbol, day),
+            _ => delta,
+            (_, prev) => prev + delta);
+    }
+
+    public decimal GetDayRealized(string endClient, SubAccountId subAccount, string symbol, DateOnly day) =>
+        _realized.TryGetValue((endClient, subAccount.Value, symbol, day), out var v) ? v : 0m;
+
+    public IEnumerable<(string Symbol, decimal Realized)> ForSubAccountDay(string endClient, SubAccountId subAccount, DateOnly day)
+    {
+        foreach (var kv in _realized)
+            if (kv.Key.EndClient == endClient
+                && kv.Key.SubAccount == subAccount.Value
+                && kv.Key.Day == day)
+                yield return (kv.Key.Symbol, kv.Value);
+    }
+
+    /// <summary>
+    /// Lock-side snapshot capture for the two-phase pipeline.
+    /// </summary>
+    public Persistence.SubAccountPnlSnapshot[] Snapshot()
+    {
+        var pairs = _realized.ToArray();
+        if (pairs.Length == 0) return Array.Empty<Persistence.SubAccountPnlSnapshot>();
+        var arr = new Persistence.SubAccountPnlSnapshot[pairs.Length];
+        for (var i = 0; i < pairs.Length; i++)
+            arr[i] = new Persistence.SubAccountPnlSnapshot(
+                pairs[i].Key.EndClient, pairs[i].Key.SubAccount,
+                pairs[i].Key.Symbol, pairs[i].Key.Day, pairs[i].Value);
+        return arr;
+    }
+
+    public void Restore(IEnumerable<Persistence.SubAccountPnlSnapshot> snaps)
+    {
+        ArgumentNullException.ThrowIfNull(snaps);
+        _realized.Clear();
+        foreach (var s in snaps)
+            _realized[(s.EndClientId, s.SubAccountId, s.Symbol, s.Day)] = s.RealizedTotal;
+    }
+}

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -5,22 +5,29 @@ namespace B3.Trading.Application;
 
 /// <summary>
 /// Q4.1 (#301). Parallel realized-P&amp;L store keyed by
-/// <c>(EndClientId, SubAccountId, Symbol, Day)</c> for sub-account
-/// segregation. Fed by <see cref="ExecutionReportProcessor"/>
+/// <c>(FirmId, EndClientId, SubAccountId, Symbol, Day)</c> for
+/// sub-account segregation. Fed by <see cref="ExecutionReportProcessor"/>
 /// alongside the master <see cref="PnlKeeper"/> whenever the
 /// originating order carries a non-null
 /// <see cref="SubAccountId"/>; the master keeper continues to
 /// receive every fill (sub-account-null and sub-account-tagged
 /// alike) so that endpoint reads without a filter naturally show
 /// the aggregate.
+///
+/// <para>
+/// <b>Firm namespace.</b> The same login under FIRM01 and FIRM02
+/// with the same <c>SubAccountId</c> MUST NOT share realized P&amp;L
+/// — sub-accounts are scoped per-firm, mirroring
+/// <see cref="SubAccountsRegistry"/>.
+/// </para>
 /// </summary>
 public sealed class SubAccountPnlKeeper
 {
-    private readonly ConcurrentDictionary<(string EndClient, string SubAccount, string Symbol, DateOnly Day), decimal>
+    private readonly ConcurrentDictionary<(string FirmId, string EndClient, string SubAccount, string Symbol, DateOnly Day), decimal>
         _realized = new();
 
     /// <summary>
-    /// Adds <paramref name="delta"/> to the (owner, subAccount,
+    /// Adds <paramref name="delta"/> to the (firm, owner, subAccount,
     /// symbol, day) bucket. Idempotence is the caller's
     /// responsibility — the master <see cref="PnlKeeper"/> already
     /// dedupes on <see cref="Persistence.RealizedPnlEvent.ExecutionId"/>
@@ -29,23 +36,25 @@ public sealed class SubAccountPnlKeeper
     /// keeper too. Tracking a second seen-set would add storage for
     /// no marginal protection.
     /// </summary>
-    public void Add(string endClient, SubAccountId subAccount, string symbol, DateOnly day, decimal delta)
+    public void Add(string firmId, string endClient, SubAccountId subAccount, string symbol, DateOnly day, decimal delta)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
         ArgumentException.ThrowIfNullOrWhiteSpace(endClient);
         ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
         ArgumentNullException.ThrowIfNull(subAccount);
-        _realized.AddOrUpdate((endClient, subAccount.Value, symbol, day),
+        _realized.AddOrUpdate((firmId, endClient, subAccount.Value, symbol, day),
             _ => delta,
             (_, prev) => prev + delta);
     }
 
-    public decimal GetDayRealized(string endClient, SubAccountId subAccount, string symbol, DateOnly day) =>
-        _realized.TryGetValue((endClient, subAccount.Value, symbol, day), out var v) ? v : 0m;
+    public decimal GetDayRealized(string firmId, string endClient, SubAccountId subAccount, string symbol, DateOnly day) =>
+        _realized.TryGetValue((firmId, endClient, subAccount.Value, symbol, day), out var v) ? v : 0m;
 
-    public IEnumerable<(string Symbol, decimal Realized)> ForSubAccountDay(string endClient, SubAccountId subAccount, DateOnly day)
+    public IEnumerable<(string Symbol, decimal Realized)> ForSubAccountDay(string firmId, string endClient, SubAccountId subAccount, DateOnly day)
     {
         foreach (var kv in _realized)
-            if (kv.Key.EndClient == endClient
+            if (string.Equals(kv.Key.FirmId, firmId, StringComparison.Ordinal)
+                && kv.Key.EndClient == endClient
                 && kv.Key.SubAccount == subAccount.Value
                 && kv.Key.Day == day)
                 yield return (kv.Key.Symbol, kv.Value);
@@ -61,7 +70,7 @@ public sealed class SubAccountPnlKeeper
         var arr = new Persistence.SubAccountPnlSnapshot[pairs.Length];
         for (var i = 0; i < pairs.Length; i++)
             arr[i] = new Persistence.SubAccountPnlSnapshot(
-                pairs[i].Key.EndClient, pairs[i].Key.SubAccount,
+                pairs[i].Key.FirmId, pairs[i].Key.EndClient, pairs[i].Key.SubAccount,
                 pairs[i].Key.Symbol, pairs[i].Key.Day, pairs[i].Value);
         return arr;
     }
@@ -71,6 +80,6 @@ public sealed class SubAccountPnlKeeper
         ArgumentNullException.ThrowIfNull(snaps);
         _realized.Clear();
         foreach (var s in snaps)
-            _realized[(s.EndClientId, s.SubAccountId, s.Symbol, s.Day)] = s.RealizedTotal;
+            _realized[(s.FirmId, s.EndClientId, s.SubAccountId, s.Symbol, s.Day)] = s.RealizedTotal;
     }
 }

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace B3.Trading.Application;
 
@@ -55,6 +56,15 @@ public sealed class SubAccountPnlKeeper
     /// </summary>
     private readonly ConcurrentDictionary<(string FirmId, string EndClient, string SubAccount, string Symbol), PnlKeeper.AvgCostState>
         _bucketAvgCost = new();
+
+    private readonly ILogger<SubAccountPnlKeeper>? _logger;
+
+    public SubAccountPnlKeeper() : this(logger: null) { }
+
+    public SubAccountPnlKeeper(ILogger<SubAccountPnlKeeper>? logger)
+    {
+        _logger = logger;
+    }
 
     /// <summary>
     /// Adds <paramref name="delta"/> to the (firm, owner, subAccount,
@@ -166,16 +176,30 @@ public sealed class SubAccountPnlKeeper
     /// </para>
     ///
     /// <para>
-    /// <b>Seed-price caveat.</b> The master bucket basis is seeded
-    /// from the aggregate <see cref="Persistence.PositionSnapshot"/>'s
-    /// <c>AverageEntryPrice</c> (best available — when there's no sub
-    /// activity yet, aggregate == master). Sub-bucket basis is seeded
-    /// from its own <see cref="Persistence.SubAccountPositionSnapshot.AverageEntryPrice"/>;
-    /// when the sub-position snapshot pre-dates per-bucket basis
-    /// tracking (zero avg), the row is skipped — there's no per-bucket
-    /// history to recover and seeding from the aggregate avg would
-    /// import pollution from sibling buckets. After at least one
-    /// snapshot is taken post-recovery, <see cref="SnapshotBasis"/>
+    /// <b>Seed-price caveat.</b> The master bucket basis can only be
+    /// seeded from <see cref="Persistence.PlatformSnapshot.Positions"/>
+    /// when that aggregate row is master-only — i.e. when no
+    /// <see cref="Persistence.SubAccountPositionSnapshot"/> exists for
+    /// the same <c>(FirmId, EndClientId, Symbol)</c>. Otherwise the
+    /// aggregate row is the SUM of master + every sub bucket and its
+    /// <c>AverageEntryPrice</c> is a cross-bucket weighted average;
+    /// seeding master from it would import sibling-bucket basis as
+    /// master-only history (PR #316 P1 review). In the incoherent case
+    /// — sub positions present AND no authoritative
+    /// <see cref="Persistence.SubAccountPnlBasisSnapshot"/> row for the
+    /// master bucket — the master basis is left absent; the statement
+    /// endpoint already fail-closes (<c>AvgPrice = 0</c> +
+    /// <c>trading.statement.master_avg_basis_degraded_total</c>) and a
+    /// new metric
+    /// <c>trading.subaccount.master_basis_unrecoverable_total</c>
+    /// fires (plus a one-shot warn log per <c>(firm, owner, symbol)</c>)
+    /// so operators can investigate the snapshot writer.
+    /// Sub-bucket basis is seeded from its own
+    /// <see cref="Persistence.SubAccountPositionSnapshot.AverageEntryPrice"/>
+    /// (each sub bucket maintains its own basis natively, no
+    /// pollution); when the sub-position snapshot pre-dates per-bucket
+    /// basis tracking (zero avg), the row is skipped. After at least
+    /// one snapshot is taken post-recovery, <see cref="SnapshotBasis"/>
     /// includes the seeded buckets and subsequent recoveries hydrate
     /// them directly without going through this path.
     /// </para>
@@ -187,16 +211,56 @@ public sealed class SubAccountPnlKeeper
     {
         ArgumentNullException.ThrowIfNull(masterPositions);
         ArgumentNullException.ThrowIfNull(subPositions);
+        // Materialize sub positions once: needed both to seed each sub
+        // bucket and to build a (firm, owner, symbol) presence set the
+        // master loop consults to detect the incoherent-snapshot case
+        // (sub positions present, master basis absent — aggregate
+        // Positions is polluted, cannot reconstruct master basis).
+        var subList = subPositions as IReadOnlyCollection<Persistence.SubAccountPositionSnapshot>
+                      ?? subPositions.ToArray();
+        var subKeys = new HashSet<(string FirmId, string EndClient, string Symbol)>();
+        foreach (var p in subList)
+        {
+            if (p.NetQuantity == 0) continue;
+            subKeys.Add((p.FirmId, p.EndClientId, p.Symbol));
+        }
+
         var seeded = 0;
+        var warnedUnrecoverable = new HashSet<(string FirmId, string EndClient, string Symbol)>();
         foreach (var p in masterPositions)
         {
             if (p.NetQuantity == 0) continue;
             if (p.AverageEntryPrice <= 0m) continue;
             var key = (p.FirmId, p.EndClientId, MasterBucketKey, p.Symbol);
+            // Authoritative basis (restored from SubAccountPnlBasis)
+            // wins — never overwrite, regardless of whether the
+            // aggregate row would be coherent.
+            if (_bucketAvgCost.ContainsKey(key)) continue;
+            var symbolKey = (p.FirmId, p.EndClientId, p.Symbol);
+            if (subKeys.Contains(symbolKey))
+            {
+                // Incoherent legacy snapshot: aggregate Positions
+                // mixes master + sub bucket fills. Leaving master
+                // unseeded is intentional — the statement endpoint's
+                // fail-closed path (AvgPrice = 0 + degraded metric)
+                // surfaces the gap to operators, and ApplyBucketFill
+                // will treat the next master fill as a fresh open
+                // (realized = 0) until basis re-establishes. Seeding
+                // from the polluted aggregate would silently realise
+                // wrong P&L instead.
+                if (warnedUnrecoverable.Add(symbolKey))
+                {
+                    Observability.MetricsRegistry.SubAccountMasterBasisUnrecoverable.Add(1);
+                    _logger?.LogWarning(
+                        "Sub-account master bucket basis unrecoverable from legacy snapshot (firm={FirmId}, owner={EndClientId}, symbol={Symbol}): aggregate Positions row pollutes master with cross-bucket avg cost; SubAccountPnlBasis block absent. Master basis left empty; statement endpoint will fail-closed (AvgPrice=0) and master realised PnL will be 0 until basis re-establishes via a fresh master fill.",
+                        p.FirmId, p.EndClientId, p.Symbol);
+                }
+                continue;
+            }
             if (_bucketAvgCost.TryAdd(key, new PnlKeeper.AvgCostState(p.NetQuantity, p.AverageEntryPrice)))
                 seeded++;
         }
-        foreach (var p in subPositions)
+        foreach (var p in subList)
         {
             if (p.NetQuantity == 0) continue;
             if (p.AverageEntryPrice <= 0m) continue;

--- a/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPnlKeeper.cs
@@ -111,6 +111,31 @@ public sealed class SubAccountPnlKeeper
     /// non-zero return.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// PR #316 P1.1. Seed the master-bucket avg-cost basis from a
+    /// host-startup <see cref="PositionKeeper.SeedIfAbsent"/> entry
+    /// so subsequent realised-PnL math on master fills, AND the
+    /// daily-statement master-row avg-price, can read the seed
+    /// directly from the bucket store rather than falling back to
+    /// the aggregate avg (which gets polluted the moment a
+    /// sub-account fill mirrors into the aggregate
+    /// <see cref="PositionKeeper"/>). No-op when a basis already
+    /// exists for the master bucket: mirrors
+    /// <see cref="PositionKeeper.SeedIfAbsent"/>'s "warm restart
+    /// preserves recovered state" rule (snapshots restore bucket
+    /// basis BEFORE seeding runs).
+    /// </summary>
+    public bool SeedMasterBucketBasisIfAbsent(
+        string firmId, string endClient, string symbol, long signedQuantity, decimal avgPrice)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(endClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        if (signedQuantity == 0) return false;
+        var key = (firmId, endClient, MasterBucketKey, symbol);
+        return _bucketAvgCost.TryAdd(key, new PnlKeeper.AvgCostState(signedQuantity, avgPrice));
+    }
+
     public decimal ApplyBucketFill(
         string firmId, string endClient, SubAccountId? subAccount, string symbol,
         OrderSide side, long fillQuantity, decimal fillPrice)

--- a/backend/src/B3.Trading.Application/SubAccountPositionKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPositionKeeper.cs
@@ -5,12 +5,22 @@ namespace B3.Trading.Application;
 
 /// <summary>
 /// Q4.1 (#301). Parallel position store keyed by
-/// <c>(EndClientId, SubAccountId, Symbol)</c> for sub-account
+/// <c>(FirmId, EndClientId, SubAccountId, Symbol)</c> for sub-account
 /// segregation. Fed by every fill whose originating order carries a
 /// non-null <see cref="SubAccountId"/>; the existing
 /// <see cref="PositionKeeper"/> continues to track the cross-account
 /// aggregate so the master view is naturally available without
 /// summing.
+///
+/// <para>
+/// <b>Firm namespace.</b> The same login under FIRM01 and FIRM02 with
+/// the same <c>SubAccountId</c> (e.g. <c>tradingdesk</c>) MUST NOT
+/// share state — sub-accounts are scoped per-firm. The
+/// <see cref="SubAccountsRegistry"/> already namespaces its rows by
+/// <c>(FirmId, Id)</c>; the keepers mirror that key so multi-firm
+/// hosts get clean segregation without relying on the REST validator
+/// alone.
+/// </para>
 ///
 /// <para>
 /// <b>Sub-account-null fills are not stored here.</b> A submission
@@ -23,16 +33,19 @@ namespace B3.Trading.Application;
 /// </summary>
 public sealed class SubAccountPositionKeeper
 {
-    private readonly ConcurrentDictionary<(EndClientId Owner, string SubAccount, string Symbol), Position> _positions =
+    private readonly ConcurrentDictionary<(string FirmId, EndClientId Owner, string SubAccount, string Symbol), Position> _positions =
         new();
 
-    public Position GetOrCreate(EndClientId owner, SubAccountId subAccount, string symbol) =>
-        _positions.GetOrAdd((owner, subAccount.Value, symbol),
-            key => new Position(key.Owner, key.Symbol));
-
-    public void ApplyFill(EndClientId owner, SubAccountId subAccount, string symbol, OrderSide side, long quantity, decimal price)
+    public Position GetOrCreate(string firmId, EndClientId owner, SubAccountId subAccount, string symbol)
     {
-        var position = GetOrCreate(owner, subAccount, symbol);
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        return _positions.GetOrAdd((firmId, owner, subAccount.Value, symbol),
+            key => new Position(key.Owner, key.Symbol));
+    }
+
+    public void ApplyFill(string firmId, EndClientId owner, SubAccountId subAccount, string symbol, OrderSide side, long quantity, decimal price)
+    {
+        var position = GetOrCreate(firmId, owner, subAccount, symbol);
         lock (position)
         {
             position.ApplyFill(side, quantity, price);
@@ -40,14 +53,16 @@ public sealed class SubAccountPositionKeeper
     }
 
     /// <summary>
-    /// Rows for one sub-account under one owner. Includes flat
-    /// positions (callers are expected to filter if they care).
+    /// Rows for one sub-account under one owner within a firm.
+    /// Includes flat positions (callers are expected to filter if
+    /// they care).
     /// </summary>
-    public IReadOnlyCollection<Position> ForSubAccount(EndClientId owner, SubAccountId subAccount)
+    public IReadOnlyCollection<Position> ForSubAccount(string firmId, EndClientId owner, SubAccountId subAccount)
     {
         var list = new List<Position>();
         foreach (var kv in _positions)
         {
+            if (!string.Equals(kv.Key.FirmId, firmId, StringComparison.Ordinal)) continue;
             if (kv.Key.Owner != owner) continue;
             if (!string.Equals(kv.Key.SubAccount, subAccount.Value, StringComparison.Ordinal)) continue;
             list.Add(kv.Value);
@@ -56,15 +71,17 @@ public sealed class SubAccountPositionKeeper
     }
 
     /// <summary>
-    /// Rows for every sub-account under one owner, tagged with the
-    /// sub-account id. Used by <c>GET /positions</c> when no filter
-    /// is supplied and the response wants per-sub-account breakdowns.
+    /// Rows for every sub-account under one owner within a firm,
+    /// tagged with the sub-account id. Used by <c>GET /positions</c>
+    /// when no filter is supplied and the response wants
+    /// per-sub-account breakdowns.
     /// </summary>
-    public IReadOnlyList<(SubAccountId SubAccount, Position Position)> EnumerateForOwner(EndClientId owner)
+    public IReadOnlyList<(SubAccountId SubAccount, Position Position)> EnumerateForOwner(string firmId, EndClientId owner)
     {
         var list = new List<(SubAccountId, Position)>();
         foreach (var kv in _positions)
         {
+            if (!string.Equals(kv.Key.FirmId, firmId, StringComparison.Ordinal)) continue;
             if (kv.Key.Owner != owner) continue;
             list.Add((new SubAccountId(kv.Key.SubAccount), kv.Value));
         }
@@ -86,7 +103,7 @@ public sealed class SubAccountPositionKeeper
             var p = pairs[i].Value;
             if (p.NetQuantity == 0) continue;
             buf[n++] = new Persistence.SubAccountPositionSnapshot(
-                pairs[i].Key.Owner.Value, pairs[i].Key.SubAccount, pairs[i].Key.Symbol,
+                pairs[i].Key.FirmId, pairs[i].Key.Owner.Value, pairs[i].Key.SubAccount, pairs[i].Key.Symbol,
                 p.NetQuantity, p.AverageEntryPrice);
         }
         if (n == buf.Length) return buf;
@@ -102,7 +119,7 @@ public sealed class SubAccountPositionKeeper
         foreach (var s in snaps)
         {
             var owner = new EndClientId(s.EndClientId);
-            _positions[(owner, s.SubAccountId, s.Symbol)] =
+            _positions[(s.FirmId, owner, s.SubAccountId, s.Symbol)] =
                 Position.Hydrate(owner, s.Symbol, s.NetQuantity, s.AverageEntryPrice);
         }
     }

--- a/backend/src/B3.Trading.Application/SubAccountPositionKeeper.cs
+++ b/backend/src/B3.Trading.Application/SubAccountPositionKeeper.cs
@@ -1,0 +1,109 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q4.1 (#301). Parallel position store keyed by
+/// <c>(EndClientId, SubAccountId, Symbol)</c> for sub-account
+/// segregation. Fed by every fill whose originating order carries a
+/// non-null <see cref="SubAccountId"/>; the existing
+/// <see cref="PositionKeeper"/> continues to track the cross-account
+/// aggregate so the master view is naturally available without
+/// summing.
+///
+/// <para>
+/// <b>Sub-account-null fills are not stored here.</b> A submission
+/// without a sub-account is the legacy "master bucket" and would
+/// double-count if booked into the per-sub-account map; the spec's
+/// "master = aggregate of all sub-accounts + null bucket" is then
+/// served by reading <see cref="PositionKeeper.ForEndClient"/>
+/// (which sees every fill, including sub-account-null ones).
+/// </para>
+/// </summary>
+public sealed class SubAccountPositionKeeper
+{
+    private readonly ConcurrentDictionary<(EndClientId Owner, string SubAccount, string Symbol), Position> _positions =
+        new();
+
+    public Position GetOrCreate(EndClientId owner, SubAccountId subAccount, string symbol) =>
+        _positions.GetOrAdd((owner, subAccount.Value, symbol),
+            key => new Position(key.Owner, key.Symbol));
+
+    public void ApplyFill(EndClientId owner, SubAccountId subAccount, string symbol, OrderSide side, long quantity, decimal price)
+    {
+        var position = GetOrCreate(owner, subAccount, symbol);
+        lock (position)
+        {
+            position.ApplyFill(side, quantity, price);
+        }
+    }
+
+    /// <summary>
+    /// Rows for one sub-account under one owner. Includes flat
+    /// positions (callers are expected to filter if they care).
+    /// </summary>
+    public IReadOnlyCollection<Position> ForSubAccount(EndClientId owner, SubAccountId subAccount)
+    {
+        var list = new List<Position>();
+        foreach (var kv in _positions)
+        {
+            if (kv.Key.Owner != owner) continue;
+            if (!string.Equals(kv.Key.SubAccount, subAccount.Value, StringComparison.Ordinal)) continue;
+            list.Add(kv.Value);
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Rows for every sub-account under one owner, tagged with the
+    /// sub-account id. Used by <c>GET /positions</c> when no filter
+    /// is supplied and the response wants per-sub-account breakdowns.
+    /// </summary>
+    public IReadOnlyList<(SubAccountId SubAccount, Position Position)> EnumerateForOwner(EndClientId owner)
+    {
+        var list = new List<(SubAccountId, Position)>();
+        foreach (var kv in _positions)
+        {
+            if (kv.Key.Owner != owner) continue;
+            list.Add((new SubAccountId(kv.Key.SubAccount), kv.Value));
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Lock-side capture for the snapshot pipeline. Skips flat
+    /// positions, matching <see cref="PositionKeeper.RawSnapshot"/>.
+    /// </summary>
+    public Persistence.SubAccountPositionSnapshot[] Snapshot()
+    {
+        var pairs = _positions.ToArray();
+        if (pairs.Length == 0) return Array.Empty<Persistence.SubAccountPositionSnapshot>();
+        var buf = new Persistence.SubAccountPositionSnapshot[pairs.Length];
+        var n = 0;
+        for (var i = 0; i < pairs.Length; i++)
+        {
+            var p = pairs[i].Value;
+            if (p.NetQuantity == 0) continue;
+            buf[n++] = new Persistence.SubAccountPositionSnapshot(
+                pairs[i].Key.Owner.Value, pairs[i].Key.SubAccount, pairs[i].Key.Symbol,
+                p.NetQuantity, p.AverageEntryPrice);
+        }
+        if (n == buf.Length) return buf;
+        var trimmed = new Persistence.SubAccountPositionSnapshot[n];
+        Array.Copy(buf, trimmed, n);
+        return trimmed;
+    }
+
+    public void Restore(IEnumerable<Persistence.SubAccountPositionSnapshot> snaps)
+    {
+        ArgumentNullException.ThrowIfNull(snaps);
+        _positions.Clear();
+        foreach (var s in snaps)
+        {
+            var owner = new EndClientId(s.EndClientId);
+            _positions[(owner, s.SubAccountId, s.Symbol)] =
+                Position.Hydrate(owner, s.Symbol, s.NetQuantity, s.AverageEntryPrice);
+        }
+    }
+}

--- a/backend/src/B3.Trading.Application/SubAccountsRegistry.cs
+++ b/backend/src/B3.Trading.Application/SubAccountsRegistry.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Q4.1 (#301). In-memory registry of known sub-accounts per firm.
+/// Seeded from the WAL — every <see cref="SubAccountCreatedEvent"/>
+/// and <see cref="SubAccountDeactivatedEvent"/> is replayed through
+/// <see cref="ApplyCreated"/> / <see cref="ApplyDeactivated"/> on
+/// recovery so a snapshot+tail restart converges on the same
+/// registry state. Snapshotted as a flat list via
+/// <see cref="Snapshot"/> for the two-phase capture pipeline.
+///
+/// <para>
+/// <b>Per-firm namespace.</b> Sub-accounts are scoped per-firm
+/// (FIRM01:tradingdesk and FIRM02:tradingdesk are distinct). The
+/// keys here are <c>(firmId, id)</c> tuples; lookups for the submit
+/// pipeline always carry both. Soft-delete: deactivated entries
+/// stay in the map (so historical orders still resolve) but
+/// <see cref="IsActive"/> returns <c>false</c> and re-issuing a
+/// <see cref="SubAccountCreatedEvent"/> for the same id revives the
+/// entry (with a possibly updated display name).
+/// </para>
+/// </summary>
+public sealed class SubAccountsRegistry
+{
+    private readonly ConcurrentDictionary<(string Firm, string Id), Entry> _entries =
+        new(KeyEqualityComparer.Instance);
+
+    public sealed record Entry(string FirmId, string Id, string? DisplayName, bool Active);
+
+    /// <summary>
+    /// Idempotent. Returns <c>true</c> when the call actually
+    /// created (or revived) the entry; <c>false</c> when it
+    /// re-activated an already-active row without changes.
+    /// </summary>
+    public bool ApplyCreated(string firmId, string id, string? displayName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        var key = (firmId, id);
+        var entry = new Entry(firmId, id, displayName, Active: true);
+        var prev = _entries.AddOrUpdate(key, _ => entry,
+            (_, _) => entry);
+        return !object.ReferenceEquals(prev, entry) || prev.Active is false;
+    }
+
+    /// <summary>
+    /// Soft-delete. Returns <c>true</c> when the entry was active
+    /// before the call; <c>false</c> when it was already deactivated
+    /// or missing entirely.
+    /// </summary>
+    public bool ApplyDeactivated(string firmId, string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        var key = (firmId, id);
+        if (!_entries.TryGetValue(key, out var prev))
+            return false;
+        if (!prev.Active)
+            return false;
+        _entries[key] = prev with { Active = false };
+        return true;
+    }
+
+    public bool TryGet(string firmId, string id, out Entry entry)
+    {
+        if (_entries.TryGetValue((firmId, id), out var found))
+        {
+            entry = found;
+            return true;
+        }
+        entry = default!;
+        return false;
+    }
+
+    /// <summary>True when the id is known AND not soft-deleted.</summary>
+    public bool IsActive(string firmId, string id) =>
+        TryGet(firmId, id, out var e) && e.Active;
+
+    /// <summary>
+    /// Lists every entry for <paramref name="firmId"/>, active or
+    /// deactivated. The caller filters in the API surface as needed
+    /// (default <c>GET /sub-accounts</c> hides deactivated rows).
+    /// </summary>
+    public IReadOnlyList<Entry> ListForFirm(string firmId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        var list = new List<Entry>();
+        foreach (var kv in _entries)
+            if (string.Equals(kv.Key.Firm, firmId, StringComparison.Ordinal))
+                list.Add(kv.Value);
+        list.Sort(static (a, b) => string.CompareOrdinal(a.Id, b.Id));
+        return list;
+    }
+
+    /// <summary>
+    /// Lock-side capture for the snapshot pipeline (RFC §5.8 / P6).
+    /// Caller must hold <c>EventDispatcher.WithSnapshotLock</c>;
+    /// returns a deterministically-ordered array independent of
+    /// concurrent <see cref="ApplyCreated"/> / <see cref="ApplyDeactivated"/>.
+    /// </summary>
+    public SubAccountSnapshot[] Snapshot()
+    {
+        var rows = _entries.ToArray();
+        if (rows.Length == 0) return Array.Empty<SubAccountSnapshot>();
+        Array.Sort(rows, static (a, b) =>
+        {
+            var cmp = string.CompareOrdinal(a.Key.Firm, b.Key.Firm);
+            return cmp != 0 ? cmp : string.CompareOrdinal(a.Key.Id, b.Key.Id);
+        });
+        var arr = new SubAccountSnapshot[rows.Length];
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var e = rows[i].Value;
+            arr[i] = new SubAccountSnapshot(e.FirmId, e.Id, e.DisplayName, e.Active);
+        }
+        return arr;
+    }
+
+    /// <summary>
+    /// Restores the registry from a snapshot row set. Replaces every
+    /// existing entry (snapshot is authoritative — replay folds the
+    /// tail back in on top via <see cref="ApplyCreated"/> /
+    /// <see cref="ApplyDeactivated"/>).
+    /// </summary>
+    public void Restore(IEnumerable<SubAccountSnapshot> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        _entries.Clear();
+        foreach (var s in entries)
+            _entries[(s.FirmId, s.Id)] = new Entry(s.FirmId, s.Id, s.DisplayName, s.Active);
+    }
+
+    private sealed class KeyEqualityComparer : IEqualityComparer<(string Firm, string Id)>
+    {
+        public static readonly KeyEqualityComparer Instance = new();
+
+        public bool Equals((string Firm, string Id) x, (string Firm, string Id) y) =>
+            string.Equals(x.Firm, y.Firm, StringComparison.Ordinal)
+            && string.Equals(x.Id, y.Id, StringComparison.Ordinal);
+
+        public int GetHashCode((string Firm, string Id) obj) =>
+            HashCode.Combine(obj.Firm, obj.Id);
+    }
+}

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -156,6 +156,53 @@ public sealed class WorkingOrderBook
     }
 
     /// <summary>
+    /// PR #316 P1. Firm-scoped variant of <see cref="ForEndClient"/>.
+    /// Filters the owner's orders to those tagged with
+    /// <paramref name="firmId"/> so the same JWT <c>sub</c> registered
+    /// in multiple firms sees only the orders that belong to the firm
+    /// it is currently authenticated under. Used by
+    /// <c>GET /orders</c> + <c>orders.me</c> snapshot.
+    /// </summary>
+    public IReadOnlyCollection<Order> ForEndClientAndFirm(string firmId, EndClientId owner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        var list = new List<Order>();
+        foreach (var kv in _orders)
+        {
+            if (kv.Value.Owner != owner) continue;
+            if (!string.Equals(kv.Value.FirmId, firmId, StringComparison.Ordinal)) continue;
+            list.Add(kv.Value);
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// PR #316 P1. Firm-scoped variant of
+    /// <see cref="SumOpenSellLeavesForSymbol"/>. Used by the naked-short
+    /// gate so that open Sell leaves of the same JWT <c>sub</c> in a
+    /// different firm don't restrict sellable inventory in the current
+    /// firm bucket.
+    /// </summary>
+    public long SumOpenSellLeavesForSymbolAndFirm(string firmId, EndClientId owner, string symbol)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(symbol);
+        if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
+        long total = 0;
+        foreach (var clOrdId in set.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (order.Side != OrderSide.Sell) continue;
+            if (!string.Equals(order.Symbol, symbol, StringComparison.Ordinal)) continue;
+            if (!string.Equals(order.FirmId, firmId, StringComparison.Ordinal)) continue;
+            if (IsTerminal(order.Status)) continue;
+            if (order.IsStale) continue;
+            total += order.LeavesQuantity;
+        }
+        return total;
+    }
+
+    /// <summary>
     /// Snapshots the orders associated with <paramref name="firmId"/>. By default
     /// only non-terminal orders are returned (PendingNew / Working / PartiallyFilled),
     /// which matches the FIXP "outstanding orders" semantics used to reconcile

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -85,14 +85,17 @@ public sealed class WorkingOrderBook
 
     /// <summary>
     /// Q4.1 (#301). Counts an owner's non-terminal orders restricted to
-    /// the given sub-account bucket. Orders without a sub-account tag
-    /// are NOT included (they live in the master bucket and are
-    /// counted by <see cref="CountOpenForOwner"/>). Used by
-    /// <c>SubAccountLimitsCheck</c> to apply per-sub-account
+    /// the given <c>(firm, sub-account)</c> bucket. Orders without a
+    /// sub-account tag are NOT included (they live in the master bucket
+    /// and are counted by <see cref="CountOpenForOwner"/>), and orders
+    /// from a different firm are excluded so the same login under two
+    /// firms with the same sub-account id does not share the cap.
+    /// Used by <c>SubAccountLimitsCheck</c> to apply per-sub-account
     /// max-open-orders caps without re-scanning the whole book.
     /// </summary>
-    public int CountOpenForOwnerAndSubAccount(EndClientId owner, SubAccountId subAccount)
+    public int CountOpenForOwnerAndSubAccount(string firmId, EndClientId owner, SubAccountId subAccount)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
         ArgumentNullException.ThrowIfNull(subAccount);
         if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
         var count = 0;
@@ -101,6 +104,7 @@ public sealed class WorkingOrderBook
             if (!_orders.TryGetValue(clOrdId, out var order)) continue;
             if (IsTerminal(order.Status)) continue;
             if (order.IsStale) continue;
+            if (!string.Equals(order.FirmId, firmId, StringComparison.Ordinal)) continue;
             if (order.SubAccountId is not { } sa) continue;
             if (sa != subAccount) continue;
             count++;

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -84,6 +84,31 @@ public sealed class WorkingOrderBook
     }
 
     /// <summary>
+    /// Q4.1 (#301). Counts an owner's non-terminal orders restricted to
+    /// the given sub-account bucket. Orders without a sub-account tag
+    /// are NOT included (they live in the master bucket and are
+    /// counted by <see cref="CountOpenForOwner"/>). Used by
+    /// <c>SubAccountLimitsCheck</c> to apply per-sub-account
+    /// max-open-orders caps without re-scanning the whole book.
+    /// </summary>
+    public int CountOpenForOwnerAndSubAccount(EndClientId owner, SubAccountId subAccount)
+    {
+        ArgumentNullException.ThrowIfNull(subAccount);
+        if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
+        var count = 0;
+        foreach (var clOrdId in set.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (IsTerminal(order.Status)) continue;
+            if (order.IsStale) continue;
+            if (order.SubAccountId is not { } sa) continue;
+            if (sa != subAccount) continue;
+            count++;
+        }
+        return count;
+    }
+
+    /// <summary>
     /// Sums <see cref="Order.LeavesQuantity"/> across the end-client's
     /// non-terminal Sell orders for a single symbol. Used by the
     /// pre-trade naked-short gate to compute available sellable
@@ -212,6 +237,7 @@ public sealed class WorkingOrderBook
                 GoodTillDate = o.GoodTillDate,
                 DisplayQty = o.DisplayQty,
                 DisplayResetPolicy = o.DisplayResetPolicy?.ToString(),
+                SubAccountId = o.SubAccountId?.Value,
             };
         }
     }
@@ -265,12 +291,14 @@ public sealed class WorkingOrderBook
             DisplayResetPolicy? policy = s.DisplayResetPolicy is { } dpName
                 ? Enum.Parse<DisplayResetPolicy>(dpName)
                 : (DisplayResetPolicy?)null;
+            var subAccount = SubAccountId.FromNullableString(s.SubAccountId);
             _orders[s.ClOrdId] = Order.Hydrate(s.ClOrdId, owner, s.Symbol, s.SecurityId, side, type,
                 s.Quantity, s.Price, s.LeavesQuantity, s.CumulativeQuantity, status, s.FirmId,
                 s.ParentAlgoId, s.AlgoSliceSeq,
                 isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc,
                 timeInForce: tif, stopPrice: s.StopPrice, goodTillDate: s.GoodTillDate,
-                displayQty: s.DisplayQty, displayResetPolicy: policy);
+                displayQty: s.DisplayQty, displayResetPolicy: policy,
+                subAccountId: subAccount);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -84,6 +84,32 @@ public sealed class WorkingOrderBook
     }
 
     /// <summary>
+    /// PR #316 P2.1. Firm-scoped variant of
+    /// <see cref="CountOpenForOwner"/>. Restricts the count to the
+    /// owner's non-terminal orders tagged with <paramref name="firmId"/>
+    /// so the same JWT <c>sub</c> active in multiple firms does not
+    /// consume another firm's max-open-orders quota. Used by
+    /// <see cref="Risk.Checks.MaxOpenOrdersCheck"/> — that cap is
+    /// resolved per-(firm, end-client) by <see cref="Risk.RiskLimitsResolver"/>,
+    /// so the counter must also be firm-scoped.
+    /// </summary>
+    public int CountOpenForOwnerAndFirm(string firmId, EndClientId owner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        if (!_byOwner.TryGetValue(owner.Value, out var set)) return 0;
+        var count = 0;
+        foreach (var clOrdId in set.Keys)
+        {
+            if (!_orders.TryGetValue(clOrdId, out var order)) continue;
+            if (IsTerminal(order.Status)) continue;
+            if (order.IsStale) continue;
+            if (!string.Equals(order.FirmId, firmId, StringComparison.Ordinal)) continue;
+            count++;
+        }
+        return count;
+    }
+
+    /// <summary>
     /// Q4.1 (#301). Counts an owner's non-terminal orders restricted to
     /// the given <c>(firm, sub-account)</c> bucket. Orders without a
     /// sub-account tag are NOT included (they live in the master bucket

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -181,7 +181,8 @@ public sealed class Order
         decimal? stopPrice = null,
         DateTimeOffset? goodTillDate = null,
         long? displayQty = null,
-        DisplayResetPolicy? displayResetPolicy = null)
+        DisplayResetPolicy? displayResetPolicy = null,
+        SubAccountId? subAccountId = null)
     {
         if (clOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(clOrdId), "ClOrdID cannot be zero (reserved as null sentinel by EntryPoint).");
@@ -261,6 +262,7 @@ public sealed class Order
         GoodTillDate = goodTillDate;
         DisplayQty = displayQty;
         DisplayResetPolicy = displayResetPolicy;
+        SubAccountId = subAccountId;
         LeavesQuantity = quantity;
         Status = OrderStatus.PendingNew;
     }
@@ -337,6 +339,16 @@ public sealed class Order
     /// a refresh-policy flag; the venue defaults to <c>Always</c>).
     /// </summary>
     public DisplayResetPolicy? DisplayResetPolicy { get; }
+
+    /// <summary>
+    /// Q4.1 (#301). Optional sub-account bucket the order is booked
+    /// against. <c>null</c> = master bucket (the only value legacy
+    /// callers ever produced). Sub-accounts are namespaced per-firm
+    /// at the registry level — see
+    /// <see cref="Domain.SubAccountId"/> and
+    /// <c>SubAccountsRegistry</c>.
+    /// </summary>
+    public SubAccountId? SubAccountId { get; }
 
     public long LeavesQuantity { get; private set; }
     public long CumulativeQuantity { get; private set; }
@@ -515,10 +527,11 @@ public sealed class Order
         decimal? stopPrice = null,
         DateTimeOffset? goodTillDate = null,
         long? displayQty = null,
-        DisplayResetPolicy? displayResetPolicy = null)
+        DisplayResetPolicy? displayResetPolicy = null,
+        SubAccountId? subAccountId = null)
     {
         var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq,
-            timeInForce, stopPrice, goodTillDate, displayQty, displayResetPolicy);
+            timeInForce, stopPrice, goodTillDate, displayQty, displayResetPolicy, subAccountId);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;
@@ -624,7 +637,8 @@ public sealed class Order
             stopPrice: effStop,
             goodTillDate: effGtd,
             displayQty: effDisplayQty,
-            displayResetPolicy: effPolicy);
+            displayResetPolicy: effPolicy,
+            subAccountId: original.SubAccountId);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Domain/SubAccountId.cs
+++ b/backend/src/B3.Trading.Domain/SubAccountId.cs
@@ -1,0 +1,76 @@
+namespace B3.Trading.Domain;
+
+/// <summary>
+/// Q4.1 (#301). Sub-account identifier inside an end-client / trader.
+/// A single <see cref="EndClientId"/> may carry N sub-accounts
+/// (e.g. <c>tradingdesk</c>, <c>prop</c>, <c>clientA</c>) so that
+/// orders, fills, positions, P&amp;L, and per-sub-account risk
+/// buckets can be tracked separately while the master end-client
+/// view continues to aggregate naturally.
+///
+/// <para>
+/// <b>Nullability convention.</b> Every sub-account-aware field on
+/// the public API (orders, snapshots, WAL events, risk options) is
+/// modelled as <see cref="SubAccountId"/>? — <c>null</c> means
+/// "master bucket / no sub-account specified", which is also the
+/// only value legacy callers (pre-#301) ever supplied. This keeps
+/// forward-compat with every persisted WAL segment and snapshot
+/// already on disk: missing field deserialises as <c>null</c> ==
+/// master bucket, exactly the semantic those rows actually carried.
+/// </para>
+///
+/// <para>
+/// <b>Identifier shape.</b> Case-sensitive string keyed verbatim
+/// off the wire (POST /sub-accounts body). The constructor rejects
+/// empty/whitespace and any token longer than 64 characters or
+/// containing characters outside <c>[A-Za-z0-9._-]</c> so the id
+/// can flow safely through JSON payloads, log messages, and metric
+/// tags without escaping. Sub-accounts are namespaced per-firm at
+/// the registry level (see <c>SubAccountsRegistry</c>), so the same
+/// id under FIRM01 and FIRM02 are distinct addresses — this value
+/// type carries only the leaf id.
+/// </para>
+/// </summary>
+public sealed record SubAccountId
+{
+    /// <summary>Hard cap on the id length. Sized to fit comfortably
+    /// in a single short JSON field without ballooning WAL rows or
+    /// metric cardinality.</summary>
+    public const int MaxLength = 64;
+
+    public SubAccountId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("SubAccountId cannot be null or whitespace.", nameof(value));
+        if (value.Length > MaxLength)
+            throw new ArgumentException(
+                $"SubAccountId length {value.Length} exceeds max {MaxLength}.",
+                nameof(value));
+        foreach (var c in value)
+        {
+            if (!IsValidChar(c))
+                throw new ArgumentException(
+                    $"SubAccountId '{value}' contains invalid character '{c}'; allowed: A-Z a-z 0-9 . _ -",
+                    nameof(value));
+        }
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+
+    public static bool IsValidChar(char c) =>
+        char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '-';
+
+    /// <summary>
+    /// Convenience parser used by REST/WAL replay paths: empty/null
+    /// query-string arguments map to <c>null</c> (master bucket); a
+    /// non-empty value is validated through the regular constructor.
+    /// </summary>
+    public static SubAccountId? FromNullableString(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return new SubAccountId(raw);
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -44,6 +44,12 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<IFeeCalculator, BpsFeeCalculator>();
         services.AddSingleton<FeeKeeper>();
         services.AddSingleton<PnlKeeper>();
+        // Q4.1 (#301). Sub-account model — registry + per-sub-account
+        // position and P&L keepers. All singletons so live folds, WAL
+        // replay, and snapshot capture/restore share the same instance.
+        services.AddSingleton<SubAccountsRegistry>();
+        services.AddSingleton<SubAccountPositionKeeper>();
+        services.AddSingleton<SubAccountPnlKeeper>();
         services.AddSingleton<InMemoryUserBotCredentialRegistry>();
         services.AddSingleton<IUserBotCredentialRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -31,6 +31,7 @@ public static class TradingEndpointsExtensions
         app.MapPositions();
         app.MapBalance();
         app.MapPnl();
+        app.MapSubAccounts();
         app.MapStatement();
         app.MapPolicy();
         app.MapAdmin();

--- a/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
@@ -132,6 +132,17 @@ internal static class TradingHostStartup
         if (seedOpts.Seeds.Count > 0)
         {
             var keeper = scope.ServiceProvider.GetRequiredService<PositionKeeper>();
+            // PR #316 P1.1. Mirror the seed into the bucket-aware
+            // realised-PnL store so the master bucket's avg-cost basis
+            // is anchored to the seed BEFORE the first fill mutates
+            // the aggregate keeper. Without this, a sub-account fill
+            // would silently pollute the master statement-row avg
+            // (the only other source of master avg was
+            // PositionKeeper.AverageEntryPrice, which mixes master +
+            // sub fills) and a master close after a seed would skip
+            // RealizedPnlEvent emission entirely (bucket basis
+            // empty → ApplyBucketFill returns 0).
+            var subAccountPnl = scope.ServiceProvider.GetService<SubAccountPnlKeeper>();
             var seedLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("PositionSeeder");
 
             // PR #316 P2: real-mode users are namespaced under FIRM01 /
@@ -182,6 +193,8 @@ internal static class TradingHostStartup
                     seedLogger.LogInformation(
                         "Seeded opening position {Firm}/{Owner}/{Symbol} = {Qty} @ {AvgPx}.",
                         firm, seed.EndClientId, seed.Symbol, seed.Quantity, seed.AverageEntryPrice);
+                    subAccountPnl?.SeedMasterBucketBasisIfAbsent(
+                        firm, owner.Value, seed.Symbol, seed.Quantity, seed.AverageEntryPrice);
                 }
                 else
                 {

--- a/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
@@ -133,6 +133,37 @@ internal static class TradingHostStartup
         {
             var keeper = scope.ServiceProvider.GetRequiredService<PositionKeeper>();
             var seedLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("PositionSeeder");
+
+            // PR #316 P2: real-mode users are namespaced under FIRM01 /
+            // FIRM02 etc., but legacy PositionSeed entries land in
+            // PositionKeeper.DefaultFirmId (a sentinel no real user is
+            // ever authenticated under). When the operator has wired
+            // more than one firm AND any seed still lacks an explicit
+            // Firm value, log a loud one-shot warning so the silent
+            // "naked-short rejects on first Sell" symptom does not
+            // recur. The warning is informational; the seed is still
+            // applied to whatever firm the seed itself names (explicit
+            // > default).
+            var authOpts = scope.ServiceProvider.GetRequiredService<IOptions<B3.Trading.Api.Auth.AuthOptions>>().Value;
+            var configuredFirms = authOpts.Users
+                .Select(u => string.IsNullOrWhiteSpace(u.Firm) ? "default" : u.Firm)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var unfirmedSeed = seedOpts.Seeds.Any(s => string.IsNullOrWhiteSpace(s.Firm));
+            if (unfirmedSeed && configuredFirms.Length > 1)
+            {
+                seedLogger.LogWarning(
+                    "PositionSeeder: {Count} seed(s) without an explicit Firm will land in "
+                    + "PositionKeeper.DefaultFirmId, but {FirmCount} firms are configured under "
+                    + "Trading:Auth:Users ([{Firms}]). Real-mode users authenticated under a firm "
+                    + "will NOT see those positions — set Trading:Positions:Seeds[N]:Firm to the "
+                    + "user's firm (typically FIRM01) so the naked-short gate does not block their "
+                    + "first Sell.",
+                    seedOpts.Seeds.Count(s => string.IsNullOrWhiteSpace(s.Firm)),
+                    configuredFirms.Length,
+                    string.Join(", ", configuredFirms));
+            }
+
             var applied = 0;
             var skipped = 0;
             foreach (var seed in seedOpts.Seeds)
@@ -144,19 +175,20 @@ internal static class TradingHostStartup
                     continue;
                 }
                 var owner = new EndClientId(seed.EndClientId);
-                if (keeper.SeedIfAbsent(owner, seed.Symbol, seed.Quantity, seed.AverageEntryPrice))
+                var firm = string.IsNullOrWhiteSpace(seed.Firm) ? PositionKeeper.DefaultFirmId : seed.Firm;
+                if (keeper.SeedIfAbsent(firm, owner, seed.Symbol, seed.Quantity, seed.AverageEntryPrice))
                 {
                     applied++;
                     seedLogger.LogInformation(
-                        "Seeded opening position {Owner}/{Symbol} = {Qty} @ {AvgPx}.",
-                        seed.EndClientId, seed.Symbol, seed.Quantity, seed.AverageEntryPrice);
+                        "Seeded opening position {Firm}/{Owner}/{Symbol} = {Qty} @ {AvgPx}.",
+                        firm, seed.EndClientId, seed.Symbol, seed.Quantity, seed.AverageEntryPrice);
                 }
                 else
                 {
                     skipped++;
                     seedLogger.LogInformation(
-                        "Skipped seed for {Owner}/{Symbol}: position already present from recovery.",
-                        seed.EndClientId, seed.Symbol);
+                        "Skipped seed for {Firm}/{Owner}/{Symbol}: position already present from recovery.",
+                        firm, seed.EndClientId, seed.Symbol);
                 }
             }
             seedLogger.LogInformation("PositionSeeder finished: {Applied} applied, {Skipped} skipped.", applied, skipped);

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -29,6 +29,11 @@ public static class TradingRiskServiceCollectionExtensions
     {
         services.Configure<RiskOptions>(
             configuration.GetSection(RiskOptions.SectionName));
+        // Q4.1 (#301). Optional per-(firm, sub-account) cap config.
+        // Bound from Trading:Risk:SubAccount; missing section is fine —
+        // the resolver returns null and the check becomes a no-op.
+        services.Configure<SubAccountRiskOptions>(
+            configuration.GetSection(SubAccountRiskOptions.SectionName));
         services.Configure<SymbolDirectoryOptions>(
             configuration.GetSection(SymbolDirectoryOptions.SectionName));
         services.AddSingleton(sp =>
@@ -92,6 +97,7 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<IRiskCheck, RollingNotionalCheck>();
         services.AddSingleton<IRiskCheck, OrderRateLimitCheck>();
         services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
+        services.AddSingleton<IRiskCheck, SubAccountLimitsCheck>();
         services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
         services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
         services.AddSingleton<IRiskCheck, PriceCollarCheck>();

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -278,7 +278,7 @@ public sealed class StateSnapshotter
         for (var i = 0; i < raw.Positions.Length; i++)
         {
             var p = raw.Positions[i];
-            positions.Add(new PositionSnapshot(p.EndClientId, p.Symbol, p.NetQuantity, p.AverageEntryPrice));
+            positions.Add(new PositionSnapshot(p.EndClientId, p.Symbol, p.NetQuantity, p.AverageEntryPrice, p.FirmId));
         }
 
         var ownership = new List<OwnershipMappingSnapshot>(raw.Ownership.Length);
@@ -320,19 +320,19 @@ public sealed class StateSnapshotter
         for (var i = 0; i < raw.PnlRealizedByEndclientSymbolDay.Length; i++)
         {
             var p = raw.PnlRealizedByEndclientSymbolDay[i];
-            pnlRealized[PnlKeeper.FormatRealizedKey(p.EndClientId, p.Symbol, p.Day)] = p.Realized;
+            pnlRealized[PnlKeeper.FormatRealizedKey(p.FirmId, p.EndClientId, p.Symbol, p.Day)] = p.Realized;
         }
         var pnlAvgCost = new List<PnlAvgCostSnapshot>(raw.PnlAvgCost.Length);
         for (var i = 0; i < raw.PnlAvgCost.Length; i++)
         {
             var a = raw.PnlAvgCost[i];
-            pnlAvgCost.Add(new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice));
+            pnlAvgCost.Add(new PnlAvgCostSnapshot(a.EndClientId, a.Symbol, a.NetQuantity, a.AvgPrice, a.FirmId));
         }
         var pnlUnknownBasis = new List<PnlUnknownBasisSnapshot>(raw.PnlUnknownBasis.Length);
         for (var i = 0; i < raw.PnlUnknownBasis.Length; i++)
         {
             var u = raw.PnlUnknownBasis[i];
-            pnlUnknownBasis.Add(new PnlUnknownBasisSnapshot(u.EndClientId, u.Symbol, u.NetQuantity));
+            pnlUnknownBasis.Add(new PnlUnknownBasisSnapshot(u.EndClientId, u.Symbol, u.NetQuantity, u.FirmId));
         }
         var pnlSeen = new List<string>(raw.PnlSeenExecutionIds.Length);
         for (var i = 0; i < raw.PnlSeenExecutionIds.Length; i++)

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -74,6 +74,9 @@ public sealed class StateSnapshotter
     /// </summary>
     private readonly PendingReplacementRegistry? _replacements;
     private readonly IReplaceMarginCoordinator? _replaceMargin;
+    private readonly SubAccountsRegistry? _subAccounts;
+    private readonly SubAccountPositionKeeper? _subAccountPositions;
+    private readonly SubAccountPnlKeeper? _subAccountPnl;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -96,7 +99,10 @@ public sealed class StateSnapshotter
         PovProgressBook? povProgress = null,
         PeggedRepegBook? peggedRepeg = null,
         PendingReplacementRegistry? replacements = null,
-        IReplaceMarginCoordinator? replaceMargin = null)
+        IReplaceMarginCoordinator? replaceMargin = null,
+        SubAccountsRegistry? subAccounts = null,
+        SubAccountPositionKeeper? subAccountPositions = null,
+        SubAccountPnlKeeper? subAccountPnl = null)
     {
         _orders = orders;
         _positions = positions;
@@ -119,6 +125,9 @@ public sealed class StateSnapshotter
         _peggedRepeg = peggedRepeg;
         _replacements = replacements;
         _replaceMargin = replaceMargin;
+        _subAccounts = subAccounts;
+        _subAccountPositions = subAccountPositions;
+        _subAccountPnl = subAccountPnl;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -211,6 +220,9 @@ public sealed class StateSnapshotter
                     AmbiguousAtUtc: s.AmbiguousAt,
                     NewRemainingNotional: s.NewRemainingNotional))
                 .ToArray(),
+        SubAccounts = _subAccounts?.Snapshot() ?? Array.Empty<SubAccountSnapshot>(),
+        SubAccountPositions = _subAccountPositions?.Snapshot() ?? Array.Empty<SubAccountPositionSnapshot>(),
+        SubAccountPnl = _subAccountPnl?.Snapshot() ?? Array.Empty<SubAccountPnlSnapshot>(),
     };
 
     /// <summary>
@@ -254,6 +266,7 @@ public sealed class StateSnapshotter
                 GoodTillDate = o.GoodTillDate,
                 DisplayQty = o.DisplayQty,
                 DisplayResetPolicy = o.DisplayResetPolicy?.ToString(),
+                SubAccountId = o.SubAccountId?.Value,
             });
         }
 
@@ -470,6 +483,9 @@ public sealed class StateSnapshotter
             PeggedRepegPending = peggedRepeg,
             PeggedRepegHistory = peggedRepegHistory,
             PendingReplacements = pendingReplacements,
+            SubAccounts = raw.SubAccounts.ToList(),
+            SubAccountPositions = raw.SubAccountPositions.ToList(),
+            SubAccountPnl = raw.SubAccountPnl.ToList(),
         };
     }
 
@@ -628,6 +644,17 @@ public sealed class StateSnapshotter
                 }
             }
         }
+        // Q4.1 (#301). Restore the sub-account registry + parallel
+        // keepers BEFORE WAL replay starts. EventReplayer's
+        // SubAccountCreated/Deactivated branches and the
+        // SubAccountId-tagged RealizedPnlEvent fan-out are then
+        // applied on top of the snapshot baseline — idempotent for
+        // the registry (last-write-wins on Active) and additive for
+        // the per-sub-account P&L bucket (delta-add). Empty lists on
+        // legacy snapshots collapse to the no-sub-account world.
+        _subAccounts?.Restore(snap.SubAccounts);
+        _subAccountPositions?.Restore(snap.SubAccountPositions);
+        _subAccountPnl?.Restore(snap.SubAccountPnl);
     }
 }
 
@@ -672,6 +699,9 @@ public sealed class EventReplayer
     private readonly CashKeeper? _cashKeeper;
     private readonly FeeKeeper? _feeKeeper;
     private readonly PnlKeeper? _pnlKeeper;
+    private readonly SubAccountsRegistry? _subAccounts;
+    private readonly SubAccountPositionKeeper? _subAccountPositions;
+    private readonly SubAccountPnlKeeper? _subAccountPnl;
     private readonly IFeeCalculator? _feeCalculator;
     /// <summary>
     /// Pass-1 review (#295) P1#1. Optional. When wired, replay folds
@@ -724,7 +754,10 @@ public sealed class EventReplayer
         // double-add (if Prepare ran again) or land in the
         // "neither side has owner" branch of <c>CommitReplace</c> —
         // both break the over-allocation invariant.
-        IReplaceMarginCoordinator? replaceMargin = null)
+        IReplaceMarginCoordinator? replaceMargin = null,
+        SubAccountsRegistry? subAccounts = null,
+        SubAccountPositionKeeper? subAccountPositions = null,
+        SubAccountPnlKeeper? subAccountPnl = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -747,6 +780,9 @@ public sealed class EventReplayer
         _povProgress = povProgress;
         _peggedRepeg = peggedRepeg;
         _replaceMargin = replaceMargin;
+        _subAccounts = subAccounts;
+        _subAccountPositions = subAccountPositions;
+        _subAccountPnl = subAccountPnl;
     }
 
     /// <summary>
@@ -791,7 +827,8 @@ public sealed class EventReplayer
                 _orders.TryAdd(new Order(o.ClOrdId, owner, o.Symbol, o.SecurityId, side, type,
                     o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq,
                     timeInForce: tif, stopPrice: o.StopPrice, goodTillDate: o.GoodTillDate,
-                    displayQty: o.DisplayQty, displayResetPolicy: policy));
+                    displayQty: o.DisplayQty, displayResetPolicy: policy,
+                    subAccountId: SubAccountId.FromNullableString(o.SubAccountId)));
                 _ownership.Register(o.ClOrdId, owner);
                 // #157: advance the ClOrdID registry watermark so the next
                 // live Generate(owner) cannot re-allocate this ID.
@@ -1063,6 +1100,25 @@ public sealed class EventReplayer
                 // recovery converges on the persisted value even if the
                 // basis tracker projection drifts.
                 _pnlKeeper?.Apply(rpe);
+                // Q4.1 (#301). Sub-account-tagged realized rows also
+                // flow into the per-sub-account keeper. Legacy events
+                // pre-dating the field carry null and short-circuit.
+                if (rpe.SubAccountId is { } subPnlId)
+                    _subAccountPnl?.Add(rpe.EndClientId, new SubAccountId(subPnlId),
+                        rpe.Symbol, rpe.DayKey, rpe.DeltaRealized);
+                break;
+            case SubAccountCreatedEvent sac:
+                // Q4.1 (#301). Seeds / revives the registry row. The
+                // submit pipeline gate reads IsActive directly off this
+                // map; deactivated entries that get re-created here
+                // flip back to active.
+                _subAccounts?.ApplyCreated(sac.FirmId, sac.Id, sac.DisplayName);
+                break;
+            case SubAccountDeactivatedEvent sad:
+                // Q4.1 (#301). Soft-delete — the entry stays in the map
+                // (so historical orders still resolve) but IsActive
+                // flips to false and the submit gate rejects new ones.
+                _subAccounts?.ApplyDeactivated(sad.FirmId, sad.Id);
                 break;
         }
     }

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -671,6 +671,18 @@ public sealed class StateSnapshotter
         // the aggregate result is discarded once _subAccountPnl is
         // wired). Idempotent on already-present keys (a #316-shaped
         // snapshot with SubAccountPnlBasis populated is a no-op).
+        //
+        // Caveat: when SubAccountPositions are present for the same
+        // (firm, owner, symbol) as a master Positions row AND no
+        // authoritative basis exists, the aggregate row is polluted
+        // (every fill — master- and sub-tagged alike — books into
+        // it). The keeper detects that case, refuses to seed master
+        // from the aggregate, and surfaces
+        // trading.subaccount.master_basis_unrecoverable_total +
+        // a one-shot warn so operators can investigate the snapshot
+        // writer. The statement endpoint already fail-closes
+        // (AvgPrice = 0 + master_avg_basis_degraded_total) on a
+        // missing master basis, so the absence is consistent.
         if (_subAccountPnl is not null)
         {
             _subAccountPnl.SeedBucketBasisFromLegacyPositions(snap.Positions, snap.SubAccountPositions);

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -1103,8 +1103,18 @@ public sealed class EventReplayer
                 // Q4.1 (#301). Sub-account-tagged realized rows also
                 // flow into the per-sub-account keeper. Legacy events
                 // pre-dating the field carry null and short-circuit.
+                // The fan-out is firm-scoped: FirmId is emitted
+                // alongside SubAccountId at append time (PR review
+                // #301 P1). For belt-and-braces parity with WAL
+                // segments written between the original #301 merge
+                // and this fix — where SubAccountId may be set but
+                // FirmId is missing — fall back to "default", which
+                // is the same sentinel the API uses when no firm
+                // claim is present.
                 if (rpe.SubAccountId is { } subPnlId)
-                    _subAccountPnl?.Add(rpe.EndClientId, new SubAccountId(subPnlId),
+                    _subAccountPnl?.Add(
+                        rpe.FirmId ?? "default",
+                        rpe.EndClientId, new SubAccountId(subPnlId),
                         rpe.Symbol, rpe.DayKey, rpe.DeltaRealized);
                 break;
             case SubAccountCreatedEvent sac:

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -804,7 +804,11 @@ public sealed class EventReplayer
         if (_feeKeeper is not null && _feeCalculator is not null)
             n += _feeKeeper.FinalizeReplay(_feeCalculator);
         if (_pnlKeeper is not null)
-            n += _pnlKeeper.FinalizeReplay();
+            // PR #316 P1.2. Route bucket-tagged synthesized deltas into
+            // SubAccountPnlKeeper so sub-bucket realised totals don't
+            // diverge from the live path when the durable
+            // RealizedPnlEvent did not survive the ER-then-crash window.
+            n += _pnlKeeper.FinalizeReplay(_subAccountPnl);
         return n;
     }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -223,6 +223,7 @@ public sealed class StateSnapshotter
         SubAccounts = _subAccounts?.Snapshot() ?? Array.Empty<SubAccountSnapshot>(),
         SubAccountPositions = _subAccountPositions?.Snapshot() ?? Array.Empty<SubAccountPositionSnapshot>(),
         SubAccountPnl = _subAccountPnl?.Snapshot() ?? Array.Empty<SubAccountPnlSnapshot>(),
+        SubAccountPnlBasis = _subAccountPnl?.SnapshotBasis() ?? Array.Empty<SubAccountPnlBasisSnapshot>(),
     };
 
     /// <summary>
@@ -486,6 +487,7 @@ public sealed class StateSnapshotter
             SubAccounts = raw.SubAccounts.ToList(),
             SubAccountPositions = raw.SubAccountPositions.ToList(),
             SubAccountPnl = raw.SubAccountPnl.ToList(),
+            SubAccountPnlBasis = raw.SubAccountPnlBasis.ToList(),
         };
     }
 
@@ -654,7 +656,7 @@ public sealed class StateSnapshotter
         // legacy snapshots collapse to the no-sub-account world.
         _subAccounts?.Restore(snap.SubAccounts);
         _subAccountPositions?.Restore(snap.SubAccountPositions);
-        _subAccountPnl?.Restore(snap.SubAccountPnl);
+        _subAccountPnl?.Restore(snap.SubAccountPnl, snap.SubAccountPnlBasis);
     }
 }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -657,6 +657,24 @@ public sealed class StateSnapshotter
         _subAccounts?.Restore(snap.SubAccounts);
         _subAccountPositions?.Restore(snap.SubAccountPositions);
         _subAccountPnl?.Restore(snap.SubAccountPnl, snap.SubAccountPnlBasis);
+        // PR #316 P1 (review). Backfill bucket-level avg-cost basis
+        // from the (master Positions, SubAccountPositions) blocks
+        // whenever a snapshot lands without a complete
+        // SubAccountPnlBasis block — i.e. a pre-#316 snapshot taken
+        // before the basis store existed, or a partial snapshot
+        // whose basis is missing for some buckets. Without this
+        // seed, the first close on a restored bucket whose basis is
+        // absent would route through ApplyBucketFill's fresh-open
+        // branch and emit realized PnL = 0, dropping a real economic
+        // delta on the floor (the aggregate keeper would compute it
+        // correctly via SeedAvgCostFromLegacyPositions above, but
+        // the aggregate result is discarded once _subAccountPnl is
+        // wired). Idempotent on already-present keys (a #316-shaped
+        // snapshot with SubAccountPnlBasis populated is a no-op).
+        if (_subAccountPnl is not null)
+        {
+            _subAccountPnl.SeedBucketBasisFromLegacyPositions(snap.Positions, snap.SubAccountPositions);
+        }
     }
 }
 

--- a/backend/tests/B3.Trading.Api.Tests/OrderStaleAdminEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrderStaleAdminEndpointTests.cs
@@ -92,9 +92,13 @@ public class OrderStaleAdminEndpointTests : IClassFixture<TestAppFactory>
     [Fact]
     public async Task DeleteOrder_OnStaleOrder_Returns409()
     {
-        var order = SeedWorkingOrder(_factory, 9005UL);
+        // PR #316 P1: alice's JWT firm is "default" (no Firm set on
+        // the test user config), so the seeded order's firmId must
+        // match to exercise the stale gate (vs. being short-circuited
+        // by the cross-firm NotFound check on cancel).
+        var order = SeedWorkingOrder(_factory, 9005UL, firmId: "default");
         using var admin = await _factory.CreateAuthedClientAsync("admin");
-        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9005/mark-stale", new { reason = "x" });
+        await admin.PostAsJsonAsync("/admin/firms/default/orders/9005/mark-stale", new { reason = "x" });
         Assert.True(order.IsStale);
 
         // alice owns the order; she gets 409 trying to cancel.
@@ -106,9 +110,12 @@ public class OrderStaleAdminEndpointTests : IClassFixture<TestAppFactory>
     [Fact]
     public async Task ModifyOrder_OnStaleOrder_Returns409()
     {
-        var order = SeedWorkingOrder(_factory, 9006UL);
+        // PR #316 P1: see DeleteOrder_OnStaleOrder_Returns409 — order
+        // must be seeded under alice's firm ("default") so the stale
+        // gate is reached.
+        var order = SeedWorkingOrder(_factory, 9006UL, firmId: "default");
         using var admin = await _factory.CreateAuthedClientAsync("admin");
-        await admin.PostAsJsonAsync("/admin/firms/TEST/orders/9006/mark-stale", new { reason = "x" });
+        await admin.PostAsJsonAsync("/admin/firms/default/orders/9006/mark-stale", new { reason = "x" });
 
         using var alice = await _factory.CreateAuthedClientAsync();
         var resp = await alice.PutAsJsonAsync("/orders/9006", new { quantity = 200, price = 30m });

--- a/backend/tests/B3.Trading.Api.Tests/OrdersFirmScopingEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersFirmScopingEndpointTests.cs
@@ -46,4 +46,95 @@ public class OrdersFirmScopingEndpointTests : IClassFixture<TestAppFactory>
         Assert.Single(firm2!);
         Assert.Equal("102", firm2![0].ClOrdId);
     }
+
+    [Fact]
+    public async Task PutModify_CrossFirm_SameOwner_ReturnsNotFound()
+    {
+        // PR #316 P1. A FIRM02 token must not be able to modify a
+        // FIRM01 order even when the JWT sub is the same end-client
+        // and the caller happens to know the FIRM01 ClOrdId.
+        // Same NotFound posture as cross-owner / unknown id —
+        // existence is not leaked across the firm boundary.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        book.TryAdd(new Order(201UL, owner, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM01"));
+        book.TryAdd(new Order(202UL, owner, "PETR4", 9002UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM02"));
+
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var client = factory.CreateClient();
+
+        // FIRM02 token attacking FIRM01's order id.
+        var (firm2Token, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+        var crossFirm = new HttpRequestMessage(HttpMethod.Put, "/orders/201")
+        {
+            Content = JsonContent.Create(new { Quantity = 200, Price = 30m }),
+        };
+        crossFirm.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm2Token);
+        var crossResp = await client.SendAsync(crossFirm);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, crossResp.StatusCode);
+
+        // Sanity: a completely unknown id from the same FIRM02
+        // session returns the same NotFound — proving cross-firm
+        // is indistinguishable from non-existence.
+        var unknown = new HttpRequestMessage(HttpMethod.Put, "/orders/9999999")
+        {
+            Content = JsonContent.Create(new { Quantity = 200, Price = 30m }),
+        };
+        unknown.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm2Token);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, (await client.SendAsync(unknown)).StatusCode);
+
+        // FIRM01 happy-path against its own order is unaffected —
+        // it can still reach the order through the modify pipeline
+        // (the modify itself will go further, but here we just
+        // assert we don't get a NotFound from the firm check).
+        var (firm1Token, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        var sameFirm = new HttpRequestMessage(HttpMethod.Put, "/orders/201")
+        {
+            Content = JsonContent.Create(new { Quantity = 200, Price = 30m }),
+        };
+        sameFirm.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm1Token);
+        var sameResp = await client.SendAsync(sameFirm);
+        Assert.NotEqual(System.Net.HttpStatusCode.NotFound, sameResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCancel_CrossFirm_SameOwner_ReturnsNotFound()
+    {
+        // PR #316 P1. Mirror of the modify test for DELETE /orders.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        book.TryAdd(new Order(301UL, owner, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM01"));
+        book.TryAdd(new Order(302UL, owner, "PETR4", 9002UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM02"));
+
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var client = factory.CreateClient();
+
+        var (firm2Token, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+
+        // FIRM02 cancelling FIRM01's order → NotFound.
+        var crossFirm = new HttpRequestMessage(HttpMethod.Delete, "/orders/301");
+        crossFirm.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm2Token);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, (await client.SendAsync(crossFirm)).StatusCode);
+
+        // Same NotFound for a non-existent id — indistinguishable.
+        var unknown = new HttpRequestMessage(HttpMethod.Delete, "/orders/9999999");
+        unknown.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm2Token);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, (await client.SendAsync(unknown)).StatusCode);
+
+        // FIRM01 path unaffected: the cancel proceeds through the
+        // service (Accepted / NoContent) for its own order.
+        var (firm1Token, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        var sameFirm = new HttpRequestMessage(HttpMethod.Delete, "/orders/301");
+        sameFirm.Headers.Authorization = new AuthenticationHeaderValue("Bearer", firm1Token);
+        var sameResp = await client.SendAsync(sameFirm);
+        Assert.NotEqual(System.Net.HttpStatusCode.NotFound, sameResp.StatusCode);
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/OrdersFirmScopingEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/OrdersFirmScopingEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// PR #316 P1. GET /orders must be firm-scoped so a JWT sub registered
+/// under two firms does not leak the other firm's orders.
+/// </summary>
+public class OrdersFirmScopingEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    public OrdersFirmScopingEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task GetOrders_ScopedByFirm_DoesNotLeakAcrossFirms()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        book.TryAdd(new Order(101UL, owner, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM01"));
+        book.TryAdd(new Order(102UL, owner, "PETR4", 9002UL, OrderSide.Buy, OrderType.Limit, 200, 31m, firmId: "FIRM02"));
+
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var client = factory.CreateClient();
+
+        var (t1, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", t1);
+        var firm1 = await client.GetFromJsonAsync<List<OrderDto>>("/orders/");
+        Assert.NotNull(firm1);
+        Assert.Single(firm1!);
+        Assert.Equal("101", firm1![0].ClOrdId);
+
+        var (t2, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", t2);
+        var firm2 = await client.GetFromJsonAsync<List<OrderDto>>("/orders/");
+        Assert.NotNull(firm2);
+        Assert.Single(firm2!);
+        Assert.Equal("102", firm2![0].ClOrdId);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlEndpointTests.cs
@@ -144,4 +144,70 @@ public class PnlEndpointTests : IClassFixture<TestAppFactory>
         public StubAllPrices(decimal px) => _px = px;
         public bool TryGet(string symbol, out decimal price) { price = _px; return true; }
     }
+
+    [Fact]
+    public async Task GetPnlToday_ScopedByFirm_DoesNotLeakAcrossFirms()
+    {
+        // PR #316 P1. /pnl/today must scope realized + unrealized by
+        // firm so a JWT sub registered under two firms never sees the
+        // other firm's pnl bucket.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var positions = factory.Services.GetRequiredService<PositionKeeper>();
+        var pnl = factory.Services.GetRequiredService<PnlKeeper>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+
+        positions.ApplyFill("FIRM01", owner, "PETR4", OrderSide.Buy, 100, 30m);
+        pnl.ApplyFillToAvgCost("FIRM01", owner.Value, "PETR4", OrderSide.Buy, 100, 30m);
+        pnl.Apply(new Application.Persistence.RealizedPnlEvent
+        {
+            ClOrdId = 10,
+            ExecutionId = "10:1",
+            EndClientId = owner.Value,
+            FirmId = "FIRM01",
+            Symbol = "PETR4",
+            DayKey = day,
+            DeltaRealized = 111m,
+            RunningTotal = 111m,
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+
+        positions.ApplyFill("FIRM02", owner, "VALE3", OrderSide.Buy, 50, 60m);
+        pnl.ApplyFillToAvgCost("FIRM02", owner.Value, "VALE3", OrderSide.Buy, 50, 60m);
+        pnl.Apply(new Application.Persistence.RealizedPnlEvent
+        {
+            ClOrdId = 20,
+            ExecutionId = "20:1",
+            EndClientId = owner.Value,
+            FirmId = "FIRM02",
+            Symbol = "VALE3",
+            DayKey = day,
+            DeltaRealized = 222m,
+            RunningTotal = 222m,
+            TimestampUtc = DateTimeOffset.UtcNow,
+        });
+
+        var issuer = factory.Services.GetRequiredService<Auth.JwtIssuer>();
+        var http = factory.CreateClient();
+
+        var (t1, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", t1);
+        var body1 = await http.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
+        Assert.NotNull(body1);
+        Assert.Equal(111m, body1!.TotalRealized);
+        Assert.Single(body1.Realized, r => r.Symbol == "PETR4");
+        Assert.DoesNotContain(body1.Realized, r => r.Symbol == "VALE3");
+        Assert.DoesNotContain(body1.Unrealized, r => r.Symbol == "VALE3");
+
+        var (t2, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+        http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", t2);
+        var body2 = await http.GetFromJsonAsync<PnlTodayDto>("/pnl/today");
+        Assert.NotNull(body2);
+        Assert.Equal(222m, body2!.TotalRealized);
+        Assert.Single(body2.Realized, r => r.Symbol == "VALE3");
+        Assert.DoesNotContain(body2.Realized, r => r.Symbol == "PETR4");
+        Assert.DoesNotContain(body2.Unrealized, r => r.Symbol == "PETR4");
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -63,7 +63,7 @@ public class PnlRefPriceFanOutTests
             NullLogger<MarketDataReferencePrice>.Instance);
 
         var subs = new SubscriptionManager(new WorkingOrderBook(), positions, new AlgoBook(), pnl, refPrice);
-        var client = new SubscribedClient(owner, "TEST");
+        var client = new SubscribedClient(owner, "DEFAULT");
         subs.Add(client);
         subs.SubscribeWithSnapshot(client, Channels.PnlMe);
         // Drain the snapshot frame so we only observe the delta.

--- a/backend/tests/B3.Trading.Api.Tests/PositionsFirmScopingEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PositionsFirmScopingEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// PR #316 P1. GET /positions must be firm-scoped so a JWT sub registered
+/// under two firms does not leak the other firm's positions.
+/// </summary>
+public class PositionsFirmScopingEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    public PositionsFirmScopingEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task GetPositions_ScopedByFirm_DoesNotLeakAcrossFirms()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var positions = factory.Services.GetRequiredService<PositionKeeper>();
+        var owner = registry.Register(TestAppFactory.TestUser);
+
+        positions.ApplyFill("FIRM01", owner, "PETR4", OrderSide.Buy, 100, 30m);
+        positions.ApplyFill("FIRM02", owner, "VALE3", OrderSide.Buy, 50, 60m);
+
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var client = factory.CreateClient();
+
+        var (t1, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", t1);
+        var firm1 = await client.GetFromJsonAsync<List<PositionDto>>("/positions");
+        Assert.NotNull(firm1);
+        Assert.Single(firm1!);
+        Assert.Equal("PETR4", firm1![0].Symbol);
+
+        var (t2, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", t2);
+        var firm2 = await client.GetFromJsonAsync<List<PositionDto>>("/positions");
+        Assert.NotNull(firm2);
+        Assert.Single(firm2!);
+        Assert.Equal("VALE3", firm2![0].Symbol);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/StatementEndpointTests.cs
@@ -400,7 +400,7 @@ public class StatementEndpointTests : IDisposable
                 {
                     ClOrdId = clOrdId,
                     EndClientId = owner.Value,
-                    FirmId = "TEST",
+                    FirmId = "default",
                     Symbol = "PETR4",
                     SecurityId = 4321UL,
                     Side = nameof(OrderSide.Buy),

--- a/backend/tests/B3.Trading.Api.Tests/StatementMasterAvgFallbackTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/StatementMasterAvgFallbackTests.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Api;
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// PR #316 P2 (review). Master-row avg-cost fallback for the daily
+/// statement projection. The pre-review code fell back to the
+/// (potentially polluted) aggregate avg when the per-bucket basis
+/// store was missing or qty-mismatched — that read the master row's
+/// avg cost as <c>aggregate.Avg</c> even though sub-bucket fills had
+/// already pushed the aggregate basis around. The fixed code emits
+/// <c>AvgPrice = 0m</c> (fail-closed) and bumps
+/// <c>statement.master_avg_basis_degraded_total</c>, surfacing the
+/// invariant violation post-P1 backfill instead of silently shipping
+/// a polluted avg downstream.
+/// </summary>
+public class StatementMasterAvgFallbackTests
+{
+    private const string Firm = "FIRM01";
+    private const string OwnerStr = "alice";
+
+    [Fact]
+    public void BuildMasterBucketRows_BucketBasisMissing_EmitsZeroAvgAndBumpsCounter()
+    {
+        StatementEndpoints.ResetMasterAvgDegradedWarnDedupeForTesting();
+        var owner = new EndClientId(OwnerStr);
+        var aggregate = new Dictionary<string, (long Qty, decimal Avg)>(StringComparer.Ordinal)
+        {
+            // Pollution baseline: the aggregate basis includes
+            // sub-bucket fills, so its avg is NOT a faithful master
+            // avg. If the projection fell back to it, this is the
+            // number that would leak.
+            ["PETR4"] = (Qty: 100, Avg: 27.5m),
+        };
+        var subSum = new Dictionary<string, long>(StringComparer.Ordinal)
+        {
+            ["PETR4"] = 40, // anySub == true, masterQty = 100 - 40 = 60.
+        };
+        // Bucket basis intentionally absent — the degraded branch.
+        var subAccountPnl = new SubAccountPnlKeeper();
+
+        using var collector = new CounterCollector("trading.statement.master_avg_basis_degraded_total");
+        var rows = StatementEndpoints.BuildMasterBucketRows(
+            Firm, owner, new[] { "PETR4" }, aggregate, subSum, subAccountPnl, NullLoggerFactory.Instance);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("PETR4", row.Symbol);
+        Assert.Equal(60, row.NetQty);
+        Assert.Equal(0m, row.AvgPrice); // fail-closed, NOT 27.5m.
+        Assert.Equal(1, collector.Total);
+    }
+
+    [Fact]
+    public void BuildMasterBucketRows_BucketBasisQtyMismatched_EmitsZeroAvgAndBumpsCounter()
+    {
+        StatementEndpoints.ResetMasterAvgDegradedWarnDedupeForTesting();
+        var owner = new EndClientId(OwnerStr);
+        var aggregate = new Dictionary<string, (long Qty, decimal Avg)>(StringComparer.Ordinal)
+        {
+            ["VALE3"] = (Qty: 200, Avg: 50m),
+        };
+        var subSum = new Dictionary<string, long>(StringComparer.Ordinal)
+        {
+            ["VALE3"] = 80, // masterQty = 200 - 80 = 120.
+        };
+        var subAccountPnl = new SubAccountPnlKeeper();
+        // Seed the master bucket with a DIFFERENT qty so the
+        // basis-vs-master invariant fails the equality check.
+        subAccountPnl.SeedMasterBucketBasisIfAbsent(Firm, OwnerStr, "VALE3", signedQuantity: 90, avgPrice: 48m);
+
+        using var collector = new CounterCollector("trading.statement.master_avg_basis_degraded_total");
+        var rows = StatementEndpoints.BuildMasterBucketRows(
+            Firm, owner, new[] { "VALE3" }, aggregate, subSum, subAccountPnl, NullLoggerFactory.Instance);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(120, row.NetQty);
+        Assert.Equal(0m, row.AvgPrice);
+        Assert.Equal(1, collector.Total);
+    }
+
+    [Fact]
+    public void BuildMasterBucketRows_BucketBasisPresent_UsesBucketAvgAndNoCounter()
+    {
+        StatementEndpoints.ResetMasterAvgDegradedWarnDedupeForTesting();
+        var owner = new EndClientId(OwnerStr);
+        var aggregate = new Dictionary<string, (long Qty, decimal Avg)>(StringComparer.Ordinal)
+        {
+            ["PETR4"] = (Qty: 100, Avg: 27.5m), // polluted aggregate.
+        };
+        var subSum = new Dictionary<string, long>(StringComparer.Ordinal)
+        {
+            ["PETR4"] = 40,
+        };
+        var subAccountPnl = new SubAccountPnlKeeper();
+        // Real master basis: 60 @ 30.
+        subAccountPnl.SeedMasterBucketBasisIfAbsent(Firm, OwnerStr, "PETR4", signedQuantity: 60, avgPrice: 30m);
+
+        using var collector = new CounterCollector("trading.statement.master_avg_basis_degraded_total");
+        var rows = StatementEndpoints.BuildMasterBucketRows(
+            Firm, owner, new[] { "PETR4" }, aggregate, subSum, subAccountPnl, NullLoggerFactory.Instance);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(60, row.NetQty);
+        Assert.Equal(30m, row.AvgPrice); // bucket basis, not aggregate.
+        Assert.Equal(0, collector.Total);
+    }
+
+    /// <summary>
+    /// Lightweight MeterListener wrapper that subscribes to a single
+    /// instrument by name and accumulates the long values it sees.
+    /// Disposed automatically per-test so listeners don't pile up.
+    /// </summary>
+    private sealed class CounterCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+        public long Total;
+
+        public CounterCollector(string instrumentName)
+        {
+            _listener = new MeterListener();
+            _listener.InstrumentPublished = (instr, listener) =>
+            {
+                if (instr.Name == instrumentName) listener.EnableMeasurementEvents(instr);
+            };
+            _listener.SetMeasurementEventCallback<long>((_, m, _, _) => Interlocked.Add(ref Total, m));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/SubscriptionManagerTests.cs
@@ -181,4 +181,59 @@ public class WebSocketExecutionEventSinkTests
         Assert.Contains(Channels.ExecutionsMe, channels);
         Assert.DoesNotContain(Channels.PositionsMe, channels);
     }
+
+    [Fact]
+    public void Publish_WithFirmId_DoesNotFanOutAcrossFirms()
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var owner = new EndClientId("alice");
+
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var firm1 = new SubscribedClient(owner, "FIRM01");
+        var firm2 = new SubscribedClient(owner, "FIRM02");
+        mgr.Add(firm1);
+        mgr.Add(firm2);
+        mgr.SubscribeWithSnapshot(firm1, Channels.ExecutionsMe);
+        mgr.SubscribeWithSnapshot(firm2, Channels.ExecutionsMe);
+        firm1.Reader.TryRead(out _);
+        firm2.Reader.TryRead(out _);
+
+        mgr.Publish(owner, "FIRM01", Channels.ExecutionsMe, new { x = 1 });
+
+        Assert.True(firm1.Reader.TryRead(out var got));
+        Assert.Equal(1, got!.Seq);
+        Assert.False(firm2.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public void SubscribeSnapshot_FiltersOrdersAndPositionsByFirm()
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var owner = new EndClientId("alice");
+
+        var orderFirm1 = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: "FIRM01");
+        var orderFirm2 = new Order(2UL, owner, "PETR4", 4322UL, OrderSide.Buy, OrderType.Limit, 200, 31m, firmId: "FIRM02");
+        book.TryAdd(orderFirm1);
+        book.TryAdd(orderFirm2);
+        positions.ApplyFill("FIRM01", owner, "PETR4", OrderSide.Buy, 100, 30m);
+        positions.ApplyFill("FIRM02", owner, "VALE3", OrderSide.Buy, 50, 60m);
+
+        var mgr = new SubscriptionManager(book, positions, new AlgoBook());
+        var client = new SubscribedClient(owner, "FIRM01");
+        mgr.Add(client);
+        mgr.SubscribeWithSnapshot(client, Channels.OrdersMe);
+        mgr.SubscribeWithSnapshot(client, Channels.PositionsMe);
+
+        Assert.True(client.Reader.TryRead(out var ordersSnap));
+        Assert.True(client.Reader.TryRead(out var positionsSnap));
+
+        var ordersJson = System.Text.Json.JsonSerializer.Serialize(ordersSnap!.Data);
+        var posJson = System.Text.Json.JsonSerializer.Serialize(positionsSnap!.Data);
+        Assert.Contains("4321", ordersJson);
+        Assert.DoesNotContain("4322", ordersJson);
+        Assert.Contains("PETR4", posJson);
+        Assert.DoesNotContain("VALE3", posJson);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorSubAccountPnlTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorSubAccountPnlTests.cs
@@ -1,0 +1,299 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// PR #316 P2. Integration coverage for the per-bucket realized-PnL
+/// basis on the <see cref="ExecutionReportProcessor"/> live path.
+/// Validates the spec contract: "fill in sub-account A increments
+/// only A's P&amp;L; master shows sum". A sub-account fill that
+/// offsets a position held in the master bucket MUST NOT realise
+/// against the master's avg-cost basis — it must realise against
+/// the sub-bucket's own basis.
+/// </summary>
+public class ExecutionReportProcessorSubAccountPnlTests
+{
+    private const string Firm = "FIRM01";
+
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        public ConcurrentQueue<(long Seq, WalEvent Event)> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+        public long Append(WalEvent evt)
+        {
+            var s = Interlocked.Increment(ref _seq);
+            Recorded.Enqueue((s, evt));
+            return s;
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> _) => Append(evt);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class Bench
+    {
+        public ExecutionReportProcessor Proc { get; init; } = null!;
+        public EventDispatcher Dispatcher { get; init; } = null!;
+        public RecordingEventStore Store { get; init; } = null!;
+        public PnlKeeper Pnl { get; init; } = null!;
+        public SubAccountPnlKeeper SubPnl { get; init; } = null!;
+        public OrderOwnershipMap Ownership { get; init; } = null!;
+        public WorkingOrderBook Book { get; init; } = null!;
+        public PositionKeeper Positions { get; init; } = null!;
+        public SubAccountPositionKeeper SubPositions { get; init; } = null!;
+        private ulong _nextClOrdId = 1;
+
+        public ulong AddOrder(EndClientId owner, OrderSide side, long qty, decimal px, SubAccountId? sub = null)
+        {
+            var id = _nextClOrdId++;
+            Book.TryAdd(new Order(id, owner, "PETR4", 1UL, side, OrderType.Limit, qty, px,
+                firmId: Firm, subAccountId: sub));
+            Ownership.Register(id, owner);
+            return id;
+        }
+
+        public void Fill(ulong clOrdId, long qty, decimal px)
+        {
+            Dispatcher.Dispatch(
+                new ExecutionReportReceivedEvent
+                {
+                    ClOrdId = clOrdId,
+                    ExecKind = nameof(ExecKind.Fill),
+                    LeavesQuantity = 0,
+                    CumulativeQuantity = qty,
+                    LastQuantity = qty,
+                    LastPrice = px,
+                    Synthetic = false,
+                    OrigClOrdId = 0,
+                },
+                fanOut => Proc.Apply(clOrdId, ExecKind.Fill, 0, qty, qty, px, null, 0, fanOut));
+        }
+    }
+
+    private static Bench Build()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var subPositions = new SubAccountPositionKeeper();
+        var pnl = new PnlKeeper();
+        var subPnl = new SubAccountPnlKeeper();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, new NullSink(), new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: null,
+            feeCalculator: null,
+            feeKeeper: null,
+            dispatcher: dispatcher,
+            pnlKeeper: pnl,
+            subAccountPositions: subPositions,
+            subAccountPnl: subPnl);
+        return new Bench
+        {
+            Proc = proc,
+            Dispatcher = dispatcher,
+            Store = store,
+            Pnl = pnl,
+            SubPnl = subPnl,
+            Ownership = ownership,
+            Book = book,
+            Positions = positions,
+            SubPositions = subPositions,
+        };
+    }
+
+    private static List<RealizedPnlEvent> RealizedEvents(Bench b) =>
+        b.Store.Recorded.Select(r => r.Event).OfType<RealizedPnlEvent>().ToList();
+
+    /// <summary>
+    /// Spec scenario #1: master seed 200 @ 30; sub-A buys 50 @ 31;
+    /// sub-A sells 20 @ 32 → sub-A realized = (32-31)*20 = 20.
+    /// CRITICALLY: must NOT realise against master's 30 basis.
+    /// </summary>
+    [Fact]
+    public void SubBucketClose_RealisesAgainstSubBasis_NotMaster()
+    {
+        var b = Build();
+        var owner = new EndClientId("alice");
+        var subA = new SubAccountId("subA");
+        var day = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Master seed: buy 200 @ 30 (no sub-account tag).
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 200, 30m), 200, 30m);
+        // Sub-A: buy 50 @ 31 (opens sub-bucket; no realized).
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 50, 31m, subA), 50, 31m);
+        // Sub-A: sell 20 @ 32 — closes against SUB basis (31), not master (30).
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 20, 32m, subA), 20, 32m);
+
+        var events = RealizedEvents(b);
+        var subEvent = Assert.Single(events, e => e.SubAccountId == "subA");
+        Assert.Equal(20m, subEvent.DeltaRealized); // (32 - 31) * 20
+        Assert.Equal(20m, b.SubPnl.GetDayRealized(Firm, owner.Value, subA, "PETR4", day));
+        // Aggregate per-symbol day-realized equals the sum of the
+        // emitted bucket deltas (here just the sub fill).
+        Assert.Equal(20m, b.Pnl.GetDayRealized(Firm, owner.Value, "PETR4", day));
+    }
+
+    /// <summary>
+    /// Spec scenario #2: continuing from #1, master sells 50 @ 35
+    /// → master realised = (35-30)*50 = 250. Master basis untouched
+    /// by sub activity.
+    /// </summary>
+    [Fact]
+    public void MasterClose_RealisesAgainstMasterOnlyBasis()
+    {
+        var b = Build();
+        var owner = new EndClientId("alice");
+        var subA = new SubAccountId("subA");
+        var day = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 200, 30m), 200, 30m);
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 50, 31m, subA), 50, 31m);
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 20, 32m, subA), 20, 32m); // sub realises 20
+        // Master sells 50 @ 35 — basis is master-only (30), not aggregate.
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 50, 35m), 50, 35m);
+
+        var events = RealizedEvents(b);
+        var masterEvent = Assert.Single(events, e => e.SubAccountId is null);
+        Assert.Equal(250m, masterEvent.DeltaRealized); // (35 - 30) * 50
+
+        // Aggregate keeper sums all bucket deltas (master 250 + sub 20 = 270).
+        Assert.Equal(270m, b.Pnl.GetDayRealized(Firm, owner.Value, "PETR4", day));
+        // Sub bucket is unaffected by master close.
+        Assert.Equal(20m, b.SubPnl.GetDayRealized(Firm, owner.Value, subA, "PETR4", day));
+    }
+
+    /// <summary>
+    /// Spec scenario #3: sub-A sells 20 @ 33 with NO prior buy →
+    /// short-from-zero at 33; realized PnL is 0 (opening leg).
+    /// Demonstrates that a sub-bucket sell never accidentally
+    /// realises against the master's long basis.
+    /// </summary>
+    [Fact]
+    public void SubSell_FromZeroBucket_RealisesZero_EvenWhenMasterIsLong()
+    {
+        var b = Build();
+        var owner = new EndClientId("alice");
+        var subA = new SubAccountId("subA");
+        var day = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Master holds a big long.
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 200, 30m), 200, 30m);
+        // Sub-A sells 20 @ 33 (no prior sub buy). Bucket = 0 → short opens.
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 20, 33m, subA), 20, 33m);
+
+        // No realized event emitted (opening leg).
+        Assert.Empty(RealizedEvents(b));
+        Assert.Equal(0m, b.SubPnl.GetDayRealized(Firm, owner.Value, subA, "PETR4", day));
+
+        // Sub-bucket basis is now (-20 @ 33).
+        var basis = b.SubPnl.GetBucketAvgCost(Firm, owner.Value, subA, "PETR4")!;
+        Assert.Equal(-20, basis.NetQuantity);
+        Assert.Equal(33m, basis.AvgPrice);
+    }
+
+    /// <summary>
+    /// Spec scenario #4: aggregate position invariant.
+    /// Seed master 200 @ 30; master sells 50 @ 35; sub buys 50 @ 31;
+    /// sub sells 20 @ 32. Expected: master.qty=150, sub.qty=30,
+    /// aggregate=180. Combined with the realized expectations from
+    /// scenarios #1 + #2, this is the full pass-7 invariant
+    /// (master = liveAggregate − sumSub).
+    /// </summary>
+    [Fact]
+    public void BucketPositionInvariant_HoldsAfterMixedFills()
+    {
+        var b = Build();
+        var owner = new EndClientId("alice");
+        var subA = new SubAccountId("subA");
+
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 200, 30m), 200, 30m);
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 50, 35m), 50, 35m); // master close
+        b.Fill(b.AddOrder(owner, OrderSide.Buy, 50, 31m, subA), 50, 31m);
+        b.Fill(b.AddOrder(owner, OrderSide.Sell, 20, 32m, subA), 20, 32m);
+
+        var aggPosition = b.Positions.ForEndClientAndFirm(Firm, owner)
+            .Single(p => p.Symbol == "PETR4");
+        var subPosition = b.SubPositions.ForSubAccount(Firm, owner, subA)
+            .Single(p => p.Symbol == "PETR4");
+        Assert.Equal(180, aggPosition.NetQuantity); // 200 - 50 + 50 - 20
+        Assert.Equal(30, subPosition.NetQuantity);  // 50 - 20
+        // master = aggregate − sumSub
+        Assert.Equal(150, aggPosition.NetQuantity - subPosition.NetQuantity);
+    }
+
+    /// <summary>
+    /// PR #316 P2. Snapshot/restore round-trips the per-bucket
+    /// avg-cost basis so the first post-restore closing fill on each
+    /// bucket realises against its OWN basis (not aggregate / not
+    /// zero).
+    /// </summary>
+    [Fact]
+    public void BucketBasis_SnapshotRoundTrip_PreservesPerBucketBasis()
+    {
+        var k = new SubAccountPnlKeeper();
+        var subA = new SubAccountId("subA");
+        var subB = new SubAccountId("subB");
+
+        // Master bucket builds 100 @ 30.
+        Assert.Equal(0m, k.ApplyBucketFill(Firm, "alice", null, "PETR4", OrderSide.Buy, 100, 30m));
+        // Sub-A bucket builds 50 @ 31.
+        Assert.Equal(0m, k.ApplyBucketFill(Firm, "alice", subA, "PETR4", OrderSide.Buy, 50, 31m));
+        // Sub-B bucket builds short 20 @ 33.
+        Assert.Equal(0m, k.ApplyBucketFill(Firm, "alice", subB, "PETR4", OrderSide.Sell, 20, 33m));
+
+        var realized = k.Snapshot();
+        var basis = k.SnapshotBasis();
+        Assert.Equal(3, basis.Length);
+
+        var k2 = new SubAccountPnlKeeper();
+        k2.Restore(realized, basis);
+
+        // Master close after restore → realises against master's 30,
+        // not against zero (which would silently miss the realised
+        // P&L) nor against an aggregate average that mixed the subs.
+        Assert.Equal((32m - 30m) * 40, k2.ApplyBucketFill(Firm, "alice", null, "PETR4", OrderSide.Sell, 40, 32m));
+        // Sub-A close after restore → realises against sub-A's 31.
+        Assert.Equal((32m - 31m) * 20, k2.ApplyBucketFill(Firm, "alice", subA, "PETR4", OrderSide.Sell, 20, 32m));
+        // Sub-B close (short cover) → realises (33 - 30) * 10 = 30.
+        Assert.Equal((33m - 30m) * 10, k2.ApplyBucketFill(Firm, "alice", subB, "PETR4", OrderSide.Buy, 10, 30m));
+    }
+
+    /// <summary>
+    /// PR #316 P2. Legacy snapshot path (no basis block) hydrates to
+    /// an empty bucket basis map without throwing — preserves the
+    /// pre-PR <c>Restore(snaps)</c> overload behaviour.
+    /// </summary>
+    [Fact]
+    public void Restore_WithoutBasisBlock_LeavesBucketBasisEmpty()
+    {
+        var k = new SubAccountPnlKeeper();
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        k.Add(Firm, "alice", new SubAccountId("subA"), "PETR4", day, 42m);
+
+        var k2 = new SubAccountPnlKeeper();
+        k2.Restore(k.Snapshot()); // legacy single-arg overload
+        Assert.Equal(42m, k2.GetDayRealized(Firm, "alice", new SubAccountId("subA"), "PETR4", day));
+        Assert.Null(k2.GetBucketAvgCost(Firm, "alice", new SubAccountId("subA"), "PETR4"));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NoNakedShortCheckTests.cs
@@ -69,7 +69,7 @@ public class NoNakedShortCheckTests
     public void Sell_LongCoversFully_Approved()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         SubmitInto(orders, MakeSell(1UL, 500));
         Assert.True(check.Check(SellCtx(500)).Approved);
     }
@@ -78,7 +78,7 @@ public class NoNakedShortCheckTests
     public void Sell_LongInsufficientByOne_Rejected()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         SubmitInto(orders, MakeSell(1UL, 501));
         Assert.False(check.Check(SellCtx(501)).Approved);
     }
@@ -87,7 +87,7 @@ public class NoNakedShortCheckTests
     public void Sell_OpenSellsConsumeAvailableInventory()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         // 300 already working as Sell; this incoming Sell of 200 just
         // fills the remaining sellable inventory exactly.
         SubmitInto(orders, MakeSell(1UL, 300));
@@ -99,7 +99,7 @@ public class NoNakedShortCheckTests
     public void Sell_OpenSellsExceedAvailableInventory_Rejected()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         SubmitInto(orders, MakeSell(1UL, 300));
         SubmitInto(orders, MakeSell(2UL, 201));
         Assert.False(check.Check(SellCtx(201)).Approved);
@@ -109,7 +109,7 @@ public class NoNakedShortCheckTests
     public void Sell_OpenBuysDoNotCount_PessimisticProjection()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 100, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 100, 30m);
         // A pending Buy of 1000 would, if it filled, give plenty of
         // inventory. The check must not credit it — open Buys can be
         // cancelled.
@@ -122,7 +122,7 @@ public class NoNakedShortCheckTests
     public void Sell_TerminalSellsDoNotConsumeInventory()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         var oldSell = MakeSell(99UL, 500);
         SubmitInto(orders, oldSell);
         oldSell.MarkCancelled();
@@ -134,14 +134,14 @@ public class NoNakedShortCheckTests
     public void Sell_PartiallyFilled_OnlyLeavesConsumeInventory()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         var partial = MakeSell(99UL, 400);
         SubmitInto(orders, partial);
         partial.ApplyFill(300); // 100 leaves
         // PositionKeeper would have been updated by the fill, but the
         // check reads the current net at evaluation time. Mirror that
         // here: net long is now 200, leaves on the partial sell are 100.
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Sell, 300, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Sell, 300, 30m);
         SubmitInto(orders, MakeSell(1UL, 100));
         Assert.True(check.Check(SellCtx(100)).Approved);
     }
@@ -150,7 +150,7 @@ public class NoNakedShortCheckTests
     public void Sell_OtherSymbolLeaves_DoNotConsumeThisSymbolInventory()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol, OrderSide.Buy, 500, 30m);
         SubmitInto(orders, MakeSell(99UL, 500, symbol: "VALE3"));
         SubmitInto(orders, MakeSell(1UL, 500));
         Assert.True(check.Check(SellCtx(500)).Approved);
@@ -160,7 +160,7 @@ public class NoNakedShortCheckTests
     public void Sell_OtherOwnerInventory_DoesNotCoverThisOwner()
     {
         var (check, positions, orders) = Build();
-        positions.ApplyFill(new EndClientId("bob"), DefaultSymbol, OrderSide.Buy, 1000, 30m);
+        positions.ApplyFill(DefaultFirm, new EndClientId("bob"), DefaultSymbol, OrderSide.Buy, 1000, 30m);
         SubmitInto(orders, MakeSell(1UL, 100, owner: DefaultOwner));
         Assert.False(check.Check(SellCtx(100, owner: DefaultOwner)).Approved);
     }
@@ -228,7 +228,7 @@ public class NoNakedShortCheckTests
         // ceiling. Modifying that Sell down to 60 should approve —
         // the original is going away.
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
         SubmitInto(orders, MakeSell(1UL, 100));
 
         var ctx = SellReplaceCtx(newQty: 60, origClOrdId: 1UL, effectiveLeaves: 60);
@@ -240,7 +240,7 @@ public class NoNakedShortCheckTests
     public void Replace_upsize_rejected_whenProjectionExceedsInventory()
     {
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
         SubmitInto(orders, MakeSell(1UL, 100));
 
         // Try to upsize from 100 to 150 — would need long ≥ 150.
@@ -253,7 +253,7 @@ public class NoNakedShortCheckTests
     public void Replace_upsize_approved_whenInventorySufficient()
     {
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 200, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 200, 30m);
         SubmitInto(orders, MakeSell(1UL, 100));
 
         var ctx = SellReplaceCtx(newQty: 200, origClOrdId: 1UL, effectiveLeaves: 200);
@@ -271,7 +271,7 @@ public class NoNakedShortCheckTests
         // (80) it would compute 80 ≤ 100 here, but the meaningful
         // figure is the leaves the venue will assign.
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
         var orig = MakeSell(1UL, 100);
         orig.MarkWorking();
         orig.ApplyCumulativeFill(40);
@@ -289,7 +289,7 @@ public class NoNakedShortCheckTests
         // against this in the endpoint), the projection adjustment
         // is a no-op — behavior matches a fresh submission.
         var (check, positions, _) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 50, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 50, 30m);
 
         // No order in book + ctx claims to replace ID 999.
         var ctx = SellReplaceCtx(newQty: 100, origClOrdId: 999UL, effectiveLeaves: 100);
@@ -317,7 +317,7 @@ public class NoNakedShortCheckTests
         // the happy path; this defends the deeper invariant in case
         // that gate ever drifts.
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 50, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 50, 30m);
         var orig = MakeSell(1UL, 100);
         orig.MarkCancelled();
         SubmitInto(orders, orig); // terminal; SumOpenSellLeavesForSymbol skips it
@@ -340,7 +340,7 @@ public class NoNakedShortCheckTests
         // the openSellLeaves sum). The replacement must still be
         // projected because it would be a fresh order at the venue.
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
         var orig = MakeSell(1UL, 100);
         orig.MarkWorking();
         SubmitInto(orders, orig);
@@ -366,7 +366,7 @@ public class NoNakedShortCheckTests
         // Slice 4 of #132. A ghost stale Sell must not block a new,
         // legitimate Sell against held inventory.
         var (check, positions, orders) = Build();
-        positions.GetOrCreate(new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
+        positions.GetOrCreate(DefaultFirm, new EndClientId(DefaultOwner), DefaultSymbol).ApplyFill(OrderSide.Buy, 100, 30m);
         var ghost = MakeSell(1UL, 100);
         ghost.MarkWorking();
         SubmitInto(orders, ghost);

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -778,7 +778,7 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Equal(0, newOrder.LeavesQuantity);
         Assert.Equal(100, newOrder.CumulativeQuantity);
         // Position booked.
-        var pos = positions.GetOrCreate(bob, "PETR4");
+        var pos = positions.GetOrCreate("FIRM", bob, "PETR4");
         Assert.Equal(100, pos.NetQuantity);
         Assert.Equal(32.50m, pos.AverageEntryPrice);
         // Cash debited (Buy: available drops by notional).

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -1460,4 +1460,103 @@ public class OrderModifyMarginAndProcessorTests
                 replaceMargin: Margin);
         }
     }
+
+    // ---------------- PR #316 P1: sub-account risk on modify ----------------
+
+    private static (OrderModifyService svc, CapturingGateway gw, SubAccountPositionKeeper subPos, SubAccountsRegistry reg)
+        BuildModifyServiceWithSubAccountRisk(
+            Order seedOrder,
+            SubAccountRiskOptions opts,
+            Action<SubAccountsRegistry>? configureRegistry = null)
+    {
+        var owner = seedOrder.Owner;
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        Assert.True(book.TryAdd(seedOrder));
+        ownership.Register(seedOrder.ClOrdId, owner);
+        var gateway = new CapturingGateway();
+        var sink = new CapturingSink();
+        var subPos = new SubAccountPositionKeeper();
+        var registry = new SubAccountsRegistry();
+        configureRegistry?.Invoke(registry);
+        var subCheck = new Risk.Checks.SubAccountLimitsCheck(
+            new StaticOptionsMonitor<SubAccountRiskOptions>(opts), book, subPos, registry);
+        var risk = new Risk.RiskPipeline(new Risk.IRiskCheck[] { subCheck });
+        var margin = new NoOpReplaceMargin();
+        var replacements = new PendingReplacementRegistry();
+        var dispatcher = new EventDispatcher(new NullEventStore());
+        var svc = new OrderModifyService(
+            clOrdIds, ownership, book, gateway, sink, risk, margin, replacements, dispatcher,
+            new NeverDrain(), NullLogger<OrderModifyService>.Instance);
+        return (svc, gateway, subPos, registry);
+    }
+
+    [Fact]
+    public async Task Modify_subAccountPositionCap_rejectsWhenReplacementWouldBreach()
+    {
+        // PR #316 P1. Build a working buy in sub-account A with a
+        // pre-existing 60-lot position; sub-account cap is 100. A
+        // resize to 50 (delta +50) would project net 110 → reject.
+        const string firm = "FIRM01";
+        const string sub = "A";
+        var owner = new EndClientId("alice");
+        var seed = new Order(
+            2_000_001UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            10, 30m, firm, subAccountId: new SubAccountId(sub));
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [firm] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [sub] = new SubAccountRiskLimits { PositionLimit = 100 } },
+                },
+            },
+        };
+        var (svc, gw, subPos, _) = BuildModifyServiceWithSubAccountRisk(
+            seed, opts, reg => reg.ApplyCreated(firm, sub, null));
+        // Seed an existing 60-lot net long in the sub-account.
+        subPos.ApplyFill(firm, owner, new SubAccountId(sub), "PETR4", OrderSide.Buy, 60, 30m);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, seed.ClOrdId, NewQuantity: 50, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.RiskRejected, result.Kind);
+        Assert.StartsWith("sub_account_limit_exceeded", result.Reason);
+        Assert.Empty(gw.Replaces);
+    }
+
+    [Fact]
+    public async Task Modify_deactivatedSubAccount_rejectsWithDistinctReason()
+    {
+        // PR #316 P1. The original is booked against sub-account A;
+        // A is then deactivated. A modify must be rejected with the
+        // dedicated `sub_account_deactivated` reason (not aliased to
+        // the cap-breach reason) so operators and metrics can tell
+        // them apart.
+        const string firm = "FIRM01";
+        const string sub = "A";
+        var owner = new EndClientId("alice");
+        var seed = new Order(
+            2_000_002UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            10, 30m, firm, subAccountId: new SubAccountId(sub));
+        var (svc, gw, _, _) = BuildModifyServiceWithSubAccountRisk(
+            seed, new SubAccountRiskOptions(),
+            reg =>
+            {
+                reg.ApplyCreated(firm, sub, null);
+                reg.ApplyDeactivated(firm, sub);
+            });
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(owner, seed.ClOrdId, NewQuantity: 15, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.RiskRejected, result.Kind);
+        Assert.StartsWith("sub_account_deactivated", result.Reason);
+        Assert.DoesNotContain("sub_account_limit_exceeded", result.Reason);
+        Assert.Empty(gw.Replaces);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/SubAccountPnlLegacyBackfillTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/SubAccountPnlLegacyBackfillTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
@@ -9,12 +10,21 @@ namespace B3.Trading.Application.Tests.Persistence;
 
 /// <summary>
 /// PR #316 P1 (review). A pre-#316 snapshot has open positions but
-/// NO <see cref="PlatformSnapshot.SubAccountPnlBasis"/> block. Without
-/// the legacy backfill, the first closing fill on a restored bucket
-/// goes through <see cref="SubAccountPnlKeeper.ApplyBucketFill"/>'s
-/// missing-basis branch and silently realises 0 — even though a
-/// non-restarted host would have computed the realized delta against
-/// the existing basis.
+/// NO <see cref="PlatformSnapshot.SubAccountPnlBasis"/> block. The
+/// backfill must seed master basis from the aggregate
+/// <see cref="PlatformSnapshot.Positions"/> ONLY when that aggregate
+/// is master-only (no sub-position rows for the same key) — pre-#316
+/// snapshots never carry sub positions, so the aggregate IS the
+/// master-only basis for those. When sub positions are present
+/// alongside an absent basis block, the aggregate row is the sum of
+/// master + every sub bucket and its average is a cross-bucket
+/// weighted average; seeding master from it would pollute master with
+/// sibling-bucket basis. In that incoherent case the backfill leaves
+/// master unseeded, fires
+/// <c>trading.subaccount.master_basis_unrecoverable_total</c>, and
+/// the statement endpoint's existing fail-closed path
+/// (AvgPrice = 0 + <c>master_avg_basis_degraded_total</c>) surfaces
+/// the gap.
 /// </summary>
 public class SubAccountPnlLegacyBackfillTests
 {
@@ -22,67 +32,178 @@ public class SubAccountPnlLegacyBackfillTests
     private const string Owner = "alice";
 
     [Fact]
-    public void Restore_LegacySnapshotWithoutBasis_SeedsMasterAndSubBucketBasis()
+    public void Restore_LegacyMasterOnlySnapshot_SeedsMasterBucketBasis()
     {
-        // Synthesize a pre-#316 snapshot: positions + sub-positions
-        // present, but SubAccountPnlBasis intentionally empty.
+        // Pre-#316 snapshot shape: positions present, sub positions
+        // empty, basis block empty. The aggregate row IS the master-
+        // only basis (no sub fills ever existed in the pre-#316
+        // world) — backfill must seed it.
         var snap = new PlatformSnapshot
         {
             Seq = 1,
             Positions =
             {
-                new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 150, AverageEntryPrice: 30m, FirmId: Firm),
             },
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        NewSnapshotter(subAccountPnl).Restore(snap);
+
+        var master = subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4");
+        Assert.NotNull(master);
+        Assert.Equal(150, master!.NetQuantity);
+        Assert.Equal(30m, master.AvgPrice);
+    }
+
+    [Fact]
+    public void FirstCloseAfterRestore_MasterOnlySnapshot_RealizedMatchesLive()
+    {
+        // Live keeper builds master basis via a buy fill, then a
+        // sell close establishes the baseline realised delta.
+        var live = new SubAccountPnlKeeper();
+        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Buy, 150, 30m));
+        var liveClose = live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 60, 32m);
+        Assert.NotEqual(0m, liveClose);
+
+        // Restore from a master-only legacy snapshot (no basis
+        // block) and replay the same close. The backfill must
+        // reconstruct master basis from Positions so realized
+        // matches.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 150, AverageEntryPrice: 30m, FirmId: Firm),
+            },
+        };
+        var restored = new SubAccountPnlKeeper();
+        NewSnapshotter(restored).Restore(snap);
+
+        Assert.Equal(liveClose, restored.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 60, 32m));
+    }
+
+    [Fact]
+    public void Restore_IncoherentSnapshot_DoesNotSeedMaster_AndFiresUnrecoverableMetric()
+    {
+        // Sub positions present for the same (firm, owner, symbol)
+        // as the master Positions row AND no SubAccountPnlBasis
+        // block: the aggregate row is polluted (its avg blends
+        // master + sub bucket history). Backfill MUST refuse to
+        // seed master from the aggregate and surface the
+        // unrecoverable metric.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 150, AverageEntryPrice: 31m, FirmId: Firm),
+            },
+            SubAccountPositions =
+            {
+                new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
+            },
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        using var unrecoverable = new CounterCollector("trading.subaccount.master_basis_unrecoverable_total");
+        NewSnapshotter(subAccountPnl).Restore(snap);
+
+        // Master basis MUST be absent — seeding from the polluted
+        // aggregate would silently realise wrong P&L on the next
+        // close.
+        Assert.Null(subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4"));
+        // Sub bucket still seeded from its own (clean) avg.
+        var subA = subAccountPnl.GetBucketAvgCost(Firm, Owner, new SubAccountId("subA"), "PETR4");
+        Assert.NotNull(subA);
+        Assert.Equal(50, subA!.NetQuantity);
+        Assert.Equal(31m, subA.AvgPrice);
+
+        // Metric fires once per (firm, owner, symbol).
+        Assert.Equal(1, unrecoverable.Total);
+
+        // Subsequent master close goes through ApplyBucketFill's
+        // fresh-open branch and realises 0 — the consistent
+        // fail-closed behaviour. The aggregate-pollution avg
+        // (31m) is never imported.
+        var realised = subAccountPnl.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 50, 32m);
+        Assert.Equal(0m, realised);
+    }
+
+    [Fact]
+    public void Restore_IncoherentSnapshot_WithAuthoritativeBasis_BackfillIsNoOp()
+    {
+        // Sub positions present AND authoritative SubAccountPnlBasis
+        // row present for the master bucket: the backfill must leave
+        // the restored basis untouched (basis wins) and must NOT
+        // fire the unrecoverable metric (the basis is recoverable
+        // from the snapshot).
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 150, AverageEntryPrice: 31m, FirmId: Firm),
+            },
+            SubAccountPositions =
+            {
+                new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
+            },
+            SubAccountPnlBasis =
+            {
+                new SubAccountPnlBasisSnapshot(Firm, Owner, SubAccountPnlKeeper.MasterBucketKey, "PETR4", NetQuantity: 100, AvgPrice: 27.5m),
+            },
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        using var unrecoverable = new CounterCollector("trading.subaccount.master_basis_unrecoverable_total");
+        NewSnapshotter(subAccountPnl).Restore(snap);
+
+        var master = subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4");
+        Assert.NotNull(master);
+        Assert.Equal(100, master!.NetQuantity);
+        Assert.Equal(27.5m, master.AvgPrice);
+        Assert.Equal(0, unrecoverable.Total);
+    }
+
+    [Fact]
+    public void Restore_LegacySubPositions_SeedSubBucketBasis()
+    {
+        // Sub-bucket basis is recoverable directly from the
+        // SubAccountPositionSnapshot rows — they're per-bucket by
+        // construction, no cross-bucket pollution. Validate the
+        // sub-bucket seed still happens even when the master row is
+        // absent (e.g. flat master, long sub).
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
             SubAccountPositions =
             {
                 new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
                 new SubAccountPositionSnapshot(Firm, Owner, "subB", "PETR4", NetQuantity: -20, AverageEntryPrice: 33m),
             },
-            // SubAccountPnlBasis intentionally empty.
         };
 
         var subAccountPnl = new SubAccountPnlKeeper();
-        var snapshotter = NewSnapshotter(subAccountPnl);
-        snapshotter.Restore(snap);
+        NewSnapshotter(subAccountPnl).Restore(snap);
 
-        // All three buckets must have a basis after restore.
-        var master = subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4");
         var subA = subAccountPnl.GetBucketAvgCost(Firm, Owner, new SubAccountId("subA"), "PETR4");
         var subB = subAccountPnl.GetBucketAvgCost(Firm, Owner, new SubAccountId("subB"), "PETR4");
-
-        Assert.NotNull(master);
-        Assert.Equal(100, master!.NetQuantity);
-        Assert.Equal(30m, master.AvgPrice);
-
         Assert.NotNull(subA);
         Assert.Equal(50, subA!.NetQuantity);
         Assert.Equal(31m, subA.AvgPrice);
-
         Assert.NotNull(subB);
         Assert.Equal(-20, subB!.NetQuantity);
         Assert.Equal(33m, subB.AvgPrice);
     }
 
     [Fact]
-    public void FirstCloseAfterRestore_ComputesRealizedIdenticalToLiveWithoutRestart()
+    public void Restore_LegacyBasisAlreadyPresent_BackfillIsNoOp()
     {
-        // Live keeper builds the bucket history then takes a snapshot
-        // that DROPS the basis block (simulating a pre-#316 snapshot
-        // shape).
-        var live = new SubAccountPnlKeeper();
-        var subA = new SubAccountId("subA");
-        var subB = new SubAccountId("subB");
-        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Buy, 100, 30m));
-        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Buy, 50, 31m));
-        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Sell, 20, 33m));
-
-        // Live realised on the next close — baseline.
-        var liveMasterClose = live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 40, 32m);
-        var liveSubAClose = live.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Sell, 20, 32m);
-        var liveSubBClose = live.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Buy, 10, 30m);
-
-        // Now restore from a legacy-shaped snapshot (positions only,
-        // no basis block) and replay the same closes.
+        // Authoritative basis present for a master-only row: the
+        // backfill TryAdd must be a no-op so the snapshot value
+        // wins over the (otherwise-equivalent) seed path.
         var snap = new PlatformSnapshot
         {
             Seq = 1,
@@ -90,36 +211,6 @@ public class SubAccountPnlLegacyBackfillTests
             {
                 new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
             },
-            SubAccountPositions =
-            {
-                new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
-                new SubAccountPositionSnapshot(Firm, Owner, "subB", "PETR4", NetQuantity: -20, AverageEntryPrice: 33m),
-            },
-        };
-
-        var restored = new SubAccountPnlKeeper();
-        NewSnapshotter(restored).Restore(snap);
-
-        Assert.Equal(liveMasterClose, restored.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 40, 32m));
-        Assert.Equal(liveSubAClose, restored.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Sell, 20, 32m));
-        Assert.Equal(liveSubBClose, restored.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Buy, 10, 30m));
-
-        // And — the bug we're fixing — the master close MUST NOT realise 0.
-        Assert.NotEqual(0m, liveMasterClose);
-    }
-
-    [Fact]
-    public void Backfill_IsIdempotent_DoesNotOverwriteExistingBasis()
-    {
-        var snap = new PlatformSnapshot
-        {
-            Seq = 1,
-            Positions =
-            {
-                new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
-            },
-            // Authoritative basis block already present — backfill
-            // must not clobber it with the legacy seed.
             SubAccountPnlBasis =
             {
                 new SubAccountPnlBasisSnapshot(Firm, Owner, SubAccountPnlKeeper.MasterBucketKey, "PETR4", NetQuantity: 100, AvgPrice: 27.5m),
@@ -168,4 +259,27 @@ public class SubAccountPnlLegacyBackfillTests
             new CashLedger(),
             subAccountPositions: new SubAccountPositionKeeper(),
             subAccountPnl: subAccountPnl);
+
+    /// <summary>
+    /// Lightweight MeterListener wrapper that subscribes to a single
+    /// instrument by name and accumulates the long values it sees.
+    /// </summary>
+    private sealed class CounterCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+        public long Total;
+
+        public CounterCollector(string instrumentName)
+        {
+            _listener = new MeterListener();
+            _listener.InstrumentPublished = (instr, listener) =>
+            {
+                if (instr.Name == instrumentName) listener.EnableMeasurementEvents(instr);
+            };
+            _listener.SetMeasurementEventCallback<long>((_, m, _, _) => Interlocked.Add(ref Total, m));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/SubAccountPnlLegacyBackfillTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/SubAccountPnlLegacyBackfillTests.cs
@@ -1,0 +1,171 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// PR #316 P1 (review). A pre-#316 snapshot has open positions but
+/// NO <see cref="PlatformSnapshot.SubAccountPnlBasis"/> block. Without
+/// the legacy backfill, the first closing fill on a restored bucket
+/// goes through <see cref="SubAccountPnlKeeper.ApplyBucketFill"/>'s
+/// missing-basis branch and silently realises 0 — even though a
+/// non-restarted host would have computed the realized delta against
+/// the existing basis.
+/// </summary>
+public class SubAccountPnlLegacyBackfillTests
+{
+    private const string Firm = "FIRM01";
+    private const string Owner = "alice";
+
+    [Fact]
+    public void Restore_LegacySnapshotWithoutBasis_SeedsMasterAndSubBucketBasis()
+    {
+        // Synthesize a pre-#316 snapshot: positions + sub-positions
+        // present, but SubAccountPnlBasis intentionally empty.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
+            },
+            SubAccountPositions =
+            {
+                new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
+                new SubAccountPositionSnapshot(Firm, Owner, "subB", "PETR4", NetQuantity: -20, AverageEntryPrice: 33m),
+            },
+            // SubAccountPnlBasis intentionally empty.
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        var snapshotter = NewSnapshotter(subAccountPnl);
+        snapshotter.Restore(snap);
+
+        // All three buckets must have a basis after restore.
+        var master = subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4");
+        var subA = subAccountPnl.GetBucketAvgCost(Firm, Owner, new SubAccountId("subA"), "PETR4");
+        var subB = subAccountPnl.GetBucketAvgCost(Firm, Owner, new SubAccountId("subB"), "PETR4");
+
+        Assert.NotNull(master);
+        Assert.Equal(100, master!.NetQuantity);
+        Assert.Equal(30m, master.AvgPrice);
+
+        Assert.NotNull(subA);
+        Assert.Equal(50, subA!.NetQuantity);
+        Assert.Equal(31m, subA.AvgPrice);
+
+        Assert.NotNull(subB);
+        Assert.Equal(-20, subB!.NetQuantity);
+        Assert.Equal(33m, subB.AvgPrice);
+    }
+
+    [Fact]
+    public void FirstCloseAfterRestore_ComputesRealizedIdenticalToLiveWithoutRestart()
+    {
+        // Live keeper builds the bucket history then takes a snapshot
+        // that DROPS the basis block (simulating a pre-#316 snapshot
+        // shape).
+        var live = new SubAccountPnlKeeper();
+        var subA = new SubAccountId("subA");
+        var subB = new SubAccountId("subB");
+        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Buy, 100, 30m));
+        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Buy, 50, 31m));
+        Assert.Equal(0m, live.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Sell, 20, 33m));
+
+        // Live realised on the next close — baseline.
+        var liveMasterClose = live.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 40, 32m);
+        var liveSubAClose = live.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Sell, 20, 32m);
+        var liveSubBClose = live.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Buy, 10, 30m);
+
+        // Now restore from a legacy-shaped snapshot (positions only,
+        // no basis block) and replay the same closes.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
+            },
+            SubAccountPositions =
+            {
+                new SubAccountPositionSnapshot(Firm, Owner, "subA", "PETR4", NetQuantity: 50, AverageEntryPrice: 31m),
+                new SubAccountPositionSnapshot(Firm, Owner, "subB", "PETR4", NetQuantity: -20, AverageEntryPrice: 33m),
+            },
+        };
+
+        var restored = new SubAccountPnlKeeper();
+        NewSnapshotter(restored).Restore(snap);
+
+        Assert.Equal(liveMasterClose, restored.ApplyBucketFill(Firm, Owner, null, "PETR4", OrderSide.Sell, 40, 32m));
+        Assert.Equal(liveSubAClose, restored.ApplyBucketFill(Firm, Owner, subA, "PETR4", OrderSide.Sell, 20, 32m));
+        Assert.Equal(liveSubBClose, restored.ApplyBucketFill(Firm, Owner, subB, "PETR4", OrderSide.Buy, 10, 30m));
+
+        // And — the bug we're fixing — the master close MUST NOT realise 0.
+        Assert.NotEqual(0m, liveMasterClose);
+    }
+
+    [Fact]
+    public void Backfill_IsIdempotent_DoesNotOverwriteExistingBasis()
+    {
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "PETR4", NetQuantity: 100, AverageEntryPrice: 30m, FirmId: Firm),
+            },
+            // Authoritative basis block already present — backfill
+            // must not clobber it with the legacy seed.
+            SubAccountPnlBasis =
+            {
+                new SubAccountPnlBasisSnapshot(Firm, Owner, SubAccountPnlKeeper.MasterBucketKey, "PETR4", NetQuantity: 100, AvgPrice: 27.5m),
+            },
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        NewSnapshotter(subAccountPnl).Restore(snap);
+
+        var master = subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "PETR4");
+        Assert.NotNull(master);
+        Assert.Equal(27.5m, master!.AvgPrice);
+    }
+
+    [Fact]
+    public void Backfill_SkipsZeroAvgRow_LeavesBucketUnseeded()
+    {
+        // Pre-position-basis legacy row (zero avg). Cannot recover a
+        // real basis — skip rather than seed phantom zero.
+        var snap = new PlatformSnapshot
+        {
+            Seq = 1,
+            Positions =
+            {
+                new PositionSnapshot(Owner, "VALE3", NetQuantity: 75, AverageEntryPrice: 0m, FirmId: Firm),
+            },
+        };
+
+        var subAccountPnl = new SubAccountPnlKeeper();
+        NewSnapshotter(subAccountPnl).Restore(snap);
+
+        Assert.Null(subAccountPnl.GetBucketAvgCost(Firm, Owner, subAccount: null, "VALE3"));
+    }
+
+    private static StateSnapshotter NewSnapshotter(SubAccountPnlKeeper subAccountPnl) =>
+        new(
+            new WorkingOrderBook(),
+            new PositionKeeper(),
+            new KillSwitchService(),
+            new SymbolHaltService(),
+            new SessionPhaseService(),
+            new ClOrdIdPrefixRegistry(),
+            new OrderOwnershipMap(),
+            new AlgoBook(),
+            new AlgoIdRegistry(),
+            new CashLedger(),
+            subAccountPositions: new SubAccountPositionKeeper(),
+            subAccountPnl: subAccountPnl);
+}

--- a/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PnlKeeperTests.cs
@@ -218,6 +218,64 @@ public class PnlKeeperTests
     }
 
     [Fact]
+    public void FinalizeReplay_RoutesSubAccountDelta_IntoBucketKeeper()
+    {
+        // PR #316 P1.2 regression. ER for a sub-account A fill was
+        // processed in-memory on replay (RegisterPendingReplaySynth)
+        // but the RealizedPnlEvent didn't survive the ER-then-crash
+        // window. FinalizeReplay must materialise the delta into
+        // BOTH the aggregate keeper AND the per-bucket realised
+        // total in SubAccountPnlKeeper so a sub-account-filtered
+        // statement matches the live path.
+        var k = new PnlKeeper();
+        var sub = new SubAccountPnlKeeper();
+        // Pre-fill bucket state: sub-A long 100 @ 30. Replay synth
+        // closes 50 @ 31 ⇒ realized delta = (31 − 30)·50 = 50.
+        k.RegisterPendingReplaySynth(
+            firmId: "FIRM01",
+            executionId: "9:50",
+            endClientId: "alice",
+            symbol: "PETR4",
+            side: OrderSide.Sell,
+            fillQuantity: 50,
+            fillPrice: 31m,
+            timestampUtc: Ts,
+            preFillQuantity: 100,
+            preFillAvgPrice: 30m,
+            subAccountId: "A");
+
+        Assert.Equal(1, k.FinalizeReplay(sub));
+
+        // Aggregate keeper folded the delta (existing behaviour).
+        Assert.Equal(50m, k.GetDayRealized("FIRM01", "alice", "PETR4", Day));
+        // Per-bucket keeper received the same delta tagged for
+        // sub-account A — the new contract.
+        Assert.Equal(50m, sub.GetDayRealized("FIRM01", "alice", new SubAccountId("A"), "PETR4", Day));
+    }
+
+    [Fact]
+    public void FinalizeReplay_NoSubAccountKeeper_AggregateOnly_StillMaterialises()
+    {
+        // Backwards-compat: existing callers that pass no
+        // SubAccountPnlKeeper still get the aggregate fold-in.
+        var k = new PnlKeeper();
+        k.RegisterPendingReplaySynth(
+            firmId: "FIRM01",
+            executionId: "9:50",
+            endClientId: "alice",
+            symbol: "PETR4",
+            side: OrderSide.Sell,
+            fillQuantity: 50,
+            fillPrice: 31m,
+            timestampUtc: Ts,
+            preFillQuantity: 100,
+            preFillAvgPrice: 30m,
+            subAccountId: "A");
+        Assert.Equal(1, k.FinalizeReplay());
+        Assert.Equal(50m, k.GetDayRealized("FIRM01", "alice", "PETR4", Day));
+    }
+
+    [Fact]
     public void SeedAvgCostFromLegacyPositions_FillsBasis_WhenPnlAvgCostEmpty()
     {
         // Pass-1 review (#278) P1#1. Legacy snapshot scenario:

--- a/backend/tests/B3.Trading.Application.Tests/PositionKeeperSeedTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/PositionKeeperSeedTests.cs
@@ -52,4 +52,33 @@ public class PositionKeeperSeedTests
         Assert.Equal(2000, keeper.GetOrCreate(bob, "PETR4").NetQuantity);
         Assert.Equal(0, keeper.GetOrCreate(bob, "VALE3").NetQuantity);
     }
+
+    // PR #316 P2.2. Position seeds carry an explicit Firm field; a
+    // seed for FIRM01 must be visible to the FIRM01 firm-scoped read
+    // path and NOT to a hypothetical FIRM02 user with the same JWT
+    // sub. Pre-fix the seed always landed in DefaultFirmId and was
+    // invisible to every real-mode user, causing naked-short rejects
+    // on the first Sell.
+    [Fact]
+    public void SeedIfAbsent_FirmScoped_VisibleOnlyToOwningFirm()
+    {
+        var keeper = new PositionKeeper();
+        var owner = new EndClientId("alice");
+
+        Assert.True(keeper.SeedIfAbsent("FIRM01", owner, "PETR4", 2000, 32.50m));
+
+        var firm01 = keeper.ForEndClientAndFirm("FIRM01", owner);
+        var seeded = Assert.Single(firm01);
+        Assert.Equal("PETR4", seeded.Symbol);
+        Assert.Equal(2000, seeded.NetQuantity);
+        Assert.Equal(32.50m, seeded.AverageEntryPrice);
+
+        // Same owner login under FIRM02 must not see the FIRM01 seed.
+        Assert.Empty(keeper.ForEndClientAndFirm("FIRM02", owner));
+
+        // Default-firm bucket is also empty (no legacy DefaultFirmId
+        // leakage), so the firm-aware read paths see what the
+        // operator configured and nothing else.
+        Assert.Empty(keeper.ForEndClientAndFirm(PositionKeeper.DefaultFirmId, owner));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -492,7 +492,7 @@ public class RiskPipelineTests
     public void PositionLimit_RejectsWhenProjectedExceeds()
     {
         var positions = new PositionKeeper();
-        positions.ApplyFill(new EndClientId("alice"), "PETR4", OrderSide.Buy, 400, 30m);
+        positions.ApplyFill("default", new EndClientId("alice"), "PETR4", OrderSide.Buy, 400, 30m);
         var opts = Wrap(new RiskOptions { Default = new RiskLimits { PositionLimit = 500 } });
         var check = new PositionLimitCheck(opts, positions);
         Assert.True(check.Check(Ctx(qty: 100, side: OrderSide.Buy)).Approved);   // 400+100=500

--- a/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
@@ -174,4 +174,39 @@ public class SelfTradePreventionCheckTests
         Assert.True(book.TryAdd(Make(1, OrderSide.Buy, 32.40m)));
         Assert.True(check.Check(Ctx(OrderSide.Buy, 32.50m)).Approved);
     }
+
+    // PR #316 P2.3. The owner index spans every firm; without an
+    // explicit firm filter on the contra scan, a working opposite-side
+    // order in FIRM02 would falsely reject an order from the SAME JWT
+    // sub authenticated under FIRM01. Self-trade prevention only makes
+    // sense within one matching-engine session (one firm).
+    [Fact]
+    public void ContraOrder_DifferentFirm_SameOwner_Approves()
+    {
+        var (check, book) = Build();
+        // FIRM02 working buy for owner alice on PETR4.
+        var firm02Order = new Order(
+            clOrdId: 42, owner: OwnerId, symbol: Symbol, securityId: 4321UL,
+            side: OrderSide.Buy, type: OrderType.Limit, quantity: 100, price: 32.40m,
+            firmId: "FIRM02");
+        Assert.True(book.TryAdd(firm02Order));
+
+        // FIRM01 same owner submitting an opposite-side Sell on PETR4
+        // must NOT trip STP — the FIRM02 contra is in a different
+        // matching session and can never self-cross.
+        var decision = check.Check(Ctx(OrderSide.Sell, 32.50m));
+        Assert.True(decision.Approved);
+    }
+
+    [Fact]
+    public void ContraOrder_SameFirm_SameOwner_StillRejects()
+    {
+        // Regression guard for the cross-firm fix: the within-firm
+        // rejection path must keep working after we narrowed the scan.
+        var (check, book) = Build();
+        Assert.True(book.TryAdd(Make(7, OrderSide.Buy, 32.40m))); // FIRM01 (test default)
+        var decision = check.Check(Ctx(OrderSide.Sell, 32.50m));
+        Assert.False(decision.Approved);
+        Assert.Contains("clOrdId=7", decision.Reason);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -577,11 +577,10 @@ public class StatementProjectionTests
 
         var seedFallback = new List<PositionRowDto>
         {
-            // Master-bucket seed plus the live master aggregate of
-            // the sub-X fill (the live master keeper mirrors every
-            // sub-bucket fill alongside its own).
+            // Master-bucket-only snapshot (PR #316 P1.1):
+            // PETR4 was seeded so master qty = 200 (no sub activity).
+            // PETR3 master qty = aggregate(50) − sub(50) = 0 → dropped.
             new("PETR4", 200, 28m, null),
-            new("PETR3", 50, 25m, null),
         };
 
         var dto = StatementProjection.Build(
@@ -677,8 +676,11 @@ public class StatementProjectionTests
         };
         var seedFallback = new List<PositionRowDto>
         {
-            // Master keeper sees seed 200 + sub-X fill 50 = 250.
-            new("PETR4", 250, 28m, null),
+            // PR #316 P1.1. Master-bucket-only snapshot: master qty =
+            // aggregate(250) − sub-X(50) = 200; master avg = bucket
+            // store master basis (the seed avg, unaltered by sub
+            // fills because the bucket store tracks them separately).
+            new("PETR4", 200, 28m, null),
         };
 
         var dto = StatementProjection.Build(
@@ -730,18 +732,18 @@ public class StatementProjectionTests
     [Fact]
     public void TodayUnfiltered_SeedNetZeroAggregate_WithSubBucketActivity_SynthesizesMasterFromInvariant()
     {
-        // PR #316 P2 follow-up. Live aggregate nets to exactly zero
-        // (so the symbol is omitted from the live snapshot) but WAL
-        // has sub-bucket activity. The invariant
-        //   master = liveAggregate - sumSub
-        // must still hold, treating liveAggregate as 0. The raw
-        // WAL master row must NOT be preserved (that would double-
-        // count the seed already cancelled inside the live zero).
+        // PR #316 P1.1. Live aggregate nets to exactly zero but the
+        // master bucket itself has a residual (seed 200@30 + master
+        // sell 250@32 ⇒ master bucket flips through zero to
+        // −50@32). The caller now passes the master-bucket snapshot
+        // directly (qty + avg from the bucket-aware store), so the
+        // merge emits that −50@32 row verbatim alongside sub-A's WAL
+        // row. The avg-price is the bucket store's basis after the
+        // flip — meaningful, no longer the legacy "0m no-anchor"
+        // placeholder.
         //
         // Scenario: seed PETR4=200; master sell 250 today; sub-A
-        // buy 50 today. Live master aggregate = 200 - 250 + 50 = 0
-        // (omitted). Expected: master = -50, sub-A = +50, no
-        // spurious raw WAL master row.
+        // buy 50 today. Expected: master = −50 @ 32, sub-A = +50.
         var wal = new List<(long Seq, WalEvent Event)>
         {
             (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Sell, 250, 32m)),
@@ -749,8 +751,11 @@ public class StatementProjectionTests
             (3, SubmitWithSubAccount(2UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 50, 31m)),
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 31m, at: DayStart.AddHours(11))),
         };
-        // Live aggregate netted to zero → PETR4 omitted from snapshot.
-        var seedFallback = new List<PositionRowDto>();
+        var seedFallback = new List<PositionRowDto>
+        {
+            // Master-bucket snapshot: post-flip basis −50 @ 32.
+            new("PETR4", -50, 32m, null),
+        };
 
         var dto = StatementProjection.Build(
             Alice, Day, "FIRM01", wal,
@@ -762,8 +767,7 @@ public class StatementProjectionTests
         var master = Assert.Single(dto.Positions, p => p.SubAccountId is null);
         Assert.Equal("PETR4", master.Symbol);
         Assert.Equal(-50, master.NetQty);
-        // Synthesized row — no live anchor available, avg-price zeroed.
-        Assert.Equal(0m, master.AvgPrice);
+        Assert.Equal(32m, master.AvgPrice);
         var subA = Assert.Single(dto.Positions, p => p.SubAccountId == "A");
         Assert.Equal("PETR4", subA.Symbol);
         Assert.Equal(50, subA.NetQty);
@@ -790,7 +794,9 @@ public class StatementProjectionTests
         };
         var seedFallback = new List<PositionRowDto>
         {
-            new("PETR4", 30, 32m, null),
+            // PR #316 P1.1. Master qty = aggregate(30) − sub-A(30) = 0
+            // → caller drops the row from the snapshot. The merge
+            // then emits sub-A alone from the WAL projection.
         };
 
         var dto = StatementProjection.Build(
@@ -803,5 +809,86 @@ public class StatementProjectionTests
         Assert.Equal("PETR4", subA.Symbol);
         Assert.Equal("A", subA.SubAccountId);
         Assert.Equal(30, subA.NetQty);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedMaster_SubBuy_MasterAvgUnpolluted()
+    {
+        // PR #316 P1.1 regression. Seed master PETR4=200 @ 30; sub-A
+        // buys 50 @ 31 today. The live aggregate keeper records
+        // 250 @ (200·30 + 50·31)/250 = 30.2 — its avg is polluted
+        // by the sub-bucket fill. Before the fix, the statement's
+        // master row inherited that polluted avg (30.2). After the
+        // fix, the master row's avg comes from the bucket-aware
+        // store (master-bucket basis seeded at 30 by host startup
+        // and untouched by sub fills), so it stays at 30.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 50, 31m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 31m, at: DayStart.AddHours(10))),
+        };
+        // Caller (StatementEndpoints) builds the master-bucket
+        // snapshot: qty = aggregate(250) − sub-A(50) = 200, avg =
+        // bucket basis = 30 (seed). Sub fills do NOT touch this.
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 200, 30m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        Assert.Equal(2, dto.Positions.Count);
+        var master = Assert.Single(dto.Positions, p => p.SubAccountId is null);
+        Assert.Equal("PETR4", master.Symbol);
+        Assert.Equal(200, master.NetQty);
+        Assert.Equal(30m, master.AvgPrice);
+        var subA = Assert.Single(dto.Positions, p => p.SubAccountId == "A");
+        Assert.Equal(50, subA.NetQty);
+        Assert.Equal(31m, subA.AvgPrice);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedMaster_MasterSell_SubBuy_MasterAvgUnpolluted()
+    {
+        // PR #316 P1.1 regression #2. Seed master PETR4=200 @ 30;
+        // master sells 50 @ 35 today; sub-A buys 50 @ 31 today.
+        // After both fills the live aggregate is 200 qty (partial
+        // close 50 + sub buy 50 cancel out) at some weighted avg.
+        // The bucket store tracks master separately: post-master-
+        // sell the master bucket basis is still 30 (avg unchanged
+        // on a partial close that doesn't flip). Statement master
+        // row must read 150 @ 30; sub-A row 50 @ 31.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Sell, 50, 35m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 35m, at: DayStart.AddHours(10))),
+            (3, SubmitWithSubAccount(2UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 50, 31m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 31m, at: DayStart.AddHours(11))),
+        };
+        // Master-bucket snapshot: qty = aggregate(200) − sub-A(50)
+        // = 150, avg = bucket master basis after partial close = 30.
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 150, 30m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        Assert.Equal(2, dto.Positions.Count);
+        var master = Assert.Single(dto.Positions, p => p.SubAccountId is null);
+        Assert.Equal("PETR4", master.Symbol);
+        Assert.Equal(150, master.NetQty);
+        Assert.Equal(30m, master.AvgPrice);
+        var subA = Assert.Single(dto.Positions, p => p.SubAccountId == "A");
+        Assert.Equal(50, subA.NetQty);
+        Assert.Equal(31m, subA.AvgPrice);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -23,7 +23,7 @@ public class StatementProjectionTests
     {
         var wal = Array.Empty<(long Seq, WalEvent Event)>();
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         Assert.Equal("2024-06-17", dto.DayKey);
         Assert.Empty(dto.Positions);
@@ -61,7 +61,7 @@ public class StatementProjectionTests
             (7, Realized(2UL, Alice, "PETR4", 100m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         Assert.Equal(2, dto.Fills.Count);
         Assert.Contains(dto.Fills, f => f.Side == "Buy" && f.Quantity == 100);
@@ -99,7 +99,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 32m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal("PETR4", ir.Symbol);
@@ -123,7 +123,7 @@ public class StatementProjectionTests
             (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         Assert.Empty(dto.IrDayTrade.PerSymbol);
         Assert.Equal(0m, dto.IrDayTrade.TotalTax);
@@ -145,7 +145,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 28m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal(-200m, ir.GrossProfit);
@@ -168,7 +168,7 @@ public class StatementProjectionTests
             (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 60, last: 60, price: 31m, at: DayStart.AddHours(11))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal(60, ir.QtyMatched);
@@ -197,7 +197,7 @@ public class StatementProjectionTests
             (7, Realized(2UL, Bob, "PETR4", 999m, at: DayStart.AddHours(11))),
         };
 
-        var aliceDto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var aliceDto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
         Assert.Single(aliceDto.Fills);
         Assert.Equal(100, aliceDto.Fills[0].Quantity);
         Assert.Equal(1m, aliceDto.FeesTotal);
@@ -205,7 +205,7 @@ public class StatementProjectionTests
         var pos = Assert.Single(aliceDto.Positions);
         Assert.Equal(100, pos.NetQty);
 
-        var bobDto = StatementProjection.Build(Bob, Day, wal, livePositionsSnapshot: null);
+        var bobDto = StatementProjection.Build(Bob, Day, "TEST", wal, livePositionsSnapshot: null);
         Assert.Single(bobDto.Fills);
         Assert.Equal(50, bobDto.Fills[0].Quantity);
         Assert.Equal(5m, bobDto.FeesTotal);
@@ -229,7 +229,7 @@ public class StatementProjectionTests
             (6, Er(3UL, ExecKind.Fill, 0, 30, 30, 32m, next)),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
         var fill = Assert.Single(dto.Fills);
         Assert.Equal(20, fill.Quantity);
         Assert.Equal(31m, fill.Price);
@@ -264,7 +264,7 @@ public class StatementProjectionTests
             (8, Er(4UL, ExecKind.Fill, 0, 100, 100, 31m, DayStart.AddHours(13))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal("PETR4", ir.Symbol);
@@ -295,7 +295,7 @@ public class StatementProjectionTests
             (8, Er(4UL, ExecKind.Fill, 0, 100, 100, 25m, DayStart.AddHours(13))),
         };
 
-        var dto = StatementProjection.Build(Alice, Day, wal, livePositionsSnapshot: null);
+        var dto = StatementProjection.Build(Alice, Day, "TEST", wal, livePositionsSnapshot: null);
 
         var ir = Assert.Single(dto.IrDayTrade.PerSymbol);
         Assert.Equal(-800m, ir.GrossProfit);
@@ -367,6 +367,79 @@ public class StatementProjectionTests
             ClOrdId = clOrdId,
             ExecutionId = $"{clOrdId}:r",
             EndClientId = owner.Value,
+            Symbol = symbol,
+            DayKey = DateOnly.FromDateTime(at.UtcDateTime),
+            DeltaRealized = delta,
+            RunningTotal = delta,
+            TimestampUtc = at,
+        };
+
+    [Fact]
+    public void ScopeIsolation_ProjectionFiltersOutOtherFirms_SameOwner()
+    {
+        // PR #316 P2.1. Same JWT sub trades in FIRM01 and FIRM02 on
+        // day D. A statement requested as FIRM01 must include only the
+        // FIRM01 fills, fees, realized PnL and projected positions —
+        // no leakage from the FIRM02 slice of the same owner login.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            // FIRM01 leg: buy 100 PETR4 @ 30.
+            (1, SubmitWithFirm(1UL, Alice, "FIRM01", "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, Fee(1UL, Alice, "PETR4", OrderSide.Buy, 100, 30m,
+                brokerage: 1m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(10))),
+            (4, RealizedWithFirm(1UL, Alice, "FIRM01", "PETR4", 111m, at: DayStart.AddHours(10))),
+
+            // FIRM02 leg: same owner, different firm — must not leak.
+            (5, SubmitWithFirm(2UL, Alice, "FIRM02", "VALE3", OrderSide.Buy, 50, 60m)),
+            (6, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 60m, at: DayStart.AddHours(11))),
+            (7, Fee(2UL, Alice, "VALE3", OrderSide.Buy, 50, 60m,
+                brokerage: 9m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(11))),
+            (8, RealizedWithFirm(2UL, Alice, "FIRM02", "VALE3", 999m, at: DayStart.AddHours(11))),
+        };
+
+        var firm01 = StatementProjection.Build(Alice, Day, "FIRM01", wal, livePositionsSnapshot: null);
+        var fill01 = Assert.Single(firm01.Fills);
+        Assert.Equal("PETR4", fill01.Symbol);
+        Assert.Equal(100, fill01.Quantity);
+        Assert.Equal(1m, firm01.FeesTotal);
+        Assert.Equal(111m, firm01.Pnl.RealizedGross);
+        var pos01 = Assert.Single(firm01.Positions);
+        Assert.Equal("PETR4", pos01.Symbol);
+        Assert.Equal(100, pos01.NetQty);
+
+        // Sanity: the FIRM02 view sees only its own slice.
+        var firm02 = StatementProjection.Build(Alice, Day, "FIRM02", wal, livePositionsSnapshot: null);
+        var fill02 = Assert.Single(firm02.Fills);
+        Assert.Equal("VALE3", fill02.Symbol);
+        Assert.Equal(9m, firm02.FeesTotal);
+        Assert.Equal(999m, firm02.Pnl.RealizedGross);
+    }
+
+    private static OrderSubmittedEvent SubmitWithFirm(
+        ulong clOrdId, EndClientId owner, string firmId, string symbol, OrderSide side, long qty, decimal price) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            EndClientId = owner.Value,
+            FirmId = firmId,
+            Symbol = symbol,
+            SecurityId = 4321UL,
+            Side = side.ToString(),
+            Type = "Limit",
+            Quantity = qty,
+            Price = price,
+            TimestampUtc = DayStart.AddHours(9),
+        };
+
+    private static RealizedPnlEvent RealizedWithFirm(
+        ulong clOrdId, EndClientId owner, string firmId, string symbol, decimal delta, DateTimeOffset at) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = $"{clOrdId}:r",
+            EndClientId = owner.Value,
+            FirmId = firmId,
             Symbol = symbol,
             DayKey = DateOnly.FromDateTime(at.UtcDateTime),
             DeltaRealized = delta,

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -576,8 +577,11 @@ public class StatementProjectionTests
 
         var seedFallback = new List<PositionRowDto>
         {
-            // Master-bucket seed only — no SubAccountId tag.
+            // Master-bucket seed plus the live master aggregate of
+            // the sub-X fill (the live master keeper mirrors every
+            // sub-bucket fill alongside its own).
             new("PETR4", 200, 28m, null),
+            new("PETR3", 50, 25m, null),
         };
 
         var dto = StatementProjection.Build(
@@ -721,5 +725,83 @@ public class StatementProjectionTests
         Assert.Null(petr4.SubAccountId);
         Assert.Equal(170, petr4.NetQty);
         Assert.Equal(28m, petr4.AvgPrice);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedNetZeroAggregate_WithSubBucketActivity_SynthesizesMasterFromInvariant()
+    {
+        // PR #316 P2 follow-up. Live aggregate nets to exactly zero
+        // (so the symbol is omitted from the live snapshot) but WAL
+        // has sub-bucket activity. The invariant
+        //   master = liveAggregate - sumSub
+        // must still hold, treating liveAggregate as 0. The raw
+        // WAL master row must NOT be preserved (that would double-
+        // count the seed already cancelled inside the live zero).
+        //
+        // Scenario: seed PETR4=200; master sell 250 today; sub-A
+        // buy 50 today. Live master aggregate = 200 - 250 + 50 = 0
+        // (omitted). Expected: master = -50, sub-A = +50, no
+        // spurious raw WAL master row.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Sell, 250, 32m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 250, last: 250, price: 32m, at: DayStart.AddHours(10))),
+            (3, SubmitWithSubAccount(2UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 50, 31m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 31m, at: DayStart.AddHours(11))),
+        };
+        // Live aggregate netted to zero → PETR4 omitted from snapshot.
+        var seedFallback = new List<PositionRowDto>();
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        Assert.Equal(2, dto.Positions.Count);
+        var master = Assert.Single(dto.Positions, p => p.SubAccountId is null);
+        Assert.Equal("PETR4", master.Symbol);
+        Assert.Equal(-50, master.NetQty);
+        // Synthesized row — no live anchor available, avg-price zeroed.
+        Assert.Equal(0m, master.AvgPrice);
+        var subA = Assert.Single(dto.Positions, p => p.SubAccountId == "A");
+        Assert.Equal("PETR4", subA.Symbol);
+        Assert.Equal(50, subA.NetQty);
+        // Aggregate reconciles to 0 (the live aggregate).
+        Assert.Equal(0, dto.Positions.Sum(p => p.NetQty));
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SubOnlyOnZeroedMasterSymbol_MasterRowDropped()
+    {
+        // PR #316 P2 follow-up. Master fills cancel out (qty 0 in
+        // the WAL master keeper → no master row produced) but a
+        // sub-bucket has activity. Live aggregate = sub qty (30),
+        // so the symbol IS present in the live snapshot. Expected:
+        // master row dropped (qty = 30 - 30 = 0), sub-A = +30.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, SubmitWithSubAccount(2UL, Alice, "FIRM01", null, "PETR4", OrderSide.Sell, 100, 31m)),
+            (4, Er(2UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 31m, at: DayStart.AddHours(11))),
+            (5, SubmitWithSubAccount(3UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 30, 32m)),
+            (6, Er(3UL, ExecKind.Fill, leaves: 0, cum: 30, last: 30, price: 32m, at: DayStart.AddHours(12))),
+        };
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 30, 32m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        var subA = Assert.Single(dto.Positions);
+        Assert.Equal("PETR4", subA.Symbol);
+        Assert.Equal("A", subA.SubAccountId);
+        Assert.Equal(30, subA.NetQty);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -446,4 +446,109 @@ public class StatementProjectionTests
             RunningTotal = delta,
             TimestampUtc = at,
         };
+
+    private static OrderSubmittedEvent SubmitWithSubAccount(
+        ulong clOrdId, EndClientId owner, string firmId, string? subAccount,
+        string symbol, OrderSide side, long qty, decimal price) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            EndClientId = owner.Value,
+            FirmId = firmId,
+            Symbol = symbol,
+            SecurityId = 4321UL,
+            Side = side.ToString(),
+            Type = "Limit",
+            Quantity = qty,
+            Price = price,
+            TimestampUtc = DayStart.AddHours(9),
+            SubAccountId = subAccount,
+        };
+
+    private static FeeAccruedEvent FeeWithSubAccount(
+        ulong clOrdId, EndClientId owner, string? subAccount, string symbol, OrderSide side, long qty, decimal price,
+        decimal brokerage, decimal emolumentos, decimal liquidacao, DateTimeOffset at) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = $"{clOrdId}:{qty}",
+            EndClientId = owner.Value,
+            Symbol = symbol,
+            Side = side.ToString(),
+            FillQuantity = qty,
+            FillPrice = price,
+            Notional = qty * price,
+            Brokerage = brokerage,
+            Emolumentos = emolumentos,
+            Liquidacao = liquidacao,
+            Total = brokerage + emolumentos + liquidacao,
+            TimestampUtc = at,
+            SubAccountId = subAccount,
+        };
+
+    private static RealizedPnlEvent RealizedWithSubAccount(
+        ulong clOrdId, EndClientId owner, string firmId, string? subAccount, string symbol,
+        decimal delta, DateTimeOffset at) =>
+        new()
+        {
+            ClOrdId = clOrdId,
+            ExecutionId = $"{clOrdId}:r",
+            EndClientId = owner.Value,
+            FirmId = firmId,
+            Symbol = symbol,
+            DayKey = DateOnly.FromDateTime(at.UtcDateTime),
+            DeltaRealized = delta,
+            RunningTotal = delta,
+            TimestampUtc = at,
+            SubAccountId = subAccount,
+        };
+
+    [Fact]
+    public void SubAccountProjection_TagsRowsAndFiltersWhenRequested()
+    {
+        // PR #316 P2.2. Same owner+firm with two sub-accounts (A & B)
+        // trading on the same day. The default unfiltered statement
+        // tags every row with its originating sub-account (avg-cost is
+        // per-bucket, so positions show one row per (symbol, sub)).
+        // The ?subAccount=A filter drops every B row.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            // Sub-account A: 100 PETR4 @ 30
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", "A", "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+            (3, FeeWithSubAccount(1UL, Alice, "A", "PETR4", OrderSide.Buy, 100, 30m,
+                brokerage: 1m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(10))),
+            (4, RealizedWithSubAccount(1UL, Alice, "FIRM01", "A", "PETR4", 11m, at: DayStart.AddHours(10))),
+
+            // Sub-account B: 50 VALE3 @ 60
+            (5, SubmitWithSubAccount(2UL, Alice, "FIRM01", "B", "VALE3", OrderSide.Buy, 50, 60m)),
+            (6, Er(2UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 60m, at: DayStart.AddHours(11))),
+            (7, FeeWithSubAccount(2UL, Alice, "B", "VALE3", OrderSide.Buy, 50, 60m,
+                brokerage: 7m, emolumentos: 0, liquidacao: 0, at: DayStart.AddHours(11))),
+            (8, RealizedWithSubAccount(2UL, Alice, "FIRM01", "B", "VALE3", 77m, at: DayStart.AddHours(11))),
+        };
+
+        // Unfiltered: rows are tagged per-sub-account, both buckets visible.
+        var all = StatementProjection.Build(Alice, Day, "FIRM01", wal, livePositionsSnapshot: null);
+        Assert.Equal(2, all.Fills.Count);
+        Assert.Contains(all.Fills, f => f.Symbol == "PETR4" && f.SubAccountId == "A");
+        Assert.Contains(all.Fills, f => f.Symbol == "VALE3" && f.SubAccountId == "B");
+        Assert.Equal(2, all.Positions.Count);
+        Assert.Contains(all.Positions, p => p.Symbol == "PETR4" && p.SubAccountId == "A" && p.NetQty == 100);
+        Assert.Contains(all.Positions, p => p.Symbol == "VALE3" && p.SubAccountId == "B" && p.NetQty == 50);
+        Assert.Equal(8m, all.FeesTotal); // 1 + 7
+        Assert.Equal(88m, all.Pnl.RealizedGross); // 11 + 77
+
+        // Filter to sub-account A.
+        var onlyA = StatementProjection.Build(Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null, subAccountFilter: "A");
+        var fillA = Assert.Single(onlyA.Fills);
+        Assert.Equal("PETR4", fillA.Symbol);
+        Assert.Equal("A", fillA.SubAccountId);
+        var posA = Assert.Single(onlyA.Positions);
+        Assert.Equal("PETR4", posA.Symbol);
+        Assert.Equal("A", posA.SubAccountId);
+        Assert.Equal(1m, onlyA.FeesTotal);
+        Assert.Equal(11m, onlyA.Pnl.RealizedGross);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -597,13 +597,18 @@ public class StatementProjectionTests
     }
 
     [Fact]
-    public void TodayUnfiltered_SeedFallback_DoesNotOverwriteWalProjectedMasterRow()
+    public void TodayUnfiltered_SeedFallback_MasterRow_ReflectsLiveAggregateMinusSubBuckets()
     {
-        // Defensive: if the WAL already projected a master-bucket
-        // position for a symbol the live keeper also reports, the
-        // WAL row wins (it reflects the day's master fills; the live
-        // keeper aggregates seed + today's fills and would double
-        // count if merged on top).
+        // PR #316 P2 — approach (b). The live master keeper
+        // aggregates seed + ALL fills (master and sub). The WAL
+        // projects per-bucket. The master row we surface is
+        //   masterQty = liveAggregate - sumOfWalSubBucketQty
+        // so the seed contribution is preserved without double-
+        // counting sub-bucket fills.
+        //
+        // Scenario: master-bucket buy 100 PETR4 today; live
+        // aggregate is 300 (seed 200 + today 100). With no sub-
+        // bucket activity, masterQty = 300 - 0 = 300.
         var wal = new List<(long Seq, WalEvent Event)>
         {
             (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Buy, 100, 30m)),
@@ -611,7 +616,7 @@ public class StatementProjectionTests
         };
         var seedFallback = new List<PositionRowDto>
         {
-            new("PETR4", 300, 28m, null), // seed (200) + today (100) aggregated
+            new("PETR4", 300, 28m, null),
         };
 
         var dto = StatementProjection.Build(
@@ -623,8 +628,98 @@ public class StatementProjectionTests
         var petr4 = Assert.Single(dto.Positions);
         Assert.Equal("PETR4", petr4.Symbol);
         Assert.Null(petr4.SubAccountId);
-        // WAL-projected row preserved; seed not merged on top.
-        Assert.Equal(100, petr4.NetQty);
-        Assert.Equal(30m, petr4.AvgPrice);
+        Assert.Equal(300, petr4.NetQty);
+        Assert.Equal(28m, petr4.AvgPrice);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedOnly_NoActivity_StillEmitsMasterRow()
+    {
+        // PR #316 P2 — approach (b). Seed PETR4=200, no fills today.
+        // We still fall into the WAL-replay branch (caller passes a
+        // seed fallback); the master row must come back at 200.
+        var wal = new List<(long Seq, WalEvent Event)>();
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 200, 28m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        var petr4 = Assert.Single(dto.Positions);
+        Assert.Equal("PETR4", petr4.Symbol);
+        Assert.Null(petr4.SubAccountId);
+        Assert.Equal(200, petr4.NetQty);
+        Assert.Equal(28m, petr4.AvgPrice);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedPlusSubAccountFill_NoDoubleCount()
+    {
+        // PR #316 P2 — primary regression. Seed PETR4=200; sub-account
+        // X buys PETR4=50 today. The live master keeper aggregates
+        // both → liveAggregate = 250. Previously the merge would
+        // inject the full 250 alongside the sub row (50), giving
+        // master 250 + sub 50 = 300 total exposure. The correct
+        // output is master 200 + sub 50.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", "X", "PETR4", OrderSide.Buy, 50, 32m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 32m, at: DayStart.AddHours(10))),
+        };
+        var seedFallback = new List<PositionRowDto>
+        {
+            // Master keeper sees seed 200 + sub-X fill 50 = 250.
+            new("PETR4", 250, 28m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        Assert.Equal(2, dto.Positions.Count);
+        var master = Assert.Single(dto.Positions, p => p.SubAccountId is null);
+        Assert.Equal("PETR4", master.Symbol);
+        Assert.Equal(200, master.NetQty);
+        var subX = Assert.Single(dto.Positions, p => p.SubAccountId == "X");
+        Assert.Equal("PETR4", subX.Symbol);
+        Assert.Equal(50, subX.NetQty);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedPlusMasterSell_NoDoubleSeedRow()
+    {
+        // PR #316 P2. Seed PETR4=200; master bucket sells PETR4=30
+        // today. Live aggregate = 170. WAL projects master bucket
+        // at -30 (zero-based). With approach (b) the surfaced
+        // master row reflects the live aggregate (170) — no
+        // separate seed row, no -30 ghost row.
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Sell, 30, 32m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 30, last: 30, price: 32m, at: DayStart.AddHours(10))),
+        };
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 170, 28m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        var petr4 = Assert.Single(dto.Positions);
+        Assert.Equal("PETR4", petr4.Symbol);
+        Assert.Null(petr4.SubAccountId);
+        Assert.Equal(170, petr4.NetQty);
+        Assert.Equal(28m, petr4.AvgPrice);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/StatementProjectionTests.cs
@@ -551,4 +551,80 @@ public class StatementProjectionTests
         Assert.Equal(1m, onlyA.FeesTotal);
         Assert.Equal(11m, onlyA.Pnl.RealizedGross);
     }
+
+    [Fact]
+    public void TodayUnfiltered_WithSubAccountActivity_MergesSeededMasterPositions()
+    {
+        // PR #316 P2. When today's statement falls off the snapshot
+        // fast-path (because at least one sub-account row exists for
+        // (firm, owner)), the projection replays the WAL — but WAL
+        // replay misses positions seeded straight into PositionKeeper
+        // at host startup. The caller passes the live master snapshot
+        // through `liveMasterSeedFallback`: for symbols present there
+        // but missing from the WAL-projected master bucket we inject
+        // the live row as a master-bucket entry (SubAccountId=null).
+        //
+        // Scenario: PETR4 was seeded at startup (qty 200, no WAL).
+        // userA then trades 50 PETR3 via sub-account X. Today's
+        // unfiltered statement must show BOTH PETR4 (master, qty 200
+        // from the seed) AND PETR3 (sub=X, qty 50 from the fill).
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", "X", "PETR3", OrderSide.Buy, 50, 25m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 50, last: 50, price: 25m, at: DayStart.AddHours(10))),
+        };
+
+        var seedFallback = new List<PositionRowDto>
+        {
+            // Master-bucket seed only — no SubAccountId tag.
+            new("PETR4", 200, 28m, null),
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        Assert.Equal(2, dto.Positions.Count);
+        var petr4 = Assert.Single(dto.Positions, p => p.Symbol == "PETR4");
+        Assert.Null(petr4.SubAccountId);
+        Assert.Equal(200, petr4.NetQty);
+        Assert.Equal(28m, petr4.AvgPrice);
+        var petr3 = Assert.Single(dto.Positions, p => p.Symbol == "PETR3");
+        Assert.Equal("X", petr3.SubAccountId);
+        Assert.Equal(50, petr3.NetQty);
+    }
+
+    [Fact]
+    public void TodayUnfiltered_SeedFallback_DoesNotOverwriteWalProjectedMasterRow()
+    {
+        // Defensive: if the WAL already projected a master-bucket
+        // position for a symbol the live keeper also reports, the
+        // WAL row wins (it reflects the day's master fills; the live
+        // keeper aggregates seed + today's fills and would double
+        // count if merged on top).
+        var wal = new List<(long Seq, WalEvent Event)>
+        {
+            (1, SubmitWithSubAccount(1UL, Alice, "FIRM01", null, "PETR4", OrderSide.Buy, 100, 30m)),
+            (2, Er(1UL, ExecKind.Fill, leaves: 0, cum: 100, last: 100, price: 30m, at: DayStart.AddHours(10))),
+        };
+        var seedFallback = new List<PositionRowDto>
+        {
+            new("PETR4", 300, 28m, null), // seed (200) + today (100) aggregated
+        };
+
+        var dto = StatementProjection.Build(
+            Alice, Day, "FIRM01", wal,
+            livePositionsSnapshot: null,
+            subAccountFilter: null,
+            liveMasterSeedFallback: seedFallback);
+
+        var petr4 = Assert.Single(dto.Positions);
+        Assert.Equal("PETR4", petr4.Symbol);
+        Assert.Null(petr4.SubAccountId);
+        // WAL-projected row preserved; seed not merged on top.
+        Assert.Equal(100, petr4.NetQty);
+        Assert.Equal(30m, petr4.AvgPrice);
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
@@ -41,12 +41,16 @@ public class SubAccountLimitsCheckTests
     }
 
     [Fact]
-    public void DeactivatedSubAccount_Rejects()
+    public void DeactivatedSubAccount_Rejects_WithDistinctReason()
     {
         var (check, _, _, _) = Build(new SubAccountRiskOptions(), registerSub: true, active: false);
         var d = check.Check(Ctx(new SubAccountId(Sub)));
         Assert.False(d.Approved);
-        Assert.StartsWith("sub_account_limit_exceeded", d.Reason);
+        // PR review #301 P2 — distinct reason for deactivation. Must
+        // NOT alias the limit-exceeded prefix (clients/metrics need
+        // to distinguish operator-disabled from cap breach).
+        Assert.StartsWith("sub_account_deactivated", d.Reason);
+        Assert.DoesNotContain("sub_account_limit_exceeded", d.Reason);
         Assert.Contains("deactivated", d.Reason);
     }
 
@@ -93,7 +97,7 @@ public class SubAccountLimitsCheckTests
         };
         var (check, _, _, pos) = Build(opts);
         // existing 30 net buy + new 25 buy = 55 > 50
-        pos.ApplyFill(new EndClientId(Owner), new SubAccountId(Sub), Symbol, OrderSide.Buy, 30, 10m);
+        pos.ApplyFill(Firm, new EndClientId(Owner), new SubAccountId(Sub), Symbol, OrderSide.Buy, 30, 10m);
         var d = check.Check(Ctx(new SubAccountId(Sub), qty: 25));
         Assert.False(d.Approved);
         Assert.Contains("position", d.Reason);
@@ -115,5 +119,57 @@ public class SubAccountLimitsCheckTests
         var (check, _, _, _) = Build(opts);
         var d = check.Check(Ctx(new SubAccountId(Sub)));
         Assert.False(d.Approved);
+    }
+
+    /// <summary>
+    /// PR review #301 P1 — multi-firm segregation of risk-limit
+    /// consumption. The same login/sub-account under two firms must
+    /// see independent open-order counts and position caps; the
+    /// FIRM01 ceiling must not be tripped by FIRM02 activity.
+    /// </summary>
+    [Fact]
+    public void RiskCaps_AreFirmSegregated_ForSameOwnerAndSubAccount()
+    {
+        const string firm1 = "FIRM01";
+        const string firm2 = "FIRM02";
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [firm1] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { PositionLimit = 50 } },
+                },
+                [firm2] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { PositionLimit = 50 } },
+                },
+            },
+        };
+        var book = new WorkingOrderBook();
+        var pos = new SubAccountPositionKeeper();
+        var reg = new SubAccountsRegistry();
+        reg.ApplyCreated(firm1, Sub, null);
+        reg.ApplyCreated(firm2, Sub, null);
+        var check = new SubAccountLimitsCheck(
+            new StaticOptionsMonitor<SubAccountRiskOptions>(opts), book, pos, reg);
+
+        // Saturate the FIRM02 bucket — would breach the cap there but
+        // must not consume FIRM01's budget.
+        pos.ApplyFill(firm2, new EndClientId(Owner), new SubAccountId(Sub), Symbol, OrderSide.Buy, 50, 10m);
+
+        var ctxFirm1 = new RiskContext(
+            new EndClientId(Owner), firm1, Symbol, OrderSide.Buy, OrderType.Limit, 25, 10m,
+            SubAccountId: new SubAccountId(Sub));
+        var ctxFirm2 = new RiskContext(
+            new EndClientId(Owner), firm2, Symbol, OrderSide.Buy, OrderType.Limit, 25, 10m,
+            SubAccountId: new SubAccountId(Sub));
+
+        // FIRM01 sees a fresh book: 0 + 25 = 25 ≤ 50 → approve.
+        Assert.True(check.Check(ctxFirm1).Approved);
+        // FIRM02 already at 50 + 25 = 75 > 50 → reject.
+        var f2 = check.Check(ctxFirm2);
+        Assert.False(f2.Approved);
+        Assert.Contains("position", f2.Reason);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
@@ -1,0 +1,119 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Application.Tests;
+
+public class SubAccountLimitsCheckTests
+{
+    private const string Owner = "alice";
+    private const string Firm = "FIRM01";
+    private const string Symbol = "PETR4";
+    private const string Sub = "tradingdesk";
+
+    private static (SubAccountLimitsCheck Check, SubAccountsRegistry Reg, WorkingOrderBook Book, SubAccountPositionKeeper Pos)
+        Build(SubAccountRiskOptions opts, bool registerSub = true, bool active = true)
+    {
+        var book = new WorkingOrderBook();
+        var pos = new SubAccountPositionKeeper();
+        var reg = new SubAccountsRegistry();
+        if (registerSub)
+        {
+            reg.ApplyCreated(Firm, Sub, null);
+            if (!active) reg.ApplyDeactivated(Firm, Sub);
+        }
+        var check = new SubAccountLimitsCheck(
+            new StaticOptionsMonitor<SubAccountRiskOptions>(opts),
+            book, pos, reg);
+        return (check, reg, book, pos);
+    }
+
+    private static RiskContext Ctx(SubAccountId? sub, OrderSide side = OrderSide.Buy, long qty = 100, decimal? px = 10m) =>
+        new(new EndClientId(Owner), Firm, Symbol, side, OrderType.Limit, qty, px, SubAccountId: sub);
+
+    [Fact]
+    public void NoSubAccount_OnContext_Approves()
+    {
+        var (check, _, _, _) = Build(new SubAccountRiskOptions());
+        var d = check.Check(Ctx(sub: null));
+        Assert.True(d.Approved);
+    }
+
+    [Fact]
+    public void DeactivatedSubAccount_Rejects()
+    {
+        var (check, _, _, _) = Build(new SubAccountRiskOptions(), registerSub: true, active: false);
+        var d = check.Check(Ctx(new SubAccountId(Sub)));
+        Assert.False(d.Approved);
+        Assert.StartsWith("sub_account_limit_exceeded", d.Reason);
+        Assert.Contains("deactivated", d.Reason);
+    }
+
+    [Fact]
+    public void NoConfigForFirm_Approves()
+    {
+        var (check, _, _, _) = Build(new SubAccountRiskOptions());
+        var d = check.Check(Ctx(new SubAccountId(Sub)));
+        Assert.True(d.Approved);
+    }
+
+    [Fact]
+    public void NotionalCap_Exceeded_Rejects()
+    {
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [Firm] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { MaxNotional = 500m } },
+                },
+            },
+        };
+        var (check, _, _, _) = Build(opts);
+        // 100 * 10 = 1000 > 500
+        var d = check.Check(Ctx(new SubAccountId(Sub)));
+        Assert.False(d.Approved);
+        Assert.StartsWith("sub_account_limit_exceeded", d.Reason);
+    }
+
+    [Fact]
+    public void PositionCap_Exceeded_Rejects()
+    {
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [Firm] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { PositionLimit = 50 } },
+                },
+            },
+        };
+        var (check, _, _, pos) = Build(opts);
+        // existing 30 net buy + new 25 buy = 55 > 50
+        pos.ApplyFill(new EndClientId(Owner), new SubAccountId(Sub), Symbol, OrderSide.Buy, 30, 10m);
+        var d = check.Check(Ctx(new SubAccountId(Sub), qty: 25));
+        Assert.False(d.Approved);
+        Assert.Contains("position", d.Reason);
+    }
+
+    [Fact]
+    public void PerFirmDefault_AppliesWhenSubAccountNotListed()
+    {
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [Firm] = new FirmSubAccountRiskOptions
+                {
+                    Default = new SubAccountRiskLimits { MaxNotional = 100m },
+                },
+            },
+        };
+        var (check, _, _, _) = Build(opts);
+        var d = check.Check(Ctx(new SubAccountId(Sub)));
+        Assert.False(d.Approved);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/SubAccountTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SubAccountTests.cs
@@ -125,11 +125,11 @@ public class SubAccountPositionKeeperTests
         var k = new SubAccountPositionKeeper();
         var owner = new EndClientId("trader-1");
 
-        k.ApplyFill(owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
-        k.ApplyFill(owner, new SubAccountId("prop"), "PETR4", OrderSide.Buy, 50, 32m);
+        k.ApplyFill("FIRM01", owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFill("FIRM01", owner, new SubAccountId("prop"), "PETR4", OrderSide.Buy, 50, 32m);
 
-        var td = k.ForSubAccount(owner, new SubAccountId("td")).Single();
-        var prop = k.ForSubAccount(owner, new SubAccountId("prop")).Single();
+        var td = k.ForSubAccount("FIRM01", owner, new SubAccountId("td")).Single();
+        var prop = k.ForSubAccount("FIRM01", owner, new SubAccountId("prop")).Single();
 
         Assert.Equal(100, td.NetQuantity);
         Assert.Equal(30m, td.AverageEntryPrice);
@@ -142,17 +142,47 @@ public class SubAccountPositionKeeperTests
     {
         var k = new SubAccountPositionKeeper();
         var owner = new EndClientId("trader-1");
-        k.ApplyFill(owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
-        k.ApplyFill(owner, new SubAccountId("td"), "VALE3", OrderSide.Sell, 20, 60m);
+        k.ApplyFill("FIRM01", owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFill("FIRM01", owner, new SubAccountId("td"), "VALE3", OrderSide.Sell, 20, 60m);
 
         var snap = k.Snapshot();
         var k2 = new SubAccountPositionKeeper();
         k2.Restore(snap);
 
-        var rows = k2.ForSubAccount(owner, new SubAccountId("td")).ToList();
+        var rows = k2.ForSubAccount("FIRM01", owner, new SubAccountId("td")).ToList();
         Assert.Equal(2, rows.Count);
         Assert.Equal(100, rows.Single(p => p.Symbol == "PETR4").NetQuantity);
         Assert.Equal(-20, rows.Single(p => p.Symbol == "VALE3").NetQuantity);
+    }
+
+    /// <summary>
+    /// PR review #301 P1 — multi-firm segregation. Same login under
+    /// FIRM01 and FIRM02 with the same <c>SubAccountId</c> MUST NOT
+    /// share position state; the keeper key includes FirmId so the
+    /// rows live in disjoint buckets.
+    /// </summary>
+    [Fact]
+    public void ApplyFill_SegregatesByFirm_SameOwnerSameSubAccount()
+    {
+        var k = new SubAccountPositionKeeper();
+        var owner = new EndClientId("alice");
+        var sub = new SubAccountId("tradingdesk");
+
+        k.ApplyFill("FIRM01", owner, sub, "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFill("FIRM02", owner, sub, "PETR4", OrderSide.Buy, 25, 32m);
+
+        var f1 = k.ForSubAccount("FIRM01", owner, sub).Single();
+        var f2 = k.ForSubAccount("FIRM02", owner, sub).Single();
+        Assert.Equal(100, f1.NetQuantity);
+        Assert.Equal(25, f2.NetQuantity);
+
+        // Round-trip preserves the firm split.
+        var k2 = new SubAccountPositionKeeper();
+        k2.Restore(k.Snapshot());
+        Assert.Equal(100, k2.ForSubAccount("FIRM01", owner, sub).Single().NetQuantity);
+        Assert.Equal(25, k2.ForSubAccount("FIRM02", owner, sub).Single().NetQuantity);
+        // Cross-firm peek returns nothing.
+        Assert.Empty(k2.ForSubAccount("FIRM03", owner, sub));
     }
 }
 
@@ -163,11 +193,11 @@ public class SubAccountPnlKeeperTests
     {
         var k = new SubAccountPnlKeeper();
         var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
-        k.Add("trader-1", new SubAccountId("td"), "PETR4", day, 100m);
-        k.Add("trader-1", new SubAccountId("prop"), "PETR4", day, 50m);
+        k.Add("FIRM01", "trader-1", new SubAccountId("td"), "PETR4", day, 100m);
+        k.Add("FIRM01", "trader-1", new SubAccountId("prop"), "PETR4", day, 50m);
 
-        Assert.Equal(100m, k.GetDayRealized("trader-1", new SubAccountId("td"), "PETR4", day));
-        Assert.Equal(50m, k.GetDayRealized("trader-1", new SubAccountId("prop"), "PETR4", day));
+        Assert.Equal(100m, k.GetDayRealized("FIRM01", "trader-1", new SubAccountId("td"), "PETR4", day));
+        Assert.Equal(50m, k.GetDayRealized("FIRM01", "trader-1", new SubAccountId("prop"), "PETR4", day));
     }
 
     [Fact]
@@ -175,12 +205,38 @@ public class SubAccountPnlKeeperTests
     {
         var k = new SubAccountPnlKeeper();
         var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
-        k.Add("o", new SubAccountId("td"), "S", day, 7m);
+        k.Add("FIRM01", "o", new SubAccountId("td"), "S", day, 7m);
 
         var snap = k.Snapshot();
         var k2 = new SubAccountPnlKeeper();
         k2.Restore(snap);
 
-        Assert.Equal(7m, k2.GetDayRealized("o", new SubAccountId("td"), "S", day));
+        Assert.Equal(7m, k2.GetDayRealized("FIRM01", "o", new SubAccountId("td"), "S", day));
+    }
+
+    /// <summary>
+    /// PR review #301 P1 — multi-firm segregation. Same login under
+    /// FIRM01 and FIRM02 with the same <c>SubAccountId</c> MUST NOT
+    /// share realized P&amp;L.
+    /// </summary>
+    [Fact]
+    public void Add_SegregatesByFirm_SameOwnerSameSubAccount()
+    {
+        var k = new SubAccountPnlKeeper();
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        var owner = "alice";
+        var sub = new SubAccountId("tradingdesk");
+
+        k.Add("FIRM01", owner, sub, "PETR4", day, 100m);
+        k.Add("FIRM02", owner, sub, "PETR4", day, 25m);
+
+        Assert.Equal(100m, k.GetDayRealized("FIRM01", owner, sub, "PETR4", day));
+        Assert.Equal(25m, k.GetDayRealized("FIRM02", owner, sub, "PETR4", day));
+        Assert.Equal(0m, k.GetDayRealized("FIRM03", owner, sub, "PETR4", day));
+
+        var rows1 = k.ForSubAccountDay("FIRM01", owner, sub, day).ToList();
+        var rows2 = k.ForSubAccountDay("FIRM02", owner, sub, day).ToList();
+        Assert.Equal(100m, rows1.Single().Realized);
+        Assert.Equal(25m, rows2.Single().Realized);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/SubAccountTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SubAccountTests.cs
@@ -1,0 +1,186 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Application.Tests;
+
+public class SubAccountsRegistryTests
+{
+    [Fact]
+    public void ApplyCreated_TwoFirmsSameId_AreIndependent()
+    {
+        var r = new SubAccountsRegistry();
+        r.ApplyCreated("FIRM01", "tradingdesk", "TD A");
+        r.ApplyCreated("FIRM02", "tradingdesk", "TD B");
+
+        Assert.True(r.TryGet("FIRM01", "tradingdesk", out var a));
+        Assert.True(r.TryGet("FIRM02", "tradingdesk", out var b));
+        Assert.Equal("TD A", a.DisplayName);
+        Assert.Equal("TD B", b.DisplayName);
+    }
+
+    [Fact]
+    public void ApplyDeactivated_KeepsEntryButFlipsActive()
+    {
+        var r = new SubAccountsRegistry();
+        r.ApplyCreated("F", "td", null);
+        Assert.True(r.ApplyDeactivated("F", "td"));
+
+        Assert.False(r.IsActive("F", "td"));
+        Assert.True(r.TryGet("F", "td", out var e));
+        Assert.False(e.Active);
+    }
+
+    [Fact]
+    public void ApplyCreated_AfterDeactivate_RevivesEntry()
+    {
+        var r = new SubAccountsRegistry();
+        r.ApplyCreated("F", "td", "old");
+        r.ApplyDeactivated("F", "td");
+        r.ApplyCreated("F", "td", "new");
+
+        Assert.True(r.IsActive("F", "td"));
+        Assert.True(r.TryGet("F", "td", out var e));
+        Assert.Equal("new", e.DisplayName);
+    }
+
+    [Fact]
+    public void ListForFirm_ReturnsOnlyThatFirmsRows()
+    {
+        var r = new SubAccountsRegistry();
+        r.ApplyCreated("F1", "a", null);
+        r.ApplyCreated("F1", "b", null);
+        r.ApplyCreated("F2", "a", null);
+
+        var f1 = r.ListForFirm("F1").Select(e => e.Id).OrderBy(x => x).ToArray();
+        var f2 = r.ListForFirm("F2").Select(e => e.Id).ToArray();
+        Assert.Equal(new[] { "a", "b" }, f1);
+        Assert.Equal(new[] { "a" }, f2);
+    }
+
+    [Fact]
+    public void Snapshot_RoundTrips()
+    {
+        var r = new SubAccountsRegistry();
+        r.ApplyCreated("F1", "a", "A");
+        r.ApplyCreated("F1", "b", null);
+        r.ApplyDeactivated("F1", "b");
+
+        var snap = r.Snapshot();
+        var r2 = new SubAccountsRegistry();
+        r2.Restore(snap);
+
+        Assert.True(r2.IsActive("F1", "a"));
+        Assert.False(r2.IsActive("F1", "b"));
+        Assert.True(r2.TryGet("F1", "b", out var b));
+        Assert.Equal("F1", b.FirmId);
+    }
+}
+
+public class SubAccountIdTests
+{
+    [Theory]
+    [InlineData("tradingdesk")]
+    [InlineData("prop")]
+    [InlineData("sub.1_a-X")]
+    [InlineData("a")]
+    public void Constructor_AcceptsValidIds(string id)
+    {
+        var sa = new SubAccountId(id);
+        Assert.Equal(id, sa.Value);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("has space")]
+    [InlineData("has/slash")]
+    [InlineData("trailing!")]
+    public void Constructor_RejectsInvalidIds(string id)
+    {
+        Assert.Throws<ArgumentException>(() => new SubAccountId(id));
+    }
+
+    [Fact]
+    public void Constructor_RejectsTooLong()
+    {
+        var id = new string('a', 65);
+        Assert.Throws<ArgumentException>(() => new SubAccountId(id));
+    }
+
+    [Fact]
+    public void FromNullableString_PassesThroughNullAndEmpty()
+    {
+        Assert.Null(SubAccountId.FromNullableString(null));
+        Assert.Null(SubAccountId.FromNullableString(""));
+        Assert.Equal("td", SubAccountId.FromNullableString("td")!.Value);
+    }
+}
+
+public class SubAccountPositionKeeperTests
+{
+    [Fact]
+    public void ApplyFill_SegregatesBySubAccount()
+    {
+        var k = new SubAccountPositionKeeper();
+        var owner = new EndClientId("trader-1");
+
+        k.ApplyFill(owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFill(owner, new SubAccountId("prop"), "PETR4", OrderSide.Buy, 50, 32m);
+
+        var td = k.ForSubAccount(owner, new SubAccountId("td")).Single();
+        var prop = k.ForSubAccount(owner, new SubAccountId("prop")).Single();
+
+        Assert.Equal(100, td.NetQuantity);
+        Assert.Equal(30m, td.AverageEntryPrice);
+        Assert.Equal(50, prop.NetQuantity);
+        Assert.Equal(32m, prop.AverageEntryPrice);
+    }
+
+    [Fact]
+    public void Snapshot_RoundTrips_SegregatedPositions()
+    {
+        var k = new SubAccountPositionKeeper();
+        var owner = new EndClientId("trader-1");
+        k.ApplyFill(owner, new SubAccountId("td"), "PETR4", OrderSide.Buy, 100, 30m);
+        k.ApplyFill(owner, new SubAccountId("td"), "VALE3", OrderSide.Sell, 20, 60m);
+
+        var snap = k.Snapshot();
+        var k2 = new SubAccountPositionKeeper();
+        k2.Restore(snap);
+
+        var rows = k2.ForSubAccount(owner, new SubAccountId("td")).ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(100, rows.Single(p => p.Symbol == "PETR4").NetQuantity);
+        Assert.Equal(-20, rows.Single(p => p.Symbol == "VALE3").NetQuantity);
+    }
+}
+
+public class SubAccountPnlKeeperTests
+{
+    [Fact]
+    public void Add_SegregatesBySubAccount()
+    {
+        var k = new SubAccountPnlKeeper();
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        k.Add("trader-1", new SubAccountId("td"), "PETR4", day, 100m);
+        k.Add("trader-1", new SubAccountId("prop"), "PETR4", day, 50m);
+
+        Assert.Equal(100m, k.GetDayRealized("trader-1", new SubAccountId("td"), "PETR4", day));
+        Assert.Equal(50m, k.GetDayRealized("trader-1", new SubAccountId("prop"), "PETR4", day));
+    }
+
+    [Fact]
+    public void Snapshot_RoundTrips()
+    {
+        var k = new SubAccountPnlKeeper();
+        var day = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+        k.Add("o", new SubAccountId("td"), "S", day, 7m);
+
+        var snap = k.Snapshot();
+        var k2 = new SubAccountPnlKeeper();
+        k2.Restore(snap);
+
+        Assert.Equal(7m, k2.GetDayRealized("o", new SubAccountId("td"), "S", day));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/ThrottleChecksTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ThrottleChecksTests.cs
@@ -262,6 +262,27 @@ public class ThrottleChecksTests
         Assert.True(new MaxOpenOrdersCheck(opts, book).Check(Ctx()).Approved);
     }
 
+    [Fact]
+    public void MaxOpenOrders_OtherFirmsDoNotConsumeQuota()
+    {
+        // PR #316 P2.1. Cap is per-(firm, end-client). FIRM02 has the
+        // same owner at quota; a FIRM01 submission for the same owner
+        // must be approved against the empty FIRM01 quota — the
+        // FIRM02 working orders must not bleed across.
+        var book = new WorkingOrderBook();
+        AddOpenForFirm(book, "alice", "FIRM02", clOrdId: 10);
+        AddOpenForFirm(book, "alice", "FIRM02", clOrdId: 11);
+        // The current submission lands in the book before risk runs.
+        AddOpenForFirm(book, "alice", "FIRM01", clOrdId: 12);
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MaxOpenOrders = 2 } });
+        var check = new MaxOpenOrdersCheck(opts, book);
+
+        Assert.True(check.Check(Ctx(firm: "FIRM01")).Approved);
+        // Sanity: FIRM02 actually IS at its cap (2 own + 0 cross).
+        AddOpenForFirm(book, "alice", "FIRM02", clOrdId: 13);
+        Assert.False(check.Check(Ctx(firm: "FIRM02")).Approved);
+    }
+
     // ────────────────── CompositeRiskAccountant ──────────────────
 
     [Fact]
@@ -316,6 +337,10 @@ public class ThrottleChecksTests
 
     private static void AddOpen(WorkingOrderBook book, string owner, ulong clOrdId) =>
         book.TryAdd(NewOrder(owner, clOrdId));
+
+    private static void AddOpenForFirm(WorkingOrderBook book, string owner, string firmId, ulong clOrdId) =>
+        book.TryAdd(new Order(clOrdId, new EndClientId(owner), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            quantity: 100, price: 30m, firmId: firmId));
 
     private static Order NewOrder(string owner, ulong clOrdId) =>
         new(clOrdId, new EndClientId(owner), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,

--- a/docker/docker-compose.unavailable.yml
+++ b/docker/docker-compose.unavailable.yml
@@ -54,6 +54,14 @@ services:
       # before any gateway routing.
       Trading__Auth__Users__0__Firm: default
       Trading__Auth__Users__5__Firm: default
+      # PR #316 P2: when the user firm reverts to "default" the position
+      # seeds must follow, otherwise the FIRM01-tagged seeds from the
+      # base compose file are invisible to the now-default users and
+      # the naked-short gate blocks every Sell.
+      Trading__Positions__Seeds__0__Firm: default
+      Trading__Positions__Seeds__1__Firm: default
+      Trading__Positions__Seeds__2__Firm: default
+      Trading__Positions__Seeds__3__Firm: default
       # Live ref-prices are unreachable without marketdata; kill the
       # subscriber so it doesn't churn reconnect attempts in logs.
       # Static fallback Trading:Risk:ReferencePrices map (still set by

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -222,18 +222,27 @@ services:
       Trading__Positions__Seeds__0__Symbol: PETR4
       Trading__Positions__Seeds__0__Quantity: "2000"
       Trading__Positions__Seeds__0__AverageEntryPrice: "32.50"
+      # PR #316 P2: explicit firm namespace. Without this the seed lands
+      # in PositionKeeper.DefaultFirmId and is invisible to FIRM01 users
+      # (the naked-short gate then rejects the first Sell). The
+      # Mode=Unavailable overlay reverts the user firm to "default"; its
+      # own seed-firm override matches.
+      Trading__Positions__Seeds__0__Firm: FIRM01
       Trading__Positions__Seeds__1__EndClientId: ${TRADING_SEED_USER:-alice}
       Trading__Positions__Seeds__1__Symbol: VALE3
       Trading__Positions__Seeds__1__Quantity: "2000"
       Trading__Positions__Seeds__1__AverageEntryPrice: "65.00"
+      Trading__Positions__Seeds__1__Firm: FIRM01
       Trading__Positions__Seeds__2__EndClientId: ${TRADING_SEED_USER_2:-bob}
       Trading__Positions__Seeds__2__Symbol: PETR4
       Trading__Positions__Seeds__2__Quantity: "2000"
       Trading__Positions__Seeds__2__AverageEntryPrice: "32.50"
+      Trading__Positions__Seeds__2__Firm: FIRM01
       Trading__Positions__Seeds__3__EndClientId: ${TRADING_SEED_USER_2:-bob}
       Trading__Positions__Seeds__3__Symbol: VALE3
       Trading__Positions__Seeds__3__Quantity: "2000"
       Trading__Positions__Seeds__3__AverageEntryPrice: "65.00"
+      Trading__Positions__Seeds__3__Firm: FIRM01
       # Live reference price via the marketdata WS leg (RFC §4.5 D3).
       # MarketDataReferencePrice subscribes to PETR4/VALE3/ITUB4 on boot;
       # cache misses fall back to Trading:Risk:ReferencePrices map. The


### PR DESCRIPTION
Closes #301.

## Summary
Implements Q4.1 — a single end-client / trader can now own N named sub-accounts (e.g. `tradingdesk`, `prop`, `clientA`) so orders, fills, positions, P&L, and per-bucket risk limits are tracked separately. The master view aggregates naturally — no client breaks.

## Approach: dual-keeper
The existing `PositionKeeper` / `PnlKeeper` keep their master semantics unchanged (every fill folds into the aggregate). New parallel `SubAccountPositionKeeper` + `SubAccountPnlKeeper`, keyed by `(EndClientId, SubAccountId, Symbol)`, are populated alongside whenever the originating order carries a sub-account tag. Reads without a filter return the master view (legacy wire shape preserved); reads with `?subAccount=X` return the segregated bucket.

## What changed

### Domain / WAL / persistence
- New `SubAccountId` value type (validated: 1-64 chars, `[A-Za-z0-9._-]`)
- New WAL events `SubAccountCreatedEvent` / `SubAccountDeactivatedEvent`, namespaced per `(FirmId, Id)` — soft-delete; re-create revives
- Additive `SubAccountId` (string?) on `Order` / `OrderSnapshot` / `OrderSubmittedEvent` / `RealizedPnlEvent` / `RiskContext` — every pre-#301 WAL segment and snapshot deserialises with `null` = master bucket, matching prior semantics exactly
- Two-phase snapshot pipeline extended (`CaptureRaw` + `Project` + `Restore`) for registry + per-sub-account keepers; `EventReplayer.Apply` switch handles new event kinds and fans out sub-account-tagged `RealizedPnlEvent` into the parallel keeper

### REST
- New endpoints: `GET /sub-accounts` (auth, supports `?includeDeactivated=true`), `POST /sub-accounts` (admin), `DELETE /sub-accounts/{id}` (admin)
- `POST /orders` accepts optional `subAccountId`; 400 on validation failure, unknown id, or deactivated id
- `GET /positions?subAccount=X` and `GET /pnl/today?subAccount=X` filter to the segregated bucket

### Risk
- New `SubAccountLimitsCheck` (`Order=175`, between MaxOpenOrders=170 and PositionLimit=200) — per-`(firm, subAccount)` caps on open-orders, position, notional; rejects with reason prefix `sub_account_limit_exceeded`
- Also rejects any submit targeting a soft-deleted sub-account (defence-in-depth: the API layer also fast-fails)
- Configured via `SubAccountRiskOptions` (`Trading:Risk:SubAccount`); resolver supports `PerFirm[firm].PerSubAccount[id]` + `PerFirm[firm].Default` fallback; no-op when unconfigured
- Sub-account-null submissions skip the check entirely — pre-#301 master-only behaviour preserved exactly

### WebSocket DTOs
- `OrderDto` and `PositionDto` carry additive `SubAccountId` (`null` on master-bucket rows)
- Aggregation default decision: emit per-sub-account rows with `subAccountId=null` representing the master aggregate computed by the existing keeper

## Tests
- 26 new tests covering id validation, registry CRUD + multi-firm namespacing, position/P&L segregation, snapshot round-trips, limits check with deactivation + per-firm default fallback
- Baseline counts: 81 domain + 374 API + 134 EntryPointListener + (932 → 958) application
- `dotnet test B3TradingPlatform.slnx`: **all passing** (no regressions; the previously-flaky `GtdSchedulerRegressionTests.DispatchExpire_PersistentWalBackpressure_FollowsExponentialBackoff` passed this run)
- `dotnet format B3TradingPlatform.slnx --verify-no-changes`: clean

## Deferred (intentionally out of scope, follow-ups)
- Per-sub-account avg-cost basis tracker (this PR's `GET /pnl/today?subAccount=X` returns realized only; unrealized is empty until a per-sub-account basis tracker lands)
- WebSocket subscribe-time `?subAccount=X` channel filter on `orders.me` / `positions.me` / `pnl.me` (the DTOs already carry `subAccountId` so clients can filter client-side as an interim)
- `OrderHistoryItemDto.SubAccountId` on the history endpoint
