### PR TITLE
Q4.3: TOTP-based 2FA at /auth/login (#303)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -32,6 +32,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="Otp.NET" Version="1.4.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Api.Auth.Totp;
 using B3.Trading.Application;
 using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
@@ -34,7 +35,8 @@ public static class AuthEndpoints
             IUserStore users,
             JwtIssuer issuer,
             EndClientRegistry registry,
-            ILoginAttemptTracker lockout) =>
+            ILoginAttemptTracker lockout,
+            ITotpChallengeStore totpChallenges) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrWhiteSpace(req.Password))
                 return Results.BadRequest(new { error = "username and password required" });
@@ -59,15 +61,38 @@ public static class AuthEndpoints
                 return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
             }
 
-            // Successful auth wipes the failure counter for this user.
+            // Password ok. Clear the password-side failure counter
+            // before deciding the second-factor path so a repeated
+            // 2FA-pending login doesn't pile up password failures.
             lockout.RecordSuccess(user.Username);
+
+            // 2FA branch #1: user has an active TOTP enrollment. Mint a
+            // short-lived challenge token and bail before issuing a JWT.
+            if (user.Totp is { EnrolledAt: not null, SharedSecret.Length: > 0 })
+            {
+                var token = totpChallenges.Issue(user.Username, TotpChallengeKind.Verify);
+                return Results.Ok(new LoginTwoFactorRequiredResponse(
+                    Requires2fa: true,
+                    TotpChallengeToken: token));
+            }
+
+            // 2FA branch #2: user is REQUIRED to enroll (admin-forced)
+            // but hasn't yet. Mint a ForceEnroll token; the client
+            // calls /auth/2fa/enroll with that token instead of a JWT.
+            if (user.Require2FA)
+            {
+                var token = totpChallenges.Issue(user.Username, TotpChallengeKind.ForceEnroll);
+                return Results.Ok(new LoginEnrollmentRequiredResponse(
+                    Requires2faEnrollment: true,
+                    EnrollmentToken: token));
+            }
 
             // Pre-register so subsequent ER routing / WS subscribe work
             // immediately even before the first business call.
             registry.Register(user.Username);
 
-            var (token, expires) = issuer.Issue(user.Username, user.Role, user.Firm);
-            return Results.Ok(new LoginResponse(token, expires));
+            var (jwt, expires) = issuer.Issue(user.Username, user.Role, user.Firm);
+            return Results.Ok(new LoginResponse(jwt, expires));
         });
 
         app.MapPost("/auth/signup", (
@@ -222,3 +247,18 @@ public static class AuthEndpoints
 public sealed record LoginRequest(string Username, string Password);
 public sealed record LoginResponse(string Token, DateTimeOffset ExpiresAt);
 public sealed record SignupRequest(string Username, string Password);
+
+/// <summary>
+/// Returned by <c>/auth/login</c> when the user has an active TOTP
+/// enrollment. The client must POST <c>{ totpChallengeToken, code }</c>
+/// to <c>/auth/2fa/verify</c> to receive the real JWT. (#303)
+/// </summary>
+public sealed record LoginTwoFactorRequiredResponse(bool Requires2fa, string TotpChallengeToken);
+
+/// <summary>
+/// Returned by <c>/auth/login</c> when the user has
+/// <c>Require2FA=true</c> but no active enrollment. The client must
+/// POST <c>{ enrollmentToken }</c> as <c>X-Enrollment-Token</c> (or
+/// body field) to <c>/auth/2fa/enroll</c> to bootstrap. (#303)
+/// </summary>
+public sealed record LoginEnrollmentRequiredResponse(bool Requires2faEnrollment, string EnrollmentToken);

--- a/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
@@ -107,6 +107,34 @@ public sealed class UserTotpConfig
     public List<string> RecoveryCodes { get; set; } = new();
 
     /// <summary>
+    /// FIFO-bounded ring of recently-consumed recovery-code hashes.
+    /// Used to distinguish a wrong-code attempt from a previously-valid
+    /// code (concurrent race loser or replay-after-success) so the TOTP
+    /// lockout counter is not incremented in the latter case. Capped at
+    /// <see cref="ConsumedRecoveryCodesCap"/> entries with FIFO
+    /// eviction — generous enough to cover realistic re-enrollment
+    /// churn (defaults: 10 codes per enrollment) while keeping the
+    /// persisted footprint small.
+    /// <para>
+    /// Trade-off: an attacker who learns a hash that has already been
+    /// consumed can hit /auth/2fa/verify forever without tripping
+    /// lockout. That is acceptable — knowing a consumed code is no
+    /// stronger than knowing the JWT the code originally produced, and
+    /// the alternative (counting consumed-list hits as failures) would
+    /// let any attacker brute-force-lock the legitimate user.
+    /// </para>
+    /// </summary>
+    public List<string> ConsumedRecoveryCodes { get; set; } = new();
+
+    /// <summary>
+    /// Maximum size of <see cref="ConsumedRecoveryCodes"/>. Set well
+    /// above a single enrollment's <see cref="Totp.TotpOptions.RecoveryCodeCount"/>
+    /// (default 10) so multiple re-enrollments fit before FIFO
+    /// eviction; small enough to keep the persisted user record bounded.
+    /// </summary>
+    public const int ConsumedRecoveryCodesCap = 64;
+
+    /// <summary>
     /// Most recent successfully-consumed TOTP time step (RFC 6238 T,
     /// i.e. seconds-since-epoch / period). Used to block replay of a
     /// valid code within the same 30s window via a fresh challenge

--- a/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
@@ -67,4 +67,42 @@ public sealed class UserConfig
     public int Iterations { get; set; } = 600_000;
     public string Role { get; set; } = "user";
     public string Firm { get; set; } = "default";
+
+    /// <summary>
+    /// TOTP 2FA configuration (issue #303). Null when the user has not
+    /// enrolled. <see cref="UserTotpConfig.SharedSecret"/> is the
+    /// Data-Protection-encrypted base32 secret — never plaintext on
+    /// disk.
+    /// </summary>
+    public UserTotpConfig? Totp { get; set; }
+
+    /// <summary>
+    /// When true, the user MUST enroll a TOTP factor; login returns
+    /// <c>requires2faEnrollment=true</c> with a short-lived enrollment
+    /// token instead of a JWT. Defaults to false.
+    /// </summary>
+    public bool Require2FA { get; set; }
+}
+
+/// <summary>
+/// Per-user TOTP state (#303). Persisted as part of <see cref="UserConfig"/>.
+/// </summary>
+public sealed class UserTotpConfig
+{
+    /// <summary>
+    /// Base32 TOTP shared secret, encrypted at rest via ASP.NET Core
+    /// Data Protection (<see cref="Auth.Totp.ITotpSecretProtector"/>).
+    /// The wire format is the protector's opaque ciphertext; do NOT
+    /// assume it is base32 itself.
+    /// </summary>
+    public string SharedSecret { get; set; } = string.Empty;
+
+    /// <summary>When the user completed enrollment (verify step).</summary>
+    public DateTimeOffset? EnrolledAt { get; set; }
+
+    /// <summary>
+    /// SHA-256 hashes of unused recovery codes. Each entry is consumed
+    /// on use (removed from the list).
+    /// </summary>
+    public List<string> RecoveryCodes { get; set; } = new();
 }

--- a/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthOptions.cs
@@ -105,4 +105,14 @@ public sealed class UserTotpConfig
     /// on use (removed from the list).
     /// </summary>
     public List<string> RecoveryCodes { get; set; } = new();
+
+    /// <summary>
+    /// Most recent successfully-consumed TOTP time step (RFC 6238 T,
+    /// i.e. seconds-since-epoch / period). Used to block replay of a
+    /// valid code within the same 30s window via a fresh challenge
+    /// token. Nullable so users persisted before this field existed
+    /// (legacy / on-disk envelopes) default cleanly to "no prior step
+    /// recorded" — the first verify after restart simply seeds it.
+    /// </summary>
+    public long? LastUsedTimeStep { get; set; }
 }

--- a/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
@@ -124,6 +124,47 @@ public sealed class FileBackedUserStore : IUserStore
         }
     }
 
+    public bool TryUpdate(UserConfig user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        if (string.IsNullOrWhiteSpace(user.Username)) return false;
+
+        lock (_writeGate)
+        {
+            // Env-seeded users: mutate in place (config remains
+            // authoritative for credentials; TOTP overlay survives only
+            // process lifetime — matches InMemoryUserStore).
+            if (_seeded.TryGetValue(user.Username, out var seeded))
+            {
+                seeded.Totp = user.Totp;
+                seeded.Require2FA = user.Require2FA;
+                return true;
+            }
+
+            if (!_runtime.ContainsKey(user.Username)) return false;
+            var previous = _runtime[user.Username];
+            _runtime[user.Username] = user;
+
+            try
+            {
+                PersistRuntimeUsersLocked();
+            }
+            catch (Exception ex)
+            {
+                // Roll the in-memory state back to the prior snapshot
+                // so we don't expose an unpersisted TOTP secret.
+                _runtime[user.Username] = previous;
+                _logger.LogError(ex,
+                    "FileBackedUserStore: failed to persist updated user {Username} to {Path}; " +
+                    "in-memory update rolled back.",
+                    user.Username, _filePath);
+                throw;
+            }
+
+            return true;
+        }
+    }
+
     private void LoadRuntimeUsers()
     {
         if (!File.Exists(_filePath))

--- a/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
@@ -165,6 +165,98 @@ public sealed class FileBackedUserStore : IUserStore
         }
     }
 
+    public bool TryRecordTotpUse(string username, long matchedStep, out UserConfig? updatedUser)
+    {
+        updatedUser = null;
+        if (string.IsNullOrWhiteSpace(username)) return false;
+
+        lock (_writeGate)
+        {
+            if (!TryGet(username, out var user) || user is null || user.Totp is null
+                || user.Totp.EnrolledAt is null)
+                return false;
+
+            if (user.Totp.LastUsedTimeStep is { } prev && matchedStep <= prev)
+                return false;
+
+            var previous = user.Totp.LastUsedTimeStep;
+            user.Totp.LastUsedTimeStep = matchedStep;
+
+            // Env-seeded users are mutated in place only — no disk
+            // write (config is authoritative on restart).
+            if (_seeded.ContainsKey(username))
+            {
+                updatedUser = user;
+                return true;
+            }
+
+            try
+            {
+                PersistRuntimeUsersLocked();
+            }
+            catch (Exception ex)
+            {
+                user.Totp.LastUsedTimeStep = previous;
+                _logger.LogError(ex,
+                    "FileBackedUserStore: failed to persist TOTP time step for {Username} to {Path}; " +
+                    "in-memory update rolled back.",
+                    username, _filePath);
+                throw;
+            }
+
+            updatedUser = user;
+            return true;
+        }
+    }
+
+    public bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
+    {
+        updatedUser = null;
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash)) return false;
+
+        lock (_writeGate)
+        {
+            if (!TryGet(username, out var user) || user is null || user.Totp is null)
+                return false;
+
+            // Constant-time-ish scan; full pass so timing reveals
+            // nothing about which slot matched.
+            var idx = -1;
+            for (var i = 0; i < user.Totp.RecoveryCodes.Count; i++)
+            {
+                if (string.Equals(user.Totp.RecoveryCodes[i], codeHash, StringComparison.Ordinal))
+                    idx = i;
+            }
+            if (idx < 0) return false;
+
+            var removed = user.Totp.RecoveryCodes[idx];
+            user.Totp.RecoveryCodes.RemoveAt(idx);
+
+            if (_seeded.ContainsKey(username))
+            {
+                updatedUser = user;
+                return true;
+            }
+
+            try
+            {
+                PersistRuntimeUsersLocked();
+            }
+            catch (Exception ex)
+            {
+                user.Totp.RecoveryCodes.Insert(idx, removed);
+                _logger.LogError(ex,
+                    "FileBackedUserStore: failed to persist recovery-code consumption for {Username} to {Path}; " +
+                    "in-memory update rolled back.",
+                    username, _filePath);
+                throw;
+            }
+
+            updatedUser = user;
+            return true;
+        }
+    }
+
     private void LoadRuntimeUsers()
     {
         if (!File.Exists(_filePath))

--- a/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/FileBackedUserStore.cs
@@ -209,15 +209,16 @@ public sealed class FileBackedUserStore : IUserStore
         }
     }
 
-    public bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
+    public RecoveryCodeConsumeResult TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
     {
         updatedUser = null;
-        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash)) return false;
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash))
+            return RecoveryCodeConsumeResult.NotFound;
 
         lock (_writeGate)
         {
             if (!TryGet(username, out var user) || user is null || user.Totp is null)
-                return false;
+                return RecoveryCodeConsumeResult.NotFound;
 
             // Constant-time-ish scan; full pass so timing reveals
             // nothing about which slot matched.
@@ -227,15 +228,28 @@ public sealed class FileBackedUserStore : IUserStore
                 if (string.Equals(user.Totp.RecoveryCodes[i], codeHash, StringComparison.Ordinal))
                     idx = i;
             }
-            if (idx < 0) return false;
+            if (idx < 0)
+            {
+                for (var i = 0; i < user.Totp.ConsumedRecoveryCodes.Count; i++)
+                {
+                    if (string.Equals(user.Totp.ConsumedRecoveryCodes[i], codeHash, StringComparison.Ordinal))
+                        return RecoveryCodeConsumeResult.AlreadyConsumed;
+                }
+                return RecoveryCodeConsumeResult.NotFound;
+            }
 
             var removed = user.Totp.RecoveryCodes[idx];
             user.Totp.RecoveryCodes.RemoveAt(idx);
 
+            // Snapshot the consumed list so we can roll back atomically
+            // alongside the removal on a failed disk write.
+            var consumedBefore = new List<string>(user.Totp.ConsumedRecoveryCodes);
+            AppendConsumed(user.Totp, codeHash);
+
             if (_seeded.ContainsKey(username))
             {
                 updatedUser = user;
-                return true;
+                return RecoveryCodeConsumeResult.Consumed;
             }
 
             try
@@ -245,6 +259,8 @@ public sealed class FileBackedUserStore : IUserStore
             catch (Exception ex)
             {
                 user.Totp.RecoveryCodes.Insert(idx, removed);
+                user.Totp.ConsumedRecoveryCodes.Clear();
+                user.Totp.ConsumedRecoveryCodes.AddRange(consumedBefore);
                 _logger.LogError(ex,
                     "FileBackedUserStore: failed to persist recovery-code consumption for {Username} to {Path}; " +
                     "in-memory update rolled back.",
@@ -253,8 +269,15 @@ public sealed class FileBackedUserStore : IUserStore
             }
 
             updatedUser = user;
-            return true;
+            return RecoveryCodeConsumeResult.Consumed;
         }
+    }
+
+    private static void AppendConsumed(UserTotpConfig totp, string codeHash)
+    {
+        while (totp.ConsumedRecoveryCodes.Count >= UserTotpConfig.ConsumedRecoveryCodesCap)
+            totp.ConsumedRecoveryCodes.RemoveAt(0);
+        totp.ConsumedRecoveryCodes.Add(codeHash);
     }
 
     private void LoadRuntimeUsers()

--- a/backend/src/B3.Trading.Api/Auth/IUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/IUserStore.cs
@@ -32,4 +32,29 @@ public interface IUserStore
     /// authoritative on restart for credential fields. Thread-safe.
     /// </summary>
     bool TryUpdate(UserConfig user);
+
+    /// <summary>
+    /// Atomically validates that <paramref name="matchedStep"/> is
+    /// strictly greater than the user's persisted
+    /// <see cref="UserTotpConfig.LastUsedTimeStep"/> and, if so,
+    /// persists it. Returns <c>false</c> when the user is unknown, has
+    /// no enrolled TOTP, or the step would be a same-window replay.
+    /// On success, <paramref name="updatedUser"/> is the post-write
+    /// snapshot. Implementations must serialize the read-modify-write
+    /// under a per-user lock so two concurrent verifies racing on the
+    /// same time step cannot both succeed.
+    /// </summary>
+    bool TryRecordTotpUse(string username, long matchedStep, out UserConfig? updatedUser);
+
+    /// <summary>
+    /// Atomically removes a single recovery-code hash from the user's
+    /// <see cref="UserTotpConfig.RecoveryCodes"/> list. Returns
+    /// <c>false</c> when the user is unknown, has no enrolled TOTP, or
+    /// the hash is not present (already consumed by a racing request,
+    /// or simply wrong). On success, <paramref name="updatedUser"/> is
+    /// the post-write snapshot. Implementations must serialize the
+    /// scan-remove-persist under a per-user lock so two concurrent
+    /// verifies presenting the SAME recovery code cannot both succeed.
+    /// </summary>
+    bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser);
 }

--- a/backend/src/B3.Trading.Api/Auth/IUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/IUserStore.cs
@@ -48,13 +48,49 @@ public interface IUserStore
 
     /// <summary>
     /// Atomically removes a single recovery-code hash from the user's
-    /// <see cref="UserTotpConfig.RecoveryCodes"/> list. Returns
-    /// <c>false</c> when the user is unknown, has no enrolled TOTP, or
-    /// the hash is not present (already consumed by a racing request,
-    /// or simply wrong). On success, <paramref name="updatedUser"/> is
-    /// the post-write snapshot. Implementations must serialize the
-    /// scan-remove-persist under a per-user lock so two concurrent
-    /// verifies presenting the SAME recovery code cannot both succeed.
+    /// <see cref="UserTotpConfig.RecoveryCodes"/> list. Returns a
+    /// tri-state result so the caller can distinguish a genuinely
+    /// wrong/typed code from a previously-valid code that has since
+    /// been consumed (concurrent race winner already took it, or a
+    /// straight replay after success). On <see cref="RecoveryCodeConsumeResult.Consumed"/>,
+    /// <paramref name="updatedUser"/> is the post-write snapshot;
+    /// otherwise it is <c>null</c>. Implementations must serialize
+    /// the scan-remove-persist under a per-user lock so two concurrent
+    /// verifies presenting the SAME recovery code cannot both succeed,
+    /// and must record the consumed hash in
+    /// <see cref="UserTotpConfig.ConsumedRecoveryCodes"/> as part of
+    /// the same atomic write so the loser of a race observes
+    /// <see cref="RecoveryCodeConsumeResult.AlreadyConsumed"/>.
     /// </summary>
-    bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser);
+    RecoveryCodeConsumeResult TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser);
+}
+
+/// <summary>
+/// Outcome of <see cref="IUserStore.TryConsumeRecoveryCode"/>. The
+/// distinction matters at the endpoint layer: a <see cref="NotFound"/>
+/// is a wrong-code attempt (lockout counter must tick), while an
+/// <see cref="AlreadyConsumed"/> is a benign race-loser or a
+/// replay-after-success and MUST NOT increment the lockout counter
+/// — otherwise a small concurrent burst (e.g. a user double-clicking
+/// "Submit") could lock the account out instantly.
+/// </summary>
+public enum RecoveryCodeConsumeResult
+{
+    /// <summary>Hash matched an unused code and was consumed.</summary>
+    Consumed,
+
+    /// <summary>
+    /// Hash was not in the unused list and has never been observed as
+    /// consumed for this user. Treat as a genuine wrong-code attempt.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// Hash was previously valid for this user but is no longer in the
+    /// unused list — either a concurrent verify already won the race
+    /// for the same code or the client is replaying a code that has
+    /// already succeeded. Treat as a failed verify (401) but DO NOT
+    /// increment the lockout counter.
+    /// </summary>
+    AlreadyConsumed,
 }

--- a/backend/src/B3.Trading.Api/Auth/IUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/IUserStore.cs
@@ -22,4 +22,14 @@ public interface IUserStore
     /// Thread-safe.
     /// </summary>
     bool TryAdd(UserConfig user);
+
+    /// <summary>
+    /// Persist mutations to an existing user (e.g. TOTP enrollment
+    /// state). Returns <c>false</c> when the username is not known.
+    /// Updates apply to both env-seeded and runtime users; for
+    /// env-seeded users only the runtime-mutable fields (currently
+    /// <see cref="UserConfig.Totp"/>) survive — config remains
+    /// authoritative on restart for credential fields. Thread-safe.
+    /// </summary>
+    bool TryUpdate(UserConfig user);
 }

--- a/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
@@ -16,6 +16,8 @@ public sealed class InMemoryUserStore : IUserStore
     private readonly Dictionary<string, UserConfig> _seeded;
     private readonly ConcurrentDictionary<string, UserConfig> _runtime =
         new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, object> _userLocks =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public InMemoryUserStore(IOptions<AuthOptions> options)
     {
@@ -59,19 +61,71 @@ public sealed class InMemoryUserStore : IUserStore
         ArgumentNullException.ThrowIfNull(user);
         if (string.IsNullOrWhiteSpace(user.Username)) return false;
 
-        // Env-seeded users: mutate the existing UserConfig in place so
-        // TOTP overlays persist for the lifetime of the process. They
-        // are intentionally NOT persisted (config is authoritative);
-        // operator-controlled accounts re-enroll if the host restarts.
-        if (_seeded.TryGetValue(user.Username, out var seeded))
+        lock (LockFor(user.Username))
         {
-            seeded.Totp = user.Totp;
-            seeded.Require2FA = user.Require2FA;
+            // Env-seeded users: mutate the existing UserConfig in place so
+            // TOTP overlays persist for the lifetime of the process. They
+            // are intentionally NOT persisted (config is authoritative);
+            // operator-controlled accounts re-enroll if the host restarts.
+            if (_seeded.TryGetValue(user.Username, out var seeded))
+            {
+                seeded.Totp = user.Totp;
+                seeded.Require2FA = user.Require2FA;
+                return true;
+            }
+
+            if (!_runtime.ContainsKey(user.Username)) return false;
+            _runtime[user.Username] = user;
             return true;
         }
-
-        if (!_runtime.ContainsKey(user.Username)) return false;
-        _runtime[user.Username] = user;
-        return true;
     }
+
+    public bool TryRecordTotpUse(string username, long matchedStep, out UserConfig? updatedUser)
+    {
+        updatedUser = null;
+        if (string.IsNullOrWhiteSpace(username)) return false;
+
+        lock (LockFor(username))
+        {
+            if (!TryGet(username, out var user) || user is null || user.Totp is null
+                || user.Totp.EnrolledAt is null)
+                return false;
+
+            if (user.Totp.LastUsedTimeStep is { } prev && matchedStep <= prev)
+                return false;
+
+            user.Totp.LastUsedTimeStep = matchedStep;
+            updatedUser = user;
+            return true;
+        }
+    }
+
+    public bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
+    {
+        updatedUser = null;
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash)) return false;
+
+        lock (LockFor(username))
+        {
+            if (!TryGet(username, out var user) || user is null || user.Totp is null)
+                return false;
+
+            // Constant-time-ish scan: full pass without early-out so
+            // timing leaks no information about which index matched.
+            var idx = -1;
+            for (var i = 0; i < user.Totp.RecoveryCodes.Count; i++)
+            {
+                if (string.Equals(user.Totp.RecoveryCodes[i], codeHash, StringComparison.Ordinal))
+                    idx = i;
+            }
+            if (idx < 0) return false;
+
+            user.Totp.RecoveryCodes.RemoveAt(idx);
+            updatedUser = user;
+            return true;
+        }
+    }
+
+    private object LockFor(string username)
+        => _userLocks.GetOrAdd(username, _ => new object());
 }

--- a/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
@@ -53,4 +53,25 @@ public sealed class InMemoryUserStore : IUserStore
         if (_seeded.ContainsKey(user.Username)) return false;
         return _runtime.TryAdd(user.Username, user);
     }
+
+    public bool TryUpdate(UserConfig user)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        if (string.IsNullOrWhiteSpace(user.Username)) return false;
+
+        // Env-seeded users: mutate the existing UserConfig in place so
+        // TOTP overlays persist for the lifetime of the process. They
+        // are intentionally NOT persisted (config is authoritative);
+        // operator-controlled accounts re-enroll if the host restarts.
+        if (_seeded.TryGetValue(user.Username, out var seeded))
+        {
+            seeded.Totp = user.Totp;
+            seeded.Require2FA = user.Require2FA;
+            return true;
+        }
+
+        if (!_runtime.ContainsKey(user.Username)) return false;
+        _runtime[user.Username] = user;
+        return true;
+    }
 }

--- a/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
+++ b/backend/src/B3.Trading.Api/Auth/InMemoryUserStore.cs
@@ -100,15 +100,16 @@ public sealed class InMemoryUserStore : IUserStore
         }
     }
 
-    public bool TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
+    public RecoveryCodeConsumeResult TryConsumeRecoveryCode(string username, string codeHash, out UserConfig? updatedUser)
     {
         updatedUser = null;
-        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash)) return false;
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(codeHash))
+            return RecoveryCodeConsumeResult.NotFound;
 
         lock (LockFor(username))
         {
             if (!TryGet(username, out var user) || user is null || user.Totp is null)
-                return false;
+                return RecoveryCodeConsumeResult.NotFound;
 
             // Constant-time-ish scan: full pass without early-out so
             // timing leaks no information about which index matched.
@@ -118,12 +119,34 @@ public sealed class InMemoryUserStore : IUserStore
                 if (string.Equals(user.Totp.RecoveryCodes[i], codeHash, StringComparison.Ordinal))
                     idx = i;
             }
-            if (idx < 0) return false;
+            if (idx < 0)
+            {
+                // Distinguish race-loser / replay from a wrong code so
+                // the endpoint can skip the lockout counter increment.
+                for (var i = 0; i < user.Totp.ConsumedRecoveryCodes.Count; i++)
+                {
+                    if (string.Equals(user.Totp.ConsumedRecoveryCodes[i], codeHash, StringComparison.Ordinal))
+                        return RecoveryCodeConsumeResult.AlreadyConsumed;
+                }
+                return RecoveryCodeConsumeResult.NotFound;
+            }
 
             user.Totp.RecoveryCodes.RemoveAt(idx);
+            AppendConsumed(user.Totp, codeHash);
             updatedUser = user;
-            return true;
+            return RecoveryCodeConsumeResult.Consumed;
         }
+    }
+
+    private static void AppendConsumed(UserTotpConfig totp, string codeHash)
+    {
+        // FIFO eviction: drop oldest entries until we're under the
+        // cap. The cap is sized for many enrollments' worth of churn,
+        // so eviction is rare; the loop tolerates a cap reduced via
+        // future config without unbounded growth.
+        while (totp.ConsumedRecoveryCodes.Count >= UserTotpConfig.ConsumedRecoveryCodesCap)
+            totp.ConsumedRecoveryCodes.RemoveAt(0);
+        totp.ConsumedRecoveryCodes.Add(codeHash);
     }
 
     private object LockFor(string username)

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpAttemptTracker.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpAttemptTracker.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// Per-user rate limit for /auth/2fa/verify (#303). Mirrors
+/// <see cref="ILoginAttemptTracker"/> shape but tracks a separate
+/// counter so a TOTP-brute flood does not lock the user out of
+/// password login (and vice-versa). Returns a Retry-After hint so the
+/// endpoint can emit a sensible 429.
+/// </summary>
+public interface ITotpAttemptTracker
+{
+    bool IsLocked(string username, out TimeSpan retryAfter);
+    void RecordFailure(string username);
+    void RecordSuccess(string username);
+}
+
+internal sealed class InMemoryTotpAttemptTracker : ITotpAttemptTracker
+{
+    private const int MaxTrackedUsernames = 50_000;
+
+    private readonly IOptionsMonitor<TotpLockoutOptions> _options;
+    private readonly ILogger<InMemoryTotpAttemptTracker> _logger;
+    private readonly TimeProvider _clock;
+    private readonly ConcurrentDictionary<string, AttemptState> _state =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public InMemoryTotpAttemptTracker(
+        IOptionsMonitor<TotpLockoutOptions> options,
+        ILogger<InMemoryTotpAttemptTracker> logger,
+        TimeProvider clock)
+    {
+        _options = options;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public bool IsLocked(string username, out TimeSpan retryAfter)
+    {
+        retryAfter = TimeSpan.Zero;
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled || string.IsNullOrEmpty(username)) return false;
+        if (!_state.TryGetValue(username, out var st)) return false;
+        lock (st)
+        {
+            if (st.LockedUntil is { } until && until > _clock.GetUtcNow())
+            {
+                retryAfter = until - _clock.GetUtcNow();
+                if (retryAfter < TimeSpan.FromSeconds(1)) retryAfter = TimeSpan.FromSeconds(1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void RecordFailure(string username)
+    {
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled || string.IsNullOrEmpty(username)) return;
+
+        var now = _clock.GetUtcNow();
+        var state = _state.GetOrAdd(username, _ => new AttemptState());
+        bool engaged = false;
+        DateTimeOffset until = default;
+
+        lock (state)
+        {
+            if (state.LockedUntil is { } existing && existing <= now)
+            {
+                state.LockedUntil = null;
+                state.FirstFailure = default;
+                state.FailureCount = 0;
+            }
+            if (state.LockedUntil is not null) return;
+            if (state.FailureCount == 0 || now - state.FirstFailure > opts.Window)
+            {
+                state.FirstFailure = now;
+                state.FailureCount = 0;
+            }
+            state.FailureCount++;
+            if (state.FailureCount >= opts.MaxFailedAttempts)
+            {
+                state.LockedUntil = now + opts.LockoutDuration;
+                engaged = true;
+                until = state.LockedUntil.Value;
+            }
+        }
+
+        if (engaged)
+        {
+            _logger.LogInformation(
+                "TOTP verify lockout engaged for username={Username} until {Until:o}.",
+                username, until);
+        }
+
+        MaybePrune(now, opts);
+    }
+
+    public void RecordSuccess(string username)
+    {
+        if (string.IsNullOrEmpty(username)) return;
+        _state.TryRemove(username, out _);
+    }
+
+    private void MaybePrune(DateTimeOffset now, TotpLockoutOptions opts)
+    {
+        if (_state.Count <= MaxTrackedUsernames) return;
+        foreach (var kvp in _state)
+        {
+            var st = kvp.Value;
+            bool evict;
+            lock (st)
+            {
+                var lockoutClear = st.LockedUntil is null || st.LockedUntil <= now;
+                var windowStale = st.FailureCount == 0 || now - st.FirstFailure > opts.Window;
+                evict = lockoutClear && windowStale;
+            }
+            if (evict)
+            {
+                _state.TryRemove(kvp.Key, out _);
+                if (_state.Count <= MaxTrackedUsernames * 9 / 10) break;
+            }
+        }
+    }
+
+    private sealed class AttemptState
+    {
+        public DateTimeOffset FirstFailure;
+        public int FailureCount;
+        public DateTimeOffset? LockedUntil;
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
@@ -143,15 +143,31 @@ public static class TotpEndpoints
                 }
 
                 var recoveryOk = false;
+                var recoveryAlreadyConsumed = false;
                 if (!totpOk)
                 {
-                    recoveryOk = users.TryConsumeRecoveryCode(
+                    var consumeResult = users.TryConsumeRecoveryCode(
                         user.Username, totp.HashRecoveryCode(req.Code), out _);
+                    recoveryOk = consumeResult == RecoveryCodeConsumeResult.Consumed;
+                    recoveryAlreadyConsumed = consumeResult == RecoveryCodeConsumeResult.AlreadyConsumed;
                 }
 
                 if (!totpOk && !recoveryOk)
                 {
-                    lockout.RecordFailure(ch.Username);
+                    // Race-loser / replay-after-success: the hash WAS a
+                    // real recovery code for this user, just not anymore.
+                    // Reject with the same generic 401 (no info leak —
+                    // identical body to wrong-code) but skip the lockout
+                    // counter so a 10-way concurrent burst presenting
+                    // ONE valid code doesn't auto-lock the user out.
+                    // Trade-off documented on
+                    // UserTotpConfig.ConsumedRecoveryCodes: an attacker
+                    // who already knows a USED code can spam without
+                    // lockout, but that knowledge is strictly weaker
+                    // than the JWT the code produced, and the
+                    // alternative lets attackers brute-force lockout.
+                    if (!recoveryAlreadyConsumed)
+                        lockout.RecordFailure(ch.Username);
                     return Results.Json(new { error = "invalid code" },
                         statusCode: StatusCodes.Status401Unauthorized);
                 }
@@ -234,6 +250,7 @@ public static class TotpEndpoints
             catch { return Results.BadRequest(new { error = "2fa not enrolled" }); }
 
             var (ok, disableStep) = totp.Verify(base32, req.Code);
+            var recoveryAlreadyConsumed = false;
             if (ok)
             {
                 // Replay guard: even on the disable path, a same-window
@@ -250,12 +267,17 @@ public static class TotpEndpoints
                 // Recovery codes can also satisfy disable so a user
                 // who lost their device but kept the codes isn't
                 // stuck.
-                ok = users.TryConsumeRecoveryCode(
+                var consumeResult = users.TryConsumeRecoveryCode(
                     user.Username, totp.HashRecoveryCode(req.Code), out _);
+                ok = consumeResult == RecoveryCodeConsumeResult.Consumed;
+                recoveryAlreadyConsumed = consumeResult == RecoveryCodeConsumeResult.AlreadyConsumed;
             }
             if (!ok)
             {
-                lockout.RecordFailure(subject);
+                // Mirror the verify path: AlreadyConsumed is a benign
+                // replay / race-loser and must not tick lockout.
+                if (!recoveryAlreadyConsumed)
+                    lockout.RecordFailure(subject);
                 return Results.Json(new { error = "invalid code" }, statusCode: StatusCodes.Status401Unauthorized);
             }
 

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
@@ -126,11 +126,27 @@ public static class TotpEndpoints
                     statusCode: StatusCodes.Status401Unauthorized);
                 }
 
-                var totpOk = totp.Verify(base32, req.Code);
+                var (totpOk, matchedStep) = totp.Verify(base32, req.Code);
+                if (totpOk)
+                {
+                    // Atomic replay guard: persist matchedStep only if it
+                    // is strictly greater than the prior step. Two
+                    // concurrent verifies presenting the same valid code
+                    // race here; exactly one wins, the loser is treated
+                    // as an invalid-code attempt (lockout counter ticks).
+                    if (!users.TryRecordTotpUse(ch.Username, matchedStep, out _))
+                    {
+                        lockout.RecordFailure(ch.Username);
+                        return Results.Json(new { error = "invalid code" },
+                            statusCode: StatusCodes.Status401Unauthorized);
+                    }
+                }
+
                 var recoveryOk = false;
                 if (!totpOk)
                 {
-                    recoveryOk = TryConsumeRecoveryCode(user, req.Code, totp, users);
+                    recoveryOk = users.TryConsumeRecoveryCode(
+                        user.Username, totp.HashRecoveryCode(req.Code), out _);
                 }
 
                 if (!totpOk && !recoveryOk)
@@ -162,7 +178,8 @@ public static class TotpEndpoints
             if (!pending.TryConsume(jwtUser.Username, out var enrollment) || enrollment is null)
                 return Results.BadRequest(new { error = "no pending enrollment (expired or never started)" });
 
-            if (!totp.Verify(enrollment.Base32Secret, req.Code))
+            var (enrollOk, enrollStep) = totp.Verify(enrollment.Base32Secret, req.Code);
+            if (!enrollOk)
             {
                 // Re-stash the pending enrollment so the user gets
                 // another shot inside the same 5-min window — typing
@@ -179,6 +196,12 @@ public static class TotpEndpoints
                 SharedSecret = protector.Protect(enrollment.Base32Secret),
                 EnrolledAt = TimeProviderFor(http).GetUtcNow(),
                 RecoveryCodes = enrollment.RecoveryCodeHashes.ToList(),
+                // Seed LastUsedTimeStep with the enrollment-confirm step
+                // so the same code cannot be replayed at login during
+                // the same 30s window (defense-in-depth — the pending
+                // store is single-use, but the property cannot rely on
+                // that).
+                LastUsedTimeStep = enrollStep,
             };
             users.TryUpdate(jwtUser);
             return Results.Ok(new { enrolled = true });
@@ -210,13 +233,25 @@ public static class TotpEndpoints
             try { base32 = protector.Unprotect(user.Totp.SharedSecret); }
             catch { return Results.BadRequest(new { error = "2fa not enrolled" }); }
 
-            var ok = totp.Verify(base32, req.Code);
-            if (!ok)
+            var (ok, disableStep) = totp.Verify(base32, req.Code);
+            if (ok)
+            {
+                // Replay guard: even on the disable path, a same-window
+                // reuse must be rejected so a captured code cannot
+                // disable + JWT-issue back-to-back.
+                if (!users.TryRecordTotpUse(subject, disableStep, out _))
+                {
+                    lockout.RecordFailure(subject);
+                    return Results.Json(new { error = "invalid code" }, statusCode: StatusCodes.Status401Unauthorized);
+                }
+            }
+            else
             {
                 // Recovery codes can also satisfy disable so a user
                 // who lost their device but kept the codes isn't
                 // stuck.
-                ok = TryConsumeRecoveryCode(user, req.Code, totp, users);
+                ok = users.TryConsumeRecoveryCode(
+                    user.Username, totp.HashRecoveryCode(req.Code), out _);
             }
             if (!ok)
             {
@@ -262,28 +297,6 @@ public static class TotpEndpoints
         return true;
     }
 
-    private static bool TryConsumeRecoveryCode(UserConfig user, string code, ITotpService totp, IUserStore users)
-    {
-        if (user.Totp is null) return false;
-        var hash = totp.HashRecoveryCode(code);
-        // Constant-time-ish scan: comparing hex strings of equal length
-        // through SequenceEqual + a full pass avoids leaking which
-        // index matched. For 10 codes this is microseconds.
-        var idx = -1;
-        for (var i = 0; i < user.Totp.RecoveryCodes.Count; i++)
-        {
-            if (string.Equals(user.Totp.RecoveryCodes[i], hash, StringComparison.Ordinal))
-            {
-                idx = i;
-                // intentionally do NOT break — full scan keeps timing
-                // independent of code position.
-            }
-        }
-        if (idx < 0) return false;
-        user.Totp.RecoveryCodes.RemoveAt(idx);
-        users.TryUpdate(user);
-        return true;
-    }
 
     private static TimeProvider TimeProviderFor(HttpContext http)
         => http.RequestServices.GetService(typeof(TimeProvider)) as TimeProvider ?? TimeProvider.System;

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
@@ -1,0 +1,326 @@
+using System.Security.Claims;
+using B3.Trading.Application;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// TOTP (RFC 6238) endpoints for #303. Three routes:
+/// <list type="bullet">
+///   <item><c>POST /auth/2fa/enroll</c> — start enrollment (JWT or
+///   ForceEnroll token). Returns the base32 secret, otpauth URI and
+///   one-time recovery codes.</item>
+///   <item><c>POST /auth/2fa/verify</c> — dual-purpose: confirm a
+///   pending enrollment (JWT mode) OR finish login (challenge-token
+///   mode, accepts TOTP or recovery code).</item>
+///   <item><c>POST /auth/2fa/disable</c> — remove TOTP (JWT, requires
+///   current TOTP code).</item>
+/// </list>
+/// </summary>
+public static class TotpEndpoints
+{
+    public static IEndpointRouteBuilder MapTotp(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/auth/2fa/enroll", (
+            HttpContext http,
+            EnrollRequest? req,
+            IUserStore users,
+            IPendingTotpEnrollmentStore pending,
+            ITotpChallengeStore challenges,
+            ITotpService totp,
+            ITotpSecretProtector protector,
+            IOptions<TotpOptions> opts) =>
+        {
+            // Two auth modes:
+            //   (a) JWT bearer — normal self-service enrollment.
+            //   (b) enrollmentToken from a Require2FA-forced login —
+            //       lets the user bootstrap before they own a JWT.
+            // Either mode resolves to a username; both reuse the rest
+            // of the body path.
+            if (!TryResolveActor(http, req?.EnrollmentToken, challenges, TotpChallengeKind.ForceEnroll, out var username, out var enrollmentToken))
+                return Results.Json(new { error = "unauthorized" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            if (!users.TryGet(username, out var user) || user is null)
+                return Results.Json(new { error = "unauthorized" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            // Block re-enroll if a secret is already active — operators
+            // must disable first. Returning 409 (not 403) matches the
+            // "resource already exists" semantics signup uses.
+            if (user.Totp is { EnrolledAt: not null })
+                return Results.Conflict(new { error = "2fa already enrolled; disable first" });
+
+            var options = opts.Value;
+            var secret = totp.GenerateBase32Secret();
+            var uri = totp.BuildOtpAuthUri(options.Issuer, user.Username, secret);
+            var codes = totp.GenerateRecoveryCodes(options.RecoveryCodeCount);
+            var hashes = codes.Select(totp.HashRecoveryCode).ToList();
+
+            pending.Put(user.Username, new PendingTotpEnrollment(
+                Base32Secret: secret,
+                RecoveryCodes: codes,
+                RecoveryCodeHashes: hashes,
+                CreatedAt: TimeProviderFor(http).GetUtcNow()));
+
+            // ForceEnroll token is consumed once enroll is issued —
+            // client must keep the JWT-less ride going via the standard
+            // /auth/2fa/verify (JWT mode is the alternative for already-
+            // logged-in users).
+            if (enrollmentToken is not null)
+                challenges.Invalidate(enrollmentToken);
+
+            return Results.Ok(new EnrollResponse(
+                Secret: secret,
+                OtpauthUri: uri,
+                RecoveryCodes: codes));
+        });
+
+        app.MapPost("/auth/2fa/verify", (
+            HttpContext http,
+            VerifyRequest req,
+            IUserStore users,
+            JwtIssuer issuer,
+            IPendingTotpEnrollmentStore pending,
+            ITotpChallengeStore challenges,
+            ITotpAttemptTracker lockout,
+            ITotpService totp,
+            ITotpSecretProtector protector,
+            EndClientRegistry registry) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Code))
+                return Results.BadRequest(new { error = "code required" });
+
+            // Mode (b): login-flow second factor. Challenge token wins
+            // over JWT — we never want a stale JWT (somehow held by an
+            // attacker) to short-circuit a fresh 2FA challenge.
+            if (!string.IsNullOrEmpty(req.TotpChallengeToken))
+            {
+                var ch = challenges.Peek(req.TotpChallengeToken);
+                if (ch is null || ch.Kind != TotpChallengeKind.Verify)
+                    return Results.Json(new { error = "invalid or expired challenge" },
+                        statusCode: StatusCodes.Status401Unauthorized);
+
+                if (lockout.IsLocked(ch.Username, out var retry))
+                    return TooManyRequests(retry);
+
+                if (!users.TryGet(ch.Username, out var user) || user is null || user.Totp is null
+                    || user.Totp.EnrolledAt is null || string.IsNullOrEmpty(user.Totp.SharedSecret))
+                {
+                    // Challenge referenced a user that has since lost
+                    // their TOTP. Reject with a generic 401; do NOT
+                    // fall through to JWT issuance — the client should
+                    // re-POST /auth/login (which will not return a
+                    // 2fa challenge for an un-enrolled user).
+                    challenges.Invalidate(req.TotpChallengeToken);
+                    return Results.Json(new { error = "invalid or expired challenge" },
+                        statusCode: StatusCodes.Status401Unauthorized);
+                }
+
+                string base32;
+                try { base32 = protector.Unprotect(user.Totp.SharedSecret); }
+                catch
+                {
+                    return Results.Json(new { error = "invalid or expired challenge" },
+                    statusCode: StatusCodes.Status401Unauthorized);
+                }
+
+                var totpOk = totp.Verify(base32, req.Code);
+                var recoveryOk = false;
+                if (!totpOk)
+                {
+                    recoveryOk = TryConsumeRecoveryCode(user, req.Code, totp, users);
+                }
+
+                if (!totpOk && !recoveryOk)
+                {
+                    lockout.RecordFailure(ch.Username);
+                    return Results.Json(new { error = "invalid code" },
+                        statusCode: StatusCodes.Status401Unauthorized);
+                }
+
+                lockout.RecordSuccess(ch.Username);
+                challenges.Invalidate(req.TotpChallengeToken);
+
+                registry.Register(user.Username);
+                var (jwt, expires) = issuer.Issue(user.Username, user.Role, user.Firm);
+                return Results.Ok(new LoginResponse(jwt, expires));
+            }
+
+            // Mode (a): confirm a pending enrollment. Requires JWT.
+            var subject = http.User?.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            if (string.IsNullOrEmpty(subject))
+                return Results.Json(new { error = "unauthorized" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            if (lockout.IsLocked(subject, out var retryE))
+                return TooManyRequests(retryE);
+
+            if (!users.TryGet(subject, out var jwtUser) || jwtUser is null)
+                return Results.Json(new { error = "unauthorized" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            if (!pending.TryConsume(jwtUser.Username, out var enrollment) || enrollment is null)
+                return Results.BadRequest(new { error = "no pending enrollment (expired or never started)" });
+
+            if (!totp.Verify(enrollment.Base32Secret, req.Code))
+            {
+                // Re-stash the pending enrollment so the user gets
+                // another shot inside the same 5-min window — typing
+                // the wrong code once shouldn't force a fresh /enroll.
+                pending.Put(jwtUser.Username, enrollment);
+                lockout.RecordFailure(jwtUser.Username);
+                return Results.Json(new { error = "invalid code" },
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            lockout.RecordSuccess(jwtUser.Username);
+            jwtUser.Totp = new UserTotpConfig
+            {
+                SharedSecret = protector.Protect(enrollment.Base32Secret),
+                EnrolledAt = TimeProviderFor(http).GetUtcNow(),
+                RecoveryCodes = enrollment.RecoveryCodeHashes.ToList(),
+            };
+            users.TryUpdate(jwtUser);
+            return Results.Ok(new { enrolled = true });
+        });
+
+        app.MapPost("/auth/2fa/disable", (
+            HttpContext http,
+            DisableRequest req,
+            IUserStore users,
+            IPendingTotpEnrollmentStore pending,
+            ITotpAttemptTracker lockout,
+            ITotpService totp,
+            ITotpSecretProtector protector) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Code))
+                return Results.BadRequest(new { error = "current TOTP code required" });
+
+            var subject = http.User?.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            if (string.IsNullOrEmpty(subject))
+                return Results.Json(new { error = "unauthorized" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            if (lockout.IsLocked(subject, out var retry)) return TooManyRequests(retry);
+
+            if (!users.TryGet(subject, out var user) || user is null || user.Totp is null
+                || user.Totp.EnrolledAt is null)
+                return Results.BadRequest(new { error = "2fa not enrolled" });
+
+            string base32;
+            try { base32 = protector.Unprotect(user.Totp.SharedSecret); }
+            catch { return Results.BadRequest(new { error = "2fa not enrolled" }); }
+
+            var ok = totp.Verify(base32, req.Code);
+            if (!ok)
+            {
+                // Recovery codes can also satisfy disable so a user
+                // who lost their device but kept the codes isn't
+                // stuck.
+                ok = TryConsumeRecoveryCode(user, req.Code, totp, users);
+            }
+            if (!ok)
+            {
+                lockout.RecordFailure(subject);
+                return Results.Json(new { error = "invalid code" }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            lockout.RecordSuccess(subject);
+            user.Totp = null;
+            users.TryUpdate(user);
+            pending.Remove(user.Username);
+            return Results.Ok(new { disabled = true });
+        }).RequireAuthorization();
+
+        return app;
+    }
+
+    private static bool TryResolveActor(
+        HttpContext http,
+        string? enrollmentToken,
+        ITotpChallengeStore challenges,
+        TotpChallengeKind expectedKind,
+        out string username,
+        out string? consumedToken)
+    {
+        username = string.Empty;
+        consumedToken = null;
+
+        // Prefer the enrollment token when supplied — operator-forced
+        // first-time enrollment doesn't have a JWT yet.
+        if (!string.IsNullOrEmpty(enrollmentToken))
+        {
+            var ch = challenges.Peek(enrollmentToken);
+            if (ch is null || ch.Kind != expectedKind) return false;
+            username = ch.Username;
+            consumedToken = enrollmentToken;
+            return true;
+        }
+
+        var sub = http.User?.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+        if (string.IsNullOrEmpty(sub) || http.User?.Identity?.IsAuthenticated != true) return false;
+        username = sub;
+        return true;
+    }
+
+    private static bool TryConsumeRecoveryCode(UserConfig user, string code, ITotpService totp, IUserStore users)
+    {
+        if (user.Totp is null) return false;
+        var hash = totp.HashRecoveryCode(code);
+        // Constant-time-ish scan: comparing hex strings of equal length
+        // through SequenceEqual + a full pass avoids leaking which
+        // index matched. For 10 codes this is microseconds.
+        var idx = -1;
+        for (var i = 0; i < user.Totp.RecoveryCodes.Count; i++)
+        {
+            if (string.Equals(user.Totp.RecoveryCodes[i], hash, StringComparison.Ordinal))
+            {
+                idx = i;
+                // intentionally do NOT break — full scan keeps timing
+                // independent of code position.
+            }
+        }
+        if (idx < 0) return false;
+        user.Totp.RecoveryCodes.RemoveAt(idx);
+        users.TryUpdate(user);
+        return true;
+    }
+
+    private static TimeProvider TimeProviderFor(HttpContext http)
+        => http.RequestServices.GetService(typeof(TimeProvider)) as TimeProvider ?? TimeProvider.System;
+
+    private static IResult TooManyRequests(TimeSpan retry)
+    {
+        var seconds = Math.Max(1, (int)Math.Ceiling(retry.TotalSeconds));
+        return Results.Json(
+            new { error = "too many attempts", retryAfterSeconds = seconds },
+            statusCode: StatusCodes.Status429TooManyRequests,
+            contentType: "application/json")
+            .WithRetryAfter(seconds);
+    }
+}
+
+internal static class TotpResultExtensions
+{
+    // Attach Retry-After through a tiny wrapper so the 429 path can
+    // express the standard header without giving up Results.Json's
+    // JSON serialization.
+    public static IResult WithRetryAfter(this IResult inner, int seconds) =>
+        new RetryAfterResult(inner, seconds);
+
+    private sealed class RetryAfterResult : IResult
+    {
+        private readonly IResult _inner;
+        private readonly int _seconds;
+        public RetryAfterResult(IResult inner, int seconds) { _inner = inner; _seconds = seconds; }
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            httpContext.Response.Headers["Retry-After"] = _seconds.ToString();
+            return _inner.ExecuteAsync(httpContext);
+        }
+    }
+}
+
+public sealed record EnrollRequest(string? EnrollmentToken);
+public sealed record EnrollResponse(string Secret, string OtpauthUri, IReadOnlyList<string> RecoveryCodes);
+public sealed record VerifyRequest(string Code, string? TotpChallengeToken);
+public sealed record DisableRequest(string Code);

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpOptions.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpOptions.cs
@@ -1,0 +1,48 @@
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// Configuration for TOTP-based 2FA (#303). Bound from
+/// <c>Trading:Auth:Totp</c>.
+/// </summary>
+public sealed class TotpOptions
+{
+    public const string SectionName = "Trading:Auth:Totp";
+
+    /// <summary>Issuer label shown in authenticator apps.</summary>
+    public string Issuer { get; set; } = "B3";
+
+    /// <summary>How long a pending enrollment stays valid before expiring.</summary>
+    public TimeSpan PendingEnrollmentTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>How long a login-flow TOTP challenge token stays valid.</summary>
+    public TimeSpan ChallengeTokenTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>How many recovery codes are minted at enrollment.</summary>
+    public int RecoveryCodeCount { get; set; } = 10;
+
+    /// <summary>
+    /// Optional override for the Data Protection key ring directory used
+    /// to encrypt TOTP shared secrets at rest. Empty means "reuse the
+    /// host's existing key ring under <c>{DataDirectory}/dp-keys</c>",
+    /// which is the sensible default. Operators wanting a separate ring
+    /// (e.g. <c>/var/lib/b3/data-protection-keys</c>) set this to the
+    /// absolute path.
+    /// </summary>
+    public string KeyRingDirectory { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Lockout policy for TOTP verify attempts (#303). Bound from
+/// <c>Trading:Auth:TotpLockout</c>. Mirrors <see cref="LoginLockoutOptions"/>
+/// but is tracked separately so a TOTP-only flood does not lock the
+/// password login channel and vice-versa.
+/// </summary>
+public sealed class TotpLockoutOptions
+{
+    public const string SectionName = "Trading:Auth:TotpLockout";
+
+    public bool Enabled { get; set; } = true;
+    public int MaxFailedAttempts { get; set; } = 5;
+    public TimeSpan Window { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan LockoutDuration { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpSecretProtector.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpSecretProtector.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// Encrypts / decrypts TOTP shared secrets using ASP.NET Core Data
+/// Protection so the persisted user file (<c>users.json</c>) never
+/// contains plaintext base32 secrets. A leaked file alone is useless
+/// without the host's data-protection key ring.
+/// </summary>
+public interface ITotpSecretProtector
+{
+    /// <summary>Encrypts a base32 shared secret for at-rest storage.</summary>
+    string Protect(string base32Secret);
+
+    /// <summary>Reverses <see cref="Protect"/>; throws on tamper.</summary>
+    string Unprotect(string protectedSecret);
+}
+
+internal sealed class TotpSecretProtector : ITotpSecretProtector
+{
+    // Stable purpose string. Changing this rotates secrets out of the
+    // existing protection envelope, so it is a one-way migration.
+    private const string Purpose = "B3.Trading.Api.Auth.Totp.SharedSecret.v1";
+
+    private readonly IDataProtector _protector;
+
+    public TotpSecretProtector(IDataProtectionProvider provider)
+    {
+        _protector = provider.CreateProtector(Purpose);
+    }
+
+    public string Protect(string base32Secret)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(base32Secret);
+        return _protector.Protect(base32Secret);
+    }
+
+    public string Unprotect(string protectedSecret)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(protectedSecret);
+        return _protector.Unprotect(protectedSecret);
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpService.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpService.cs
@@ -24,8 +24,10 @@ public interface ITotpService
     /// Verifies <paramref name="code"/> against <paramref name="base32Secret"/>.
     /// Accepts the previous + current + next step (±1 window) so a code
     /// generated at second 29 is still valid when received at second 30.
+    /// Returns the matched RFC 6238 time step on success so callers can
+    /// persist it and reject same-step replays.
     /// </summary>
-    bool Verify(string base32Secret, string code);
+    (bool Valid, long MatchedStep) Verify(string base32Secret, string code);
 
     /// <summary>Generate <paramref name="count"/> human-friendly recovery codes.</summary>
     IReadOnlyList<string> GenerateRecoveryCodes(int count);
@@ -55,22 +57,23 @@ internal sealed class TotpService : ITotpService
         return $"otpauth://totp/{encIssuer}:{encUser}?secret={base32Secret}&issuer={encIssuer}&algorithm=SHA1&digits=6&period=30";
     }
 
-    public bool Verify(string base32Secret, string code)
+    public (bool Valid, long MatchedStep) Verify(string base32Secret, string code)
     {
         if (string.IsNullOrWhiteSpace(base32Secret) || string.IsNullOrWhiteSpace(code))
-            return false;
+            return (false, 0);
 
         // Strip whitespace so users pasting "123 456" from authenticator
         // apps don't get a needless rejection.
         var trimmed = new string(code.Where(c => !char.IsWhiteSpace(c)).ToArray());
-        if (trimmed.Length != 6 || !trimmed.All(char.IsDigit)) return false;
+        if (trimmed.Length != 6 || !trimmed.All(char.IsDigit)) return (false, 0);
 
         byte[] secret;
         try { secret = Base32Encoding.ToBytes(base32Secret); }
-        catch (ArgumentException) { return false; }
+        catch (ArgumentException) { return (false, 0); }
 
         var totp = new OtpNet.Totp(secret);
-        return totp.VerifyTotp(trimmed, out _, new VerificationWindow(previous: 1, future: 1));
+        var ok = totp.VerifyTotp(trimmed, out var matchedStep, new VerificationWindow(previous: 1, future: 1));
+        return (ok, matchedStep);
     }
 
     public IReadOnlyList<string> GenerateRecoveryCodes(int count)

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpService.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpService.cs
@@ -1,0 +1,112 @@
+using System.Security.Cryptography;
+using System.Text;
+using OtpNet;
+
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// Pure helpers for generating, encoding and verifying TOTP material
+/// per RFC 6238 (SHA-1, 6 digits, 30-second step). Wraps Otp.NET so
+/// the rest of the codebase has a single seam.
+/// </summary>
+public interface ITotpService
+{
+    /// <summary>Generate a fresh 20-byte (160-bit) base32 shared secret.</summary>
+    string GenerateBase32Secret();
+
+    /// <summary>
+    /// Build the standard otpauth URI consumed by Google Authenticator,
+    /// 1Password, Authy, etc.
+    /// </summary>
+    string BuildOtpAuthUri(string issuer, string username, string base32Secret);
+
+    /// <summary>
+    /// Verifies <paramref name="code"/> against <paramref name="base32Secret"/>.
+    /// Accepts the previous + current + next step (±1 window) so a code
+    /// generated at second 29 is still valid when received at second 30.
+    /// </summary>
+    bool Verify(string base32Secret, string code);
+
+    /// <summary>Generate <paramref name="count"/> human-friendly recovery codes.</summary>
+    IReadOnlyList<string> GenerateRecoveryCodes(int count);
+
+    /// <summary>One-way hash used to store / compare recovery codes.</summary>
+    string HashRecoveryCode(string code);
+}
+
+internal sealed class TotpService : ITotpService
+{
+    // 20 bytes (160 bits) is the SHA-1 RFC 4226 recommendation.
+    private const int SecretByteLength = 20;
+
+    public string GenerateBase32Secret()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(SecretByteLength);
+        return Base32Encoding.ToString(bytes).TrimEnd('=');
+    }
+
+    public string BuildOtpAuthUri(string issuer, string username, string base32Secret)
+    {
+        var encIssuer = Uri.EscapeDataString(issuer);
+        var encUser = Uri.EscapeDataString(username);
+        // Label is "Issuer:User" so authenticator apps show it grouped
+        // under the issuer; query string repeats issuer per the de-facto
+        // Google Authenticator extension.
+        return $"otpauth://totp/{encIssuer}:{encUser}?secret={base32Secret}&issuer={encIssuer}&algorithm=SHA1&digits=6&period=30";
+    }
+
+    public bool Verify(string base32Secret, string code)
+    {
+        if (string.IsNullOrWhiteSpace(base32Secret) || string.IsNullOrWhiteSpace(code))
+            return false;
+
+        // Strip whitespace so users pasting "123 456" from authenticator
+        // apps don't get a needless rejection.
+        var trimmed = new string(code.Where(c => !char.IsWhiteSpace(c)).ToArray());
+        if (trimmed.Length != 6 || !trimmed.All(char.IsDigit)) return false;
+
+        byte[] secret;
+        try { secret = Base32Encoding.ToBytes(base32Secret); }
+        catch (ArgumentException) { return false; }
+
+        var totp = new OtpNet.Totp(secret);
+        return totp.VerifyTotp(trimmed, out _, new VerificationWindow(previous: 1, future: 1));
+    }
+
+    public IReadOnlyList<string> GenerateRecoveryCodes(int count)
+    {
+        if (count <= 0) return Array.Empty<string>();
+        // 10 chars from a 32-symbol alphabet (Crockford-ish, no I/O/0/1
+        // to avoid confusion). Formatted "XXXXX-XXXXX" for legibility.
+        // 32^10 ≈ 1.1e15: more than enough for a 10-code budget that
+        // gets rotated on disable/re-enroll.
+        const string alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        var codes = new List<string>(count);
+        Span<byte> buf = stackalloc byte[10];
+        for (var i = 0; i < count; i++)
+        {
+            RandomNumberGenerator.Fill(buf);
+            var sb = new StringBuilder(11);
+            for (var j = 0; j < buf.Length; j++)
+            {
+                if (j == 5) sb.Append('-');
+                sb.Append(alphabet[buf[j] & 31]);
+            }
+            codes.Add(sb.ToString());
+        }
+        return codes;
+    }
+
+    public string HashRecoveryCode(string code)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(code);
+        // Recovery codes carry ~50 bits of entropy each — plenty for
+        // SHA-256 without an additional salt/iteration scheme. Normalize
+        // to uppercase + strip dashes/whitespace so user typing variants
+        // (with or without the formatting dash) all hash identically.
+        var canonical = new string(code.Where(c => !char.IsWhiteSpace(c) && c != '-')
+            .Select(char.ToUpperInvariant).ToArray());
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        return Convert.ToHexString(bytes);
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpStores.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpStores.cs
@@ -1,0 +1,155 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.Auth.Totp;
+
+/// <summary>
+/// In-memory bag of TOTP enrollments that have been started but not
+/// yet confirmed. An entry lives for <see cref="TotpOptions.PendingEnrollmentTtl"/>
+/// (default 5 min) then is treated as expired. Single-host only —
+/// matches the rest of the auth stack (<see cref="InMemoryLoginAttemptTracker"/>,
+/// <see cref="InMemoryUserStore"/>).
+/// </summary>
+public interface IPendingTotpEnrollmentStore
+{
+    /// <summary>Stash a pending enrollment, overwriting any prior one for the user.</summary>
+    void Put(string username, PendingTotpEnrollment enrollment);
+
+    /// <summary>Pop the pending enrollment (consume on confirm).</summary>
+    bool TryConsume(string username, out PendingTotpEnrollment? enrollment);
+
+    /// <summary>Drop a pending enrollment without consuming (e.g. on disable).</summary>
+    void Remove(string username);
+}
+
+public sealed record PendingTotpEnrollment(
+    string Base32Secret,
+    IReadOnlyList<string> RecoveryCodes,
+    IReadOnlyList<string> RecoveryCodeHashes,
+    DateTimeOffset CreatedAt);
+
+internal sealed class InMemoryPendingTotpEnrollmentStore : IPendingTotpEnrollmentStore
+{
+    private readonly ConcurrentDictionary<string, PendingTotpEnrollment> _entries =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly IOptionsMonitor<TotpOptions> _options;
+    private readonly TimeProvider _clock;
+
+    public InMemoryPendingTotpEnrollmentStore(IOptionsMonitor<TotpOptions> options, TimeProvider clock)
+    {
+        _options = options;
+        _clock = clock;
+    }
+
+    public void Put(string username, PendingTotpEnrollment enrollment)
+    {
+        if (string.IsNullOrEmpty(username)) return;
+        _entries[username] = enrollment;
+    }
+
+    public bool TryConsume(string username, out PendingTotpEnrollment? enrollment)
+    {
+        enrollment = null;
+        if (string.IsNullOrEmpty(username)) return false;
+        if (!_entries.TryRemove(username, out var found)) return false;
+        if (_clock.GetUtcNow() - found.CreatedAt > _options.CurrentValue.PendingEnrollmentTtl)
+            return false;
+        enrollment = found;
+        return true;
+    }
+
+    public void Remove(string username)
+    {
+        if (string.IsNullOrEmpty(username)) return;
+        _entries.TryRemove(username, out _);
+    }
+}
+
+/// <summary>
+/// Short-lived opaque tokens minted by <c>/auth/login</c> when the
+/// caller still has to clear the second factor. The token is bound to
+/// the username + a flag indicating whether it grants completion of
+/// 2FA verification (existing enrollment) or kicks off forced
+/// enrollment (<see cref="UserConfig.Require2FA"/> with no secret yet).
+/// </summary>
+public interface ITotpChallengeStore
+{
+    /// <summary>Create + persist a fresh challenge; returns the opaque token.</summary>
+    string Issue(string username, TotpChallengeKind kind);
+
+    /// <summary>
+    /// Look up a challenge by token. Returns null when unknown or
+    /// expired. Does NOT consume — the caller decides whether to
+    /// invalidate on success vs. leave for retries.
+    /// </summary>
+    TotpChallenge? Peek(string token);
+
+    /// <summary>Permanently invalidate a challenge (e.g. on successful 2FA).</summary>
+    void Invalidate(string token);
+}
+
+public enum TotpChallengeKind
+{
+    /// <summary>User has TOTP enrolled; client must POST a code.</summary>
+    Verify = 0,
+
+    /// <summary>User has <see cref="UserConfig.Require2FA"/> set but hasn't enrolled — client must POST /auth/2fa/enroll using this token.</summary>
+    ForceEnroll = 1,
+}
+
+public sealed record TotpChallenge(
+    string Username,
+    TotpChallengeKind Kind,
+    DateTimeOffset IssuedAt);
+
+internal sealed class InMemoryTotpChallengeStore : ITotpChallengeStore
+{
+    private readonly ConcurrentDictionary<string, TotpChallenge> _entries = new(StringComparer.Ordinal);
+    private readonly IOptionsMonitor<TotpOptions> _options;
+    private readonly TimeProvider _clock;
+
+    public InMemoryTotpChallengeStore(IOptionsMonitor<TotpOptions> options, TimeProvider clock)
+    {
+        _options = options;
+        _clock = clock;
+    }
+
+    public string Issue(string username, TotpChallengeKind kind)
+    {
+        // 32 bytes of CSPRNG → base64url (43 chars). Indistinguishable
+        // from session-token shape, intentionally opaque to clients.
+        var token = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+        _entries[token] = new TotpChallenge(username, kind, _clock.GetUtcNow());
+        return token;
+    }
+
+    public TotpChallenge? Peek(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+        if (!_entries.TryGetValue(token, out var ch)) return null;
+        if (_clock.GetUtcNow() - ch.IssuedAt > _options.CurrentValue.ChallengeTokenTtl)
+        {
+            _entries.TryRemove(token, out _);
+            return null;
+        }
+        return ch;
+    }
+
+    public void Invalidate(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return;
+        _entries.TryRemove(token, out _);
+    }
+}
+
+internal static class WebEncoders
+{
+    // Tiny base64url shim to avoid pulling in
+    // Microsoft.AspNetCore.WebUtilities just for a 6-line helper.
+    public static string Base64UrlEncode(byte[] data)
+    {
+        var s = Convert.ToBase64String(data);
+        return s.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpStores.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpStores.cs
@@ -45,6 +45,7 @@ internal sealed class InMemoryPendingTotpEnrollmentStore : IPendingTotpEnrollmen
     public void Put(string username, PendingTotpEnrollment enrollment)
     {
         if (string.IsNullOrEmpty(username)) return;
+        PurgeExpired();
         _entries[username] = enrollment;
     }
 
@@ -52,6 +53,7 @@ internal sealed class InMemoryPendingTotpEnrollmentStore : IPendingTotpEnrollmen
     {
         enrollment = null;
         if (string.IsNullOrEmpty(username)) return false;
+        PurgeExpired();
         if (!_entries.TryRemove(username, out var found)) return false;
         if (_clock.GetUtcNow() - found.CreatedAt > _options.CurrentValue.PendingEnrollmentTtl)
             return false;
@@ -62,7 +64,24 @@ internal sealed class InMemoryPendingTotpEnrollmentStore : IPendingTotpEnrollmen
     public void Remove(string username)
     {
         if (string.IsNullOrEmpty(username)) return;
+        PurgeExpired();
         _entries.TryRemove(username, out _);
+    }
+
+    // Opportunistic sweep: every mutating call drops expired entries.
+    // Single-host in-memory store + low-frequency call site (enrollment
+    // is rare) makes a background timer overkill; piggy-backing on the
+    // normal traffic keeps _entries from growing unbounded for users
+    // who Put once and never Consume.
+    private void PurgeExpired()
+    {
+        var ttl = _options.CurrentValue.PendingEnrollmentTtl;
+        var now = _clock.GetUtcNow();
+        foreach (var kvp in _entries)
+        {
+            if (now - kvp.Value.CreatedAt > ttl)
+                _entries.TryRemove(kvp.Key, out _);
+        }
     }
 }
 

--- a/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
+++ b/backend/src/B3.Trading.Api/B3.Trading.Api.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Otp.NET" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 

--- a/backend/src/B3.Trading.Host/Composition/TradingAuthServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingAuthServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Api.Auth;
+using B3.Trading.Api.Auth.Totp;
 using B3.Trading.Application;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
@@ -30,7 +31,16 @@ public static class TradingAuthServiceCollectionExtensions
             configuration.GetSection(UserStoreOptions.SectionName));
         services.Configure<LoginLockoutOptions>(
             configuration.GetSection(LoginLockoutOptions.SectionName));
+        services.Configure<TotpOptions>(
+            configuration.GetSection(TotpOptions.SectionName));
+        services.Configure<TotpLockoutOptions>(
+            configuration.GetSection(TotpLockoutOptions.SectionName));
         services.AddSingleton<ILoginAttemptTracker, InMemoryLoginAttemptTracker>();
+        services.AddSingleton<ITotpAttemptTracker, InMemoryTotpAttemptTracker>();
+        services.AddSingleton<ITotpService, TotpService>();
+        services.AddSingleton<ITotpSecretProtector, TotpSecretProtector>();
+        services.AddSingleton<IPendingTotpEnrollmentStore, InMemoryPendingTotpEnrollmentStore>();
+        services.AddSingleton<ITotpChallengeStore, InMemoryTotpChallengeStore>();
         services.AddAuthRateLimiter();
 
         // Slice 3 of #97: when Trading:Auth:UserStore:Enabled is true (the

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -1,5 +1,6 @@
 using B3.Trading.Api;
 using B3.Trading.Api.Auth;
+using B3.Trading.Api.Auth.Totp;
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
@@ -25,6 +26,7 @@ public static class TradingEndpointsExtensions
         app.MapHealth();
 
         app.MapAuth();
+        app.MapTotp();
         app.MapOrders();
         app.MapHistory();
         app.MapAlgo();

--- a/backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj
+++ b/backend/tests/B3.Trading.Api.Tests/B3.Trading.Api.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Otp.NET" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.Auth.Totp;
+using OtpNet;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Integration tests for the TOTP 2FA flow (#303). Cover enrollment,
+/// login second factor, recovery codes, lockout, disable, pending
+/// expiry, encrypted-at-rest, multi-firm, and the non-enrolled
+/// no-change path.
+/// </summary>
+public class TotpEndpointTests
+{
+    private static string ComputeCode(string base32)
+    {
+        var totp = new OtpNet.Totp(Base32Encoding.ToBytes(base32));
+        return totp.ComputeTotp();
+    }
+
+    private sealed record EnrollResponseDto(string Secret, string OtpauthUri, List<string> RecoveryCodes);
+    private sealed record LoginRequiresDto(bool Requires2fa, string TotpChallengeToken);
+
+    [Fact]
+    public async Task NonEnrolledLogin_BehavesAsBefore_NoRequires2fa()
+    {
+        await using var factory = new TestAppFactory();
+        var http = factory.CreateClient();
+        var resp = await http.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wonderland" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(body.TryGetProperty("token", out var tokenEl));
+        Assert.False(string.IsNullOrEmpty(tokenEl.GetString()));
+        Assert.False(body.TryGetProperty("requires2fa", out _));
+    }
+
+    [Fact]
+    public async Task Enroll_Verify_Activates_AndSubsequentLoginReturnsRequires2fa()
+    {
+        await using var factory = new TestAppFactory();
+        var http = await factory.CreateAuthedClientAsync();
+
+        var enrollResp = await http.PostAsJsonAsync("/auth/2fa/enroll", new { });
+        Assert.Equal(HttpStatusCode.OK, enrollResp.StatusCode);
+        var enroll = await enrollResp.Content.ReadFromJsonAsync<EnrollResponseDto>();
+        Assert.NotNull(enroll);
+        Assert.Equal(10, enroll!.RecoveryCodes.Count);
+        Assert.StartsWith("otpauth://totp/B3:alice?", enroll.OtpauthUri);
+
+        var code = ComputeCode(enroll.Secret);
+        var verifyResp = await http.PostAsJsonAsync("/auth/2fa/verify", new { code });
+        Assert.Equal(HttpStatusCode.OK, verifyResp.StatusCode);
+
+        // Subsequent login: returns challenge token, NOT a JWT.
+        var plainClient = factory.CreateClient();
+        var login = await plainClient.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wonderland" });
+        Assert.Equal(HttpStatusCode.OK, login.StatusCode);
+        var loginBody = await login.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(loginBody.GetProperty("requires2fa").GetBoolean());
+        var challenge = loginBody.GetProperty("totpChallengeToken").GetString();
+        Assert.False(string.IsNullOrEmpty(challenge));
+
+        // Now /auth/2fa/verify with the challenge + a fresh code → real JWT.
+        var freshCode = ComputeCode(enroll.Secret);
+        var second = await plainClient.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = freshCode, totpChallengeToken = challenge });
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        var jwtBody = await second.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.False(string.IsNullOrEmpty(jwtBody.GetProperty("token").GetString()));
+    }
+
+    [Fact]
+    public async Task Login_InvalidCode_Rejected_FiveWrong_Lock429()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:TotpLockout:Enabled"] = "true",
+            ["Trading:Auth:TotpLockout:MaxFailedAttempts"] = "5",
+            ["Trading:Auth:TotpLockout:Window"] = "00:05:00",
+            ["Trading:Auth:TotpLockout:LockoutDuration"] = "00:05:00",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        var plain = factory.CreateClient();
+        var loginBody = await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>();
+        var challenge = loginBody!.TotpChallengeToken;
+
+        for (var i = 0; i < 5; i++)
+        {
+            var r = await plain.PostAsJsonAsync("/auth/2fa/verify",
+                new { code = "000000", totpChallengeToken = challenge });
+            Assert.Equal(HttpStatusCode.Unauthorized, r.StatusCode);
+        }
+
+        var locked = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = ComputeCode(enroll.Secret), totpChallengeToken = challenge });
+        Assert.Equal(HttpStatusCode.TooManyRequests, locked.StatusCode);
+        Assert.NotNull(locked.Headers.RetryAfter);
+    }
+
+    [Fact]
+    public async Task RecoveryCode_AcceptedOnce_SecondUseRejected()
+    {
+        await using var factory = new TestAppFactory();
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        var recovery = enroll.RecoveryCodes[0];
+
+        var plain = factory.CreateClient();
+        var login1 = await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>();
+        var first = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = recovery, totpChallengeToken = login1!.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        // Second login attempt with the same recovery code: must be rejected.
+        var login2 = await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>();
+        var second = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = recovery, totpChallengeToken = login2!.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task Disable_RequiresCurrentCode_ThenReEnrollWorks()
+    {
+        await using var factory = new TestAppFactory();
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        // Wrong code: rejected.
+        var bad = await http.PostAsJsonAsync("/auth/2fa/disable", new { code = "000000" });
+        Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+
+        // Correct code: disables.
+        var ok = await http.PostAsJsonAsync("/auth/2fa/disable", new { code = ComputeCode(enroll.Secret) });
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+
+        // Re-enroll works (no 409 because disabled cleared the prior state).
+        var reenroll = await http.PostAsJsonAsync("/auth/2fa/enroll", new { });
+        Assert.Equal(HttpStatusCode.OK, reenroll.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReEnrollBlockedWhenAlreadyEnrolled()
+    {
+        await using var factory = new TestAppFactory();
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        var reenroll = await http.PostAsJsonAsync("/auth/2fa/enroll", new { });
+        Assert.Equal(HttpStatusCode.Conflict, reenroll.StatusCode);
+    }
+
+    [Fact]
+    public async Task PendingEnrollment_ExpiresAfterTtl()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:Totp:PendingEnrollmentTtl"] = "00:00:01",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await Task.Delay(1500);
+
+        var verify = await http.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = ComputeCode(enroll.Secret) });
+        Assert.Equal(HttpStatusCode.BadRequest, verify.StatusCode);
+    }
+
+    [Fact]
+    public async Task SharedSecret_PersistedEncrypted_NotPlaintextBase32()
+    {
+        // Use the file-backed user store + a signup user so we can
+        // inspect users.json on disk.
+        var dir = Path.Combine(Path.GetTempPath(), "b3-303-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var usersPath = Path.Combine(dir, "users.json");
+            await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+            {
+                ["Trading:Auth:UserStore:Enabled"] = "true",
+                ["Trading:Auth:UserStore:FilePath"] = usersPath,
+                ["Trading:Persistence:DataDirectory"] = dir,
+            });
+
+            var http = factory.CreateClient();
+            var signup = await http.PostAsJsonAsync("/auth/signup",
+                new { username = "carol", password = "Wonderland1!" });
+            signup.EnsureSuccessStatusCode();
+            var token = (await signup.Content.ReadFromJsonAsync<LoginResponse>())!.Token;
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+                .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+            await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+            var json = await File.ReadAllTextAsync(usersPath);
+            Assert.Contains("carol", json);
+            // The plaintext base32 secret must NOT appear verbatim.
+            Assert.DoesNotContain(enroll.Secret, json);
+            // Sanity: the encrypted blob is present under SharedSecret.
+            Assert.Contains("\"SharedSecret\"", json);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task MultiFirm_DifferentUsernamesHaveIndependentTotp()
+    {
+        // Design pin (#303): TOTP is keyed by username. Each username
+        // maps to exactly one firm in the current user store, so this
+        // is naturally per-(user, firm). Two users in different firms
+        // enroll independently; one's secret does not validate the
+        // other's challenge.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:Users:1:Firm"] = "FIRM02",
+        });
+        var aliceClient = await factory.CreateAuthedClientAsync("alice", "wonderland");
+        var bobClient = await factory.CreateAuthedClientAsync("bob", "wonderland");
+
+        var aliceEnroll = (await (await aliceClient.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        var bobEnroll = (await (await bobClient.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        Assert.NotEqual(aliceEnroll.Secret, bobEnroll.Secret);
+
+        await aliceClient.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(aliceEnroll.Secret) });
+        await bobClient.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(bobEnroll.Secret) });
+
+        // alice's challenge cannot be cleared with bob's code.
+        var plain = factory.CreateClient();
+        var ch = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var crossed = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = ComputeCode(bobEnroll.Secret), totpChallengeToken = ch.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, crossed.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
@@ -304,12 +304,16 @@ public class TotpEndpointTests
     {
         // 10 racing verify requests presenting the SAME recovery code
         // must result in exactly one 200 — the store consumes
-        // atomically.
+        // atomically. The 9 race-losers must NOT tick the TOTP lockout
+        // counter (they presented a real code; only the race lost), so
+        // even with the default MaxFailedAttempts=5 a 10-way race must
+        // leave the account fully unlocked.
         await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
         {
-            // Lockout off so the 9 losers don't trip 429 and mask the
-            // 401 the test is actually checking for.
-            ["Trading:Auth:TotpLockout:Enabled"] = "false",
+            ["Trading:Auth:TotpLockout:Enabled"] = "true",
+            ["Trading:Auth:TotpLockout:MaxFailedAttempts"] = "5",
+            ["Trading:Auth:TotpLockout:Window"] = "00:05:00",
+            ["Trading:Auth:TotpLockout:LockoutDuration"] = "00:05:00",
         });
         var http = await factory.CreateAuthedClientAsync();
         var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
@@ -344,7 +348,119 @@ public class TotpEndpointTests
         Assert.Equal(1, successes);
         Assert.Equal(N - 1, failures);
 
+        // Lockout counter must still be 0: walk to MaxFailedAttempts
+        // truly-wrong codes and observe the FIRST 5 return 401 then
+        // the 6th trips 429 (the 5th call ticks the counter to 5 and
+        // sets LockedUntil, but the IsLocked check runs at the TOP of
+        // the next request). If race-losers had ticked the counter,
+        // the very first wrong code below would already be 429.
+        var plain = factory.CreateClient();
+        for (var i = 0; i < 5; i++)
+        {
+            var login = (await (await plain.PostAsJsonAsync("/auth/login",
+                new { username = "alice", password = "wonderland" }))
+                .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+            var wrong = await plain.PostAsJsonAsync("/auth/2fa/verify",
+                new { code = "wrong-recovery-code-xyz", totpChallengeToken = login.TotpChallengeToken });
+            Assert.Equal(HttpStatusCode.Unauthorized, wrong.StatusCode);
+        }
+        var sixthLogin = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var locked = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = "wrong-recovery-code-xyz", totpChallengeToken = sixthLogin.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.TooManyRequests, locked.StatusCode);
+
         foreach (var c in clients) c.Dispose();
+        plain.Dispose();
+    }
+
+    [Fact]
+    public async Task RecoveryCode_ReplayAfterSuccess_RejectedButDoesNotIncrementLockout()
+    {
+        // A client that successfully used a recovery code and then —
+        // due to retry, page reload, or replay attempt — submits the
+        // same code again must get 401 (same as wrong) but the
+        // lockout counter must NOT tick. Otherwise a single replayed
+        // success could chew up a sizeable chunk of the lockout
+        // budget for no security gain.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:TotpLockout:Enabled"] = "true",
+            ["Trading:Auth:TotpLockout:MaxFailedAttempts"] = "5",
+            ["Trading:Auth:TotpLockout:Window"] = "00:05:00",
+            ["Trading:Auth:TotpLockout:LockoutDuration"] = "00:05:00",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+        var recovery = enroll.RecoveryCodes[0];
+
+        var plain = factory.CreateClient();
+        var login1 = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var ok = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = recovery, totpChallengeToken = login1.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+
+        // Replay the SAME recovery code (simulating the 5-minutes-later
+        // retry the spec calls out — wall-clock here is irrelevant
+        // because consumed status is permanent within the user record).
+        for (var i = 0; i < 6; i++)
+        {
+            var loginR = (await (await plain.PostAsJsonAsync("/auth/login",
+                new { username = "alice", password = "wonderland" }))
+                .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+            var replay = await plain.PostAsJsonAsync("/auth/2fa/verify",
+                new { code = recovery, totpChallengeToken = loginR.TotpChallengeToken });
+            // Always 401 (no info leak vs wrong code), never 429 —
+            // proves lockout counter never moved off 0.
+            Assert.Equal(HttpStatusCode.Unauthorized, replay.StatusCode);
+        }
+
+        plain.Dispose();
+    }
+
+    [Fact]
+    public async Task RecoveryCode_TrulyWrongCodes_StillEngageLockout()
+    {
+        // Sanity check that the AlreadyConsumed silent-path didn't
+        // accidentally disarm the wrong-code path: 5 genuinely wrong
+        // codes (never enrolled for this user) MUST lock the account.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:TotpLockout:Enabled"] = "true",
+            ["Trading:Auth:TotpLockout:MaxFailedAttempts"] = "5",
+            ["Trading:Auth:TotpLockout:Window"] = "00:05:00",
+            ["Trading:Auth:TotpLockout:LockoutDuration"] = "00:05:00",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        var plain = factory.CreateClient();
+        // First 5 wrong → 401 (the 5th call ticks the counter to 5 and
+        // engages the lock), 6th request hits the IsLocked check → 429.
+        for (var i = 0; i < 5; i++)
+        {
+            var login = (await (await plain.PostAsJsonAsync("/auth/login",
+                new { username = "alice", password = "wonderland" }))
+                .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+            var wrong = await plain.PostAsJsonAsync("/auth/2fa/verify",
+                new { code = $"never-issued-{i}", totpChallengeToken = login.TotpChallengeToken });
+            Assert.Equal(HttpStatusCode.Unauthorized, wrong.StatusCode);
+        }
+        var lastLogin = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var locked = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = "never-issued-final", totpChallengeToken = lastLogin.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.TooManyRequests, locked.StatusCode);
+
+        plain.Dispose();
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TotpEndpointTests.cs
@@ -17,10 +17,15 @@ namespace B3.Trading.Api.Tests;
 /// </summary>
 public class TotpEndpointTests
 {
-    private static string ComputeCode(string base32)
+    private static string ComputeCode(string base32, int stepOffset = 0)
     {
         var totp = new OtpNet.Totp(Base32Encoding.ToBytes(base32));
-        return totp.ComputeTotp();
+        // OtpNet computes against the supplied DateTime (UTC). Offset
+        // by N * 30s to produce a code one or more RFC 6238 steps in
+        // the future — used by tests that need a distinct step from a
+        // prior verify (the server now rejects same-step replays).
+        var when = DateTime.UtcNow.AddSeconds(stepOffset * 30.0);
+        return totp.ComputeTotp(when);
     }
 
     private sealed record EnrollResponseDto(string Secret, string OtpauthUri, List<string> RecoveryCodes);
@@ -66,7 +71,9 @@ public class TotpEndpointTests
         Assert.False(string.IsNullOrEmpty(challenge));
 
         // Now /auth/2fa/verify with the challenge + a fresh code → real JWT.
-        var freshCode = ComputeCode(enroll.Secret);
+        // Use step offset = 1 to advance past the step consumed during
+        // enrollment confirm (server seeds LastUsedTimeStep there).
+        var freshCode = ComputeCode(enroll.Secret, stepOffset: 1);
         var second = await plainClient.PostAsJsonAsync("/auth/2fa/verify",
             new { code = freshCode, totpChallengeToken = challenge });
         Assert.Equal(HttpStatusCode.OK, second.StatusCode);
@@ -149,8 +156,10 @@ public class TotpEndpointTests
         var bad = await http.PostAsJsonAsync("/auth/2fa/disable", new { code = "000000" });
         Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
 
-        // Correct code: disables.
-        var ok = await http.PostAsJsonAsync("/auth/2fa/disable", new { code = ComputeCode(enroll.Secret) });
+        // Correct code: disables. Offset by one step so we don't trip
+        // the same-window replay guard against the enrollment-confirm
+        // step.
+        var ok = await http.PostAsJsonAsync("/auth/2fa/disable", new { code = ComputeCode(enroll.Secret, stepOffset: 1) });
         Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
 
         // Re-enroll works (no 409 because disabled cleared the prior state).
@@ -227,6 +236,168 @@ public class TotpEndpointTests
         {
             try { Directory.Delete(dir, recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public async Task TotpCode_ReusedWithinSameStep_RejectedAndIncrementsLockout()
+    {
+        // Same valid TOTP code presented twice through two distinct
+        // challenge tokens must be accepted exactly once. Second use
+        // looks like an invalid-code attempt (401 + lockout tick).
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:Auth:TotpLockout:Enabled"] = "true",
+            ["Trading:Auth:TotpLockout:MaxFailedAttempts"] = "5",
+            ["Trading:Auth:TotpLockout:Window"] = "00:05:00",
+            ["Trading:Auth:TotpLockout:LockoutDuration"] = "00:05:00",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+
+        var plain = factory.CreateClient();
+        // Offset by 1 so the test code is NOT the one consumed during
+        // enrollment confirm (which already seeded LastUsedTimeStep).
+        var code = ComputeCode(enroll.Secret, stepOffset: 1);
+
+        // First login: code accepted, JWT issued.
+        var login1 = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var ok1 = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code, totpChallengeToken = login1.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.OK, ok1.StatusCode);
+        Assert.False(string.IsNullOrEmpty(
+            (await ok1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("token").GetString()));
+
+        // Second login with SAME code via a fresh challenge: rejected
+        // with the same shape as a wrong code (401 + {"error":"invalid code"}).
+        var login2 = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var bad = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code, totpChallengeToken = login2.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+        var badBody = await bad.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("invalid code", badBody.GetProperty("error").GetString());
+
+        // Lockout counter ticked: 4 more wrong attempts should trip 429.
+        for (var i = 0; i < 4; i++)
+        {
+            var login = (await (await plain.PostAsJsonAsync("/auth/login",
+                new { username = "alice", password = "wonderland" }))
+                .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+            await plain.PostAsJsonAsync("/auth/2fa/verify",
+                new { code = "000000", totpChallengeToken = login.TotpChallengeToken });
+        }
+        var lockedLogin = (await (await plain.PostAsJsonAsync("/auth/login",
+            new { username = "alice", password = "wonderland" }))
+            .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+        var locked = await plain.PostAsJsonAsync("/auth/2fa/verify",
+            new { code = "000000", totpChallengeToken = lockedLogin.TotpChallengeToken });
+        Assert.Equal(HttpStatusCode.TooManyRequests, locked.StatusCode);
+    }
+
+    [Fact]
+    public async Task RecoveryCode_ConcurrentVerifies_OnlyOneSucceeds()
+    {
+        // 10 racing verify requests presenting the SAME recovery code
+        // must result in exactly one 200 — the store consumes
+        // atomically.
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            // Lockout off so the 9 losers don't trip 429 and mask the
+            // 401 the test is actually checking for.
+            ["Trading:Auth:TotpLockout:Enabled"] = "false",
+        });
+        var http = await factory.CreateAuthedClientAsync();
+        var enroll = (await (await http.PostAsJsonAsync("/auth/2fa/enroll", new { }))
+            .Content.ReadFromJsonAsync<EnrollResponseDto>())!;
+        await http.PostAsJsonAsync("/auth/2fa/verify", new { code = ComputeCode(enroll.Secret) });
+        var recovery = enroll.RecoveryCodes[0];
+
+        const int N = 10;
+        // Mint N distinct challenge tokens via N login calls so each
+        // verify request is independently authorized.
+        var challenges = new string[N];
+        var clients = new HttpClient[N];
+        for (var i = 0; i < N; i++)
+        {
+            clients[i] = factory.CreateClient();
+            var login = (await (await clients[i].PostAsJsonAsync("/auth/login",
+                new { username = "alice", password = "wonderland" }))
+                .Content.ReadFromJsonAsync<LoginRequiresDto>())!;
+            challenges[i] = login.TotpChallengeToken;
+        }
+
+        using var barrier = new Barrier(N);
+        var responses = await Task.WhenAll(Enumerable.Range(0, N).Select(i => Task.Run(async () =>
+        {
+            barrier.SignalAndWait();
+            return await clients[i].PostAsJsonAsync("/auth/2fa/verify",
+                new { code = recovery, totpChallengeToken = challenges[i] });
+        })));
+
+        var successes = responses.Count(r => r.StatusCode == HttpStatusCode.OK);
+        var failures = responses.Count(r => r.StatusCode == HttpStatusCode.Unauthorized);
+        Assert.Equal(1, successes);
+        Assert.Equal(N - 1, failures);
+
+        foreach (var c in clients) c.Dispose();
+    }
+
+    [Fact]
+    public void PendingTotpEnrollmentStore_PutPurgesExpiredEntries()
+    {
+        // Opportunistic sweep: pre-seed an entry with an old
+        // CreatedUtc, then Put a different user — the stale entry
+        // must be dropped even though TryConsume was never called for
+        // its username.
+        var clock = new FakeClock(DateTimeOffset.UnixEpoch);
+        var opts = new TestOptionsMonitor<TotpOptions>(new TotpOptions
+        {
+            PendingEnrollmentTtl = TimeSpan.FromMinutes(5),
+        });
+        var store = new InMemoryPendingTotpEnrollmentStore(opts, clock);
+
+        store.Put("ghost", new PendingTotpEnrollment(
+            Base32Secret: "JBSWY3DPEHPK3PXP",
+            RecoveryCodes: Array.Empty<string>(),
+            RecoveryCodeHashes: Array.Empty<string>(),
+            CreatedAt: clock.GetUtcNow()));
+
+        // Advance past TTL.
+        clock.Advance(TimeSpan.FromMinutes(10));
+
+        store.Put("alive", new PendingTotpEnrollment(
+            Base32Secret: "JBSWY3DPEHPK3PXP",
+            RecoveryCodes: Array.Empty<string>(),
+            RecoveryCodeHashes: Array.Empty<string>(),
+            CreatedAt: clock.GetUtcNow()));
+
+        // "ghost" must have been purged.
+        Assert.False(store.TryConsume("ghost", out _));
+        // "alive" still consumable.
+        Assert.True(store.TryConsume("alive", out var found));
+        Assert.NotNull(found);
+    }
+
+    private sealed class FakeClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeClock(DateTimeOffset start) { _now = start; }
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) { _now += delta; }
+    }
+
+    private sealed class TestOptionsMonitor<T> : Microsoft.Extensions.Options.IOptionsMonitor<T>
+    {
+        public TestOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable OnChange(Action<T, string?> listener) => new Noop();
+        private sealed class Noop : IDisposable { public void Dispose() { } }
     }
 
     [Fact]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,6 +39,24 @@
       </p>
     </form>
 
+    <!-- #303. Second-factor step. Hidden until /auth/login returns
+         requires2fa=true. Distinct card so the password fields aren't
+         posted with the TOTP code. -->
+    <form id="totp-form" class="login-card" hidden>
+      <h1>Two-factor authentication</h1>
+      <p class="subtitle">Enter the 6-digit code from your authenticator app.</p>
+      <label>
+        <span>Code or recovery code</span>
+        <input id="totp-code" type="text" inputmode="numeric" autocomplete="one-time-code"
+               required autofocus maxlength="32" />
+      </label>
+      <button type="submit" id="totp-submit">Verify</button>
+      <p id="totp-error" class="error" role="alert" hidden></p>
+      <p class="login-switch">
+        <button type="button" id="totp-cancel" class="link-button">Back to sign in</button>
+      </p>
+    </form>
+
     <form id="signup-form" class="login-card" hidden>
       <h1>Criar conta</h1>
       <p class="subtitle">Self-service · FIRM01</p>
@@ -93,6 +111,8 @@
         <span id="user-role" class="role-badge" hidden></span>
         <button id="bot-credentials-open" class="link-button" type="button"
                 aria-label="Bot credentials">Bot credentials</button>
+        <button id="security-open" class="link-button" type="button"
+                aria-label="Security (two-factor authentication)">Security</button>
         <button id="history-open" class="link-button" type="button"
                 aria-label="History, P&amp;L and statement">History</button>
         <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
@@ -757,6 +777,64 @@
                 aria-label="Close statement JSON">×</button>
       </header>
       <pre id="statement-json-body" class="statement-json-body"></pre>
+    </div>
+  </div>
+
+  <!-- SECURITY (2FA) MODAL (#303) ------------------------------------ -->
+  <div id="security-modal" class="modal-backdrop" hidden role="dialog"
+       aria-modal="true" aria-labelledby="security-title">
+    <div class="modal-card">
+      <header class="order-detail-title-row">
+        <h2 id="security-title">Two-factor authentication</h2>
+        <button type="button" id="security-close" class="order-detail-close"
+                aria-label="Close security panel">×</button>
+      </header>
+      <div id="security-body">
+        <p id="security-status" class="subtitle"></p>
+
+        <div id="security-enroll-start" hidden>
+          <p>2FA is not enrolled on this account. Click below to begin.</p>
+          <button type="button" id="security-enroll-begin">Enroll TOTP</button>
+        </div>
+
+        <div id="security-enroll-show" hidden>
+          <p>Scan this URI in your authenticator app (Google Authenticator,
+             1Password, Authy…) or paste the secret manually:</p>
+          <label>
+            <span>otpauth URI</span>
+            <input id="security-otpauth-uri" type="text" readonly />
+          </label>
+          <label>
+            <span>Secret (base32)</span>
+            <input id="security-secret" type="text" readonly />
+          </label>
+          <p><strong>Recovery codes — save them now. They are shown ONCE.</strong></p>
+          <pre id="security-recovery-codes"></pre>
+          <label class="row">
+            <input id="security-recovery-ack" type="checkbox" />
+            <span>I've saved my recovery codes</span>
+          </label>
+          <label>
+            <span>Enter a 6-digit code from your app to activate</span>
+            <input id="security-confirm-code" type="text" inputmode="numeric"
+                   autocomplete="one-time-code" maxlength="8" />
+          </label>
+          <button type="button" id="security-confirm" disabled>Activate 2FA</button>
+        </div>
+
+        <div id="security-enrolled" hidden>
+          <p>2FA is enrolled. To disable, enter a current 6-digit code (or
+             a recovery code).</p>
+          <label>
+            <span>Code</span>
+            <input id="security-disable-code" type="text" inputmode="numeric"
+                   autocomplete="one-time-code" maxlength="32" />
+          </label>
+          <button type="button" id="security-disable">Disable 2FA</button>
+        </div>
+
+        <p id="security-error" class="error" role="alert" hidden></p>
+      </div>
     </div>
   </div>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -7,7 +7,8 @@ import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cance
          runEod,
          listUserBotCredentials, createUserBotCredential, deleteUserBotCredential,
          getOrdersHistory, getExecutionsHistory, getPnlToday,
-         getStatement, downloadStatementCsv } from "./protocol.js";
+         getStatement, downloadStatementCsv,
+         verifyTotp, enrollTotp, disableTotp } from "./protocol.js";
 import { claimsFromToken } from "./jwt.js";
 import { validateOrder, pretradeWarnings, payloadKey } from "./validation.js";
 import * as state from "./state.js";
@@ -55,6 +56,9 @@ let expiryTimer = null;
 let warningTimer = null;
 let firmsPollTimer = null;
 let gatewayPollTimer = null;
+// #303. State for the in-flight 2FA challenge between /auth/login and
+// /auth/2fa/verify. Cleared on success / cancel / refresh.
+let pendingTotp = null; // { backend, username, remember, totpChallengeToken }
 
 function init() {
   document.getElementById("login-backend").placeholder = defaultBackend();
@@ -65,6 +69,20 @@ function init() {
   if (signupForm) signupForm.addEventListener("submit", onSignup);
   document.getElementById("login-go-signup")?.addEventListener("click", () => showSignupCard(true));
   document.getElementById("signup-go-login")?.addEventListener("click", () => showSignupCard(false));
+  // #303. 2FA second-factor step + Security panel.
+  document.getElementById("totp-form")?.addEventListener("submit", onTotpSubmit);
+  document.getElementById("totp-cancel")?.addEventListener("click", () => {
+    pendingTotp = null;
+    showTotpCard(false);
+  });
+  document.getElementById("security-open")?.addEventListener("click", openSecurityPanel);
+  document.getElementById("security-close")?.addEventListener("click", closeSecurityPanel);
+  document.getElementById("security-enroll-begin")?.addEventListener("click", onSecurityEnrollBegin);
+  document.getElementById("security-recovery-ack")?.addEventListener("change", (e) => {
+    document.getElementById("security-confirm").disabled = !e.target.checked;
+  });
+  document.getElementById("security-confirm")?.addEventListener("click", onSecurityEnrollConfirm);
+  document.getElementById("security-disable")?.addEventListener("click", onSecurityDisable);
   ui.bindUi();
   adminUi.bindAdminUi();
   botCredentialsUi.bindBotCredentialsUi();
@@ -166,23 +184,184 @@ async function onLogin(e) {
   ui.setLoginSubmitting(true);
   try {
     const resp = await login(backend, username, password);
-    const claims = claimsFromToken(resp.token);
-    const next = {
-      token: resp.token,
-      expiresAt: resp.expiresAt,
-      username,
-      backend,
-      role: claims.role,
-      firm: claims.firm,
-      remember,
-    };
-    sessionStore = remember ? localStorage : sessionStorage;
-    writeSession(next);
-    startSession(next);
+    // #303. Server may demand a TOTP code or a forced first-time
+    // enrollment before issuing a JWT. Stash context and switch cards.
+    if (resp && resp.requires2fa && resp.totpChallengeToken) {
+      pendingTotp = { backend, username, remember, totpChallengeToken: resp.totpChallengeToken };
+      showTotpCard(true);
+      return;
+    }
+    if (resp && resp.requires2faEnrollment && resp.enrollmentToken) {
+      // Force-enroll path: open enrollment immediately. We don't have a
+      // JWT yet, so we pass the enrollment token through to /auth/2fa/enroll.
+      pendingTotp = { backend, username, remember, enrollmentToken: resp.enrollmentToken };
+      await beginForcedEnrollment();
+      return;
+    }
+    finishLoginWithToken(resp, { backend, username, remember });
   } catch (err) {
     ui.setLoginError(err.message || "Login failed");
   } finally {
     ui.setLoginSubmitting(false);
+  }
+}
+
+function finishLoginWithToken(resp, { backend, username, remember }) {
+  const claims = claimsFromToken(resp.token);
+  const next = {
+    token: resp.token,
+    expiresAt: resp.expiresAt,
+    username,
+    backend,
+    role: claims.role,
+    firm: claims.firm,
+    remember,
+  };
+  sessionStore = remember ? localStorage : sessionStorage;
+  writeSession(next);
+  startSession(next);
+}
+
+function showTotpCard(show) {
+  const loginCard = document.getElementById("login-form");
+  const signupCard = document.getElementById("signup-form");
+  const totpCard = document.getElementById("totp-form");
+  if (!totpCard) return;
+  if (loginCard) loginCard.hidden = !!show;
+  if (signupCard) signupCard.hidden = true;
+  totpCard.hidden = !show;
+  const errEl = document.getElementById("totp-error");
+  if (errEl) { errEl.hidden = true; errEl.textContent = ""; }
+  if (show) document.getElementById("totp-code")?.focus();
+  else {
+    const codeEl = document.getElementById("totp-code");
+    if (codeEl) codeEl.value = "";
+  }
+}
+
+async function onTotpSubmit(e) {
+  e.preventDefault();
+  if (!pendingTotp || !pendingTotp.totpChallengeToken) return;
+  const code = document.getElementById("totp-code").value.trim();
+  const errEl = document.getElementById("totp-error");
+  if (errEl) { errEl.hidden = true; errEl.textContent = ""; }
+  const submitBtn = document.getElementById("totp-submit");
+  if (submitBtn) submitBtn.disabled = true;
+  try {
+    const resp = await verifyTotp(pendingTotp.backend, {
+      code,
+      totpChallengeToken: pendingTotp.totpChallengeToken,
+    });
+    const ctx = pendingTotp;
+    pendingTotp = null;
+    showTotpCard(false);
+    finishLoginWithToken(resp, { backend: ctx.backend, username: ctx.username, remember: ctx.remember });
+  } catch (err) {
+    if (errEl) { errEl.hidden = false; errEl.textContent = err.message || "Invalid code"; }
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
+  }
+}
+
+// ── Security panel (TOTP enrollment / disable) — #303 ───────────────
+function openSecurityPanel() {
+  const modal = document.getElementById("security-modal");
+  if (!modal || !session) return;
+  modal.hidden = false;
+  setSecurityError(null);
+  // We can't distinguish "enrolled" vs "not enrolled" without a probe
+  // endpoint, so show both controls and let the user choose: enrolling
+  // when already enrolled returns 409 (caught + surfaced); disabling
+  // when not enrolled returns 400. Keeps the FE thin.
+  document.getElementById("security-enroll-start").hidden = false;
+  document.getElementById("security-enroll-show").hidden = true;
+  document.getElementById("security-enrolled").hidden = false;
+  document.getElementById("security-status").textContent =
+    "Enroll to add a second factor, or disable an existing enrollment.";
+}
+
+function closeSecurityPanel() {
+  const modal = document.getElementById("security-modal");
+  if (modal) modal.hidden = true;
+  // Wipe the recovery codes from the DOM as soon as the user dismisses.
+  const pre = document.getElementById("security-recovery-codes");
+  if (pre) pre.textContent = "";
+  const ack = document.getElementById("security-recovery-ack");
+  if (ack) ack.checked = false;
+  const confirm = document.getElementById("security-confirm");
+  if (confirm) confirm.disabled = true;
+  pendingEnrollSecret = null;
+}
+
+function setSecurityError(msg) {
+  const el = document.getElementById("security-error");
+  if (!el) return;
+  if (!msg) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false; el.textContent = msg;
+}
+
+let pendingEnrollSecret = null; // base32, only kept until confirm/cancel
+
+async function onSecurityEnrollBegin() {
+  if (!session) return;
+  setSecurityError(null);
+  try {
+    const resp = await enrollTotp(session.backend, session.token);
+    pendingEnrollSecret = resp.secret;
+    document.getElementById("security-otpauth-uri").value = resp.otpauthUri;
+    document.getElementById("security-secret").value = resp.secret;
+    document.getElementById("security-recovery-codes").textContent = resp.recoveryCodes.join("\n");
+    document.getElementById("security-enroll-start").hidden = true;
+    document.getElementById("security-enroll-show").hidden = false;
+    document.getElementById("security-recovery-ack").checked = false;
+    document.getElementById("security-confirm").disabled = true;
+  } catch (err) {
+    setSecurityError(err.message || "Enrollment failed");
+  }
+}
+
+async function onSecurityEnrollConfirm() {
+  if (!session) return;
+  const code = document.getElementById("security-confirm-code").value.trim();
+  if (!code) { setSecurityError("Code required"); return; }
+  setSecurityError(null);
+  try {
+    await verifyTotp(session.backend, { code, token: session.token });
+    document.getElementById("security-status").textContent = "2FA enrollment confirmed. Recovery codes are no longer recoverable — keep your saved copy.";
+    document.getElementById("security-enroll-show").hidden = true;
+    pendingEnrollSecret = null;
+  } catch (err) {
+    setSecurityError(err.message || "Verification failed");
+  }
+}
+
+async function onSecurityDisable() {
+  if (!session) return;
+  const code = document.getElementById("security-disable-code").value.trim();
+  if (!code) { setSecurityError("Code required"); return; }
+  setSecurityError(null);
+  try {
+    await disableTotp(session.backend, session.token, code);
+    document.getElementById("security-status").textContent = "2FA disabled.";
+  } catch (err) {
+    setSecurityError(err.message || "Disable failed");
+  }
+}
+
+async function beginForcedEnrollment() {
+  if (!pendingTotp || !pendingTotp.enrollmentToken) return;
+  try {
+    const resp = await enrollTotp(pendingTotp.backend, null, pendingTotp.enrollmentToken);
+    alert(
+      "Two-factor authentication is required on this account.\n\n" +
+      "Set up your authenticator with this URI:\n" + resp.otpauthUri + "\n\n" +
+      "Recovery codes (save now — shown ONCE):\n" + resp.recoveryCodes.join("\n") + "\n\n" +
+      "Then sign in again — you'll be asked for a 6-digit code."
+    );
+    pendingTotp = null;
+    showTotpCard(false);
+  } catch (err) {
+    ui.setLoginError(err.message || "Forced enrollment failed");
   }
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -47,6 +47,47 @@ export async function login(backend, username, password) {
   return jsonOrThrow(resp);
 }
 
+// #303. Submits a 2FA verification: either a TOTP code or a recovery
+// code (server detects via length/shape). When `totpChallengeToken` is
+// supplied this finishes the login flow and returns `{ token, expiresAt }`;
+// when omitted, the request must be authenticated and confirms a pending
+// enrollment.
+export async function verifyTotp(backend, { code, totpChallengeToken, token }) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const body = totpChallengeToken ? { code, totpChallengeToken } : { code };
+  const resp = await fetch(`${backend}/auth/2fa/verify`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return jsonOrThrow(resp);
+}
+
+// Begin TOTP enrollment. Returns `{ secret, otpauthUri, recoveryCodes }`.
+// Recovery codes are shown ONCE — store them client-side until the user
+// acknowledges, then discard.
+export async function enrollTotp(backend, token, enrollmentToken) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const resp = await fetch(`${backend}/auth/2fa/enroll`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(enrollmentToken ? { enrollmentToken } : {}),
+  });
+  return jsonOrThrow(resp);
+}
+
+// Disable TOTP. Requires a currently-valid TOTP code (or recovery code).
+export async function disableTotp(backend, token, code) {
+  const resp = await fetch(`${backend}/auth/2fa/disable`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ code }),
+  });
+  return jsonOrThrow(resp);
+}
+
 // Self-service signup. Returns the same shape as /auth/login (token +
 // expiresAt) so the caller can drop the new user straight into the
 // trader view without a follow-up login round-trip. v0 is FIRM01-only,


### PR DESCRIPTION
Closes #303.

## Summary
Adds RFC 6238 TOTP as the password second factor.

- `POST /auth/login` returns `{requires2fa, totpChallengeToken}` when the user has an active TOTP enrollment, or `{requires2faEnrollment, enrollmentToken}` when `Require2FA=true` but the user has not enrolled yet.
- `POST /auth/2fa/enroll` (JWT or ForceEnroll token) — returns `{secret, otpauthUri, recoveryCodes}`. Recovery codes (10) are shown ONCE.
- `POST /auth/2fa/verify` — dual-purpose:
  - JWT mode: confirms a pending enrollment;
  - challenge-token mode: finishes login, accepts TOTP or single-use recovery code, returns JWT.
- `POST /auth/2fa/disable` (JWT, requires current code).

## Key design decisions

| Concern | Choice |
|---|---|
| Challenge token shape | 32 random bytes → base64url (`~43` chars). Opaque to clients. |
| Challenge / pending TTL | 5 min each (configurable via `Trading:Auth:Totp:ChallengeTokenTtl` / `PendingEnrollmentTtl`). |
| Lockout | Separate `TotpLockout` (mirror of `LoginLockout`): 5 fails / 5 min → 429 + Retry-After. |
| Data Protection key ring | Reuses the host's existing `AddTradingDataProtection` ring at `{Trading:Persistence:DataDirectory}/dp-keys` — already sensible and configurable. `Trading:Auth:Totp:KeyRingDirectory` reserved for future override. |
| Recovery codes | 10 codes, 10-char base32-ish alphabet (no I/O/0/1), formatted `XXXXX-XXXXX`. Stored as SHA-256 hex; consumed on use. |
| FE QR | Server returns the `otpauth://` URI only — no PNG dependency. FE displays the URI + secret for the user to paste into any authenticator. Follow-up will add a client-side QR render. |
| Multi-firm | TOTP is keyed by username. Each username maps to exactly one firm in the existing store, so this is naturally per-(user,firm). Test `MultiFirm_DifferentUsernamesHaveIndependentTotp` pins the choice. |
| Forced enrollment | `UserConfig.Require2FA=true` returns `{requires2faEnrollment, enrollmentToken}` from `/auth/login`; that token authenticates the next `/auth/2fa/enroll` call (no JWT yet). |

## Encryption at rest
TOTP shared secrets pass through `ITotpSecretProtector` (Data Protection, purpose `B3.Trading.Api.Auth.Totp.SharedSecret.v1`). The test `SharedSecret_PersistedEncrypted_NotPlaintextBase32` reads `users.json` and asserts the base32 secret does not appear plaintext.

## Tests (9 new)
- `NonEnrolledLogin_BehavesAsBefore_NoRequires2fa`
- `Enroll_Verify_Activates_AndSubsequentLoginReturnsRequires2fa`
- `Login_InvalidCode_Rejected_FiveWrong_Lock429`
- `RecoveryCode_AcceptedOnce_SecondUseRejected`
- `Disable_RequiresCurrentCode_ThenReEnrollWorks`
- `ReEnrollBlockedWhenAlreadyEnrolled`
- `PendingEnrollment_ExpiresAfterTtl`
- `SharedSecret_PersistedEncrypted_NotPlaintextBase32`
- `MultiFirm_DifferentUsernamesHaveIndependentTotp`

`dotnet test B3TradingPlatform.slnx` → 1640 passing.
`dotnet format B3TradingPlatform.slnx --verify-no-changes` → clean.

## Out of scope (follow-ups)
- WebAuthn / passkey 2FA
- Server-side QR PNG generation