### PR TITLE
Q4.4 (#304): per-user × endpoint token-bucket rate limit

### DIFF
--- a/backend/src/B3.Trading.Api/RateLimit/IRateLimiter.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/IRateLimiter.cs
@@ -1,0 +1,39 @@
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). Service abstraction over the token-bucket rate limiter
+/// so unit tests can swap a deterministic fake in for the production
+/// implementation.
+/// </summary>
+public interface IRateLimiter
+{
+    /// <summary>
+    /// Attempts to acquire a single token for the
+    /// <c>(userKey, endpointKey)</c> bucket.
+    /// </summary>
+    /// <param name="userKey">
+    /// Identity-or-IP partition key. See
+    /// <c>TokenBucketRateLimitOptions</c> remarks for the resolution
+    /// rules (sub-claim ?? remote IP ?? "anonymous").
+    /// </param>
+    /// <param name="endpointKey">
+    /// Bucket-grouping key — typically the matched rule's
+    /// <c>PathPattern</c>, NOT the raw request path. Keeping this low
+    /// cardinality is what makes the per-user × endpoint metric tag
+    /// safe.
+    /// </param>
+    /// <param name="burst">Bucket capacity.</param>
+    /// <param name="refillPerSecond">Refill rate (tokens / second).</param>
+    /// <param name="retryAfterSeconds">
+    /// On a denied acquire, the number of seconds the caller must wait
+    /// before at least one token becomes available. Always 0 when the
+    /// method returns true.
+    /// </param>
+    /// <returns>True if a token was deducted; false if the bucket is empty.</returns>
+    bool TryAcquire(
+        string userKey,
+        string endpointKey,
+        int burst,
+        double refillPerSecond,
+        out double retryAfterSeconds);
+}

--- a/backend/src/B3.Trading.Api/RateLimit/RateLimitRuleResolver.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/RateLimitRuleResolver.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Http;
+
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). Resolves the effective <see cref="TokenBucketRule"/> a
+/// given <see cref="HttpContext"/> belongs to.
+/// </summary>
+/// <remarks>
+/// Resolution priority (deterministic, evaluated in order):
+/// <list type="number">
+///   <item><description>
+///     Non-<c>IsGenericFallback</c> rules always outrank the catch-all
+///     read/write defaults — an explicit pattern wins even if it is
+///     method-less and the fallback is method-restricted.
+///   </description></item>
+///   <item><description>
+///     Longer <c>PathPattern</c> outranks shorter (longest-prefix-wins
+///     so <c>/algo/twap</c> beats <c>/algo/</c>).
+///   </description></item>
+///   <item><description>
+///     Method-aware rules outrank method-less ones at equal length so
+///     a future POST-only <c>/foo</c> would win against a method-less
+///     <c>/foo</c>.
+///   </description></item>
+/// </list>
+/// <para>
+/// Operator-supplied rules from <c>Trading:RateLimit:Rules</c> override
+/// any code default with the same <c>(PathPattern, Methods)</c>; new
+/// patterns are appended to the merged set.
+/// </para>
+/// </remarks>
+public sealed class RateLimitRuleResolver
+{
+    private readonly TokenBucketRule[] _ordered;
+
+    public RateLimitRuleResolver(TokenBucketRateLimitOptions options)
+    {
+        var merged = MergeWithDefaults(options.Rules);
+        // Pre-sort so the per-request match is a linear scan with
+        // first-match semantics. The comparator implements the priority
+        // documented in the class remarks.
+        _ordered = merged
+            // Explicit rules ALWAYS outrank generic fallbacks, even when
+            // the fallback is method-restricted — otherwise the generic
+            // POST fallback (length 1, POST-restricted) would beat the
+            // method-less /auth/login (length 11).
+            .OrderBy(r => r.IsGenericFallback)
+            .ThenByDescending(r => r.PathPattern.Length)
+            .ThenByDescending(r => r.Methods.Count > 0)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Returns the matching rule for <paramref name="ctx"/>, or
+    /// <c>null</c> when no rule (including the generic fallbacks)
+    /// matched — which the middleware treats as "no limit applied".
+    /// </summary>
+    public TokenBucketRule? Resolve(HttpContext ctx)
+    {
+        var path = ctx.Request.Path.Value ?? "/";
+        var method = ctx.Request.Method;
+
+        foreach (var rule in _ordered)
+        {
+            if (rule.Methods.Count > 0
+                && !rule.Methods.Contains(method, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (PathMatches(path, rule.PathPattern))
+            {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    private static bool PathMatches(string path, string pattern)
+    {
+        if (pattern == "/") return true; // generic fallback
+        // Prefix match: "/orders" matches "/orders" and "/orders/123"
+        // but NOT "/orders-archive". The trailing-slash test is what
+        // keeps "/algo" from accidentally swallowing "/algorithm".
+        if (!path.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (path.Length == pattern.Length) return true;
+        // pattern ends in '/'? then any continuation is a child path.
+        if (pattern.EndsWith('/')) return true;
+        // otherwise the character after the prefix must be a path
+        // separator for it to count as a child route.
+        return path[pattern.Length] == '/';
+    }
+
+    private static List<TokenBucketRule> MergeWithDefaults(IList<TokenBucketRule> overrides)
+    {
+        var merged = TokenBucketRateLimitOptions.Defaults();
+        foreach (var ov in overrides)
+        {
+            // Match defaults by (pattern, methods set). Different
+            // methods-sets are different rules so operators can,
+            // for instance, override the GET fallback without touching
+            // the write fallback.
+            var existing = merged.FindIndex(d =>
+                string.Equals(d.PathPattern, ov.PathPattern, StringComparison.OrdinalIgnoreCase)
+                && SameMethodSet(d.Methods, ov.Methods));
+            if (existing >= 0)
+            {
+                merged[existing] = ov;
+            }
+            else
+            {
+                merged.Add(ov);
+            }
+        }
+        return merged;
+    }
+
+    private static bool SameMethodSet(List<string> a, List<string> b)
+    {
+        if (a.Count != b.Count) return false;
+        var setA = new HashSet<string>(a, StringComparer.OrdinalIgnoreCase);
+        return b.All(m => setA.Contains(m));
+    }
+}

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitMiddleware.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitMiddleware.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Security.Claims;
+using B3.Trading.Application.Observability;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). ASP.NET Core middleware that gates each request through
+/// the <see cref="IRateLimiter"/> using a rule resolved by
+/// <see cref="RateLimitRuleResolver"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mounted AFTER <c>UseAuthentication</c> so <c>User.Identity.Name</c>
+/// is populated for already-authenticated requests. Pre-auth requests
+/// (login, 2FA challenge/enroll endpoints) have no identity and fall
+/// back to the client IP — the per-IP bucket is what stops a single
+/// host from credential-stuffing the login endpoint.
+/// </para>
+/// <para>
+/// On rejection the response is <c>429 Too Many Requests</c> with
+/// <c>Retry-After: &lt;ceil(seconds-to-next-token)&gt;</c> and a JSON
+/// body of <c>{"error":"rate_limited","retryAfterSeconds":N}</c>. The
+/// metric <c>trading.ratelimit.rejected_total</c> increments with low-
+/// cardinality tags <c>path</c> (matched rule pattern, not raw path)
+/// and <c>user</c> (sub-claim or IP).
+/// </para>
+/// </remarks>
+public sealed class TokenBucketRateLimitMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IRateLimiter _limiter;
+    private readonly RateLimitRuleResolver _resolver;
+    private readonly IOptionsMonitor<TokenBucketRateLimitOptions> _options;
+    private readonly ILogger<TokenBucketRateLimitMiddleware> _logger;
+
+    public TokenBucketRateLimitMiddleware(
+        RequestDelegate next,
+        IRateLimiter limiter,
+        RateLimitRuleResolver resolver,
+        IOptionsMonitor<TokenBucketRateLimitOptions> options,
+        ILogger<TokenBucketRateLimitMiddleware> logger)
+    {
+        _next = next;
+        _limiter = limiter;
+        _resolver = resolver;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled)
+        {
+            await _next(context);
+            return;
+        }
+
+        // Bypass roles: an admin with the role configured in
+        // BypassRoles skips the limiter entirely. Default (empty)
+        // means admins are ALSO throttled — operators must opt in.
+        if (opts.BypassRoles.Count > 0 && HasBypassRole(context.User, opts.BypassRoles))
+        {
+            await _next(context);
+            return;
+        }
+
+        var rule = _resolver.Resolve(context);
+        if (rule is null)
+        {
+            await _next(context);
+            return;
+        }
+
+        var userKey = ResolveUserKey(context);
+        var endpointKey = rule.PathPattern;
+
+        if (_limiter.TryAcquire(userKey, endpointKey, rule.Burst, rule.RefillPerSecond, out var retryAfterSeconds))
+        {
+            await _next(context);
+            return;
+        }
+
+        var retryAfter = Math.Max(1, (int)Math.Ceiling(retryAfterSeconds));
+
+        MetricsRegistry.RateLimitRejected.Add(1,
+            new KeyValuePair<string, object?>("path", endpointKey),
+            new KeyValuePair<string, object?>("user", userKey));
+
+        _logger.LogWarning(
+            "ratelimit.rejected path={Path} user={User} retryAfterSeconds={RetryAfter}",
+            endpointKey, userKey, retryAfter);
+
+        context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(
+            $"{{\"error\":\"rate_limited\",\"retryAfterSeconds\":{retryAfter.ToString(CultureInfo.InvariantCulture)}}}");
+    }
+
+    private static bool HasBypassRole(ClaimsPrincipal user, IReadOnlyList<string> bypassRoles)
+    {
+        if (user?.Identity?.IsAuthenticated != true) return false;
+        foreach (var role in bypassRoles)
+        {
+            if (user.IsInRole(role)) return true;
+        }
+        return false;
+    }
+
+    private static string ResolveUserKey(HttpContext ctx)
+    {
+        // Prefer the JWT sub-claim (set as User.Identity.Name via
+        // NameClaimType = sub in the bearer configuration). Pre-auth
+        // requests fall back to the connection peer IP — see class
+        // remarks for why X-Forwarded-For is not consulted here.
+        var name = ctx.User?.Identity?.Name;
+        if (!string.IsNullOrWhiteSpace(name)) return name;
+        var ip = ctx.Connection.RemoteIpAddress;
+        return ip is null ? "anonymous" : ip.ToString();
+    }
+}

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitMiddleware.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitMiddleware.cs
@@ -26,7 +26,11 @@ namespace B3.Trading.Api.RateLimit;
 /// body of <c>{"error":"rate_limited","retryAfterSeconds":N}</c>. The
 /// metric <c>trading.ratelimit.rejected_total</c> increments with low-
 /// cardinality tags <c>path</c> (matched rule pattern, not raw path)
-/// and <c>user</c> (sub-claim or IP).
+/// and <c>principal_kind</c> (one of <c>user</c>, <c>ip</c>,
+/// <c>anonymous</c>). The throttled identity itself (sub-claim or
+/// remote IP) is intentionally NOT a metric tag — under an IP-spray
+/// attack that would explode the time series cardinality — but it IS
+/// emitted on the rejection log line for forensics.
 /// </para>
 /// </remarks>
 public sealed class TokenBucketRateLimitMiddleware
@@ -76,7 +80,7 @@ public sealed class TokenBucketRateLimitMiddleware
             return;
         }
 
-        var userKey = ResolveUserKey(context);
+        var (userKey, principalKind) = ResolveUserKey(context);
         var endpointKey = rule.PathPattern;
 
         if (_limiter.TryAcquire(userKey, endpointKey, rule.Burst, rule.RefillPerSecond, out var retryAfterSeconds))
@@ -87,13 +91,18 @@ public sealed class TokenBucketRateLimitMiddleware
 
         var retryAfter = Math.Max(1, (int)Math.Ceiling(retryAfterSeconds));
 
+        // Tags are intentionally bounded: `path` is the rule pattern
+        // (a short, operator-defined list) and `principal_kind` is one
+        // of three string constants. The user/IP identity is captured
+        // on the log line below so operators can still attribute a
+        // spike to a specific actor.
         MetricsRegistry.RateLimitRejected.Add(1,
             new KeyValuePair<string, object?>("path", endpointKey),
-            new KeyValuePair<string, object?>("user", userKey));
+            new KeyValuePair<string, object?>("principal_kind", principalKind));
 
-        _logger.LogWarning(
-            "ratelimit.rejected path={Path} user={User} retryAfterSeconds={RetryAfter}",
-            endpointKey, userKey, retryAfter);
+        _logger.LogInformation(
+            "ratelimit.rejected path={Path} principalKind={PrincipalKind} user={User} retryAfterSeconds={RetryAfter}",
+            endpointKey, principalKind, userKey, retryAfter);
 
         context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
         context.Response.Headers.RetryAfter = retryAfter.ToString(CultureInfo.InvariantCulture);
@@ -112,15 +121,18 @@ public sealed class TokenBucketRateLimitMiddleware
         return false;
     }
 
-    private static string ResolveUserKey(HttpContext ctx)
+    private static (string Key, string Kind) ResolveUserKey(HttpContext ctx)
     {
         // Prefer the JWT sub-claim (set as User.Identity.Name via
         // NameClaimType = sub in the bearer configuration). Pre-auth
         // requests fall back to the connection peer IP — see class
-        // remarks for why X-Forwarded-For is not consulted here.
+        // remarks for why X-Forwarded-For is not consulted here. The
+        // returned Kind is a low-cardinality category used as a metric
+        // tag; the Key remains the bucket identity and is logged but
+        // never exported as a tag.
         var name = ctx.User?.Identity?.Name;
-        if (!string.IsNullOrWhiteSpace(name)) return name;
+        if (!string.IsNullOrWhiteSpace(name)) return (name, "user");
         var ip = ctx.Connection.RemoteIpAddress;
-        return ip is null ? "anonymous" : ip.ToString();
+        return ip is null ? ("anonymous", "anonymous") : (ip.ToString(), "ip");
     }
 }

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitOptions.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitOptions.cs
@@ -1,0 +1,166 @@
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). Per-user × endpoint token-bucket rate-limit options
+/// bound from <c>Trading:RateLimit</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two semantically separate sources of rules contribute to the final
+/// resolution table the limiter consults at request time:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="Defaults"/> — code-shipped rules that document the
+///     out-of-the-box policy (orders write, auth, algo write, generic
+///     read/write). Always merged in so operators only have to override
+///     the buckets they care about.
+///   </description></item>
+///   <item><description>
+///     <see cref="Rules"/> — operator-supplied rules (config). A rule
+///     whose <see cref="TokenBucketRule.PathPattern"/> matches a default
+///     replaces it; new patterns are appended.
+///   </description></item>
+/// </list>
+/// <para>
+/// Pre-auth requests (login, 2FA verify/enroll) are bucketed by client
+/// IP (<c>HttpContext.Connection.RemoteIpAddress</c>) since there is no
+/// authenticated identity yet. The user key resolution is
+/// <c>User.Identity.Name ?? RemoteIp ?? "anonymous"</c>.
+/// </para>
+/// <para>
+/// Multi-firm note: the user key is the JWT <c>sub</c> claim only, NOT
+/// <c>(sub, firm)</c>. Therefore the same login active in two firms
+/// shares a single bucket across both firms. This is intentional — an
+/// abusive script that floods POST /orders should be throttled
+/// regardless of which firm context the calls target.
+/// </para>
+/// </remarks>
+public sealed class TokenBucketRateLimitOptions
+{
+    public const string SectionName = "Trading:RateLimit";
+
+    /// <summary>
+    /// Master kill-switch. When <c>false</c> the middleware is a no-op
+    /// (no buckets, no metrics, no 429s). Default is <c>true</c> for
+    /// production hosts; the test factory flips this to <c>false</c>
+    /// so the broad test suite does not have to reason about buckets.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Operator-supplied rules. Each rule with a path pattern that
+    /// matches one of <see cref="Defaults"/> overrides that default;
+    /// new patterns are appended. Order in config is preserved for
+    /// stable tie-breaking but the final match priority is by
+    /// descending pattern length (longest-prefix-wins).
+    /// </summary>
+    public List<TokenBucketRule> Rules { get; set; } = new();
+
+    /// <summary>
+    /// Role names whose bearers bypass the limiter entirely. Default
+    /// is empty so admins are throttled along with everybody else —
+    /// operators must opt-in explicitly (e.g. <c>["admin"]</c>) to
+    /// give an emergency console headroom.
+    /// </summary>
+    public List<string> BypassRoles { get; set; } = new();
+
+    /// <summary>
+    /// Code-shipped defaults. Exposed as a static method (not a
+    /// constant collection) so each <see cref="TokenBucketRateLimitOptions"/>
+    /// instance gets a fresh list — otherwise concurrent option binds
+    /// would mutate a shared default.
+    /// </summary>
+    public static List<TokenBucketRule> Defaults() => new()
+    {
+        // Order write: high-value endpoint, modest burst to absorb
+        // batched flat-out events without letting a runaway script
+        // saturate the gateway.
+        new TokenBucketRule
+        {
+            PathPattern = "/orders",
+            Methods = new() { "POST", "PUT", "DELETE", "PATCH" },
+            Burst = 5,
+            RefillPerSecond = 5,
+        },
+        // Auth endpoints: tight bucket so brute-force/credential-
+        // stuffing attempts trip well before the password-hashing
+        // pipeline gets backed up. Methods unrestricted (the routes
+        // only accept POST anyway).
+        new TokenBucketRule
+        {
+            PathPattern = "/auth/login",
+            Burst = 3,
+            RefillPerSecond = 1,
+        },
+        new TokenBucketRule
+        {
+            PathPattern = "/auth/2fa/verify",
+            Burst = 3,
+            RefillPerSecond = 1,
+        },
+        new TokenBucketRule
+        {
+            PathPattern = "/auth/2fa/enroll",
+            Burst = 3,
+            RefillPerSecond = 1,
+        },
+        // Algo writes: same family as /orders but algos can legitimately
+        // produce many child operations (slice cancel/replace) so the
+        // burst is larger and the refill leaves headroom.
+        new TokenBucketRule
+        {
+            PathPattern = "/algo/",
+            Methods = new() { "POST", "PUT", "DELETE", "PATCH" },
+            Burst = 10,
+            RefillPerSecond = 5,
+        },
+        // Generic write/read fall-through. Catch-all patterns kick in
+        // when no explicit rule matched the request. Read defaults
+        // are deliberately generous since they are typically polling
+        // queries from dashboards.
+        new TokenBucketRule
+        {
+            PathPattern = "/",
+            Methods = new() { "POST", "PUT", "DELETE", "PATCH" },
+            Burst = 20,
+            RefillPerSecond = 20,
+            IsGenericFallback = true,
+        },
+        new TokenBucketRule
+        {
+            PathPattern = "/",
+            Methods = new() { "GET", "HEAD", "OPTIONS" },
+            Burst = 100,
+            RefillPerSecond = 100,
+            IsGenericFallback = true,
+        },
+    };
+}
+
+/// <summary>
+/// A single token-bucket rule. The <see cref="PathPattern"/> matches an
+/// incoming request path by prefix (case-insensitive). When
+/// <see cref="Methods"/> is non-empty the rule only applies to those
+/// HTTP methods; an empty list matches any method.
+/// </summary>
+public sealed class TokenBucketRule
+{
+    public string PathPattern { get; set; } = "/";
+
+    /// <summary>
+    /// HTTP methods this rule applies to (upper-case). Empty list
+    /// means "any method".
+    /// </summary>
+    public List<string> Methods { get; set; } = new();
+
+    public int Burst { get; set; } = 20;
+    public double RefillPerSecond { get; set; } = 20;
+
+    /// <summary>
+    /// Internal flag — <c>true</c> for the generic read/write
+    /// fall-through entries so the resolver can deprioritise them
+    /// behind any explicit pattern of identical depth.
+    /// </summary>
+    public bool IsGenericFallback { get; set; }
+}

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimitServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). DI wiring for the per-user × endpoint token-bucket
+/// rate limiter.
+/// </summary>
+public static class TokenBucketRateLimitServiceCollectionExtensions
+{
+    public static IServiceCollection AddTradingRateLimit(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<TokenBucketRateLimitOptions>(
+            configuration.GetSection(TokenBucketRateLimitOptions.SectionName));
+
+        services.AddSingleton<IRateLimiter, TokenBucketRateLimiter>();
+
+        // Resolver is a snapshot of the merged rule set at startup.
+        // Mid-flight config reloads (operator changes a Burst in
+        // appsettings) are NOT picked up — that's a deliberate
+        // simplification for a non-hot-reloadable subsystem; a host
+        // restart re-reads the rules.
+        services.AddSingleton<RateLimitRuleResolver>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<TokenBucketRateLimitOptions>>().Value;
+            return new RateLimitRuleResolver(opts);
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseTradingRateLimit(this IApplicationBuilder app)
+        => app.UseMiddleware<TokenBucketRateLimitMiddleware>();
+}

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimiter.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimiter.cs
@@ -72,32 +72,62 @@ public sealed class TokenBucketRateLimiter : IRateLimiter, IDisposable
         }
 
         var key = new BucketKey(userKey, endpointKey);
-        var bucket = _buckets.GetOrAdd(key, _ => new Bucket(burst, _utcNow()));
 
-        lock (bucket.Gate)
+        // Outer loop handles the sweeper-vs-acquire race: the sweeper
+        // may evict our bucket AFTER GetOrAdd returns it but BEFORE we
+        // take its lock. The Evicted flag, set under the bucket lock
+        // by the sweeper, lets us detect that and retry against the
+        // (fresh) replacement bucket. Two iterations is the worst case:
+        // by the second pass the sweeper would have to evict a bucket
+        // we just inserted, which requires it to also pass the IdleTtl
+        // check — impossible without time travel.
+        for (var attempt = 0; attempt < 2; attempt++)
         {
-            var now = _utcNow();
-            var elapsed = (now - bucket.LastRefillUtc).TotalSeconds;
-            if (elapsed > 0)
-            {
-                bucket.Tokens = Math.Min(burst, bucket.Tokens + elapsed * refillPerSecond);
-                bucket.LastRefillUtc = now;
-            }
+            var bucket = _buckets.GetOrAdd(key, _ => new Bucket(burst, _utcNow()));
+            OnBucketAcquiredForTest?.Invoke();
 
-            if (bucket.Tokens >= 1.0)
+            lock (bucket.Gate)
             {
-                bucket.Tokens -= 1.0;
-                retryAfterSeconds = 0;
-                return true;
-            }
+                if (bucket.Evicted)
+                {
+                    // The sweeper removed `bucket` from the dictionary
+                    // between our GetOrAdd and this lock. Any tokens we
+                    // hand out from this orphan would be in addition to
+                    // those that the replacement bucket will hand out —
+                    // i.e. up to 2× burst across two requests racing
+                    // the sweep. Drop the lock and try again.
+                    continue;
+                }
 
-            // tokens shortfall / refillPerSecond → seconds until the
-            // next whole token is available. Ceiling to a friendly
-            // integer second below in the middleware.
-            var needed = 1.0 - bucket.Tokens;
-            retryAfterSeconds = needed / refillPerSecond;
-            return false;
+                var now = _utcNow();
+                var elapsed = (now - bucket.LastRefillUtc).TotalSeconds;
+                if (elapsed > 0)
+                {
+                    bucket.Tokens = Math.Min(burst, bucket.Tokens + elapsed * refillPerSecond);
+                    bucket.LastRefillUtc = now;
+                }
+
+                if (bucket.Tokens >= 1.0)
+                {
+                    bucket.Tokens -= 1.0;
+                    retryAfterSeconds = 0;
+                    return true;
+                }
+
+                // tokens shortfall / refillPerSecond → seconds until the
+                // next whole token is available. Ceiling to a friendly
+                // integer second below in the middleware.
+                var needed = 1.0 - bucket.Tokens;
+                retryAfterSeconds = needed / refillPerSecond;
+                return false;
+            }
         }
+
+        // Defensive: if we somehow lost the race twice in a row, deny
+        // rather than loop forever. In practice this branch is
+        // unreachable — see the comment on the for loop above.
+        retryAfterSeconds = 1.0 / refillPerSecond;
+        return false;
     }
 
     /// <summary>
@@ -110,19 +140,34 @@ public sealed class TokenBucketRateLimiter : IRateLimiter, IDisposable
     /// </summary>
     internal void SweepIdleBucketsForTest() => SweepIdleBuckets();
 
+    /// <summary>
+    /// Test hook fired between <c>GetOrAdd</c> and the per-bucket lock
+    /// in <see cref="TryAcquire"/>. Used to deterministically reproduce
+    /// the sweeper-vs-acquire race; never set in production.
+    /// </summary>
+    internal Action? OnBucketAcquiredForTest { get; set; }
+
     private void SweepIdleBuckets()
     {
         var cutoff = _utcNow() - IdleTtl;
         foreach (var kvp in _buckets)
         {
-            // Read under the bucket's own lock so we don't race a
-            // TryAcquire that is in the middle of advancing
-            // LastRefillUtc.
-            DateTime lastRefill;
-            lock (kvp.Value.Gate) lastRefill = kvp.Value.LastRefillUtc;
-            if (lastRefill < cutoff)
+            // Take the bucket's own lock so we don't race a TryAcquire
+            // that is in the middle of advancing LastRefillUtc, and so
+            // any TryAcquire that has already obtained a reference to
+            // this bucket but is still waiting on the lock sees the
+            // Evicted flag we set below and retries.
+            lock (kvp.Value.Gate)
             {
-                _buckets.TryRemove(kvp.Key, out _);
+                if (kvp.Value.LastRefillUtc >= cutoff) continue;
+                kvp.Value.Evicted = true;
+                // Atomic compare-and-remove: only drop the entry if it
+                // STILL maps to the same bucket instance. Belt-and-
+                // braces — the Evicted flag is already authoritative,
+                // but this avoids accidentally removing a replacement
+                // bucket inserted by a concurrent retry.
+                ((ICollection<KeyValuePair<BucketKey, Bucket>>)_buckets)
+                    .Remove(kvp);
             }
         }
     }
@@ -136,6 +181,13 @@ public sealed class TokenBucketRateLimiter : IRateLimiter, IDisposable
         public readonly object Gate = new();
         public double Tokens;
         public DateTime LastRefillUtc;
+        // Set by the sweeper under Gate when the bucket is removed
+        // from the dictionary. TryAcquire checks this after taking
+        // Gate and retries the outer GetOrAdd loop if true — without
+        // it, a request that captured this bucket reference before
+        // eviction would happily decrement tokens while a concurrent
+        // request hands out a full fresh burst on the replacement.
+        public bool Evicted;
 
         public Bucket(int burst, DateTime nowUtc)
         {

--- a/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimiter.cs
+++ b/backend/src/B3.Trading.Api/RateLimit/TokenBucketRateLimiter.cs
@@ -1,0 +1,146 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Api.RateLimit;
+
+/// <summary>
+/// Q4.4 (#304). Thread-safe in-memory token-bucket limiter keyed by
+/// <c>(userKey, endpointKey)</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bucket dictionary is a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// keyed by a struct composite key. Each bucket carries its own lock
+/// (a plain <see cref="object"/>) — refill+deduct is a few floating-
+/// point ops so the critical section is short enough that the simple
+/// monitor wins over a CAS loop on a packed long. The "atomic via
+/// Interlocked CAS on packed long" alternative is documented in the
+/// design note on #304 but not implemented here; profile first if the
+/// per-bucket lock ever shows up under contention.
+/// </para>
+/// <para>
+/// Idle-bucket sweep: every <see cref="SweepInterval"/> the limiter
+/// removes buckets whose <c>lastRefillUtc</c> is older than
+/// <see cref="IdleTtl"/> (default: 1 hour). This bounds memory in the
+/// face of long-tail user keys (e.g. one-shot scripts) without
+/// affecting active sessions — an evicted bucket simply reappears full
+/// on the next request, which is the correct semantics for a token
+/// bucket that has been idle long enough to refill anyway.
+/// </para>
+/// </remarks>
+public sealed class TokenBucketRateLimiter : IRateLimiter, IDisposable
+{
+    /// <summary>Window between idle-bucket sweeps.</summary>
+    public static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// A bucket whose last refill timestamp is older than this is
+    /// eligible for eviction by the sweeper. One hour is well above
+    /// any realistic refill horizon for the configured policies.
+    /// </summary>
+    public static readonly TimeSpan IdleTtl = TimeSpan.FromHours(1);
+
+    private readonly ConcurrentDictionary<BucketKey, Bucket> _buckets = new();
+    private readonly Func<DateTime> _utcNow;
+    private readonly Timer? _sweepTimer;
+
+    public TokenBucketRateLimiter() : this(() => DateTime.UtcNow, startSweeper: true) { }
+
+    // Test-only ctor — deterministic clock + opt-out of the timer so
+    // unit tests don't race with the sweeper.
+    internal TokenBucketRateLimiter(Func<DateTime> utcNow, bool startSweeper)
+    {
+        _utcNow = utcNow;
+        if (startSweeper)
+        {
+            _sweepTimer = new Timer(_ => SweepIdleBuckets(), null, SweepInterval, SweepInterval);
+        }
+    }
+
+    public bool TryAcquire(
+        string userKey,
+        string endpointKey,
+        int burst,
+        double refillPerSecond,
+        out double retryAfterSeconds)
+    {
+        if (burst <= 0 || refillPerSecond <= 0)
+        {
+            // A misconfigured rule should fail open rather than lock
+            // every user out forever; surface as "no limit applied".
+            retryAfterSeconds = 0;
+            return true;
+        }
+
+        var key = new BucketKey(userKey, endpointKey);
+        var bucket = _buckets.GetOrAdd(key, _ => new Bucket(burst, _utcNow()));
+
+        lock (bucket.Gate)
+        {
+            var now = _utcNow();
+            var elapsed = (now - bucket.LastRefillUtc).TotalSeconds;
+            if (elapsed > 0)
+            {
+                bucket.Tokens = Math.Min(burst, bucket.Tokens + elapsed * refillPerSecond);
+                bucket.LastRefillUtc = now;
+            }
+
+            if (bucket.Tokens >= 1.0)
+            {
+                bucket.Tokens -= 1.0;
+                retryAfterSeconds = 0;
+                return true;
+            }
+
+            // tokens shortfall / refillPerSecond → seconds until the
+            // next whole token is available. Ceiling to a friendly
+            // integer second below in the middleware.
+            var needed = 1.0 - bucket.Tokens;
+            retryAfterSeconds = needed / refillPerSecond;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Snapshot the current number of tracked buckets. Test-only.
+    /// </summary>
+    internal int BucketCount => _buckets.Count;
+
+    /// <summary>
+    /// Force an idle sweep. Test-only.
+    /// </summary>
+    internal void SweepIdleBucketsForTest() => SweepIdleBuckets();
+
+    private void SweepIdleBuckets()
+    {
+        var cutoff = _utcNow() - IdleTtl;
+        foreach (var kvp in _buckets)
+        {
+            // Read under the bucket's own lock so we don't race a
+            // TryAcquire that is in the middle of advancing
+            // LastRefillUtc.
+            DateTime lastRefill;
+            lock (kvp.Value.Gate) lastRefill = kvp.Value.LastRefillUtc;
+            if (lastRefill < cutoff)
+            {
+                _buckets.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    public void Dispose() => _sweepTimer?.Dispose();
+
+    private readonly record struct BucketKey(string UserKey, string EndpointKey);
+
+    private sealed class Bucket
+    {
+        public readonly object Gate = new();
+        public double Tokens;
+        public DateTime LastRefillUtc;
+
+        public Bucket(int burst, DateTime nowUtc)
+        {
+            Tokens = burst;
+            LastRefillUtc = nowUtc;
+        }
+    }
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -809,10 +809,12 @@ public static class MetricsRegistry
     /// Q4.4 (#304). Count of requests rejected by the per-user × endpoint
     /// token-bucket rate limiter. Tags: <c>path</c> = the matched bucket
     /// key (rule's PathPattern, NOT the raw URL — keeps cardinality
-    /// bounded), <c>user</c> = the JWT sub or client IP that was
-    /// throttled. User cardinality is acceptable here since the user
-    /// base is finite and the metric is the primary signal for spotting
-    /// individual abuse.
+    /// bounded), <c>principal_kind</c> ∈ {<c>user</c>, <c>ip</c>,
+    /// <c>anonymous</c>} — also bounded. The throttled identity (sub-
+    /// claim or remote IP) is NOT a tag because an IP-spray attack
+    /// would create an unbounded number of series; for per-actor
+    /// attribution see the corresponding <c>ratelimit.rejected</c>
+    /// log line emitted by the middleware.
     /// </summary>
     public static readonly Counter<long> RateLimitRejected =
         Meter.CreateCounter<long>("trading.ratelimit.rejected_total");

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -804,4 +804,16 @@ public static class MetricsRegistry
             description: "Configured Trading:Persistence:GroupCommitMaxRecords. Build-info-style gauge sourced from IOptionsMonitor; reflects config reloads.");
     public static void RegisterGroupCommitMaxRecordsSource(Func<int> source) =>
         _groupCommitMaxRecordsSource = source;
+
+    /// <summary>
+    /// Q4.4 (#304). Count of requests rejected by the per-user × endpoint
+    /// token-bucket rate limiter. Tags: <c>path</c> = the matched bucket
+    /// key (rule's PathPattern, NOT the raw URL — keeps cardinality
+    /// bounded), <c>user</c> = the JWT sub or client IP that was
+    /// throttled. User cardinality is acceptable here since the user
+    /// base is finite and the metric is the primary signal for spotting
+    /// individual abuse.
+    /// </summary>
+    public static readonly Counter<long> RateLimitRejected =
+        Meter.CreateCounter<long>("trading.ratelimit.rejected_total");
 }

--- a/backend/src/B3.Trading.Host/Program.cs
+++ b/backend/src/B3.Trading.Host/Program.cs
@@ -1,4 +1,5 @@
 using B3.Trading.EntryPointListener;
+using B3.Trading.Api.RateLimit;
 using B3.Trading.Host.Composition;
 using B3.Trading.Host.Observability;
 
@@ -25,6 +26,7 @@ builder.Services.AddTradingRisk(builder.Configuration);
 builder.Services.AddTradingExchangeGateway(builder.Configuration);
 builder.Services.AddTradingDataProtection(builder.Configuration);
 builder.Services.AddTradingObservability(builder.Configuration);
+builder.Services.AddTradingRateLimit(builder.Configuration);
 
 var app = builder.Build();
 
@@ -42,6 +44,11 @@ app.UseRateLimiter();
 
 app.UseWebSockets();
 app.UseAuthentication();
+// Q4.4 (#304). Per-user × endpoint token-bucket runs AFTER auth so the
+// JWT sub-claim is the partition key for authenticated traffic, and
+// BEFORE authorization so the 429 short-circuits the handler pipeline
+// before any per-firm scoping or claims check runs.
+app.UseTradingRateLimit();
 app.UseAuthorization();
 
 app.MapTradingEndpoints();

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -121,6 +121,12 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 // hammering /auth/login with bad creds don't trip the
                 // gate. Lockout-specific tests opt in via WithOverrides.
                 ["Trading:Auth:LoginLockout:Enabled"] = "false",
+                // Q4.4 (#304). Per-user × endpoint token-bucket disabled
+                // by default in tests so the broad suite hammering
+                // /orders, /algo, /auth etc. doesn't trip the buckets.
+                // Tests in TokenBucketRateLimitTests opt in explicitly
+                // via WithOverrides.
+                ["Trading:RateLimit:Enabled"] = "false",
             });
 
             if (_configOverrides is not null)

--- a/backend/tests/B3.Trading.Api.Tests/TokenBucketRateLimitTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TokenBucketRateLimitTests.cs
@@ -124,6 +124,50 @@ public class TokenBucketRateLimitTests
         Assert.Equal(0, limiter.BucketCount);
     }
 
+    [Fact]
+    public void TryAcquire_RaceWithSweep_DoesNotAdmitDoubleBurst()
+    {
+        // Reproduces the bug fixed in P2.2 on PR #321: the sweeper
+        // could evict a bucket between a request's GetOrAdd and its
+        // lock-and-acquire; a concurrent request would then create a
+        // fresh full bucket. Without the Evicted-flag retry both
+        // requests grant tokens — up to 2× the configured burst.
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        const int burst = 5;
+        const double refill = 5;
+
+        // Prime bucket B1.
+        Assert.True(limiter.TryAcquire("u", "/orders", burst, refill, out _));
+
+        // On the NEXT TryAcquire, after GetOrAdd returns the existing
+        // bucket but before the lock is taken, simulate the race:
+        // advance the clock past IdleTtl, sweep (which sets Evicted
+        // and removes B1), and then drain a brand-new replacement
+        // bucket B2 from inside the hook. When the outer call finally
+        // takes B1's lock, the fix must observe Evicted=true, retry
+        // GetOrAdd → B2 (now empty), and DENY.
+        var fired = 0;
+        limiter.OnBucketAcquiredForTest = () =>
+        {
+            if (Interlocked.Increment(ref fired) != 1) return;
+            clock = clock.AddHours(2);
+            limiter.SweepIdleBucketsForTest();
+            for (var i = 0; i < burst; i++)
+                Assert.True(limiter.TryAcquire("u", "/orders", burst, refill, out _));
+        };
+
+        var granted = limiter.TryAcquire("u", "/orders", burst, refill, out _);
+        Assert.False(granted);
+
+        // Sanity: total tokens consumed = 1 (prime) + 5 (nested) = 6;
+        // the outer attempt that lost the race against the sweep must
+        // not push that over 6 (i.e. burst+1 across two generations).
+        var nextOk = limiter.TryAcquire("u", "/orders", burst, refill, out _);
+        Assert.False(nextOk);
+    }
+
     // ---- HTTP integration tests via WebApplicationFactory. ----
 
     [Fact]
@@ -213,12 +257,13 @@ public class TokenBucketRateLimitTests
     }
 
     [Fact]
-    public async Task Rejection_IncrementsMetric_WithPathAndUserTags()
+    public async Task Rejection_IncrementsMetric_WithPathAndPrincipalKindTags()
     {
         await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
 
         var observedPath = (string?)null;
-        var observedUser = (string?)null;
+        var observedPrincipalKind = (string?)null;
+        var userTagSeen = false;
         var total = 0L;
         using var listener = new MeterListener();
         listener.InstrumentPublished = (instr, l) =>
@@ -234,7 +279,11 @@ public class TokenBucketRateLimitTests
             foreach (var tag in tags)
             {
                 if (tag.Key == "path" && tag.Value is string p) observedPath = p;
-                if (tag.Key == "user" && tag.Value is string u) observedUser = u;
+                if (tag.Key == "principal_kind" && tag.Value is string k) observedPrincipalKind = k;
+                // P2.1 fix on PR #321: `user` must NOT be a metric tag
+                // — under an IP-spray attack the unbounded set of
+                // RemoteIpAddress values would explode cardinality.
+                if (tag.Key == "user") userTagSeen = true;
             }
             Interlocked.Add(ref total, value);
         });
@@ -247,7 +296,10 @@ public class TokenBucketRateLimitTests
 
         Assert.True(total >= 1);
         Assert.Equal("/orders", observedPath);
-        Assert.Equal(TestAppFactory.TestUser, observedUser);
+        Assert.Equal("user", observedPrincipalKind);
+        Assert.False(userTagSeen,
+            "The `user` tag must be dropped to keep the metric cardinality bounded; "
+            + "the throttled identity is logged on the rejection log line instead.");
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Api.Tests/TokenBucketRateLimitTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TokenBucketRateLimitTests.cs
@@ -1,0 +1,349 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.RateLimit;
+using B3.Trading.Application;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q4.4 (#304). End-to-end + unit coverage for the per-user × endpoint
+/// token-bucket rate limiter. Every HTTP-flavoured test opts in to the
+/// limiter via <c>WithOverrides</c> — the test factory defaults it OFF
+/// so the rest of the suite (which hammers /orders / /algo) is
+/// unaffected.
+/// </summary>
+public class TokenBucketRateLimitTests
+{
+    /// <summary>
+    /// Shared overrides for the HTTP integration tests: enable the
+    /// limiter and pin the /orders POST rule to burst=5 with a glacial
+    /// refill so the assertions are not racing the token-bucket
+    /// regeneration on a busy CI host. The default refill (5/s) plus
+    /// HTTP round-trip latency under parallel test execution would
+    /// otherwise top the bucket back up between calls.
+    /// </summary>
+    private static Dictionary<string, string?> EnableLimiterDeterministic() => new()
+    {
+        ["Trading:RateLimit:Enabled"] = "true",
+        ["Trading:RateLimit:Rules:0:PathPattern"] = "/orders",
+        ["Trading:RateLimit:Rules:0:Methods:0"] = "POST",
+        ["Trading:RateLimit:Rules:0:Methods:1"] = "PUT",
+        ["Trading:RateLimit:Rules:0:Methods:2"] = "DELETE",
+        ["Trading:RateLimit:Rules:0:Methods:3"] = "PATCH",
+        ["Trading:RateLimit:Rules:0:Burst"] = "5",
+        ["Trading:RateLimit:Rules:0:RefillPerSecond"] = "0.01",
+        ["Trading:RateLimit:Rules:1:PathPattern"] = "/auth/login",
+        ["Trading:RateLimit:Rules:1:Burst"] = "3",
+        ["Trading:RateLimit:Rules:1:RefillPerSecond"] = "0.01",
+    };
+
+    // ---- Pure unit tests over the limiter primitive (no HTTP). ----
+
+    [Fact]
+    public void TryAcquire_BurstThenRejects_ReportsRetryAfter()
+    {
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.True(limiter.TryAcquire("u", "/orders", burst: 5, refillPerSecond: 5, out _));
+        }
+
+        var ok = limiter.TryAcquire("u", "/orders", burst: 5, refillPerSecond: 5, out var retry);
+        Assert.False(ok);
+        // No time elapsed and 0 tokens left → wait 1/5s = 0.2s.
+        Assert.InRange(retry, 0.15, 0.25);
+    }
+
+    [Fact]
+    public void TryAcquire_AfterRefillWindow_GrantsMoreTokens()
+    {
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        for (var i = 0; i < 5; i++)
+            Assert.True(limiter.TryAcquire("u", "/orders", 5, 5, out _));
+        Assert.False(limiter.TryAcquire("u", "/orders", 5, 5, out _));
+
+        // Advance 1.1 s; with refill=5/s that gives 5.5 tokens
+        // (capped at burst=5). Five more must succeed.
+        clock = clock.AddMilliseconds(1100);
+        for (var i = 0; i < 5; i++)
+            Assert.True(limiter.TryAcquire("u", "/orders", 5, 5, out _));
+        Assert.False(limiter.TryAcquire("u", "/orders", 5, 5, out _));
+    }
+
+    [Fact]
+    public void TryAcquire_PerUserBucketIsolation()
+    {
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        // Exhaust user A.
+        for (var i = 0; i < 5; i++)
+            Assert.True(limiter.TryAcquire("alice", "/orders", 5, 5, out _));
+        Assert.False(limiter.TryAcquire("alice", "/orders", 5, 5, out _));
+
+        // User B is untouched — still has a full bucket.
+        for (var i = 0; i < 5; i++)
+            Assert.True(limiter.TryAcquire("bob", "/orders", 5, 5, out _));
+    }
+
+    [Fact]
+    public void TryAcquire_PerEndpointBucketIsolation()
+    {
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        for (var i = 0; i < 5; i++)
+            Assert.True(limiter.TryAcquire("alice", "/orders", 5, 5, out _));
+        Assert.False(limiter.TryAcquire("alice", "/orders", 5, 5, out _));
+
+        // Same user, different endpoint key — independent bucket.
+        Assert.True(limiter.TryAcquire("alice", "/positions", 100, 100, out _));
+    }
+
+    [Fact]
+    public void IdleBuckets_EvictedBySweeper()
+    {
+        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var limiter = new TokenBucketRateLimiter(() => clock, startSweeper: false);
+
+        limiter.TryAcquire("ghost", "/orders", 5, 5, out _);
+        Assert.Equal(1, limiter.BucketCount);
+
+        // Advance past the 1-hour idle TTL.
+        clock = clock.AddHours(2);
+        limiter.SweepIdleBucketsForTest();
+        Assert.Equal(0, limiter.BucketCount);
+    }
+
+    // ---- HTTP integration tests via WebApplicationFactory. ----
+
+    [Fact]
+    public async Task Orders_BurstThenRejects_With429AndRetryAfter()
+    {
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        var http = await factory.CreateAuthedClientAsync();
+
+        // First 5 POSTs against /orders ride the default burst=5
+        // rule and are accepted (Accepted/OK status — never 429).
+        for (var i = 0; i < 5; i++)
+        {
+            var resp = await PostMinimalOrder(http);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+
+        // The 6th must hit the limiter.
+        var rejected = await PostMinimalOrder(http);
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+        Assert.True(rejected.Headers.Contains("Retry-After"));
+        var body = await rejected.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("rate_limited", body.GetProperty("error").GetString());
+        Assert.True(body.GetProperty("retryAfterSeconds").GetInt32() > 0);
+    }
+
+    [Fact]
+    public async Task Orders_PerUserIsolation_UserBUnaffectedWhenUserAExhausted()
+    {
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        var alice = await factory.CreateAuthedClientAsync(user: "alice");
+        var bob = await factory.CreateAuthedClientAsync(user: "bob");
+
+        // Drain alice's bucket.
+        for (var i = 0; i < 5; i++) await PostMinimalOrder(alice);
+        var aliceRejected = await PostMinimalOrder(alice);
+        Assert.Equal(HttpStatusCode.TooManyRequests, aliceRejected.StatusCode);
+
+        // Bob still has full burst.
+        for (var i = 0; i < 5; i++)
+        {
+            var resp = await PostMinimalOrder(bob);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Orders_PerEndpointIsolation_PositionsUnaffectedByOrdersExhaustion()
+    {
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        var http = await factory.CreateAuthedClientAsync();
+
+        for (var i = 0; i < 5; i++) await PostMinimalOrder(http);
+        var ordersBlocked = await PostMinimalOrder(http);
+        Assert.Equal(HttpStatusCode.TooManyRequests, ordersBlocked.StatusCode);
+
+        // GET /positions rides the generic-read rule (burst=100); it
+        // must NOT inherit the /orders write bucket's exhaustion.
+        var positions = await http.GetAsync("/positions");
+        Assert.NotEqual(HttpStatusCode.TooManyRequests, positions.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_PreAuthIpBucket_RejectsAfterBurst()
+    {
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        // Default /auth/login rule: burst=3, refill=1/s. From the same
+        // IP (localhost in the test host) the 4th attempt — within the
+        // same second — must be rejected with 429. Use a deliberately
+        // bad password so the test isn't sensitive to login success
+        // semantics (the limiter trips BEFORE the handler runs).
+        using var http = factory.CreateClient();
+
+        for (var i = 0; i < 3; i++)
+        {
+            var resp = await http.PostAsJsonAsync("/auth/login",
+                new LoginRequest("does-not-exist", "wrong"));
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+        var rejected = await http.PostAsJsonAsync("/auth/login",
+            new LoginRequest("does-not-exist", "wrong"));
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+        Assert.True(rejected.Headers.Contains("Retry-After"));
+    }
+
+    [Fact]
+    public async Task Rejection_IncrementsMetric_WithPathAndUserTags()
+    {
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        var observedPath = (string?)null;
+        var observedUser = (string?)null;
+        var total = 0L;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instr, l) =>
+        {
+            if (instr.Meter.Name == "B3.Trading"
+                && instr.Name == "trading.ratelimit.rejected_total")
+            {
+                l.EnableMeasurementEvents(instr);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "path" && tag.Value is string p) observedPath = p;
+                if (tag.Key == "user" && tag.Value is string u) observedUser = u;
+            }
+            Interlocked.Add(ref total, value);
+        });
+        listener.Start();
+
+        var http = await factory.CreateAuthedClientAsync();
+        for (var i = 0; i < 5; i++) await PostMinimalOrder(http);
+        var rejected = await PostMinimalOrder(http);
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+
+        Assert.True(total >= 1);
+        Assert.Equal("/orders", observedPath);
+        Assert.Equal(TestAppFactory.TestUser, observedUser);
+    }
+
+    [Fact]
+    public async Task BypassRoles_AdminSkipsLimiter()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>(EnableLimiterDeterministic())
+        {
+            ["Trading:RateLimit:BypassRoles:0"] = "admin",
+        });
+
+        // Mint an admin JWT directly via the issuer so we don't even
+        // burn an /auth/login token to do the test.
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var (token, _) = issuer.Issue("admin", "admin");
+
+        using var http = factory.CreateClient();
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Push well past the 5-token burst — must NEVER 429 with
+        // bypass active.
+        for (var i = 0; i < 12; i++)
+        {
+            var resp = await PostMinimalOrder(http);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task MultiFirm_BucketKeyedByUsernameOnly_LimitsAcrossFirms()
+    {
+        // Documented design choice: the bucket key is the JWT sub
+        // alone, NOT (sub, firm). So the same login flooding /orders
+        // across FIRM01 and FIRM02 hits the same bucket — i.e. the
+        // limiter clamps the user, not the user-in-a-firm.
+        await using var factory = TestAppFactory.WithOverrides(EnableLimiterDeterministic());
+
+        var issuer = factory.Services.GetRequiredService<JwtIssuer>();
+        var (firm1, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM01");
+        var (firm2, _) = issuer.Issue(TestAppFactory.TestUser, "user", "FIRM02");
+
+        using var http1 = factory.CreateClient();
+        http1.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", firm1);
+        using var http2 = factory.CreateClient();
+        http2.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", firm2);
+
+        // Pre-register the owner so /orders POST doesn't 404 on
+        // EndClient resolution. Both firm tokens share the same
+        // sub-claim so a single Register() call covers both.
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        registry.Register(TestAppFactory.TestUser);
+
+        var sawRejection = false;
+        // 6 total writes spread across the two firms (3 each); the
+        // shared bucket has burst=5 so at least one must 429.
+        for (var i = 0; i < 3; i++) await PostMinimalOrder(http1);
+        for (var i = 0; i < 3; i++)
+        {
+            var resp = await PostMinimalOrder(http2);
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests) sawRejection = true;
+        }
+        Assert.True(sawRejection,
+            "Expected at least one 429 — same username across firms must share a bucket.");
+    }
+
+    [Fact]
+    public async Task RateLimit_DisabledByDefault_InTestFactory()
+    {
+        // Regression guard: the test factory MUST default the limiter
+        // off so the broad suite (which fires hundreds of writes) is
+        // unaffected. Hammer /orders past the burst and assert no 429.
+        using var factory = new TestAppFactory();
+        var http = await factory.CreateAuthedClientAsync();
+
+        for (var i = 0; i < 20; i++)
+        {
+            var resp = await PostMinimalOrder(http);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, resp.StatusCode);
+        }
+    }
+
+    // ---- helpers ----
+
+    private static Task<HttpResponseMessage> PostMinimalOrder(HttpClient http)
+    {
+        // Minimal but valid SubmitOrderRequest — matches the shape
+        // OrdersIcebergEndpointTests uses. PETR4 reference price is
+        // seeded in the test factory so the collar check is happy.
+        var payload = new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            Quantity = 10,
+            Price = 30.0m,
+        };
+        return http.PostAsJsonAsync("/orders", payload);
+    }
+}

--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -29,6 +29,14 @@ services:
       Trading__Auth__Users__4__Iterations: "600000"
       Trading__Auth__Users__4__Role: admin
       Trading__Auth__Users__4__Firm: default
+      # Q4.4 (#304). The conformance suite authenticates from a single
+      # container IP and issues many logins in rapid succession across
+      # specs. With the default per-IP auth bucket (burst=3, 1/s refill)
+      # that legitimate volume trips the limiter and fails specs that
+      # are not exercising rate-limit behaviour. The suite does not
+      # itself cover rate-limit semantics, so disable the limiter for
+      # the conformance overlay only — production hosts keep it on.
+      Trading__RateLimit__Enabled: "false"
 
   conformance:
     build:


### PR DESCRIPTION
Closes #304

## Summary
ASP.NET Core middleware that gates each HTTP request through a
token-bucket keyed by `(user, endpoint-rule)`.

## Defaults (code-shipped, overridable via `Trading:RateLimit:Rules`)
| Endpoint                                | Methods                     | Burst | Refill/s |
|-----------------------------------------|-----------------------------|------:|---------:|
| `/orders`                             | POST/PUT/DELETE/PATCH       |     5 |        5 |
| `/auth/login`                         | (any)                       |     3 |        1 |
| `/auth/2fa/verify`, `/auth/2fa/enroll` | (any)                     |     3 |        1 |
| `/algo/*`                             | POST/PUT/DELETE/PATCH       |    10 |        5 |
| generic write fallback (`/`)          | POST/PUT/DELETE/PATCH       |    20 |       20 |
| generic read fallback (`/`)           | GET/HEAD/OPTIONS            |   100 |      100 |

## Contract
- Rejection: `429 Too Many Requests` + `Retry-After: <ceil(seconds)>` header.
- Body: `{"error":"rate_limited","retryAfterSeconds":N}`.
- Metric: `trading.ratelimit.rejected_total` tagged `{path, user}` where `path` is the matched **bucket key** (rule PathPattern), not the raw URL — keeps cardinality bounded.
- Bypass: `Trading:RateLimit:BypassRoles` (default empty — admins are throttled too).
- Master kill-switch: `Trading:RateLimit:Enabled` (default `true`; the test factory flips it off).

## Key design decisions
- **Resolution priority**: non-fallback rules outrank generic catch-alls (even method-restricted ones), then longest-prefix-wins, then method-aware ties. Means `/auth/login` (length 11, method-less) beats `/` POST fallback.
- **Idle eviction TTL**: 1 hour; sweeper runs every 5 minutes. An evicted bucket reappears full — correct semantics for a bucket that has been idle long enough to refill anyway.
- **Pre-auth user-key**: `User.Identity.Name ?? RemoteIpAddress ?? "anonymous"`. Login + 2FA endpoints inherently fall back to IP. `X-Forwarded-For` is **not** consulted — operators must wire `UseForwardedHeaders` upstream when behind a proxy (same stance as the existing `AuthRateLimiterSetup`).
- **Multi-firm**: bucket key is JWT `sub` alone, **not** `(sub, firm)`. The same login flooding `/orders` across FIRM01/FIRM02 shares one bucket — the limiter clamps the human, not the human-in-a-firm. Documented in `TokenBucketRateLimitOptions`.
- **Composition order**: middleware mounted after `UseAuthentication` (sub-claim is the partition key) and before `UseAuthorization` (429 short-circuits the handler).

## Tests (13)
HTTP/integration:
- Burst → 6th POST /orders returns 429 with Retry-After.
- Per-user isolation (alice exhausted ≠ bob).
- Per-endpoint isolation (/orders exhausted ≠ /positions).
- Pre-auth IP bucket on /auth/login (4th rejected).
- 429 increments `trading.ratelimit.rejected_total` with `path=/orders user=alice`.
- BypassRoles=[admin] → admin token never 429s.
- Multi-firm: same sub across FIRM01/02 shares the bucket.
- Test factory default disabled → regression guard.

Unit (deterministic clock):
- Burst → reject + retryAfter ≈ 0.2s.
- Wait 1.1s with refill=5/s → 5 more tokens.
- Per-user / per-endpoint bucket isolation.
- Idle sweeper evicts buckets older than 1h.

`dotnet test B3TradingPlatform.slnx` → 1658 passed, 30 skipped, 0 failed.
`dotnet format B3TradingPlatform.slnx --verify-no-changes` → clean.