### PR TITLE
Q4.5 (#305): admin audit log

### DIFF
--- a/backend/src/B3.Trading.Api/AdminAuditEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminAuditEndpoints.cs
@@ -1,0 +1,88 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using B3.Trading.Application.Audit;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// Q4.5 (#305). Read-only admin surface over <see cref="AuditLogKeeper"/>.
+/// Mounted under <c>/admin/audit</c>, gated by the existing <c>"admin"</c>
+/// authorization policy (anonymous → 401, non-admin → 403). The endpoint
+/// returns events newest-first with opaque base64 cursor pagination.
+///
+/// <para>Scope is global by design: a single admin role exists today, so
+/// audit is visible across firms. Once #314 introduces a dedicated
+/// compliance role this should be retightened. Filters: <c>since</c>,
+/// <c>until</c>, <c>user</c>, <c>type</c> (exact or <c>prefix.*</c>),
+/// <c>outcome</c>, <c>limit</c> (default 100, max 500), <c>cursor</c>.</para>
+/// </summary>
+public static class AdminAuditEndpoints
+{
+    public static IEndpointRouteBuilder MapAdminAudit(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/admin").RequireAuthorization("admin");
+
+        group.MapGet("/audit", (HttpContext ctx, AuditLogKeeper keeper) =>
+        {
+            var q = ctx.Request.Query;
+            var now = DateTimeOffset.UtcNow;
+
+            DateTimeOffset since = now.AddHours(-24);
+            DateTimeOffset until = now;
+            if (q.TryGetValue("since", out var s) && DateTimeOffset.TryParse(s.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedSince))
+                since = parsedSince;
+            if (q.TryGetValue("until", out var u) && DateTimeOffset.TryParse(u.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedUntil))
+                until = parsedUntil;
+
+            int limit = 100;
+            if (q.TryGetValue("limit", out var l) && int.TryParse(l.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedLimit))
+                limit = parsedLimit;
+
+            string? user = q.TryGetValue("user", out var us) && !string.IsNullOrWhiteSpace(us) ? us.ToString() : null;
+            string? type = q.TryGetValue("type", out var t) && !string.IsNullOrWhiteSpace(t) ? t.ToString() : null;
+            string? outcome = q.TryGetValue("outcome", out var o) && !string.IsNullOrWhiteSpace(o) ? o.ToString() : null;
+
+            long? cursorSeq = null;
+            if (q.TryGetValue("cursor", out var c) && !string.IsNullOrWhiteSpace(c))
+            {
+                if (!TryDecodeCursor(c.ToString(), out var decoded))
+                    return Results.BadRequest(new { error = "invalid cursor" });
+                cursorSeq = decoded;
+            }
+
+            var result = keeper.Query(since, until, user, type, outcome, limit, cursorSeq);
+            return Results.Ok(new
+            {
+                entries = result.Entries,
+                nextCursor = result.NextCursorSeq is long ns ? EncodeCursor(ns) : null,
+            });
+        });
+
+        return app;
+    }
+
+    private static string EncodeCursor(long seq)
+    {
+        var raw = Encoding.UTF8.GetBytes(seq.ToString(CultureInfo.InvariantCulture));
+        return Convert.ToBase64String(raw);
+    }
+
+    private static bool TryDecodeCursor(string cursor, out long seq)
+    {
+        seq = 0;
+        try
+        {
+            var raw = Convert.FromBase64String(cursor);
+            var str = Encoding.UTF8.GetString(raw);
+            return long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out seq);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -98,20 +98,22 @@ public static class AdminEndpoints
                 var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
                 try
                 {
-                    var result = svc.MarkStale(firmId, clOrdIdU, reason, DateTimeOffset.UtcNow, actor);
-                    var outcome = result switch
-                    {
-                        MarkStaleResult.Marked or MarkStaleResult.AlreadyStale => AuditOutcomes.Success,
-                        MarkStaleResult.NotEligible => AuditOutcomes.Denied,
-                        _ => AuditOutcomes.Failure,
-                    };
-                    EmitAdminConfigChange(audit, ctx, "/admin/orders/mark-stale", outcome, new()
+                    // Pass-1 review (#322) P1.2. Audit-first ordering —
+                    // emit the operator's stale-mark intent before the
+                    // service call so a WAL-backpressured audit append
+                    // refuses the mutation with 503 rather than letting
+                    // the OrderStalenessService dispatch its own WAL
+                    // event un-audited. The actual mark result
+                    // (Marked/AlreadyStale/NotEligible/NotFound) is
+                    // communicated by the HTTP response below; the
+                    // audit envelope records the attempt.
+                    EmitAdminConfigChange(audit, ctx, "/admin/orders/mark-stale", AuditOutcomes.Success, new()
                     {
                         ["firm"] = firmId,
                         ["cl_ord_id"] = clOrdId,
-                        ["result"] = result.ToString(),
                         ["reason"] = reason,
-                    });
+                    }, failClosed: true);
+                    var result = svc.MarkStale(firmId, clOrdIdU, reason, DateTimeOffset.UtcNow, actor);
                     return result switch
                     {
                         MarkStaleResult.Marked => Results.NoContent(),
@@ -140,18 +142,14 @@ public static class AdminEndpoints
                 var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
                 try
                 {
-                    var result = svc.ClearStale(firmId, clOrdIdU, actor);
-                    var outcome = result switch
-                    {
-                        ClearStaleResult.Cleared or ClearStaleResult.NotStale => AuditOutcomes.Success,
-                        _ => AuditOutcomes.Failure,
-                    };
-                    EmitAdminConfigChange(audit, ctx, "/admin/orders/clear-stale", outcome, new()
+                    // Pass-1 review (#322) P1.2. Audit-first ordering —
+                    // see mark-stale above.
+                    EmitAdminConfigChange(audit, ctx, "/admin/orders/clear-stale", AuditOutcomes.Success, new()
                     {
                         ["firm"] = firmId,
                         ["cl_ord_id"] = clOrdId,
-                        ["result"] = result.ToString(),
-                    });
+                    }, failClosed: true);
+                    var result = svc.ClearStale(firmId, clOrdIdU, actor);
                     return result switch
                     {
                         ClearStaleResult.Cleared => Results.NoContent(),
@@ -177,17 +175,36 @@ public static class AdminEndpoints
             // is a no-op (and arguably misleading) when persistence is
             // disabled. Surface that as 409 rather than silently producing
             // an empty report.
-            if (!eod.IsAvailable)
+            try
             {
-                EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Denied, new()
+                if (!eod.IsAvailable)
                 {
-                    ["reason"] = "persistence_disabled",
-                });
-                return Results.Conflict(new { error = "persistence_disabled" });
+                    // Pass-1 review (#322) P1.2. Up-front denial: audit
+                    // the denied outcome with the precise reason and
+                    // surface 409 — no business work to perform, so the
+                    // single audit record carries the full picture.
+                    EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Denied, new()
+                    {
+                        ["reason"] = "persistence_disabled",
+                    }, failClosed: true);
+                    return Results.Conflict(new { error = "persistence_disabled" });
+                }
+                // Audit-first ordering — record the operator's EOD
+                // trigger before the (potentially expensive)
+                // materialisation runs so a WAL-backpressured audit
+                // append refuses the run with 503.
+                EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Success, failClosed: true);
+                var report = eod.Materialise(DateOnly.FromDateTime(DateTime.UtcNow));
+                return Results.Ok(report);
             }
-            var report = eod.Materialise(DateOnly.FromDateTime(DateTime.UtcNow));
-            EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Success);
-            return Results.Ok(report);
+            catch (WalBackpressureException ex)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "admin.eod"));
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         });
 
         // Per-firm operator visibility. In Real mode the response folds in
@@ -248,13 +265,30 @@ public static class AdminEndpoints
         // immediately re-query /admin/risk/limits to verify.
         group.MapPost("/risk/reload", (IServiceProvider sp, HttpContext ctx, IAuditLogger audit) =>
         {
-            var reloader = sp.GetService<IRiskOptionsReloader>();
-            reloader?.Reload();
-            EmitAdminConfigChange(audit, ctx, "/admin/risk/reload", AuditOutcomes.Success, new()
+            try
             {
-                ["reloader_present"] = reloader is null ? "false" : "true",
-            });
-            return Results.NoContent();
+                // Pass-1 review (#322) P1.2. Audit-first ordering for
+                // a risk-config reload: a backpressured audit append
+                // refuses the reload with 503 rather than reloading
+                // silently un-audited (this endpoint can flip
+                // resolver behaviour platform-wide once a custom
+                // provider is wired).
+                EmitAdminConfigChange(audit, ctx, "/admin/risk/reload", AuditOutcomes.Success, new()
+                {
+                    ["reloader_present"] = sp.GetService<IRiskOptionsReloader>() is null ? "false" : "true",
+                }, failClosed: true);
+                var reloader = sp.GetService<IRiskOptionsReloader>();
+                reloader?.Reload();
+                return Results.NoContent();
+            }
+            catch (WalBackpressureException ex)
+            {
+                MetricsRegistry.WalBackpressure.Add(1,
+                    new KeyValuePair<string, object?>("call_site", "admin.risk.reload"));
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         });
 
         // GET /admin/marketdata/reference-prices?symbols=ITUB4,VALE3
@@ -401,6 +435,25 @@ public static class AdminEndpoints
 
         try
         {
+            // Pass-1 review (#322) P1.2. Audit-first ordering — emit
+            // the operator's cash-ledger intent BEFORE the dispatch
+            // so a WAL-backpressured audit append refuses the
+            // (cash-affecting) mutation with 503 rather than
+            // committing it un-audited. For withdrawals the dispatch
+            // below uses DispatchWithPreApply (atomic under the
+            // snapshot lock) and may still be denied at runtime
+            // (insufficient_funds); that downstream denial is
+            // surfaced by the HTTP response and the cash counter —
+            // the audit envelope records the attempt.
+            EmitAdminConfigChange(audit, ctx, "/admin/cash", AuditOutcomes.Success, new()
+            {
+                ["endclient"] = req.Endclient!,
+                ["kind"] = kind,
+                ["amount"] = req.Amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["currency"] = currency,
+                ["reference"] = req.Reference ?? "",
+            }, failClosed: true);
+
             // Q2.2 (#269) P1 fix: debit + WAL append must be atomic with
             // respect to the snapshot lock. The previous flow ran
             // TryWithdraw OUTSIDE the dispatcher lock; a snapshot could
@@ -427,14 +480,6 @@ public static class AdminEndpoints
 
                 if (!outcome.Applied)
                 {
-                    EmitAdminConfigChange(audit, ctx, "/admin/cash", AuditOutcomes.Denied, new()
-                    {
-                        ["endclient"] = req.Endclient!,
-                        ["kind"] = kind,
-                        ["amount"] = req.Amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                        ["currency"] = currency,
-                        ["reason"] = "insufficient_funds",
-                    }, reasonCode: "insufficient_funds");
                     return Results.UnprocessableEntity(new
                     {
                         error = "insufficient_funds",
@@ -458,14 +503,6 @@ public static class AdminEndpoints
                     () => keeper.ApplyDeposit(owner, req.Amount));
             }
 
-            EmitAdminConfigChange(audit, ctx, "/admin/cash", AuditOutcomes.Success, new()
-            {
-                ["endclient"] = req.Endclient!,
-                ["kind"] = kind,
-                ["amount"] = req.Amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                ["currency"] = currency,
-                ["reference"] = req.Reference ?? "",
-            });
             return Results.Ok(new
             {
                 endclient = req.Endclient,
@@ -495,8 +532,22 @@ public static class AdminEndpoints
         Action mutate)
     {
         var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+        // Pass-1 review (#322) P1.2. Audit-first: emit the audit
+        // envelope BEFORE the business dispatch so a WAL-backpressured
+        // audit append refuses the mutation with 503 rather than
+        // silently committing the kill-switch toggle un-audited. The
+        // catch below converts the audit-site backpressure into a
+        // structured 503; the inner dispatch's own backpressure is
+        // converted by the same handler (the audit record then
+        // documents the operator's attempt regardless).
         try
         {
+            EmitAdminConfigChange(audit, ctx, "/admin/kill", AuditOutcomes.Success, new()
+            {
+                ["scope"] = scope,
+                ["target"] = target,
+                ["killed"] = killed ? "true" : "false",
+            }, failClosed: true);
             dispatcher.Dispatch(
                 new KillSwitchToggledEvent
                 {
@@ -509,12 +560,6 @@ public static class AdminEndpoints
             MetricsRegistry.KillSwitchToggled.Add(1,
                 new KeyValuePair<string, object?>("scope", scope),
                 new KeyValuePair<string, object?>("killed", killed));
-            EmitAdminConfigChange(audit, ctx, "/admin/kill", AuditOutcomes.Success, new()
-            {
-                ["scope"] = scope,
-                ["target"] = target,
-                ["killed"] = killed ? "true" : "false",
-            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -538,6 +583,13 @@ public static class AdminEndpoints
         var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
         try
         {
+            // Pass-1 review (#322) P1.2. Audit-first ordering — see
+            // ToggleKill for the rationale.
+            EmitAdminConfigChange(audit, ctx, "/admin/halts", AuditOutcomes.Success, new()
+            {
+                ["symbol"] = symbol,
+                ["halted"] = halted ? "true" : "false",
+            }, failClosed: true);
             dispatcher.Dispatch(
                 new SymbolHaltToggledEvent
                 {
@@ -548,11 +600,6 @@ public static class AdminEndpoints
                 mutate);
             MetricsRegistry.SymbolHaltToggled.Add(1,
                 new KeyValuePair<string, object?>("halted", halted));
-            EmitAdminConfigChange(audit, ctx, "/admin/halts", AuditOutcomes.Success, new()
-            {
-                ["symbol"] = symbol,
-                ["halted"] = halted ? "true" : "false",
-            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -584,6 +631,17 @@ public static class AdminEndpoints
         var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
         try
         {
+            // Pass-1 review (#322) P1.2. Audit-first — emit the
+            // operator's intent before the business dispatch so a
+            // WAL-backpressured audit append refuses the phase change
+            // with 503 rather than silently committing it un-audited.
+            EmitAdminConfigChange(audit, ctx, "/admin/session-phase", AuditOutcomes.Success, new()
+            {
+                ["scope"] = string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol",
+                ["symbol"] = symbol ?? "",
+                ["cleared"] = cleared ? "true" : "false",
+                ["phase"] = cleared ? "cleared" : parsed.ToString(),
+            }, failClosed: true);
             dispatcher.Dispatch(
                 new SessionPhaseChangedEvent
                 {
@@ -596,13 +654,6 @@ public static class AdminEndpoints
             MetricsRegistry.SessionPhaseChanged.Add(1,
                 new KeyValuePair<string, object?>("scope", string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol"),
                 new KeyValuePair<string, object?>("phase", cleared ? "cleared" : parsed.ToString()));
-            EmitAdminConfigChange(audit, ctx, "/admin/session-phase", AuditOutcomes.Success, new()
-            {
-                ["scope"] = string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol",
-                ["symbol"] = symbol ?? "",
-                ["cleared"] = cleared ? "true" : "false",
-                ["phase"] = cleared ? "cleared" : parsed.ToString(),
-            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -622,6 +673,17 @@ public static class AdminEndpoints
     /// place. The caller is responsible for the
     /// <paramref name="details"/> map's call-site-specific keys
     /// (target id, before/after value, etc.).
+    ///
+    /// <para>Pass-1 review (#322) P1.2. When
+    /// <paramref name="failClosed"/> is <c>true</c> the call routes
+    /// through <see cref="IAuditLogger.LogOrFail"/> so a
+    /// WAL-backpressured audit append propagates a
+    /// <see cref="WalBackpressureException"/> the endpoint can
+    /// convert to HTTP 503; callers MUST emit BEFORE the business
+    /// dispatch when using this mode (audit-first ordering). The
+    /// default best-effort mode is retained for tail-audit emits on
+    /// paths where the operator decision has already been
+    /// communicated (e.g. denial branches).</para>
     /// </summary>
     internal static void EmitAdminConfigChange(
         IAuditLogger audit,
@@ -630,9 +692,10 @@ public static class AdminEndpoints
         string outcome,
         Dictionary<string, string>? details = null,
         string eventType = AuditEventTypes.AdminConfigChange,
-        string? reasonCode = null)
+        string? reasonCode = null,
+        bool failClosed = false)
     {
-        audit.Log(new AuditLogEvent
+        var evt = new AuditLogEvent
         {
             EventType = eventType,
             Outcome = outcome,
@@ -644,7 +707,11 @@ public static class AdminEndpoints
             ResourcePath = resourcePath,
             ReasonCode = reasonCode,
             Details = details,
-        });
+        };
+        if (failClosed)
+            audit.LogOrFail(evt);
+        else
+            audit.Log(evt);
     }
 }
 

--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
@@ -27,17 +28,17 @@ public static class AdminEndpoints
             Firms = svc.ListKilledFirms(),
         }));
 
-        group.MapPost("/kill/end-client/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher) =>
-            ToggleKill(dispatcher, "end-client", id, killed: true, ctx, () => svc.KillEndClient(new EndClientId(id))));
+        group.MapPost("/kill/end-client/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleKill(dispatcher, audit, "end-client", id, killed: true, ctx, () => svc.KillEndClient(new EndClientId(id))));
 
-        group.MapDelete("/kill/end-client/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher) =>
-            ToggleKill(dispatcher, "end-client", id, killed: false, ctx, () => svc.ReviveEndClient(new EndClientId(id))));
+        group.MapDelete("/kill/end-client/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleKill(dispatcher, audit, "end-client", id, killed: false, ctx, () => svc.ReviveEndClient(new EndClientId(id))));
 
-        group.MapPost("/kill/firm/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher) =>
-            ToggleKill(dispatcher, "firm", id, killed: true, ctx, () => svc.KillFirm(id)));
+        group.MapPost("/kill/firm/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleKill(dispatcher, audit, "firm", id, killed: true, ctx, () => svc.KillFirm(id)));
 
-        group.MapDelete("/kill/firm/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher) =>
-            ToggleKill(dispatcher, "firm", id, killed: false, ctx, () => svc.ReviveFirm(id)));
+        group.MapDelete("/kill/firm/{id}", (string id, HttpContext ctx, KillSwitchService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleKill(dispatcher, audit, "firm", id, killed: false, ctx, () => svc.ReviveFirm(id)));
 
         // ── Symbol trading halts ─────────────────────────────────
         // Per-symbol pre-trade gate (#108 slice 2). Halts are
@@ -47,11 +48,11 @@ public static class AdminEndpoints
         group.MapGet("/halts", (SymbolHaltService svc) =>
             Results.Ok(new { Symbols = svc.ListHalted() }));
 
-        group.MapPost("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
-            ToggleHalt(dispatcher, symbol, halted: true, ctx, () => svc.Halt(symbol)));
+        group.MapPost("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleHalt(dispatcher, audit, symbol, halted: true, ctx, () => svc.Halt(symbol)));
 
-        group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher) =>
-            ToggleHalt(dispatcher, symbol, halted: false, ctx, () => svc.Resume(symbol)));
+        group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ToggleHalt(dispatcher, audit, symbol, halted: false, ctx, () => svc.Resume(symbol)));
 
         // ── Session phase (#108) ──────────────────────────────────
         // Per-symbol override + global default trading phase. Drives
@@ -66,18 +67,18 @@ public static class AdminEndpoints
             Overrides = svc.ListOverrides().ToDictionary(kv => kv.Key, kv => kv.Value.ToString()),
         }));
 
-        group.MapPost("/session-phase/default", (SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
-            ChangeSessionPhase(dispatcher, symbol: null, cleared: false, req?.Phase, ctx,
+        group.MapPost("/session-phase/default", (SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ChangeSessionPhase(dispatcher, audit, symbol: null, cleared: false, req?.Phase, ctx,
                 phase => svc.SetDefaultPhase(phase),
                 requirePhase: true));
 
-        group.MapPost("/session-phase/{symbol}", (string symbol, SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
-            ChangeSessionPhase(dispatcher, symbol, cleared: false, req?.Phase, ctx,
+        group.MapPost("/session-phase/{symbol}", (string symbol, SessionPhasePayload req, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ChangeSessionPhase(dispatcher, audit, symbol, cleared: false, req?.Phase, ctx,
                 phase => svc.SetPhase(symbol, phase),
                 requirePhase: true));
 
-        group.MapDelete("/session-phase/{symbol}", (string symbol, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher) =>
-            ChangeSessionPhase(dispatcher, symbol, cleared: true, phaseStr: null, ctx,
+        group.MapDelete("/session-phase/{symbol}", (string symbol, HttpContext ctx, SessionPhaseService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
+            ChangeSessionPhase(dispatcher, audit, symbol, cleared: true, phaseStr: null, ctx,
                 _ => svc.ClearPhase(symbol),
                 requirePhase: false));
 
@@ -89,7 +90,7 @@ public static class AdminEndpoints
         // are firm-scoped so the same ClOrdID across firms (rare —
         // ClOrdIDs are per-firm) cannot be addressed from another firm.
         group.MapPost("/firms/{firmId}/orders/{clOrdId}/mark-stale",
-            (string firmId, string clOrdId, MarkStaleRequest req, HttpContext ctx, OrderStalenessService svc) =>
+            (string firmId, string clOrdId, MarkStaleRequest req, HttpContext ctx, OrderStalenessService svc, IAuditLogger audit) =>
             {
                 if (!ulong.TryParse(clOrdId, out var clOrdIdU))
                     return Results.NotFound();
@@ -98,6 +99,19 @@ public static class AdminEndpoints
                 try
                 {
                     var result = svc.MarkStale(firmId, clOrdIdU, reason, DateTimeOffset.UtcNow, actor);
+                    var outcome = result switch
+                    {
+                        MarkStaleResult.Marked or MarkStaleResult.AlreadyStale => AuditOutcomes.Success,
+                        MarkStaleResult.NotEligible => AuditOutcomes.Denied,
+                        _ => AuditOutcomes.Failure,
+                    };
+                    EmitAdminConfigChange(audit, ctx, "/admin/orders/mark-stale", outcome, new()
+                    {
+                        ["firm"] = firmId,
+                        ["cl_ord_id"] = clOrdId,
+                        ["result"] = result.ToString(),
+                        ["reason"] = reason,
+                    });
                     return result switch
                     {
                         MarkStaleResult.Marked => Results.NoContent(),
@@ -119,7 +133,7 @@ public static class AdminEndpoints
             });
 
         group.MapPost("/firms/{firmId}/orders/{clOrdId}/clear-stale",
-            (string firmId, string clOrdId, HttpContext ctx, OrderStalenessService svc) =>
+            (string firmId, string clOrdId, HttpContext ctx, OrderStalenessService svc, IAuditLogger audit) =>
             {
                 if (!ulong.TryParse(clOrdId, out var clOrdIdU))
                     return Results.NotFound();
@@ -127,6 +141,17 @@ public static class AdminEndpoints
                 try
                 {
                     var result = svc.ClearStale(firmId, clOrdIdU, actor);
+                    var outcome = result switch
+                    {
+                        ClearStaleResult.Cleared or ClearStaleResult.NotStale => AuditOutcomes.Success,
+                        _ => AuditOutcomes.Failure,
+                    };
+                    EmitAdminConfigChange(audit, ctx, "/admin/orders/clear-stale", outcome, new()
+                    {
+                        ["firm"] = firmId,
+                        ["cl_ord_id"] = clOrdId,
+                        ["result"] = result.ToString(),
+                    });
                     return result switch
                     {
                         ClearStaleResult.Cleared => Results.NoContent(),
@@ -146,15 +171,22 @@ public static class AdminEndpoints
                 }
             });
 
-        group.MapPost("/eod", (IEodMaterialiser eod) =>
+        group.MapPost("/eod", (IEodMaterialiser eod, HttpContext ctx, IAuditLogger audit) =>
         {
             // EOD materialisation runs against persisted segments, so it
             // is a no-op (and arguably misleading) when persistence is
             // disabled. Surface that as 409 rather than silently producing
             // an empty report.
             if (!eod.IsAvailable)
+            {
+                EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Denied, new()
+                {
+                    ["reason"] = "persistence_disabled",
+                });
                 return Results.Conflict(new { error = "persistence_disabled" });
+            }
             var report = eod.Materialise(DateOnly.FromDateTime(DateTime.UtcNow));
+            EmitAdminConfigChange(audit, ctx, "/admin/eod", AuditOutcomes.Success);
             return Results.Ok(report);
         });
 
@@ -214,10 +246,14 @@ public static class AdminEndpoints
         // an IRiskOptionsReloader and have the body trigger an
         // out-of-band reload. Returns 204 either way; the caller can
         // immediately re-query /admin/risk/limits to verify.
-        group.MapPost("/risk/reload", (IServiceProvider sp) =>
+        group.MapPost("/risk/reload", (IServiceProvider sp, HttpContext ctx, IAuditLogger audit) =>
         {
             var reloader = sp.GetService<IRiskOptionsReloader>();
             reloader?.Reload();
+            EmitAdminConfigChange(audit, ctx, "/admin/risk/reload", AuditOutcomes.Success, new()
+            {
+                ["reloader_present"] = reloader is null ? "false" : "true",
+            });
             return Results.NoContent();
         });
 
@@ -302,8 +338,8 @@ public static class AdminEndpoints
         // CashLedgerEvent on the WAL and projected into CashKeeper.
         // Decoupled from ER fills — fill-driven cash deltas land via
         // the existing CashLedger and the future P&L engine (#271).
-        group.MapPost("/cash", (CashLedgerRequest? req, HttpContext ctx, CashKeeper keeper, EventDispatcher dispatcher) =>
-            HandleCashLedger(req, ctx, keeper, dispatcher));
+        group.MapPost("/cash", (CashLedgerRequest? req, HttpContext ctx, CashKeeper keeper, EventDispatcher dispatcher, IAuditLogger audit) =>
+            HandleCashLedger(req, ctx, keeper, dispatcher, audit));
 
         // POST /admin/simulator/er — synthetic ER injection (formerly the
         // ExchangeMode.Simulator-only route; merged into Mock+AllowErInjection
@@ -333,7 +369,8 @@ public static class AdminEndpoints
         CashLedgerRequest? req,
         HttpContext ctx,
         CashKeeper keeper,
-        EventDispatcher dispatcher)
+        EventDispatcher dispatcher,
+        IAuditLogger audit)
     {
         if (req is null)
             return Results.BadRequest(new { error = "request body required" });
@@ -389,12 +426,22 @@ public static class AdminEndpoints
                     rollback: () => keeper.ApplyDeposit(owner, req.Amount));
 
                 if (!outcome.Applied)
+                {
+                    EmitAdminConfigChange(audit, ctx, "/admin/cash", AuditOutcomes.Denied, new()
+                    {
+                        ["endclient"] = req.Endclient!,
+                        ["kind"] = kind,
+                        ["amount"] = req.Amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        ["currency"] = currency,
+                        ["reason"] = "insufficient_funds",
+                    }, reasonCode: "insufficient_funds");
                     return Results.UnprocessableEntity(new
                     {
                         error = "insufficient_funds",
                         available = keeper.GetAvailable(owner),
                         requested = req.Amount,
                     });
+                }
             }
             else
             {
@@ -411,6 +458,14 @@ public static class AdminEndpoints
                     () => keeper.ApplyDeposit(owner, req.Amount));
             }
 
+            EmitAdminConfigChange(audit, ctx, "/admin/cash", AuditOutcomes.Success, new()
+            {
+                ["endclient"] = req.Endclient!,
+                ["kind"] = kind,
+                ["amount"] = req.Amount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["currency"] = currency,
+                ["reference"] = req.Reference ?? "",
+            });
             return Results.Ok(new
             {
                 endclient = req.Endclient,
@@ -432,6 +487,7 @@ public static class AdminEndpoints
 
     private static IResult ToggleKill(
         EventDispatcher dispatcher,
+        IAuditLogger audit,
         string scope,
         string target,
         bool killed,
@@ -453,6 +509,12 @@ public static class AdminEndpoints
             MetricsRegistry.KillSwitchToggled.Add(1,
                 new KeyValuePair<string, object?>("scope", scope),
                 new KeyValuePair<string, object?>("killed", killed));
+            EmitAdminConfigChange(audit, ctx, "/admin/kill", AuditOutcomes.Success, new()
+            {
+                ["scope"] = scope,
+                ["target"] = target,
+                ["killed"] = killed ? "true" : "false",
+            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -467,6 +529,7 @@ public static class AdminEndpoints
 
     private static IResult ToggleHalt(
         EventDispatcher dispatcher,
+        IAuditLogger audit,
         string symbol,
         bool halted,
         HttpContext ctx,
@@ -485,6 +548,11 @@ public static class AdminEndpoints
                 mutate);
             MetricsRegistry.SymbolHaltToggled.Add(1,
                 new KeyValuePair<string, object?>("halted", halted));
+            EmitAdminConfigChange(audit, ctx, "/admin/halts", AuditOutcomes.Success, new()
+            {
+                ["symbol"] = symbol,
+                ["halted"] = halted ? "true" : "false",
+            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -498,6 +566,7 @@ public static class AdminEndpoints
     }
     private static IResult ChangeSessionPhase(
         EventDispatcher dispatcher,
+        IAuditLogger audit,
         string? symbol,
         bool cleared,
         string? phaseStr,
@@ -527,6 +596,13 @@ public static class AdminEndpoints
             MetricsRegistry.SessionPhaseChanged.Add(1,
                 new KeyValuePair<string, object?>("scope", string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol"),
                 new KeyValuePair<string, object?>("phase", cleared ? "cleared" : parsed.ToString()));
+            EmitAdminConfigChange(audit, ctx, "/admin/session-phase", AuditOutcomes.Success, new()
+            {
+                ["scope"] = string.IsNullOrWhiteSpace(symbol) ? "default" : "symbol",
+                ["symbol"] = symbol ?? "",
+                ["cleared"] = cleared ? "true" : "false",
+                ["phase"] = cleared ? "cleared" : parsed.ToString(),
+            });
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -537,6 +613,38 @@ public static class AdminEndpoints
                 new { error = "system busy (WAL backpressure)", detail = ex.Message },
                 statusCode: StatusCodes.Status503ServiceUnavailable);
         }
+    }
+
+    /// <summary>
+    /// Q4.5 (#305). Single audit-emit site for the admin mutating
+    /// endpoints. Centralised so the (actor, ip, firm, role)
+    /// extraction is uniform and a future field add lands in one
+    /// place. The caller is responsible for the
+    /// <paramref name="details"/> map's call-site-specific keys
+    /// (target id, before/after value, etc.).
+    /// </summary>
+    internal static void EmitAdminConfigChange(
+        IAuditLogger audit,
+        HttpContext ctx,
+        string resourcePath,
+        string outcome,
+        Dictionary<string, string>? details = null,
+        string eventType = AuditEventTypes.AdminConfigChange,
+        string? reasonCode = null)
+    {
+        audit.Log(new AuditLogEvent
+        {
+            EventType = eventType,
+            Outcome = outcome,
+            ActorUserId = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub),
+            ActorUsername = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub),
+            ActorFirm = ctx.User.FindFirstValue(JwtIssuer.FirmClaim),
+            ActorRole = ctx.User.FindFirstValue(JwtIssuer.RoleClaim),
+            SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ResourcePath = resourcePath,
+            ReasonCode = reasonCode,
+            Details = details,
+        });
     }
 }
 

--- a/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/AuthEndpoints.cs
@@ -1,5 +1,7 @@
 using B3.Trading.Api.Auth.Totp;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.AspNetCore.Builder;
@@ -31,15 +33,29 @@ public static class AuthEndpoints
     public static IEndpointRouteBuilder MapAuth(this IEndpointRouteBuilder app)
     {
         app.MapPost("/auth/login", (
+            HttpContext http,
             LoginRequest req,
             IUserStore users,
             JwtIssuer issuer,
             EndClientRegistry registry,
             ILoginAttemptTracker lockout,
-            ITotpChallengeStore totpChallenges) =>
+            ITotpChallengeStore totpChallenges,
+            IAuditLogger audit) =>
         {
+            var sourceIp = http.Connection.RemoteIpAddress?.ToString();
             if (req is null || string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrWhiteSpace(req.Password))
+            {
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AuthLoginFailure,
+                    Outcome = AuditOutcomes.Failure,
+                    ActorUsername = req?.Username,
+                    SourceIp = sourceIp,
+                    ResourcePath = "/auth/login",
+                    ReasonCode = "missing_credentials",
+                });
                 return Results.BadRequest(new { error = "username and password required" });
+            }
 
             // Lockout check uses the trimmed username so "alice " and
             // "alice" share the same bucket. Response is intentionally
@@ -48,7 +64,18 @@ public static class AuthEndpoints
             // usernames exist.
             var loginUsername = req.Username.Trim();
             if (lockout.IsLocked(loginUsername))
+            {
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AuthLoginFailure,
+                    Outcome = AuditOutcomes.Failure,
+                    ActorUsername = loginUsername,
+                    SourceIp = sourceIp,
+                    ResourcePath = "/auth/login",
+                    ReasonCode = "locked",
+                });
                 return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
+            }
 
             if (!users.TryGet(loginUsername, out var user) || user is null
                 || !PasswordHasher.Verify(req.Password, user.PasswordHash, user.Salt, user.Iterations))
@@ -58,6 +85,15 @@ public static class AuthEndpoints
                 // intentional — otherwise an attacker can probe which
                 // usernames exist by observing whether lockouts engage.
                 lockout.RecordFailure(loginUsername);
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AuthLoginFailure,
+                    Outcome = AuditOutcomes.Failure,
+                    ActorUsername = loginUsername,
+                    SourceIp = sourceIp,
+                    ResourcePath = "/auth/login",
+                    ReasonCode = user is null ? "unknown_user" : "bad_password",
+                });
                 return Results.Json(new { error = "invalid credentials" }, statusCode: StatusCodes.Status401Unauthorized);
             }
 
@@ -71,6 +107,18 @@ public static class AuthEndpoints
             if (user.Totp is { EnrolledAt: not null, SharedSecret.Length: > 0 })
             {
                 var token = totpChallenges.Issue(user.Username, TotpChallengeKind.Verify);
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AuthLoginFailure,
+                    Outcome = AuditOutcomes.Failure,
+                    ActorUserId = user.Username,
+                    ActorUsername = user.Username,
+                    ActorFirm = user.Firm,
+                    ActorRole = user.Role,
+                    SourceIp = sourceIp,
+                    ResourcePath = "/auth/login",
+                    ReasonCode = "2fa_required",
+                });
                 return Results.Ok(new LoginTwoFactorRequiredResponse(
                     Requires2fa: true,
                     TotpChallengeToken: token));
@@ -82,6 +130,18 @@ public static class AuthEndpoints
             if (user.Require2FA)
             {
                 var token = totpChallenges.Issue(user.Username, TotpChallengeKind.ForceEnroll);
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AuthLoginFailure,
+                    Outcome = AuditOutcomes.Failure,
+                    ActorUserId = user.Username,
+                    ActorUsername = user.Username,
+                    ActorFirm = user.Firm,
+                    ActorRole = user.Role,
+                    SourceIp = sourceIp,
+                    ResourcePath = "/auth/login",
+                    ReasonCode = "2fa_required_but_missing",
+                });
                 return Results.Ok(new LoginEnrollmentRequiredResponse(
                     Requires2faEnrollment: true,
                     EnrollmentToken: token));
@@ -92,6 +152,17 @@ public static class AuthEndpoints
             registry.Register(user.Username);
 
             var (jwt, expires) = issuer.Issue(user.Username, user.Role, user.Firm);
+            audit.Log(new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthLoginSuccess,
+                Outcome = AuditOutcomes.Success,
+                ActorUserId = user.Username,
+                ActorUsername = user.Username,
+                ActorFirm = user.Firm,
+                ActorRole = user.Role,
+                SourceIp = sourceIp,
+                ResourcePath = "/auth/login",
+            });
             return Results.Ok(new LoginResponse(jwt, expires));
         });
 

--- a/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
+++ b/backend/src/B3.Trading.Api/Auth/Totp/TotpEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -32,7 +34,8 @@ public static class TotpEndpoints
             ITotpChallengeStore challenges,
             ITotpService totp,
             ITotpSecretProtector protector,
-            IOptions<TotpOptions> opts) =>
+            IOptions<TotpOptions> opts,
+            IAuditLogger audit) =>
         {
             // Two auth modes:
             //   (a) JWT bearer — normal self-service enrollment.
@@ -71,6 +74,21 @@ public static class TotpEndpoints
             if (enrollmentToken is not null)
                 challenges.Invalidate(enrollmentToken);
 
+            audit.Log(new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthTwoFactorEnrollStart,
+                Outcome = AuditOutcomes.Success,
+                ActorUserId = user.Username,
+                ActorUsername = user.Username,
+                ActorFirm = user.Firm,
+                ActorRole = user.Role,
+                SourceIp = http.Connection.RemoteIpAddress?.ToString(),
+                ResourcePath = "/auth/2fa/enroll",
+                Details = enrollmentToken is null
+                    ? null
+                    : new Dictionary<string, string> { ["mode"] = "force_enroll_token" },
+            });
+
             return Results.Ok(new EnrollResponse(
                 Secret: secret,
                 OtpauthUri: uri,
@@ -87,7 +105,8 @@ public static class TotpEndpoints
             ITotpAttemptTracker lockout,
             ITotpService totp,
             ITotpSecretProtector protector,
-            EndClientRegistry registry) =>
+            EndClientRegistry registry,
+            IAuditLogger audit) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Code))
                 return Results.BadRequest(new { error = "code required" });
@@ -168,6 +187,18 @@ public static class TotpEndpoints
                     // alternative lets attackers brute-force lockout.
                     if (!recoveryAlreadyConsumed)
                         lockout.RecordFailure(ch.Username);
+                    audit.Log(new AuditLogEvent
+                    {
+                        EventType = AuditEventTypes.AuthTwoFactorVerifyFailure,
+                        Outcome = AuditOutcomes.Failure,
+                        ActorUserId = user.Username,
+                        ActorUsername = user.Username,
+                        ActorFirm = user.Firm,
+                        ActorRole = user.Role,
+                        SourceIp = http.Connection.RemoteIpAddress?.ToString(),
+                        ResourcePath = "/auth/2fa/verify",
+                        ReasonCode = recoveryAlreadyConsumed ? "recovery_code_replayed" : "2fa_wrong_code",
+                    });
                     return Results.Json(new { error = "invalid code" },
                         statusCode: StatusCodes.Status401Unauthorized);
                 }
@@ -177,6 +208,19 @@ public static class TotpEndpoints
 
                 registry.Register(user.Username);
                 var (jwt, expires) = issuer.Issue(user.Username, user.Role, user.Firm);
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = recoveryOk
+                        ? AuditEventTypes.AuthTwoFactorRecoveryCodeConsumed
+                        : AuditEventTypes.AuthTwoFactorVerifySuccess,
+                    Outcome = AuditOutcomes.Success,
+                    ActorUserId = user.Username,
+                    ActorUsername = user.Username,
+                    ActorFirm = user.Firm,
+                    ActorRole = user.Role,
+                    SourceIp = http.Connection.RemoteIpAddress?.ToString(),
+                    ResourcePath = "/auth/2fa/verify",
+                });
                 return Results.Ok(new LoginResponse(jwt, expires));
             }
 
@@ -220,6 +264,17 @@ public static class TotpEndpoints
                 LastUsedTimeStep = enrollStep,
             };
             users.TryUpdate(jwtUser);
+            audit.Log(new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthTwoFactorEnrollConfirm,
+                Outcome = AuditOutcomes.Success,
+                ActorUserId = jwtUser.Username,
+                ActorUsername = jwtUser.Username,
+                ActorFirm = jwtUser.Firm,
+                ActorRole = jwtUser.Role,
+                SourceIp = http.Connection.RemoteIpAddress?.ToString(),
+                ResourcePath = "/auth/2fa/verify",
+            });
             return Results.Ok(new { enrolled = true });
         });
 
@@ -230,7 +285,8 @@ public static class TotpEndpoints
             IPendingTotpEnrollmentStore pending,
             ITotpAttemptTracker lockout,
             ITotpService totp,
-            ITotpSecretProtector protector) =>
+            ITotpSecretProtector protector,
+            IAuditLogger audit) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Code))
                 return Results.BadRequest(new { error = "current TOTP code required" });
@@ -285,6 +341,17 @@ public static class TotpEndpoints
             user.Totp = null;
             users.TryUpdate(user);
             pending.Remove(user.Username);
+            audit.Log(new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthTwoFactorDisable,
+                Outcome = AuditOutcomes.Success,
+                ActorUserId = user.Username,
+                ActorUsername = user.Username,
+                ActorFirm = user.Firm,
+                ActorRole = user.Role,
+                SourceIp = http.Connection.RemoteIpAddress?.ToString(),
+                ResourcePath = "/auth/2fa/disable",
+            });
             return Results.Ok(new { disabled = true });
         }).RequireAuthorization();
 

--- a/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using B3.Trading.Api.Auth;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
 using Microsoft.AspNetCore.Builder;
@@ -40,7 +41,8 @@ public static class SubAccountsEndpoints
             SubAccountCreateRequest? req,
             HttpContext ctx,
             SubAccountsRegistry registry,
-            EventDispatcher dispatcher) =>
+            EventDispatcher dispatcher,
+            IAuditLogger audit) =>
         {
             if (req is null) return Results.BadRequest(new { error = "missing body" });
             SubAccountId id;
@@ -62,6 +64,23 @@ public static class SubAccountsEndpoints
                         ActorUserId = actor,
                     },
                     () => registry.ApplyCreated(firm, id.Value, req.DisplayName));
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AdminSubAccountCreate,
+                    Outcome = AuditOutcomes.Success,
+                    ActorUserId = actor,
+                    ActorUsername = actor,
+                    ActorFirm = firm,
+                    ActorRole = ctx.User.FindFirstValue(JwtIssuer.RoleClaim),
+                    SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+                    ResourcePath = "/sub-accounts",
+                    Details = new Dictionary<string, string>
+                    {
+                        ["firm"] = firm,
+                        ["sub_account_id"] = id.Value,
+                        ["display_name"] = req.DisplayName ?? "",
+                    },
+                });
                 return Results.Created($"/sub-accounts/{id.Value}",
                     new SubAccountDto(id.Value, req.DisplayName, Active: true));
             }
@@ -77,7 +96,8 @@ public static class SubAccountsEndpoints
             string id,
             HttpContext ctx,
             SubAccountsRegistry registry,
-            EventDispatcher dispatcher) =>
+            EventDispatcher dispatcher,
+            IAuditLogger audit) =>
         {
             SubAccountId sub;
             try { sub = new SubAccountId(id); }
@@ -99,6 +119,22 @@ public static class SubAccountsEndpoints
                         ActorUserId = actor,
                     },
                     () => registry.ApplyDeactivated(firm, sub.Value));
+                audit.Log(new AuditLogEvent
+                {
+                    EventType = AuditEventTypes.AdminSubAccountDeactivate,
+                    Outcome = AuditOutcomes.Success,
+                    ActorUserId = actor,
+                    ActorUsername = actor,
+                    ActorFirm = firm,
+                    ActorRole = ctx.User.FindFirstValue(JwtIssuer.RoleClaim),
+                    SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+                    ResourcePath = $"/sub-accounts/{sub.Value}",
+                    Details = new Dictionary<string, string>
+                    {
+                        ["firm"] = firm,
+                        ["sub_account_id"] = sub.Value,
+                    },
+                });
                 return Results.NoContent();
             }
             catch (WalBackpressureException ex)

--- a/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/SubAccountsEndpoints.cs
@@ -55,16 +55,13 @@ public static class SubAccountsEndpoints
             var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
             try
             {
-                dispatcher.Dispatch(
-                    new SubAccountCreatedEvent
-                    {
-                        FirmId = firm,
-                        Id = id.Value,
-                        DisplayName = req.DisplayName,
-                        ActorUserId = actor,
-                    },
-                    () => registry.ApplyCreated(firm, id.Value, req.DisplayName));
-                audit.Log(new AuditLogEvent
+                // Pass-1 review (#322) P1.2. Audit-first ordering —
+                // emit the operator's sub-account create intent
+                // BEFORE the WAL business event so a backpressured
+                // audit append refuses the registry mutation with
+                // 503 rather than committing a sub-account
+                // un-audited.
+                audit.LogOrFail(new AuditLogEvent
                 {
                     EventType = AuditEventTypes.AdminSubAccountCreate,
                     Outcome = AuditOutcomes.Success,
@@ -81,6 +78,15 @@ public static class SubAccountsEndpoints
                         ["display_name"] = req.DisplayName ?? "",
                     },
                 });
+                dispatcher.Dispatch(
+                    new SubAccountCreatedEvent
+                    {
+                        FirmId = firm,
+                        Id = id.Value,
+                        DisplayName = req.DisplayName,
+                        ActorUserId = actor,
+                    },
+                    () => registry.ApplyCreated(firm, id.Value, req.DisplayName));
                 return Results.Created($"/sub-accounts/{id.Value}",
                     new SubAccountDto(id.Value, req.DisplayName, Active: true));
             }
@@ -111,15 +117,9 @@ public static class SubAccountsEndpoints
             var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
             try
             {
-                dispatcher.Dispatch(
-                    new SubAccountDeactivatedEvent
-                    {
-                        FirmId = firm,
-                        Id = sub.Value,
-                        ActorUserId = actor,
-                    },
-                    () => registry.ApplyDeactivated(firm, sub.Value));
-                audit.Log(new AuditLogEvent
+                // Pass-1 review (#322) P1.2. Audit-first ordering —
+                // see create handler above.
+                audit.LogOrFail(new AuditLogEvent
                 {
                     EventType = AuditEventTypes.AdminSubAccountDeactivate,
                     Outcome = AuditOutcomes.Success,
@@ -135,6 +135,14 @@ public static class SubAccountsEndpoints
                         ["sub_account_id"] = sub.Value,
                     },
                 });
+                dispatcher.Dispatch(
+                    new SubAccountDeactivatedEvent
+                    {
+                        FirmId = firm,
+                        Id = sub.Value,
+                        ActorUserId = actor,
+                    },
+                    () => registry.ApplyDeactivated(firm, sub.Value));
                 return Results.NoContent();
             }
             catch (WalBackpressureException ex)

--- a/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
@@ -1,0 +1,216 @@
+using System.Collections.Generic;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// Q4.5 (#305). Outcome class for an <see cref="AuditEntry"/>. Stored on
+/// the WAL as the lowercase string the read-path filter expects.
+/// </summary>
+public static class AuditOutcomes
+{
+    public const string Success = "success";
+    public const string Failure = "failure";
+    public const string Denied = "denied";
+}
+
+/// <summary>
+/// Q4.5 (#305). Canonical event-type strings emitted by the platform.
+/// Centralised so the capture sites + tests + ops dashboards agree
+/// on the wire spelling. Strings (not an enum) so the WAL stays
+/// open-set — new capture sites can land without bumping the
+/// snapshot schema.
+/// </summary>
+public static class AuditEventTypes
+{
+    public const string AuthLoginSuccess = "auth.login.success";
+    public const string AuthLoginFailure = "auth.login.failure";
+    public const string AuthTwoFactorEnrollStart = "auth.2fa.enroll.start";
+    public const string AuthTwoFactorEnrollConfirm = "auth.2fa.enroll.confirm";
+    public const string AuthTwoFactorVerifySuccess = "auth.2fa.verify.success";
+    public const string AuthTwoFactorVerifyFailure = "auth.2fa.verify.failure";
+    public const string AuthTwoFactorDisable = "auth.2fa.disable";
+    public const string AuthTwoFactorRecoveryCodeConsumed = "auth.2fa.recovery_code_consumed";
+
+    public const string AdminConfigChange = "admin.config.change";
+    public const string AdminSubAccountCreate = "admin.subaccount.create";
+    public const string AdminSubAccountDeactivate = "admin.subaccount.deactivate";
+
+    // Prefix helpers used by the read-path filter for type=auth.* style globs.
+    public const string AuthPrefix = "auth.";
+    public const string AdminPrefix = "admin.";
+}
+
+/// <summary>
+/// Q4.5 (#305). Read-side projection of <see cref="AuditLogEvent"/>:
+/// the WAL envelope plus the monotonic sequence number assigned at
+/// append time. Used as the API response shape for <c>GET
+/// /admin/audit</c> and as the opaque-cursor anchor (the cursor is a
+/// base64-encoded packing of <see cref="Seq"/> + <see cref="TimestampUtc"/>).
+/// </summary>
+public sealed record AuditEntry(
+    long Seq,
+    string Id,
+    DateTimeOffset TimestampUtc,
+    string EventType,
+    string Outcome,
+    string? ActorUserId,
+    string? ActorUsername,
+    string? ActorFirm,
+    string? ActorRole,
+    string? SourceIp,
+    string? ResourcePath,
+    string? ReasonCode,
+    IReadOnlyDictionary<string, string>? Details);
+
+/// <summary>
+/// Q4.5 (#305). Bounded in-memory ring-buffer projection of every
+/// <see cref="AuditLogEvent"/> that lands on the WAL. Backs
+/// <c>GET /admin/audit</c>. Append is synchronous and called from
+/// both the live capture path (under the dispatcher lock, via
+/// <see cref="EventDispatcher.Dispatch(WalEvent, System.Action)"/>)
+/// and the recovery replayer (single-threaded). Reads are taken
+/// under a lock to give the API a stable, time-ordered snapshot of
+/// the buffer.
+///
+/// <para>The keeper is intentionally <i>not</i> projected into the
+/// platform snapshot: audit history is naturally append-only and
+/// time-bounded, the WAL is the source of truth, and a snapshot
+/// field would just duplicate it. On restart the keeper rehydrates
+/// from the WAL tail driven through <c>EventReplayer.Apply</c>.</para>
+/// </summary>
+public sealed class AuditLogKeeper
+{
+    private readonly object _lock = new();
+    private readonly List<AuditEntry> _ring;
+    private readonly int _capacity;
+
+    public AuditLogKeeper(IOptions<AuditLogOptions> options)
+    {
+        var opts = options?.Value ?? new AuditLogOptions();
+        _capacity = opts.Capacity > 0 ? opts.Capacity : 100_000;
+        _ring = new List<AuditEntry>(Math.Min(_capacity, 1024));
+    }
+
+    /// <summary>
+    /// Total number of entries currently retained. Exposed for tests
+    /// and the eviction counter.
+    /// </summary>
+    public int Count
+    {
+        get { lock (_lock) return _ring.Count; }
+    }
+
+    public int Capacity => _capacity;
+
+    /// <summary>
+    /// Folds a WAL envelope onto the buffer. Called by both live
+    /// dispatch and recovery replay. <paramref name="seq"/> is the
+    /// WAL seq assigned at append time. Older entries are silently
+    /// dropped once <see cref="Capacity"/> is reached.
+    /// </summary>
+    public void Apply(long seq, AuditLogEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        var entry = new AuditEntry(
+            Seq: seq,
+            Id: Guid.NewGuid().ToString("N"),
+            TimestampUtc: evt.TimestampUtc,
+            EventType: evt.EventType,
+            Outcome: evt.Outcome,
+            ActorUserId: evt.ActorUserId,
+            ActorUsername: evt.ActorUsername,
+            ActorFirm: evt.ActorFirm,
+            ActorRole: evt.ActorRole,
+            SourceIp: evt.SourceIp,
+            ResourcePath: evt.ResourcePath,
+            ReasonCode: evt.ReasonCode,
+            Details: evt.Details is null ? null : new Dictionary<string, string>(evt.Details));
+
+        lock (_lock)
+        {
+            _ring.Add(entry);
+            if (_ring.Count > _capacity)
+            {
+                // Drop the oldest. RemoveAt(0) is O(n) but the cap is
+                // small (100k by default) and admin reads dwarf the
+                // append rate; the simple shape avoids a custom ring
+                // index for what is essentially a forensic surface.
+                _ring.RemoveAt(0);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns matching entries in newest-first order, paginated by an
+    /// opaque cursor. The cursor anchors on a previously returned
+    /// <see cref="AuditEntry.Seq"/>: callers see entries with
+    /// <c>Seq &lt; cursorSeq</c>.
+    ///
+    /// <para>Filters are AND-composed. <paramref name="user"/> matches
+    /// <see cref="AuditEntry.ActorUsername"/> OR the
+    /// <c>"target_user"</c> detail (so role/2FA changes targeting
+    /// that user surface). <paramref name="typePattern"/> is exact
+    /// match unless it ends with <c>".*"</c>, in which case it is a
+    /// prefix glob.</para>
+    /// </summary>
+    public AuditQueryResult Query(
+        DateTimeOffset since,
+        DateTimeOffset until,
+        string? user,
+        string? typePattern,
+        string? outcome,
+        int limit,
+        long? cursorSeq)
+    {
+        if (limit <= 0) limit = 100;
+        if (limit > 500) limit = 500;
+
+        var isPrefix = typePattern is not null && typePattern.EndsWith(".*", StringComparison.Ordinal);
+        var typePrefix = isPrefix ? typePattern!.Substring(0, typePattern!.Length - 1) : null;
+
+        var matches = new List<AuditEntry>(Math.Min(limit, 64));
+        lock (_lock)
+        {
+            // Walk newest-first.
+            for (var i = _ring.Count - 1; i >= 0; i--)
+            {
+                var e = _ring[i];
+                if (cursorSeq is long c && e.Seq >= c) continue;
+                if (e.TimestampUtc < since || e.TimestampUtc > until) continue;
+                if (!string.IsNullOrEmpty(outcome) && !string.Equals(e.Outcome, outcome, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (typePattern is not null)
+                {
+                    if (isPrefix)
+                    {
+                        if (!e.EventType.StartsWith(typePrefix!, StringComparison.Ordinal)) continue;
+                    }
+                    else
+                    {
+                        if (!string.Equals(e.EventType, typePattern, StringComparison.Ordinal)) continue;
+                    }
+                }
+                if (!string.IsNullOrEmpty(user))
+                {
+                    var actorMatch = string.Equals(e.ActorUsername, user, StringComparison.OrdinalIgnoreCase)
+                                   || string.Equals(e.ActorUserId, user, StringComparison.OrdinalIgnoreCase);
+                    var targetMatch = e.Details is not null
+                        && e.Details.TryGetValue("target_user", out var tu)
+                        && string.Equals(tu, user, StringComparison.OrdinalIgnoreCase);
+                    if (!actorMatch && !targetMatch) continue;
+                }
+
+                matches.Add(e);
+                if (matches.Count >= limit) break;
+            }
+        }
+
+        long? next = matches.Count == limit ? matches[^1].Seq : (long?)null;
+        return new AuditQueryResult(matches, next);
+    }
+}
+
+/// <summary>Result of <see cref="AuditLogKeeper.Query"/>.</summary>
+public sealed record AuditQueryResult(IReadOnlyList<AuditEntry> Entries, long? NextCursorSeq);

--- a/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
@@ -155,13 +155,23 @@ public sealed class AuditLogKeeper
             {
                 // Pre-cap: grow the backing array geometrically up to
                 // the cap so initial sparse usage doesn't allocate the
-                // full bound. `_head` equals `_count` until we wrap.
+                // full bound. `_head` may already have wrapped to 0 by
+                // the time we reach the grow trigger (head advances
+                // modulo ring length, so a sequential 0..len-1 fill
+                // leaves head==0). After Array.Copy the entries occupy
+                // physical slots 0.._count-1 in logical order, so the
+                // next append must go to slot _count. Pass-3 review
+                // (#322) caught the missing reset: without it the new
+                // entry overwrites slot 0 and slots _count..len-1
+                // stay null, crashing Query with NRE at the first
+                // walk past the original ring length.
                 if (_count == _ring.Length)
                 {
                     var newLen = Math.Min(_capacity, Math.Max(_ring.Length * 2, 16));
                     var grown = new AuditEntry?[newLen];
                     Array.Copy(_ring, grown, _count);
                     _ring = grown;
+                    _head = _count;
                 }
                 _ring[_head] = entry;
                 _head = (_head + 1) % _ring.Length;

--- a/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
@@ -78,7 +78,19 @@ public sealed record AuditEntry(
 /// platform snapshot: audit history is naturally append-only and
 /// time-bounded, the WAL is the source of truth, and a snapshot
 /// field would just duplicate it. On restart the keeper rehydrates
-/// from the WAL tail driven through <c>EventReplayer.Apply</c>.</para>
+/// from the <b>full WAL</b> driven by
+/// <see cref="Infrastructure.Persistence.PersistenceRecovery"/> —
+/// not just the post-snapshot tail. Pass-1 review (#322) P1.1: an
+/// older design replayed only from <c>snapshot.Seq</c>, which
+/// silently dropped every audit event captured before the latest
+/// snapshot on cold restart. The recovery driver now does two
+/// passes against <see cref="Application.Persistence.IEventStore.ReadFromAsync"/>:
+/// an audit-only pre-pass for <c>seq &lt;= snapshot.Seq</c> that
+/// folds historic audit envelopes into this keeper, then the main
+/// snapshot+tail replay. Cost is O(N) where N is total WAL events
+/// — the bounded ring (default <see cref="AuditLogOptions.Capacity"/>
+/// = 100k) caps in-memory occupancy; older entries silently fall
+/// off the head as the pre-pass scans forward.</para>
 /// </summary>
 public sealed class AuditLogKeeper
 {

--- a/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
@@ -95,14 +95,23 @@ public sealed record AuditEntry(
 public sealed class AuditLogKeeper
 {
     private readonly object _lock = new();
-    private readonly List<AuditEntry> _ring;
+    // True circular buffer. `_ring` is lazily grown up to `_capacity`,
+    // then becomes a fixed-size wrap-around array indexed by `_head`
+    // (the next write slot). Pass-2 review (#322) P2: an earlier
+    // List<T>+RemoveAt(0) eviction was O(capacity) per evicted entry,
+    // turning the recovery pre-pass into O(N · capacity) once N
+    // exceeded the cap. The head-indexed ring evicts in O(1) and keeps
+    // both append and recovery linear in N.
+    private AuditEntry?[] _ring;
+    private int _head;
+    private int _count;
     private readonly int _capacity;
 
     public AuditLogKeeper(IOptions<AuditLogOptions> options)
     {
         var opts = options?.Value ?? new AuditLogOptions();
         _capacity = opts.Capacity > 0 ? opts.Capacity : 100_000;
-        _ring = new List<AuditEntry>(Math.Min(_capacity, 1024));
+        _ring = new AuditEntry?[Math.Min(_capacity, 1024)];
     }
 
     /// <summary>
@@ -111,7 +120,7 @@ public sealed class AuditLogKeeper
     /// </summary>
     public int Count
     {
-        get { lock (_lock) return _ring.Count; }
+        get { lock (_lock) return _count; }
     }
 
     public int Capacity => _capacity;
@@ -142,14 +151,28 @@ public sealed class AuditLogKeeper
 
         lock (_lock)
         {
-            _ring.Add(entry);
-            if (_ring.Count > _capacity)
+            if (_count < _capacity)
             {
-                // Drop the oldest. RemoveAt(0) is O(n) but the cap is
-                // small (100k by default) and admin reads dwarf the
-                // append rate; the simple shape avoids a custom ring
-                // index for what is essentially a forensic surface.
-                _ring.RemoveAt(0);
+                // Pre-cap: grow the backing array geometrically up to
+                // the cap so initial sparse usage doesn't allocate the
+                // full bound. `_head` equals `_count` until we wrap.
+                if (_count == _ring.Length)
+                {
+                    var newLen = Math.Min(_capacity, Math.Max(_ring.Length * 2, 16));
+                    var grown = new AuditEntry?[newLen];
+                    Array.Copy(_ring, grown, _count);
+                    _ring = grown;
+                }
+                _ring[_head] = entry;
+                _head = (_head + 1) % _ring.Length;
+                _count++;
+            }
+            else
+            {
+                // Steady-state wrap: overwrite the oldest slot (the one
+                // `_head` currently points at) in O(1) and advance head.
+                _ring[_head] = entry;
+                _head = (_head + 1) % _capacity;
             }
         }
     }
@@ -185,10 +208,13 @@ public sealed class AuditLogKeeper
         var matches = new List<AuditEntry>(Math.Min(limit, 64));
         lock (_lock)
         {
-            // Walk newest-first.
-            for (var i = _ring.Count - 1; i >= 0; i--)
+            // Walk newest-first. Newest entry is at (_head - 1) mod
+            // ring length; walk backwards `_count` slots.
+            var ringLen = _ring.Length;
+            var idx = (_head - 1 + ringLen) % ringLen;
+            for (var n = 0; n < _count; n++, idx = (idx - 1 + ringLen) % ringLen)
             {
-                var e = _ring[i];
+                var e = _ring[idx]!;
                 if (cursorSeq is long c && e.Seq >= c) continue;
                 if (e.TimestampUtc < since || e.TimestampUtc > until) continue;
                 if (!string.IsNullOrEmpty(outcome) && !string.Equals(e.Outcome, outcome, StringComparison.OrdinalIgnoreCase))

--- a/backend/src/B3.Trading.Application/Audit/AuditLogOptions.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogOptions.cs
@@ -1,0 +1,22 @@
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// Q4.5 (#305). Tunables for the in-memory <see cref="AuditLogKeeper"/>.
+/// Bound from <c>Trading:Audit</c>. The keeper itself is fed by
+/// <c>EventReplayer</c> on recovery and by every audit-emitting site
+/// at runtime, so the cap bounds both replay-rehydrate cost and
+/// steady-state memory — events evicted from the ring buffer are
+/// still recoverable from WAL segments via the EOD materialiser.
+/// </summary>
+public sealed class AuditLogOptions
+{
+    public const string SectionName = "Trading:Audit";
+
+    /// <summary>
+    /// Maximum number of audit entries retained in memory. Older entries
+    /// silently drop off the head of the ring buffer once this is hit;
+    /// the WAL on disk keeps the full history (subject to segment
+    /// retention). Default mirrors the value called out in #305.
+    /// </summary>
+    public int Capacity { get; set; } = 100_000;
+}

--- a/backend/src/B3.Trading.Application/Audit/AuditLogger.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogger.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// Q4.5 (#305). Pipeline-uniform helper for emitting an
+/// <see cref="AuditLogEvent"/>. Every capture site funnels through
+/// this so the WAL append + keeper fold + metric increment happen in
+/// the same order, under the same dispatcher lock, regardless of
+/// where the call site lives (Auth, TOTP, AdminEndpoints,
+/// SubAccountsEndpoints, AdminFixp).
+///
+/// <para><b>Failure posture (RFC §4.4).</b> Audit is best-effort by
+/// design — a WAL backpressure exception while logging a failed
+/// login MUST NOT mask the underlying login failure to the caller.
+/// <see cref="Log"/> swallows <see cref="WalBackpressureException"/>
+/// (after counting it) and any unexpected exception (after
+/// logging at <c>Error</c>); the caller's own structured response
+/// to the user is unaffected. Positions-style fail-closed is the
+/// wrong default here — the audit log is forensic, not
+/// transactional.</para>
+/// </summary>
+public interface IAuditLogger
+{
+    void Log(AuditLogEvent evt);
+}
+
+/// <summary>Concrete <see cref="IAuditLogger"/> backed by the dispatcher + keeper.</summary>
+public sealed class AuditLogger : IAuditLogger
+{
+    private readonly EventDispatcher _dispatcher;
+    private readonly AuditLogKeeper _keeper;
+    private readonly ILogger<AuditLogger> _log;
+
+    public AuditLogger(EventDispatcher dispatcher, AuditLogKeeper keeper, ILogger<AuditLogger> log)
+    {
+        _dispatcher = dispatcher;
+        _keeper = keeper;
+        _log = log;
+    }
+
+    public void Log(AuditLogEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        try
+        {
+            // Dispatch under the lock so the WAL seq assigned by Append
+            // is the same seq the keeper records. Reading CurrentSeq
+            // post-dispatch would race against another dispatcher tick.
+            _dispatcher.Dispatch(evt, () =>
+            {
+                // The dispatcher's apply() runs under the lock with the
+                // current seq already assigned to evt. CurrentSeq reads
+                // a different lock-guarded field, so it is safe here.
+                _keeper.Apply(_dispatcher.CurrentSeq, evt);
+            });
+        }
+        catch (WalBackpressureException ex)
+        {
+            // Audit is best-effort — never let the writer's backpressure
+            // mask the underlying business outcome to the caller. The
+            // WAL backpressure counter already classifies these.
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "audit.log"));
+            _log.LogWarning(ex, "Audit append dropped under WAL backpressure: type={EventType}", evt.EventType);
+        }
+        catch (Exception ex)
+        {
+            // Defensive: keepers / serialisers should never throw, but
+            // if they do we still must not poison the caller.
+            _log.LogError(ex, "Audit append failed: type={EventType}", evt.EventType);
+        }
+
+        // Steady-state metric. Always incremented (success or swallowed
+        // failure) so the operator sees the attempted-emit rate; the
+        // WAL counter above gives the dropped-by-backpressure subset.
+        MetricsRegistry.AuditEventsTotal.Add(1,
+            new KeyValuePair<string, object?>("event_type", evt.EventType),
+            new KeyValuePair<string, object?>("outcome", evt.Outcome));
+
+        Debug.Assert(evt.EventType.Length > 0, "EventType must not be empty");
+    }
+}
+
+/// <summary>
+/// Q4.5 (#305). No-op <see cref="IAuditLogger"/> for tests that
+/// don't wire the WAL + keeper. The default composition uses
+/// <see cref="AuditLogger"/>; <c>NullAuditLogger</c> exists so unit
+/// tests of capture sites don't need a full host.
+/// </summary>
+public sealed class NullAuditLogger : IAuditLogger
+{
+    public void Log(AuditLogEvent evt) { }
+}

--- a/backend/src/B3.Trading.Application/Audit/AuditLogger.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogger.cs
@@ -13,19 +13,62 @@ namespace B3.Trading.Application.Audit;
 /// where the call site lives (Auth, TOTP, AdminEndpoints,
 /// SubAccountsEndpoints, AdminFixp).
 ///
-/// <para><b>Failure posture (RFC §4.4).</b> Audit is best-effort by
-/// design — a WAL backpressure exception while logging a failed
-/// login MUST NOT mask the underlying login failure to the caller.
-/// <see cref="Log"/> swallows <see cref="WalBackpressureException"/>
-/// (after counting it) and any unexpected exception (after
-/// logging at <c>Error</c>); the caller's own structured response
-/// to the user is unaffected. Positions-style fail-closed is the
-/// wrong default here — the audit log is forensic, not
-/// transactional.</para>
+/// <para><b>Two failure postures.</b> Audit capture lives on the
+/// availability/forensics boundary, so the logger exposes two
+/// explicit modes — picking the right one is the call site's
+/// contract:
+/// <list type="bullet">
+///   <item><see cref="Log"/> — <i>best-effort</i>. Swallows
+///   <see cref="WalBackpressureException"/> (after counting it) and
+///   any unexpected exception (after logging at <c>Error</c>). Use
+///   for high-frequency, attacker-influenced paths where audit
+///   loss is preferable to amplifying a DoS against the WAL —
+///   notably <c>auth.login.success</c>/<c>auth.login.failure</c>
+///   and the TOTP verify paths. Pass-1 review (#322) P1.2 — the
+///   contract here is that the caller's structured response is
+///   unaffected by audit failures.</item>
+///   <item><see cref="LogOrFail"/> — <i>fail-closed for the
+///   WAL</i>. Propagates <see cref="WalBackpressureException"/> to
+///   the caller so admin endpoints can translate it into HTTP 503
+///   (with the call-site WAL backpressure counter incremented
+///   exactly once at the audit site). Other unexpected exceptions
+///   are still swallowed-and-logged to avoid bricking the endpoint
+///   on a defect in the keeper. Use for security-sensitive
+///   <c>/admin/*</c> mutations where the audit-first ordering
+///   (audit append accepted by the WAL → business event
+///   dispatched) means a successful response implies a durable
+///   audit record exists; if audit cannot be captured we MUST
+///   refuse the mutation rather than silently un-audit it.</item>
+/// </list></para>
+///
+/// <para><b>Ordering contract for admin mutations.</b> Admin
+/// mutating endpoints invoke <see cref="LogOrFail"/> BEFORE
+/// dispatching the business <see cref="WalEvent"/> for the same
+/// request. The audit envelope therefore records the operator's
+/// <i>attempt</i> — if the subsequent business dispatch crashes,
+/// is backpressured, or is rejected by a post-validation gate, the
+/// audit trail still shows the intent (which is what auditors
+/// want). Pre-validation that yields a deterministic denial (input
+/// shape, missing body) runs first and emits a single audit with
+/// the appropriate <c>denied</c> outcome via
+/// <see cref="LogOrFail"/>.</para>
 /// </summary>
 public interface IAuditLogger
 {
+    /// <summary>Best-effort audit append. Swallows WAL backpressure and unexpected exceptions; see the interface remarks for when to choose this mode.</summary>
     void Log(AuditLogEvent evt);
+
+    /// <summary>
+    /// Fail-closed audit append for security-sensitive admin
+    /// mutations. Propagates <see cref="WalBackpressureException"/>
+    /// to the caller (admin endpoints translate to HTTP 503) so the
+    /// caller can refuse the business action rather than silently
+    /// un-audit it. Other unexpected exceptions are swallowed (the
+    /// keeper/dispatcher contract is that they never throw — see
+    /// interface remarks). See the interface remarks for the
+    /// audit-first ordering contract.
+    /// </summary>
+    void LogOrFail(AuditLogEvent evt);
 }
 
 /// <summary>Concrete <see cref="IAuditLogger"/> backed by the dispatcher + keeper.</summary>
@@ -47,16 +90,7 @@ public sealed class AuditLogger : IAuditLogger
         ArgumentNullException.ThrowIfNull(evt);
         try
         {
-            // Dispatch under the lock so the WAL seq assigned by Append
-            // is the same seq the keeper records. Reading CurrentSeq
-            // post-dispatch would race against another dispatcher tick.
-            _dispatcher.Dispatch(evt, () =>
-            {
-                // The dispatcher's apply() runs under the lock with the
-                // current seq already assigned to evt. CurrentSeq reads
-                // a different lock-guarded field, so it is safe here.
-                _keeper.Apply(_dispatcher.CurrentSeq, evt);
-            });
+            DispatchUnderLock(evt);
         }
         catch (WalBackpressureException ex)
         {
@@ -74,6 +108,61 @@ public sealed class AuditLogger : IAuditLogger
             _log.LogError(ex, "Audit append failed: type={EventType}", evt.EventType);
         }
 
+        RecordEmitMetric(evt);
+    }
+
+    public void LogOrFail(AuditLogEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        try
+        {
+            DispatchUnderLock(evt);
+        }
+        catch (WalBackpressureException)
+        {
+            // Pass-1 review (#322) P1.2. Admin mutating endpoints rely
+            // on this exception bubbling up so they can refuse the
+            // business mutation with HTTP 503; swallowing it here would
+            // re-introduce the fail-open audit gap. Count it at the
+            // audit call site so the operator's WAL backpressure
+            // dashboard separates audit-driven backpressure from
+            // business-event-driven backpressure.
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "audit.log_or_fail"));
+            // We still account the emit attempt so the audit-throughput
+            // metric reflects offered load. Outcome on the event is
+            // whatever the call site chose (typically "success" for the
+            // intent record; denial paths emit with "denied").
+            RecordEmitMetric(evt);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Defensive: the keeper/dispatcher contract is that these
+            // never throw. If they do (genuine bug), we still must not
+            // brick the endpoint — fall through to best-effort.
+            _log.LogError(ex, "Audit append failed (LogOrFail path): type={EventType}", evt.EventType);
+        }
+
+        RecordEmitMetric(evt);
+    }
+
+    private void DispatchUnderLock(AuditLogEvent evt)
+    {
+        // Dispatch under the lock so the WAL seq assigned by Append
+        // is the same seq the keeper records. Reading CurrentSeq
+        // post-dispatch would race against another dispatcher tick.
+        _dispatcher.Dispatch(evt, () =>
+        {
+            // The dispatcher's apply() runs under the lock with the
+            // current seq already assigned to evt. CurrentSeq reads
+            // a different lock-guarded field, so it is safe here.
+            _keeper.Apply(_dispatcher.CurrentSeq, evt);
+        });
+    }
+
+    private static void RecordEmitMetric(AuditLogEvent evt)
+    {
         // Steady-state metric. Always incremented (success or swallowed
         // failure) so the operator sees the attempted-emit rate; the
         // WAL counter above gives the dropped-by-backpressure subset.
@@ -94,4 +183,5 @@ public sealed class AuditLogger : IAuditLogger
 public sealed class NullAuditLogger : IAuditLogger
 {
     public void Log(AuditLogEvent evt) { }
+    public void LogOrFail(AuditLogEvent evt) { }
 }

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -93,6 +93,19 @@ public static class MetricsRegistry
     public static readonly Counter<long> KillSwitchToggled =
         Meter.CreateCounter<long>("trading.kill_switch.toggled");
 
+    /// <summary>
+    /// Q4.5 (#305). Counts every audit envelope emitted via
+    /// <c>IAuditLogger</c>. Tags are bounded by design:
+    /// <c>event_type</c> is the canonical hierarchical string
+    /// (<c>auth.login.success</c>, <c>admin.config.change</c>, …),
+    /// <c>outcome</c> is one of <c>success|failure|denied</c>. NO
+    /// per-user / per-firm / per-IP tag — those are high-cardinality
+    /// dimensions that belong on the read side
+    /// (<c>/admin/audit</c>), not on a Prometheus counter.
+    /// </summary>
+    public static readonly Counter<long> AuditEventsTotal =
+        Meter.CreateCounter<long>("trading.audit.events_total");
+
     public static readonly Counter<long> SymbolHaltToggled =
         Meter.CreateCounter<long>("trading.symbol_halt.toggled");
 

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -56,6 +56,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(RealizedPnlEvent))]
 [JsonSerializable(typeof(SubAccountCreatedEvent))]
 [JsonSerializable(typeof(SubAccountDeactivatedEvent))]
+[JsonSerializable(typeof(AuditLogEvent))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {
 }

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -54,6 +54,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(RealizedPnlEvent), "pnl.realized")]
 [JsonDerivedType(typeof(SubAccountCreatedEvent), "sub-account.created")]
 [JsonDerivedType(typeof(SubAccountDeactivatedEvent), "sub-account.deactivated")]
+[JsonDerivedType(typeof(AuditLogEvent), "audit.log")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -1027,4 +1028,60 @@ public sealed record SubAccountDeactivatedEvent : WalEvent
     public required string FirmId { get; init; }
     public required string Id { get; init; }
     public string? ActorUserId { get; init; }
+}
+
+/// <summary>
+/// Q4.5 (#305). Single envelope for every operationally-significant
+/// audit event the trading host emits — login attempts, 2FA
+/// lifecycle, admin role/config mutations. Persisted on the WAL so
+/// the audit surface survives crash + restart and is reconstructible
+/// from segments alone (forensic replay). Additive type — older
+/// readers that don't know <c>"audit.log"</c> skip the record with
+/// a structured warning (see <see cref="WalEvent"/> remarks),
+/// preserving forward-compat.
+///
+/// <para>The <see cref="EventType"/> field is a hierarchical string
+/// (e.g. <c>"auth.login.success"</c>, <c>"admin.config.change"</c>)
+/// so the read-path filter supports both exact match and prefix
+/// glob (<c>"auth.*"</c>) without an enum bound on the WAL.
+/// <see cref="Details"/> carries call-site-specific context
+/// (endpoint path, target user, before/after summary) as a flat
+/// string map so the on-disk schema is stable as new capture sites
+/// land. Audit replay folds these into an in-memory ring-buffer
+/// keeper — see <c>AuditLogKeeper</c> — which is the source of
+/// truth for <c>GET /admin/audit</c>; no snapshot field is
+/// reserved (the keeper rehydrates from a WAL tail on recovery,
+/// bounded by its configured retention cap).</para>
+/// </summary>
+public sealed record AuditLogEvent : WalEvent
+{
+    /// <summary>Hierarchical event type, e.g. <c>auth.login.success</c>.</summary>
+    public required string EventType { get; init; }
+
+    /// <summary>Outcome class: <c>success</c>, <c>failure</c>, or <c>denied</c>.</summary>
+    public required string Outcome { get; init; }
+
+    /// <summary>Acting user's JWT subject when authenticated; null for anonymous capture sites (e.g. failed login of an unknown user).</summary>
+    public string? ActorUserId { get; init; }
+
+    /// <summary>Username the client presented at the capture site. May differ from <see cref="ActorUserId"/> on failed-login paths.</summary>
+    public string? ActorUsername { get; init; }
+
+    /// <summary>Firm assigned at the capture site (success branch) or the actor's firm claim. Null when not resolvable.</summary>
+    public string? ActorFirm { get; init; }
+
+    /// <summary>Role claim at the capture site. Null when not resolvable.</summary>
+    public string? ActorRole { get; init; }
+
+    /// <summary>Source IP from <c>HttpContext.Connection.RemoteIpAddress</c>, normalised to its string form. Null for non-HTTP capture sites.</summary>
+    public string? SourceIp { get; init; }
+
+    /// <summary>HTTP path being exercised at the capture site (e.g. <c>/auth/login</c>, <c>/admin/cash</c>). Null for non-HTTP capture sites.</summary>
+    public string? ResourcePath { get; init; }
+
+    /// <summary>Machine-readable reason code, especially for failure / denied outcomes (<c>unknown_user</c>, <c>bad_password</c>, <c>locked</c>, <c>2fa_wrong_code</c>, …).</summary>
+    public string? ReasonCode { get; init; }
+
+    /// <summary>Free-form per-capture-site context — endpoint args, before/after summaries, target user, etc. Bounded to small string values by convention so the WAL record stays compact.</summary>
+    public Dictionary<string, string>? Details { get; init; }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.UserBots;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -46,6 +48,11 @@ public static class AdminFixpEndpoints
             var sessions = ctx.RequestServices.GetService<IUserBotSessionRegistry>();
             if (sessions is null) return Results.NotFound();
             var newVer = await sessions.BumpVersionAsync(credentialId, "operator", ct);
+            EmitAuditIfWired(ctx, "/admin/fixp/sessions/bump", AuditOutcomes.Success, new()
+            {
+                ["credential_id"] = credentialId.ToString(),
+                ["new_version"] = newVer.ToString(),
+            });
             return Results.Ok(new { credentialId, newVersion = newVer });
         });
 
@@ -54,6 +61,9 @@ public static class AdminFixpEndpoints
             var dir = ctx.RequestServices.GetService<BotSessionConnectionDirectory>();
             if (dir is null) return Results.NotFound();
             var terminated = dir.TryForceTerminate(credentialId);
+            EmitAuditIfWired(ctx, "/admin/fixp/sessions/terminate",
+                terminated ? AuditOutcomes.Success : AuditOutcomes.Failure,
+                new() { ["credential_id"] = credentialId.ToString(), ["terminated"] = terminated ? "true" : "false" });
             return terminated ? Results.Ok(new { credentialId, terminated = true })
                              : Results.NotFound();
         });
@@ -71,5 +81,23 @@ public static class AdminFixpEndpoints
         });
 
         return app;
+    }
+
+    private static void EmitAuditIfWired(HttpContext ctx, string resourcePath, string outcome, Dictionary<string, string>? details = null)
+    {
+        var audit = ctx.RequestServices.GetService<IAuditLogger>();
+        if (audit is null) return;
+        audit.Log(new B3.Trading.Application.Persistence.AuditLogEvent
+        {
+            EventType = AuditEventTypes.AdminConfigChange,
+            Outcome = outcome,
+            ActorUserId = ctx.User.FindFirstValue("sub"),
+            ActorUsername = ctx.User.FindFirstValue("sub"),
+            ActorFirm = ctx.User.FindFirstValue("firm"),
+            ActorRole = ctx.User.FindFirstValue("role"),
+            SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ResourcePath = resourcePath,
+            Details = details,
+        });
     }
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/Admin/AdminFixpEndpoints.cs
@@ -47,25 +47,54 @@ public static class AdminFixpEndpoints
         {
             var sessions = ctx.RequestServices.GetService<IUserBotSessionRegistry>();
             if (sessions is null) return Results.NotFound();
-            var newVer = await sessions.BumpVersionAsync(credentialId, "operator", ct);
-            EmitAuditIfWired(ctx, "/admin/fixp/sessions/bump", AuditOutcomes.Success, new()
+            try
             {
-                ["credential_id"] = credentialId.ToString(),
-                ["new_version"] = newVer.ToString(),
-            });
-            return Results.Ok(new { credentialId, newVersion = newVer });
+                // Pass-1 review (#322) P1.2. Audit-first ordering —
+                // emit the operator's bump intent BEFORE the version
+                // bump so a backpressured audit append refuses the
+                // mutation with 503 rather than letting the version
+                // counter advance un-audited.
+                EmitAuditOrFailIfWired(ctx, "/admin/fixp/sessions/bump", AuditOutcomes.Success, new()
+                {
+                    ["credential_id"] = credentialId.ToString(),
+                });
+                var newVer = await sessions.BumpVersionAsync(credentialId, "operator", ct);
+                return Results.Ok(new { credentialId, newVersion = newVer });
+            }
+            catch (B3.Trading.Application.Persistence.WalBackpressureException ex)
+            {
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         });
 
         group.MapPost("/sessions/{credentialId:guid}/terminate", (Guid credentialId, HttpContext ctx) =>
         {
             var dir = ctx.RequestServices.GetService<BotSessionConnectionDirectory>();
             if (dir is null) return Results.NotFound();
-            var terminated = dir.TryForceTerminate(credentialId);
-            EmitAuditIfWired(ctx, "/admin/fixp/sessions/terminate",
-                terminated ? AuditOutcomes.Success : AuditOutcomes.Failure,
-                new() { ["credential_id"] = credentialId.ToString(), ["terminated"] = terminated ? "true" : "false" });
-            return terminated ? Results.Ok(new { credentialId, terminated = true })
-                             : Results.NotFound();
+            try
+            {
+                // Pass-1 review (#322) P1.2. Audit-first ordering —
+                // record the operator's terminate intent before the
+                // dispatcher action. TryForceTerminate may still
+                // return false (no live session matches) — that's
+                // surfaced as 404 but the audit envelope already
+                // captured the attempt.
+                EmitAuditOrFailIfWired(ctx, "/admin/fixp/sessions/terminate", AuditOutcomes.Success, new()
+                {
+                    ["credential_id"] = credentialId.ToString(),
+                });
+                var terminated = dir.TryForceTerminate(credentialId);
+                return terminated ? Results.Ok(new { credentialId, terminated = true })
+                                 : Results.NotFound();
+            }
+            catch (B3.Trading.Application.Persistence.WalBackpressureException ex)
+            {
+                return Results.Json(
+                    new { error = "system busy (WAL backpressure)", detail = ex.Message },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         });
 
         group.MapGet("/credentials/{credentialId:guid}/buffer", (Guid credentialId, HttpContext ctx) =>
@@ -81,6 +110,29 @@ public static class AdminFixpEndpoints
         });
 
         return app;
+    }
+
+    private static void EmitAuditOrFailIfWired(HttpContext ctx, string resourcePath, string outcome, Dictionary<string, string>? details = null)
+    {
+        // Pass-1 review (#322) P1.2. Fail-closed audit on /admin/fixp/*
+        // mutating routes: a backpressured audit append propagates so
+        // the endpoint can refuse the mutation with 503. We still
+        // tolerate IAuditLogger not being wired (degenerate composition
+        // / minimal-host tests) by short-circuiting.
+        var audit = ctx.RequestServices.GetService<IAuditLogger>();
+        if (audit is null) return;
+        audit.LogOrFail(new B3.Trading.Application.Persistence.AuditLogEvent
+        {
+            EventType = AuditEventTypes.AdminConfigChange,
+            Outcome = outcome,
+            ActorUserId = ctx.User.FindFirstValue("sub"),
+            ActorUsername = ctx.User.FindFirstValue("sub"),
+            ActorFirm = ctx.User.FindFirstValue("firm"),
+            ActorRole = ctx.User.FindFirstValue("role"),
+            SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ResourcePath = resourcePath,
+            Details = details,
+        });
     }
 
     private static void EmitAuditIfWired(HttpContext ctx, string resourcePath, string outcome, Dictionary<string, string>? details = null)

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -50,6 +50,17 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<SubAccountsRegistry>();
         services.AddSingleton<SubAccountPositionKeeper>();
         services.AddSingleton<SubAccountPnlKeeper>();
+        // Q4.5 (#305). Audit log keeper + dispatcher-backed logger.
+        // Both singletons so the live-dispatch path, recovery replay
+        // and admin read endpoint all share the same in-memory ring
+        // buffer. AuditLogger has a hard dep on EventDispatcher which
+        // is registered in AddTradingPersistence; Program.cs orders
+        // ApplicationCore → Persistence, so resolution at first use
+        // (HTTP handlers) sees both wired.
+        services.Configure<B3.Trading.Application.Audit.AuditLogOptions>(
+            configuration.GetSection(B3.Trading.Application.Audit.AuditLogOptions.SectionName));
+        services.AddSingleton<B3.Trading.Application.Audit.AuditLogKeeper>();
+        services.AddSingleton<B3.Trading.Application.Audit.IAuditLogger, B3.Trading.Application.Audit.AuditLogger>();
         services.AddSingleton<InMemoryUserBotCredentialRegistry>();
         services.AddSingleton<IUserBotCredentialRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotCredentialRegistry>());

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -37,6 +37,7 @@ public static class TradingEndpointsExtensions
         app.MapStatement();
         app.MapPolicy();
         app.MapAdmin();
+        app.MapAdminAudit();
         {
             // #188: simulator/er moved to Infrastructure (it's the only consumer
             // of MockEntryPointClient + ExecutionReportEnvelope). Mounted here

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
@@ -54,9 +54,8 @@ public sealed class PersistenceRecovery
         var replayed = 0;
         await foreach (var (seq, evt) in _store.ReadFromAsync(since, ct).ConfigureAwait(false))
         {
-            _replayer.Apply(evt);
+            _replayer.Apply(seq, evt);
             replayed++;
-            _ = seq;
         }
         // Q2.3 (#270) pass-3. After draining the WAL, materialise any
         // ER-fill fee synths that were not superseded by a durable

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using Microsoft.Extensions.Logging;
@@ -20,19 +21,28 @@ public sealed class PersistenceRecovery
     private readonly EventReplayer _replayer;
     private readonly SnapshotStore _snapshots;
     private readonly ILogger<PersistenceRecovery> _logger;
+    // Pass-1 review (#322) P1.1. Optional. When wired AND a snapshot
+    // is loaded, recovery does a pre-pass over the WAL filtered to
+    // AuditLogEvent for seq <= snapshot.Seq so the in-memory audit
+    // ring rehydrates the pre-snapshot history that the main replay
+    // (which starts at snapshot.Seq+1) cannot see. Cost is O(N) where
+    // N is total WAL events; the keeper's bounded ring caps memory.
+    private readonly AuditLogKeeper? _auditKeeper;
 
     public PersistenceRecovery(
         IEventStore store,
         StateSnapshotter snapshotter,
         EventReplayer replayer,
         SnapshotStore snapshots,
-        ILogger<PersistenceRecovery> logger)
+        ILogger<PersistenceRecovery> logger,
+        AuditLogKeeper? auditKeeper = null)
     {
         _store = store;
         _snapshotter = snapshotter;
         _replayer = replayer;
         _snapshots = snapshots;
         _logger = logger;
+        _auditKeeper = auditKeeper;
     }
 
     public async Task RunAsync(CancellationToken ct = default)
@@ -45,6 +55,30 @@ public sealed class PersistenceRecovery
             since = snap.Seq;
             _logger.LogInformation("Persistence recovery: restored snapshot at seq={Seq} ({Orders} orders, {Positions} positions).",
                 snap.Seq, snap.WorkingOrders.Count, snap.Positions.Count);
+
+            // Pass-1 review (#322) P1.1. Audit-only pre-pass for
+            // seq <= snapshot.Seq. The main replay below starts at
+            // since+1 and would otherwise leave the audit ring empty
+            // of pre-snapshot history (the keeper is not part of the
+            // snapshot envelope by design — see AuditLogKeeper doc).
+            // The ring is bounded so streaming the full prefix is
+            // safe; oldest entries silently fall off the head as the
+            // pre-pass scans forward.
+            if (_auditKeeper is not null && since > 0)
+            {
+                var rehydrated = 0;
+                await foreach (var (seq, evt) in _store.ReadFromAsync(0, ct).ConfigureAwait(false))
+                {
+                    if (seq > since) break;
+                    if (evt is AuditLogEvent ae)
+                    {
+                        _auditKeeper.Apply(seq, ae);
+                        rehydrated++;
+                    }
+                }
+                _logger.LogInformation("Persistence recovery: rehydrated {Count} audit envelopes from pre-snapshot WAL prefix (cap={Cap}).",
+                    rehydrated, _auditKeeper.Capacity);
+            }
         }
         else
         {

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Scheduling;
@@ -736,6 +737,14 @@ public sealed class EventReplayer
     private readonly SubAccountPnlKeeper? _subAccountPnl;
     private readonly IFeeCalculator? _feeCalculator;
     /// <summary>
+    /// Q4.5 (#305). Optional. When wired, replay folds every
+    /// <see cref="AuditLogEvent"/> into the in-memory ring-buffer
+    /// keeper that backs <c>GET /admin/audit</c>, so post-restart
+    /// reads converge with steady state (bounded by the keeper's
+    /// configured capacity).
+    /// </summary>
+    private readonly AuditLogKeeper? _auditKeeper;
+    /// <summary>
     /// Pass-1 review (#295) P1#1. Optional. When wired, replay folds
     /// <see cref="AlgoPovSlicedEvent.MarketVolumeSeen"/> +
     /// <see cref="AlgoPovSlicedEvent.LastEvaluateAtUtc"/> into the
@@ -789,7 +798,11 @@ public sealed class EventReplayer
         IReplaceMarginCoordinator? replaceMargin = null,
         SubAccountsRegistry? subAccounts = null,
         SubAccountPositionKeeper? subAccountPositions = null,
-        SubAccountPnlKeeper? subAccountPnl = null)
+        SubAccountPnlKeeper? subAccountPnl = null,
+        // Q4.5 (#305). Optional. When wired, replay of
+        // <see cref="AuditLogEvent"/> folds the envelope into the
+        // in-memory ring-buffer keeper that backs GET /admin/audit.
+        AuditLogKeeper? auditKeeper = null)
     {
         _orders = orders;
         _ownership = ownership;
@@ -815,6 +828,26 @@ public sealed class EventReplayer
         _subAccounts = subAccounts;
         _subAccountPositions = subAccountPositions;
         _subAccountPnl = subAccountPnl;
+        _auditKeeper = auditKeeper;
+    }
+
+    /// <summary>
+    /// Q4.5 (#305). Overload that carries the WAL seq so an
+    /// <see cref="AuditLogEvent"/> can be folded into
+    /// <see cref="AuditLogKeeper"/> with the canonical
+    /// monotonic id used by the read-path cursor. Every non-audit
+    /// event routes through the legacy <see cref="Apply(WalEvent)"/>
+    /// path unchanged so existing callers (tests that don't track
+    /// seq) keep working.
+    /// </summary>
+    public void Apply(long seq, WalEvent evt)
+    {
+        if (evt is AuditLogEvent ae)
+        {
+            _auditKeeper?.Apply(seq, ae);
+            return;
+        }
+        Apply(evt);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
+++ b/backend/src/B3.Trading.Infrastructure/SimulatorEndpoint.cs
@@ -1,4 +1,7 @@
+using System.Security.Claims;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -50,6 +53,15 @@ public static class SimulatorEndpoint
         long? CumQty = null);
 
     /// <summary>
+    /// Q4.5 (#305) — canonical event type for simulator ER injection
+    /// audit envelopes. Picked as a sub-namespace of
+    /// <c>admin.config.change</c> so existing <c>admin.*</c> read
+    /// filters surface these too, but distinct enough that ops
+    /// dashboards can split them out.
+    /// </summary>
+    public const string SimulatorErEventType = "admin.simulator.er_inject";
+
+    /// <summary>
     /// Maps <c>POST /admin/simulator/er</c> under the admin authorization
     /// policy. URL kept stable for conformance-contract compatibility
     /// (#163) — callers must check <c>ExchangeOptions.ResolveMode()==Mock
@@ -67,17 +79,29 @@ public static class SimulatorEndpoint
     public static IResult Inject(
         [FromBody] InjectRequest req,
         WorkingOrderBook book,
-        MockEntryPointClient mock)
+        MockEntryPointClient mock,
+        HttpContext ctx,
+        IAuditLogger audit)
     {
+        // Pass-1 review (#322) P2. The simulator endpoint is gated on
+        // Mock + AllowErInjection (dev/test-only) and is intentionally
+        // routed through the best-effort audit mode — operator
+        // visibility of every accepted/rejected injection is the
+        // goal; fail-closed gating against a backpressured WAL would
+        // be the wrong default for a dev surface. Both happy-path
+        // and validation-failure branches funnel through EmitAudit
+        // so the audit trail records what the operator attempted
+        // regardless of the outcome.
         if (req is null)
-            return Results.BadRequest(new { error = "missing_body" });
+            return RejectWithAudit(audit, ctx, req: null, AuditOutcomes.Failure, "missing_body", new { error = "missing_body" });
         if (req.ClOrdId == 0)
-            return Results.BadRequest(new { error = "missing_clOrdId" });
+            return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "missing_clOrdId", new { error = "missing_clOrdId" });
         if (string.IsNullOrWhiteSpace(req.Type))
-            return Results.BadRequest(new { error = "missing_type" });
+            return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "missing_type", new { error = "missing_type" });
 
         if (!Enum.TryParse<EpExecType>(req.Type, ignoreCase: true, out var execType))
-            return Results.BadRequest(new { error = "invalid_type", detail = $"unknown ExecType '{req.Type}'" });
+            return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "invalid_type",
+                new { error = "invalid_type", detail = $"unknown ExecType '{req.Type}'" });
 
         // Q3.5 (#285). Replaced ER lookup is keyed on the NEW
         // ClOrdID via PendingReplacementRegistry; the new order is
@@ -90,7 +114,8 @@ public static class SimulatorEndpoint
         if (execType == EpExecType.Replaced)
         {
             if ((req.OrigClOrdId ?? 0UL) == 0UL)
-                return Results.BadRequest(new { error = "missing_origClOrdId", detail = "origClOrdId is required for type=Replaced." });
+                return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "missing_origClOrdId",
+                    new { error = "missing_origClOrdId", detail = "origClOrdId is required for type=Replaced." });
             var leavesR = req.LastQty ?? 0L;
             var cumR = req.CumQty ?? 0L;
             var envR = new ExecutionReportEnvelope(
@@ -103,6 +128,7 @@ public static class SimulatorEndpoint
                 RejectReason: null,
                 OrigClOrdId: req.OrigClOrdId!.Value);
             mock.EmitExecutionReport(envR);
+            EmitAudit(audit, ctx, req, execType, AuditOutcomes.Success, reasonCode: null);
             return Results.Accepted(value: new
             {
                 clOrdId = req.ClOrdId,
@@ -113,7 +139,8 @@ public static class SimulatorEndpoint
         }
 
         if (!book.TryGet(req.ClOrdId, out var order) || order is null)
-            return Results.NotFound(new { error = "unknown_clOrdId", clOrdId = req.ClOrdId });
+            return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "unknown_clOrdId",
+                new { error = "unknown_clOrdId", clOrdId = req.ClOrdId }, execType: execType, status: StatusCodes.Status404NotFound);
 
         long leaves;
         long cum;
@@ -133,13 +160,16 @@ public static class SimulatorEndpoint
             case EpExecType.PartialFill:
             case EpExecType.Fill:
                 if (lastQty <= 0)
-                    return Results.BadRequest(new { error = "missing_lastQty", detail = "lastQty must be > 0 for Fill/PartialFill." });
+                    return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "missing_lastQty",
+                        new { error = "missing_lastQty", detail = "lastQty must be > 0 for Fill/PartialFill." }, execType: execType);
                 cum = order.CumulativeQuantity + lastQty;
                 if (cum > order.Quantity)
-                    return Results.BadRequest(new { error = "overfill", detail = $"cum {cum} would exceed order quantity {order.Quantity}." });
+                    return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "overfill",
+                        new { error = "overfill", detail = $"cum {cum} would exceed order quantity {order.Quantity}." }, execType: execType);
                 leaves = order.Quantity - cum;
                 if (execType == EpExecType.PartialFill && leaves == 0)
-                    return Results.BadRequest(new { error = "partial_consumes_full", detail = "PartialFill would zero leaves; use type=Fill instead." });
+                    return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "partial_consumes_full",
+                        new { error = "partial_consumes_full", detail = "PartialFill would zero leaves; use type=Fill instead." }, execType: execType);
                 break;
 
             case EpExecType.Canceled:
@@ -151,7 +181,8 @@ public static class SimulatorEndpoint
 
             case EpExecType.Rejected:
                 if (string.IsNullOrWhiteSpace(rejectReason))
-                    return Results.BadRequest(new { error = "missing_rejectReason", detail = "rejectReason is required for type=Rejected." });
+                    return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "missing_rejectReason",
+                        new { error = "missing_rejectReason", detail = "rejectReason is required for type=Rejected." }, execType: execType);
                 leaves = order.LeavesQuantity;
                 cum = order.CumulativeQuantity;
                 lastQty = 0;
@@ -159,7 +190,8 @@ public static class SimulatorEndpoint
                 break;
 
             default:
-                return Results.BadRequest(new { error = "invalid_type", detail = $"ExecType '{execType}' not supported." });
+                return RejectWithAudit(audit, ctx, req, AuditOutcomes.Failure, "invalid_type",
+                    new { error = "invalid_type", detail = $"ExecType '{execType}' not supported." }, execType: execType);
         }
 
         var envelope = new ExecutionReportEnvelope(
@@ -173,6 +205,7 @@ public static class SimulatorEndpoint
             FirmId: order.FirmId);
 
         mock.EmitExecutionReport(envelope);
+        EmitAudit(audit, ctx, req, execType, AuditOutcomes.Success, reasonCode: null);
 
         return Results.Accepted(value: new
         {
@@ -180,6 +213,59 @@ public static class SimulatorEndpoint
             execType = execType.ToString(),
             leavesQuantity = leaves,
             cumulativeQuantity = cum,
+        });
+    }
+
+    private static IResult RejectWithAudit(
+        IAuditLogger audit,
+        HttpContext ctx,
+        InjectRequest? req,
+        string outcome,
+        string reasonCode,
+        object body,
+        EpExecType? execType = null,
+        int status = StatusCodes.Status400BadRequest)
+    {
+        EmitAudit(audit, ctx, req, execType, outcome, reasonCode);
+        return status == StatusCodes.Status404NotFound
+            ? Results.NotFound(body)
+            : Results.BadRequest(body);
+    }
+
+    private static void EmitAudit(
+        IAuditLogger audit,
+        HttpContext ctx,
+        InjectRequest? req,
+        EpExecType? execType,
+        string outcome,
+        string? reasonCode)
+    {
+        // Pass-1 review (#322) P2. Best-effort capture — see Inject
+        // doc for the LogOrFail/Log rationale.
+        var details = new Dictionary<string, string>();
+        if (req is not null)
+        {
+            details["cl_ord_id"] = req.ClOrdId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (!string.IsNullOrEmpty(req.Type)) details["type"] = req.Type;
+            if (execType is not null) details["exec_type"] = execType.Value.ToString();
+            if (req.LastQty is long lq) details["last_qty"] = lq.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (req.LastPx is decimal lp) details["last_px"] = lp.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (req.OrigClOrdId is ulong oc && oc != 0UL) details["orig_cl_ord_id"] = oc.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (req.CumQty is long cq) details["cum_qty"] = cq.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (!string.IsNullOrEmpty(req.RejectReason)) details["reject_reason"] = req.RejectReason;
+        }
+        audit.Log(new AuditLogEvent
+        {
+            EventType = SimulatorErEventType,
+            Outcome = outcome,
+            ActorUserId = ctx.User.FindFirstValue("sub"),
+            ActorUsername = ctx.User.FindFirstValue("sub"),
+            ActorFirm = ctx.User.FindFirstValue("firm"),
+            ActorRole = ctx.User.FindFirstValue("role"),
+            SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ResourcePath = "/admin/simulator/er",
+            ReasonCode = reasonCode,
+            Details = details.Count == 0 ? null : details,
         });
     }
 }

--- a/backend/tests/B3.Trading.Api.Tests/AdminAuditEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminAuditEndpointTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q4.5 (#305). End-to-end coverage of the admin audit log surface:
+/// capture sites (login, 2FA, admin mutations), the GET /admin/audit
+/// read endpoint, pagination, filters, and cross-firm visibility.
+/// Engine-driven via HTTP — no mocks per project convention.
+/// </summary>
+public class AdminAuditEndpointTests : IClassFixture<TestAppFactory>
+{
+    private readonly TestAppFactory _factory;
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public AdminAuditEndpointTests(TestAppFactory factory) => _factory = factory;
+
+    private sealed record AuditPage(List<AuditEntryDto> Entries, string? NextCursor);
+    private sealed record AuditEntryDto(
+        long Seq,
+        string Id,
+        DateTimeOffset TimestampUtc,
+        string EventType,
+        string Outcome,
+        string? ActorUserId,
+        string? ActorUsername,
+        string? ActorFirm,
+        string? ActorRole,
+        string? SourceIp,
+        string? ResourcePath,
+        string? ReasonCode,
+        Dictionary<string, string>? Details);
+
+    private static async Task<AuditPage> QueryAuditAsync(HttpClient admin, string queryString = "")
+    {
+        var resp = await admin.GetAsync($"/admin/audit{queryString}");
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<AuditPage>(Json))!;
+    }
+
+    [Fact]
+    public async Task Get_AnonymousReturns401()
+    {
+        using var anon = _factory.CreateClient();
+        var resp = await anon.GetAsync("/admin/audit");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TraderReturns403()
+    {
+        using var trader = await _factory.CreateAuthedClientAsync(); // alice (user)
+        var resp = await trader.GetAsync("/admin/audit");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_FailedAttempt_EmitsAuditEvent()
+    {
+        using var anon = _factory.CreateClient();
+        var bad = await anon.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wrong" });
+        Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var page = await QueryAuditAsync(admin, "?type=auth.login.failure&limit=50");
+        Assert.Contains(page.Entries, e =>
+            e.EventType == "auth.login.failure" &&
+            e.Outcome == "failure" &&
+            e.ActorUsername == "alice" &&
+            e.ReasonCode == "bad_password");
+    }
+
+    [Fact]
+    public async Task Login_Success_EmitsAuditEvent()
+    {
+        using var anon = _factory.CreateClient();
+        await _factory.LoginAsync(anon, "alice");
+
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var page = await QueryAuditAsync(admin, "?user=alice&type=auth.login.success&limit=20");
+        Assert.Contains(page.Entries, e =>
+            e.EventType == "auth.login.success" &&
+            e.Outcome == "success" &&
+            e.ActorUsername == "alice");
+    }
+
+    [Fact]
+    public async Task AdminKill_EmitsConfigChangeAudit()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+
+        // Toggle kill on/off for a firm so we leave the platform in a clean state.
+        var on = await admin.PostAsync("/admin/kill/firm/default", content: null);
+        on.EnsureSuccessStatusCode();
+        var off = await admin.DeleteAsync("/admin/kill/firm/default");
+        off.EnsureSuccessStatusCode();
+
+        var page = await QueryAuditAsync(admin, "?type=admin.config.change&limit=100");
+        Assert.Contains(page.Entries, e =>
+            e.EventType == "admin.config.change" &&
+            e.ResourcePath != null && e.ResourcePath.StartsWith("/admin/kill") &&
+            e.ActorRole == "admin");
+    }
+
+    [Fact]
+    public async Task TypePrefixFilter_MatchesAllAuthEvents()
+    {
+        using var anon = _factory.CreateClient();
+        await _factory.LoginAsync(anon, "alice");
+        var bad = await anon.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wrong" });
+        Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var page = await QueryAuditAsync(admin, "?type=auth.*&limit=100");
+        Assert.NotEmpty(page.Entries);
+        Assert.All(page.Entries, e => Assert.StartsWith("auth.", e.EventType));
+    }
+
+    [Fact]
+    public async Task OutcomeFilter_OnlyReturnsMatching()
+    {
+        using var anon = _factory.CreateClient();
+        var bad = await anon.PostAsJsonAsync("/auth/login", new { username = "alice", password = "wrong" });
+        Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var page = await QueryAuditAsync(admin, "?outcome=failure&limit=50");
+        Assert.NotEmpty(page.Entries);
+        Assert.All(page.Entries, e => Assert.Equal("failure", e.Outcome));
+    }
+
+    [Fact]
+    public async Task Pagination_CursorReturnsNextPageAndEventuallyStops()
+    {
+        using var anon = _factory.CreateClient();
+        // Generate a known burst of failure events.
+        for (var i = 0; i < 7; i++)
+        {
+            var bad = await anon.PostAsJsonAsync("/auth/login", new { username = "alice", password = $"wrong-{i}" });
+            Assert.Equal(HttpStatusCode.Unauthorized, bad.StatusCode);
+        }
+
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var first = await QueryAuditAsync(admin, "?type=auth.login.failure&limit=3");
+        Assert.Equal(3, first.Entries.Count);
+        Assert.NotNull(first.NextCursor);
+
+        var second = await QueryAuditAsync(admin, $"?type=auth.login.failure&limit=3&cursor={Uri.EscapeDataString(first.NextCursor!)}");
+        Assert.Equal(3, second.Entries.Count);
+        // Newest-first: second page seqs are strictly older than first page seqs.
+        Assert.True(second.Entries[0].Seq < first.Entries[^1].Seq);
+    }
+
+    [Fact]
+    public async Task InvalidCursor_Returns400()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var resp = await admin.GetAsync("/admin/audit?cursor=%21%21not-base64%21%21");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/AdminMutationAuditFailClosedTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AdminMutationAuditFailClosedTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Http.Json;
+using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Pass-1 review (#322) P1.2. Regression coverage for the
+/// admin-mutation fail-open audit gap: prior to the fix the
+/// AuditLogger swallowed <see cref="WalBackpressureException"/>
+/// even for security-sensitive admin endpoints, so a kill-switch
+/// toggle could commit without an audit record being durably
+/// captured. The fix introduces a fail-closed <c>LogOrFail</c>
+/// mode + audit-first ordering: when the audit append throws
+/// backpressure, the endpoint returns HTTP 503 and the business
+/// dispatch never runs.
+/// </summary>
+public class AdminMutationAuditFailClosedTests
+{
+    private sealed class BackpressuringAuditLogger : IAuditLogger
+    {
+        public int LogCalls;
+        public int LogOrFailCalls;
+        public void Log(AuditLogEvent evt) => Interlocked.Increment(ref LogCalls);
+        public void LogOrFail(AuditLogEvent evt)
+        {
+            Interlocked.Increment(ref LogOrFailCalls);
+            // Simulate the WAL writer rejecting the audit envelope —
+            // the contract is that LogOrFail propagates this so the
+            // caller can refuse the business mutation.
+            throw new WalBackpressureException("test-injected backpressure");
+        }
+    }
+
+    private static TestAppFactory NewFactory(out BackpressuringAuditLogger fake)
+    {
+        var f = new BackpressuringAuditLogger();
+        fake = f;
+        return TestAppFactory.WithOverrides(
+            configOverrides: new Dictionary<string, string?>(),
+            services: s =>
+            {
+                s.RemoveAll(typeof(IAuditLogger));
+                s.AddSingleton<IAuditLogger>(f);
+            });
+    }
+
+    [Fact]
+    public async Task AdminKill_AuditBackpressured_Returns503_AndKillSwitchNotToggled()
+    {
+        var factory = NewFactory(out var fake);
+        using var _ = factory;
+        using var admin = await factory.CreateAuthedClientAsync("admin");
+        // Pre-condition: end-client not killed.
+        var svc = factory.Services.GetRequiredService<KillSwitchService>();
+        var ec = new EndClientId("victim-1");
+        Assert.False(svc.IsEndClientKilled(ec));
+
+        var resp = await admin.PostAsync("/admin/kill/end-client/victim-1", content: null);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+        Assert.True(fake.LogOrFailCalls >= 1, "expected LogOrFail invoked (audit-first ordering)");
+        // Business mutation MUST NOT have committed.
+        Assert.False(svc.IsEndClientKilled(ec));
+        // KillSwitchService also exposes ListKilledEndClients; the
+        // attempted target must be absent there too.
+        Assert.DoesNotContain("victim-1", svc.ListKilledEndClients());
+    }
+
+    [Fact]
+    public async Task SubAccountCreate_AuditBackpressured_Returns503_AndRegistryNotMutated()
+    {
+        var factory = NewFactory(out var fake);
+        using var _ = factory;
+        using var admin = await factory.CreateAuthedClientAsync("admin");
+        var registry = factory.Services.GetRequiredService<SubAccountsRegistry>();
+        var firm = "default"; // anon firm assignment in TestAppFactory
+        var before = registry.ListForFirm(firm).Count;
+
+        var resp = await admin.PostAsJsonAsync(
+            "/sub-accounts/",
+            new SubAccountCreateRequest("subA", "Display"));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+        Assert.True(fake.LogOrFailCalls >= 1);
+        // Registry must not contain the would-be sub-account.
+        Assert.Equal(before, registry.ListForFirm(firm).Count);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Audit/AuditLogKeeperEvictionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Audit/AuditLogKeeperEvictionTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.Audit;
+
+/// <summary>
+/// Pass-2 review (#322) P2: an earlier <c>List&lt;T&gt;.RemoveAt(0)</c>
+/// implementation of the bounded ring was O(capacity) per evicted
+/// entry, turning the recovery pre-pass into O(N · capacity) once the
+/// WAL audit-event count exceeded the cap. The keeper now uses a
+/// head-indexed circular buffer so eviction is O(1).
+/// </summary>
+public class AuditLogKeeperEvictionTests
+{
+    [Fact]
+    public void FullRingEviction_KeepsNewestCapacityEntries_NewestFirst()
+    {
+        var keeper = new AuditLogKeeper(Options.Create(new AuditLogOptions { Capacity = 4 }));
+        var baseUtc = new DateTimeOffset(2026, 5, 18, 0, 0, 0, TimeSpan.Zero);
+
+        for (long seq = 1; seq <= 10; seq++)
+        {
+            keeper.Apply(seq, new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthLoginSuccess,
+                Outcome = AuditOutcomes.Success,
+                TimestampUtc = baseUtc.AddSeconds(seq),
+                ActorUsername = $"u{seq}",
+            });
+        }
+
+        Assert.Equal(4, keeper.Count);
+        var page = keeper.Query(
+            since: baseUtc.AddYears(-1),
+            until: baseUtc.AddYears(1),
+            user: null, typePattern: null, outcome: null,
+            limit: 100, cursorSeq: null);
+
+        Assert.Equal(new long[] { 10, 9, 8, 7 }, page.Entries.Select(e => e.Seq).ToArray());
+    }
+
+    [Fact]
+    public void RepeatedWrap_PreservesCircularInvariants()
+    {
+        var keeper = new AuditLogKeeper(Options.Create(new AuditLogOptions { Capacity = 3 }));
+        var baseUtc = new DateTimeOffset(2026, 5, 18, 0, 0, 0, TimeSpan.Zero);
+
+        for (long seq = 1; seq <= 9; seq++)
+        {
+            keeper.Apply(seq, new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AdminConfigChange,
+                Outcome = AuditOutcomes.Success,
+                TimestampUtc = baseUtc.AddSeconds(seq),
+            });
+        }
+
+        Assert.Equal(3, keeper.Count);
+        var page = keeper.Query(baseUtc.AddYears(-1), baseUtc.AddYears(1), null, null, null, 100, null);
+        Assert.Equal(new long[] { 9, 8, 7 }, page.Entries.Select(e => e.Seq).ToArray());
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Audit/AuditLogKeeperEvictionTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Audit/AuditLogKeeperEvictionTests.cs
@@ -63,4 +63,43 @@ public class AuditLogKeeperEvictionTests
         var page = keeper.Query(baseUtc.AddYears(-1), baseUtc.AddYears(1), null, null, null, 100, null);
         Assert.Equal(new long[] { 9, 8, 7 }, page.Entries.Select(e => e.Seq).ToArray());
     }
+
+    /// <summary>
+    /// Pass-3 review (#322): pre-cap geometric growth must reset
+    /// <c>_head</c> after the underlying array doubles. The previous
+    /// implementation left <c>_head</c> at its wrapped value (0) after
+    /// the first growth at <c>len=1024</c>, so the 1025th append
+    /// overwrote slot 0 and left slots <c>1024..len-1</c> null —
+    /// <see cref="AuditLogKeeper.Query"/> then dereferenced a null
+    /// entry and crashed with NRE. Capacity 2048 forces at least one
+    /// growth from the initial 1024-slot ring while staying well
+    /// below the cap.
+    /// </summary>
+    [Fact]
+    public void GeometricGrowthPastInitialRingLength_DoesNotLoseEntriesOrCrashQuery()
+    {
+        var keeper = new AuditLogKeeper(Options.Create(new AuditLogOptions { Capacity = 2048 }));
+        var baseUtc = new DateTimeOffset(2026, 5, 18, 0, 0, 0, TimeSpan.Zero);
+
+        const int total = 1100;
+        for (long seq = 1; seq <= total; seq++)
+        {
+            keeper.Apply(seq, new AuditLogEvent
+            {
+                EventType = AuditEventTypes.AuthLoginSuccess,
+                Outcome = AuditOutcomes.Success,
+                TimestampUtc = baseUtc.AddSeconds(seq),
+            });
+        }
+
+        Assert.Equal(total, keeper.Count);
+
+        var page = keeper.Query(baseUtc.AddYears(-1), baseUtc.AddYears(1), null, null, null, limit: 500, cursorSeq: null);
+        Assert.Equal(500, page.Entries.Count);
+        // Newest-first; no NRE; no gaps.
+        for (var i = 0; i < page.Entries.Count; i++)
+        {
+            Assert.Equal(total - i, page.Entries[i].Seq);
+        }
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/AuditLogRecoveryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/AuditLogRecoveryTests.cs
@@ -1,0 +1,202 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// Pass-1 review (#322) P1.1. Regression coverage for the
+/// audit-history-lost-before-snapshot bug: prior to the fix
+/// <see cref="PersistenceRecovery"/> drove the WAL drain from
+/// <c>snapshot.Seq + 1</c>, leaving the <see cref="AuditLogKeeper"/>
+/// empty of every audit envelope captured before the latest snapshot.
+/// </summary>
+public class AuditLogRecoveryTests : IDisposable
+{
+    private readonly string _root;
+
+    public AuditLogRecoveryTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-audit-recovery-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private PersistenceOptions Opts() => new()
+    {
+        DataDirectory = _root,
+        FirmId = "test",
+        ChannelCapacity = 1024,
+        GroupCommitMaxRecords = 8,
+        GroupCommitWindow = TimeSpan.FromMilliseconds(5),
+        FsyncOnFlush = false,
+    };
+
+    private static AuditLogKeeper Keeper(int capacity = 1000) =>
+        new(Options.Create(new AuditLogOptions { Capacity = capacity }));
+
+    private static AuditLogger Logger(EventDispatcher dispatcher, AuditLogKeeper keeper) =>
+        new(dispatcher, keeper, NullLogger<AuditLogger>.Instance);
+
+    private static EventReplayer EmptyReplayer(AuditLogKeeper keeper)
+    {
+        // Minimum-viable replayer for an audit-only recovery test:
+        // the audit pre-pass routes audit envelopes through the
+        // keeper, but the main replay needs a fully-formed
+        // EventReplayer too (the recovery driver always calls it).
+        var book = new WorkingOrderBook();
+        var ownership = new OrderOwnershipMap();
+        var killSwitch = new KillSwitchService();
+        var phases = new SessionPhaseService();
+        var algos = new AlgoBook();
+        var processor = new ExecutionReportProcessor(
+            ownership, book, new PositionKeeper(), new NullSink(), new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance);
+        return new EventReplayer(
+            book, ownership, killSwitch, new SymbolHaltService(), phases,
+            processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry(),
+            auditKeeper: keeper);
+    }
+
+    private static AuditLogEvent NewAudit(string suffix) => new()
+    {
+        EventType = AuditEventTypes.AdminConfigChange,
+        Outcome = AuditOutcomes.Success,
+        ActorUsername = "admin",
+        ResourcePath = $"/admin/test/{suffix}",
+        Details = new Dictionary<string, string> { ["k"] = suffix },
+    };
+
+    [Fact]
+    public async Task ColdRestart_AfterSnapshotAndMoreAudits_RebuildsRingWithBothHistoricAndTailEntries()
+    {
+        // Phase 1: emit N audits, snapshot, emit M more, then close.
+        const int n = 12;
+        const int m = 5;
+        var snapStore = new SnapshotStore(_root, "test");
+        long snapSeq;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var dispatcher = new EventDispatcher(store);
+            var keeper = Keeper();
+            var logger = Logger(dispatcher, keeper);
+
+            for (var i = 0; i < n; i++)
+                logger.Log(NewAudit($"pre-{i}"));
+
+            // Take a snapshot at the current WAL seq.
+            B3.Trading.Application.Persistence.PlatformSnapshot? snap = null;
+            var snapshotter = BuildSnapshotter();
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            snapSeq = snap!.Seq;
+
+            for (var i = 0; i < m; i++)
+                logger.Log(NewAudit($"post-{i}"));
+
+            await store.FlushAsync();
+        }
+
+        // Phase 2: cold boot — recovery must rehydrate ALL N+M audits.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = Keeper();
+            var replayer = EmptyReplayer(keeper);
+            var recovery = new PersistenceRecovery(
+                store, BuildSnapshotter(), replayer, snapStore,
+                NullLogger<PersistenceRecovery>.Instance,
+                auditKeeper: keeper);
+            await recovery.RunAsync();
+
+            Assert.Equal(n + m, keeper.Count);
+            // Newest-first scan via Query — confirm the seq ordering
+            // matches what live capture would have produced.
+            var page = keeper.Query(
+                since: DateTimeOffset.MinValue,
+                until: DateTimeOffset.MaxValue,
+                user: null, typePattern: null, outcome: null,
+                limit: n + m + 10, cursorSeq: null);
+            Assert.Equal(n + m, page.Entries.Count);
+            // Pre-snapshot entries must be present (the bug being fixed).
+            for (var i = 0; i < n; i++)
+            {
+                var suffix = $"pre-{i}";
+                Assert.Contains(page.Entries, e =>
+                    e.Details is not null && e.Details.TryGetValue("k", out var v) && v == suffix);
+            }
+            // Post-snapshot entries equally restored from the tail.
+            for (var i = 0; i < m; i++)
+            {
+                var suffix = $"post-{i}";
+                Assert.Contains(page.Entries, e =>
+                    e.Details is not null && e.Details.TryGetValue("k", out var v) && v == suffix);
+            }
+            // Sanity — every restored entry's seq is <= the post-batch
+            // WAL position and > 0.
+            Assert.All(page.Entries, e => Assert.True(e.Seq > 0));
+        }
+    }
+
+    [Fact]
+    public async Task ColdRestart_NoSnapshot_RehydratesAllAuditsViaMainReplay()
+    {
+        // Without a snapshot the main replay starts at seq=0 and
+        // already folds audit envelopes — the pre-pass should be a
+        // no-op. Guards the "no snapshot found; full WAL replay" path.
+        const int n = 8;
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var dispatcher = new EventDispatcher(store);
+            var keeper = Keeper();
+            var logger = Logger(dispatcher, keeper);
+            for (var i = 0; i < n; i++)
+                logger.Log(NewAudit($"only-{i}"));
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var keeper = Keeper();
+            var replayer = EmptyReplayer(keeper);
+            var recovery = new PersistenceRecovery(
+                store, BuildSnapshotter(), replayer, new SnapshotStore(_root, "test"),
+                NullLogger<PersistenceRecovery>.Instance,
+                auditKeeper: keeper);
+            await recovery.RunAsync();
+
+            Assert.Equal(n, keeper.Count);
+        }
+    }
+
+    private static StateSnapshotter BuildSnapshotter()
+    {
+        // Minimal snapshotter — the audit-recovery test only needs
+        // the snapshot to carry a non-zero Seq; the order/position
+        // arrays are empty. Mirrors the ctor wiring used by
+        // RecoveryAndSnapshotTests.BuildState.
+        var book = new WorkingOrderBook();
+        var ownership = new OrderOwnershipMap();
+        var killSwitch = new KillSwitchService();
+        var halts = new SymbolHaltService();
+        var phases = new SessionPhaseService();
+        var positions = new PositionKeeper();
+        var algos = new AlgoBook();
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algoIds = new AlgoIdRegistry();
+        return new StateSnapshotter(
+            book, positions, killSwitch, halts, phases, clOrdIds, ownership, algos, algoIds, new CashLedger());
+    }
+
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent evt) { }
+    }
+}


### PR DESCRIPTION
Closes #305

## Summary
Structured audit-log surface for compliance forensics.

### WAL & projection
- New `AuditLogEvent` envelope (discriminator `audit.log`) registered in `WalEventJsonContext`. Additive — unknown discriminators are already skipped by `FileEventStore`, so older snapshots/WALs continue to load.
- `AuditLogKeeper` ring buffer (default capacity **100k**, configurable via `Trading:Audit:Capacity`) folds every `AuditLogEvent` projected from the WAL. **Not** snapshotted: rehydrates from the WAL tail on recovery via a new `EventReplayer.Apply(long seq, WalEvent)` overload that preserves the monotonic WAL seq.
- `IAuditLogger` helper dispatches the event and feeds the keeper under the same `EventDispatcher` lock, then increments `MetricsRegistry.AuditEventsTotal` (bounded tags: `event_type`, `outcome` — no per-user cardinality).

### Capture sites
- `/auth/login` (success / bad_password / unknown_user / 2fa_required / 2fa_required_but_missing / locked / missing_credentials)
- `/auth/2fa/enroll-start`, `/auth/2fa/verify` (success TOTP + recovery code, failure + recovery code replay), `/auth/2fa/enroll-confirm`, `/auth/2fa/disable`
- All `/admin/*` mutations: firm/end-client switches (POST + DELETE), halt, session-phase, mark-stale, clear-stale, eod, risk/reload, cash (success + denied for insufficient_funds), sub-accounts create/deactivate, FIXP session bump/terminate

### Read API
`GET /admin/audit` mounted on the existing `MapGroup("/admin").RequireAuthorization("admin")` group (anonymous → 401, non-admin → 403). Query params:
- `since` / `until` (ISO-8601; default last 24h)
- `user` (matches `actor_username` OR `actor_user_id` OR `details.target_user`, case-insensitive)
- `type` (exact, or `prefix.*` glob)
- `outcome` (success / failure / denied)
- `limit` (default 100, max 500)
- `cursor` (opaque base64; `400` on malformed)

Response: `{ entries: AuditEntry[], nextCursor?: string }`, newest-first.

### Tests
9 new tests in `AdminAuditEndpointTests` (engine-driven, no mocks):
- 401/403 role gates
- login failure & success capture
- admin.config.change capture (firm switch toggle)
- `type=auth.*` prefix glob filter
- `outcome=failure` filter
- cursor pagination across two pages
- malformed cursor → 400

### Design decisions
- **Global scope**: only one admin role exists today, so audit is visible across firms. TODO marker for #314 (compliance role) to retighten.
- **Best-effort logger**: swallows `WalBackpressureException` and general exceptions so audit failures never mask the caller's business outcome; the metric counter increments regardless.
- **2FA challenge as failure**: `/auth/login` returning a 2FA challenge emits `auth.login.failure` with `reason_code=2fa_required` to match the issue's reason-code matrix (debatable — happy to flip to success+reason if reviewers prefer).
- **Snapshot-free keeper**: WAL is the source of truth, snapshots stay backward-compatible.
- **Bounded metric cardinality**: only `event_type` + `outcome` tags.

### Verification
- `dotnet build B3TradingPlatform.slnx` — 0 warnings, 0 errors
- `dotnet test B3TradingPlatform.slnx` — passes (with retry on two pre-existing flakies: `OrdersSubmittedCounter_CarriesFirmIdTag`, `PastDayConcurrentDispatch_StatementRead_NeverProducesTornSnapshot`)
- `dotnet format B3TradingPlatform.slnx --verify-no-changes` — clean
