### PR TITLE
Q4.6 (#306): drop-copy WebSocket feed

### DIFF
--- a/backend/src/B3.Trading.Api/Auth/Roles.cs
+++ b/backend/src/B3.Trading.Api/Auth/Roles.cs
@@ -1,0 +1,29 @@
+namespace B3.Trading.Api.Auth;
+
+/// <summary>
+/// Q4.6 (#306). Canonical role-claim strings emitted by <see cref="JwtIssuer"/>
+/// and matched by <c>[Authorize(Roles = ...)]</c> / policy gates. The role
+/// claim itself is open-set (any string operators put in
+/// <c>Trading:Auth:Users:N:Role</c> ends up in the JWT), but every
+/// first-class role recognised by the host is named here so the capture
+/// sites + policy registration agree on the wire spelling.
+///
+/// <para><b>Compliance.</b> Added in Q4.6 to gate the drop-copy WebSocket
+/// feed (<c>/ws/dropcopy</c>). A compliance principal sees every order /
+/// fill / cancel for its own firm regardless of the originating user; an
+/// admin principal is treated symmetrically and may additionally pass
+/// <c>?firmId=</c> to view another firm. No /admin/* surface was
+/// broadened — compliance read-paths land via #306-style endpoints, not
+/// by mixing roles into the existing admin policy.</para>
+/// </summary>
+public static class Roles
+{
+    /// <summary>Default end-user role for trading clients.</summary>
+    public const string User = "user";
+
+    /// <summary>Administrative role; can also exercise compliance surfaces (cross-firm).</summary>
+    public const string Admin = "admin";
+
+    /// <summary>Compliance role; firm-scoped read-only oversight (Q4.6 / #306).</summary>
+    public const string Compliance = "compliance";
+}

--- a/backend/src/B3.Trading.Api/WebSockets/CompositeExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/CompositeExecutionEventSink.cs
@@ -1,0 +1,37 @@
+using B3.Trading.Application;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// Q4.6 (#306). Tee a single <see cref="IExecutionEventSink.Publish"/>
+/// call to multiple downstream sinks. Used to forward synthetic
+/// publishes (<see cref="Application.OrderStalenessService"/> /
+/// EntryPoint WAL-backpressure fallback) to BOTH the per-user WS hub
+/// (<see cref="WebSocketExecutionEventSink"/>) and the compliance
+/// drop-copy fan-out
+/// (<see cref="DropCopy.DropCopyExecutionEventSink"/>) so the
+/// drop-copy feed's "all traffic" guarantee covers events that did
+/// NOT travel through the dispatcher's fan-out target machinery.
+/// Each leg's <see cref="IExecutionEventSink.Publish"/> is a
+/// non-blocking channel write; failure on one leg does not affect the
+/// other.
+/// </summary>
+public sealed class CompositeExecutionEventSink : IExecutionEventSink
+{
+    private readonly IExecutionEventSink[] _sinks;
+
+    public CompositeExecutionEventSink(params IExecutionEventSink[] sinks)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        _sinks = sinks;
+    }
+
+    public void Publish(ExecutionEvent ev)
+    {
+        for (var i = 0; i < _sinks.Length; i++)
+        {
+            try { _sinks[i].Publish(ev); }
+            catch { /* per-sink failure is isolated; sinks bound + report their own metrics */ }
+        }
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
@@ -117,6 +117,24 @@ public sealed class DropCopyClient
         }
     }
 
+    /// <summary>
+    /// Forces this client into the disconnect path with
+    /// <paramref name="reason"/>. Used by the fan-out sink when an
+    /// upstream drop event would cause an undetectable gap in this
+    /// session's stream (pass-3 review #323): we fail-closed and let
+    /// the client reconnect-and-resnapshot rather than silently
+    /// continue with contiguous per-client seqs that hide the loss.
+    /// Idempotent and thread-safe.
+    /// </summary>
+    public void RequestResyncDisconnect(string reason)
+    {
+        if (MarkedForDisconnect) return;
+        MarkedForDisconnect = true;
+        DisconnectReason = reason;
+        _outbound.Writer.TryComplete();
+        _disconnectRequested.TrySetResult();
+    }
+
     public void Complete()
     {
         _outbound.Writer.TryComplete();

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
@@ -1,0 +1,103 @@
+using System.Threading.Channels;
+
+namespace B3.Trading.Api.WebSockets.DropCopy;
+
+/// <summary>
+/// Q4.6 (#306). One per active drop-copy WebSocket connection. Owns a
+/// bounded outbound channel + per-logical-channel monotonic sequence
+/// counter. Mirrors the per-user <see cref="SubscribedClient"/> shape so
+/// the wire envelope is identical (snapshot at <c>seq=0</c>, deltas
+/// from <c>seq=1</c>), but is scoped on <see cref="FirmId"/> rather
+/// than an owner identity — a drop-copy session is firm-fanned and
+/// not user-keyed.
+/// </summary>
+public sealed class DropCopyClient
+{
+    public const int OutboundCapacity = 4096;
+
+    private readonly Channel<OutboundMessage> _outbound;
+    private readonly object _channelsSync = new();
+    private readonly Dictionary<string, long> _seqByChannel = new(StringComparer.Ordinal);
+
+    public DropCopyClient(string firmId, string username, string role)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(username);
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        FirmId = firmId;
+        Username = username;
+        Role = role;
+        Id = Guid.NewGuid();
+        _outbound = Channel.CreateBounded<OutboundMessage>(new BoundedChannelOptions(OutboundCapacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public Guid Id { get; }
+
+    /// <summary>Firm being observed — sourced from the JWT firm claim (compliance) or the <c>?firmId=</c> override (admin).</summary>
+    public string FirmId { get; }
+
+    /// <summary>JWT <c>sub</c> of the principal that opened the session — captured for audit + diagnostics.</summary>
+    public string Username { get; }
+
+    /// <summary>Role claim of the principal that opened the session — captured for audit.</summary>
+    public string Role { get; }
+
+    public ChannelReader<OutboundMessage> Reader => _outbound.Reader;
+
+    public bool MarkedForDisconnect { get; private set; }
+    public string? DisconnectReason { get; private set; }
+
+    /// <summary>
+    /// Registers <paramref name="channel"/> for sequence tracking.
+    /// Returns false if the channel was already registered (a redundant
+    /// subscribe; the snapshot is implicitly already-sent).
+    /// </summary>
+    public bool Subscribe(string channel)
+    {
+        lock (_channelsSync)
+        {
+            if (_seqByChannel.ContainsKey(channel))
+                return false;
+            _seqByChannel[channel] = 0;
+            return true;
+        }
+    }
+
+    public bool IsSubscribed(string channel)
+    {
+        lock (_channelsSync)
+            return _seqByChannel.ContainsKey(channel);
+    }
+
+    public long NextSeq(string channel)
+    {
+        lock (_channelsSync)
+        {
+            if (!_seqByChannel.TryGetValue(channel, out var current))
+                return -1;
+            var next = current + 1;
+            _seqByChannel[channel] = next;
+            return next;
+        }
+    }
+
+    public void Enqueue(OutboundMessage message)
+    {
+        if (MarkedForDisconnect)
+            return;
+
+        if (!_outbound.Writer.TryWrite(message))
+        {
+            MarkedForDisconnect = true;
+            DisconnectReason = "slow_consumer_resync_required";
+            _outbound.Writer.TryComplete();
+        }
+    }
+
+    public void Complete() => _outbound.Writer.TryComplete();
+}

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyClient.cs
@@ -52,6 +52,23 @@ public sealed class DropCopyClient
     public bool MarkedForDisconnect { get; private set; }
     public string? DisconnectReason { get; private set; }
 
+    private readonly TaskCompletionSource _disconnectRequested =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Completes the first time <see cref="Enqueue"/> trips the slow-
+    /// consumer guard (or any other internal teardown reason). The hub
+    /// awaits this alongside the send/receive loops so that a peer
+    /// stuck in <c>ws.SendAsync</c> (TCP write buffer full while the
+    /// peer never reads) still triggers the cleanup path — completing
+    /// the outbound channel is not enough on its own, since SendLoop
+    /// is blocked inside <c>SendAsync</c> rather than at the channel
+    /// read. Pass-2 review (#323) P1: without this signal,
+    /// <c>manager.Remove</c> never runs for the exact slow-consumer
+    /// case the feature is meant to handle.
+    /// </summary>
+    public Task DisconnectRequested => _disconnectRequested.Task;
+
     /// <summary>
     /// Registers <paramref name="channel"/> for sequence tracking.
     /// Returns false if the channel was already registered (a redundant
@@ -96,8 +113,13 @@ public sealed class DropCopyClient
             MarkedForDisconnect = true;
             DisconnectReason = "slow_consumer_resync_required";
             _outbound.Writer.TryComplete();
+            _disconnectRequested.TrySetResult();
         }
     }
 
-    public void Complete() => _outbound.Writer.TryComplete();
+    public void Complete()
+    {
+        _outbound.Writer.TryComplete();
+        _disconnectRequested.TrySetResult();
+    }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -68,7 +68,19 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                 SingleWriter = false,
                 FullMode = BoundedChannelFullMode.DropOldest,
             },
-            itemDropped: static _ => MetricsRegistry.WsHubFanOutDropped.Add(1));
+            itemDropped: _ =>
+            {
+                // Pass-3 review (#323) P1: DropOldest hides the loss
+                // from drop-copy subscribers because per-client seqs
+                // are assigned downstream (after the sink) and snapshots
+                // for fills/cancels are empty by design — a silent
+                // discard would be unrecoverable. Fail-closed: mark
+                // every active subscriber for resync. Clients reconnect
+                // and pick up a fresh snapshot from a known state.
+                MetricsRegistry.WsHubFanOutDropped.Add(1);
+                try { _manager.DisconnectAllForResync("drop_copy_sink_overflow_resync_required"); }
+                catch (Exception ex) { _logger?.LogWarning(ex, "drop-copy resync-disconnect on sink overflow failed"); }
+            });
     }
 
     /// <inheritdoc />

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -130,7 +130,14 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
         // No firm => no fan-out (legacy / pre-multi-firm events default-cased through tests).
         var firmId = ev.FirmId;
         if (string.IsNullOrEmpty(firmId)) return;
-        if (_manager.SubscriberCount(firmId) == 0) return;
+
+        // No out-of-lock SubscriberCount fast-path here: the per-firm
+        // empty-set check happens INSIDE DropCopyManager.Publish (under
+        // the per-firm lock). Reading _byFirm here without the lock
+        // would re-introduce the Publish-vs-Add race (Q4.6 RFC §4.3):
+        // a concurrent Add() could register a subscriber whose snapshot
+        // has been enqueued but whose first live delta would then be
+        // dropped because the unlocked fast-path saw zero subscribers.
 
         // orders.* — current order state after mutation (skip if the
         // order is no longer in the book, same fall-through as orders.me).

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -52,6 +52,15 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
     private readonly CancellationTokenSource _cts = new();
     private Task? _drainTask;
     private int _stopped;
+    // Pass-4 review (#323) P2: itemDropped fires from inside
+    // IExecutionFanOutSink.Enqueue, which the dispatcher invokes UNDER
+    // its global dispatch lock. A sustained overflow burst would otherwise
+    // synchronously re-walk every firm + subscriber per dropped item and
+    // stall unrelated execution dispatch. Coalesce: only the first drop in
+    // each overflow burst triggers DisconnectAllForResync. The drain loop
+    // resets the flag after draining the backlog so a later, distinct
+    // overflow re-triggers the disconnect for fresh subscribers.
+    private int _overflowSignaled;
 
     public DropCopyExecutionEventSink(
         DropCopyManager manager,
@@ -78,6 +87,7 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                 // every active subscriber for resync. Clients reconnect
                 // and pick up a fresh snapshot from a known state.
                 MetricsRegistry.WsHubFanOutDropped.Add(1);
+                if (Interlocked.Exchange(ref _overflowSignaled, 1) != 0) return;
                 try { _manager.DisconnectAllForResync("drop_copy_sink_overflow_resync_required"); }
                 catch (Exception ex) { _logger?.LogWarning(ex, "drop-copy resync-disconnect on sink overflow failed"); }
             });
@@ -132,6 +142,9 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                             ev.FirmId, ev.ClOrdId);
                     }
                 }
+                // Backlog cleared — arm the overflow signal for any
+                // subsequent (independent) burst with fresh subscribers.
+                Interlocked.Exchange(ref _overflowSignaled, 0);
             }
         }
         catch (OperationCanceledException) { /* shutdown */ }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -1,0 +1,149 @@
+using System.Threading.Channels;
+using B3.Trading.Application;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Api.WebSockets.DropCopy;
+
+/// <summary>
+/// Q4.6 (#306). Channel-backed drop-copy fan-out sink. Same shape as
+/// <see cref="WebSocketExecutionEventSink"/>: both the dispatcher
+/// <see cref="IExecutionFanOutSink.Enqueue"/> path (called UNDER the
+/// dispatcher lock — must be non-blocking) and the synthetic
+/// <see cref="IExecutionEventSink.Publish"/> path
+/// (<c>OrderStalenessService</c> / WAL-backpressure fallback) funnel
+/// into the same bounded <see cref="Channel{T}"/>. A single background
+/// drain runs the firm-scoped subscriber walk + DTO build OFF the
+/// dispatcher lock while preserving WAL-append order for events that
+/// arrived via the dispatcher (RFC §4.1 / §5.2 ordering note).
+///
+/// <para><b>Per-sink overflow policy</b> is identical to the per-user
+/// WS sink (bounded + DropOldest + metric). A drop indicates the
+/// drain is stuck; drop-copy subscribers detect the gap via the same
+/// reconnect-and-snapshot pattern as <c>orders.me</c> consumers.</para>
+///
+/// <para><b>Channel routing.</b> For every captured
+/// <see cref="ExecutionEvent"/> the drain emits:
+/// <list type="bullet">
+///   <item><c>dropcopy.orders</c> — latest order DTO (when the order
+///   is still in the book; venue events that pre-date the in-memory
+///   order are silently skipped, same as <c>orders.me</c>).</item>
+///   <item><c>dropcopy.fills</c> — <see cref="ExecutionDto"/> for
+///   <see cref="ExecKind.Fill"/> / <see cref="ExecKind.PartialFill"/>
+///   with <c>LastQuantity &gt; 0</c>.</item>
+///   <item><c>dropcopy.cancels</c> — <see cref="ExecutionDto"/> for
+///   <see cref="ExecKind.Canceled"/> (venue-cancelled or GTD-expired
+///   — replaces and rejects show up only on the orders channel, as
+///   order-state transitions, matching FIX drop-copy convention).
+///   </item>
+/// </list></para>
+/// </summary>
+public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutionEventSink, IHostedService, IAsyncDisposable
+{
+    /// <summary>Drain bound — same order of magnitude as <see cref="WebSocketExecutionEventSink.ChannelCapacity"/>.</summary>
+    public const int ChannelCapacity = 65_536;
+
+    private readonly DropCopyManager _manager;
+    private readonly WorkingOrderBook _orders;
+    private readonly ILogger<DropCopyExecutionEventSink>? _logger;
+    private readonly Channel<ExecutionEvent> _channel;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _drainTask;
+    private int _stopped;
+
+    public DropCopyExecutionEventSink(
+        DropCopyManager manager,
+        WorkingOrderBook orders,
+        ILogger<DropCopyExecutionEventSink>? logger = null)
+    {
+        _manager = manager;
+        _orders = orders;
+        _logger = logger;
+        _channel = Channel.CreateBounded<ExecutionEvent>(
+            new BoundedChannelOptions(ChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.DropOldest,
+            },
+            itemDropped: static _ => MetricsRegistry.WsHubFanOutDropped.Add(1));
+    }
+
+    /// <inheritdoc />
+    public ExecutionFanOutTargets Target => ExecutionFanOutTargets.DropCopy;
+
+    /// <inheritdoc />
+    public void Enqueue(long seq, ExecutionEvent ev) => _channel.Writer.TryWrite(ev);
+
+    /// <inheritdoc />
+    public void Publish(ExecutionEvent ev) => _channel.Writer.TryWrite(ev);
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _drainTask = Task.Run(DrainAsync);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0) return;
+        _cts.Cancel();
+        _channel.Writer.TryComplete();
+        if (_drainTask is not null)
+        {
+            try { await _drainTask.ConfigureAwait(false); } catch { /* drain stop is best-effort */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private async Task DrainAsync()
+    {
+        var reader = _channel.Reader;
+        try
+        {
+            while (await reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var ev))
+                {
+                    try { PublishCore(ev); }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning(ex,
+                            "drop-copy fan-out publish failed for firmId={Firm} clOrdId={ClOrdId}",
+                            ev.FirmId, ev.ClOrdId);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void PublishCore(ExecutionEvent ev)
+    {
+        // No firm => no fan-out (legacy / pre-multi-firm events default-cased through tests).
+        var firmId = ev.FirmId;
+        if (string.IsNullOrEmpty(firmId)) return;
+        if (_manager.SubscriberCount(firmId) == 0) return;
+
+        // orders.* — current order state after mutation (skip if the
+        // order is no longer in the book, same fall-through as orders.me).
+        if (_orders.TryGet(ev.ClOrdId, out var order) && order is not null)
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Orders, order.ToDto());
+
+        // fills.* — only economic fills.
+        if (ev.Kind is ExecKind.Fill or ExecKind.PartialFill && ev.LastQuantity > 0)
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Fills, ev.ToDto());
+
+        // cancels.* — venue cancels (incl. GTD-expired). Replaces/rejects
+        // are visible via the orders channel as state transitions.
+        if (ev.Kind == ExecKind.Canceled)
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Cancels, ev.ToDto());
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -52,15 +52,6 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
     private readonly CancellationTokenSource _cts = new();
     private Task? _drainTask;
     private int _stopped;
-    // Pass-4 review (#323) P2: itemDropped fires from inside
-    // IExecutionFanOutSink.Enqueue, which the dispatcher invokes UNDER
-    // its global dispatch lock. A sustained overflow burst would otherwise
-    // synchronously re-walk every firm + subscriber per dropped item and
-    // stall unrelated execution dispatch. Coalesce: only the first drop in
-    // each overflow burst triggers DisconnectAllForResync. The drain loop
-    // resets the flag after draining the backlog so a later, distinct
-    // overflow re-triggers the disconnect for fresh subscribers.
-    private int _overflowSignaled;
 
     public DropCopyExecutionEventSink(
         DropCopyManager manager,
@@ -87,7 +78,6 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                 // every active subscriber for resync. Clients reconnect
                 // and pick up a fresh snapshot from a known state.
                 MetricsRegistry.WsHubFanOutDropped.Add(1);
-                if (Interlocked.Exchange(ref _overflowSignaled, 1) != 0) return;
                 try { _manager.DisconnectAllForResync("drop_copy_sink_overflow_resync_required"); }
                 catch (Exception ex) { _logger?.LogWarning(ex, "drop-copy resync-disconnect on sink overflow failed"); }
             });
@@ -142,9 +132,6 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                             ev.FirmId, ev.ClOrdId);
                     }
                 }
-                // Backlog cleared — arm the overflow signal for any
-                // subsequent (independent) burst with fresh subscribers.
-                Interlocked.Exchange(ref _overflowSignaled, 0);
             }
         }
         catch (OperationCanceledException) { /* shutdown */ }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -133,4 +133,31 @@ public sealed class DropCopyManager
     /// </summary>
     public int SubscriberCount(string firmId) =>
         _byFirm.TryGetValue(firmId, out var set) ? set.Count : 0;
+
+    /// <summary>
+    /// Fail-closed when an upstream component (e.g. the bounded
+    /// fan-out sink) detects an event drop that would otherwise be
+    /// invisible to subscribers. Marks every currently-registered
+    /// drop-copy session — across ALL firms — for resync disconnect
+    /// with <paramref name="reason"/>. The hub teardown observes the
+    /// per-client signal and runs the standard cleanup; clients then
+    /// reconnect, receive a fresh snapshot, and resume from a known
+    /// state. Pass-3 review (#323): fills/cancels snapshots are
+    /// empty by design, so a silent <c>DropOldest</c> on the sink
+    /// channel would lose an event forever even though per-client
+    /// seqs stayed contiguous.
+    /// </summary>
+    public void DisconnectAllForResync(string reason)
+    {
+        foreach (var firmId in _byFirm.Keys)
+        {
+            lock (LockFor(firmId))
+            {
+                if (!_byFirm.TryGetValue(firmId, out var clients) || clients.IsEmpty)
+                    continue;
+                foreach (var c in clients)
+                    c.RequestResyncDisconnect(reason);
+            }
+        }
+    }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -114,10 +114,30 @@ public sealed class DropCopyManager
         var firmId = client.FirmId;
         lock (LockFor(firmId))
         {
-            _byFirm.AddOrUpdate(
-                firmId,
-                _ => ImmutableHashSet<DropCopyClient>.Empty,
-                (_, set) => set.Remove(client));
+            if (!_byFirm.TryGetValue(firmId, out var set))
+                return;
+            set = set.Remove(client);
+            if (set.IsEmpty)
+            {
+                // Pass-7 review (#323) P2: with admin firmId override
+                // accepting arbitrary tenant strings, leaving an empty
+                // bucket per ever-seen firmId is a process-lifetime
+                // dictionary growth vector. Clean up _byFirm and
+                // _firmResyncArmed when the last subscriber leaves.
+                // _firmLocks intentionally retained — removing it would
+                // race concurrent Add()s that already captured the lock
+                // reference and could end up serializing on different
+                // monitors. The monitor object itself is ~24 bytes and
+                // bounded growth is acceptable for the rare admin
+                // override path (also gated by firmId validation in the
+                // hub).
+                _byFirm.TryRemove(firmId, out _);
+                _firmResyncArmed.TryRemove(firmId, out _);
+            }
+            else
+            {
+                _byFirm[firmId] = set;
+            }
         }
     }
 
@@ -179,22 +199,17 @@ public sealed class DropCopyManager
     /// </summary>
     public void DisconnectAllForResync(string reason)
     {
-        // Coalesce per-firm: only the first drop in a per-firm burst
-        // pays for walking that firm's subscribers. The gate is armed
-        // by Add() under the SAME per-firm lock used here to consume
-        // it, so the visibility/arm/consume sequence is atomic and a
-        // newly registered client can never be missed (see _firmResyncArmed).
+        // Per-firm coalesce: arm is set under LockFor(firmId) by Add,
+        // and we consume it under the SAME lock here. NO unlocked
+        // fast-path: a stale armed==0 read outside the lock could race
+        // a registration-in-progress and skip the firm entirely (pass-7
+        // P1). The firm count is bounded by tenant cardinality so the
+        // per-drop O(firms) lock acquisition is acceptable.
         foreach (var firmId in _firmResyncArmed.Keys)
         {
-            // Fast path: if no Add has armed since the last walk, skip
-            // the lock acquisition entirely.
-            if (!_firmResyncArmed.TryGetValue(firmId, out var armed) || armed == 0)
-                continue;
-
             lock (LockFor(firmId))
             {
-                // Re-check under the lock and atomically consume.
-                if (!_firmResyncArmed.TryGetValue(firmId, out armed) || armed == 0)
+                if (!_firmResyncArmed.TryGetValue(firmId, out var armed) || armed == 0)
                     continue;
                 _firmResyncArmed[firmId] = 0;
 

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -100,11 +100,21 @@ public sealed class DropCopyManager
     public void Publish(string firmId, string channel, object payload)
     {
         if (string.IsNullOrEmpty(firmId)) return;
-        if (!_byFirm.TryGetValue(firmId, out var clients) || clients.IsEmpty)
-            return;
 
+        // Atomicity contract (Q4.6 / RFC §4.3): the per-firm lock is the
+        // single serialization point between subscriber registration
+        // (Add) and delta fan-out. We must take the lock BEFORE reading
+        // _byFirm — otherwise a concurrent Add() could register a new
+        // subscriber + enqueue its snapshot frame while we are still
+        // holding a stale subscriber set, causing the racing delta to
+        // be silently lost for the new subscriber. The empty-set
+        // early-out happens INSIDE the lock so it remains cheap when
+        // no compliance session is active (the common case).
         lock (LockFor(firmId))
         {
+            if (!_byFirm.TryGetValue(firmId, out var clients) || clients.IsEmpty)
+                return;
+
             foreach (var client in clients)
             {
                 if (client.MarkedForDisconnect) continue;

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -38,19 +38,24 @@ public sealed class DropCopyManager
     private readonly ConcurrentDictionary<string, object> _firmLocks =
         new(StringComparer.OrdinalIgnoreCase);
 
-    // Pass-5 review (#323) coalesce: itemDropped in the sink fires on
-    // every dropped event under EventDispatcher's global dispatch lock.
-    // To avoid an O(drops × firms × subscribers) walk-storm without the
-    // sink-side flag race (which had a TOCTOU between drain-empty and
-    // reset), we coalesce here: the disconnect walk is a single-shot
-    // "armed" gate. A drop "consumes" the gate (Exchange→0) so only the
-    // first drop in a burst walks. The gate is re-armed by Add() AFTER
-    // a fresh subscriber is registered, so any later burst that could
-    // affect the new subscriber re-triggers the walk. Subscribers added
-    // before the drop are disconnected by that drop's walk; subscribers
-    // added after see a clean snapshot at subscribe-time and don't need
-    // a retroactive resync for events they were never registered for.
-    private int _resyncArmed;
+    // Pass-6 review (#323) — per-firm armed gate, NOT global.
+    // Coalesces overflow drops: itemDropped fires per dropped event
+    // under EventDispatcher's global dispatch lock; with N concurrent
+    // drops in a burst we don't want O(drops × firms × subscribers).
+    //
+    // Atomicity (vs the prior global gate): a global flag let a drop
+    // race the post-insert/pre-arm window in Add() and silently miss a
+    // freshly registered client. Per-firm flag fixes that — registration
+    // (bucket insert) AND arm happen under LockFor(firmId), and the
+    // disconnect walk consumes the flag under the SAME lock, so
+    // visibility + arm + consume are atomic relative to the firm-lock.
+    //
+    // Cost on drop storms: O(firms) uncontended TryGetValue + lock +
+    // Volatile.Read per drop after the first; the per-firm lock is the
+    // same one Publish takes, so we trade against (already-backpressured)
+    // publish throughput, not against unrelated firms.
+    private readonly ConcurrentDictionary<string, int> _firmResyncArmed =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private readonly WorkingOrderBook _orders;
 
@@ -90,12 +95,18 @@ public sealed class DropCopyManager
                 client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Fills, 0, Array.Empty<ExecutionDto>()));
             if (client.Subscribe(DropCopyChannels.Cancels))
                 client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Cancels, 0, Array.Empty<ExecutionDto>()));
-        }
 
-        // Arm AFTER the client is in _byFirm so that a subsequent drop's
-        // walk will see and disconnect it. The opposite order would let
-        // the walk miss the new subscriber.
-        Interlocked.Exchange(ref _resyncArmed, 1);
+            // Arm the per-firm resync gate UNDER THE SAME LOCK as the
+            // bucket insert above. The disconnect walk consumes this
+            // gate under the same lock, so a concurrent drop either
+            // (a) acquires the lock AFTER us and sees the new client
+            // and the armed gate, or (b) acquires the lock BEFORE us
+            // and walks subscribers that do NOT include this client —
+            // which is correct, because the event that triggered the
+            // drop happened before we became visible in _byFirm and
+            // therefore wasn't ours to receive.
+            _firmResyncArmed[firmId] = 1;
+        }
     }
 
     public void Remove(DropCopyClient client)
@@ -168,17 +179,25 @@ public sealed class DropCopyManager
     /// </summary>
     public void DisconnectAllForResync(string reason)
     {
-        // Coalesce: only the first overflow drop in a burst pays for the
-        // per-firm lock walk. The gate is re-armed by Add() once a new
-        // subscriber appears, so any later burst that COULD affect the
-        // new subscriber re-triggers a walk. See _resyncArmed XML doc.
-        if (Interlocked.Exchange(ref _resyncArmed, 0) == 0)
-            return;
-
-        foreach (var firmId in _byFirm.Keys)
+        // Coalesce per-firm: only the first drop in a per-firm burst
+        // pays for walking that firm's subscribers. The gate is armed
+        // by Add() under the SAME per-firm lock used here to consume
+        // it, so the visibility/arm/consume sequence is atomic and a
+        // newly registered client can never be missed (see _firmResyncArmed).
+        foreach (var firmId in _firmResyncArmed.Keys)
         {
+            // Fast path: if no Add has armed since the last walk, skip
+            // the lock acquisition entirely.
+            if (!_firmResyncArmed.TryGetValue(firmId, out var armed) || armed == 0)
+                continue;
+
             lock (LockFor(firmId))
             {
+                // Re-check under the lock and atomically consume.
+                if (!_firmResyncArmed.TryGetValue(firmId, out armed) || armed == 0)
+                    continue;
+                _firmResyncArmed[firmId] = 0;
+
                 if (!_byFirm.TryGetValue(firmId, out var clients) || clients.IsEmpty)
                     continue;
                 foreach (var c in clients)

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using B3.Trading.Application;
+
+namespace B3.Trading.Api.WebSockets.DropCopy;
+
+/// <summary>
+/// Q4.6 (#306). Per-firm subscriber registry + fan-out for the drop-copy
+/// WebSocket feed. Mirrors the snapshot/delta atomicity contract of
+/// <see cref="SubscriptionManager"/> but keys on firmId instead of an
+/// owner identity — a single drop-copy session observes every
+/// order/fill/cancel for its firm, regardless of which user originated
+/// the event.
+///
+/// <para><b>Atomicity contract.</b> Subscribe takes a per-firm lock and
+/// enqueues the initial snapshot frame for each requested channel
+/// under that lock; subsequent <see cref="Publish"/> calls also take
+/// the same per-firm lock when fanning out to that firm's subscribers.
+/// A delta published concurrently with the subscribe therefore lands
+/// AFTER the snapshot on the subscriber's outbound channel — same
+/// pattern <c>SubscribeWithSnapshot</c> uses on the per-user hub
+/// (see RFC §4.3 / RFC §5.2 ordering notes).</para>
+/// </summary>
+public sealed class DropCopyManager
+{
+    /// <summary>Logical channel names exposed by the drop-copy feed.</summary>
+    public static class DropCopyChannels
+    {
+        public const string Orders = "dropcopy.orders";
+        public const string Fills = "dropcopy.fills";
+        public const string Cancels = "dropcopy.cancels";
+
+        public static readonly IReadOnlyList<string> All = new[] { Orders, Fills, Cancels };
+    }
+
+    private readonly ConcurrentDictionary<string, ImmutableHashSet<DropCopyClient>> _byFirm =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, object> _firmLocks =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly WorkingOrderBook _orders;
+
+    public DropCopyManager(WorkingOrderBook orders)
+    {
+        _orders = orders;
+    }
+
+    private object LockFor(string firmId) =>
+        _firmLocks.GetOrAdd(firmId, _ => new object());
+
+    /// <summary>
+    /// Atomically registers <paramref name="client"/> for every drop-copy
+    /// channel in <see cref="DropCopyChannels.All"/> and enqueues the
+    /// initial snapshot frame for each (orders = firm-scoped working
+    /// order DTOs; fills/cancels = empty — no historical exec log in
+    /// v1, matching <c>executions.me</c>). The per-firm lock ensures
+    /// any concurrent <see cref="Publish"/> for the same firm queues
+    /// AFTER the snapshots.
+    /// </summary>
+    public void Add(DropCopyClient client)
+    {
+        var firmId = client.FirmId;
+        lock (LockFor(firmId))
+        {
+            _byFirm.AddOrUpdate(
+                firmId,
+                _ => ImmutableHashSet.Create(client),
+                (_, set) => set.Add(client));
+
+            // Orders snapshot: every non-terminal working order in the firm.
+            var orderDtos = _orders.EnumerateForFirm(firmId).Select(o => o.ToDto()).ToArray();
+
+            if (client.Subscribe(DropCopyChannels.Orders))
+                client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Orders, 0, orderDtos));
+            if (client.Subscribe(DropCopyChannels.Fills))
+                client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Fills, 0, Array.Empty<ExecutionDto>()));
+            if (client.Subscribe(DropCopyChannels.Cancels))
+                client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Cancels, 0, Array.Empty<ExecutionDto>()));
+        }
+    }
+
+    public void Remove(DropCopyClient client)
+    {
+        var firmId = client.FirmId;
+        lock (LockFor(firmId))
+        {
+            _byFirm.AddOrUpdate(
+                firmId,
+                _ => ImmutableHashSet<DropCopyClient>.Empty,
+                (_, set) => set.Remove(client));
+        }
+    }
+
+    /// <summary>
+    /// Fans out <paramref name="payload"/> as a delta on
+    /// <paramref name="channel"/> to every drop-copy subscriber of
+    /// <paramref name="firmId"/>. No-op when no subscriber exists for
+    /// the firm (the common case — drop-copy sessions are rare).
+    /// </summary>
+    public void Publish(string firmId, string channel, object payload)
+    {
+        if (string.IsNullOrEmpty(firmId)) return;
+        if (!_byFirm.TryGetValue(firmId, out var clients) || clients.IsEmpty)
+            return;
+
+        lock (LockFor(firmId))
+        {
+            foreach (var client in clients)
+            {
+                if (client.MarkedForDisconnect) continue;
+                if (!client.IsSubscribed(channel)) continue;
+                var seq = client.NextSeq(channel);
+                if (seq < 0) continue;
+                client.Enqueue(new OutboundMessage("delta", channel, seq, payload));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Diagnostic: number of currently-registered subscribers for
+    /// <paramref name="firmId"/>. Used by the disconnect-cleanup test
+    /// to assert no leak.
+    /// </summary>
+    public int SubscriberCount(string firmId) =>
+        _byFirm.TryGetValue(firmId, out var set) ? set.Count : 0;
+}

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -217,13 +217,22 @@ public sealed class DropCopyManager
     /// </summary>
     public void DisconnectAllForResync(string reason)
     {
+        // Pass-9 review (#323) P1: enumerate from _byFirm.Keys (the
+        // source-of-truth for active subscribers) rather than from
+        // _firmResyncArmed.Keys. Add() inserts into _byFirm BEFORE
+        // writing _firmResyncArmed under the same stripe lock; iterating
+        // the armed-dict would skip a firm whose first subscriber is
+        // mid-Add (visible in _byFirm, arm-key not yet written), letting
+        // a concurrent drop survive without forcing a resync. Iterating
+        // _byFirm.Keys means the walker will acquire the stripe lock,
+        // block until Add releases, and then see armed=1 and the new
+        // client together — atomically.
+        //
         // Per-firm coalesce: arm is set under LockFor(firmId) by Add,
-        // and we consume it under the SAME lock here. NO unlocked
+        // and we consume it under the SAME lock here. No unlocked
         // fast-path: a stale armed==0 read outside the lock could race
-        // a registration-in-progress and skip the firm entirely (pass-7
-        // P1). The firm count is bounded by tenant cardinality so the
-        // per-drop O(firms) lock acquisition is acceptable.
-        foreach (var firmId in _firmResyncArmed.Keys)
+        // a registration-in-progress and skip the firm (pass-7 P1).
+        foreach (var firmId in _byFirm.Keys)
         {
             lock (LockFor(firmId))
             {

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -33,10 +33,17 @@ public sealed class DropCopyManager
         public static readonly IReadOnlyList<string> All = new[] { Orders, Fills, Cancels };
     }
 
+    // Pass-8 review (#323) P1: align firm-keyed dictionaries to
+    // StringComparer.Ordinal to match WorkingOrderBook and the rest of
+    // the firm-scoped state. Using OrdinalIgnoreCase here would let a
+    // subscriber registered for "firm01" receive deltas for "FIRM01"
+    // while the order-book snapshot for "firm01" returns nothing
+    // (Ordinal lookup) — cross-firm leakage hidden behind a casing
+    // mismatch. Firm IDs are platform-issued (JWT claim) or admin-
+    // validated [A-Za-z0-9_-]; we keep the same exact-match semantics
+    // everywhere they appear.
     private readonly ConcurrentDictionary<string, ImmutableHashSet<DropCopyClient>> _byFirm =
-        new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, object> _firmLocks =
-        new(StringComparer.OrdinalIgnoreCase);
+        new(StringComparer.Ordinal);
 
     // Pass-6 review (#323) — per-firm armed gate, NOT global.
     // Coalesces overflow drops: itemDropped fires per dropped event
@@ -54,8 +61,25 @@ public sealed class DropCopyManager
     // Volatile.Read per drop after the first; the per-firm lock is the
     // same one Publish takes, so we trade against (already-backpressured)
     // publish throughput, not against unrelated firms.
+    // Pass-8 review (#323) P2: bound _firmLocks memory to a fixed-size
+    // stripe pool regardless of admin firmId cardinality. The prior
+    // per-firm-key ConcurrentDictionary grew for every distinct admin
+    // firmId override and could not be safely reclaimed without losing
+    // monitor identity for concurrent Add()s. 64 stripes is plenty for
+    // drop-copy (compliance feed traffic is light; the only contention
+    // path is Publish vs Add vs DisconnectAllForResync on the same
+    // firm). Collisions across unrelated firms serialize harmlessly.
+    private const int LockStripeCount = 64;
+    private readonly object[] _firmLockStripes = CreateLockStripes(LockStripeCount);
+    private static object[] CreateLockStripes(int n)
+    {
+        var stripes = new object[n];
+        for (var i = 0; i < n; i++) stripes[i] = new object();
+        return stripes;
+    }
+
     private readonly ConcurrentDictionary<string, int> _firmResyncArmed =
-        new(StringComparer.OrdinalIgnoreCase);
+        new(StringComparer.Ordinal);
 
     private readonly WorkingOrderBook _orders;
 
@@ -65,7 +89,7 @@ public sealed class DropCopyManager
     }
 
     private object LockFor(string firmId) =>
-        _firmLocks.GetOrAdd(firmId, _ => new object());
+        _firmLockStripes[(int)((uint)StringComparer.Ordinal.GetHashCode(firmId) % LockStripeCount)];
 
     /// <summary>
     /// Atomically registers <paramref name="client"/> for every drop-copy
@@ -119,18 +143,12 @@ public sealed class DropCopyManager
             set = set.Remove(client);
             if (set.IsEmpty)
             {
-                // Pass-7 review (#323) P2: with admin firmId override
-                // accepting arbitrary tenant strings, leaving an empty
-                // bucket per ever-seen firmId is a process-lifetime
-                // dictionary growth vector. Clean up _byFirm and
-                // _firmResyncArmed when the last subscriber leaves.
-                // _firmLocks intentionally retained — removing it would
-                // race concurrent Add()s that already captured the lock
-                // reference and could end up serializing on different
-                // monitors. The monitor object itself is ~24 bytes and
-                // bounded growth is acceptable for the rare admin
-                // override path (also gated by firmId validation in the
-                // hub).
+                // Pass-7 review (#323) P2: clean up _byFirm and
+                // _firmResyncArmed when the last subscriber leaves so
+                // process-lifetime memory stays bounded under repeated
+                // admin firmId overrides. The lock pool is striped
+                // (fixed size) so no per-firm lock entry exists to
+                // reclaim (pass-8).
                 _byFirm.TryRemove(firmId, out _);
                 _firmResyncArmed.TryRemove(firmId, out _);
             }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -38,6 +38,20 @@ public sealed class DropCopyManager
     private readonly ConcurrentDictionary<string, object> _firmLocks =
         new(StringComparer.OrdinalIgnoreCase);
 
+    // Pass-5 review (#323) coalesce: itemDropped in the sink fires on
+    // every dropped event under EventDispatcher's global dispatch lock.
+    // To avoid an O(drops × firms × subscribers) walk-storm without the
+    // sink-side flag race (which had a TOCTOU between drain-empty and
+    // reset), we coalesce here: the disconnect walk is a single-shot
+    // "armed" gate. A drop "consumes" the gate (Exchange→0) so only the
+    // first drop in a burst walks. The gate is re-armed by Add() AFTER
+    // a fresh subscriber is registered, so any later burst that could
+    // affect the new subscriber re-triggers the walk. Subscribers added
+    // before the drop are disconnected by that drop's walk; subscribers
+    // added after see a clean snapshot at subscribe-time and don't need
+    // a retroactive resync for events they were never registered for.
+    private int _resyncArmed;
+
     private readonly WorkingOrderBook _orders;
 
     public DropCopyManager(WorkingOrderBook orders)
@@ -77,6 +91,11 @@ public sealed class DropCopyManager
             if (client.Subscribe(DropCopyChannels.Cancels))
                 client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Cancels, 0, Array.Empty<ExecutionDto>()));
         }
+
+        // Arm AFTER the client is in _byFirm so that a subsequent drop's
+        // walk will see and disconnect it. The opposite order would let
+        // the walk miss the new subscriber.
+        Interlocked.Exchange(ref _resyncArmed, 1);
     }
 
     public void Remove(DropCopyClient client)
@@ -149,6 +168,13 @@ public sealed class DropCopyManager
     /// </summary>
     public void DisconnectAllForResync(string reason)
     {
+        // Coalesce: only the first overflow drop in a burst pays for the
+        // per-firm lock walk. The gate is re-armed by Add() once a new
+        // subscriber appears, so any later burst that COULD affect the
+        // new subscriber re-triggers a walk. See _resyncArmed XML doc.
+        if (Interlocked.Exchange(ref _resyncArmed, 0) == 0)
+            return;
+
         foreach (var firmId in _byFirm.Keys)
         {
             lock (LockFor(firmId))

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
@@ -91,8 +91,17 @@ public static class DropCopyWebSocketHub
             if (isAdmin && ctx.Request.Query.TryGetValue("firmId", out var qFirm))
             {
                 var requested = qFirm.ToString();
-                if (!string.IsNullOrWhiteSpace(requested))
+                // Pass-7 review (#323) P2: bound the admin firmId space
+                // to prevent process-lifetime growth in DropCopyManager
+                // dictionaries. Require non-empty, ≤32 chars, ASCII
+                // alphanumeric + dash/underscore (matches the format
+                // used by Firm claims throughout the platform).
+                if (!string.IsNullOrWhiteSpace(requested)
+                    && requested.Length <= 32
+                    && IsValidFirmId(requested))
+                {
                     effectiveFirm = requested;
+                }
             }
 
             using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
@@ -278,5 +287,16 @@ public static class DropCopyWebSocketHub
             ResourcePath = "/ws/dropcopy",
             Details = details,
         });
+    }
+
+    private static bool IsValidFirmId(string s)
+    {
+        foreach (var ch in s)
+        {
+            if (!((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_'))
+                return false;
+        }
+        return true;
     }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
@@ -120,7 +120,15 @@ public static class DropCopyWebSocketHub
             var recvTask = ReceiveLoopAsync(ws, cts.Token);
             try
             {
-                await Task.WhenAny(sendTask, recvTask);
+                // Wait for ANY of: send/receive loop exit, OR the
+                // client's slow-consumer disconnect signal. The signal
+                // is critical for the case where SendLoopAsync is
+                // blocked inside ws.SendAsync (peer's TCP recv window
+                // full because it never reads) — completing the
+                // outbound channel does not unblock SendAsync, so
+                // without an external trigger the WhenAny on just the
+                // two loops never fires. Pass-2 review (#323) P1.
+                await Task.WhenAny(sendTask, recvTask, client.DisconnectRequested);
             }
             finally
             {

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
@@ -1,0 +1,228 @@
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Application.Audit;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api.WebSockets.DropCopy;
+
+/// <summary>
+/// Q4.6 (#306). Compliance drop-copy WebSocket endpoint
+/// (<c>/ws/dropcopy</c>). Auth: JWT required; role must be
+/// <see cref="Roles.Compliance"/> or <see cref="Roles.Admin"/>. The
+/// session is firm-scoped and auto-subscribes to every drop-copy
+/// channel (<see cref="DropCopyManager.DropCopyChannels"/>) on accept
+/// — there is no inbound subscribe/unsubscribe protocol on this
+/// endpoint, by design (drop-copy is "all traffic, no opt-out").
+///
+/// <para><b>Firm selection.</b> Compliance principals always observe
+/// their own JWT firm claim — the <c>?firmId=</c> query is silently
+/// IGNORED for compliance (it is not an authorisation bypass — a
+/// compliance user with the wrong firm claim has no path to view
+/// another firm's flow). Admin principals MAY pass <c>?firmId=</c> to
+/// override and view that firm; omitted, an admin defaults to its
+/// own firm claim.</para>
+///
+/// <para><b>Audit.</b> A best-effort <c>audit.dropcopy.connect</c>
+/// event is emitted on accept, and <c>audit.dropcopy.disconnect</c>
+/// on the finally-block teardown — capturing the actor, role, firmId
+/// being viewed, and source IP. Per spec these go through
+/// <see cref="IAuditLogger.Log"/> (best-effort) so audit-WAL
+/// backpressure does not refuse the WS connection itself.</para>
+///
+/// <para><b>Atomicity.</b> The initial snapshot frames are enqueued
+/// under <see cref="DropCopyManager"/>'s per-firm lock, so any delta
+/// fan-out for the same firm racing the accept lands AFTER the
+/// snapshot — same contract <c>orders.me</c> uses for the per-user
+/// hub (RFC §4.3 / §5.2).</para>
+/// </summary>
+public static class DropCopyWebSocketHub
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static IEndpointRouteBuilder MapDropCopyWebSocket(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/ws/dropcopy", [Authorize] async (
+            HttpContext ctx,
+            DropCopyManager manager) =>
+        {
+            // Role gate: only compliance / admin may open a drop-copy
+            // session. Non-WS shape returns 403; WS upgrade attempt
+            // accepts and closes with policy-violation (1008) so a
+            // browser-side handshake surfaces a structured error.
+            var role = ctx.User.FindFirstValue(JwtIssuer.RoleClaim);
+            var isCompliance = string.Equals(role, Roles.Compliance, StringComparison.OrdinalIgnoreCase);
+            var isAdmin = string.Equals(role, Roles.Admin, StringComparison.OrdinalIgnoreCase);
+            if (!isCompliance && !isAdmin)
+            {
+                if (!ctx.WebSockets.IsWebSocketRequest)
+                    return Results.StatusCode(StatusCodes.Status403Forbidden);
+
+                using var rejected = await ctx.WebSockets.AcceptWebSocketAsync();
+                await rejected.CloseAsync(
+                    WebSocketCloseStatus.PolicyViolation,
+                    "drop-copy requires compliance or admin role",
+                    CancellationToken.None);
+                return Results.Empty;
+            }
+
+            if (!ctx.WebSockets.IsWebSocketRequest)
+                return Results.BadRequest(new { error = "websocket required" });
+
+            var sub = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            if (string.IsNullOrEmpty(sub))
+                return Results.Unauthorized();
+
+            var jwtFirm = ctx.User.FindFirstValue(JwtIssuer.FirmClaim) ?? "default";
+
+            // Firm selection: admin may override via ?firmId=; compliance
+            // ALWAYS observes its JWT firm. The compliance override is
+            // silently ignored (not 4xx) so a misconfigured client does
+            // not break — the audit record still reflects the effective
+            // firm being observed.
+            string effectiveFirm = jwtFirm;
+            if (isAdmin && ctx.Request.Query.TryGetValue("firmId", out var qFirm))
+            {
+                var requested = qFirm.ToString();
+                if (!string.IsNullOrWhiteSpace(requested))
+                    effectiveFirm = requested;
+            }
+
+            using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
+            var client = new DropCopyClient(effectiveFirm, sub, role!);
+
+            // Audit the connect BEFORE we register so the audit log
+            // records the operator's intent even if the snapshot build
+            // throws. Best-effort: a WAL-backpressured audit append
+            // must not refuse the WS session.
+            EmitAuditIfWired(ctx, AuditEventTypes.DropCopyConnect, AuditOutcomes.Success, effectiveFirm, sub, role!);
+
+            manager.Add(client);
+            MetricsRegistry.WsConnectionsActive.Add(1);
+
+            try
+            {
+                var sendTask = SendLoopAsync(ws, client, ctx.RequestAborted);
+                var recvTask = ReceiveLoopAsync(ws, ctx.RequestAborted);
+                await Task.WhenAny(sendTask, recvTask);
+                client.Complete();
+                await Task.WhenAll(SafeAwait(sendTask), SafeAwait(recvTask));
+            }
+            finally
+            {
+                manager.Remove(client);
+                MetricsRegistry.WsConnectionsActive.Add(-1);
+                EmitAuditIfWired(ctx, AuditEventTypes.DropCopyDisconnect, AuditOutcomes.Success, effectiveFirm, sub, role!);
+
+                if (ws.State == WebSocketState.Open)
+                {
+                    var reason = client.DisconnectReason ?? "closing";
+                    try
+                    {
+                        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, reason, CancellationToken.None);
+                    }
+                    catch (WebSocketException) { /* best-effort */ }
+                }
+            }
+
+            return Results.Empty;
+        });
+
+        return app;
+    }
+
+    private static async Task SendLoopAsync(WebSocket ws, DropCopyClient client, CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var msg in client.Reader.ReadAllAsync(ct))
+            {
+                if (ws.State != WebSocketState.Open)
+                    return;
+                var bytes = JsonSerializer.SerializeToUtf8Bytes(msg, JsonOptions);
+                await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct);
+                MetricsRegistry.WsMessagesSent.Add(1,
+                    new KeyValuePair<string, object?>("channel", msg.Channel ?? "unknown"));
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (WebSocketException) { /* peer gone */ }
+    }
+
+    /// <summary>
+    /// Drop-copy has no inbound subscribe/unsubscribe protocol — the
+    /// session auto-subscribes to all channels on accept. We still
+    /// drain inbound frames so the WS half-close (client → server
+    /// close frame) is handled cleanly and large rogue frames are
+    /// detected.
+    /// </summary>
+    private static async Task ReceiveLoopAsync(WebSocket ws, CancellationToken ct)
+    {
+        const int MaxInboundFrameBytes = 8 * 1024;
+        var buffer = new byte[MaxInboundFrameBytes];
+        try
+        {
+            while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                var sb = new StringBuilder();
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await ws.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        return;
+                    sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                    if (sb.Length > MaxInboundFrameBytes)
+                        return;
+                } while (!result.EndOfMessage);
+                // Body intentionally ignored — drop-copy is server-push only.
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (WebSocketException) { /* peer gone */ }
+    }
+
+    private static async Task SafeAwait(Task t)
+    {
+        try { await t; } catch { /* already-handled in loop */ }
+    }
+
+    private static void EmitAuditIfWired(
+        HttpContext ctx,
+        string eventType,
+        string outcome,
+        string firmIdViewed,
+        string actorUserId,
+        string actorRole)
+    {
+        var audit = ctx.RequestServices.GetService(typeof(IAuditLogger)) as IAuditLogger;
+        if (audit is null) return;
+        var jwtFirm = ctx.User.FindFirstValue(JwtIssuer.FirmClaim);
+        var details = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["firmIdViewed"] = firmIdViewed,
+        };
+        if (!string.IsNullOrEmpty(jwtFirm) && !string.Equals(jwtFirm, firmIdViewed, StringComparison.OrdinalIgnoreCase))
+            details["firmIdOverride"] = "true";
+
+        audit.Log(new AuditLogEvent
+        {
+            EventType = eventType,
+            Outcome = outcome,
+            ActorUserId = actorUserId,
+            ActorUsername = actorUserId,
+            ActorFirm = jwtFirm,
+            ActorRole = actorRole,
+            SourceIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ResourcePath = "/ws/dropcopy",
+            Details = details,
+        });
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyWebSocketHub.cs
@@ -107,29 +107,80 @@ public static class DropCopyWebSocketHub
             manager.Add(client);
             MetricsRegistry.WsConnectionsActive.Add(1);
 
+            // Use a linked CTS so that when either loop exits (slow
+            // consumer disconnect, peer-close, or request-aborted), we
+            // cancel the OTHER loop too. Without this, an idle peer
+            // (no inbound frames) keeps ReceiveLoopAsync blocked
+            // forever after the send loop has already exited — and the
+            // finally block below (which runs manager.Remove) never
+            // executes, leaking the subscriber + channel + metrics
+            // counter. See Q4.6 P2 / RFC §5.2 slow-consumer note.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            var sendTask = SendLoopAsync(ws, client, cts.Token);
+            var recvTask = ReceiveLoopAsync(ws, cts.Token);
             try
             {
-                var sendTask = SendLoopAsync(ws, client, ctx.RequestAborted);
-                var recvTask = ReceiveLoopAsync(ws, ctx.RequestAborted);
                 await Task.WhenAny(sendTask, recvTask);
-                client.Complete();
-                await Task.WhenAll(SafeAwait(sendTask), SafeAwait(recvTask));
             }
             finally
             {
+                // Tear down in order:
+                //  1. Cancel the linked token so the still-running loop
+                //     (typically ReceiveLoopAsync on an idle peer)
+                //     observes cancellation immediately.
+                //  2. Best-effort graceful close while the socket is
+                //     still Open — surfaces a clean close frame to the
+                //     peer if it ever resumes reading.
+                //  3. Abort to forcibly unblock any in-flight
+                //     ReceiveAsync that ignored the cancellation token
+                //     (peer that never sends; TestHost in particular).
+                //  4. Complete the outbound channel so SendLoopAsync
+                //     exits if it was still draining.
+                //  5. Await both loops (swallow expected cancellation)
+                //     before the subscriber-removal step so we don't
+                //     race the manager bookkeeping against a stray
+                //     send.
+                //  6. Finally, deregister + metrics + audit.
+                cts.Cancel();
+
+                var reason = client.DisconnectReason ?? "drop-copy closing";
+                if (ws.State == WebSocketState.Open)
+                {
+                    // Bounded graceful close: ws.CloseAsync awaits the
+                    // peer's reciprocal Close frame, which an aborted
+                    // / disappeared peer will never send — and not
+                    // every WebSocket implementation (notably TestHost)
+                    // honours the cancellation token here. We give the
+                    // peer a short window to ack, then fall through
+                    // to the unconditional Abort below which forcibly
+                    // tears the socket down — exactly the leak P2 is
+                    // meant to fix.
+                    try
+                    {
+                        var closeTask = ws.CloseAsync(WebSocketCloseStatus.NormalClosure, reason, CancellationToken.None);
+                        await Task.WhenAny(closeTask, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                    }
+                    catch (WebSocketException) { /* best-effort */ }
+                    catch (OperationCanceledException) { /* peer gone / timed out */ }
+                }
+                try { ws.Abort(); } catch { /* best-effort */ }
+
+                client.Complete();
+                // Bounded join on the loops. The Abort() above should
+                // have unblocked any pending ReceiveAsync, but a
+                // hostile WS implementation that ignores both
+                // cancellation and Abort must not be allowed to pin
+                // the subscriber in the manager forever.
+                try
+                {
+                    var both = Task.WhenAll(sendTask, recvTask);
+                    await Task.WhenAny(both, Task.Delay(TimeSpan.FromSeconds(2)));
+                }
+                catch { /* loops already log / swallow their own exits */ }
+
                 manager.Remove(client);
                 MetricsRegistry.WsConnectionsActive.Add(-1);
                 EmitAuditIfWired(ctx, AuditEventTypes.DropCopyDisconnect, AuditOutcomes.Success, effectiveFirm, sub, role!);
-
-                if (ws.State == WebSocketState.Open)
-                {
-                    var reason = client.DisconnectReason ?? "closing";
-                    try
-                    {
-                        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, reason, CancellationToken.None);
-                    }
-                    catch (WebSocketException) { /* best-effort */ }
-                }
             }
 
             return Results.Empty;
@@ -187,11 +238,6 @@ public static class DropCopyWebSocketHub
         }
         catch (OperationCanceledException) { /* shutdown */ }
         catch (WebSocketException) { /* peer gone */ }
-    }
-
-    private static async Task SafeAwait(Task t)
-    {
-        try { await t; } catch { /* already-handled in loop */ }
     }
 
     private static void EmitAuditIfWired(

--- a/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
+++ b/backend/src/B3.Trading.Application/Audit/AuditLogKeeper.cs
@@ -37,6 +37,12 @@ public static class AuditEventTypes
     public const string AdminSubAccountCreate = "admin.subaccount.create";
     public const string AdminSubAccountDeactivate = "admin.subaccount.deactivate";
 
+    /// <summary>Q4.6 (#306). Drop-copy WS session opened by a compliance / admin principal.</summary>
+    public const string DropCopyConnect = "audit.dropcopy.connect";
+
+    /// <summary>Q4.6 (#306). Drop-copy WS session closed (clean or peer-gone).</summary>
+    public const string DropCopyDisconnect = "audit.dropcopy.disconnect";
+
     // Prefix helpers used by the read-path filter for type=auth.* style globs.
     public const string AuthPrefix = "auth.";
     public const string AdminPrefix = "admin.";

--- a/backend/src/B3.Trading.Application/Persistence/IExecutionFanOutSink.cs
+++ b/backend/src/B3.Trading.Application/Persistence/IExecutionFanOutSink.cs
@@ -57,6 +57,15 @@ public enum ExecutionFanOutTargets : byte
     WsHub = 1,
     /// <summary>FIXP outbound multiplexer to the originating bot session.</summary>
     BotRouter = 2,
+    /// <summary>
+    /// Q4.6 (#306). Compliance drop-copy WebSocket feed
+    /// (<c>/ws/dropcopy</c>). Firm-scoped fan-out of every order /
+    /// fill / cancel regardless of which user originated the event —
+    /// the compliance subscriber is not user-scoped, so it bypasses
+    /// the WsHub's per-owner subscriber map and reads off its own
+    /// firm-keyed registry.
+    /// </summary>
+    DropCopy = 4,
     /// <summary>Default for an ER captured during apply — routes to every sink.</summary>
-    All = WsHub | BotRouter,
+    All = WsHub | BotRouter | DropCopy,
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -81,10 +81,36 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // same per-sink channel — see the type doc-comment for ordering
         // semantics.
         services.AddSingleton<WebSocketExecutionEventSink>();
-        services.AddSingleton<IExecutionEventSink>(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
         services.AddSingleton<IExecutionFanOutSink>(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
         services.AddHostedService(sp => sp.GetRequiredService<WebSocketExecutionEventSink>());
         services.AddSingleton<IAlgoEventSink, WebSocketAlgoEventSink>();
+
+        // Q4.6 (#306). Compliance drop-copy fan-out: a parallel WS sink
+        // that fans every captured ExecutionEvent out to firm-scoped
+        // drop-copy subscribers (orders / fills / cancels). Registered
+        // as an IExecutionFanOutSink (dispatcher main path,
+        // target=DropCopy); synthetic publishes from
+        // OrderStalenessService / WAL-backpressure fallback also reach
+        // it via the composite IExecutionEventSink wired below.
+        services.AddSingleton<B3.Trading.Api.WebSockets.DropCopy.DropCopyManager>();
+        services.AddSingleton<B3.Trading.Api.WebSockets.DropCopy.DropCopyExecutionEventSink>();
+        services.AddSingleton<IExecutionFanOutSink>(sp =>
+            sp.GetRequiredService<B3.Trading.Api.WebSockets.DropCopy.DropCopyExecutionEventSink>());
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Api.WebSockets.DropCopy.DropCopyExecutionEventSink>());
+
+        // Composite IExecutionEventSink. The single IExecutionEventSink
+        // dependency on OrderStalenessService (and the
+        // EntryPointExecutionReportRouter WAL-backpressure fallback) is
+        // wrapped so synthetic Publish() calls reach BOTH the per-user
+        // WS hub AND the drop-copy fan-out — without it, a
+        // suspect-stale flag or a WAL-backpressured ER would surface on
+        // orders.me but go unseen by compliance, which would defeat
+        // the "all traffic" guarantee of the drop-copy feed.
+        services.AddSingleton<IExecutionEventSink>(sp =>
+            new CompositeExecutionEventSink(
+                sp.GetRequiredService<WebSocketExecutionEventSink>(),
+                sp.GetRequiredService<B3.Trading.Api.WebSockets.DropCopy.DropCopyExecutionEventSink>()));
 
         // Q1.5 (#257). Auction state-store + public WS channels
         // (phases.${symbol} / auction.${symbol}). The store is wired

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -3,6 +3,7 @@ using B3.Trading.Api.Auth;
 using B3.Trading.Api.Auth.Totp;
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
+using B3.Trading.Api.WebSockets.DropCopy;
 using B3.Trading.Application;
 using B3.Trading.EntryPointListener;
 using B3.Trading.EntryPointListener.Hosting.Admin;
@@ -55,6 +56,7 @@ public static class TradingEndpointsExtensions
         }
         app.MapUserBotCredentials();
         app.MapWebSocketHub();
+        app.MapDropCopyWebSocket();
 
         return app;
     }

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -427,4 +427,172 @@ public class DropCopyWebSocketTests
             await Task.Delay(50);
         }
     }
+
+    // 11. P1 regression — concurrent subscribe must not drop deltas (atomicity).
+    //
+    // Pre-fix the manager read the per-firm subscriber set BEFORE
+    // taking the per-firm lock, so a Publish racing an Add() could
+    // iterate a stale snapshot (no new subscriber) and silently drop
+    // the live delta — the new subscriber received its snapshot but
+    // missed the delta that crossed the registration boundary.
+    //
+    // The fix moves the subscriber-set read inside the lock. This test
+    // hammers the race: a worker continuously publishes deltas to
+    // FIRM01 while a separate task registers a new subscriber. After
+    // Add() returns we keep publishing for a small window; every
+    // delta emitted in that post-registration window MUST land in the
+    // new subscriber's outbound channel (no gap). The test runs many
+    // iterations to reliably catch the race window if the fix is
+    // reverted.
+    [Fact]
+    public async Task DropCopyManager_Add_AtomicWithConcurrentPublish_NoDeltaGap()
+    {
+        const int Iterations = 200;
+        const string Firm = Firm01;
+        const string Channel = DropCopyManager.DropCopyChannels.Orders;
+
+        for (var iter = 0; iter < Iterations; iter++)
+        {
+            var book = new WorkingOrderBook();
+            var manager = new DropCopyManager(book);
+            var client = new DropCopyClient(Firm, "compliance-" + iter, "compliance");
+
+            long published = 0;
+            long stop = 0;
+
+            var publisher = Task.Run(() =>
+            {
+                while (Volatile.Read(ref stop) == 0)
+                {
+                    var seq = Interlocked.Increment(ref published);
+                    manager.Publish(Firm, Channel, seq);
+                    // Keep the channel from overflowing across iterations
+                    // (DropCopyClient.OutboundCapacity = 4096): the
+                    // post-Add window is intentionally short.
+                    if (seq > DropCopyClient.OutboundCapacity - 64) break;
+                }
+            });
+
+            // Let the publisher spin up so we're truly racing.
+            Thread.SpinWait(2_000);
+
+            manager.Add(client);
+
+            // Boundary: any seq strictly greater than this was assigned
+            // by an Interlocked.Increment that happened-after Add()
+            // returned, so its Publish() call entered after Add's lock
+            // was released. The fix guarantees every such delta lands
+            // on the new subscriber. With the pre-fix code, a
+            // Publish() that had already read the stale subscriber
+            // set could silently iterate it under the lock acquired
+            // after Add — and the matching delta would never reach
+            // the client.
+            //
+            // Note we cannot use the strict "Publish entered after
+            // Add returned" boundary directly: in the pre-fix code
+            // the race window is exactly the period during which
+            // Publish has captured the stale set but not yet locked.
+            // The simplest deterministic check is to publish a few
+            // more items AFTER Add returns and require the client to
+            // observe them — this still exercises the path that was
+            // broken, because the publisher's pre-Add captures may
+            // still be racing for the lock when these post-Add items
+            // are issued.
+            const int PostAddDeltas = 32;
+            var postAddSeqs = new long[PostAddDeltas];
+            for (var i = 0; i < PostAddDeltas; i++)
+            {
+                var seq = Interlocked.Increment(ref published);
+                postAddSeqs[i] = seq;
+                manager.Publish(Firm, Channel, seq);
+            }
+
+            Volatile.Write(ref stop, 1);
+            await publisher;
+            client.Complete();
+
+            var seen = new HashSet<long>();
+            await foreach (var msg in client.Reader.ReadAllAsync())
+            {
+                if (msg.Type != "delta") continue;
+                if (msg.Data is long s) seen.Add(s);
+            }
+
+            foreach (var s in postAddSeqs)
+            {
+                Assert.True(
+                    seen.Contains(s),
+                    $"iter {iter}: post-registration delta seq={s} was dropped — Publish-vs-Add race regression.");
+            }
+
+            // Sanity: the client must not have been disconnected for
+            // channel overflow; that would mask a real gap by
+            // converting it to a slow-consumer drop. The publisher
+            // bounds itself well under OutboundCapacity.
+            Assert.False(client.MarkedForDisconnect,
+                $"iter {iter}: client unexpectedly marked for disconnect (channel overflow); test bound too loose.");
+        }
+    }
+
+    // 12. P2 regression — a slow consumer (idle peer that never reads
+    // and never sends) must still be torn down promptly: when the
+    // outbound channel fills, the send loop marks the client for
+    // disconnect, but pre-fix the hub then awaited Task.WhenAll(send,
+    // recv) — and the receive loop blocked forever on ReceiveAsync
+    // for an idle peer, so manager.Remove(client) was never called
+    // and the subscriber leaked.
+    //
+    // The fix wires both loops through a linked CTS, cancels it after
+    // WhenAny, and aborts the socket so the receive loop unblocks.
+    // We assert the subscriber count returns to zero within a
+    // reasonable timeout once the channel fills.
+    [Fact]
+    public async Task SlowConsumer_FillsChannel_SubscriberRemovedWithoutLeak()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var manager = factory.Services.GetRequiredService<DropCopyManager>();
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var alice = registry.Register("alice");
+
+        Assert.Equal(0, manager.SubscriberCount(Firm01));
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        // Connect but DO NOT read — this is the slow / idle consumer.
+        // We don't call ReadSnapshotsAsync; we don't pump the WS at all.
+        var ws = await ConnectDropCopyAsync(factory, token);
+
+        // Wait for the subscriber to land in the manager.
+        await PollAsync(() => manager.SubscriberCount(Firm01) >= 1, TimeSpan.FromSeconds(5));
+        Assert.Equal(1, manager.SubscriberCount(Firm01));
+
+        // Submit far more events than the outbound channel can hold.
+        // Each TryAdd + Publish fans out one orders delta + one fills
+        // delta, so 2× per event lands on the outbound channel.
+        // DropCopyClient.OutboundCapacity = 4096; we submit 8000
+        // events to guarantee the bounded channel saturates and
+        // Enqueue marks the client for disconnect.
+        var ordersCount = DropCopyClient.OutboundCapacity * 2 + 1000;
+        for (var i = 0; i < ordersCount; i++)
+        {
+            var clOrdId = (ulong)(10_000 + i);
+            book.TryAdd(new Order(clOrdId, alice, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: Firm01));
+            sink.Publish(new ExecutionEvent(alice, clOrdId, "PETR4", OrderSide.Buy,
+                OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+        }
+
+        // The send loop will detect the full channel inside Enqueue,
+        // mark the client for disconnect, complete the writer, and
+        // exit. The hub's finally block (post-fix) must cancel the
+        // linked CTS and abort the socket so the receive loop also
+        // exits — only THEN does manager.Remove(client) run.
+        await PollAsync(() => manager.SubscriberCount(Firm01) == 0, TimeSpan.FromSeconds(15));
+        Assert.Equal(0, manager.SubscriberCount(Firm01));
+
+        try { ws.Abort(); } catch { /* best-effort */ }
+        ws.Dispose();
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -353,6 +353,35 @@ public class DropCopyWebSocketTests
         Assert.Equal(0, manager.SubscriberCount(Firm01));
     }
 
+    // 11. Pass-3 review (#323): sink overflow must fail-closed by
+    //     disconnecting every active subscriber so they re-snapshot.
+    [Fact]
+    public void DisconnectAllForResync_MarksEverySubscriberForReconnect()
+    {
+        var book = new WorkingOrderBook();
+        var manager = new DropCopyManager(book);
+
+        var a = new DropCopyClient(Firm01, "dave", "compliance");
+        var b = new DropCopyClient(Firm01, "eve", "admin");
+        var c = new DropCopyClient(Firm02, "frank", "compliance");
+        manager.Add(a);
+        manager.Add(b);
+        manager.Add(c);
+
+        manager.DisconnectAllForResync("drop_copy_sink_overflow_resync_required");
+
+        Assert.True(a.MarkedForDisconnect);
+        Assert.True(b.MarkedForDisconnect);
+        Assert.True(c.MarkedForDisconnect);
+        Assert.Equal("drop_copy_sink_overflow_resync_required", a.DisconnectReason);
+        Assert.Equal("drop_copy_sink_overflow_resync_required", b.DisconnectReason);
+        Assert.Equal("drop_copy_sink_overflow_resync_required", c.DisconnectReason);
+        // Signal trips so hub teardown observes it.
+        Assert.True(a.DisconnectRequested.IsCompleted);
+        Assert.True(b.DisconnectRequested.IsCompleted);
+        Assert.True(c.DisconnectRequested.IsCompleted);
+    }
+
     // ----------------- helpers -----------------
 
     private static async Task<WebSocket> ConnectDropCopyAsync(TestAppFactory factory, string token)

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -1,0 +1,430 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Api.Auth;
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Api.WebSockets.DropCopy;
+using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// Q4.6 (#306). End-to-end tests for the compliance drop-copy WS feed
+/// (<c>/ws/dropcopy</c>). Driven through <see cref="TestAppFactory"/>
+/// so each test exercises the real JWT handshake, the real WS
+/// upgrade, and the real dispatcher / fan-out path.
+/// </summary>
+public class DropCopyWebSocketTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private const string Firm01 = "FIRM01";
+    private const string Firm02 = "FIRM02";
+
+    // 1. Compliance sees orders/fills/cancels submitted by OTHER users in the same firm.
+    [Fact]
+    public async Task ComplianceUser_SeesEventsFromOtherUsersInSameFirm()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var alice = registry.Register("alice");
+        var bob = registry.Register("bob");
+        book.TryAdd(new Order(101UL, alice, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: Firm01));
+        book.TryAdd(new Order(102UL, bob, "VALE3", 9002UL, OrderSide.Buy, OrderType.Limit, 200, 60m, firmId: Firm01));
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        using var ws = await ConnectDropCopyAsync(factory, token);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Three snapshot frames (orders/fills/cancels), order between channels is implementation-defined.
+        var snapByChannel = await ReadSnapshotsAsync(ws, 3, cts.Token);
+        var ordersSnap = snapByChannel[DropCopyManager.DropCopyChannels.Orders];
+        var snapItems = ordersSnap.GetProperty("data").EnumerateArray().ToArray();
+        Assert.Equal(2, snapItems.Length);
+
+        // Fill on alice's order — should appear on orders + fills.
+        sink.Publish(new ExecutionEvent(alice, 101UL, "PETR4", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+
+        // Cancel on bob's order — should appear on orders + cancels.
+        sink.Publish(new ExecutionEvent(bob, 102UL, "VALE3", OrderSide.Buy,
+            OrderStatus.Cancelled, ExecKind.Canceled, 0, 0, 0, 0m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+
+        var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "101")) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Cancels, "102")) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, "101")) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, "102")));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "101"), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Cancels, "102"), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, "101"), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, "102"), observed);
+    }
+
+    // 2. Compliance does NOT see orders from a different firm.
+    // 9. Multi-firm: a single drop-copy stream for FIRM01 receives nothing for FIRM02.
+    [Fact]
+    public async Task ComplianceUser_DoesNotSeeOtherFirmTraffic()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var bob = registry.Register("bob");
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        using var ws = await ConnectDropCopyAsync(factory, token);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+
+        // FIRM02 event for the same end-client — must NEVER surface on dave's FIRM01 socket.
+        sink.Publish(new ExecutionEvent(bob, 999UL, "VALE3", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 50, 50, 60m, null, DateTimeOffset.UtcNow, FirmId: Firm02));
+
+        // And one FIRM01 event so we have something to wait for.
+        sink.Publish(new ExecutionEvent(bob, 888UL, "PETR4", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+
+        var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "888")));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "888"), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, "999"), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Orders, "999"), observed);
+    }
+
+    // 3. Snapshot+stream consistency: N pre-connect orders → snapshot N entries; M after → stream M; no dupes/no gaps.
+    [Fact]
+    public async Task SnapshotPlusStream_HasNoGapsAndNoDuplicates()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var book = factory.Services.GetRequiredService<WorkingOrderBook>();
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var alice = registry.Register("alice");
+
+        const int N = 5;
+        const int M = 4;
+        for (var i = 0; i < N; i++)
+            book.TryAdd(new Order((ulong)(200 + i), alice, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: Firm01));
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        using var ws = await ConnectDropCopyAsync(factory, token);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var snaps = await ReadSnapshotsAsync(ws, 3, cts.Token);
+        var snapItems = snaps[DropCopyManager.DropCopyChannels.Orders].GetProperty("data").EnumerateArray().ToArray();
+        Assert.Equal(N, snapItems.Length);
+        // snapshot frame seq is 0
+        Assert.Equal(0, snaps[DropCopyManager.DropCopyChannels.Orders].GetProperty("seq").GetInt64());
+
+        // Push M more orders post-connect — each will fan-out one orders delta + one fills delta.
+        for (var i = 0; i < M; i++)
+        {
+            book.TryAdd(new Order((ulong)(300 + i), alice, "PETR4", 9001UL, OrderSide.Buy, OrderType.Limit, 100, 30m, firmId: Firm01));
+            sink.Publish(new ExecutionEvent(alice, (ulong)(300 + i), "PETR4", OrderSide.Buy,
+                OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+        }
+
+        // Collect at least M orders.* deltas. The drop-copy stream may
+        // emit an unrelated cancels delta = 0; we filter on the orders
+        // channel for the consistency assertion.
+        var orderSeqs = new List<long>();
+        var orderClOrdIds = new List<string>();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && orderSeqs.Count < M)
+        {
+            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            readCts.CancelAfter(TimeSpan.FromMilliseconds(500));
+            JsonElement msg;
+            try { msg = await ReadJsonAsync(ws, readCts.Token); }
+            catch (OperationCanceledException) { continue; }
+            if (msg.GetProperty("type").GetString() != "delta") continue;
+            if (msg.GetProperty("channel").GetString() != DropCopyManager.DropCopyChannels.Orders) continue;
+            orderSeqs.Add(msg.GetProperty("seq").GetInt64());
+            orderClOrdIds.Add(msg.GetProperty("data").GetProperty("clOrdId").GetString()!);
+        }
+
+        // Exactly M deltas, strictly monotonic 1..M, no dupes, no gaps.
+        Assert.Equal(M, orderSeqs.Count);
+        Assert.Equal(Enumerable.Range(1, M).Select(i => (long)i), orderSeqs);
+        Assert.Equal(orderClOrdIds.Distinct().Count(), orderClOrdIds.Count);
+    }
+
+    // 4. Admin can pass ?firmId=FIRM02 and see FIRM02 drop-copy.
+    [Fact]
+    public async Task AdminWithFirmIdQuery_OverridesAndSeesTargetFirm()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var bob = registry.Register("bob");
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "admin", TestAppFactory.TestPassword);
+
+        var wsClient = factory.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(factory.Server.BaseAddress)
+        {
+            Scheme = "ws",
+            Path = "/ws/dropcopy",
+            Query = $"access_token={token}&firmId={Firm02}",
+        }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var ws = await wsClient.ConnectAsync(uri, cts.Token);
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+
+        sink.Publish(new ExecutionEvent(bob, 777UL, "VALE3", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 60m, null, DateTimeOffset.UtcNow, FirmId: Firm02));
+
+        var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "777")));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "777"), observed);
+    }
+
+    // 5. Admin without ?firmId defaults to its own firm.
+    [Fact]
+    public async Task AdminWithoutFirmIdQuery_DefaultsToOwnFirm()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var alice = registry.Register("alice");
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "admin", TestAppFactory.TestPassword);
+
+        using var ws = await ConnectDropCopyAsync(factory, token); // no firmId override
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+
+        // admin's default firm in the seed is "default"; route an event
+        // tagged with "default" so it must arrive.
+        sink.Publish(new ExecutionEvent(alice, 555UL, "PETR4", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: "default"));
+
+        var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "555")));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "555"), observed);
+    }
+
+    // 6. Compliance passing ?firmId is IGNORED (returns its own firm's drop-copy).
+    [Fact]
+    public async Task ComplianceFirmIdOverride_IsIgnored()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var sink = factory.Services.GetRequiredService<IExecutionEventSink>();
+        var registry = factory.Services.GetRequiredService<EndClientRegistry>();
+        var bob = registry.Register("bob");
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        var wsClient = factory.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(factory.Server.BaseAddress)
+        {
+            Scheme = "ws",
+            Path = "/ws/dropcopy",
+            Query = $"access_token={token}&firmId={Firm02}",
+        }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var ws = await wsClient.ConnectAsync(uri, cts.Token);
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+
+        // FIRM02 event must NOT arrive (override ignored — dave is FIRM01).
+        sink.Publish(new ExecutionEvent(bob, 666UL, "VALE3", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 60m, null, DateTimeOffset.UtcNow, FirmId: Firm02));
+        // FIRM01 event must arrive.
+        sink.Publish(new ExecutionEvent(bob, 667UL, "PETR4", OrderSide.Buy,
+            OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
+
+        var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "667")));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "667"), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, "666"), observed);
+    }
+
+    // 7. Non-compliance/non-admin user is rejected (WS close 1008).
+    [Fact]
+    public async Task RegularUser_IsRejected_WithPolicyViolationClose()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http); // alice/user
+
+        var wsClient = factory.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(factory.Server.BaseAddress)
+        {
+            Scheme = "ws",
+            Path = "/ws/dropcopy",
+            Query = $"access_token={token}",
+        }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        // The server accepts then closes with PolicyViolation. ConnectAsync
+        // returns successfully because the close is post-handshake; the
+        // close frame surfaces on the first Receive.
+        using var ws = await wsClient.ConnectAsync(uri, cts.Token);
+        var buf = new byte[1024];
+        var res = await ws.ReceiveAsync(buf, cts.Token);
+        Assert.Equal(WebSocketMessageType.Close, res.MessageType);
+        Assert.Equal(WebSocketCloseStatus.PolicyViolation, res.CloseStatus);
+    }
+
+    // Anonymous (no token) is rejected at the JWT bearer layer.
+    [Fact]
+    public async Task AnonymousConnect_IsRejected()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var wsClient = factory.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(factory.Server.BaseAddress) { Scheme = "ws", Path = "/ws/dropcopy" }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => wsClient.ConnectAsync(uri, cts.Token));
+    }
+
+    // 8. Audit emission: connect event lands in /admin/audit with role + firm.
+    [Fact]
+    public async Task DropCopyConnect_EmitsAuditEntry()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+        using var ws = await ConnectDropCopyAsync(factory, token);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+
+        var keeper = factory.Services.GetRequiredService<AuditLogKeeper>();
+        var now = DateTimeOffset.UtcNow;
+        // Audit emission is best-effort but synchronous through the
+        // dispatcher; one keeper query is enough.
+        AuditQueryResult result = default!;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            result = keeper.Query(now.AddMinutes(-1), now.AddMinutes(1), user: "dave",
+                typePattern: AuditEventTypes.DropCopyConnect, outcome: null, limit: 50, cursorSeq: null);
+            if (result.Entries.Count > 0) break;
+            await Task.Delay(50, cts.Token);
+        }
+        Assert.NotEmpty(result.Entries);
+        var entry = result.Entries[0];
+        Assert.Equal(AuditEventTypes.DropCopyConnect, entry.EventType);
+        Assert.Equal("compliance", entry.ActorRole);
+        Assert.Equal(Firm01, entry.ActorFirm);
+        Assert.NotNull(entry.Details);
+        Assert.Equal(Firm01, entry.Details!["firmIdViewed"]);
+    }
+
+    // 10. Disconnect cleanup: closing the WS removes the subscriber (no leak).
+    [Fact]
+    public async Task Disconnect_RemovesSubscriber_NoLeak()
+    {
+        await using var factory = TestAppFactory.WithOverrides(new Dictionary<string, string?>());
+        var manager = factory.Services.GetRequiredService<DropCopyManager>();
+        Assert.Equal(0, manager.SubscriberCount(Firm01));
+
+        using var http = factory.CreateClient();
+        var token = await factory.LoginAsync(http, "dave", TestAppFactory.TestPassword);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var ws = await ConnectDropCopyAsync(factory, token);
+        _ = await ReadSnapshotsAsync(ws, 3, cts.Token);
+        // Verify subscriber landed.
+        await PollAsync(() => manager.SubscriberCount(Firm01) >= 1, TimeSpan.FromSeconds(2));
+        Assert.Equal(1, manager.SubscriberCount(Firm01));
+
+        // Client-initiated close. TestHost's WebSocket is sensitive to
+        // ordering; an Abort is enough to flush the server's finally
+        // block (which is what removes the subscriber) without racing
+        // a graceful close handshake.
+        ws.Abort();
+        ws.Dispose();
+
+        await PollAsync(() => manager.SubscriberCount(Firm01) == 0, TimeSpan.FromSeconds(5));
+        Assert.Equal(0, manager.SubscriberCount(Firm01));
+    }
+
+    // ----------------- helpers -----------------
+
+    private static async Task<WebSocket> ConnectDropCopyAsync(TestAppFactory factory, string token)
+    {
+        var wsClient = factory.Server.CreateWebSocketClient();
+        var uri = new UriBuilder(factory.Server.BaseAddress)
+        {
+            Scheme = "ws",
+            Path = "/ws/dropcopy",
+            Query = $"access_token={token}",
+        }.Uri;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        return await wsClient.ConnectAsync(uri, cts.Token);
+    }
+
+    private static async Task<Dictionary<string, JsonElement>> ReadSnapshotsAsync(WebSocket ws, int count, CancellationToken ct)
+    {
+        var bag = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        for (var i = 0; i < count; i++)
+        {
+            var frame = await ReadJsonAsync(ws, ct);
+            Assert.Equal("snapshot", frame.GetProperty("type").GetString());
+            bag[frame.GetProperty("channel").GetString()!] = frame;
+        }
+        return bag;
+    }
+
+    private static async Task<HashSet<(string Channel, string ClOrdId)>> DrainDeltasUntilAsync(
+        WebSocket ws,
+        CancellationToken outerCt,
+        TimeSpan deadline,
+        Predicate<HashSet<(string Channel, string ClOrdId)>> condition)
+    {
+        var observed = new HashSet<(string, string)>();
+        var endsAt = DateTime.UtcNow + deadline;
+        while (DateTime.UtcNow < endsAt && !condition(observed))
+        {
+            using var readCts = CancellationTokenSource.CreateLinkedTokenSource(outerCt);
+            readCts.CancelAfter(TimeSpan.FromMilliseconds(300));
+            JsonElement msg;
+            try { msg = await ReadJsonAsync(ws, readCts.Token); }
+            catch (OperationCanceledException) { continue; }
+            if (msg.GetProperty("type").GetString() != "delta") continue;
+            var ch = msg.GetProperty("channel").GetString()!;
+            var clOrdId = msg.GetProperty("data").GetProperty("clOrdId").GetString()!;
+            observed.Add((ch, clOrdId));
+        }
+        return observed;
+    }
+
+    private static async Task<JsonElement> ReadJsonAsync(WebSocket ws, CancellationToken ct)
+    {
+        var buf = new byte[64 * 1024];
+        var sb = new StringBuilder();
+        WebSocketReceiveResult res;
+        do
+        {
+            res = await ws.ReceiveAsync(buf, ct);
+            if (res.MessageType == WebSocketMessageType.Close)
+                throw new OperationCanceledException("ws closed");
+            sb.Append(Encoding.UTF8.GetString(buf, 0, res.Count));
+        } while (!res.EndOfMessage);
+        return JsonSerializer.Deserialize<JsonElement>(sb.ToString());
+    }
+
+    private static async Task PollAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var endsAt = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < endsAt)
+        {
+            if (condition()) return;
+            await Task.Delay(50);
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -419,6 +419,43 @@ public class DropCopyWebSocketTests
         Assert.Equal("second_burst", c.DisconnectReason);
     }
 
+    // 13. Pass-6 review (#323): registration + per-firm arm must be
+    //     atomic with the disconnect walk's consume. Stress test:
+    //     interleave Add() with concurrent DisconnectAllForResync()
+    //     and assert no client added at time T can survive a drop at
+    //     time T'>T without being marked for disconnect.
+    [Fact]
+    public async Task ConcurrentAddAndDisconnectAllForResync_NeverLeavesClientUnmarked()
+    {
+        var book = new WorkingOrderBook();
+        var manager = new DropCopyManager(book);
+        var clients = new List<DropCopyClient>(capacity: 500);
+        var cts = new CancellationTokenSource();
+
+        var dropWalker = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+                manager.DisconnectAllForResync("race_drop");
+        });
+
+        for (int i = 0; i < 500; i++)
+        {
+            var c = new DropCopyClient($"FIRM{i % 5:00}", $"user{i}", "compliance");
+            clients.Add(c);
+            manager.Add(c);
+        }
+        // Let the walker observe one more burst after the last Add.
+        manager.DisconnectAllForResync("final");
+        await Task.Delay(50);
+        cts.Cancel();
+        await dropWalker;
+        // Final pass to drain anything armed after Cancel.
+        manager.DisconnectAllForResync("post_cancel_drain");
+
+        foreach (var c in clients)
+            Assert.True(c.MarkedForDisconnect, $"client {c.Username} for firm {c.FirmId} was not marked");
+    }
+
     // ----------------- helpers -----------------
 
     private static async Task<WebSocket> ConnectDropCopyAsync(TestAppFactory factory, string token)

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -382,6 +382,43 @@ public class DropCopyWebSocketTests
         Assert.True(c.DisconnectRequested.IsCompleted);
     }
 
+    // 12. Pass-5 review (#323): repeated overflow drops in the same
+    //     burst must coalesce into a single disconnect walk; a fresh
+    //     subscriber added after the burst must re-arm the gate so a
+    //     later burst's walk reaches it.
+    [Fact]
+    public void DisconnectAllForResync_CoalescesWithinBurst_ReArmsOnAdd()
+    {
+        var book = new WorkingOrderBook();
+        var manager = new DropCopyManager(book);
+
+        var a = new DropCopyClient(Firm01, "dave", "compliance");
+        manager.Add(a);
+
+        // First call disconnects a, then "consumes" the armed gate.
+        manager.DisconnectAllForResync("first");
+        Assert.True(a.MarkedForDisconnect);
+        Assert.Equal("first", a.DisconnectReason);
+
+        // Subsequent calls within the same burst are no-ops on a fresh
+        // subscriber added without Add() (b is NOT registered) — the
+        // gate is consumed so the walk shouldn't touch anyone.
+        var b = new DropCopyClient(Firm01, "eve", "admin");
+        // b not added, so even if we walked, we'd skip it. Add a real
+        // post-burst subscriber to validate re-arm.
+        manager.DisconnectAllForResync("second_in_burst");
+        manager.DisconnectAllForResync("third_in_burst");
+        // a's reason stays "first" (RequestResyncDisconnect is idempotent).
+        Assert.Equal("first", a.DisconnectReason);
+
+        // Re-arm via Add() — a new burst should now disconnect c.
+        var c = new DropCopyClient(Firm02, "frank", "compliance");
+        manager.Add(c);
+        manager.DisconnectAllForResync("second_burst");
+        Assert.True(c.MarkedForDisconnect);
+        Assert.Equal("second_burst", c.DisconnectReason);
+    }
+
     // ----------------- helpers -----------------
 
     private static async Task<WebSocket> ConnectDropCopyAsync(TestAppFactory factory, string token)

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -97,6 +97,17 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 ["Trading:Auth:Users:2:Salt"] = salt,
                 ["Trading:Auth:Users:2:Iterations"] = TestIterations.ToString(),
                 ["Trading:Auth:Users:2:Role"] = "admin",
+                // Q4.6 (#306). Compliance principal for drop-copy WS tests.
+                // Issued against FIRM01 by default so drop-copy fan-out
+                // tests can submit orders under FIRM01 (alice's default
+                // firm via JwtIssuer's "default" firm fallback) and see
+                // them surface on dave's compliance socket.
+                ["Trading:Auth:Users:3:Username"] = "dave",
+                ["Trading:Auth:Users:3:PasswordHash"] = hash,
+                ["Trading:Auth:Users:3:Salt"] = salt,
+                ["Trading:Auth:Users:3:Iterations"] = TestIterations.ToString(),
+                ["Trading:Auth:Users:3:Role"] = "compliance",
+                ["Trading:Auth:Users:3:Firm"] = "FIRM01",
                 ["Trading:Exchange:UseStubGateway"] = "false",
                 ["Trading:Exchange:Firms:0:FirmId"] = "TEST",
                 ["Trading:Risk:Default:MaxQuantity"] = "1000",


### PR DESCRIPTION
Closes #306

## Summary
Adds `/ws/dropcopy` — a firm-scoped, server-push WebSocket feed for **Compliance** and **Admin** principals. Subscribers see every order, fill, and cancel for their firm regardless of which user originated the event.

- **Compliance role** is added (`Roles.Compliance`) symmetric with `Roles.Admin` / `Roles.User`. The role claim stays open-set on the wire; the constant centralises spelling.
- **Compliance** principals always observe their JWT firm — any `?firmId=` override is **silently ignored** (documented + tested) so a misconfigured client does not break.
- **Admin** principals may pass `?firmId=FIRM02` to view another firm; omitted, they default to their own JWT firm.
- Non-compliance, non-admin role → 403 on non-WS / WS Close 1008 PolicyViolation on WS handshake.

## Snapshot/live atomicity
`DropCopyManager.Add()` takes a **per-firm lock**, enqueues the three initial snapshot frames (orders = `WorkingOrderBook.EnumerateForFirm` DTOs; fills/cancels = empty, same v1 convention as `executions.me`), and only then releases the lock. Concurrent `Publish()` for the same firm takes the **same** lock when fanning out, so any delta racing the accept is queued AFTER the snapshot — the same contract `SubscriptionManager.SubscribeWithSnapshot` uses for the per-user hub (RFC §4.3 / §5.2).

## Wiring
- New `ExecutionFanOutTargets.DropCopy = 4` flag; `All` now `= WsHub | BotRouter | DropCopy`. Every captured `ExecutionEvent` reaches drop-copy via the existing dispatcher fan-out path — no parallel pipeline.
- `DropCopyExecutionEventSink` mirrors `WebSocketExecutionEventSink`: bounded `Channel<ExecutionEvent>`, background drain, `DropOldest` + `WsHubFanOutDropped` on overflow. Implements both `IExecutionFanOutSink` (dispatcher hot path, target=DropCopy) AND `IExecutionEventSink` so synthetic publishes (`OrderStalenessService`, WAL-backpressure fallback) also reach compliance — that is the "all traffic" guarantee.
- `CompositeExecutionEventSink` tees `IExecutionEventSink.Publish` to both the per-user WS sink and the drop-copy sink so the single dependency on `IExecutionEventSink` at synthetic call sites stays unchanged.
- Endpoint mounted in `TradingEndpointsExtensions.MapTradingEndpoints` next to `MapWebSocketHub`. JWT bearer's existing `?access_token=` extraction matches `/ws*` paths so the new endpoint inherits the browser-friendly handshake.

## Audit
`IAuditLogger.Log` (best-effort) emits:
- `audit.dropcopy.connect` on accept
- `audit.dropcopy.disconnect` on teardown

Each carries `ActorUserId`, `ActorRole`, `ActorFirm` (JWT firm), `firmIdViewed` (effective firm in `Details`), `firmIdOverride=true` when an admin overrode, and `SourceIp`. Best-effort by spec — WAL-backpressured audit must not refuse the WS connection. `/admin/audit` RBAC is intentionally NOT broadened to compliance in this PR (follow-up).

## Tests
`backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs` — 10 engine-driven tests through the real `TestAppFactory` handshake:
1. Compliance sees orders + fills + cancels submitted by OTHER users in the same firm.
2. Compliance does NOT see another firm's events (multi-firm parallel-traffic case).
3. Snapshot+stream consistency: N pre-connect + M post-connect → snapshot=N, M deltas with strictly monotonic seq 1..M, no dupes, no gaps.
4. Admin + `?firmId=FIRM02` sees FIRM02.
5. Admin without `?firmId` defaults to own firm.
6. Compliance + `?firmId` is ignored (sees own firm; cross-firm event never arrives).
7. Regular user → WS Close 1008.
8. Audit emission: connect lands in `AuditLogKeeper` with role + firmIdViewed.
9. (covered by test 2) FIRM01 stream receives nothing for FIRM02.
10. Disconnect cleanup: `DropCopyManager.SubscriberCount` returns to 0.

`TestAppFactory` seeds `dave` (compliance, FIRM01).

## Gates
- `dotnet test B3TradingPlatform.slnx` — green except two **pre-listed flaky** tests that pass on rerun (`MetricsFirmTagTests.OrdersSubmittedCounter_CarriesFirmIdTag`, `PastDayConcurrentDispatch_StatementRead_NeverProducesTornSnapshot`).
- `dotnet format B3TradingPlatform.slnx --verify-no-changes` — clean.

## Design choices
- **Compliance as a top-level role constant**: added `Roles.Compliance` constant in `B3.Trading.Api/Auth/Roles.cs` rather than leaving it string-only. The role claim is still open-set on the wire (config-driven), but the constant lets capture sites + tests agree on the spelling.
- **Compliance `?firmId` override**: silently ignored (no 4xx). A compliance user with the wrong firm claim has no path to view another firm regardless; rejecting with 400 would only confuse clients with a stale URL.
- **Snapshot/live atomicity**: per-firm lock around `Add` (snapshot enqueue) and `Publish` (delta fan-out), same pattern as `SubscriptionManager`.