### PR TITLE
fix(algo): #329 stop Pegged repeg from nulling LiveChild during replace adoption

### DIFF
--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -229,6 +229,29 @@ public sealed class AlgoEngine : BackgroundService
     }
 
     /// <summary>
+    /// Test-only deterministic adoption probe (#329 fix). Returns the
+    /// parent's currently-adopted child ClOrdID — i.e. the value the
+    /// modify path will read from <c>rt.LiveChildClOrdId</c> when the
+    /// next operator-modify signal is dispatched. The book carrying
+    /// the new child does NOT guarantee adoption has happened: the
+    /// ER processor first hydrates the child (visible in the book)
+    /// then enqueues a <see cref="ChildExecutionObservedSignal"/>;
+    /// the engine consumer task processes that signal asynchronously
+    /// and only then updates <c>LiveChildClOrdId</c>. Tests that drive
+    /// successive modify cycles MUST poll this before issuing the
+    /// next modify, otherwise the engine still sees the prior child
+    /// and dispatches a replace with the wrong OriginalClOrdId.
+    /// Returns null when the parent runtime hasn't been created yet
+    /// or has no live child (e.g. mid-terminal transition).
+    /// </summary>
+    internal ulong? TryGetLiveChildClOrdId(string firmId, ulong algoId)
+    {
+        return _runtime.TryGetValue((firmId, algoId), out var rt)
+            ? rt.LiveChildClOrdId
+            : null;
+    }
+
+    /// <summary>
     /// Boot-time pass over every non-terminal parent. Builds the runtime
     /// state from the order book (live child + cumulative-fill baseline +
     /// next slice seq) and re-enqueues an <see cref="AlgoCreatedSignal"/>
@@ -1985,9 +2008,24 @@ public sealed class AlgoEngine : BackgroundService
         if (!_orders.TryGet(liveChildClOrdId, out var child) || child is null
             || IsChildTerminal(child))
         {
-            // Child reference went stale (rare race with ER pipeline);
-            // clear and let the next tick re-evaluate from the empty
-            // slot path.
+            // #329: When the child is terminal with status Replaced, an
+            // adoption signal is already in flight from the ER processor
+            // (ApplyReplaceAccepted enqueues ChildExecutionObservedSignal
+            // for the NEW child AFTER MarkReplaced flips the OLD to
+            // Replaced). The adoption block in OnChildErAsync requires
+            // `rt.LiveChildClOrdId is { } oldLive` — if we null it here
+            // first, adoption is skipped and the parent ends up orphaned
+            // with no live child until the next scheduler tick spawns a
+            // fresh slice (which leaks a clOrdID and skips the retired-
+            // child FIFO accounting that powers AlgoModifyRetiredChildEvictedTotal).
+            // Leave the slot pointing at OLD so the imminent adoption
+            // signal can transition it atomically; the scheduler will
+            // re-tick in a few milliseconds either way. For other
+            // terminal statuses (Filled / Cancelled / Rejected) no
+            // adoption is coming, so the historical null-and-let-reactor-
+            // resubmit behavior is correct.
+            if (child is not null && child.Status == OrderStatus.Replaced)
+                return;
             rt.LiveChildClOrdId = null;
             return;
         }

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -2009,7 +2009,7 @@ public sealed class AlgoEngine : BackgroundService
             || IsChildTerminal(child))
         {
             // #329: When the child is terminal with status Replaced, an
-            // adoption signal is already in flight from the ER processor
+            // adoption signal is normally in flight from the ER processor
             // (ApplyReplaceAccepted enqueues ChildExecutionObservedSignal
             // for the NEW child AFTER MarkReplaced flips the OLD to
             // Replaced). The adoption block in OnChildErAsync requires
@@ -2019,16 +2019,36 @@ public sealed class AlgoEngine : BackgroundService
             // fresh slice (which leaks a clOrdID and skips the retired-
             // child FIFO accounting that powers AlgoModifyRetiredChildEvictedTotal).
             // Leave the slot pointing at OLD so the imminent adoption
-            // signal can transition it atomically; the scheduler will
-            // re-tick in a few milliseconds either way. For other
-            // terminal statuses (Filled / Cancelled / Rejected) no
-            // adoption is coming, so the historical null-and-let-reactor-
-            // resubmit behavior is correct.
+            // signal can transition it atomically.
+            //
+            // Safety valve: the adoption signal can be dropped if the
+            // bounded AlgoSignalQueue is full when ApplyReplaceAccepted
+            // tries to enqueue (TryEnqueue returns false and bumps
+            // AlgoSignalsDropped). Without a fallback the parent would
+            // be wedged on the terminal OLD child until process restart.
+            // After PeggedReplacedHoldMaxTicks consecutive evaluations
+            // where we still see OLD as Replaced, give up on the
+            // adoption signal, clear the slot, and let the next tick
+            // resubmit from the empty path. The threshold is generous
+            // (≈1 second @ 100ms scheduler tick) so the normal in-order
+            // case always lands before fallback kicks in.
             if (child is not null && child.Status == OrderStatus.Replaced)
-                return;
+            {
+                rt.PeggedReplacedHoldTicks++;
+                if (rt.PeggedReplacedHoldTicks < AlgoParentRuntime.PeggedReplacedHoldMaxTicks)
+                    return;
+                _logger.LogWarning(
+                    "AlgoEngine Pegged repeg: live child {Child} on {Firm}/{AlgoId} observed terminal=Replaced for {Ticks} ticks; adoption signal appears dropped — clearing slot and resubmitting on next tick.",
+                    liveChildClOrdId, algo.FirmId, algo.AlgoId, rt.PeggedReplacedHoldTicks);
+            }
+            rt.PeggedReplacedHoldTicks = 0;
             rt.LiveChildClOrdId = null;
             return;
         }
+
+        // Non-terminal child observed — clear the dropped-adoption
+        // watchdog so a future Replaced does not inherit a stale count.
+        rt.PeggedReplacedHoldTicks = 0;
 
         var currentPrice = child.Price ?? 0m;
         if (currentPrice <= 0m
@@ -2409,5 +2429,18 @@ public sealed class AlgoEngine : BackgroundService
         // "expected cancel" (so duplicate or post-restart-delayed
         // ERs do not flip the parent to Suspended/VenueCancelled).
         public ulong? LastRepegCancelledChildId;
+
+        // #329. Watchdog for the adoption-signal-dropped recovery in
+        // EvaluatePeggedRepegAsync. Counts consecutive scheduler-tick
+        // observations where the live child is terminal with status
+        // Replaced (i.e. an adoption signal is expected but hasn't been
+        // processed yet). Cleared on any non-Replaced observation OR
+        // when the watchdog fires. The threshold is generous so the
+        // normal in-order case (signal queued, consumer picks it up
+        // within one tick) never triggers it; only a genuinely dropped
+        // signal due to a full bounded queue lets the count reach the
+        // ceiling and force a fallback resubmit.
+        public int PeggedReplacedHoldTicks;
+        public const int PeggedReplacedHoldMaxTicks = 10;
     }
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -212,7 +212,8 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<B3.Trading.Application.MarketData.MarketDataPegBookPump>();
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.MarketDataPegBookPump>());
-        services.AddHostedService<AlgoEngine>();
+        services.AddSingleton<AlgoEngine>();
+        services.AddHostedService(sp => sp.GetRequiredService<AlgoEngine>());
         services.AddHostedService<AlgoScheduler>();
 
         // Lifecycle: drain flag flipped on SIGTERM /

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -679,6 +679,8 @@ public class AlgoModifyEndpointTests
         var book = f.Services.GetRequiredService<WorkingOrderBook>();
         var liveChild = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var engine = f.Services.GetRequiredService<AlgoEngine>();
+        var algoIdNum = ulong.Parse(algoId);
 
         // Drive 9 modify→Replaced cycles. Bump NewQuantity to keep each
         // modify operative without pushing past the default
@@ -687,6 +689,23 @@ public class AlgoModifyEndpointTests
         // collar — quantity-bump is the safe lever here).
         for (int cycle = 0; cycle < 9; cycle++)
         {
+            // #329: each cycle must observe the previous cycle's
+            // adoption committed in the engine runtime — NOT just the
+            // book — before sending the next modify. The ER processor
+            // hydrates the new child in the book and THEN enqueues
+            // ChildExecutionObservedSignal; the engine consumer task
+            // processes that signal asynchronously and only there does
+            // rt.LiveChildClOrdId flip to the new id. Polling the book
+            // (cycle 0 below) or sleeping a fixed delay (the previous
+            // approach) races the signal under CI load: the next
+            // modify reads the stale LiveChildClOrdId and dispatches a
+            // replace with the wrong OriginalClOrdId, making the
+            // WaitFor predicate below permanently false → 3s timeout.
+            await WaitFor(
+                () => engine.TryGetLiveChildClOrdId("default", algoIdNum) == liveChild.ClOrdId,
+                TimeSpan.FromSeconds(3),
+                () => $"cycle {cycle}: engine did not adopt child {liveChild.ClOrdId} (current LiveChild={engine.TryGetLiveChildClOrdId("default", algoIdNum)?.ToString() ?? "null"})");
+
             var newQty = 101 + cycle; // 101, 102, ..., 109
             var preReplaceCount = mock.SubmittedReplaces.Count;
             var modReq = new HttpRequestMessage(HttpMethod.Post, $"/algo/{algoId}/modify")
@@ -729,18 +748,27 @@ public class AlgoModifyEndpointTests
             }
             Assert.NotNull(hydrated);
             liveChild = hydrated!;
-            // Allow the engine consumer task to process the
-            // ChildExecutionObservedSignal that ApplyReplaceAccepted
-            // fans out — that's where RetireChildSlot runs. Without
-            // this brief delay the next cycle's modify can race the
-            // adoption (still-in-flight intent for the OLD id).
-            await Task.Delay(50);
+            // Adoption is awaited deterministically at the top of the
+            // next iteration via engine.TryGetLiveChildClOrdId — no
+            // arbitrary delay needed here.
         }
 
         // 9 adoptions on the same parent = 9 retired-child enqueues;
         // cap=8 ⇒ exactly 1 eviction; the algoType tag is the lowercased
         // AlgoType enum value (matches the algo.modify_rejected_total
         // taxonomy already in use).
+        //
+        // #329: the engine flips rt.LiveChildClOrdId BEFORE calling
+        // RetireChildSlot + Counter.Add inside OnChildErAsync, so an
+        // engine-state-based gate (TryGetLiveChildClOrdId) races the
+        // metric emission under fast CPUs. Wait on the observable side
+        // effect directly so the assertion runs strictly after the
+        // eviction counter has been published.
+        await WaitFor(
+            () => Interlocked.Read(ref evicted) >= 1L,
+            TimeSpan.FromSeconds(3),
+            () => $"eviction counter never reached 1 (current={Interlocked.Read(ref evicted)}, finalLive={engine.TryGetLiveChildClOrdId("default", algoIdNum)?.ToString() ?? "null"}, replaces={mock.SubmittedReplaces.Count})");
+
         listener.RecordObservableInstruments();
         Assert.Equal(1L, Interlocked.Read(ref evicted));
         Assert.Equal("pegged", evictedAlgoType);
@@ -975,6 +1003,9 @@ public class AlgoModifyEndpointTests
     }
 
     private static async Task WaitFor(Func<bool> predicate, TimeSpan timeout, string failMessage)
+        => await WaitFor(predicate, timeout, () => failMessage);
+
+    private static async Task WaitFor(Func<bool> predicate, TimeSpan timeout, Func<string> failMessageFactory)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         while (sw.Elapsed < timeout)
@@ -982,7 +1013,7 @@ public class AlgoModifyEndpointTests
             if (predicate()) return;
             await Task.Delay(20);
         }
-        throw new TimeoutException(failMessage + $" (waited {timeout.TotalSeconds}s)");
+        throw new TimeoutException(failMessageFactory() + $" (waited {timeout.TotalSeconds}s)");
     }
 
     private static async Task WaitForAlgoStatus(HttpClient http, string token, string algoId, params string[] anyOf)


### PR DESCRIPTION
## Summary

Definitive fix for the `Modify_RepeatedAdoptions_OverflowRetiredFifo_BumpsEvictionCounter` CI flake. Root cause is a real engine race: the Pegged scheduler reactor nulls `rt.LiveChildClOrdId` when it observes the OLD child as terminal (Replaced) after `ApplyReplaceAccepted` but before the adoption signal is consumed. The subsequent adoption block silently no-ops because `oldLive` is null → the parent's retired-child FIFO accounting is skipped, the modify pipeline orphans the in-flight replacement, and the next scheduler tick spawns a phantom slice with a fresh clOrdID.

## Fix

`AlgoEngine.EvaluatePeggedRepegAsync`: when the live child is terminal with `Status == Replaced`, return without nulling `rt.LiveChildClOrdId`. The processor has already enqueued an adoption signal for the NEW child; nulling the slot here defeats it. Other terminal statuses (Filled/Cancelled/Rejected) still take the original clear-and-resubmit path.

## Test hardening

- Replace the racy `Task.Delay(50)` between modify cycles with a deterministic gate on `engine.TryGetLiveChildClOrdId(firmId, algoId)` (new internal accessor).
- Split `AlgoEngine` DI registration into singleton + factory-based hosted service so tests can resolve it (the bare `AddHostedService<T>()` does not).
- Final eviction-counter `WaitFor` instead of a LiveChild gate — the engine emits the metric AFTER flipping LiveChild, so a LiveChild-based gate races the metric callback under fast CPUs.

## Validation

- 50× single-core (`taskset -c 0`): 50/50 pass.
- 30× multi-core: 30/30 pass.
- Full `B3.Trading.Api.Tests`: 482/482 pass.
- Full `B3.Trading.Application.Tests`: 1035/1035 pass.

Closes #329
