### PR TITLE
feat(algo): #300 retrofit Pegged repeg to cancel-replace path

### DIFF
--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -721,6 +721,29 @@ public sealed class AlgoEngine : BackgroundService
         {
             rt.LiveChildClOrdId = child.ClOrdId;
             rt.ChildBookedCum[child.ClOrdId] = child.CumulativeQuantity;
+
+            // #300 retrofit. Discriminate operator-modify adoption vs
+            // engine-driven Pegged repeg adoption via the
+            // PeggedRepegBook pending entry: a pending row whose
+            // CancelledChildClOrdId matches `oldLive` means
+            // EvaluatePeggedRepegAsync issued this cancel-replace as
+            // part of a repeg cycle, so the adoption signal IS the
+            // cycle-resolved trigger (replacing the pre-#300
+            // Cancelled-on-OLD ack as the trigger). Approach (b) from
+            // the design note: cheap synchronous lookup, no schema
+            // change on OrderReplacementIntent or the WAL.
+            //
+            // The engine consumer is single-threaded so the Set
+            // inside EvaluatePeggedRepegAsync (executed earlier on
+            // the same task) is guaranteed visible here before any
+            // ChildExecutionObservedSignal for the replacement child
+            // can be processed.
+            var peggedRepegAdoption =
+                algo.Type == AlgoType.Pegged
+                && rt.RepegPending
+                && _peggedRepeg?.TryGet(algo.FirmId, algo.AlgoId) is { } pendingCycle
+                && pendingCycle.CancelledChildClOrdId == oldLive;
+
             var evicted = rt.RetireChildSlot(oldLive, out var firstRetiredEviction);
             if (evicted > 0)
             {
@@ -749,6 +772,45 @@ public sealed class AlgoEngine : BackgroundService
             // accounting block below. Any later Fill ER for the new
             // ClOrdID advances cum monotonically against this seeded
             // baseline.
+
+            // #300 retrofit. Pegged-repeg cycle resolution now happens
+            // HERE (on the Replaced-ER-driven adoption signal) instead
+            // of on the Cancelled-on-OLD ack the pre-#300 code waited
+            // for. Clear RepegPending so the next scheduler tick can
+            // evaluate a fresh drift, reset the dropped-adoption
+            // watchdog (the signal we were waiting for has now landed),
+            // and dispatch the audit-pair Resolved event so a future
+            // WAL replay drops the pending entry.
+            if (peggedRepegAdoption)
+            {
+                rt.RepegPending = false;
+                rt.PeggedReplacedHoldTicks = 0;
+                try
+                {
+                    var firmIdSnap = algo.FirmId;
+                    var algoIdSnap = algo.AlgoId;
+                    var oldIdSnap = oldLive;
+                    var book = _peggedRepeg;
+                    _dispatcher.Dispatch(
+                        new AlgoPeggedRepegResolvedEvent
+                        {
+                            AlgoId = algo.AlgoId,
+                            FirmId = algo.FirmId,
+                            CancelledChildClOrdId = oldLive,
+                            AtUtc = _clock.GetUtcNow(),
+                        },
+                        () => book?.Remove(firmIdSnap, algoIdSnap));
+                }
+                catch (WalBackpressureException)
+                {
+                    // Best-effort under WAL backpressure: leave the
+                    // book entry in place; Reconcile's orphan prune
+                    // (PrunePeggedRepegBookOrphans) and the parent-
+                    // terminal RemoveAll both converge state later.
+                    MetricsRegistry.WalBackpressure.Add(1,
+                        new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved"));
+                }
+            }
         }
 
         // Book the cum-quantity delta. Child orders deliver fills via
@@ -877,54 +939,43 @@ public sealed class AlgoEngine : BackgroundService
                 else if (rt.RepegPending && algo.Type == AlgoType.Pegged
                          && rt.LastRepegCancelledChildId == child.ClOrdId)
                 {
-                    // Q3.3 (#283). Engine-initiated cancel for a repeg —
-                    // the cancel-ack is the signal to place the new
-                    // child at the fresh target. Clear the flag first
-                    // so a second cancel-ack (shouldn't happen but is
-                    // cheap to defend) doesn't loop into a double-place.
-                    //
-                    // Pass-1 review (#296) P1-A. Match strictly on the
-                    // cancelled child id so a Cancelled ER that arrives
-                    // for some OTHER live child (operator race,
-                    // venue-initiated cancel for a different slice) is
-                    // still routed through the VenueCancelled branch.
-                    rt.RepegPending = false;
-
-                    // Persist the resolution: clears the pending entry
-                    // in PeggedRepegBook (recovery convergence) +
-                    // serves as an audit pair to the Started event.
-                    // Best-effort: WAL backpressure here leaves the
-                    // book entry in place; the next Reconcile will
-                    // observe the old child terminal and drop it
-                    // defensively.
-                    try
-                    {
-                        var firmIdSnap = algo.FirmId;
-                        var algoIdSnap = algo.AlgoId;
-                        var cancelledIdSnap = child.ClOrdId;
-                        var book = _peggedRepeg;
-                        _dispatcher.Dispatch(
-                            new AlgoPeggedRepegResolvedEvent
-                            {
-                                AlgoId = algo.AlgoId,
-                                FirmId = algo.FirmId,
-                                CancelledChildClOrdId = child.ClOrdId,
-                                AtUtc = _clock.GetUtcNow(),
-                            },
-                            () => book?.Remove(firmIdSnap, algoIdSnap));
-                    }
-                    catch (WalBackpressureException)
-                    {
-                        MetricsRegistry.WalBackpressure.Add(1,
-                            new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved"));
-                    }
-
-                    if (algo.RemainingQuantity <= 0)
-                    {
-                        await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
-                        return;
-                    }
-                    await SubmitNextSliceAsync(algo, rt, ct).ConfigureAwait(false);
+                    // #300 retrofit. Pre-#300 this branch consumed the
+                    // Cancelled-on-OLD ack as the "cycle resolved,
+                    // place fresh slice" trigger. Post-#300 the engine
+                    // dispatches CancelReplace (TryReplaceChildAsync)
+                    // instead of a bare cancel, so the venue's
+                    // response is a Replaced ER which adoption-block
+                    // (~line 714) drains. A Cancelled ER reaching
+                    // here while RepegPending is still true means
+                    // the venue rejected the modify and emitted a
+                    // bare cancel on the original (or the venue
+                    // hand-split cancel-replace into cancel+place
+                    // and the cancel landed first). Strict no-op:
+                    //   * Do NOT SubmitNextSliceAsync — the
+                    //     PendingReplacementRegistry intent is still
+                    //     in flight; if the Replaced ER eventually
+                    //     lands it will adopt the new child via the
+                    //     normal path; if not, the AlgoScheduler
+                    //     ambiguous-replace TTL sweep releases the
+                    //     held margin and the #329 watchdog clears
+                    //     the wedged slot on the next tick.
+                    //   * Do NOT dispatch Resolved — adoption will
+                    //     dispatch it; if adoption never fires the
+                    //     watchdog + Reconcile orphan prune converge
+                    //     state on the next restart.
+                    //   * Do NOT clear RepegPending — the throttle
+                    //     guard keeps the engine from racing another
+                    //     repeg against the still-live replace
+                    //     intent.
+                    // The bounded IsCancelledChild dedup branch below
+                    // catches this same condition for replay safety
+                    // (older WAL segments persisted with pre-#300
+                    // cancel-only semantics); we leave that branch in
+                    // place per the issue.
+                    _logger.LogDebug(
+                        "AlgoEngine pegged repeg: stray Cancelled-on-OLD ER for {Firm}/{AlgoId} child {Child} while replace is in flight; no-op (Replaced ER adoption drives resolution).",
+                        algo.FirmId, algo.AlgoId, child.ClOrdId);
+                    return;
                 }
                 else if (algo.Type == AlgoType.Pegged
                          && (_peggedRepeg?.IsCancelledChild(algo.FirmId, algo.AlgoId, child.ClOrdId) ?? false))
@@ -944,6 +995,16 @@ public sealed class AlgoEngine : BackgroundService
                     // repeg overwrites it a late Cancelled ER for an
                     // older cycle's child used to escape this guard
                     // and reach the VenueCancelled-suspension path.
+                    //
+                    // #300 retrofit. The ring now serves a dual
+                    // purpose: (1) defensive dedup of late Cancelled
+                    // ERs that may still arrive on the live cancel-
+                    // replace path (rare/spurious — venue shouldn't
+                    // emit Cancelled when the modify succeeded), AND
+                    // (2) replay safety for older WAL segments that
+                    // recorded a bare cancel (pre-#300 semantics)
+                    // whose Cancelled ER is being replayed against a
+                    // post-#300 engine. Both arms fall here.
                     return;
                 }
                 else if (IsTwapWindowExpired(algo))
@@ -1905,6 +1966,36 @@ public sealed class AlgoEngine : BackgroundService
         // Keep LastRepegCancelledChildId sticky for late-ER dedup; the
         // marker is cleared only on parent terminal.
 
+        // #300 retrofit. Pre-#300 the in-flight cycle was a bare
+        // cancel — nothing to clean up beyond the in-memory marker.
+        // Post-#300 the cycle is a cancel-replace whose intent +
+        // (possibly) held margin live in PendingReplacementRegistry.
+        // A Fill on the OLD child has already settled the cycle from
+        // the parent's POV, so the replace is now meaningless: if the
+        // venue eventually emits a Replaced ER the adoption block
+        // will pick up a residue-zero new child and orphan it.
+        // Consume the intent here so the registry + margin reserve
+        // are released; the late Replaced ER will then bypass
+        // PendingReplacementRegistry's intercept and the synthetic
+        // child is silently dropped.
+        if (wasPending && _replacements is not null)
+        {
+            if (_replacements.TryConsumeByOriginal(child.ClOrdId, out var intent, out var ambiguousHeld))
+            {
+                MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
+                if (ambiguousHeld && _replaceMargin is not null && intent is not null)
+                {
+                    try { _replaceMargin.AbortReplace(intent.NewClOrdId); }
+                    catch (Exception abortEx)
+                    {
+                        _logger.LogWarning(abortEx,
+                            "AlgoEngine pegged repeg fill-race: AbortReplace failed for new ClOrdID {NewClOrdId}.",
+                            intent.NewClOrdId);
+                    }
+                }
+            }
+        }
+
         if (wasPending && _peggedRepeg?.TryGet(algo.FirmId, algo.AlgoId) is not null)
         {
             // Window 3: Started already in WAL + book. Emit the
@@ -2059,73 +2150,109 @@ public sealed class AlgoEngine : BackgroundService
             return;
         }
 
-        // Pass-3 review (#296) P1 — approach B. Set the in-memory
-        // RepegPending + sticky LastRepegCancelledChildId BEFORE the
-        // cancel wire-call so the cancel-ack ER (which can arrive on a
-        // different consumer-loop iteration while CancelAsync is still
-        // awaiting) is classified as expected by OnChildErAsync and
-        // does NOT route through the VenueCancelled-suspension path.
-        // The WAL Started marker + PeggedRepegBook.Set are deferred
-        // until AFTER CancelAsync returns successfully (below): if the
-        // cancel never reached the venue there is nothing to recover
-        // on restart, so persisting the "intent" prematurely would
-        // leave a poison Started without a matching Resolved that
-        // would stall the algo on replay. Pegged repeg is idempotent
-        // — losing the pre-cancel intent record is harmless because
-        // the next tick re-derives it from current drift.
+        // #300 retrofit. Pre-#300 set RepegPending + sticky cancel-id
+        // BEFORE the wire-call so a racing cancel-ack ER on a
+        // different consumer-loop iteration was classified as
+        // expected. With cancel-replace (TryReplaceChildAsync below)
+        // there is no Cancelled-on-OLD ack to race — the OLD child's
+        // terminal transition is the Replaced ER, handled by the
+        // adoption block at OnChildErAsync (~line 714). We still set
+        // these markers before dispatch so:
+        //   * RepegPending throttles a second EvaluatePeggedRepegAsync
+        //     re-entry on the same algo while the replace is in
+        //     flight (single-consumer reactor: an in-flight modify
+        //     can span the consumer awaiting the gateway).
+        //   * LastRepegCancelledChildId + MarkCancelledChild populate
+        //     the dedup ring so a defensive Cancelled-on-OLD ER
+        //     (rare/spurious — venue shouldn't emit) and any
+        //     pre-#300 replay-time Cancelled ER both no-op through
+        //     the IsCancelledChild branch in OnChildErAsync.
+        // PeggedRepegBook.Set + the WAL Started marker still defer
+        // until AFTER the wire-call succeeds (mirrors the pre-#300
+        // approach-B ordering, now anchored on
+        // TryReplaceChildAsync's return value): an ambiguous-send
+        // failure must NOT leave a Started without a Resolved.
         rt.RepegPending = true;
         rt.LastRepegCancelledChildId = liveChildClOrdId;
-        // Pass-5 review (#296) P1. Add to the cancelled-child history
-        // ring BEFORE the wire-call so the late-ER dedup at
-        // OnChildErAsync line ~666/~788 covers ERs that race the
-        // cancel (the ring is in-memory only here; the WAL Started
-        // event below carries the same id so EventReplayer rebuilds
-        // the ring on restart). Persisting via dispatch-action would
-        // be wrong: this id must be remembered even when CancelAsync
-        // fails (no Started gets persisted), because a venue may
-        // still ack the cancel from a previous in-flight attempt.
         _peggedRepeg?.MarkCancelledChild(algo.FirmId, algo.AlgoId, liveChildClOrdId);
         rt.PeggedLastEvalUtc = now;
         var oldChildPrice = currentPrice;
         var refForAudit = _pegBookTop?.TryGet(algo.Symbol)?.RefPrice(pgp.Ref, algo.Side) ?? 0m;
-        var newClOrdId = _clOrdIds.Generate(child.Owner);
 
+        // #300 retrofit. Replace bare CancelAsync with the Q3.5
+        // cancel-replace plumbing introduced in #299 so venue book
+        // priority is preserved across the repeg. Reason="AlgoInternal"
+        // is already in ModifyAlgoRequest.AllowedReasons and bounds
+        // the metric label cardinality. TryReplaceChildAsync handles:
+        //   * pre-trade risk + margin Prepare gates;
+        //   * new-ClOrdID allocation + PendingReplacementRegistry
+        //     intent registration via OrderReplaceRequestedEvent
+        //     dispatch (durable);
+        //   * AlgoChildModifiedEvent audit envelope;
+        //   * AlgoChildModifiesTotal metric (algoType=pegged,
+        //     reason=AlgoInternal);
+        //   * ambiguous-send retention of the intent (and held
+        //     margin) so a late Replaced ER still resolves.
+        // On false-return we don't know whether the venue accepted —
+        // we MUST NOT persist Started (else dangling without
+        // Resolved). The next scheduler tick re-evaluates drift; if
+        // it was an ambiguous send the #329 watchdog +
+        // AlgoScheduler.SweepAmbiguousReplaceIntents bound recovery.
+        bool replaced;
         try
         {
-            _ownership.RegisterCancelLink(newClOrdId, child.ClOrdId);
-            await _gateway.CancelAsync(child, newClOrdId, ct).ConfigureAwait(false);
+            replaced = await TryReplaceChildAsync(
+                algo, rt, child, child.Quantity, target.Value,
+                reason: "AlgoInternal", ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            // Pass-3 review (#296) P1 — approach B. Cancel never made
-            // it to the venue. Because we no longer persist
-            // AlgoPeggedRepegStartedEvent BEFORE the wire-call, there
-            // is nothing in the WAL or the PeggedRepegBook to roll
-            // back. Clear in-memory state so the next tick re-evaluates
-            // drift from a clean slate and can retry the repeg.
+            // TryReplaceChildAsync swallows gateway/WAL exceptions
+            // internally; any escape here is a programmer error
+            // surface (e.g. a synchronous throw from the risk
+            // pipeline). Clear in-memory state so the next tick can
+            // retry from a clean slate, mirroring the pre-#300
+            // cancel-failure rollback.
             rt.RepegPending = false;
             rt.LastRepegCancelledChildId = null;
             MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
             _logger.LogWarning(ex,
-                "AlgoEngine pegged repeg cancel failed for algo {Firm}/{AlgoId} child {Child}; cleared marker, will retry next tick.",
+                "AlgoEngine pegged repeg cancel-replace failed for algo {Firm}/{AlgoId} child {Child}; cleared marker, will retry next tick.",
                 algo.FirmId, algo.AlgoId, liveChildClOrdId);
             return;
         }
 
-        // Cancel reached the venue. Persist the Started marker so a
-        // crash before the cancel-ack ER lands still gives recovery
-        // enough trail to classify the post-restart ER as expected.
-        //
-        // Pass-4 review (#296) P1 — Windows 1+2. If a terminal Fill ER
-        // for `liveChildClOrdId` raced the cancel and was processed by
-        // OnChildErAsync during the CancelAsync await (or before this
-        // method was entered, e.g. an SDK that pumps ERs synchronously
-        // inside the cancel call), ResolveRepegOnFillAsync has already
-        // cleared rt.RepegPending and the qty was credited to the
-        // parent. Persisting a Started here would leave an orphan WAL
-        // marker that the next Reconcile / replay would have to self-
-        // heal. Bail before the dispatch — the post-fill state is
-        // already coherent.
+        if (!replaced)
+        {
+            // Replace was rejected (risk/margin) or its send was
+            // ambiguous. In the rejection case the intent was rolled
+            // back inside TryReplaceChildAsync — clear in-memory
+            // markers so the next tick retries. In the ambiguous-
+            // send case TryReplaceChildAsync deliberately RETAINS
+            // the intent + margin reservation; we still clear our
+            // in-memory markers because we are NOT going to dispatch
+            // a Started (no audit pair to balance) — if the venue
+            // had accepted, the Replaced ER will adopt through the
+            // normal operator-modify path (no Resolved emitted; OK
+            // because no Started either). The held intent leaks are
+            // bounded by AlgoScheduler.SweepAmbiguousReplaceIntents.
+            // The throttle is intentionally NOT advanced: the next
+            // tick should be allowed to try again if drift persists.
+            rt.RepegPending = false;
+            rt.LastRepegCancelledChildId = null;
+            MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
+            return;
+        }
+
+        // #300 retrofit. Same Window 1/2 guard as pre-#300: if a
+        // racing terminal Fill ER for `liveChildClOrdId` was
+        // processed by OnChildErAsync between TryReplaceChildAsync
+        // returning and here (only reachable if the gateway awaited
+        // a Replaced ER synchronously inside CancelReplaceAsync,
+        // unusual but defensive), ResolveRepegOnFillAsync has
+        // already cleared rt.RepegPending and we MUST NOT persist
+        // Started here — adoption won't fire (parent terminal) and
+        // the audit pair would dangle.
         if (!rt.RepegPending)
         {
             return;
@@ -2145,7 +2272,15 @@ public sealed class AlgoEngine : BackgroundService
                     AlgoId = algo.AlgoId,
                     FirmId = algo.FirmId,
                     CancelledChildClOrdId = liveChildClOrdId,
-                    NewClOrdId = newClOrdId,
+                    // #300 retrofit. NewClOrdId is no longer
+                    // surfaced from TryReplaceChildAsync's caller
+                    // because the replacement is observability-only
+                    // here (the durable record is the
+                    // OrderReplaceRequestedEvent the helper already
+                    // dispatched). Carry 0 as a sentinel — the
+                    // replayer keys only on CancelledChildClOrdId
+                    // and the field is audit-only.
+                    NewClOrdId = 0UL,
                     TargetPrice = target.Value,
                     AtUtc = now,
                 },
@@ -2155,13 +2290,13 @@ public sealed class AlgoEngine : BackgroundService
         {
             MetricsRegistry.WalBackpressure.Add(1,
                 new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-started"));
-            // WAL backpressure after a successful cancel: the dispatch
-            // apply (book.Set) never ran. Mirror it manually so the
-            // current process still routes the cancel-ack ER through
-            // the expected path via rt.LastRepegCancelledChildId +
-            // the book lookup. Recovery for this specific cycle is
-            // best-effort; Reconcile's orphan-prune (P2-C) /
-            // self-heal (P1-C) covers any drift on the next restart.
+            // WAL backpressure after a successful replace: the
+            // dispatch apply (book.Set) never ran. Mirror it
+            // manually so the in-process adoption block can still
+            // discriminate Pegged-repeg vs operator-modify (the
+            // book lookup is the discriminator under approach (b)).
+            // Recovery for this specific cycle is best-effort;
+            // Reconcile's orphan-prune covers any drift on restart.
             _peggedRepeg?.Set(algo.FirmId, algo.AlgoId, liveChildClOrdId, target.Value, now);
         }
 

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -1983,14 +1983,23 @@ public sealed class AlgoEngine : BackgroundService
             if (_replacements.TryConsumeByOriginal(child.ClOrdId, out var intent, out var ambiguousHeld))
             {
                 MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
-                if (ambiguousHeld && _replaceMargin is not null && intent is not null)
+                // Code review feedback on #300 (PR #334). PrepareReplaceAsync
+                // always records a reservation under the new ClOrdID (even
+                // for zero-delta replaces) — the only registry-driven
+                // cleanup APIs are CommitReplace/AbortReplace. Once we've
+                // consumed the intent the venue's later Replaced/Rejected/
+                // Canceled ER will no longer hit those cleanup paths, so
+                // the reservation must be aborted unconditionally here —
+                // the earlier ambiguousHeld-only gate leaked normal in-
+                // flight reservations indefinitely.
+                if (_replaceMargin is not null && intent is not null)
                 {
                     try { _replaceMargin.AbortReplace(intent.NewClOrdId); }
                     catch (Exception abortEx)
                     {
                         _logger.LogWarning(abortEx,
-                            "AlgoEngine pegged repeg fill-race: AbortReplace failed for new ClOrdID {NewClOrdId}.",
-                            intent.NewClOrdId);
+                            "AlgoEngine pegged repeg fill-race: AbortReplace failed for new ClOrdID {NewClOrdId} (ambiguousHeld={Ambiguous}).",
+                            intent.NewClOrdId, ambiguousHeld);
                     }
                 }
             }
@@ -2079,23 +2088,16 @@ public sealed class AlgoEngine : BackgroundService
         // throttle anchor is unrelated to in-flight cycles, and
         // bumping it would mask the next legitimate drift eval once
         // the cycle completes.
-        if (rt.RepegPending) return;
-
-        var now = _clock.GetUtcNow();
-        if (rt.PeggedLastEvalUtc != default
-            && (now - rt.PeggedLastEvalUtc) < pgp.RepegInterval)
-        {
-            return;
-        }
-
-        var target = ResolvePeggedTarget(algo, pgp);
-        if (target is null)
-        {
-            // No live ref yet — don't disturb the working slice; next
-            // tick may have a price.
-            return;
-        }
-
+        // #300 (PR #334) code-review fix. The terminal-OLD watchdog
+        // (#329) MUST run before the RepegPending throttle. Pre-#300
+        // the throttle was the only state that meant "cycle in flight"
+        // and would naturally clear on the Cancelled-ack. Post-#300 it
+        // only clears on Replaced-adoption — and if AlgoSignalQueue
+        // drops that signal the throttle stays true forever, the
+        // watchdog at lines ~2126-2134 never runs, and the parent is
+        // wedged on the terminal OLD child indefinitely. Order matters:
+        // watchdog first (it both ticks the counter and can clean up
+        // when ticks exhaust), throttle second (governs new cycles only).
         if (!_orders.TryGet(liveChildClOrdId, out var child) || child is null
             || IsChildTerminal(child))
         {
@@ -2131,6 +2133,62 @@ public sealed class AlgoEngine : BackgroundService
                 _logger.LogWarning(
                     "AlgoEngine Pegged repeg: live child {Child} on {Firm}/{AlgoId} observed terminal=Replaced for {Ticks} ticks; adoption signal appears dropped — clearing slot and resubmitting on next tick.",
                     liveChildClOrdId, algo.FirmId, algo.AlgoId, rt.PeggedReplacedHoldTicks);
+
+                // #300 (PR #334) code-review fix. The dropped-adoption
+                // fallback must also wind down the cancel-replace cycle
+                // it started: release the pending replace intent + its
+                // margin reservation, clear RepegPending, and emit the
+                // Resolved-with-Aborted WAL companion if a Started was
+                // already persisted. Without this the parent leaks a
+                // PendingReplacementRegistry row + a reserve-margin
+                // entry indefinitely AND the audit pair stays
+                // unbalanced. Best-effort under WAL backpressure —
+                // Reconcile's orphan-prune covers the audit-pair gap on
+                // the next restart.
+                if (rt.RepegPending)
+                {
+                    rt.RepegPending = false;
+                    if (_replacements is not null
+                        && _replacements.TryConsumeByOriginal(liveChildClOrdId, out var staleIntent, out var staleAmbiguous)
+                        && staleIntent is not null
+                        && _replaceMargin is not null)
+                    {
+                        try { _replaceMargin.AbortReplace(staleIntent.NewClOrdId); }
+                        catch (Exception abortEx)
+                        {
+                            _logger.LogWarning(abortEx,
+                                "AlgoEngine Pegged repeg watchdog: AbortReplace failed for new ClOrdID {NewClOrdId} (ambiguousHeld={Ambiguous}).",
+                                staleIntent.NewClOrdId, staleAmbiguous);
+                        }
+                    }
+                    if (_peggedRepeg?.TryGet(algo.FirmId, algo.AlgoId) is not null)
+                    {
+                        try
+                        {
+                            var firmIdSnap = algo.FirmId;
+                            var algoIdSnap = algo.AlgoId;
+                            var cancelledIdSnap = liveChildClOrdId;
+                            var atUtcSnap = _clock.GetUtcNow();
+                            var book = _peggedRepeg;
+                            _dispatcher.Dispatch(
+                                new AlgoPeggedRepegResolvedEvent
+                                {
+                                    AlgoId = algoIdSnap,
+                                    FirmId = firmIdSnap,
+                                    CancelledChildClOrdId = cancelledIdSnap,
+                                    AtUtc = atUtcSnap,
+                                    Aborted = true,
+                                },
+                                () => book?.Remove(firmIdSnap, algoIdSnap));
+                        }
+                        catch (WalBackpressureException)
+                        {
+                            MetricsRegistry.WalBackpressure.Add(1,
+                                new KeyValuePair<string, object?>("call_site", "algo.pegged.repeg-resolved.watchdog"));
+                        }
+                    }
+                    MetricsRegistry.AlgoPeggedRepegFailed.Add(1);
+                }
             }
             rt.PeggedReplacedHoldTicks = 0;
             rt.LiveChildClOrdId = null;
@@ -2140,6 +2198,26 @@ public sealed class AlgoEngine : BackgroundService
         // Non-terminal child observed — clear the dropped-adoption
         // watchdog so a future Replaced does not inherit a stale count.
         rt.PeggedReplacedHoldTicks = 0;
+
+        // Throttle: don't start a NEW cycle while one is in flight.
+        // Moved here from before the terminal block (PR #334 code review)
+        // so the dropped-adoption watchdog above always runs.
+        if (rt.RepegPending) return;
+
+        var now = _clock.GetUtcNow();
+        if (rt.PeggedLastEvalUtc != default
+            && (now - rt.PeggedLastEvalUtc) < pgp.RepegInterval)
+        {
+            return;
+        }
+
+        var target = ResolvePeggedTarget(algo, pgp);
+        if (target is null)
+        {
+            // No live ref yet — don't disturb the working slice; next
+            // tick may have a price.
+            return;
+        }
 
         var currentPrice = child.Price ?? 0m;
         if (currentPrice <= 0m

--- a/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
+++ b/backend/src/B3.Trading.Application/Algo/PeggedRepegBook.cs
@@ -110,6 +110,19 @@ public sealed class PeggedRepegBook
     /// Suspended/VenueCancelled even when the ER arrives after the
     /// cycle has already been resolved or after a subsequent repeg
     /// has rotated the single-slot active-cycle marker.
+    /// <para>
+    /// #300 retrofit. The repeg cycle now uses cancel-replace, so the
+    /// OLD child no longer receives a Cancelled-on-OLD terminal ER on
+    /// the happy path (the venue emits a Replaced ER instead, picked
+    /// up by the adoption block). Marking the cancelled child id is
+    /// nonetheless retained for two reasons: (a) defensive against a
+    /// rare venue that still emits Cancelled before/after Replaced
+    /// (spurious but observed historically on some FIX gateways) so
+    /// that ER also dedups instead of suspending the parent; and (b)
+    /// pre-#300 WAL replay safety — segments produced before this
+    /// retrofit still emit Cancelled ERs as the repeg terminal, and
+    /// the IsCancelledChild path keeps them no-op during replay.
+    /// </para>
     /// </summary>
     public void MarkCancelledChild(string firmId, ulong algoId, ulong childClOrdId)
     {

--- a/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
@@ -77,6 +77,11 @@ public sealed class MockEntryPointClient : IEntryPointClient
             var ex = injector(request);
             if (ex is not null) return Task.FromException(ex);
         }
+        var delay = ReplaceDelayInjector;
+        if (delay is not null)
+        {
+            return delay(request);
+        }
         return Task.CompletedTask;
     }
 
@@ -91,6 +96,21 @@ public sealed class MockEntryPointClient : IEntryPointClient
     /// venue — but the SDK reports failure to the caller).
     /// </summary>
     public Func<OrderCancelReplaceRequest, Exception?>? ReplaceFailureInjector { get; set; }
+
+    /// <summary>
+    /// #300 retrofit. Mirror of <see cref="CancelDelayInjector"/> for
+    /// the cancel-replace path: when non-null, the gateway awaits the
+    /// supplied <see cref="Task"/> AFTER enqueueing the request and
+    /// AFTER the failure-injector check, BEFORE returning to the
+    /// caller. Used by the Pegged fill-races-replace regression test
+    /// to deterministically gate the engine's
+    /// <c>CancelReplaceAsync</c> await: the test injects a Fill ER on
+    /// the OLD child while the replace is held, then releases the
+    /// gate and asserts the post-condition (no orphan replacement
+    /// child, audit pair balanced, replacement intent + margin
+    /// reservation released). Left null in production composition.
+    /// </summary>
+    public Func<OrderCancelReplaceRequest, Task>? ReplaceDelayInjector { get; set; }
 
     /// <summary>
     /// Test/host hook to push an ER through the exchange-side event.

--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -575,12 +575,20 @@ public class AlgoModifyEndpointTests
             r => r.OriginalClOrdId == child.ClOrdId);
 
         // Margin-reason rejection observed; no child-modify success
-        // counter bump (which would have implied an
-        // AlgoChildModifiedEvent emit).
+        // counter bump for THIS child (proven by the mock gateway
+        // assertions above — no SubmittedReplaces for child.ClOrdId).
+        //
+        // #300 (PR #334): we used to also assert the global
+        // trading.algo.child_modifies_total counter stayed at 0, but
+        // engine-driven Pegged repegs in PARALLEL test classes now
+        // also bump that counter (cross-test pollution via the static
+        // MetricsRegistry). The mock-gateway assertion above is the
+        // authoritative per-test signal for "no successful modify
+        // happened for this child".
         listener.RecordObservableInstruments();
         Assert.True(Interlocked.Read(ref rejectedByMargin) >= 1,
             "expected algo.modify_rejected_total{reason=margin_rejected} to bump at least once");
-        Assert.Equal(0, Interlocked.Read(ref childModifies));
+        _ = childModifies; // unused under #300; see comment above
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Api.Tests/CvmReportEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/CvmReportEndpointTests.cs
@@ -96,9 +96,44 @@ public class CvmReportEndpointTests : IDisposable
             LastQty = 10L,
             LastPx = 30.0m,
         });
+
+        // /admin/simulator/er returns 202 once the ER is enqueued on the
+        // mock gateway channel; the ExecutionReportProcessor drains the
+        // channel on a background task. Without an explicit wait the
+        // CVM report query can race past the in-flight Fill, see zero
+        // rows, and return 404. Poll /executions/history (user scope)
+        // until the fill is observable. Bounded at ~3s wall clock;
+        // empirically completes in <20ms locally.
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, "/executions/history?limit=10");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+            using var resp = await userHttp.SendAsync(req);
+            if (resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+                if (body.TryGetProperty("items", out var items) && items.GetArrayLength() > 0)
+                    return;
+            }
+            await Task.Delay(20);
+        }
+        throw new Xunit.Sdk.XunitException("SeedOneFillAsync timed out waiting for fill to be visible in /executions/history.");
     }
 
-    private static DateOnly TodayUtc() => DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime);
+    private static DateOnly TodayUtc()
+    {
+        // CvmReportSource buckets fills by São Paulo business day
+        // (UTC-3). When the test runs late UTC evening (e.g. ~00:00
+        // UTC == ~21:00 SP), a fill landing "today" UTC is
+        // bucketed to "yesterday" SP. Compute the date the source
+        // will use so the query and the fill agree.
+        TimeZoneInfo tz;
+        try { tz = TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo"); }
+        catch { tz = TimeZoneInfo.CreateCustomTimeZone("BRT", TimeSpan.FromHours(-3), "BRT", "BRT"); }
+        var nowSp = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz);
+        return DateOnly.FromDateTime(nowSp.DateTime);
+    }
 
     [Fact]
     public async Task UserRole_IsForbidden_ByPolicy()

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -169,18 +169,23 @@ public class PeggedAlgoEndpointTests
         // delta (= 2 ticks at 0.5) is comfortably over the threshold.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
 
-        // Engine must enqueue exactly one cancel for the live child.
+        // #300 retrofit. Engine must enqueue exactly one cancel-replace
+        // for the live child (preserving venue time-priority) — not a
+        // bare cancel + new-order.
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
             TimeSpan.FromSeconds(3),
-            "engine never cancelled the live child after mid moved");
+            "engine never issued CancelReplace for the live child after mid moved");
+        Assert.Empty(mock.SubmittedCancels);
 
-        // Mirror what the venue would do — emit the Cancelled ER for
-        // the old child. The engine's RepegPending flag routes this
-        // through SubmitNextSliceAsync (rather than VenueCancelled
-        // suspension) — assertable via the new child appearing at the
-        // fresh target price.
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        // Mirror what the venue would do — emit the Replaced ER for
+        // the cancel-replace request. The processor hydrates the new
+        // child into the book at the fresh target price.
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
 
         var newChild = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
         Assert.Equal(31.0m, newChild.Price);
@@ -216,6 +221,7 @@ public class PeggedAlgoEndpointTests
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
         Assert.Empty(mock.SubmittedCancels);
+        Assert.Empty(mock.SubmittedReplaces);
     }
 
     [Fact]
@@ -244,23 +250,29 @@ public class PeggedAlgoEndpointTests
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
 
-        // First move clamps to the limit (30.5) — one repeg.
+        // First move clamps to the limit (30.5) — one repeg via
+        // cancel-replace (#300 retrofit).
         cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Count == 1,
+        await WaitFor(() => mock.SubmittedReplaces.Count == 1,
             TimeSpan.FromSeconds(3), "engine did not repeg to the price limit");
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        var replace1 = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace1.NewClOrdId,
+            origClOrdId: replace1.OriginalClOrdId,
+            leavesQuantity: replace1.NewQuantity);
         var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
         Assert.Equal(30.5m, child2.Price);
 
         // Subsequent further-aggressive moves stay clamped at 30.5,
         // identical to child2.Price → IsRepegNeeded false → engine
-        // must not enqueue another cancel.
+        // must not enqueue another replace.
         for (int i = 0; i < 6; i++)
         {
             cache.UpdateBookTop("PETR4", 32.5m + i, 33.5m + i, DateTimeOffset.UtcNow);
             await Task.Delay(50);
         }
-        Assert.Single(mock.SubmittedCancels);
+        Assert.Single(mock.SubmittedReplaces);
+        Assert.Empty(mock.SubmittedCancels);
     }
 
     // ───────────────────── Cancel-mid-flight ─────────────────────
@@ -455,11 +467,12 @@ public class PeggedAlgoEndpointTests
     [Fact]
     public async Task Pegged_RepegCancelAck_DoesNotSuspendParent()
     {
-        // Pass-1 review (#296) P1-A. Repeg cancel-ack lands → engine
-        // submits replacement. A duplicate / late Cancelled ER for
-        // the SAME old child must NOT be routed through the
-        // VenueCancelled branch (which would suspend the parent and
-        // orphan the live replacement child).
+        // #300 retrofit. Repeg replace lands → engine adopts new
+        // child via the Replaced ER. A defensive duplicate / late
+        // Cancelled ER for the SAME old child must still be a no-op
+        // (the cancelled-child dedup ring keeps it from routing
+        // through the VenueCancelled branch). The replacement child
+        // stays live and the parent stays Working.
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -473,19 +486,24 @@ public class PeggedAlgoEndpointTests
         var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
         Assert.Equal(30.0m, child1.Price);
 
-        // Drift the mid → engine cancels child1.
+        // Drift the mid → engine issues cancel-replace targeting child1.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine never cancelled child1 after mid moved");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine never issued CancelReplace for child1 after mid moved");
 
-        // First Cancelled ER → engine routes through SubmitNextSlice.
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        // Replaced ER → adoption path drives Resolved + new child.
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
         var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
         Assert.Equal(31.0m, child2.Price);
 
-        // Duplicate / late Cancelled ER for the SAME old child must
-        // be a no-op — parent stays Working, no terminal published.
+        // Spurious / late Cancelled ER for the OLD child must be a
+        // no-op (dedup-ring hit) — parent stays Working, no terminal
+        // published.
         await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
         await Task.Delay(150);
 
@@ -521,35 +539,38 @@ public class PeggedAlgoEndpointTests
         var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
         Assert.Equal(30.0m, child1.Price);
 
-        // First mid move → first cancel (do NOT inject the ER yet).
+        // First mid move → first cancel-replace (do NOT inject the
+        // Replaced ER yet).
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit the first cancel");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the first cancel-replace");
 
         // Burst of further mid moves spanning well past RepegInterval.
-        // With the P1-B fix (RepegPending short-circuit) the engine
-        // must NOT enqueue another cancel for child1 while the ack
-        // is still outstanding. Keep the cumulative delta small so
-        // the eventual replacement child stays inside risk price
-        // bands (we're not exercising risk here).
+        // The RepegPending short-circuit must NOT enqueue another
+        // cancel-replace for child1 while the ack is outstanding.
         for (int i = 0; i < 4; i++)
         {
             cache.UpdateBookTop("PETR4", 30.5m + i * 0.1m, 31.5m + i * 0.1m,
                 DateTimeOffset.UtcNow);
             await Task.Delay(60);
         }
-        Assert.Single(mock.SubmittedCancels);
+        Assert.Single(mock.SubmittedReplaces);
+        Assert.Empty(mock.SubmittedCancels);
 
-        // Now release the cycle: the cancel-ack lands and the engine
-        // submits exactly one replacement child.
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        // Now release the cycle: the Replaced ER lands and the
+        // engine adopts the replacement child.
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
         var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId, TimeSpan.FromSeconds(3));
         Assert.NotNull(child2);
 
-        // The parent must remain Working — a duplicate / late ER for
-        // child1 must not flip it Suspended (the P1-A marker keeps
-        // the classification correct even after the cycle resolved).
+        // The parent must remain Working — a spurious / late Cancelled
+        // ER for child1 must not flip it Suspended (the dedup-ring
+        // marker keeps the classification correct even post-resolve).
         var snapBefore = await GetAlgo(http, token, algoId);
         var statusBefore = snapBefore.GetProperty("status").GetString();
         await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
@@ -563,12 +584,14 @@ public class PeggedAlgoEndpointTests
     [Fact]
     public async Task Pegged_RecoveryPreservesRepegIntent()
     {
-        // Pass-1 review (#296) P1-C. Engine emits the repeg cancel
-        // but crashes before the venue Cancelled ER lands. After
-        // snapshot+restart the cancel-ack ER must be classified as
-        // expected (matching the persisted pending marker) and route
-        // through SubmitNextSliceAsync — NOT into the VenueCancelled
-        // suspension branch.
+        // #300 retrofit. Engine emits the repeg cancel-replace but
+        // crashes before the venue Replaced ER lands. After
+        // snapshot+restart the OrderReplaceRequestedEvent replay
+        // re-hydrates the PendingReplacementRegistry intent and the
+        // AlgoPeggedRepegStartedEvent replay re-hydrates the
+        // PeggedRepegBook entry, so the Replaced ER that finally
+        // lands is adopted via the engine's normal adoption block
+        // (NOT the VenueCancelled-suspension branch).
         var dataDir = Path.Combine(Environment.CurrentDirectory, "test-data",
             "b3-pegged-repeg-recovery-" + Guid.NewGuid().ToString("N"));
         try
@@ -576,6 +599,8 @@ public class PeggedAlgoEndpointTests
             var overrides = PersistenceOverrides(dataDir);
             ulong algoIdNum = 0;
             ulong child1ClOrdId = 0;
+            ulong replaceNewClOrdId = 0;
+            long replaceNewQty = 0;
 
             using (var f = TestAppFactory.WithOverrides(overrides))
             using (var http = f.CreateClient())
@@ -594,44 +619,42 @@ public class PeggedAlgoEndpointTests
                 child1ClOrdId = child1.ClOrdId;
                 Assert.Equal(30.0m, child1.Price);
 
-                // Drift the mid → engine cancels child1. DO NOT
-                // inject the Cancelled ER — we want the cancel to
-                // be in-flight at snapshot time.
+                // Drift the mid → engine emits cancel-replace. DO NOT
+                // inject the Replaced ER — replace is in flight at
+                // snapshot time.
                 cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
                 var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
-                    TimeSpan.FromSeconds(3), "engine did not emit the cancel before snapshot");
+                await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel-replace before snapshot");
 
-                // Capture the snapshot with the cancel still pending.
+                var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1ClOrdId);
+                replaceNewClOrdId = replace.NewClOrdId;
+                replaceNewQty = replace.NewQuantity;
+
+                // Capture the snapshot with the replace still pending.
                 ResolveSnapshotService(f).TryTakeSnapshot();
             }
 
-            // Cold restart — engine reconciles, sees the pending
-            // repeg entry, sets RepegPending=true +
-            // LastRepegCancelledChildId so the post-restart ER is
-            // expected.
+            // Cold restart — registry + repeg book + working child
+            // are rehydrated from snapshot/WAL replay.
             using (var f2 = TestAppFactory.WithOverrides(overrides))
             using (var http2 = f2.CreateClient())
             {
                 var token = await f2.LoginAsync(http2);
                 var adminToken = await f2.LoginAsync(http2, "admin");
 
-                // Re-seed the cache so SubmitNextSlice can resolve a
-                // target for the replacement (cache is in-memory
-                // only and does not survive restart).
-                var cache2 = f2.Services.GetRequiredService<PegBookTopCache>();
-                cache2.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-
-                // Inject the cancel-ack the engine was waiting for.
-                await InjectEr(http2, adminToken, child1ClOrdId, "Canceled");
+                // Inject the Replaced ER the engine was waiting for.
+                await InjectReplacedEr(http2, adminToken,
+                    newClOrdId: replaceNewClOrdId,
+                    origClOrdId: child1ClOrdId,
+                    leavesQuantity: replaceNewQty);
 
                 // Replacement child must appear and parent must NOT
-                // be Suspended (which is what the pre-fix code would
-                // have done via the VenueCancelled branch).
+                // be Suspended.
                 var book2 = f2.Services.GetRequiredService<WorkingOrderBook>();
                 var child2 = await WaitForChildOtherThan(book2, algoIdNum.ToString(), child1ClOrdId,
                     TimeSpan.FromSeconds(5));
-                Assert.Equal(31.0m, child2.Price);
+                Assert.Equal(replaceNewClOrdId, child2.ClOrdId);
 
                 var snap = await GetAlgo(http2, token, algoIdNum.ToString());
                 Assert.Equal("Working", snap.GetProperty("status").GetString());
@@ -672,6 +695,8 @@ public class PeggedAlgoEndpointTests
             var overrides = PersistenceOverrides(dataDir);
             ulong algoIdNum = 0;
             ulong child1ClOrdId = 0;
+            ulong replaceNewClOrdId = 0;
+            long replaceNewQty = 0;
 
             using (var f = TestAppFactory.WithOverrides(overrides))
             using (var http = f.CreateClient())
@@ -695,16 +720,21 @@ public class PeggedAlgoEndpointTests
                 // intent is therefore only recoverable via WAL tail.
                 ResolveSnapshotService(f).TryTakeSnapshot();
 
-                // Now drift the mid → engine cancels child1 + persists
-                // AlgoPeggedRepegStartedEvent (post-snapshot WAL tail).
+                // Now drift the mid → engine emits cancel-replace +
+                // OrderReplaceRequestedEvent + AlgoPeggedRepegStartedEvent
+                // (all post-snapshot WAL tail).
                 cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
                 var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
-                    TimeSpan.FromSeconds(3), "engine did not emit the cancel after the drift");
+                await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel-replace after the drift");
 
-                // Do NOT inject the Cancelled ER, do NOT take another
-                // snapshot — the Started event must survive on the WAL
-                // tail alone.
+                var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1ClOrdId);
+                replaceNewClOrdId = replace.NewClOrdId;
+                replaceNewQty = replace.NewQuantity;
+
+                // Do NOT inject the Replaced ER, do NOT take another
+                // snapshot — both Started and ReplaceRequested events
+                // must survive on the WAL tail alone.
             }
 
             using (var f2 = TestAppFactory.WithOverrides(overrides))
@@ -717,23 +747,21 @@ public class PeggedAlgoEndpointTests
                 // the WAL replay (not the snapshot). Sanity-check the
                 // book directly so a regression that drops the replay
                 // handler fails loudly here, not through the more
-                // indirect "parent gets suspended" path below.
+                // indirect adoption path below.
                 var repegBook = f2.Services.GetRequiredService<PeggedRepegBook>();
                 var pending = repegBook.TryGet("default", algoIdNum);
                 Assert.NotNull(pending);
                 Assert.Equal(child1ClOrdId, pending!.Value.CancelledChildClOrdId);
 
-                // Re-seed cache so SubmitNextSlice can price the
-                // replacement (cache is volatile across restart).
-                var cache2 = f2.Services.GetRequiredService<PegBookTopCache>();
-                cache2.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-
-                await InjectEr(http2, adminToken, child1ClOrdId, "Canceled");
+                await InjectReplacedEr(http2, adminToken,
+                    newClOrdId: replaceNewClOrdId,
+                    origClOrdId: child1ClOrdId,
+                    leavesQuantity: replaceNewQty);
 
                 var book2 = f2.Services.GetRequiredService<WorkingOrderBook>();
                 var child2 = await WaitForChildOtherThan(book2, algoIdNum.ToString(), child1ClOrdId,
                     TimeSpan.FromSeconds(5));
-                Assert.Equal(31.0m, child2.Price);
+                Assert.Equal(replaceNewClOrdId, child2.ClOrdId);
 
                 var snap = await GetAlgo(http2, token, algoIdNum.ToString());
                 Assert.Equal("Working", snap.GetProperty("status").GetString());
@@ -749,37 +777,40 @@ public class PeggedAlgoEndpointTests
     // ──────────────── Pass-3 review (#296) regression tests ────────────────
 
     [Fact]
-    public async Task Pegged_RepegCancelFails_DoesNotPersistOrphanStartedAndRetriesNextTick()
+    public async Task Pegged_RepegReplaceSendAmbiguous_RetainsIntent_NoOrphanStarted()
     {
-        // Pass-3 review (#296) P1 — approach B. Simulate the gateway
-        // CancelAsync wire-call failing (venue unreachable / transient
-        // I/O fault). The repeg must:
+        // #300 retrofit. Simulate the gateway CancelReplaceAsync wire-
+        // call failing (venue unreachable / transient I/O fault). The
+        // send is AMBIGUOUS: the venue may have already accepted the
+        // replace and the Replaced ER may still land later. Therefore
+        // the engine must:
         //
-        //   1. NOT leave a poison AlgoPeggedRepegStartedEvent in the
-        //      WAL nor a PeggedRepegBook entry — both would otherwise
-        //      stall the algo on a post-restart Reconcile (book
-        //      entry + still-live child => RepegPending=true with no
-        //      ack ever coming).
-        //   2. Clear the in-memory RepegPending marker so the next
-        //      scheduler tick can re-attempt the repeg cycle.
-        //   3. Actually re-attempt and succeed once the injected
-        //      fault is removed.
+        //   1. NOT persist an AlgoPeggedRepegStartedEvent (no Started
+        //      ⇒ no orphan WAL Started without a matching Resolved).
+        //   2. NOT populate PeggedRepegBook (same reason — Reconcile
+        //      would otherwise stall the algo on restart).
+        //   3. KEEP the PendingReplacementRegistry intent in place
+        //      (and held margin) so a late Replaced ER can still
+        //      converge to the new child. AlgoScheduler.SweepAmbiguousReplaceIntents
+        //      bounds the leak via TTL.
+        //   4. Bump <c>algo.modify_send_ambiguous_total</c> for ops
+        //      visibility (tagged algoType=pegged).
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
-        var adminToken = await f.LoginAsync(http, "admin");
 
         var cache = f.Services.GetRequiredService<PegBookTopCache>();
         cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-        // First cancel attempt fails; subsequent ones succeed.
+        // First replace attempt fails; subsequent ones (none expected
+        // under the new semantics) would succeed.
         var failedCount = 0;
-        mock.CancelFailureInjector = _ =>
+        mock.ReplaceFailureInjector = _ =>
         {
             if (Interlocked.Increment(ref failedCount) == 1)
             {
-                return new InvalidOperationException("simulated gateway cancel failure");
+                return new InvalidOperationException("simulated gateway replace failure");
             }
             return null;
         };
@@ -789,42 +820,35 @@ public class PeggedAlgoEndpointTests
         var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
         Assert.Equal(30.0m, child1.Price);
 
-        // Drift the mid → engine tries to cancel child1 and the
-        // gateway rejects. With approach B, no Started event was
-        // persisted, so there is nothing in the WAL to replay.
+        // Drift the mid → engine tries cancel-replace; gateway throws
+        // (ambiguous send).
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
         await WaitFor(() => failedCount >= 1,
-            TimeSpan.FromSeconds(3), "engine did not attempt the first cancel");
+            TimeSpan.FromSeconds(3), "engine did not attempt the first cancel-replace");
 
-        // The PeggedRepegBook MUST be empty for this algo — the
-        // failed cancel path under approach B never persists a
-        // Started event nor populates the book.
+        // The PeggedRepegBook MUST be empty for this algo — Started
+        // event was deliberately not dispatched on the false return.
         var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
         Assert.Null(repegBook.TryGet("default", ulong.Parse(algoId)));
 
-        // The parent must remain Working — the failure rolled back
-        // the in-memory marker, no Suspended transition occurred.
-        var snapAfterFailure = await GetAlgo(http, token, algoId);
-        Assert.Equal("Working", snapAfterFailure.GetProperty("status").GetString());
+        // The intent IS retained in the registry (ambiguous send) so
+        // a late Replaced ER can still converge. Verify via the
+        // in-flight check on the OLD child id.
+        var registry = f.Services.GetRequiredService<PendingReplacementRegistry>();
+        Assert.True(registry.IsOriginalInFlight(child1.ClOrdId),
+            "ambiguous-send must retain the replace intent indexed by original ClOrdID");
 
-        // The next scheduler tick must re-attempt the repeg cycle
-        // (in-memory state was cleared cleanly). Drive it forward
-        // until a second cancel goes out — this time the injector
-        // returns null and the cancel succeeds.
-        await WaitFor(() => mock.SubmittedCancels.Count >= 2,
-            TimeSpan.FromSeconds(5),
-            "engine did not retry the cancel after the simulated failure");
+        // Parent stays Working — no Suspended transition.
+        var snapAfter = await GetAlgo(http, token, algoId);
+        Assert.Equal("Working", snapAfter.GetProperty("status").GetString());
 
-        // Releasing the cancel-ack drives the replacement child —
-        // proves the algo is not stalled.
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
-        var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
-            TimeSpan.FromSeconds(5));
-        Assert.Equal(31.0m, child2.Price);
-
-        var snap = await GetAlgo(http, token, algoId);
-        Assert.Equal("Working", snap.GetProperty("status").GetString());
-        Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
+        // The next scheduler tick must NOT spawn a second replace —
+        // IsOriginalInFlight short-circuits TryReplaceChildAsync to
+        // false with reason="already_in_flight" until the intent is
+        // resolved or swept.
+        await Task.Delay(400);
+        Assert.Single(mock.SubmittedReplaces);
+        Assert.Empty(mock.SubmittedCancels);
     }
 
     [Fact]
@@ -880,14 +904,18 @@ public class PeggedAlgoEndpointTests
 
                 cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
                 var mock = f.Services.GetRequiredService<MockEntryPointClient>();
-                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
-                    TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+                await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit the cancel-replace");
 
                 // Drain the cycle normally so child1 goes terminal +
                 // child2 becomes the live working slice. After this
                 // point the engine's Reconcile path is the only thing
                 // the orphan entry will encounter on restart.
-                await InjectEr(http, adminToken, child1ClOrdId, "Canceled");
+                var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1ClOrdId);
+                await InjectReplacedEr(http, adminToken,
+                    newClOrdId: replace.NewClOrdId,
+                    origClOrdId: replace.OriginalClOrdId,
+                    leavesQuantity: replace.NewQuantity);
                 _ = await WaitForChildOtherThan(book, algoIdStr, child1ClOrdId,
                     TimeSpan.FromSeconds(5));
 
@@ -927,36 +955,29 @@ public class PeggedAlgoEndpointTests
     // ──────────────── Pass-4 review (#296) regression tests ────────────────
 
     [Fact]
-    public async Task Pegged_FillRacesRepegCancel_DelayInjectedFill_NoReplacementChildAndAuditPairBalanced()
+    public async Task Pegged_FillRacesRepegReplace_DelayInjectedFill_NoOrphanReplacementChildAndIntentReleased()
     {
-        // Pass-4 review (#296) P1, Window 3 (the only race actually
-        // reachable under the single-consumer signal queue — see Pass-5
-        // P2 note further down).
+        // #300 retrofit. Window-3 race for the cancel-replace path:
+        // the engine's CancelReplaceAsync wire-call is held by the
+        // ReplaceDelayInjector, a Fill ER for the OLD child is
+        // injected while the replace is in flight, the gate is
+        // released, and we verify:
         //
-        // Pass-5 review (#296) P2. Deterministic gating via the new
-        // MockEntryPointClient.CancelDelayInjector: the engine's
-        // CancelAsync await is held by the test, the Fill ER is
-        // injected while the cancel is in-flight, then the cancel is
-        // released. The engine then drains the resulting
-        // ChildExecutionObservedSignal AFTER the Started event has been
-        // dispatched (single-consumer reactor) — so this exercises the
-        // post-Started recovery path:
-        //
-        //   * Filled-case Pegged dedup at OnChildErAsync (the
-        //     IsCancelledChild guard) → ResolveRepegOnFillAsync runs
-        //     instead of the normal Fill-then-resubmit path.
+        //   * Parent transitions to Completed (Fill consumed total).
         //   * ResolveRepegOnFillAsync emits
-        //     AlgoPeggedRepegResolvedEvent{Aborted=false,
-        //     Reason="FilledBeforeCancelAck"} so the audit pair is
-        //     balanced and the PeggedRepegBook entry is cleared by
-        //     replay convergence.
+        //     AlgoPeggedRepegResolvedEvent so the audit pair is
+        //     balanced and the PeggedRepegBook entry is cleared.
+        //   * ResolveRepegOnFillAsync's TryConsumeByOriginal release
+        //     also drops the in-flight PendingReplacementRegistry
+        //     intent + any held margin reservation. A late Replaced
+        //     ER would therefore be silently dropped (no orphan
+        //     replacement child in the book).
         //
-        // **Guard pinned**: removing the IsCancelledChild check in the
-        // Filled case (AlgoEngine line ~666) causes the Fill ER to
-        // fall through to SubmitNextSliceAsync — a SECOND child gets
-        // submitted (orphan replacement) and Assert.Single(allChildren)
-        // below fails. Verified by mental simulation against the
-        // current control flow.
+        // **Guard pinned**: removing the IsCancelledChild check in
+        // the Filled case (AlgoEngine OnChildErAsync) causes the
+        // Fill ER to fall through to SubmitNextSliceAsync — a SECOND
+        // child would get submitted and Assert.Single(allChildren)
+        // below fails.
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -972,94 +993,76 @@ public class PeggedAlgoEndpointTests
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
         var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+        var registry = f.Services.GetRequiredService<PendingReplacementRegistry>();
 
-        // Hold the engine's CancelAsync await via a TCS so we have a
-        // deterministic window to race the Fill ER against.
-        var cancelGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        mock.CancelDelayInjector = _ => cancelGate.Task;
+        // Hold the engine's CancelReplaceAsync await via a TCS so we
+        // have a deterministic window to race the Fill ER against.
+        var replaceGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        mock.ReplaceDelayInjector = _ => replaceGate.Task;
 
-        // Drift the mid → engine cancels child1; CancelAsync now parks
-        // on the gate.
+        // Drift the mid → engine issues cancel-replace; the wire-
+        // call now parks on the gate.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not invoke CancelAsync after the mid drift");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not invoke CancelReplaceAsync after the mid drift");
 
-        // While CancelAsync is held, inject the racing Fill ER. The
-        // ExecutionReportProcessor runs synchronously on the caller
-        // thread → order goes Filled / qty booked → child_er signal
-        // enqueued. The signal sits in the channel because the engine
-        // consumer is parked on CancelAsync.
+        // While the replace is held, inject the racing Fill ER for
+        // the OLD child. The ExecutionReportProcessor runs
+        // synchronously on the caller thread; the ChildExecutionObservedSignal
+        // sits in the channel because the engine consumer is parked
+        // on CancelReplaceAsync.
         await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
 
-        // Release CancelAsync → engine resumes, persists Started
-        // (in-memory rt.RepegPending is still true because the queued
-        // ER hasn't been dispatched yet), then dequeues the Fill ER on
-        // the next loop iteration and routes through the
-        // IsCancelledChild dedup → ResolveRepegOnFillAsync.
-        cancelGate.SetResult();
+        // Release CancelReplaceAsync → engine resumes, persists
+        // Started (in-memory rt.RepegPending is still true), then
+        // dequeues the Fill ER on the next loop iteration and routes
+        // through the IsCancelledChild dedup → ResolveRepegOnFillAsync
+        // which also consumes the in-flight replace intent.
+        replaceGate.SetResult();
 
-        // Parent transitions to Completed (Fill consumed total qty).
         await WaitForAlgoStatus(http, token, algoId, "Completed");
         var snap = await GetAlgo(http, token, algoId);
         Assert.Equal(100, snap.GetProperty("filledQuantity").GetInt64());
         Assert.Equal("None", snap.GetProperty("terminalReason").GetString());
 
-        // AlgoPeggedRepegResolvedEvent dispatched → book cleared. (The
-        // RecordTerminalAsync.RemoveAll also clears it as a safety
-        // net; this WaitFor doesn't distinguish.)
+        // AlgoPeggedRepegResolvedEvent dispatched → book cleared.
         await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is null,
             TimeSpan.FromSeconds(3),
             "PeggedRepegBook still has an entry after the fill race resolved");
 
-        // Exactly one cancel, no replacement child spawned from the
-        // Fill handler.
-        Assert.Single(mock.SubmittedCancels);
+        // ResolveRepegOnFillAsync's TryConsumeByOriginal must have
+        // released the in-flight intent — IsOriginalInFlight false.
+        Assert.False(registry.IsOriginalInFlight(child1.ClOrdId),
+            "in-flight replace intent for the OLD child must be released after fill-race resolution");
+
+        // Exactly one cancel-replace, no replacement child spawned
+        // from the Fill handler.
+        Assert.Single(mock.SubmittedReplaces);
+        Assert.Empty(mock.SubmittedCancels);
         var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
         Assert.Single(allChildren);
         Assert.Equal(child1.ClOrdId, allChildren[0].ClOrdId);
     }
 
     [Fact]
-    public async Task Pegged_FillRacesRepegCancel_DocumentsWindows1and2DefensiveGuard()
+    public async Task Pegged_FillRacesRepegReplace_DocumentsObservableInvariant()
     {
-        // Pass-4 review (#296) P1, Windows 1 + 2 (defensive). Windows
-        // 1 (Fill processed before CancelAsync is invoked) and 2 (Fill
-        // processed after CancelAsync returns but before Started is
-        // persisted) are NOT naturally reachable in the current
-        // single-consumer reactor: the engine awaits CancelAsync
-        // inside its own consumer task, so a ChildExecutionObservedSignal
-        // racing the cancel can only be dequeued AFTER CancelAsync
-        // returns AND the post-cancel Started dispatch runs in the
-        // same iteration (which is always Window 3).
-        //
-        // Pass-5 review (#296) P2. We tried to construct the race
-        // with the new CancelDelayInjector — emit the Fill ER while
-        // the cancel is held, release the cancel — but the engine
-        // does not observe rt.RepegPending=false until its consumer
-        // loop runs OnChildErAsync, which happens AFTER the Started
-        // dispatch completes. The "if (!rt.RepegPending) return;"
-        // guard at the top of the post-cancel block (AlgoEngine line
-        // ~1524) is therefore defensive code that a future multi-
-        // consumer reactor (or an SDK that pumps ERs synchronously
-        // inside the cancel wire-call) would actually trigger.
+        // #300 retrofit + Pass-4 review (#296) P1 spirit. Windows
+        // 1 + 2 (Fill processed before/right after CancelReplaceAsync
+        // is invoked) are NOT naturally reachable in the current
+        // single-consumer reactor under cancel-replace either: the
+        // engine awaits CancelReplaceAsync inside its own consumer
+        // task, so a ChildExecutionObservedSignal racing the replace
+        // can only be dequeued AFTER CancelReplaceAsync returns AND
+        // the post-replace Started dispatch runs in the same
+        // iteration (which is always Window 3).
         //
         // This test pins the OBSERVABLE invariant that holds across
         // every window: regardless of which sub-window the race
         // resolves in, the engine ends with (a) the parent in a
-        // coherent terminal/working state, (b) no orphan replacement
-        // child, and (c) no lingering Started without a matching
-        // Resolved (a future replay must converge on the same in-
-        // memory state). Combined with the Window 3 test above this
-        // covers the full race surface to the granularity that's
-        // observable today.
-        //
-        // **Guard pinned**: the post-Cancelled `IsCancelledChild`
-        // dedup at AlgoEngine line ~788 — removing it would let a
-        // late Cancelled-status ER (the cancel-ack arriving after the
-        // fill resolved the cycle) fall through to the VenueCancelled
-        // branch and Suspend the parent. The cycle-resolved
-        // RepegPending=false assertion below catches that regression
-        // (Suspended ≠ Completed).
+        // coherent terminal state, (b) no orphan replacement child,
+        // (c) no lingering Started without a matching Resolved, and
+        // (d) no orphan PendingReplacementRegistry entry.
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -1074,15 +1077,14 @@ public class PeggedAlgoEndpointTests
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
         var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
+        var registry = f.Services.GetRequiredService<PendingReplacementRegistry>();
 
-        // Drift → engine cancels child1.
+        // Drift → engine issues cancel-replace for child1.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the cancel-replace");
 
-        // Race the Fill ER in immediately. Settled outcome is what we
-        // verify; the exact internal window the race resolves in is
-        // intentionally not pinned.
+        // Race the Fill ER in immediately.
         await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 100);
         await WaitForAlgoStatus(http, token, algoId, "Completed");
 
@@ -1090,30 +1092,26 @@ public class PeggedAlgoEndpointTests
             TimeSpan.FromSeconds(3),
             "PeggedRepegBook still has an entry after the fill race");
 
-        Assert.Single(mock.SubmittedCancels);
+        Assert.Single(mock.SubmittedReplaces);
+        Assert.Empty(mock.SubmittedCancels);
+        Assert.False(registry.IsOriginalInFlight(child1.ClOrdId),
+            "replace intent for OLD child must be released after fill-race resolution");
         var allChildren = book.EnumerateChildrenOf("default", ulong.Parse(algoId)).ToList();
         Assert.Single(allChildren);
     }
 
     [Fact]
-    public async Task Pegged_LateCancelAckAfterFillResolution_IsNoOpNotDoubleReplacement()
+    public async Task Pegged_LateCancelOnOldChildAfterFillResolution_IsNoOpViaDedupRing()
     {
-        // Pass-4 review (#296) P1, scenario 3. After the Fill-before-
-        // cancel-ack race resolves (Resolved dispatched, book cleared,
-        // RepegPending=false, parent Completed), a venue cancel-ack ER
-        // may still arrive for the same old child (the venue processed
-        // the cancel after the fill landed). That late Cancelled wire
-        // MUST be a no-op — NOT a second SubmitNextSliceAsync call
-        // (which would duplicate the replacement child and orphan a
-        // working order).
-        //
-        // Because Pegged places the full RemainingQuantity on each
-        // working slice, a full Fill of child1 also completes the
-        // parent in this test; the parent-terminal short-circuit at
-        // the top of OnChildErAsync's Filled case is what absorbs the
-        // late ER in that path. The non-terminal-parent case
-        // (subsequent-repeg dedup) is covered separately by
-        // Pegged_LateFillAfterSubsequentRepeg_DedupViaHistoryRing.
+        // #300 retrofit. After the Fill-before-replace-ack race
+        // resolves (Resolved dispatched, book cleared,
+        // RepegPending=false, parent Completed), a spurious venue
+        // Cancelled ER may still arrive for the same OLD child (rare
+        // FIX gateways emit both Cancelled and Replaced; or a pre-
+        // #300 WAL replay still emits Cancelled). That ER MUST be a
+        // no-op via the cancelled-child dedup ring — NOT a second
+        // SubmitNextSliceAsync call (which would duplicate the
+        // replacement child).
         using var f = TestAppFactory.WithOverrides(Simulator());
         using var http = f.CreateClient();
         var token = await f.LoginAsync(http);
@@ -1130,8 +1128,8 @@ public class PeggedAlgoEndpointTests
         var repegBook = f.Services.GetRequiredService<PeggedRepegBook>();
 
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit the cancel");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit the cancel-replace");
         await WaitFor(() => repegBook.TryGet("default", ulong.Parse(algoId)) is not null,
             TimeSpan.FromSeconds(3), "Started marker did not land in book");
 
@@ -1212,21 +1210,27 @@ public class PeggedAlgoEndpointTests
 
         var mock = f.Services.GetRequiredService<MockEntryPointClient>();
 
-        // Cycle A: drift → cancel child1, then ack so child2 lands.
+        // Cycle A: drift → cancel-replace child1, then inject the
+        // Replaced ER so child2 lands.
         cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit cancel A");
-        await InjectEr(http, adminToken, child1.ClOrdId, "Canceled");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit cancel-replace A");
+        var replaceA = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replaceA.NewClOrdId,
+            origClOrdId: replaceA.OriginalClOrdId,
+            leavesQuantity: replaceA.NewQuantity);
         var child2 = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
             TimeSpan.FromSeconds(3));
-        Assert.Equal(31.0m, child2.Price);
+        Assert.Equal(replaceA.NewClOrdId, child2.ClOrdId);
 
-        // Cycle B: drift → cancel child2. Do NOT ack — leaves
-        // RepegPending=true and the single-slot marker pointing at
-        // child2 (so child1 is no longer "the" sticky cancelled id).
+        // Cycle B: drift → cancel-replace child2. Do NOT ack —
+        // leaves RepegPending=true and the single-slot marker
+        // pointing at child2 (so child1 is no longer "the" sticky
+        // cancelled id).
         cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
-        await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child2.ClOrdId),
-            TimeSpan.FromSeconds(3), "engine did not emit cancel B");
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child2.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not emit cancel-replace B");
 
         var newOrdersBeforeLateEr = mock.SubmittedNewOrders.Count;
 
@@ -1309,23 +1313,28 @@ public class PeggedAlgoEndpointTests
 
                 var mock = f.Services.GetRequiredService<MockEntryPointClient>();
 
-                // Cycle A: cancel + ack → child2 placed. child1 ends
-                // up in the history ring; the PeggedRepegBook pending
-                // entry is cleared by the Resolved event.
+                // Cycle A: cancel-replace + ack → child2 placed.
+                // child1 ends up in the history ring; the
+                // PeggedRepegBook pending entry is cleared by the
+                // Resolved event.
                 cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
-                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child1ClOrdId),
-                    TimeSpan.FromSeconds(3), "engine did not emit cancel A pre-restart");
-                await InjectEr(http, adminToken, child1ClOrdId, "Canceled");
+                await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit cancel-replace A pre-restart");
+                var replaceA = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1ClOrdId);
+                await InjectReplacedEr(http, adminToken,
+                    newClOrdId: replaceA.NewClOrdId,
+                    origClOrdId: replaceA.OriginalClOrdId,
+                    leavesQuantity: replaceA.NewQuantity);
                 var child2 = await WaitForChildOtherThan(book, algoIdStr, child1ClOrdId,
                     TimeSpan.FromSeconds(3));
                 child2ClOrdId = child2.ClOrdId;
 
-                // Cycle B: cancel child2, no ack. The pending entry
-                // now references child2; child1 lives only in the
-                // history ring.
+                // Cycle B: cancel-replace child2, no ack. The
+                // pending entry now references child2; child1 lives
+                // only in the history ring.
                 cache.UpdateBookTop("PETR4", 31.5m, 32.5m, DateTimeOffset.UtcNow);
-                await WaitFor(() => mock.SubmittedCancels.Any(c => c.OrigClOrdId == child2ClOrdId),
-                    TimeSpan.FromSeconds(3), "engine did not emit cancel B pre-restart");
+                await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child2ClOrdId),
+                    TimeSpan.FromSeconds(3), "engine did not emit cancel-replace B pre-restart");
 
                 // Snapshot under the dispatcher lock — must capture
                 // both the pending entry (for child2) and the history
@@ -1379,6 +1388,134 @@ public class PeggedAlgoEndpointTests
         return posted.GetProperty("algoId").GetString()!;
     }
 
+    // ──────────────── #300 retrofit regression tests ────────────────
+
+    [Fact]
+    public async Task Pegged_RepegUsesReplaceNotCancel()
+    {
+        // #300 retrofit. Belt-and-suspenders: explicitly assert that
+        // the Pegged repeg cycle issues a cancel-replace (preserving
+        // venue time priority) and NOT a bare cancel followed by a
+        // brand-new order. The other migrated tests check this
+        // indirectly via SubmittedReplaces / Empty(SubmittedCancels);
+        // this one keeps a dedicated, unambiguous regression anchor.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var newOrdersBefore = mock.SubmittedNewOrders.Count;
+
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "engine never issued a CancelReplace for the live child");
+
+        // Drive the cycle to completion so we can definitively assert
+        // no NewOrderSingle was sent on the repeg path.
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        await InjectReplacedEr(http, adminToken,
+            newClOrdId: replace.NewClOrdId,
+            origClOrdId: replace.OriginalClOrdId,
+            leavesQuantity: replace.NewQuantity);
+        _ = await WaitForChildOtherThan(book, algoId, child1.ClOrdId,
+            TimeSpan.FromSeconds(3));
+
+        // No bare cancel was issued by the repeg path …
+        Assert.DoesNotContain(mock.SubmittedCancels, c => c.OrigClOrdId == child1.ClOrdId);
+        // … and no NewOrderSingle either (the replacement child
+        // hydrates from the Replaced ER, not from a fresh submit).
+        Assert.Equal(newOrdersBefore, mock.SubmittedNewOrders.Count);
+    }
+
+    [Fact]
+    public async Task Pegged_FillOnOldChildDuringRepegReplace_NoDoubleCount()
+    {
+        // #300 retrofit. Operator-side analog of
+        // <c>AlgoModifyEndpointTests.Modify_FillOnOldChildBeforeReplacedEr_NoDoubleCounting</c>:
+        // a Fill ER for the OLD child arrives while the cancel-
+        // replace is in flight; a late Replaced ER for the same
+        // cycle MUST be silently dropped (the intent was consumed
+        // by ResolveRepegOnFillAsync) so the parent's filled
+        // quantity does NOT include phantom qty from a hydrated
+        // replacement child.
+        using var f = TestAppFactory.WithOverrides(Simulator());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var cache = f.Services.GetRequiredService<PegBookTopCache>();
+        cache.UpdateBookTop("PETR4", 29.5m, 30.5m, DateTimeOffset.UtcNow);
+
+        // Pegged emits a single working slice that covers the full
+        // total, so to drive the OLD child to terminal Filled (which
+        // is what routes through ResolveRepegOnFillAsync) we must
+        // fill the full quantity. The parent will also reach
+        // Completed — the "no double-count" assertion is that
+        // FilledQuantity == TotalQuantity (exactly one fill credited)
+        // even though a late Replaced ER will arrive after settlement.
+        var algoId = await PostAlgo(http, token, PeggedBody(total: 200, repegMs: 100));
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var child1 = await WaitForAnyChild(book, algoId, TimeSpan.FromSeconds(3));
+
+        var mock = f.Services.GetRequiredService<MockEntryPointClient>();
+        var registry = f.Services.GetRequiredService<PendingReplacementRegistry>();
+
+        // Hold the replace so we can race the Fill ER deterministically.
+        var replaceGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        mock.ReplaceDelayInjector = _ => replaceGate.Task;
+
+        cache.UpdateBookTop("PETR4", 30.5m, 31.5m, DateTimeOffset.UtcNow);
+        await WaitFor(() => mock.SubmittedReplaces.Any(r => r.OriginalClOrdId == child1.ClOrdId),
+            TimeSpan.FromSeconds(3), "engine did not invoke CancelReplaceAsync");
+
+        // Inject the racing Fill on the OLD child while the replace
+        // is held. Fill the full child quantity to drive the OLD
+        // child to terminal Filled (Pegged child qty == TotalQuantity).
+        // Then release the gate and let the engine drain.
+        await InjectEr(http, adminToken, child1.ClOrdId, "Fill", lastQty: 200);
+        replaceGate.SetResult();
+
+        // Wait until ResolveRepegOnFillAsync has consumed the intent.
+        await WaitFor(() => !registry.IsOriginalInFlight(child1.ClOrdId),
+            TimeSpan.FromSeconds(3),
+            "in-flight replace intent for OLD child was not released after fill-race resolution");
+
+        // Now inject the late Replaced ER. The processor's
+        // PendingReplacementRegistry intercept misses (we already
+        // consumed it) — the ER becomes a phantom replacement that
+        // must be dropped without altering parent state.
+        var replace = mock.SubmittedReplaces.Single(r => r.OriginalClOrdId == child1.ClOrdId);
+        var lateReplacedReq = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = replace.NewClOrdId,
+                Type = "Replaced",
+                LastQty = replace.NewQuantity,
+                OrigClOrdId = replace.OriginalClOrdId,
+            }),
+        };
+        lateReplacedReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        // Late ER may be rejected with 404 (order already terminal /
+        // intent already consumed) or accepted-and-dropped depending
+        // on processor pathways; both outcomes are acceptable — what
+        // we care about is the FilledQuantity assertion below.
+        await http.SendAsync(lateReplacedReq);
+        await Task.Delay(200);
+
+        var snap = await GetAlgo(http, token, algoId);
+        Assert.Equal(200, snap.GetProperty("filledQuantity").GetInt64());
+    }
+
     private static async Task<HttpResponseMessage> InjectEr(
         HttpClient http, string adminToken, ulong childClOrdId,
         string type, long? lastQty = null, decimal lastPx = 30m)
@@ -1391,6 +1528,37 @@ public class PeggedAlgoEndpointTests
                 Type = type,
                 LastQty = lastQty,
                 LastPx = lastQty.HasValue ? lastPx : (decimal?)null,
+            }),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        return resp;
+    }
+
+    /// <summary>
+    /// #300 retrofit. Pegged repeg now uses cancel-replace. Mirror of
+    /// <c>AlgoModifyEndpointTests.InjectReplacedEr</c>: posts a
+    /// Replaced-type simulator ER for the replacement <paramref name="newClOrdId"/>
+    /// with <paramref name="origClOrdId"/> echoed so the processor
+    /// hydrates the new child into the WorkingOrderBook and re-emits
+    /// <c>ChildExecutionObservedSignal</c>. <paramref name="leavesQuantity"/>
+    /// is repurposed as the LastQty hint for the Replaced injector arm
+    /// (no fill on a replace ack).
+    /// </summary>
+    private static async Task<HttpResponseMessage> InjectReplacedEr(
+        HttpClient http, string adminToken, ulong newClOrdId, ulong origClOrdId, long leavesQuantity,
+        long? cumQty = null)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/admin/simulator/er")
+        {
+            Content = JsonContent.Create(new
+            {
+                ClOrdId = newClOrdId,
+                Type = "Replaced",
+                LastQty = leavesQuantity,
+                OrigClOrdId = origClOrdId,
+                CumQty = cumQty,
             }),
         };
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);


### PR DESCRIPTION
Closes #300.

## Summary

The Pegged repeg cycle previously cancelled the live child and submitted a fresh order at the new price under a synthetic `AlgoPeggedRepegStarted/Resolved` audit envelope. With the cancel-replace plumbing landed by #299 in place, repeg now goes through `TryReplaceChildAsync` and preserves venue book time-priority across the price change — operators no longer give up queue position every time mid drifts past the repeg tolerance.

## Design choice (approach b)

The adoption block at `OnChildErAsync` must discriminate operator-modify replacement children from engine-internal Pegged-repeg replacement children so the matching `Resolved` companion is emitted only for the repeg cycle. The discriminator is a `PeggedRepegBook.TryGet(...)?.CancelledChildClOrdId == oldLive` lookup. This is safe under the single-threaded algo consumer because the `AlgoPeggedRepegStartedEvent` apply callback populates `PeggedRepegBook` **synchronously** before any `ChildExecutionObservedSignal` for the new child can be dequeued.

## Engine changes (`AlgoEngine.cs`)

* **`EvaluatePeggedRepegAsync`**: swap `_gateway.CancelAsync` + `ownership.RegisterCancelLink` for `TryReplaceChildAsync(..., reason: "AlgoInternal")`. `RepegPending` + `LastRepegCancelledChildId` + `MarkCancelledChild` are still pre-set so a defensive Cancelled-on-OLD ER (rare/spurious) and any pre-#300 WAL-replay Cancelled ER both no-op through the `IsCancelledChild` branch. `PeggedRepegBook.Set` + the WAL Started marker still defer until after `TryReplaceChildAsync` returns `true` so an ambiguous-send failure does not leave a dangling Started without a Resolved.
* **Adoption block** (`~714`): discriminate Pegged-repeg from operator-modify and dispatch `AlgoPeggedRepegResolvedEvent` for the repeg case.
* **Cancelled-status branch** (`~939`): strict no-op when the cancelled child is in the dedup ring (cycle already retired by the Replaced ER).
* **`ResolveRepegOnFillAsync`**: when a Fill ER for the OLD child wins the race against the Replaced ER, consume the `PendingReplacementRegistry` intent via `TryConsumeByOriginal` and `AbortReplace` on any ambiguous-held margin. Without this, a late Replaced ER would hydrate a phantom replacement child after the parent had already settled the cycle.

## Observable equivalence

* Audit pair (`AlgoPeggedRepegStarted` / `Resolved`) is preserved — `NewClOrdId` is now `0UL` as a sentinel (helper does not surface it; replayer keys only on `CancelledChildClOrdId`).
* `algo.pegged_repeg_failed_total` semantics unchanged on rollback/ambiguous-send paths.
* `algo.child_modifies_total{algoType=pegged, reason=AlgoInternal}` now bumps per successful repeg, sharing the operator-modify metric for free.
* #329 `PeggedReplacedHoldTicks` watchdog (dropped-adoption recovery) is preserved verbatim.

## Test changes (`PeggedAlgoEndpointTests.cs`)

* Added `InjectReplacedEr` helper mirroring the operator-modify analog.
* Migrated 9 existing tests from `SubmittedCancels` + `InjectEr("Canceled")` → `SubmittedReplaces` + `InjectReplacedEr`.
* Renamed 4 tests with new semantics:
  - `RepegReplaceSendAmbiguous_RetainsIntent_NoOrphanStarted` (ambiguous-send now retains intent, blocks retry until TTL sweep).
  - `FillRacesRepegReplace_DelayInjected` / `_DocumentsObservableInvariant` (swap `CancelDelayInjector` → `ReplaceDelayInjector`).
  - `LateCancelOnOldChildAfterFillResolution` (defensive no-op semantics).
* Added 2 #300 regression tests:
  - `Pegged_RepegUsesReplaceNotCancel` — anchors that no bare cancel + new submit pair ever hits the gateway on a repeg.
  - `Pegged_FillOnOldChildDuringRepegReplace_NoDoubleCount` — fill-on-OLD wins the race; late Replaced ER must drop silently; FilledQuantity ends at exactly TotalQuantity.

## Support changes

* `PeggedRepegBook.MarkCancelledChild` XML doc extended for the dual purpose (defensive cancelled-ER ring + pre-#300 WAL-replay safety).
* `MockEntryPointClient.ReplaceDelayInjector` added as the cancel-replace analog of `CancelDelayInjector` for race tests.

## Validation

* `B3.Trading.Application.Tests`: 1035/1035 pass.
* `B3.Trading.Api.Tests`: 484/484 pass (serial). Parallel run shows the usual #332 flakes (independent of this PR).
* `B3.Trading.Domain.Tests`: 81/81 pass.
* `B3.Trading.EntryPointListener.Tests`: 134/134 pass.
* `dotnet format B3TradingPlatform.slnx`: clean.