### PR TITLE
feat(#126): structured per-firm credentials with file-mounted secret indirection

### DIFF
--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -97,13 +97,20 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     }
                     var resolvedVerId = SessionVerIdResolver.Resolve(firm.SessionVerId, persistedVerId);
 
+                    // #126. Materialise the access key via the central
+                    // resolver so file-mounted secrets + the legacy flat
+                    // AccessKey shape both flow through the same code
+                    // path (with file-mode enforcement on Linux).
+                    var accessKey = FirmCredentialResolver.ResolveAccessKey(
+                        firm, lf.CreateLogger($"FirmCredentialResolver[{firm.FirmId}]"));
+
                     var clientOpts = new B3.EntryPoint.Client.EntryPointClientOptions
                     {
                         Endpoint = ep,
                         SessionId = firm.SessionId,
                         SessionVerId = resolvedVerId,
                         EnteringFirm = firm.EnteringFirm,
-                        Credentials = B3.EntryPoint.Client.EntryPointClientOptions.AccessKey(firm.AccessKey),
+                        Credentials = B3.EntryPoint.Client.EntryPointClientOptions.AccessKey(accessKey),
                         KeepAliveIntervalMs = firm.KeepAliveIntervalMs,
                         SenderLocation = firm.SenderLocation,
                         EnteringTrader = firm.EnteringTrader,

--- a/backend/src/B3.Trading.Infrastructure/ExchangeOptions.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeOptions.cs
@@ -3,6 +3,56 @@ using B3.Trading.Application;
 namespace B3.Trading.Infrastructure;
 
 /// <summary>
+/// #126. Selects the credential shape used in <see cref="FirmCredentialsConfig"/>.
+/// Today the B3.EntryPoint.Client SDK (0.14.3) only exposes
+/// <c>Credentials.FromUtf8(accessKey)</c>; this enum exists so future SDK
+/// modes (certificate / token) can be added without re-shaping every
+/// firm config in the wild.
+/// </summary>
+public enum FirmCredentialsMode
+{
+    /// <summary>Opaque access key passed via <c>Negotiate.Credentials</c> (the only mode supported by SDK 0.14.3).</summary>
+    AccessKey,
+}
+
+/// <summary>
+/// #126. Per-firm credential bundle. Replaces the loose
+/// <see cref="FirmConfig.AccessKey"/> with a discriminated shape so secret
+/// material can be loaded from indirection (file mount) and so new SDK
+/// credential modes can be added without breaking deployments.
+/// <para>
+/// Exactly one secret source must be supplied for each mode:
+/// <list type="bullet">
+///   <item><see cref="AccessKey"/> — inline literal (back-compat / dev).</item>
+///   <item><see cref="AccessKeyFile"/> — path read at startup (preferred for prod;
+///         file must be 0600 / 0400 on Linux, see <see cref="FirmCredentialResolver"/>).</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class FirmCredentialsConfig
+{
+    /// <summary>Discriminator. Only <see cref="FirmCredentialsMode.AccessKey"/> is wired today.</summary>
+    public FirmCredentialsMode Mode { get; set; } = FirmCredentialsMode.AccessKey;
+
+    /// <summary>Inline access-key literal. Mutually exclusive with <see cref="AccessKeyFile"/>.</summary>
+    public string? AccessKey { get; set; }
+
+    /// <summary>Path to a file containing the access key (single line, trimmed). Mutually exclusive with <see cref="AccessKey"/>.</summary>
+    public string? AccessKeyFile { get; set; }
+
+    /// <summary>
+    /// Sanitized projection — credential material is never printed. Test
+    /// fixtures + the structured logger surface this shape so a config
+    /// dump never leaks secret bytes.
+    /// </summary>
+    public override string ToString() =>
+        $"FirmCredentialsConfig {{ Mode = {Mode}, AccessKey = {Redact(AccessKey)}, AccessKeyFile = {AccessKeyFile ?? "<null>"} }}";
+
+    private static string Redact(string? value) =>
+        string.IsNullOrEmpty(value) ? "<null>" : $"<redacted:{value!.Length}>";
+}
+
+/// <summary>
 /// Per-firm FIXP session configuration. One instance per firm represented
 /// on the platform (1 platform → N FIXP sessions, see issue #1 §1).
 ///
@@ -27,8 +77,21 @@ public sealed class FirmConfig
     /// <summary>Identifies the broker firm that will enter orders.</summary>
     public uint EnteringFirm { get; set; }
 
-    /// <summary>Opaque access key sent in <c>Negotiate.Credentials</c> via <c>Credentials.FromUtf8</c>.</summary>
+    /// <summary>
+    /// Legacy. Opaque access key sent in <c>Negotiate.Credentials</c> via
+    /// <c>Credentials.FromUtf8</c>. Kept for back-compat with existing
+    /// deployments; new configs should use <see cref="Credentials"/>. When
+    /// both are set, <see cref="Credentials"/> wins and the legacy value
+    /// is ignored after a startup WARN.
+    /// </summary>
     public string AccessKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// #126. Discriminated credential bundle. When set, wins over the
+    /// legacy <see cref="AccessKey"/> field and supports file-mounted
+    /// secret indirection (preferred for production).
+    /// </summary>
+    public FirmCredentialsConfig? Credentials { get; set; }
 
     /// <summary>FIX <c>SenderLocation</c> (max 10 chars). Per-firm default; not threaded per-order in v1.</summary>
     public string SenderLocation { get; set; } = string.Empty;

--- a/backend/src/B3.Trading.Infrastructure/ExchangeOptionsValidator.cs
+++ b/backend/src/B3.Trading.Infrastructure/ExchangeOptionsValidator.cs
@@ -82,8 +82,10 @@ public sealed class ExchangeOptionsValidator : IValidateOptions<ExchangeOptions>
             failures.Add($"{p}.Endpoint is required (host:port).");
         else if (!TryParseEndpointShape(f.Endpoint))
             failures.Add($"{p}.Endpoint='{f.Endpoint}' must be 'host:port' with a numeric port.");
-        if (string.IsNullOrEmpty(f.AccessKey))
-            failures.Add($"{p}.AccessKey is required.");
+        if (!HasAnyCredentialConfigured(f))
+            failures.Add($"{p}.AccessKey or {p}.Credentials is required.");
+        else
+            ValidateCredentials(p, f, failures);
         if (f.SessionId == 0)
             failures.Add($"{p}.SessionId must be > 0 (assigned by B3 per firm).");
         if (f.SessionVerId == 0)
@@ -110,5 +112,38 @@ public sealed class ExchangeOptionsValidator : IValidateOptions<ExchangeOptions>
             && !string.IsNullOrWhiteSpace(parts[0])
             && int.TryParse(parts[1], out var port)
             && port is > 0 and <= 65535;
+    }
+
+    private static bool HasAnyCredentialConfigured(FirmConfig f) =>
+        !string.IsNullOrEmpty(f.AccessKey) || f.Credentials is not null;
+
+    /// <summary>
+    /// #126. Per-mode shape check. The detailed file-mode enforcement
+    /// (Linux 0600 / 0400) lives in <see cref="FirmCredentialResolver"/>
+    /// because it requires a filesystem stat and we want options
+    /// validation to stay pure / cheap. Here we only validate the static
+    /// shape — exactly one secret source per mode, no spurious fields.
+    /// </summary>
+    private static void ValidateCredentials(string p, FirmConfig f, List<string> failures)
+    {
+        var creds = f.Credentials;
+        if (creds is null)
+            return;
+
+        switch (creds.Mode)
+        {
+            case FirmCredentialsMode.AccessKey:
+                var hasInline = !string.IsNullOrEmpty(creds.AccessKey);
+                var hasFile = !string.IsNullOrWhiteSpace(creds.AccessKeyFile);
+                if (hasInline && hasFile)
+                    failures.Add($"{p}.Credentials sets both AccessKey and AccessKeyFile; exactly one is required for Mode=AccessKey.");
+                else if (!hasInline && !hasFile)
+                    failures.Add($"{p}.Credentials.Mode=AccessKey requires either AccessKey or AccessKeyFile to be set.");
+                break;
+
+            default:
+                failures.Add($"{p}.Credentials.Mode={creds.Mode} is not supported by the wired B3.EntryPoint.Client SDK.");
+                break;
+        }
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/FirmCredentialResolver.cs
+++ b/backend/src/B3.Trading.Infrastructure/FirmCredentialResolver.cs
@@ -1,0 +1,157 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Infrastructure;
+
+/// <summary>
+/// #126. Materialises the effective access-key bytes for a single firm,
+/// honouring the legacy plain <see cref="FirmConfig.AccessKey"/> shape AND
+/// the new <see cref="FirmCredentialsConfig"/> with file-mounted secret
+/// indirection.
+///
+/// <para>
+/// File mode is enforced on Linux: the secret file must be owned by the
+/// current user and have permissions <c>0600</c> or <c>0400</c>. World-
+/// or group-readable files are rejected so a misconfigured volume mount
+/// fails fast instead of leaking credentials. On non-Linux platforms
+/// (Windows test runners, mac dev loops) the permission check is skipped
+/// — those environments rely on filesystem ACLs the SDK can't introspect
+/// portably; we log a one-line note instead.
+/// </para>
+///
+/// <para>
+/// Pass-1 design (#126): callers receive a single <see cref="string"/>;
+/// the SDK already copies the bytes into <c>Credentials.FromUtf8</c>, so
+/// we don't widen the type to <c>byte[]</c> — that would force a
+/// double-copy with no security benefit (the SDK's internal buffer is
+/// the longest-lived holder of the secret in the process).
+/// </para>
+/// </summary>
+public static class FirmCredentialResolver
+{
+    /// <summary>
+    /// Returns the materialised access key for <paramref name="firm"/>.
+    /// Throws <see cref="InvalidOperationException"/> if no valid secret
+    /// source is configured or the file fails the permission check; this
+    /// surface bubbles out of host startup so an operator sees a clean
+    /// error before the FIXP session attempts to Negotiate.
+    /// </summary>
+    /// <param name="firm">The firm config bound from <c>Trading:Exchange:Firms[i]</c>.</param>
+    /// <param name="logger">Optional logger for the legacy-shape deprecation WARN and file-mode notes.</param>
+    public static string ResolveAccessKey(FirmConfig firm, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(firm);
+
+        if (firm.Credentials is not null)
+        {
+            if (!string.IsNullOrEmpty(firm.AccessKey))
+            {
+                logger?.LogWarning(
+                    "Firm {Firm} has both legacy AccessKey and structured Credentials configured; the structured Credentials wins. Remove the legacy AccessKey to silence this warning.",
+                    firm.FirmId);
+            }
+            return ResolveFromStructured(firm.FirmId, firm.Credentials, logger);
+        }
+
+        if (string.IsNullOrEmpty(firm.AccessKey))
+            throw new InvalidOperationException(
+                $"Firm '{firm.FirmId}' has no credentials configured. Set Trading:Exchange:Firms[i]:Credentials or the legacy Trading:Exchange:Firms[i]:AccessKey.");
+
+        logger?.LogWarning(
+            "Firm {Firm} uses the legacy flat AccessKey shape. Migrate to Credentials: {{ Mode: AccessKey, AccessKeyFile: \"/run/secrets/...\" }} to load the secret from a mounted file. This shape will be removed in a future release.",
+            firm.FirmId);
+        return firm.AccessKey;
+    }
+
+    private static string ResolveFromStructured(string firmId, FirmCredentialsConfig creds, ILogger? logger)
+    {
+        switch (creds.Mode)
+        {
+            case FirmCredentialsMode.AccessKey:
+                var hasInline = !string.IsNullOrEmpty(creds.AccessKey);
+                var hasFile = !string.IsNullOrWhiteSpace(creds.AccessKeyFile);
+                if (hasInline && hasFile)
+                    throw new InvalidOperationException(
+                        $"Firm '{firmId}' Credentials sets both AccessKey and AccessKeyFile; exactly one is required.");
+                if (!hasInline && !hasFile)
+                    throw new InvalidOperationException(
+                        $"Firm '{firmId}' Credentials.Mode=AccessKey requires either AccessKey or AccessKeyFile to be set.");
+                if (hasInline)
+                    return creds.AccessKey!;
+                return ReadSecretFile(firmId, creds.AccessKeyFile!, logger);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Firm '{firmId}' Credentials.Mode={creds.Mode} is not supported by the wired B3.EntryPoint.Client SDK.");
+        }
+    }
+
+    private static string ReadSecretFile(string firmId, string path, ILogger? logger)
+    {
+        if (!File.Exists(path))
+            throw new InvalidOperationException(
+                $"Firm '{firmId}' AccessKeyFile '{path}' does not exist.");
+
+        EnforceFileMode(firmId, path, logger);
+
+        string raw;
+        try
+        {
+            raw = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Firm '{firmId}' AccessKeyFile '{path}' could not be read: {ex.Message}", ex);
+        }
+
+        // Mounted-secret files frequently carry a trailing newline (k8s
+        // Secret, docker secrets, `echo` redirect). Trim once at load
+        // time so the gateway never spends a Negotiate round-trip on a
+        // \n-padded credential.
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0)
+            throw new InvalidOperationException(
+                $"Firm '{firmId}' AccessKeyFile '{path}' is empty after trimming whitespace.");
+        return trimmed;
+    }
+
+    private static void EnforceFileMode(string firmId, string path, ILogger? logger)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            logger?.LogInformation(
+                "Firm {Firm} AccessKeyFile permission check skipped on non-Linux platform; rely on filesystem ACLs.",
+                firmId);
+            return;
+        }
+
+        UnixFileMode perms;
+        try
+        {
+            perms = File.GetUnixFileMode(path);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Firm '{firmId}' AccessKeyFile '{path}' stat failed: {ex.Message}", ex);
+        }
+
+        // Allow only 0600 (rw-------) or 0400 (r--------). Anything
+        // group- or world-readable is a misconfigured mount and we
+        // refuse to load the secret.
+        const UnixFileMode OwnerRw = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        const UnixFileMode OwnerR = UnixFileMode.UserRead;
+        if (perms != OwnerRw && perms != OwnerR)
+        {
+            throw new InvalidOperationException(
+                $"Firm '{firmId}' AccessKeyFile '{path}' has insecure permissions {ToOctal(perms)}; must be 600 or 400 (owner-only). Run: chmod 600 {path}");
+        }
+    }
+
+    private static string ToOctal(UnixFileMode mode)
+    {
+        var bits = (int)mode & 0x1FF; // low 9 perm bits
+        return Convert.ToString(bits, 8).PadLeft(3, '0');
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/FirmCredentialsConfigTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/FirmCredentialsConfigTests.cs
@@ -1,0 +1,297 @@
+using System.Runtime.InteropServices;
+using B3.Trading.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #126. Coverage for <see cref="FirmCredentialResolver"/> + the new
+/// <see cref="FirmCredentialsConfig"/> shape: legacy compat, file-mounted
+/// indirection, Linux permission enforcement, and the validator's
+/// per-mode shape checks.
+/// </summary>
+public class FirmCredentialsConfigTests : IDisposable
+{
+    private readonly string _tmpRoot = Path.Combine(
+        Path.GetTempPath(), "b3-firmcreds-" + Guid.NewGuid().ToString("N"));
+
+    public FirmCredentialsConfigTests() => Directory.CreateDirectory(_tmpRoot);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tmpRoot)) Directory.Delete(_tmpRoot, recursive: true); }
+        catch { /* best-effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static FirmConfig BaseFirm(string firmId = "FIRM_T") => new()
+    {
+        FirmId = firmId,
+        Endpoint = "broker.example.com:9000",
+        SessionId = 100,
+        SessionVerId = 1,
+        EnteringFirm = 200,
+        SenderLocation = "BR-SP",
+        EnteringTrader = "TR1",
+        KeepAliveIntervalMs = 1000,
+    };
+
+    [Fact]
+    public void Resolve_LegacyAccessKey_Returns_Literal()
+    {
+        var firm = BaseFirm();
+        firm.AccessKey = "legacy-secret";
+        var key = FirmCredentialResolver.ResolveAccessKey(firm, NullLogger.Instance);
+        Assert.Equal("legacy-secret", key);
+    }
+
+    [Fact]
+    public void Resolve_StructuredInlineAccessKey_Returns_Literal()
+    {
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "structured-secret",
+        };
+        Assert.Equal("structured-secret", FirmCredentialResolver.ResolveAccessKey(firm));
+    }
+
+    [Fact]
+    public void Resolve_StructuredWinsOverLegacy()
+    {
+        var firm = BaseFirm();
+        firm.AccessKey = "legacy";
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "wins",
+        };
+        Assert.Equal("wins", FirmCredentialResolver.ResolveAccessKey(firm));
+    }
+
+    [Fact]
+    public void Resolve_NoCredentials_Throws()
+    {
+        var firm = BaseFirm();
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("no credentials configured", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_StructuredEmpty_Throws()
+    {
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig { Mode = FirmCredentialsMode.AccessKey };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("requires either AccessKey or AccessKeyFile", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_StructuredBothInlineAndFile_Throws()
+    {
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "x",
+            AccessKeyFile = "/tmp/x",
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("exactly one is required", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_ReadsAndTrims()
+    {
+        var path = WriteSecretFile("file-secret\n", mode: UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = path,
+        };
+        Assert.Equal("file-secret", FirmCredentialResolver.ResolveAccessKey(firm));
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_MissingPath_Throws()
+    {
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = Path.Combine(_tmpRoot, "does-not-exist"),
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("does not exist", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_EmptyFile_Throws()
+    {
+        var path = WriteSecretFile("   \n\t", mode: UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = path,
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("empty", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_AllowsMode400()
+    {
+        var path = WriteSecretFile("read-only-secret", mode: UnixFileMode.UserRead);
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = path,
+        };
+        Assert.Equal("read-only-secret", FirmCredentialResolver.ResolveAccessKey(firm));
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_GroupReadable_ThrowsOnLinux()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return; // permission check is Linux-only
+
+        var path = WriteSecretFile("leaky", mode:
+            UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.GroupRead);
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = path,
+        };
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+        Assert.Contains("insecure permissions", ex.Message);
+        Assert.Contains("must be 600 or 400", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_AccessKeyFile_WorldReadable_ThrowsOnLinux()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return;
+
+        var path = WriteSecretFile("worldleak", mode:
+            UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.OtherRead);
+        var firm = BaseFirm();
+        firm.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKeyFile = path,
+        };
+        Assert.Throws<InvalidOperationException>(() =>
+            FirmCredentialResolver.ResolveAccessKey(firm));
+    }
+
+    [Fact]
+    public void ToString_RedactsSecretMaterial()
+    {
+        var creds = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "super-secret-key",
+            AccessKeyFile = "/run/secrets/x",
+        };
+        var s = creds.ToString();
+        Assert.DoesNotContain("super-secret-key", s);
+        Assert.Contains("redacted:", s);
+        Assert.Contains("/run/secrets/x", s); // path is non-sensitive
+    }
+
+    // --------------------------------------------------------------
+    // Validator coverage — per-mode shape checks
+    // --------------------------------------------------------------
+
+    private static FirmConfig ValidRealFirm(string firmId = "FIRM_A")
+    {
+        var f = BaseFirm(firmId);
+        f.AccessKey = "secret"; // legacy shape, valid
+        return f;
+    }
+
+    [Fact]
+    public void Validator_LegacyAccessKey_Accepts()
+    {
+        var opts = new ExchangeOptions { Mode = ExchangeMode.Real, Firms = { ValidRealFirm() } };
+        Assert.True(new ExchangeOptionsValidator().Validate(null, opts).Succeeded);
+    }
+
+    [Fact]
+    public void Validator_StructuredCredentialsOnly_Accepts()
+    {
+        var f = BaseFirm();
+        f.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "x",
+        };
+        var opts = new ExchangeOptions { Mode = ExchangeMode.Real, Firms = { f } };
+        Assert.True(new ExchangeOptionsValidator().Validate(null, opts).Succeeded);
+    }
+
+    [Fact]
+    public void Validator_NeitherLegacyNorStructured_Fails()
+    {
+        var f = BaseFirm(); // no AccessKey, no Credentials
+        var opts = new ExchangeOptions { Mode = ExchangeMode.Real, Firms = { f } };
+        var result = new ExchangeOptionsValidator().Validate(null, opts);
+        Assert.False(result.Succeeded);
+        Assert.Contains("AccessKey or", string.Join(";", result.Failures!));
+    }
+
+    [Fact]
+    public void Validator_StructuredCredentialsEmpty_Fails()
+    {
+        var f = BaseFirm();
+        f.Credentials = new FirmCredentialsConfig { Mode = FirmCredentialsMode.AccessKey };
+        var opts = new ExchangeOptions { Mode = ExchangeMode.Real, Firms = { f } };
+        var result = new ExchangeOptionsValidator().Validate(null, opts);
+        Assert.False(result.Succeeded);
+        Assert.Contains("requires either AccessKey or AccessKeyFile", string.Join(";", result.Failures!));
+    }
+
+    [Fact]
+    public void Validator_StructuredCredentialsBothFields_Fails()
+    {
+        var f = BaseFirm();
+        f.Credentials = new FirmCredentialsConfig
+        {
+            Mode = FirmCredentialsMode.AccessKey,
+            AccessKey = "x",
+            AccessKeyFile = "/tmp/x",
+        };
+        var opts = new ExchangeOptions { Mode = ExchangeMode.Real, Firms = { f } };
+        var result = new ExchangeOptionsValidator().Validate(null, opts);
+        Assert.False(result.Succeeded);
+        Assert.Contains("exactly one is required", string.Join(";", result.Failures!));
+    }
+
+    // --------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------
+
+    private string WriteSecretFile(string content, UnixFileMode mode)
+    {
+        var path = Path.Combine(_tmpRoot, "secret-" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(path, content);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            File.SetUnixFileMode(path, mode);
+        return path;
+    }
+}

--- a/docs/operations/firm-credentials.md
+++ b/docs/operations/firm-credentials.md
@@ -1,0 +1,139 @@
+# Per-firm B3.EntryPoint credentials
+
+Status: shipped via #126.
+
+## Overview
+
+Each firm that the trading host opens a FIXP session for needs an access key the
+B3 EntryPoint gateway accepts in `Negotiate.Credentials`. The host supports two
+shapes for declaring that key under `Trading:Exchange:Firms[i]`:
+
+1. **Legacy flat field** (`AccessKey`) — kept for back-compat with existing
+   deployments. Logs a deprecation WARN at startup.
+2. **Structured `Credentials` bundle** (preferred) — discriminated by `Mode`,
+   supports file-mounted secret indirection.
+
+Today only `Mode: AccessKey` is wired because B3.EntryPoint.Client 0.14.3 only
+exposes `Credentials.FromUtf8(accessKey)`. New SDK modes can be added without
+re-shaping deployed configs (`Mode: Certificate`, `Mode: Token`, …).
+
+## Shapes
+
+### Legacy (back-compat)
+
+```json
+{
+  "Trading": {
+    "Exchange": {
+      "Mode": "Real",
+      "Firms": [
+        {
+          "FirmId": "FIRM01",
+          "AccessKey": "literal-access-key"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Structured — inline (dev)
+
+```json
+"Firms": [{
+  "FirmId": "FIRM01",
+  "Credentials": {
+    "Mode": "AccessKey",
+    "AccessKey": "literal-access-key"
+  }
+}]
+```
+
+### Structured — file-mounted (production)
+
+```json
+"Firms": [{
+  "FirmId": "FIRM01",
+  "Credentials": {
+    "Mode": "AccessKey",
+    "AccessKeyFile": "/run/secrets/firm01-access-key"
+  }
+}]
+```
+
+The file is read once at startup, trimmed of surrounding whitespace, and held
+in process memory by the SDK. Permission requirements (Linux only):
+
+| Mode | Accepted |
+| --- | --- |
+| `0600` (rw-------) | ✅ |
+| `0400` (r--------) | ✅ |
+| anything group- or world-readable | ❌ host refuses to boot |
+
+On non-Linux runners (Windows / macOS dev loops) the permission check is
+skipped — those environments rely on filesystem ACLs.
+
+## docker-compose example
+
+```yaml
+services:
+  trading-host:
+    image: b3-trading-host:latest
+    environment:
+      Trading__Exchange__Mode: Real
+      Trading__Exchange__Firms__0__FirmId: FIRM01
+      Trading__Exchange__Firms__0__Endpoint: broker.example.com:9000
+      Trading__Exchange__Firms__0__SessionId: "100"
+      Trading__Exchange__Firms__0__SessionVerId: "1"
+      Trading__Exchange__Firms__0__EnteringFirm: "200"
+      Trading__Exchange__Firms__0__SenderLocation: BR-SP
+      Trading__Exchange__Firms__0__EnteringTrader: TR1
+      Trading__Exchange__Firms__0__Credentials__Mode: AccessKey
+      Trading__Exchange__Firms__0__Credentials__AccessKeyFile: /run/secrets/firm01_access_key
+    secrets:
+      - firm01_access_key
+
+secrets:
+  firm01_access_key:
+    file: ./secrets/firm01_access_key.txt
+```
+
+Make sure the host-side file is `chmod 0600` and owned by the user the
+container runs as.
+
+## Validation
+
+`ExchangeOptionsValidator` (eager-fail at startup) enforces shape:
+
+- One of `AccessKey` (legacy) **or** `Credentials` must be set.
+- For `Credentials.Mode = AccessKey`: exactly one of `AccessKey` or
+  `AccessKeyFile` is required.
+- An unknown `Mode` is refused (forward-compat guard rail).
+
+The file permission check runs later, in `FirmCredentialResolver`, because it
+needs a filesystem stat that options validation deliberately avoids.
+
+## Rotation
+
+Today rotation requires a host restart (the credential is read once at startup
+and the SDK holds the bytes for the lifetime of the FIXP session). When this
+becomes operationally painful, follow up with an `IOptionsMonitor`-driven
+re-read; tracked in a separate ticket (kept out of #126).
+
+## Logging
+
+`FirmConfig` / `FirmCredentialsConfig` never write the secret material to logs.
+`FirmCredentialsConfig.ToString()` redacts both the inline value (length only)
+and any caller that structured-logs the bundle gets the redacted projection.
+Always pair `Trading__Exchange__Firms__0__AccessKey` style env vars with secret
+backends (docker secrets, k8s Secret, Vault sidecar) in production.
+
+## Out of scope
+
+The following follow-ups are intentionally deferred:
+
+- Cloud secret managers (AWS SM, Azure Key Vault, HashiCorp Vault) — wire as
+  `Mode: VaultRef` when needed.
+- Hot-reload / rotation without restart — `IOptionsMonitor` integration.
+- mTLS layered under the FIXP gateway — separate from credentials, lives at
+  the socket layer.


### PR DESCRIPTION
Closes #126.

## Summary

Adds `FirmCredentialsConfig` (discriminated by `Mode`) on top of the legacy flat `FirmConfig.AccessKey`, with file-mounted secret indirection (`AccessKeyFile`) and Linux mode 0600/0400 enforcement. Legacy shape keeps working with a deprecation WARN.

## Why

- `FirmConfig.AccessKey` is plaintext in appsettings/env. No forward-compat slot for future SDK credential modes; no clean path for ops secret hygiene.
- B3.EntryPoint.Client 0.14.3 only exposes `Credentials.FromUtf8(accessKey)` today — the discriminated shape future-proofs without forcing a re-flatten if/when cert/token modes ship.

## Changes

- `FirmCredentialsConfig { Mode, AccessKey?, AccessKeyFile? }` — exactly one secret source per mode.
- `FirmCredentialResolver.ResolveAccessKey(firm, logger)`:
  - structured shape wins over legacy (WARN if both set);
  - legacy bare `AccessKey` keeps working (deprecation WARN);
  - `AccessKeyFile` content is trimmed (mounted secrets carry trailing newlines), empty files rejected;
  - Linux mode must be 0600 or 0400; group-/world-readable trips a startup error with a `chmod` hint;
  - non-Linux platforms skip the check (logged once).
- `FirmCredentialsConfig.ToString()` redacts the inline secret (length only); path is non-sensitive.
- `ExchangeOptionsValidator` extended with per-mode shape checks; unknown `Mode` refused.
- Host composition routes both shapes through the resolver.
- 17 new unit tests + format check + full suites green locally (only known `MetricsFirmTagTests` flake — `#332`-style, in stored memory).
- `docs/operations/firm-credentials.md` with shapes, docker-compose secrets example, rotation posture.

## Out of scope (deferred follow-ups noted in docs)

- Cloud secret-manager integration (Vault / AWS SM / Azure KV).
- Hot-reload via `IOptionsMonitor`.
- New SDK credential modes (add when SDK exposes them).
