### PR TITLE
docs(#262): annotate submit/modify with risk-ordering RFC cross-refs

### DIFF
--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -230,6 +230,11 @@ public sealed class OrderModifyService
             GoodTillDate: effGtd,
             SubAccountId: orig.SubAccountId);
 
+        // Ordering note (RFC docs/rfcs/risk-pipeline-ordering-v0.md, #262):
+        // risk evaluation runs *pre-WAL* on the modify path. A rejected
+        // modify leaves no WAL footprint today — an asymmetry vs.
+        // OrderSubmissionService that the RFC tracks as an open audit gap
+        // (Option B follow-up: emit OrderReplaceRejectedEvent here).
         var decision = _risk.Evaluate(riskCtx);
         if (!decision.Approved)
         {

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -228,6 +228,13 @@ public sealed class OrderSubmissionService
                 req.Source == OrderSubmissionSource.Algo ? "algo" : "manual"),
             new KeyValuePair<string, object?>("firmId", req.FirmId));
 
+        // Ordering note (RFC docs/rfcs/risk-pipeline-ordering-v0.md, #262):
+        // risk evaluation runs *post-WAL* on the submit path. On reject we
+        // emit a synthetic ExecutionReportReceivedEvent so the rejection is
+        // recoverable from the WAL (FE executions log, /executions/history,
+        // CVM 35/505, drop-copy, best-exec touch). This is intentionally
+        // asymmetric with OrderModifyService, which evaluates pre-WAL — see
+        // RFC §1.3 and the open audit-gap follow-up.
         var riskCtx = new RiskContext(
             req.Owner, req.FirmId, req.Symbol, req.Side, req.Type, req.Quantity, req.Price,
             TimeInForce: req.TimeInForce,


### PR DESCRIPTION
Implements the second half of the RFC Option A recommendation (#336 / #262).

## Change
Adds an ordering note to:
- `OrderSubmissionService.SubmitAsync` — calls out *post-WAL* eval + synthetic-Rejected audit row.
- `OrderModifyService.ModifyAsync` — calls out *pre-WAL* eval + the audit gap tracked in #337.

Both point at `docs/rfcs/risk-pipeline-ordering-v0.md` so a future reader doesn't 'unify' one side and silently break the invariant on the other.

## Out of scope
No behaviour change — comments only. The audit-gap fix is tracked separately in #337.

Closes #262.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>