### PR TITLE
fix(#332): bounded poll for FixpOutbound abandoned-path OTel counter

### DIFF
--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
@@ -274,6 +274,22 @@ public sealed class FixpOutboundChannelWriterTests
         // (timeout + 250 ms cancel grace ≈ 300 ms).
         await writer.CompleteAsync(TimeSpan.FromMilliseconds(50));
 
+        // Issue #332. Bounded poll instead of bare assert: although
+        // MeterListener callbacks run synchronously to Counter.Add per
+        // .NET docs, under CI parallelism we have observed at least one
+        // miss (run 26064747516). The miss is most plausibly explained
+        // by a race between MeterListener.Start() and concurrent
+        // instrument publication from other test classes — Start()
+        // enumerates already-published instruments under an internal
+        // lock, but a Counter created on another thread mid-Start can
+        // slip past. Polling up to 1 s on Interlocked.Read absorbs that
+        // window without masking a real regression (an actually-missing
+        // increment would still time out and fail).
+        var deadline = Environment.TickCount64 + 1_000;
+        while (Interlocked.Read(ref captured) == 0 && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(10);
+        }
         Assert.Equal(1, Interlocked.Read(ref captured));
 
         // Unblock so the orphaned drain task can exit cleanly and


### PR DESCRIPTION
Closes #332.

CI run [26064747516](https://github.com/pedrosakuma/B3TradingPlatform/actions/runs/26064747516) hit a single failure of `CompleteAsync_AbandonedPath_IncrementsOtelCounter`. Could not reproduce locally (30/30 single + 10/10 full assembly).

## Root cause hypothesis
`MeterListener.SetMeasurementEventCallback` runs synchronously to `Counter.Add` per .NET docs — so once `MetricsRegistry.FixpOutboundDrainShutdownAbandoned.Add(1)` returns, the callback should have run and `captured` should be 1. **Except** there's a known soft race: `MeterListener.Start()` snapshots already-published instruments under an internal lock, but a Counter created on another thread mid-`Start` (xUnit runs different test classes in parallel by default) can slip past the snapshot and never fire `InstrumentPublished`. The test then never enables the instrument and the increment is silently ignored.

## Fix
Replace the bare `Assert.Equal` with a bounded poll up to 1 s on `Interlocked.Read(ref captured)` — exactly the mitigation the issue suggests. An actually-missing increment still fails (poll times out), but a sub-second propagation hiccup no longer flakes the build.

No production code touched.

## Verification
- Single test: 1/1 pass
- Full `EntryPointListener.Tests` assembly: 134/134 pass
- Format check clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>