### PR TITLE
frontend: unify number locale to en-US (#340)

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -770,9 +770,9 @@ function formatPretradeWarning(w) {
       return `fat-finger: price deviates ${pct}% from last trade ${ui.fmtPx(w.lastPrice)}`;
     }
     case "qty":
-      return `large quantity: ${w.qty.toLocaleString("pt-BR")} > ${w.multiple}× lot (${w.threshold.toLocaleString("pt-BR")})`;
+      return `large quantity: ${w.qty.toLocaleString("en-US")} > ${w.multiple}× lot (${w.threshold.toLocaleString("en-US")})`;
     case "market_notional": {
-      const fmt = (n) => `R$ ${n.toLocaleString("pt-BR", { maximumFractionDigits: 0 })}`;
+      const fmt = (n) => `R$ ${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
       return `market notional ≈ ${fmt(w.notional)} ≥ ${fmt(w.threshold)}`;
     }
     default:

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -10,13 +10,15 @@ import { rulesFor } from "./validation.js";
 
 const $ = (id) => document.getElementById(id);
 
-// ── Number formatting (pt-BR) ──────────────────────────────────────
+// ── Number formatting (en-US thousands separators / decimal point).
+// #340 quick-wins: unified locale so quantities and prices render with
+// 1,000.00 separators across the trader UI regardless of OS locale.
 // B3 traders expect Brazilian locale (`100.000,00`) for quantities,
 // prices and notionals. Centralised here so every panel stays in sync
 // and we have a single place to flip the locale if the product call
 // changes later.
-const _qtyFmt = new Intl.NumberFormat("pt-BR", { maximumFractionDigits: 0 });
-const _pxFmt  = new Intl.NumberFormat("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const _qtyFmt = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const _pxFmt  = new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 function fmtQty(n) {
   if (n == null || n === "" || Number.isNaN(Number(n))) return "—";
   return _qtyFmt.format(Number(n));
@@ -1439,7 +1441,7 @@ const MD_PANEL_SELECTORS = [".panel.market-data", ".panel.dob", ".panel.chart", 
 
 function fmtStaleTimestamp(ms) {
   if (!ms) return "no data";
-  return new Date(ms).toLocaleTimeString("pt-BR", { hour12: false });
+  return new Date(ms).toLocaleTimeString("en-US", { hour12: false });
 }
 
 function renderStaleness(kind) {

--- a/frontend/test/auction-panel.test.mjs
+++ b/frontend/test/auction-panel.test.mjs
@@ -118,8 +118,8 @@ test("renderAuctionPanel shows TOP, match qty, imbalance and arrow direction", (
   const panel = document.getElementById("auction-panel");
   assert.equal(panel.hidden, false);
   assert.equal(document.getElementById("auction-symbol-tag").textContent, SYM);
-  // Top price formatted via fmtPx (pt-BR comma decimal).
-  assert.equal(document.getElementById("auction-top-price").textContent, "30,50");
+  // Top price formatted via fmtPx (en-US dot decimal — #340).
+  assert.equal(document.getElementById("auction-top-price").textContent, "30.50");
   // Up arrow because 30.50 > 30.00.
   const arrow = document.getElementById("auction-top-arrow");
   assert.equal(arrow.textContent, "▲");
@@ -153,7 +153,7 @@ test("renderAuctionPanel renders the print history newest-first", () => {
   const html = document.getElementById("auction-prints").innerHTML;
   // Most recent (price=31) should appear before the older one in the
   // rendered list.
-  assert.ok(html.indexOf("31,00") < html.indexOf("30,00"),
+  assert.ok(html.indexOf("31.00") < html.indexOf("30.00"),
     "newest print must appear first in the list");
 });
 


### PR DESCRIPTION
Closes the locale leg of the #340 trader-UI quick-wins bundle.

## What

Switches `Intl.NumberFormat` / `toLocaleString` calls in the trader UI from `pt-BR` to `en-US`:

- `frontend/js/ui.js` — `_qtyFmt`, `_pxFmt`, and `toLocaleTimeString` (used by the trade tape).
- `frontend/js/app.js` — pretrade-warning messages (`qty`, `market_notional`).
- `frontend/test/auction-panel.test.mjs` — updates two assertions that pinned the comma-decimal output (`30,50` → `30.50`, `31,00` → `31.00`).

Net effect: quantities/prices render with thousands separators (`1,000.00`) regardless of OS locale.

## Why this is the only commit in the bundle

After auditing the 14 items in #340 against current main, ~12 were already shipped in earlier PRs:

| Item | Status |
| --- | --- |
| `role="alert"` on `#login-error` | ✅ already in `index.html` |
| `<details>` collapsing Advanced (login + backend URL) | ✅ already in `index.html` |
| SR roles on `#ticket-inflight` / `#ws-reconnect` | ✅ already shipped |
| Esc closes session/MD modals | ✅ `ui.js` |
| Symbol `<datalist>` wired | ✅ `index.html` |
| F2 focus title attr on ticket-symbol | ✅ `index.html` |
| Firm in topbar (`username @ firm`) | ✅ `ui.js` setUserLabel |
| Tape ms timestamps | ✅ `ui.js` tapeRow |
| "no book — check MD settings ⚙" message | ✅ `ui.js` |
| Ticket-symbol auto-uppercase | ✅ `ui.js` |
| `setTicketFeedbackIfMatches` auto-clear | ✅ `app.js` |
| Cancel button disabled-while-inflight ("Cancelling…") | ✅ `ui.js` orderRow |
| MD "Updated" staleness class | ✅ `ui.js` renderMarketData (`md-cell-stale` @ 5s) |
| `pendingFatFinger` 15s TTL | ✅ `app.js` (`FAT_FINGER_TTL_MS`) |
| **Quantity number locale → en-US** | **this PR** |

I'll comment on #340 with this matrix and close it after merge.

## Tests

`node --test frontend/test/*.mjs` → **284 pass / 0 fail** (was failing on the two auction-panel assertions until updated).