### PR TITLE
frontend: admin EOD idempotency + firms bad-row highlight (#342)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -507,6 +507,9 @@ tr.row-stale > td.row-stale-actions { opacity: 1; }
   font-size: .65rem; text-transform: uppercase; letter-spacing: .04em;
   margin-right: .35rem;
 }
+/* Firms admin: highlight rows whose FIXP session is not Established or
+ * is mid-reconnect so the worst row is visible at a glance (#342). */
+tr.firm-row-bad > td { background: rgba(239,83,80,.10); }
 .muted { color: var(--muted); text-align: center; padding: .8rem; }
 
 /* ---------- Blotter filter + row UX (section 3 of #30) ---------- */

--- a/frontend/js/adminUi.js
+++ b/frontend/js/adminUi.js
@@ -86,12 +86,24 @@ export function bindAdminUi() {
     $("admin-add-halt-symbol").value = "";
   });
 
-  $("admin-eod-btn").addEventListener("click", () => {
+  $("admin-eod-btn").addEventListener("click", async () => {
+    const btn = $("admin-eod-btn");
+    if (btn?.disabled) return;
     if (!confirmTwice(
       "Run EOD materialisation now?",
       "Confirm: run EOD against today's WAL. This is normally scheduled.",
     )) return;
-    onRunEod();
+    // Idempotency guard (#342): disable the button while the POST is
+    // in flight so a double-click can't fire two concurrent EOD runs.
+    // Backend would handle it, but the UI shouldn't suggest the second
+    // click "did" anything separate.
+    const originalLabel = btn?.textContent;
+    if (btn) { btn.disabled = true; btn.textContent = "Running…"; }
+    try {
+      await onRunEod();
+    } finally {
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel ?? "Run EOD now"; }
+    }
   });
 
   subscribe(renderForSlice);
@@ -148,7 +160,13 @@ function renderFirms() {
     const action = killed ? "revive" : "engage";
     const btnLabel = killed ? "Revive" : "Killswitch";
     const btnClass = killed ? "danger-btn revive" : "danger-btn engage";
-    return `<tr>
+    // Visually flag firms that are not in a healthy "Established &
+    // not-reconnecting" state so the admin's eye lands on the row that
+    // needs attention without scanning the whole table (#342). Killed
+    // firms are already flagged via the KILLED tag + Revive button.
+    const bad = !killed && (f.sessionState !== "Established" || f.reconnecting === true);
+    const rowCls = bad ? ` class="firm-row-bad"` : "";
+    return `<tr${rowCls}>
       <td><code>${escapeHtml(f.firmId)}</code></td>
       <td>${escapeHtml(f.endpoint ?? "—")}</td>
       <td>${escapeHtml(f.sessionId ?? "—")}</td>


### PR DESCRIPTION
First items from #342 trader-UI medium polish bundle.

## Changes

### EOD button idempotency
`admin-eod-btn` handler now `await`s `onRunEod()` with the button disabled and re-labelled `"Running…"` during the in-flight POST, restored in `finally`. Prevents the multi-click → multi-POST footgun (previously the click handler was fire-and-forget so a stress-click could fire several concurrent EOD materialisations).

### Firms table bad-row highlight
`renderFirms` now adds `class="firm-row-bad"` (subtle red background, see `styles.css`) to rows whose `sessionState !== "Established"` or whose `reconnecting === true`, skipping firms already flagged via the KILLED tag. Admin no longer has to scan every row to find the unhealthy firm.

## Tests

`node --test frontend/test/*.mjs` → **284 pass / 0 fail.** No existing adminUi tests to update; new behaviour is CSS + DOM-state only.

Refs #342.