### PR TITLE
frontend: blotter Working-only toggle + DOB spread/mid (#342)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -120,6 +120,13 @@ body {
   border: 1px solid var(--border);
 }
 .symbol-tag--muted { color: var(--muted); }
+/* #342: DOB sub-header with mid + spread. Same tabular-nums alignment
+ * as the symbol tag so the numbers don't dance on each update. */
+.dob-spread {
+  display: inline-block; margin-left: .5rem;
+  font-size: .72rem; font-weight: 400; font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
 .tape-all-toggle {
   display: inline-flex; align-items: center; gap: .25rem;
   font-size: .7rem; color: var(--muted);
@@ -521,6 +528,15 @@ tr.firm-row-bad > td { background: rgba(239,83,80,.10); }
   border-radius: 4px; padding: .25rem .45rem; font: inherit; font-size: .8rem;
 }
 .blotter-filter input { flex: 1; }
+/* #342: "Working only" toggle sits next to the status select. The
+ * checkbox inherits browser styling but the label text picks up the
+ * muted palette so the toggle reads as a filter, not as a status pill. */
+.blotter-filter-toggle {
+  display: inline-flex; align-items: center; gap: .3rem;
+  color: var(--muted); font-size: .78rem; white-space: nowrap;
+  user-select: none; cursor: pointer;
+}
+.blotter-filter-toggle input { flex: none; margin: 0; }
 .blotter-pagination {
   display: flex; align-items: center; justify-content: flex-end;
   gap: .5rem; margin-top: .4rem; font-size: .8rem;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -229,6 +229,10 @@
             <option value="Cancelled">Cancelled</option>
             <option value="Rejected">Rejected</option>
           </select>
+          <label class="blotter-filter-toggle" title="Hide Filled / Cancelled / Rejected">
+            <input id="blotter-hide-terminal" type="checkbox" checked />
+            Working only
+          </label>
         </div>
         <div class="table-scroll">
           <table id="blotter-table">
@@ -340,6 +344,7 @@
         <h2>
           Depth of book
           <span id="dob-symbol-tag" class="symbol-tag" aria-live="polite"></span>
+          <span id="dob-spread" class="dob-spread" aria-live="polite"></span>
         </h2>
         <p id="dob-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
         <div class="dob-grid">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1002,13 +1002,16 @@ function handleKeyboardCancel() {
 function readBlotterFilter() {
   try {
     const raw = sessionStorage.getItem(BLOTTER_FILTER_KEY);
-    if (!raw) return { text: "", status: "" };
+    if (!raw) return { text: "", status: "", hideTerminal: true };
     const parsed = JSON.parse(raw);
     return {
       text:   typeof parsed?.text   === "string" ? parsed.text   : "",
       status: typeof parsed?.status === "string" ? parsed.status : "",
+      // #342: hideTerminal defaults to true for both fresh and pre-existing
+      // sessions (no persisted value → treat as on).
+      hideTerminal: parsed?.hideTerminal !== false,
     };
-  } catch { return { text: "", status: "" }; }
+  } catch { return { text: "", status: "", hideTerminal: true }; }
 }
 function writeBlotterFilter(f) { sessionStorage.setItem(BLOTTER_FILTER_KEY, JSON.stringify(f)); }
 

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -106,7 +106,7 @@ const state = {
   // and not miss the tail-end of a high-volume burst.
   complianceFeed: { paused: false, entries: [] },
   // Blotter UX (section 3 of #30).
-  blotterFilter: { text: "", status: "" }, // { text: substring, status: "" | <OrderStatus> }
+  blotterFilter: { text: "", status: "", hideTerminal: true }, // { text, status, hideTerminal }
   // Per-ClOrdID monotonic arrival sequence. Newly-seen orders get the
   // next number; updates keep the original. Drives the default
   // newest-first sort of the working orders blotter, robust to the
@@ -763,6 +763,10 @@ export function setBlotterFilter(filter) {
   state.blotterFilter = {
     text:   typeof filter?.text   === "string" ? filter.text   : "",
     status: typeof filter?.status === "string" ? filter.status : "",
+    // #342: default-on "Working only" toggle. The common case for a
+    // trader is "what's still actionable"; terminal orders are
+    // accessible via History tab or by unchecking the box.
+    hideTerminal: filter?.hideTerminal !== false,
   };
   // Filter changes shrink the visible set; reset pagination so the
   // user lands on results instead of a now-empty page N.

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -920,15 +920,19 @@ export function bindUi() {
     });
   }
 
-  // Blotter filter: text + status select. Persisted via app.js.
+  // Blotter filter: text + status select + working-only toggle (#342).
+  // Persisted via app.js.
   const filterText = $("blotter-filter-text");
   const filterStatus = $("blotter-filter-status");
+  const filterHideTerm = $("blotter-hide-terminal");
   const fireFilter = () => onBlotterFilter({
     text:   filterText.value,
     status: filterStatus.value,
+    hideTerminal: filterHideTerm ? filterHideTerm.checked : true,
   });
-  if (filterText)   filterText.addEventListener("input",  fireFilter);
-  if (filterStatus) filterStatus.addEventListener("change", fireFilter);
+  if (filterText)     filterText.addEventListener("input",  fireFilter);
+  if (filterStatus)   filterStatus.addEventListener("change", fireFilter);
+  if (filterHideTerm) filterHideTerm.addEventListener("change", fireFilter);
 
   // Blotter pagination controls. Renderer hides the bar when there's
   // only one page; clicks here only request a page change — clamping
@@ -1824,6 +1828,7 @@ function renderDob() {
   const bidsBody = document.querySelector("#dob-bids tbody");
   const asksBody = document.querySelector("#dob-asks tbody");
   const feedback = $("dob-feedback");
+  const spreadEl = $("dob-spread");
   if (!bidsBody || !asksBody) return;
 
   const st = getState();
@@ -1833,6 +1838,7 @@ function renderDob() {
     bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">select a symbol</td></tr>`;
     asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">select a symbol</td></tr>`;
     if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+    if (spreadEl) spreadEl.textContent = "";
     return;
   }
 
@@ -1848,6 +1854,7 @@ function renderDob() {
     bidsBody.innerHTML = `<tr><td colspan="3" class="muted-cell">${msg}</td></tr>`;
     asksBody.innerHTML = `<tr><td colspan="3" class="muted-cell">${msg}</td></tr>`;
     if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+    if (spreadEl) spreadEl.textContent = "";
     return;
   }
 
@@ -1863,6 +1870,26 @@ function renderDob() {
   bidsBody.innerHTML = renderDobSide(bids, "bid");
   asksBody.innerHTML = renderDobSide(asks, "ask");
   if (feedback) { feedback.hidden = true; feedback.textContent = ""; }
+
+  // #342: Spread + mid sub-header. Saves the trader from eyeballing
+  // top-of-book themselves. Crossed / locked markets render as a
+  // muted "—" rather than a misleading negative spread.
+  if (spreadEl) {
+    if (bids.length === 0 || asks.length === 0) {
+      spreadEl.textContent = "";
+    } else {
+      const bestBid = bids[0].price;
+      const bestAsk = asks[0].price;
+      const spread = bestAsk - bestBid;
+      const mid = (bestAsk + bestBid) / 2;
+      if (!Number.isFinite(spread) || spread <= 0) {
+        spreadEl.textContent = `mid ${fmtPx(mid)} · spread —`;
+      } else {
+        const bps = mid > 0 ? Math.round((spread / mid) * 10000) : 0;
+        spreadEl.textContent = `mid ${fmtPx(mid)} · spread ${fmtPx(spread)} (${bps} bp)`;
+      }
+    }
+  }
 }
 
 function renderDobSide(levels, side) {
@@ -2101,10 +2128,11 @@ const BLOTTER_PAGE_SIZE = 25;
 function renderBlotter() {
   const body = $("blotter-body");
   const st = getState();
-  const filter = st.blotterFilter ?? { text: "", status: "" };
+  const filter = st.blotterFilter ?? { text: "", status: "", hideTerminal: true };
   syncFilterInputs(filter);
   const search = filter.text.trim().toUpperCase();
   const wantStatus = filter.status;
+  const hideTerm = filter.hideTerminal !== false;
   const all = [...st.orders.values()];
   // Default sort: newest-first by per-ClOrdID arrival sequence
   // (assigned in state.applyOrders*). Falling back to clOrdId keeps
@@ -2113,6 +2141,10 @@ function renderBlotter() {
   const filtered = all
     .filter(o => !search || o.symbol.toUpperCase().includes(search) || o.clOrdId.toUpperCase().includes(search))
     .filter(o => !wantStatus || o.status === wantStatus)
+    // #342: "Working only" hides terminal rows (Filled / Cancelled /
+    // Rejected). Skipped when an explicit status filter is set so the
+    // trader can still pin a terminal status when they want to.
+    .filter(o => !hideTerm || wantStatus || !isTerminalOrderStatus(o.status))
     .sort((a, b) => {
       const diff = seqOf(b) - seqOf(a);
       return diff !== 0 ? diff : b.clOrdId.localeCompare(a.clOrdId);
@@ -2202,8 +2234,13 @@ function orderRow(o, st) {
 function syncFilterInputs(filter) {
   const t = $("blotter-filter-text");
   const s = $("blotter-filter-status");
+  const h = $("blotter-hide-terminal");
   if (t && document.activeElement !== t) t.value = filter.text;
   if (s && s.value !== filter.status) s.value = filter.status;
+  if (h) {
+    const want = filter.hideTerminal !== false;
+    if (h.checked !== want) h.checked = want;
+  }
 }
 
 function renderPositions() {


### PR DESCRIPTION
Third batch from #342 trader-UI medium polish bundle.

## Changes

### Blotter "Working only" toggle (default on)
New checkbox in the filter bar that hides terminal rows (Filled / Cancelled / Rejected) so the trader's default view is just what's still actionable. The toggle is suppressed when the trader has pinned a specific status filter (so `status=Filled` still shows Filled orders).

Plumbing:
- `state.blotterFilter` gains a `hideTerminal` boolean (default `true`).
- `setBlotterFilter` / `readBlotterFilter` / `writeBlotterFilter` carry it through sessionStorage.
- `renderBlotter` applies it after the status filter via `isTerminalOrderStatus(o.status)`.
- New `#blotter-hide-terminal` checkbox + `.blotter-filter-toggle` CSS.

### DOB spread + mid sub-header
`#dob-spread` element next to the DOB symbol tag now renders `mid $X · spread $Y (Nbp)` derived from the top-of-book bid/ask. Cleared when no symbol / no book / both sides empty. Crossed-or-locked markets show a muted `spread —` instead of a misleading negative number.

## Tests

`node --test frontend/test/*.mjs` → **284 pass / 0 fail.** No existing assertions touch `renderBlotter`'s output or DOB header — the new behaviour is additive.

Refs #342.