### PR TITLE
frontend: positions sort + executions log symbol filter (#342)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -553,6 +553,32 @@ tr.firm-row-bad > td { background: rgba(239,83,80,.10); }
   background: rgba(255,255,255,.05);
 }
 .blotter-page-info { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+/* #342: Positions click-to-sort headers. The column whose
+ * aria-sort is set gets an inline indicator using ::after so the
+ * indicator never disturbs the column's text alignment. */
+.positions-sort-hint {
+  font-size: .65rem; font-weight: 400; text-transform: none;
+  letter-spacing: 0; color: var(--muted); opacity: .55;
+}
+.panel.positions th.sortable {
+  cursor: pointer; user-select: none;
+}
+.panel.positions th.sortable:hover { color: var(--text); }
+.panel.positions th.sortable:focus-visible {
+  outline: 1px solid var(--accent, #4aa3ff); outline-offset: 1px;
+}
+.panel.positions th.sortable[aria-sort="ascending"]::after  { content: " ▲"; opacity: .7; }
+.panel.positions th.sortable[aria-sort="descending"]::after { content: " ▼"; opacity: .7; }
+
+/* #342: Executions log symbol filter sits inside the panel <h2>. */
+.exec-filter-symbol {
+  font: inherit; font-size: .72rem; font-weight: 400; text-transform: none;
+  letter-spacing: 0; color: var(--text);
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+  padding: .15rem .4rem; width: 9rem;
+}
+.exec-filter-symbol::placeholder { color: var(--muted); opacity: .8; }
 @keyframes row-fresh-fade {
   0%   { background: rgba(79,158,255,.32); }
   100% { background: transparent; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -255,11 +255,18 @@
 
       <!-- POSITIONS -------------------------------------------------- -->
       <section class="panel positions">
-        <h2>Positions</h2>
+        <h2>
+          Positions
+          <span class="muted positions-sort-hint">click header to sort</span>
+        </h2>
         <div class="table-scroll">
           <table>
             <thead>
-              <tr><th>Symbol</th><th class="num">Net</th><th class="num">Avg price</th></tr>
+              <tr>
+                <th data-sort-key="symbol" class="sortable" role="button" tabindex="0" aria-sort="none">Symbol</th>
+                <th data-sort-key="absNet" class="num sortable" role="button" tabindex="0" aria-sort="descending">Net</th>
+                <th data-sort-key="price"  class="num sortable" role="button" tabindex="0" aria-sort="none">Avg price</th>
+              </tr>
             </thead>
             <tbody id="positions-body"></tbody>
           </table>
@@ -268,7 +275,12 @@
 
       <!-- EXECUTIONS LOG --------------------------------------------- -->
       <section class="panel executions">
-        <h2>Executions log</h2>
+        <h2>
+          Executions log
+          <input id="exec-filter-symbol" class="exec-filter-symbol"
+                 type="search" inputmode="latin" autocomplete="off"
+                 placeholder="filter by symbol" aria-label="Filter executions by symbol" />
+        </h2>
         <ol id="executions-log" class="executions-log"></ol>
       </section>
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -35,6 +35,45 @@ export { fmtQty, fmtPx };
 // stomp each other's saved target.
 const _modalReturnFocus = new Map();
 
+// #342: Positions sort + executions log symbol filter — purely view-local
+// UI state with sessionStorage persistence. Not in state.js because no
+// other module depends on it; keeping it in the renderer avoids cross-
+// module churn for what is a per-tab cosmetic preference.
+const POSITIONS_SORT_KEY = "b3tp.positions.sort";
+const EXEC_FILTER_KEY    = "b3tp.executions.symbolFilter";
+
+// Default: largest absolute net first — the position that needs the
+// most attention. Click cycles ascending → descending → none (back to
+// default). String columns omit the "none" leg since alpha-asc is a
+// useful baseline.
+const POSITIONS_SORT_DEFAULT = { col: "absNet", dir: "desc" };
+let _positionsSort = POSITIONS_SORT_DEFAULT;
+let _execSymbolFilter = "";
+
+function readPositionsSort() {
+  try {
+    const raw = sessionStorage.getItem(POSITIONS_SORT_KEY);
+    if (!raw) return { ...POSITIONS_SORT_DEFAULT };
+    const parsed = JSON.parse(raw);
+    const col = ["symbol", "absNet", "price"].includes(parsed?.col) ? parsed.col : "absNet";
+    const dir = parsed?.dir === "asc" ? "asc" : "desc";
+    return { col, dir };
+  } catch { return { ...POSITIONS_SORT_DEFAULT }; }
+}
+function writePositionsSort(s) {
+  try { sessionStorage.setItem(POSITIONS_SORT_KEY, JSON.stringify(s)); } catch { /* swallow */ }
+}
+function readExecSymbolFilter() {
+  try { return sessionStorage.getItem(EXEC_FILTER_KEY) || ""; }
+  catch { return ""; }
+}
+function writeExecSymbolFilter(v) {
+  try {
+    if (v) sessionStorage.setItem(EXEC_FILTER_KEY, v);
+    else   sessionStorage.removeItem(EXEC_FILTER_KEY);
+  } catch { /* swallow */ }
+}
+
 function rememberFocusForModal(modalId) {
   const el = document.activeElement;
   // Skip <body> / null / the dialog itself — restoring those is a no-op
@@ -933,6 +972,42 @@ export function bindUi() {
   if (filterText)     filterText.addEventListener("input",  fireFilter);
   if (filterStatus)   filterStatus.addEventListener("change", fireFilter);
   if (filterHideTerm) filterHideTerm.addEventListener("change", fireFilter);
+
+  // #342: Positions click-to-sort. Click cycles asc → desc → default
+  // (|net| desc). Keyboard activation mirrors mouse for accessibility
+  // since the headers are role="button".
+  _positionsSort = readPositionsSort();
+  document.querySelectorAll(".panel.positions th.sortable").forEach(th => {
+    const cycle = () => {
+      const key = th.getAttribute("data-sort-key");
+      if (_positionsSort.col === key) {
+        _positionsSort = _positionsSort.dir === "desc"
+          ? { col: key, dir: "asc" }
+          : { ...POSITIONS_SORT_DEFAULT };
+      } else {
+        _positionsSort = { col: key, dir: "desc" };
+      }
+      writePositionsSort(_positionsSort);
+      renderPositions();
+    };
+    th.addEventListener("click", cycle);
+    th.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); cycle(); }
+    });
+  });
+
+  // #342: Executions log symbol filter. Substring match, case-insensitive,
+  // persisted per tab so the trader's last filter survives a page reload.
+  const execFilter = $("exec-filter-symbol");
+  if (execFilter) {
+    _execSymbolFilter = readExecSymbolFilter();
+    execFilter.value = _execSymbolFilter;
+    execFilter.addEventListener("input", () => {
+      _execSymbolFilter = execFilter.value;
+      writeExecSymbolFilter(_execSymbolFilter);
+      renderExecutions();
+    });
+  }
 
   // Blotter pagination controls. Renderer hides the bar when there's
   // only one page; clicks here only request a page change — clamping
@@ -2246,8 +2321,8 @@ function syncFilterInputs(filter) {
 function renderPositions() {
   const body = $("positions-body");
   const positions = [...getState().positions.values()]
-    .filter(p => p.netQuantity !== 0)
-    .sort((a, b) => a.symbol.localeCompare(b.symbol));
+    .filter(p => p.netQuantity !== 0);
+  sortPositionsInPlace(positions, _positionsSort);
   body.innerHTML = positions.length === 0
     ? `<tr><td colspan="3" class="muted">No positions</td></tr>`
     : positions.map(p => `<tr>
@@ -2255,11 +2330,45 @@ function renderPositions() {
         <td class="num">${fmtQty(p.netQuantity)}</td>
         <td class="num">${fmtPx(p.averageEntryPrice)}</td>
       </tr>`).join("");
+  syncPositionsSortHeaders();
+}
+
+// #342: pure sort helper so the column logic can be exercised without
+// touching the DOM. `dir` is "asc" | "desc"; for the |net| column we
+// compare absolute values so longs and shorts of equal magnitude land
+// adjacent.
+export function sortPositionsInPlace(rows, sort) {
+  const dirMul = sort.dir === "asc" ? 1 : -1;
+  if (sort.col === "symbol") {
+    rows.sort((a, b) => a.symbol.localeCompare(b.symbol) * dirMul);
+  } else if (sort.col === "price") {
+    rows.sort((a, b) => ((Number(a.averageEntryPrice) || 0) - (Number(b.averageEntryPrice) || 0)) * dirMul);
+  } else {
+    // absNet (default).
+    rows.sort((a, b) => (Math.abs(Number(a.netQuantity) || 0) - Math.abs(Number(b.netQuantity) || 0)) * dirMul);
+  }
+  return rows;
+}
+
+function syncPositionsSortHeaders() {
+  const ths = document.querySelectorAll(".panel.positions th.sortable");
+  ths.forEach(th => {
+    const key = th.getAttribute("data-sort-key");
+    if (key === _positionsSort.col) {
+      th.setAttribute("aria-sort", _positionsSort.dir === "asc" ? "ascending" : "descending");
+    } else {
+      th.setAttribute("aria-sort", "none");
+    }
+  });
 }
 
 function renderExecutions() {
   const log = $("executions-log");
-  const items = getState().executions;
+  const filter = _execSymbolFilter.trim().toUpperCase();
+  let items = getState().executions;
+  if (filter) {
+    items = items.filter(e => typeof e.symbol === "string" && e.symbol.toUpperCase().includes(filter));
+  }
   // Newest first.
   log.innerHTML = items.slice().reverse().map(execRow).join("");
 }

--- a/frontend/test/positions-sort.test.mjs
+++ b/frontend/test/positions-sort.test.mjs
@@ -1,0 +1,40 @@
+// #342: Positions sort helper — three columns × two directions, with the
+// |net| column treating longs and shorts of equal magnitude as adjacent.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+installDomStub({ ids: {} });
+
+const { sortPositionsInPlace } = await import("../js/ui.js");
+
+const rows = () => [
+  { symbol: "PETR4", netQuantity:  300, averageEntryPrice: 32.10 },
+  { symbol: "VALE3", netQuantity: -800, averageEntryPrice: 65.50 },
+  { symbol: "ITUB4", netQuantity:  500, averageEntryPrice:  9.20 },
+];
+
+test("absNet desc puts largest exposure first, regardless of side", () => {
+  const r = rows();
+  sortPositionsInPlace(r, { col: "absNet", dir: "desc" });
+  assert.deepEqual(r.map(p => p.symbol), ["VALE3", "ITUB4", "PETR4"]);
+});
+
+test("absNet asc puts smallest exposure first", () => {
+  const r = rows();
+  sortPositionsInPlace(r, { col: "absNet", dir: "asc" });
+  assert.deepEqual(r.map(p => p.symbol), ["PETR4", "ITUB4", "VALE3"]);
+});
+
+test("symbol asc / desc are lexicographic", () => {
+  const a = rows(); sortPositionsInPlace(a, { col: "symbol", dir: "asc"  });
+  assert.deepEqual(a.map(p => p.symbol), ["ITUB4", "PETR4", "VALE3"]);
+  const d = rows(); sortPositionsInPlace(d, { col: "symbol", dir: "desc" });
+  assert.deepEqual(d.map(p => p.symbol), ["VALE3", "PETR4", "ITUB4"]);
+});
+
+test("price column sorts by averageEntryPrice", () => {
+  const r = rows();
+  sortPositionsInPlace(r, { col: "price", dir: "asc" });
+  assert.deepEqual(r.map(p => p.symbol), ["ITUB4", "PETR4", "VALE3"]);
+});


### PR DESCRIPTION
Fourth batch from #342 trader-UI medium polish bundle.

## Changes

### Positions panel: click-to-sort with |net|-desc default
Header cells become `role=button` + `tabindex=0` and cycle **ascending → descending → default** (Enter / Space mirrors click for keyboard users). The default sort is now **|net| desc** — the position that needs the most attention surfaces at the top — instead of the alphabetical sort that buried large exposures of less-followed names below small chunks of liquid ones like `PETR4`. Selection persists per tab via `sessionStorage` (`b3tp.positions.sort`).

A pure `sortPositionsInPlace(rows, sort)` helper is exported so the column logic can be exercised under `node --test` with no DOM.

### Executions log: symbol filter
Small search input inside the panel `<h2>` that substring-matches against `execution.symbol` (case insensitive). Empty input keeps the full feed; the filter persists per tab.

## Tests

`node --test frontend/test/*.mjs` → **288 pass / 0 fail** (4 new in `positions-sort.test.mjs`).

Refs #342.

Known flakes that may surface on rerun: #332, #345, #347.