### PR TITLE
frontend: MD not_ready colour + reconnect 1Hz + [ws] error toast (#342)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -92,14 +92,13 @@ body {
 .status-connecting   { background: rgba(245,166,35,.18); color: var(--warn); }
 .status-disconnected { background: rgba(239,83,80,.18);  color: var(--red); }
 /* `not_ready` means the WebSocket handshake completed but the server
-   hasn't yet declared itself ready for orders/snapshots. It's a
-   distinct condition from `connecting` (handshake in flight) and
-   needs its own colour so the trader can tell at a glance whether
-   the link is still being negotiated or whether the upstream feed
-   is stalled. Cyan/blue family keeps it visually different from the
-   warm tones used by `connecting` while still reading as "advisory,
-   not an error". */
-.status-not_ready    { background: rgba(74,144,226,.18); color: #4a90e2; }
+   declared the upstream feed unavailable (gateway down, snapshot
+   broker stalled). Distinct from `connecting` (link still negotiating):
+   reconnecting alone won't fix it — operator/server action is needed.
+   #342: subdued brick red so the trader reads it as "advisory error",
+   not the warm cyan/blue we used previously which read too close to
+   the in-progress `connecting` tone. */
+.status-not_ready    { background: rgba(217,122,74,.18); color: #d97a4a; }
 .user-label { color: var(--muted); }
 .symbol-select {
   display: inline-flex; align-items: center; gap: .35rem;
@@ -590,6 +589,18 @@ tr.row-selected > td {
 tr[data-clordid] { cursor: pointer; }
 tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 .feedback.warn { color: var(--warn); }
+
+/* #342: Transient WS error toast. Lives between the topbar and the
+ * panel grid, takes no space when hidden, and surfaces frame-level
+ * errors (unknown_channel, bad subscribe args, server-side close
+ * reasons) so the trader doesn't have to open the devtools console
+ * to notice that a subscription quietly failed. */
+.ws-error-toast {
+  margin: 0 1rem; padding: .35rem .7rem;
+  background: rgba(239,83,80,.14); color: var(--red);
+  border: 1px solid rgba(239,83,80,.35); border-radius: 4px;
+  font-size: .8rem; font-variant-numeric: tabular-nums;
+}
 
 /* ---------- Session-expiry modal + helpers (section 4 of #30) ---------- */
 .muted-cell { color: var(--muted); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -120,6 +120,12 @@
       </div>
     </header>
 
+    <!-- #342: Transient toast for WebSocket frame-level errors (e.g.,
+         unknown_channel, channel auth failure). Lives between the topbar
+         and the grid so it's visible from any panel without taking up
+         persistent screen real estate. Auto-dismissed after a few seconds. -->
+    <div id="ws-error-toast" class="ws-error-toast" role="status" aria-live="polite" hidden></div>
+
     <main class="grid">
       <!-- ORDER TICKET ----------------------------------------------- -->
       <section class="panel ticket">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -756,11 +756,25 @@ function onWorkerMessage(msg) {
     case "phases.frame":        state.applyPhaseFrame(msg.data); break;
     case "auction.frame":       state.applyAuctionFrame(msg.data); break;
     case "error":
-      // A frame-level error from the server (e.g., unknown_channel).
-      // Surface in the executions log to keep it visible without a toast.
+      // A frame-level error from the server (e.g., unknown_channel,
+      // bad subscribe args, channel auth). #342: surface it as a
+      // transient toast so the trader notices a quietly-failing
+      // subscription without having to open devtools.
       console.warn("[ws]", msg);
+      ui.showWsErrorToast(formatWsError(msg));
       break;
   }
+}
+
+// #342: render a worker `error` frame as a short human-readable string
+// for the WS error toast. The frame is { type:"error", channel?, code?, message? };
+// we keep noise low by collapsing missing fields rather than printing
+// "undefined" / JSON.
+function formatWsError(msg) {
+  const channel = msg?.channel ? `[${msg.channel}] ` : "";
+  const code    = msg?.code ? `${msg.code}: ` : "";
+  const body    = msg?.message ? String(msg.message) : "websocket error";
+  return `${channel}${code}${body}`;
 }
 
 function formatPretradeWarning(w) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -1239,6 +1239,27 @@ export function setTicketFeedback(message, kind) {
   el.className = `feedback ${cls}`;
 }
 
+// #342: Transient WS error toast. Surfaces frame-level errors from the
+// data WebSocket (unknown_channel, malformed subscribe, server-side
+// close) so the trader notices a quietly-failing subscription without
+// having to open devtools. Auto-dismisses after WS_ERROR_TOAST_MS;
+// successive errors restart the timer (most recent message wins).
+const WS_ERROR_TOAST_MS = 6_000;
+let _wsErrorToastTimer = null;
+export function showWsErrorToast(message) {
+  const el = $("ws-error-toast");
+  if (!el) return;
+  if (!message) { el.hidden = true; el.textContent = ""; return; }
+  el.hidden = false;
+  el.textContent = message;
+  if (_wsErrorToastTimer) clearTimeout(_wsErrorToastTimer);
+  _wsErrorToastTimer = setTimeout(() => {
+    _wsErrorToastTimer = null;
+    el.hidden = true;
+    el.textContent = "";
+  }, WS_ERROR_TOAST_MS);
+}
+
 // Clear the ticket feedback only if it still shows `expected`. Used by
 // the success-toast auto-dismiss so a later warning/error message that
 // landed before the timer fires isn't accidentally erased.
@@ -1398,11 +1419,15 @@ function ensureTicker() {
   if (tickTimer) return;
   tickTimer = setInterval(() => {
     renderInflight();
-    renderReconnect();
     // Slow tick (1s) for time-driven re-renders that don't need 4 Hz.
     const now = Date.now();
     if (now - lastSlowTick >= 1000) {
       lastSlowTick = now;
+      // #342: reconnect countdown ticks at 1Hz (integer seconds) — the
+      // previous 4Hz / decisecond display flickered without conveying
+      // useful information. State changes still trigger an immediate
+      // re-render via the wsReconnect subscription.
+      renderReconnect();
       renderMarketData();
       // Only re-render the DOB while we're still waiting for a snapshot
       // — the live render path is already wired to the book slice.
@@ -1438,9 +1463,12 @@ function renderReconnect() {
   if (!el) return;
   const r = getState().wsReconnect;
   if (!r || !r.nextAt) { el.hidden = true; el.textContent = ""; return; }
+  // #342: integer-second precision is enough at 1Hz, and prevents the
+  // jitter the old `.1s` format showed every tick even when nothing
+  // had changed at the second granularity.
   const remaining = Math.max(0, r.nextAt - Date.now());
   el.hidden = false;
-  el.textContent = `retry in ${(remaining / 1000).toFixed(1)}s`;
+  el.textContent = `retry in ${Math.ceil(remaining / 1000)}s`;
 }
 
 function renderFirmsHealth() {


### PR DESCRIPTION
Final XS bundle from #342 — three small connection-signal items.

## Changes

### MD `not_ready` distinct colour (subdued brick red)
The cyan/blue we used previously read too close to the warm `connecting` tone — the trader couldn't tell at a glance whether the link was still being negotiated or whether the upstream feed had been declared unavailable by the server. Swapped for a subdued brick red (`#d97a4a`) — close enough to error that it isn't ignored, soft enough not to be mistaken for a hard disconnect. Comment in `styles.css` updated to reflect the new intent.

### Reconnect countdown: 1Hz / integer seconds (was 4Hz / `.1s`)
Moved `renderReconnect` from the 4Hz fast tick into the existing 1s slow branch and rounded the display to whole seconds. The `.1s` precision was decorative — the underlying state only changes per attempt, and `wsReconnect` subscription already triggers an immediate re-render when the schedule itself changes.

### `[ws]` frame errors as panel toast
`type:"error"` frames from the worker now surface in a new `#ws-error-toast` between the topbar and the panel grid (auto-dismisses after 6s; latest message wins). Previously they were silently `console.warn`'d so a failing subscription (`unknown_channel`, bad subscribe args, channel auth) only became apparent when the trader noticed missing data. `role=status` + `aria-live=polite` for screen readers.

## Tests

`node --test frontend/test/*.mjs` → **288 pass / 0 fail.**

Refs #342. Known flakes that may surface on rerun: #332, #345, #347.