### PR TITLE
frontend: T5 multi-symbol volume heatmap (#71)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -212,6 +212,43 @@ body {
 .executions { grid-area: execs; min-height: 0; }
 .market-data{ grid-area: md; }
 .market-data .empty { color: var(--muted); font-size: .8rem; }
+.md-h2-controls { display: inline-flex; gap: .25rem; align-items: center; }
+
+/* #71: Volume heatmap. Compact grid of cells living at the top of the
+ * Market data panel; cell colour encodes rolling 10s volume normalised
+ * by the per-render global max. Click a cell → selectedSymbol. */
+.heatmap-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 4px; margin-bottom: .55rem;
+}
+.heatmap-empty {
+  grid-column: 1 / -1; font-size: .75rem; margin: 0;
+}
+.heatmap-cell {
+  display: flex; flex-direction: column; align-items: flex-start;
+  gap: .15rem;
+  padding: .35rem .4rem; min-height: 44px;
+  background: rgba(255,255,255,.04);
+  color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  font: inherit; cursor: pointer; text-align: left;
+  transition: transform .08s ease-out;
+}
+.heatmap-cell:hover { transform: translateY(-1px); }
+.heatmap-cell:focus-visible {
+  outline: 2px solid var(--accent, #4aa3ff); outline-offset: 1px;
+}
+.heatmap-cell--selected {
+  outline: 2px solid var(--text); outline-offset: -2px;
+}
+.heatmap-cell-sym {
+  font-size: .72rem; font-weight: 600; letter-spacing: .03em;
+}
+.heatmap-cell-vol {
+  font-size: .68rem; font-variant-numeric: tabular-nums;
+  color: rgba(255,255,255,.85);
+}
 .dob { grid-area: dob; }
 .dob-grid {
   display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; min-height: 0;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -297,8 +297,18 @@
             Market data
             <span id="md-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Market data: disconnected" title="MarketData WebSocket connection">disconnected</span>
           </span>
-          <button type="button" id="md-settings-open" class="icon-button" aria-label="Market data settings" title="Market data settings">⚙</button>
+          <span class="md-h2-controls">
+            <!-- #71: Volume heatmap toggle — opt-in per the decision gate.
+                 Persists in sessionStorage so a trader who relies on it
+                 doesn't have to re-enable on every reload. -->
+            <button type="button" id="heatmap-toggle" class="icon-button"
+                    aria-pressed="false" aria-label="Toggle volume heatmap"
+                    title="Toggle volume heatmap (10s rolling)">🔥</button>
+            <button type="button" id="md-settings-open" class="icon-button" aria-label="Market data settings" title="Market data settings">⚙</button>
+          </span>
         </h2>
+        <div id="heatmap-panel" class="heatmap-panel" role="grid"
+             aria-label="Volume heatmap (10s rolling, click cell to select symbol)" hidden></div>
         <div class="table-scroll">
           <table id="md-table">
             <thead>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -658,6 +658,7 @@ function handleApplyMd({ url, symbols }) {
     state.clearAllBooks();
     state.clearAllCandles();
     state.clearAllTape();
+    state.clearAllHeatmap();
     mbpEnabled = false;
     startMdWorker();
   } else {
@@ -712,6 +713,7 @@ function onMdWorkerMessage(msg) {
       state.clearAllBooks();
       state.clearAllCandles();
       state.clearAllTape();
+      state.clearAllHeatmap();
       break;
     case "md.trade":    state.applyMdTrade(msg); break;
     case "md.info":     state.applyMdInfo(msg); break;

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -78,6 +78,13 @@ const state = {
   // `selectedSymbol`.
   tape: new Map(),         // Symbol -> [{tradeId, price, qty, side, receivedAt, busted}]
   tapeShowAll: true,
+  // #71: Volume heatmap rolling-window buffer. Per-symbol ring of
+  // { ts, qty } entries from TRADE frames, trimmed to the configured
+  // window on each push. The render layer reads this slice and
+  // computes the per-symbol sum + global max for the colour scale
+  // — keeping the buffer raw (not pre-aggregated) lets the window
+  // size be tuned without rebuilding state.
+  heatmapTrades: new Map(), // Symbol -> [{ ts: ms, qty }]
   // Single symbol selection shared by DOB / chart / tape (the three
   // panels used to carry their own *Symbol slice; that drift made
   // it easy to look at the wrong instrument across panels). Auto-
@@ -195,7 +202,7 @@ export function subscribe(fn) {
 // coupled to the actual data flow without a separate instrumentation
 // surface every applyX has to remember to call.
 const WS_NOTIFY_SLICES = new Set(["orders", "positions", "executions"]);
-const MD_NOTIFY_SLICES = new Set(["marketData", "book", "candles", "tape"]);
+const MD_NOTIFY_SLICES = new Set(["marketData", "book", "candles", "tape", "heatmap"]);
 
 function notify(slice) {
   if (WS_NOTIFY_SLICES.has(slice)) state.lastWsActivity = Date.now();
@@ -349,6 +356,8 @@ export function applyMdTrade({ symbol, price, qty, tradeId }) {
     receivedAt: Date.now(),
     busted: false,
   });
+  // #71: heatmap rolling-window — keep raw {ts, qty}, trimmed lazily.
+  pushHeatmapTrade(symbol, qty);
 }
 
 export function applyMdInfo({ symbol, fields }) {
@@ -621,6 +630,62 @@ export function clearAllTape() {
   if (state.tape.size === 0) return;
   state.tape.clear();
   notify("tape");
+}
+
+// ── #71 Volume heatmap rolling-window slice ────────────────────────
+
+// Default window — issue #71 calls out "10 s rolling volume" but the
+// renderer is free to crop a shorter view if needed for responsiveness.
+export const HEATMAP_WINDOW_MS = 10_000;
+// Hard cap per symbol to keep the per-trade push O(1). A symbol that
+// somehow prints >5000 trades inside the window is well outside the
+// design envelope and the trim-on-push already evicts the head; the
+// cap is just a paranoid backstop against unbounded growth if the
+// clock jumps backwards.
+const HEATMAP_MAX_PER_SYMBOL = 5_000;
+
+function pushHeatmapTrade(symbol, qty) {
+  const q = Number(qty);
+  if (!Number.isFinite(q) || q <= 0) return;
+  let arr = state.heatmapTrades.get(symbol);
+  if (!arr) { arr = []; state.heatmapTrades.set(symbol, arr); }
+  const now = Date.now();
+  arr.push({ ts: now, qty: q });
+  // Trim head past the window. Linear scan is fine — entries are in
+  // chronological order so we can stop at the first in-window row.
+  const cutoff = now - HEATMAP_WINDOW_MS;
+  let i = 0;
+  while (i < arr.length && arr[i].ts < cutoff) i++;
+  if (i > 0) arr.splice(0, i);
+  if (arr.length > HEATMAP_MAX_PER_SYMBOL) {
+    arr.splice(0, arr.length - HEATMAP_MAX_PER_SYMBOL);
+  }
+  notify("heatmap");
+}
+
+// Pure reducer extracted so the renderer (and tests) can compute the
+// per-symbol volume sum without re-walking the buffer twice. Returns
+// a Map<symbol, sumQty>. Symbols with no in-window prints get 0.
+export function computeHeatmapVolumes(map, symbols, nowMs, windowMs = HEATMAP_WINDOW_MS) {
+  const cutoff = nowMs - windowMs;
+  const out = new Map();
+  for (const sym of symbols) {
+    const arr = map.get(sym);
+    if (!arr || arr.length === 0) { out.set(sym, 0); continue; }
+    let sum = 0;
+    for (let i = arr.length - 1; i >= 0; i--) {
+      if (arr[i].ts < cutoff) break;
+      sum += arr[i].qty;
+    }
+    out.set(sym, sum);
+  }
+  return out;
+}
+
+export function clearAllHeatmap() {
+  if (state.heatmapTrades.size === 0) return;
+  state.heatmapTrades.clear();
+  notify("heatmap");
 }
 
 export function setTapeSymbol(symbol) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -5,6 +5,7 @@ import {
   getState, subscribe, isTerminalOrderStatus,
   getPhase, getAuctionState, isAuctionPhase, setAuctionPanelSymbol,
   isStopOrderType, isGtdTif, ORDER_TYPE_CHIP,
+  computeHeatmapVolumes, HEATMAP_WINDOW_MS,
 } from "./state.js";
 import { rulesFor } from "./validation.js";
 
@@ -1032,6 +1033,14 @@ export function bindUi() {
   const mdModal = $("md-settings-modal");
   const mdOpen = $("md-settings-open");
   const mdClose = $("md-settings-close");
+
+  // #71: Volume heatmap toggle (🔥 button in MD panel header). Opt-in
+  // per the decision gate; persisted per tab via sessionStorage.
+  const heatmapBtn = $("heatmap-toggle");
+  if (heatmapBtn) {
+    setHeatmapEnabled(readHeatmapEnabled());
+    heatmapBtn.addEventListener("click", () => setHeatmapEnabled(!_heatmapEnabled));
+  }
   if (mdOpen && mdModal) {
     mdOpen.addEventListener("click", () => {
       rememberFocusForModal("md-settings-modal");
@@ -1428,6 +1437,10 @@ function ensureTicker() {
       // useful information. State changes still trigger an immediate
       // re-render via the wsReconnect subscription.
       renderReconnect();
+      // #71: heatmap intensity decays as the rolling window rolls,
+      // even with no new trades. A periodic re-render keeps the
+      // cells fading instead of latching on the last trade.
+      if (_heatmapEnabled) renderHeatmap();
       renderMarketData();
       // Only re-render the DOB while we're still waiting for a snapshot
       // — the live render path is already wired to the book slice.
@@ -1589,6 +1602,10 @@ export function renderForSlice(slice) {
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "book" || slice === "all") renderDob();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "chartResolution" || slice === "candles" || slice === "all") scheduleChartRender();
   if (slice === "watchlist" || slice === "selectedSymbol" || slice === "tapeShowAll" || slice === "tape" || slice === "all") scheduleTapeRender();
+  // #71: heatmap re-renders on any tape/trade update (via "heatmap"
+  // slice notify) and also when the watchlist or selection changes
+  // so the cell set + selected-cell highlight stay in sync.
+  if (slice === "heatmap" || slice === "watchlist" || slice === "selectedSymbol" || slice === "all") renderHeatmap();
   // Q1.6 (#258). Phase + auction wiring.
   if (slice === "phases" || slice === "marketData" || slice === "watchlist" || slice === "all") renderMarketData();
   if (slice === "phases" || slice === "selectedSymbol" || slice === "all") {
@@ -1711,6 +1728,115 @@ function renderMarketData() {
       <td${tsCls}>${ts}</td>
     </tr>`;
   }).join("");
+}
+
+// ── #71 Volume heatmap ──────────────────────────────────────────────
+
+const HEATMAP_KEY = "b3tp.heatmap.enabled";
+let _heatmapEnabled = false;
+
+function readHeatmapEnabled() {
+  try { return sessionStorage.getItem(HEATMAP_KEY) === "1"; }
+  catch { return false; }
+}
+function writeHeatmapEnabled(on) {
+  try {
+    if (on) sessionStorage.setItem(HEATMAP_KEY, "1");
+    else    sessionStorage.removeItem(HEATMAP_KEY);
+  } catch { /* swallow */ }
+}
+
+// Pure helper: given a Map<symbol,sum>, return a Map<symbol, intensity>
+// where intensity ∈ [0,1] normalised by the per-render global max. A
+// uniform-zero grid (no recent trades anywhere) returns all-zero so the
+// renderer can paint a uniform "cold" cell rather than divide-by-zero.
+export function normaliseHeatmap(volumes) {
+  let max = 0;
+  for (const v of volumes.values()) if (v > max) max = v;
+  const out = new Map();
+  for (const [k, v] of volumes) out.set(k, max > 0 ? v / max : 0);
+  return out;
+}
+
+function heatmapCellColor(intensity) {
+  // 0 → dark slate (no recent volume), 1 → hot red. Use HSL so the
+  // mid-range cells stay clearly distinguishable from the floor.
+  if (!(intensity > 0)) return "rgba(255,255,255,.04)";
+  // Hue 30 (warm orange) → 0 (red); lightness 18% → 50%.
+  const hue   = 30 - 30 * intensity;
+  const light = 18 + 32 * intensity;
+  return `hsl(${hue.toFixed(1)} 80% ${light.toFixed(1)}%)`;
+}
+
+function renderHeatmap() {
+  const el = $("heatmap-panel");
+  if (!el) return;
+  if (!_heatmapEnabled) {
+    if (!el.hidden) { el.hidden = true; el.replaceChildren(); }
+    return;
+  }
+  el.hidden = false;
+  const st = getState();
+  // Drive the grid from the watchlist so the cell layout matches what
+  // the user explicitly subscribed to. Fall back to any symbol that has
+  // received market data — keeps the panel useful even before the
+  // trader edits the watchlist.
+  const symbols = st.watchlist.length > 0
+    ? [...st.watchlist]
+    : [...st.marketData.keys()];
+  if (symbols.length === 0) {
+    el.replaceChildren();
+    const empty = document.createElement("p");
+    empty.className = "heatmap-empty muted";
+    empty.textContent = "no symbols subscribed";
+    el.appendChild(empty);
+    return;
+  }
+  const volumes = computeHeatmapVolumes(st.heatmapTrades, symbols, Date.now(), HEATMAP_WINDOW_MS);
+  const intensities = normaliseHeatmap(volumes);
+  const sel = st.selectedSymbol;
+  // Diff against existing cell set so we don't churn the DOM on every
+  // tick — cells are reused, only style + label content change.
+  const existing = new Map();
+  for (const child of el.children) {
+    if (child.dataset && child.dataset.symbol) existing.set(child.dataset.symbol, child);
+  }
+  const frag = document.createDocumentFragment();
+  for (const sym of symbols) {
+    const intensity = intensities.get(sym) ?? 0;
+    const vol = volumes.get(sym) ?? 0;
+    let cell = existing.get(sym);
+    if (!cell) {
+      cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = "heatmap-cell";
+      cell.setAttribute("role", "gridcell");
+      cell.dataset.symbol = sym;
+      cell.addEventListener("click", () => onSelectSymbol(sym));
+    } else {
+      existing.delete(sym);
+    }
+    cell.style.backgroundColor = heatmapCellColor(intensity);
+    cell.classList.toggle("heatmap-cell--selected", sym === sel);
+    cell.setAttribute("aria-label",
+      `${sym}: ${fmtQty(vol)} traded in last ${Math.round(HEATMAP_WINDOW_MS / 1000)}s`);
+    cell.title = cell.getAttribute("aria-label");
+    cell.innerHTML = `<span class="heatmap-cell-sym">${escapeHtml(sym)}</span>` +
+                     `<span class="heatmap-cell-vol">${fmtQty(vol)}</span>`;
+    frag.appendChild(cell);
+  }
+  // Surviving entries in `existing` are symbols no longer in the
+  // watchlist (or removed snapshot) — drop their cells.
+  for (const stale of existing.values()) stale.remove();
+  el.replaceChildren(frag);
+}
+
+function setHeatmapEnabled(on) {
+  _heatmapEnabled = !!on;
+  writeHeatmapEnabled(_heatmapEnabled);
+  const btn = $("heatmap-toggle");
+  if (btn) btn.setAttribute("aria-pressed", _heatmapEnabled ? "true" : "false");
+  renderHeatmap();
 }
 
 // ── Q1.6 (#258): Phase badge + auction panel + ticket coupling ────

--- a/frontend/test/heatmap.test.mjs
+++ b/frontend/test/heatmap.test.mjs
@@ -1,0 +1,60 @@
+// #71: Volume heatmap — pure reducer + normaliser. The renderer is
+// purely a function of these two helpers, so covering them under
+// node --test gates the colour-scale logic without a DOM.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { installDomStub } from "./dom-stub.mjs";
+installDomStub({ ids: {} });
+
+const { computeHeatmapVolumes, HEATMAP_WINDOW_MS } = await import("../js/state.js");
+const { normaliseHeatmap } = await import("../js/ui.js");
+
+test("computeHeatmapVolumes sums only entries within the window", () => {
+  const now = 10_000;
+  const map = new Map([
+    ["PETR4", [
+      { ts: now - 15_000, qty: 100 }, // outside 10s window
+      { ts: now -  9_000, qty:  50 },
+      { ts: now -  1_000, qty:  25 },
+    ]],
+    ["VALE3", [
+      { ts: now -  5_000, qty: 200 },
+    ]],
+  ]);
+  const out = computeHeatmapVolumes(map, ["PETR4", "VALE3", "ITUB4"], now);
+  assert.equal(out.get("PETR4"), 75);
+  assert.equal(out.get("VALE3"), 200);
+  assert.equal(out.get("ITUB4"), 0);
+});
+
+test("computeHeatmapVolumes respects a caller-supplied windowMs", () => {
+  const now = 10_000;
+  const map = new Map([
+    ["PETR4", [
+      { ts: now - 4_000, qty: 10 },
+      { ts: now - 2_000, qty: 20 },
+    ]],
+  ]);
+  // 3s window only includes the more recent print.
+  const out = computeHeatmapVolumes(map, ["PETR4"], now, 3_000);
+  assert.equal(out.get("PETR4"), 20);
+});
+
+test("normaliseHeatmap scales by global max in [0,1]", () => {
+  const out = normaliseHeatmap(new Map([["A", 100], ["B", 50], ["C", 0]]));
+  assert.equal(out.get("A"), 1);
+  assert.equal(out.get("B"), 0.5);
+  assert.equal(out.get("C"), 0);
+});
+
+test("normaliseHeatmap returns all-zero when no symbol has any volume", () => {
+  const out = normaliseHeatmap(new Map([["A", 0], ["B", 0]]));
+  assert.equal(out.get("A"), 0);
+  assert.equal(out.get("B"), 0);
+});
+
+test("HEATMAP_WINDOW_MS exposes the default 10s window", () => {
+  assert.equal(HEATMAP_WINDOW_MS, 10_000);
+});


### PR DESCRIPTION
Closes #71 — the decision-gated T5 of the trader-UI v2 meta (#66).

## Design choices (per #71 acceptance)

- **Grid scope** = current watchlist (falls back to any md-active symbol when watchlist is empty). Matches what the trader explicitly subscribed to.
- **Window** = 10 s rolling, configurable via the exported `HEATMAP_WINDOW_MS` if later iterations want to expose a control.
- **Colour scale** normalised by the per-render global max so the brightest cell of the moment is always 1.0. Hue 30→0 + lightness 18→50 so mid-range cells stay clearly distinguishable from the floor (no recent volume).
- **Click cell** → `setSelectedSymbol` (same pipeline DOB/chart/tape already share).
- **Refresh latency** ≤500 ms — driven by both the per-trade `heatmap` slice notify *and* the existing 1 Hz slow tick so cells visibly fade as the window rolls even with no new prints.

## Opt-in per the decision gate

"_Implementar somente após T2/T3/T4 estarem em uso e houver feedback de utilidade. Painel adicional pode poluir mais que ajudar._"

Honored by making the panel **off by default**: a 🔥 toggle lives in the Market data `<h2>` (`aria-pressed`, persisted per tab via `sessionStorage`). The heatmap container is `[hidden]` until the trader opts in, so the default trader view is unchanged.

## State + reducer

- New `heatmapTrades` slice in `state.js` — per-symbol ring of `{ ts, qty }` from `applyMdTrade`, trimmed to the 10 s window on push (hard cap 5000/symbol as a clock-skew backstop).
- Pure helpers exported so the colour logic is testable without a DOM:
  - `computeHeatmapVolumes(map, symbols, nowMs, windowMs?)` → per-symbol sum
  - `normaliseHeatmap(volumes)` → per-symbol intensity ∈ [0,1]
- Cleared together with book/candles/tape on `md.clear` / watchlist swap.

## Renderer (ui.js)

- `renderHeatmap()` reconciles a `role=grid` of `role=gridcell` buttons — cells are reused across ticks so we don't churn the DOM at 1 Hz.
- Selected cell gets an outline so the cross-panel selection stays visible inside the heatmap as well.

## Tests

`node --test frontend/test/*.mjs` → **293 pass / 0 fail** (5 new in `heatmap.test.mjs`: window cutoff, custom window, normalisation, all-zero edge, exported constant).

No E2E extension — the existing `smoke.spec.js` doesn't cover individual T2/T3/T4 panels either, so the heatmap follows the same convention.

Known flakes that may surface on rerun: #332, #345, #347.