### PR TITLE
#351 — IOC/FOK silent-drop defensive watchdog

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -46,6 +46,7 @@ public sealed class ExecutionReportProcessor
     private readonly Risk.IReplaceMarginCoordinator? _replaceMargin;
     private readonly IBotErRouter? _botErRouter;
     private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
+    private readonly Scheduling.IocFokWatchdog? _iocWatchdog;
     private readonly FillProjection? _fillProjection;
 
     public ExecutionReportProcessor(
@@ -67,7 +68,8 @@ public sealed class ExecutionReportProcessor
         PnlKeeper? pnlKeeper = null,
         SubAccountPositionKeeper? subAccountPositions = null,
         SubAccountPnlKeeper? subAccountPnl = null,
-        FillProjection? fillProjection = null)
+        FillProjection? fillProjection = null,
+        Scheduling.IocFokWatchdog? iocWatchdog = null)
     {
         _ownership = ownership;
         _orders = orders;
@@ -88,6 +90,7 @@ public sealed class ExecutionReportProcessor
         _subAccountPositions = subAccountPositions;
         _subAccountPnl = subAccountPnl;
         _fillProjection = fillProjection;
+        _iocWatchdog = iocWatchdog;
     }
 
     /// <summary>
@@ -719,6 +722,12 @@ public sealed class ExecutionReportProcessor
             or OrderStatus.Rejected or OrderStatus.Replaced)
         {
             _gtdScheduler?.OnOrderTerminal(lookupId);
+            // #351 — Cancel the IOC/FOK watchdog timer (if any). The
+            // expected happy-path: a fill / cancel / reject ER lands
+            // within the watchdog timeout, this hook disposes the
+            // pending timer, and the synthetic Cancel never fires.
+            // Cheap no-op for non IOC/FOK orders.
+            _iocWatchdog?.OnOrderTerminal(lookupId);
         }
 
         // Server-side STP detection (#117): if the matching engine

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -38,6 +38,17 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.orders.gtd_expired");
     public static readonly Counter<long> OrdersModifyRequested =
         Meter.CreateCounter<long>("trading.orders.modify_requested");
+    /// <summary>
+    /// #351 — Counts every time the IOC/FOK watchdog had to
+    /// synthesise a terminal Cancel because the gateway never
+    /// returned an ExecutionReport within the configured timeout
+    /// (defends against upstream <c>B3MatchingPlatform#357</c>
+    /// silent-drop). Tagged with <c>firmId</c>, <c>symbol</c>, and
+    /// <c>tif</c>. A non-zero rate is a regression detector after a
+    /// matching-image bump.
+    /// </summary>
+    public static readonly Counter<long> OrdersIocNoResponse =
+        Meter.CreateCounter<long>("trading.orders.ioc_no_response");
 
     // Execution reports inbound
     public static readonly Counter<long> ExecutionReportsReceived =

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -38,6 +38,7 @@ public sealed class OrderSubmissionService
     private readonly Lifecycle.IDrainGate _drain;
     private readonly IUserBotOrderMappingRegistry? _botMappings;
     private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
+    private readonly Scheduling.IocFokWatchdog? _iocWatchdog;
     private readonly ILogger<OrderSubmissionService> _logger;
 
     public OrderSubmissionService(
@@ -53,7 +54,8 @@ public sealed class OrderSubmissionService
         Lifecycle.IDrainGate drain,
         ILogger<OrderSubmissionService> logger,
         IUserBotOrderMappingRegistry? botMappings = null,
-        Scheduling.GtdExpirationScheduler? gtdScheduler = null)
+        Scheduling.GtdExpirationScheduler? gtdScheduler = null,
+        Scheduling.IocFokWatchdog? iocWatchdog = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -67,6 +69,7 @@ public sealed class OrderSubmissionService
         _drain = drain;
         _botMappings = botMappings;
         _gtdScheduler = gtdScheduler;
+        _iocWatchdog = iocWatchdog;
         _logger = logger;
     }
 
@@ -286,6 +289,16 @@ public sealed class OrderSubmissionService
         // No-ops for non-GTD orders; no-ops when the scheduler is not
         // wired (test contexts that don't need expiry firing).
         _gtdScheduler?.OnOrderTracked(order);
+
+        // #351 — Defensive watchdog for IOC/FOK. Upstream matching
+        // (B3MatchingPlatform#357) can silently drop an IOC aggressor
+        // that finds no liquidity, leaving the order pinned in
+        // WorkingOrderBook with a never-released margin reservation.
+        // Arming the watchdog AFTER the gateway submit succeeds
+        // mirrors the GTD scheduler ordering: the timer should only
+        // run once we believe the venue has the order, otherwise a
+        // submit-side failure synthesises its own rejection above.
+        _iocWatchdog?.Register(order);
 
         return OrderSubmissionResult.Accepted(clOrdId);
     }

--- a/backend/src/B3.Trading.Application/Scheduling/IocFokWatchdog.cs
+++ b/backend/src/B3.Trading.Application/Scheduling/IocFokWatchdog.cs
@@ -1,0 +1,247 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Scheduling;
+
+/// <summary>
+/// #351 — Defensive watchdog for <see cref="TimeInForce.IOC"/> and
+/// <see cref="TimeInForce.FOK"/> orders. Upstream matching can silently
+/// drop an IOC/FOK aggressor that finds no liquidity (no
+/// <c>ExecutionReport</c> ever returns; see
+/// <c>B3MatchingPlatform#357</c>). If that happens the order sits in
+/// <see cref="WorkingOrderBook"/> forever, the trader-UI shows it as
+/// live, and the margin reservation is never released.
+///
+/// <para>
+/// This watchdog arms a one-shot timer on every IOC/FOK submit. If a
+/// terminal <c>ExecutionReport</c> arrives before the timer fires the
+/// entry is canceled and the order follows the normal lifecycle. If the
+/// timer fires first, the watchdog dispatches a synthetic
+/// <see cref="ExecKind.Canceled"/> event with a deterministic reject
+/// reason so the order is retired from the book, the margin reservation
+/// is released, and downstream sinks (WS, drop-copy, executions log)
+/// see a terminal frame. Both branches are idempotent.
+/// </para>
+///
+/// <para>
+/// The watchdog is purely defensive. Once upstream emits a proper
+/// terminal ER on no-liquidity IOC the timer simply never fires (the
+/// terminal ER eviction wins) and the metric stays at zero. The metric
+/// is therefore also a regression detector — any non-zero rate after a
+/// matching-image bump points at a recurrence of the upstream bug.
+/// </para>
+/// </summary>
+public sealed class IocFokWatchdog : IDisposable
+{
+    public const string SyntheticCancelReason = "gateway_no_response_ioc";
+
+    private readonly WorkingOrderBook _book;
+    private readonly EventDispatcher _dispatcher;
+    private readonly IExecutionEventSink _sink;
+    private readonly IMarginProvider _margin;
+    private readonly TimeProvider _clock;
+    private readonly IOptionsMonitor<IocFokWatchdogOptions> _options;
+    private readonly ILogger<IocFokWatchdog>? _logger;
+
+    private readonly ConcurrentDictionary<ulong, ITimer> _active = new();
+    private int _disposed;
+
+    public IocFokWatchdog(
+        WorkingOrderBook book,
+        EventDispatcher dispatcher,
+        IExecutionEventSink sink,
+        IMarginProvider margin,
+        IOptionsMonitor<IocFokWatchdogOptions> options,
+        TimeProvider? clock = null,
+        ILogger<IocFokWatchdog>? logger = null)
+    {
+        _book = book ?? throw new ArgumentNullException(nameof(book));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _sink = sink ?? new NoOpExecutionEventSink();
+        _margin = margin ?? throw new ArgumentNullException(nameof(margin));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _clock = clock ?? TimeProvider.System;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Diagnostic surface for tests.
+    /// </summary>
+    public int TrackedCount => _active.Count;
+
+    /// <summary>
+    /// Called from <c>OrderSubmissionService</c> after the gateway
+    /// submit returns. No-op for non IOC/FOK orders, for terminal
+    /// orders (e.g. synchronously rejected), and when the watchdog is
+    /// disabled via configuration so callers don't have to gate.
+    /// </summary>
+    public void Register(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        if (Volatile.Read(ref _disposed) != 0) return;
+        if (order.TimeInForce is not (TimeInForce.IOC or TimeInForce.FOK)) return;
+        if (IsTerminal(order.Status)) return;
+
+        var opts = _options.CurrentValue;
+        if (!opts.Enabled) return;
+        var timeout = TimeSpan.FromMilliseconds(Math.Max(1, opts.TimeoutMs));
+
+        var clOrdId = order.ClOrdId;
+        // One-shot timer. We intentionally allocate a fresh timer per
+        // order rather than sharing a min-heap: IOC/FOK terminates
+        // within a few ms in the happy path so the live set is
+        // typically tiny, and a per-order timer keeps the Fire path
+        // lock-free.
+        var timer = _clock.CreateTimer(
+            static state => ((Entry)state!).Self.Fire(((Entry)state!).ClOrdId),
+            new Entry(clOrdId, this),
+            timeout,
+            Timeout.InfiniteTimeSpan);
+
+        // Replace-and-dispose pattern: a re-register for the same
+        // clOrdId (currently impossible — ClOrdIDs are unique — but
+        // defensive against future replays) supersedes the previous
+        // timer so we never leak.
+        if (_active.TryGetValue(clOrdId, out var existing))
+        {
+            _active[clOrdId] = timer;
+            existing.Dispose();
+        }
+        else
+        {
+            _active[clOrdId] = timer;
+        }
+    }
+
+    /// <summary>
+    /// Called from <c>ExecutionReportProcessor</c> whenever an order
+    /// reaches a terminal status. Disposes the pending watchdog timer
+    /// (if any). Cheap no-op when nothing is tracked for the id.
+    /// </summary>
+    public void OnOrderTerminal(ulong clOrdId)
+    {
+        if (_active.TryRemove(clOrdId, out var timer))
+        {
+            timer.Dispose();
+        }
+    }
+
+    private void Fire(ulong clOrdId)
+    {
+        // Atomic claim: if a concurrent OnOrderTerminal already won we
+        // observe the entry as gone and bail. Without the claim the
+        // synthetic Cancel could race the real terminal ER and emit a
+        // spurious event after the order already terminalised.
+        if (!_active.TryRemove(clOrdId, out var timer))
+        {
+            return;
+        }
+        timer.Dispose();
+
+        if (!_book.TryGet(clOrdId, out var orderRef) || orderRef is null)
+        {
+            // Order vanished before we could act — nothing to do. Late
+            // ER eviction or test teardown.
+            return;
+        }
+        var order = orderRef;
+        if (IsTerminal(order.Status))
+        {
+            // Terminal ER arrived in the gap between the timer firing
+            // and our claim being processed — happy outcome.
+            return;
+        }
+
+        var firmTag = new KeyValuePair<string, object?>("firmId", order.FirmId);
+        var symbolTag = new KeyValuePair<string, object?>("symbol", order.Symbol);
+        var tifTag = new KeyValuePair<string, object?>("tif", order.TimeInForce.ToString());
+        MetricsRegistry.OrdersIocNoResponse.Add(1, firmTag, symbolTag, tifTag);
+
+        _logger?.LogWarning(
+            "event=ioc.watchdog.fired clOrdId={ClOrdId} firmId={FirmId} symbol={Symbol} tif={Tif} " +
+            "owner={Owner} reason={Reason}; synthesising terminal Cancel.",
+            clOrdId, order.FirmId, order.Symbol, order.TimeInForce, order.Owner.Value, SyntheticCancelReason);
+
+        try
+        {
+            _dispatcher.Dispatch(
+                new ExecutionReportReceivedEvent
+                {
+                    ClOrdId = clOrdId,
+                    ExecKind = ExecKind.Canceled.ToString(),
+                    LeavesQuantity = order.LeavesQuantity,
+                    CumulativeQuantity = order.CumulativeQuantity,
+                    LastQuantity = 0,
+                    LastPrice = 0m,
+                    RejectReason = SyntheticCancelReason,
+                    Synthetic = true,
+                },
+                () => ApplySyntheticCancel(order));
+        }
+        catch (WalBackpressureException)
+        {
+            // WAL is jammed — still mark the order terminal locally so
+            // the trader-UI and margin reservation don't hang. The
+            // event is lost from the audit trail but the in-memory
+            // state recovers; mirrors the PublishSyntheticRejection
+            // fallback in OrderSubmissionService.
+            ApplySyntheticCancel(order);
+        }
+    }
+
+    private void ApplySyntheticCancel(Order order)
+    {
+        order.MarkCancelled();
+        _margin.OnExecution(order.ClOrdId, ExecKind.Canceled, 0);
+        _sink.Publish(new ExecutionEvent(
+            order.Owner, order.ClOrdId, order.Symbol, order.Side, order.Status,
+            ExecKind.Canceled,
+            order.LeavesQuantity, order.CumulativeQuantity, 0, 0m,
+            SyntheticCancelReason, _clock.GetUtcNow(),
+            IsNativeStp: false, FirmId: order.FirmId));
+    }
+
+    private static bool IsTerminal(OrderStatus status) =>
+        status is OrderStatus.Filled or OrderStatus.Cancelled
+            or OrderStatus.Rejected or OrderStatus.Replaced;
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        foreach (var kv in _active)
+        {
+            if (_active.TryRemove(kv.Key, out var t)) t.Dispose();
+        }
+    }
+
+    private sealed record Entry(ulong ClOrdId, IocFokWatchdog Self);
+}
+
+/// <summary>
+/// Tuning surface for the IOC/FOK watchdog (#351).
+/// </summary>
+public sealed class IocFokWatchdogOptions
+{
+    public const string SectionName = "Trading:IocFokWatchdog";
+
+    /// <summary>
+    /// Master switch. Defaults to <c>true</c> so the safeguard is
+    /// active by default; can be disabled (e.g. in single-process
+    /// tests that don't exercise the gateway) without recompiling.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Watchdog timeout in milliseconds. Should be set well above
+    /// normal venue RTT (sub-millisecond on the in-process matching,
+    /// single-digit ms across the real matching) but tight enough
+    /// that traders notice the failure within one human reaction.
+    /// Default <c>500</c> ms.
+    /// </summary>
+    public int TimeoutMs { get; set; } = 500;
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -172,6 +172,16 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.Scheduling.GtdExpirationScheduler>());
 
+        // #351 — IOC/FOK silent-drop watchdog. Defensive against
+        // upstream B3MatchingPlatform#357 (Limit/IOC against empty
+        // opposite book silently drops without an ER). Singleton so
+        // OrderSubmissionService.Register and
+        // ExecutionReportProcessor.OnOrderTerminal both target the
+        // same timer registry.
+        services.Configure<B3.Trading.Application.Scheduling.IocFokWatchdogOptions>(
+            configuration.GetSection(B3.Trading.Application.Scheduling.IocFokWatchdogOptions.SectionName));
+        services.AddSingleton<B3.Trading.Application.Scheduling.IocFokWatchdog>();
+
         // Algo engine signal channel + hosted consumer (RFC algo-orders-v0 §4.3).
         // In slice 5a the consumer body was a no-op reactor; slice 5b plugged in the
         // Iceberg state machine; slice 6 adds the AlgoScheduler hosted service that

--- a/backend/tests/B3.Trading.Application.Tests/Scheduling/IocFokWatchdogTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Scheduling/IocFokWatchdogTests.cs
@@ -1,0 +1,259 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Scheduling;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests.Scheduling;
+
+/// <summary>
+/// #351 — Behavioural coverage for the IOC/FOK silent-drop watchdog.
+/// </summary>
+public class IocFokWatchdogTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    private sealed class CapturingSink : IExecutionEventSink
+    {
+        public List<ExecutionEvent> Events { get; } = new();
+        public void Publish(ExecutionEvent ev) { lock (Events) Events.Add(ev); }
+    }
+
+    private sealed class CountingMargin : IMarginProvider
+    {
+        public int ReleaseCalls;
+        public int ExecutionCalls;
+        public Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct) =>
+            Task.FromResult(RiskDecision.Approve);
+        public void OnExecution(ulong clOrdId, ExecKind kind, long lastQty)
+        {
+            Interlocked.Increment(ref ExecutionCalls);
+        }
+        public void ReleaseReservation(ulong clOrdId) => Interlocked.Increment(ref ReleaseCalls);
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class Harness
+    {
+        public VirtualTimeProvider Clock { get; } = new(DateTimeOffset.Parse("2026-05-19T00:00:00Z"));
+        public WorkingOrderBook Book { get; } = new();
+        public EventDispatcher Dispatcher { get; } = new(new NullEventStore());
+        public CapturingSink Sink { get; } = new();
+        public CountingMargin Margin { get; } = new();
+        public IocFokWatchdog Sut { get; }
+        public IocFokWatchdogOptions Options { get; } = new() { Enabled = true, TimeoutMs = 500 };
+
+        public Harness()
+        {
+            Sut = new IocFokWatchdog(
+                Book, Dispatcher, Sink, Margin,
+                new StaticOptionsMonitor<IocFokWatchdogOptions>(Options),
+                Clock, NullLogger<IocFokWatchdog>.Instance);
+        }
+
+        public Order SeedAndRegister(ulong clOrdId, TimeInForce tif)
+        {
+            var o = new Order(
+                clOrdId, Alice, "PETR4", 4321UL, OrderSide.Sell, OrderType.Limit,
+                100, 30m, firmId: "firm-a", timeInForce: tif);
+            Book.TryAdd(o);
+            Sut.Register(o);
+            return o;
+        }
+    }
+
+    [Fact]
+    public void Ioc_no_response_within_timeout_synthesises_terminal_cancel()
+    {
+        var h = new Harness();
+        var o = h.SeedAndRegister(101UL, TimeInForce.IOC);
+
+        Assert.Equal(1, h.Sut.TrackedCount);
+        Assert.Equal(OrderStatus.PendingNew, o.Status);
+
+        h.Clock.Advance(TimeSpan.FromMilliseconds(600));
+
+        Assert.Equal(OrderStatus.Cancelled, o.Status);
+        Assert.Equal(0, h.Sut.TrackedCount);
+        Assert.Single(h.Sink.Events);
+        var ev = h.Sink.Events[0];
+        Assert.Equal(ExecKind.Canceled, ev.Kind);
+        Assert.Equal(IocFokWatchdog.SyntheticCancelReason, ev.RejectReason);
+        Assert.Equal("firm-a", ev.FirmId);
+        Assert.Equal(1, h.Margin.ExecutionCalls);
+    }
+
+    [Fact]
+    public void Terminal_er_before_timeout_cancels_watchdog_and_skips_synthetic()
+    {
+        var h = new Harness();
+        var o = h.SeedAndRegister(102UL, TimeInForce.IOC);
+
+        // Terminal ER lands quickly — the order book mutation is simulated
+        // here (the live path mutates via ExecutionReportProcessor).
+        o.MarkCancelled();
+        h.Sut.OnOrderTerminal(o.ClOrdId);
+
+        h.Clock.Advance(TimeSpan.FromMilliseconds(600));
+
+        Assert.Equal(0, h.Sut.TrackedCount);
+        Assert.Empty(h.Sink.Events);
+        Assert.Equal(0, h.Margin.ExecutionCalls);
+    }
+
+    [Fact]
+    public void Non_ioc_orders_are_not_tracked()
+    {
+        var h = new Harness();
+        h.SeedAndRegister(103UL, TimeInForce.Day);
+        h.SeedAndRegister(104UL, TimeInForce.GTC);
+
+        Assert.Equal(0, h.Sut.TrackedCount);
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        Assert.Empty(h.Sink.Events);
+    }
+
+    [Fact]
+    public void Fok_is_tracked_just_like_ioc()
+    {
+        var h = new Harness();
+        var o = h.SeedAndRegister(105UL, TimeInForce.FOK);
+
+        Assert.Equal(1, h.Sut.TrackedCount);
+        h.Clock.Advance(TimeSpan.FromMilliseconds(600));
+        Assert.Equal(OrderStatus.Cancelled, o.Status);
+        Assert.Single(h.Sink.Events);
+    }
+
+    [Fact]
+    public void Late_terminal_after_synthetic_does_not_double_fire()
+    {
+        var h = new Harness();
+        var o = h.SeedAndRegister(106UL, TimeInForce.IOC);
+
+        // Watchdog fires first.
+        h.Clock.Advance(TimeSpan.FromMilliseconds(600));
+        Assert.Single(h.Sink.Events);
+
+        // Real terminal ER arrives later — the OnOrderTerminal hook
+        // must be safe to call (no-op).
+        h.Sut.OnOrderTerminal(o.ClOrdId);
+        Assert.Single(h.Sink.Events);
+    }
+
+    [Fact]
+    public void Disabled_options_skips_registration()
+    {
+        var h = new Harness();
+        h.Options.Enabled = false;
+
+        var o = h.SeedAndRegister(107UL, TimeInForce.IOC);
+        Assert.Equal(0, h.Sut.TrackedCount);
+
+        h.Clock.Advance(TimeSpan.FromSeconds(5));
+        Assert.Equal(OrderStatus.PendingNew, o.Status);
+        Assert.Empty(h.Sink.Events);
+    }
+
+    [Fact]
+    public void Fire_against_already_terminal_order_skips_synthetic()
+    {
+        var h = new Harness();
+        var o = h.SeedAndRegister(108UL, TimeInForce.IOC);
+
+        // Status flips terminal but the watchdog wasn't notified
+        // (simulates a race: ER applied to order in the gap before
+        // the OnOrderTerminal hook runs). Fire must observe the
+        // terminal status and skip.
+        o.MarkCancelled();
+        h.Clock.Advance(TimeSpan.FromMilliseconds(600));
+
+        Assert.Empty(h.Sink.Events);
+        Assert.Equal(0, h.Sut.TrackedCount);
+    }
+
+    // ---------- Shared virtual time provider ------------
+
+    private sealed class VirtualTimeProvider : TimeProvider
+    {
+        private readonly object _lock = new();
+        private DateTimeOffset _now;
+        private readonly List<VTimer> _timers = new();
+
+        public VirtualTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() { lock (_lock) return _now; }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var t = new VTimer(this, callback, state);
+            t.Change(dueTime, period);
+            return t;
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            var deadline = Now + delta;
+            while (true)
+            {
+                VTimer? next = null;
+                lock (_lock)
+                {
+                    foreach (var t in _timers)
+                    {
+                        if (t.DueAt is { } d && d <= deadline)
+                        {
+                            if (next is null || d < next.DueAt) next = t;
+                        }
+                    }
+                }
+                if (next is null) { lock (_lock) _now = deadline; return; }
+                lock (_lock) _now = next.DueAt!.Value;
+                next.Fire();
+            }
+        }
+
+        internal void Register(VTimer t) { lock (_lock) _timers.Add(t); }
+        internal void Unregister(VTimer t) { lock (_lock) _timers.Remove(t); }
+        internal DateTimeOffset Now { get { lock (_lock) return _now; } }
+    }
+
+    private sealed class VTimer : ITimer
+    {
+        private readonly VirtualTimeProvider _owner;
+        private readonly TimerCallback _cb;
+        private readonly object? _state;
+        public DateTimeOffset? DueAt { get; private set; }
+
+        public VTimer(VirtualTimeProvider owner, TimerCallback cb, object? state)
+        {
+            _owner = owner; _cb = cb; _state = state;
+            _owner.Register(this);
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            DueAt = dueTime == Timeout.InfiniteTimeSpan ? null : _owner.Now + dueTime;
+            return true;
+        }
+
+        public void Fire()
+        {
+            DueAt = null;
+            _cb(_state);
+        }
+
+        public void Dispose() => _owner.Unregister(this);
+        public ValueTask DisposeAsync() { Dispose(); return ValueTask.CompletedTask; }
+    }
+}


### PR DESCRIPTION
Closes #351.

## What

Mirrors upstream **B3MatchingPlatform#357** (Limit/IOC against empty opposite book is silently dropped — no terminal ER returns). Adds a defensive client-side watchdog so the trading-host remains correct independent of upstream timing.

## How

- New `IocFokWatchdog` (Scheduling/): per-order one-shot timer, default 500 ms (`Trading:IocFokWatchdog:TimeoutMs`). Disposed on terminal ER. On fire → synthetic terminal `Canceled` ER with reason `gateway_no_response_ioc` via the existing event dispatcher → margin released, order retired, sinks notified.
- `OrderSubmissionService` calls `Register(order)` after a successful gateway submit (alongside the GTD scheduler hook).
- `ExecutionReportProcessor` calls `OnOrderTerminal(clOrdId)` in the terminal-status block.
- Metric `trading.orders.ioc_no_response{firmId,symbol,tif}` doubles as an upstream-regression detector.
- DI singleton + options bind in `TradingApplicationCoreServiceCollectionExtensions`.

## Tests

`IocFokWatchdogTests` — 7 tests, all green. Covers happy path, timeout fire, FOK, non-IOC bypass, late-ER no-op after fire, options-disabled, and the already-terminal race.