### PR TITLE
feat(reconciliation): D+1 fills reconciliation tool (#274)

### DIFF
--- a/B3TradingPlatform.slnx
+++ b/B3TradingPlatform.slnx
@@ -14,6 +14,7 @@
     <Project Path="backend/tests/B3.Trading.Conformance/B3.Trading.Conformance.csproj" />
     <Project Path="backend/tests/B3.Trading.SimulatorBot.Tests/B3.Trading.SimulatorBot.Tests.csproj" />
     <Project Path="backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj" />
+    <Project Path="backend/tests/B3.Trading.Reconciliation.Tests/B3.Trading.Reconciliation.Tests.csproj" />
   </Folder>
   <Folder Name="/backend/bench/">
     <Project Path="backend/bench/B3.Trading.Benchmarks/B3.Trading.Benchmarks.csproj" />
@@ -22,5 +23,6 @@
   <Folder Name="/backend/tools/">
     <Project Path="backend/tools/B3.Trading.DemoDriver/B3.Trading.DemoDriver.csproj" />
     <Project Path="backend/tools/B3.Trading.SimulatorBot/B3.Trading.SimulatorBot.csproj" />
+    <Project Path="backend/tools/B3.Trading.Reconciliation/B3.Trading.Reconciliation.csproj" />
   </Folder>
 </Solution>

--- a/backend/tests/B3.Trading.Reconciliation.Tests/B3.Trading.Reconciliation.Tests.csproj
+++ b/backend/tests/B3.Trading.Reconciliation.Tests/B3.Trading.Reconciliation.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Trading.Reconciliation.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\B3.Trading.Reconciliation\B3.Trading.Reconciliation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/B3.Trading.Reconciliation.Tests/ReconciliationTests.cs
+++ b/backend/tests/B3.Trading.Reconciliation.Tests/ReconciliationTests.cs
@@ -1,0 +1,222 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using B3.Trading.Reconciliation;
+
+namespace B3.Trading.Reconciliation.Tests;
+
+public class MatchingFillsReaderTests
+{
+    [Fact]
+    public void Parses_canonical_contract_csv()
+    {
+        var csv = "tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n" +
+                  "T1,2026-05-19T10:00:00.123456Z,PETR4,Buy,100,30.55,B1,S1,FIRM01,FIRM02\n" +
+                  "T2,2026-05-19T10:00:05.000000Z,VALE3,Sell,50,72.10,B2,S2,FIRM03,FIRM01\n";
+        var rows = MatchingFillsReader.ParseCsv(Encoding.UTF8.GetBytes(csv)).ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("T1", rows[0].TradeId);
+        Assert.Equal("PETR4", rows[0].Symbol);
+        Assert.Equal(100, rows[0].Quantity);
+        Assert.Equal(30.55m, rows[0].Price);
+        Assert.Equal("FIRM02", rows[0].SellFirm);
+        Assert.Equal("FIRM01", rows[1].SellFirm);
+    }
+
+    [Fact]
+    public void Rejects_wrong_header()
+    {
+        var csv = "tradeId,ts,symbol\nT1,2026-05-19T10:00:00Z,PETR4\n";
+        Assert.Throws<InvalidDataException>(() =>
+            MatchingFillsReader.ParseCsv(Encoding.UTF8.GetBytes(csv)).ToList());
+    }
+
+    [Fact]
+    public void Load_validates_sha256_against_done_sidecar()
+    {
+        var root = NewTempDir();
+        var dir = Path.Combine(root, "1", "2026-05-19");
+        Directory.CreateDirectory(dir);
+        var csv = "tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n" +
+                  "T1,2026-05-19T10:00:00Z,PETR4,Buy,100,30.55,B1,S1,FIRM01,FIRM02\n";
+        var bytes = Encoding.UTF8.GetBytes(csv);
+        File.WriteAllBytes(Path.Combine(dir, "fills.csv"), bytes);
+        var sha = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        var done = JsonSerializer.Serialize(new { rowCount = 1, sha256 = sha, generatedAt = "2026-05-19T18:00:00Z" });
+        File.WriteAllText(Path.Combine(dir, "fills.csv.done"), done);
+
+        var result = MatchingFillsReader.Load(root, "1", new DateOnly(2026, 5, 19));
+        Assert.Single(result.Rows);
+        Assert.Equal(sha, result.Sha256);
+    }
+
+    [Fact]
+    public void Load_rejects_mismatched_sha()
+    {
+        var root = NewTempDir();
+        var dir = Path.Combine(root, "1", "2026-05-19");
+        Directory.CreateDirectory(dir);
+        var bytes = Encoding.UTF8.GetBytes(
+            "tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n" +
+            "T1,2026-05-19T10:00:00Z,PETR4,Buy,100,30.55,B1,S1,FIRM01,FIRM02\n");
+        File.WriteAllBytes(Path.Combine(dir, "fills.csv"), bytes);
+        var done = JsonSerializer.Serialize(new { rowCount = 1, sha256 = "deadbeef", generatedAt = "2026-05-19T18:00:00Z" });
+        File.WriteAllText(Path.Combine(dir, "fills.csv.done"), done);
+
+        Assert.Throws<InvalidDataException>(() =>
+            MatchingFillsReader.Load(root, "1", new DateOnly(2026, 5, 19)));
+    }
+
+    [Fact]
+    public void Load_refuses_when_done_sidecar_absent()
+    {
+        var root = NewTempDir();
+        var dir = Path.Combine(root, "1", "2026-05-19");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "fills.csv"), "header\n");
+        Assert.Throws<FileNotFoundException>(() =>
+            MatchingFillsReader.Load(root, "1", new DateOnly(2026, 5, 19)));
+    }
+
+    private static string NewTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"b3-recon-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}
+
+public class TradingHostStatementParserTests
+{
+    [Fact]
+    public void Extracts_fills_section_and_ignores_other_sections()
+    {
+        // Mirrors the multi-section layout in StatementEndpoints.RenderCsv.
+        var csv = string.Join("\r\n", new[]
+        {
+            "symbol,netQty,avgPrice,subAccountId",
+            "PETR4,100,30.55,",
+            "",
+            "executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc,subAccountId",
+            "1001:100,1001,1001,PETR4,Buy,100,30.55,2026-05-19T10:00:00Z,",
+            "1002:50,1002,1002,VALE3,Sell,50,72.10,2026-05-19T10:00:05Z,",
+            "",
+            "feeType,total",
+            "emoluments,12.34",
+            "totalFees,12.34",
+            "",
+        });
+        var fills = TradingHostStatementParser.ParseFills(csv);
+        Assert.Equal(2, fills.Count);
+        Assert.Equal("PETR4", fills[0].Symbol);
+        Assert.Equal(100, fills[0].Quantity);
+        Assert.Equal(30.55m, fills[0].Price);
+        Assert.Equal("Sell", fills[1].Side);
+    }
+
+    [Fact]
+    public void Handles_quoted_fields_with_commas()
+    {
+        var csv = "executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc,subAccountId\r\n" +
+                  "\"1001:100\",1001,1001,\"PETR,4\",Buy,100,30.55,2026-05-19T10:00:00Z,";
+        var fills = TradingHostStatementParser.ParseFills(csv);
+        Assert.Single(fills);
+        Assert.Equal("PETR,4", fills[0].Symbol);
+    }
+}
+
+public class FillsComparatorTests
+{
+    private static readonly DateTimeOffset Ts = DateTimeOffset.Parse("2026-05-19T10:00:00Z", CultureInfo.InvariantCulture);
+
+    [Fact]
+    public void Clean_alignment_when_aggregates_match()
+    {
+        var matching = new List<MatchingFillRow>
+        {
+            new("T1", Ts, "PETR4", "Buy", 100, 30.55m, "B1", "S1", "FIRM01", "FIRM02"),
+            new("T2", Ts.AddSeconds(5), "PETR4", "Sell", 50, 30.60m, "B2", "S2", "FIRM03", "FIRM01"),
+        };
+        // FIRM01 is buyer in T1 (Buy 100@30.55) and seller in T2 (Sell 50@30.60).
+        var host = new List<HostFillRow>
+        {
+            new("1001:100", "1001", "1001", "PETR4", "Buy", 100, 30.55m, Ts, null),
+            new("1002:50", "1002", "1002", "PETR4", "Sell", 50, 30.60m, Ts.AddSeconds(5), null),
+        };
+        var report = FillsComparator.Compare(matching, host, "FIRM01");
+        Assert.True(report.IsClean, report.Render());
+        Assert.Equal(2, report.MatchingRowCount);
+        Assert.Equal(2, report.HostRowCount);
+    }
+
+    [Fact]
+    public void Internal_cross_expands_into_two_host_rows()
+    {
+        // Matching emits ONE row for an internal cross — FIRM01 buyer
+        // and FIRM01 seller. Trading-host writes two separate fill
+        // ERs (one per ClOrdId). The projection must mirror that.
+        var matching = new List<MatchingFillRow>
+        {
+            new("T1", Ts, "PETR4", "Buy", 100, 30.55m, "B1", "S1", "FIRM01", "FIRM01"),
+        };
+        var host = new List<HostFillRow>
+        {
+            new("B1:100", "B1", "B1", "PETR4", "Buy", 100, 30.55m, Ts, null),
+            new("S1:100", "S1", "S1", "PETR4", "Sell", 100, 30.55m, Ts, null),
+        };
+        var report = FillsComparator.Compare(matching, host, "FIRM01");
+        Assert.True(report.IsClean, report.Render());
+        Assert.Equal(2, report.MatchingRowCount); // projection expanded
+        Assert.Equal(2, report.HostRowCount);
+    }
+
+    [Fact]
+    public void Quantity_drift_surfaces_as_per_bucket_diff()
+    {
+        var matching = new List<MatchingFillRow>
+        {
+            new("T1", Ts, "PETR4", "Buy", 100, 30.55m, "B1", "S1", "FIRM01", "FIRM02"),
+        };
+        // Host recorded only 80 — the missing 20 is the kind of drift
+        // this tool is designed to surface.
+        var host = new List<HostFillRow>
+        {
+            new("1001:80", "1001", "1001", "PETR4", "Buy", 80, 30.55m, Ts, null),
+        };
+        var report = FillsComparator.Compare(matching, host, "FIRM01");
+        Assert.False(report.IsClean);
+        Assert.Single(report.Diffs);
+        var diff = report.Diffs[0];
+        Assert.Equal("PETR4", diff.Symbol);
+        Assert.Equal("Buy", diff.Side);
+        Assert.Equal(100, diff.Matching.TotalQty);
+        Assert.Equal(80, diff.Host.TotalQty);
+    }
+
+    [Fact]
+    public void Rows_for_other_firms_are_filtered_out()
+    {
+        var matching = new List<MatchingFillRow>
+        {
+            new("T1", Ts, "PETR4", "Buy", 100, 30.55m, "B1", "S1", "FIRM02", "FIRM03"),
+        };
+        var report = FillsComparator.Compare(matching, Array.Empty<HostFillRow>(), "FIRM01");
+        Assert.True(report.IsClean, report.Render());
+        Assert.Equal(0, report.MatchingRowCount);
+    }
+
+    [Fact]
+    public void Missing_bucket_on_host_side_surfaces_as_diff()
+    {
+        var matching = new List<MatchingFillRow>
+        {
+            new("T1", Ts, "VALE3", "Sell", 50, 72.10m, "B1", "S1", "FIRM02", "FIRM01"),
+        };
+        var report = FillsComparator.Compare(matching, Array.Empty<HostFillRow>(), "FIRM01");
+        Assert.False(report.IsClean);
+        Assert.Single(report.Diffs);
+        Assert.Equal(0, report.Diffs[0].Host.Count);
+        Assert.Equal(1, report.Diffs[0].Matching.Count);
+    }
+}

--- a/backend/tools/B3.Trading.Reconciliation/B3.Trading.Reconciliation.csproj
+++ b/backend/tools/B3.Trading.Reconciliation/B3.Trading.Reconciliation.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Trading.Reconciliation</RootNamespace>
+    <AssemblyName>b3-reconcile</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Trading.Reconciliation.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tools/B3.Trading.Reconciliation/FillsComparator.cs
+++ b/backend/tools/B3.Trading.Reconciliation/FillsComparator.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+
+namespace B3.Trading.Reconciliation;
+
+/// <summary>
+/// Pure comparator that diffs the matching platform's fills CSV
+/// against the trading-host's statement fills for a single firm on a
+/// single UTC date. The exporter on the matching side emits one row
+/// per trade with both firms; we project the firm-relative view by
+/// expanding internal crosses (buyFirm == sellFirm == ourFirm) into
+/// two host-side fills (a Buy and a Sell), matching the trading-host
+/// statement shape (FillRowDto per ER, not per trade).
+///
+/// <para>
+/// The comparator is intentionally aggregate-first: ExecutionId on the
+/// trading-host side is synthesised as <c>{clOrdId}:{cumQty}</c> and
+/// is therefore not a join key against the matching <c>tradeId</c>.
+/// We compare <c>(symbol, side)</c> aggregates (count, sum of qty, sum
+/// of notional = qty * price); any divergence produces a detailed
+/// per-bucket report identifying which (symbol, side) bucket drifted.
+/// </para>
+/// </summary>
+public static class FillsComparator
+{
+    public static ReconciliationReport Compare(
+        IReadOnlyList<MatchingFillRow> matching,
+        IReadOnlyList<HostFillRow> host,
+        string firmId)
+    {
+        ArgumentNullException.ThrowIfNull(matching);
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentException.ThrowIfNullOrEmpty(firmId);
+
+        var matchingProjected = ProjectMatchingForFirm(matching, firmId).ToList();
+        var matchingBuckets = Aggregate(matchingProjected.Select(p =>
+            (p.Symbol, p.Side, p.Quantity, p.Price)));
+        var hostBuckets = Aggregate(host.Select(h =>
+            (h.Symbol, NormaliseSide(h.Side), h.Quantity, h.Price)));
+
+        var diffs = new List<BucketDiff>();
+        var allKeys = matchingBuckets.Keys.Union(hostBuckets.Keys).OrderBy(k => k.Symbol).ThenBy(k => k.Side);
+        foreach (var key in allKeys)
+        {
+            var m = matchingBuckets.TryGetValue(key, out var mv) ? mv : Aggregates.Zero;
+            var h = hostBuckets.TryGetValue(key, out var hv) ? hv : Aggregates.Zero;
+            if (m != h)
+            {
+                diffs.Add(new BucketDiff(key.Symbol, key.Side, m, h));
+            }
+        }
+
+        return new ReconciliationReport(
+            FirmId: firmId,
+            MatchingRowCount: matchingProjected.Count,
+            HostRowCount: host.Count,
+            Diffs: diffs);
+    }
+
+    /// <summary>
+    /// Yields one entry per (firm-relative side, ClOrdId) — internal
+    /// crosses (same firm on both sides) emit two entries; outbound
+    /// matches emit one with the firm-relative side derived from
+    /// buyFirm / sellFirm.
+    /// </summary>
+    public static IEnumerable<HostShapedRow> ProjectMatchingForFirm(
+        IEnumerable<MatchingFillRow> matching, string firmId)
+    {
+        foreach (var row in matching)
+        {
+            var isBuy = string.Equals(row.BuyFirm, firmId, StringComparison.Ordinal);
+            var isSell = string.Equals(row.SellFirm, firmId, StringComparison.Ordinal);
+            if (!isBuy && !isSell) continue;
+            if (isBuy)
+            {
+                yield return new HostShapedRow(
+                    Symbol: row.Symbol, Side: "Buy",
+                    Quantity: row.Quantity, Price: row.Price,
+                    ClOrdId: row.BuyClOrdId, TimestampUtc: row.TimestampUtc,
+                    TradeId: row.TradeId);
+            }
+            if (isSell)
+            {
+                yield return new HostShapedRow(
+                    Symbol: row.Symbol, Side: "Sell",
+                    Quantity: row.Quantity, Price: row.Price,
+                    ClOrdId: row.SellClOrdId, TimestampUtc: row.TimestampUtc,
+                    TradeId: row.TradeId);
+            }
+        }
+    }
+
+    private static Dictionary<(string Symbol, string Side), Aggregates> Aggregate(
+        IEnumerable<(string Symbol, string Side, long Quantity, decimal Price)> rows)
+    {
+        var map = new Dictionary<(string, string), Aggregates>();
+        foreach (var r in rows)
+        {
+            var key = (r.Symbol, r.Side);
+            map.TryGetValue(key, out var prev);
+            map[key] = new Aggregates(
+                Count: prev.Count + 1,
+                TotalQty: prev.TotalQty + r.Quantity,
+                TotalNotional: prev.TotalNotional + r.Quantity * r.Price);
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Normalises trading-host side strings ("Buy" / "Sell" or
+    /// "BUY" / "SELL" depending on serialisation history) to the
+    /// canonical "Buy" / "Sell" used in the comparator.
+    /// </summary>
+    public static string NormaliseSide(string side) =>
+        side.Equals("Buy", StringComparison.OrdinalIgnoreCase) ? "Buy" :
+        side.Equals("Sell", StringComparison.OrdinalIgnoreCase) ? "Sell" :
+        side;
+}
+
+public readonly record struct Aggregates(int Count, long TotalQty, decimal TotalNotional)
+{
+    public static readonly Aggregates Zero = new(0, 0, 0m);
+
+    public string Pretty() =>
+        $"count={Count}, qty={TotalQty.ToString(CultureInfo.InvariantCulture)}, " +
+        $"notional={TotalNotional.ToString(CultureInfo.InvariantCulture)}";
+}
+
+public sealed record BucketDiff(string Symbol, string Side, Aggregates Matching, Aggregates Host);
+
+public sealed record HostShapedRow(
+    string Symbol,
+    string Side,
+    long Quantity,
+    decimal Price,
+    string ClOrdId,
+    DateTimeOffset TimestampUtc,
+    string TradeId);
+
+public sealed record ReconciliationReport(
+    string FirmId,
+    int MatchingRowCount,
+    int HostRowCount,
+    IReadOnlyList<BucketDiff> Diffs)
+{
+    public bool IsClean => Diffs.Count == 0;
+
+    public string Render()
+    {
+        if (IsClean)
+            return $"firm={FirmId}: reconciliation clean — {MatchingRowCount} matching row(s) match {HostRowCount} host row(s) across all (symbol, side) buckets.";
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"firm={FirmId}: reconciliation DIFFERS — {Diffs.Count} bucket(s) drifted.");
+        sb.AppendLine($"  totals: matching={MatchingRowCount} host={HostRowCount}");
+        foreach (var d in Diffs)
+        {
+            sb.AppendLine($"  - {d.Symbol}/{d.Side}: matching[{d.Matching.Pretty()}] vs host[{d.Host.Pretty()}]");
+        }
+        return sb.ToString();
+    }
+}

--- a/backend/tools/B3.Trading.Reconciliation/MatchingFillsReader.cs
+++ b/backend/tools/B3.Trading.Reconciliation/MatchingFillsReader.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace B3.Trading.Reconciliation;
+
+/// <summary>
+/// Reader for the EOD fills CSV produced by the matching platform's
+/// <c>EodFillsExporter</c> (B3MatchingPlatform#330 PR-1, columns frozen
+/// by ADR-0001):
+/// <code>tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm</code>
+/// </summary>
+public static class MatchingFillsReader
+{
+    /// <summary>
+    /// Reads and validates the drop at
+    /// <c>{dropRootDir}/{channel}/{yyyy-MM-dd}/fills.csv</c>. The
+    /// <c>.done</c> sidecar must be present (it is the consumer-visible
+    /// "ready" signal) and its declared SHA-256 must match the bytes of
+    /// <c>fills.csv</c>.
+    /// </summary>
+    public static MatchingDropReadResult Load(string dropRootDir, string channel, DateOnly date)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dropRootDir);
+        ArgumentException.ThrowIfNullOrEmpty(channel);
+        var dir = Path.Combine(dropRootDir, channel, date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var csvPath = Path.Combine(dir, "fills.csv");
+        var donePath = Path.Combine(dir, "fills.csv.done");
+        if (!File.Exists(donePath))
+            throw new FileNotFoundException(
+                $"Matching drop is not ready: missing {donePath}. The .done sidecar lands last in the atomic publish; consume only when it exists.",
+                donePath);
+        if (!File.Exists(csvPath))
+            throw new FileNotFoundException($"Missing matching fills CSV at {csvPath}.", csvPath);
+
+        var bytes = File.ReadAllBytes(csvPath);
+        var actualSha = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+        var doneJson = File.ReadAllText(donePath);
+        var done = JsonSerializer.Deserialize<DoneSidecar>(doneJson, JsonOpts)
+            ?? throw new InvalidDataException($"Unparsable .done sidecar at {donePath}.");
+        if (!string.Equals(done.Sha256, actualSha, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException(
+                $"SHA-256 mismatch for {csvPath}: sidecar declares {done.Sha256} but file hashes to {actualSha}. " +
+                "Drop is corrupt or being rewritten — refuse to reconcile.");
+
+        var rows = ParseCsv(bytes).ToList();
+        if (done.RowCount != rows.Count)
+            throw new InvalidDataException(
+                $"Row count mismatch for {csvPath}: sidecar declares {done.RowCount} but CSV has {rows.Count} data rows.");
+
+        return new MatchingDropReadResult(rows, done.Sha256, done.RowCount, done.GeneratedAt);
+    }
+
+    /// <summary>
+    /// Parses raw matching-CSV bytes. Public for unit tests that drive
+    /// the comparator without touching the filesystem.
+    /// </summary>
+    public static IEnumerable<MatchingFillRow> ParseCsv(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        using var sr = new StreamReader(ms);
+        var header = sr.ReadLine()
+            ?? throw new InvalidDataException("Empty matching fills CSV.");
+        if (!ColumnHeaderMatchesContract(header))
+            throw new InvalidDataException(
+                $"Unexpected matching fills header: '{header}'. Expected '{ContractHeader}' (ADR-0001).");
+
+        string? line;
+        var lineNo = 1;
+        while ((line = sr.ReadLine()) is not null)
+        {
+            lineNo++;
+            if (line.Length == 0) continue;
+            yield return ParseRow(line, lineNo);
+        }
+    }
+
+    private const string ContractHeader =
+        "tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm";
+
+    private static bool ColumnHeaderMatchesContract(string header) =>
+        // Allow whitespace variants in case the upstream emits "a, b, c".
+        string.Equals(
+            string.Concat(header.Where(c => !char.IsWhiteSpace(c))),
+            ContractHeader,
+            StringComparison.OrdinalIgnoreCase);
+
+    private static MatchingFillRow ParseRow(string line, int lineNo)
+    {
+        var cols = line.Split(',');
+        if (cols.Length != 10)
+            throw new InvalidDataException(
+                $"Matching fills row at line {lineNo} has {cols.Length} columns, expected 10: '{line}'.");
+        try
+        {
+            return new MatchingFillRow(
+                TradeId: cols[0],
+                TimestampUtc: DateTimeOffset.Parse(cols[1], CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                Symbol: cols[2],
+                AggressorSide: cols[3],
+                Quantity: long.Parse(cols[4], CultureInfo.InvariantCulture),
+                Price: decimal.Parse(cols[5], CultureInfo.InvariantCulture),
+                BuyClOrdId: cols[6],
+                SellClOrdId: cols[7],
+                BuyFirm: cols[8],
+                SellFirm: cols[9]);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidDataException(
+                $"Malformed matching fills row at line {lineNo}: '{line}'. {ex.Message}", ex);
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed record DoneSidecar(int RowCount, string Sha256, DateTimeOffset GeneratedAt);
+}
+
+public sealed record MatchingFillRow(
+    string TradeId,
+    DateTimeOffset TimestampUtc,
+    string Symbol,
+    string AggressorSide,
+    long Quantity,
+    decimal Price,
+    string BuyClOrdId,
+    string SellClOrdId,
+    string BuyFirm,
+    string SellFirm);
+
+public sealed record MatchingDropReadResult(
+    IReadOnlyList<MatchingFillRow> Rows,
+    string Sha256,
+    int RowCount,
+    DateTimeOffset GeneratedAt);

--- a/backend/tools/B3.Trading.Reconciliation/Program.cs
+++ b/backend/tools/B3.Trading.Reconciliation/Program.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using B3.Trading.Reconciliation;
+
+// b3-reconcile — D+1 reconciliation tool (B3TradingPlatform#274).
+//
+// Compares the matching platform's EOD fills CSV drop
+// (B3MatchingPlatform#330) against the trading-host's daily statement
+// for a single firm + UTC date. Exits 0 when the (symbol, side)
+// aggregates align (count + sum of quantity + sum of notional), 2 on
+// any difference, 1 on argument / IO / integrity errors.
+//
+// Usage:
+//   b3-reconcile \
+//     --matching-fills-dir /var/post-trade/drops \
+//     --channel 1 \
+//     --date 2026-05-19 \
+//     --firm FIRM01 \
+//     --trading-host https://trading.local \
+//     --auth-token "$TRADING_HOST_TOKEN"
+//
+// The trading-host statement is fetched from
+// {tradingHostUrl}/statement/{date}.csv with a Bearer token.
+
+try
+{
+    var parsed = Cli.Parse(args);
+    if (parsed is null) return 0;
+
+    var drop = MatchingFillsReader.Load(parsed.MatchingFillsDir, parsed.Channel, parsed.Date);
+    Console.Error.WriteLine(
+        $"loaded matching drop: rows={drop.RowCount} sha256={drop.Sha256[..12]}… generatedAt={drop.GeneratedAt:O}");
+
+    using var http = new HttpClient { BaseAddress = new Uri(parsed.TradingHostUrl) };
+    http.DefaultRequestHeaders.Authorization =
+        new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", parsed.AuthToken);
+    var statementCsv = await http.GetStringAsync(
+        $"/statement/{parsed.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}.csv");
+    var hostFills = TradingHostStatementParser.ParseFills(statementCsv);
+    Console.Error.WriteLine($"loaded trading-host statement: fillRows={hostFills.Count}");
+
+    var report = FillsComparator.Compare(drop.Rows, hostFills, parsed.Firm);
+    Console.WriteLine(report.Render());
+    return report.IsClean ? 0 : 2;
+}
+catch (CliException ex)
+{
+    Console.Error.WriteLine($"error: {ex.Message}");
+    Console.Error.WriteLine(Cli.UsageText);
+    return 1;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"error: {ex.Message}");
+    return 1;
+}
+
+internal sealed class CliException(string message) : Exception(message);
+
+internal sealed record CliArgs(
+    string MatchingFillsDir,
+    string Channel,
+    DateOnly Date,
+    string Firm,
+    string TradingHostUrl,
+    string AuthToken);
+
+internal static class Cli
+{
+    public const string UsageText =
+        "usage: b3-reconcile --matching-fills-dir <DIR> --channel <CH> --date <YYYY-MM-DD> " +
+        "--firm <FIRM> --trading-host <URL> --auth-token <TOKEN>";
+
+    public static CliArgs? Parse(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help")
+        {
+            Console.WriteLine(UsageText);
+            return null;
+        }
+        string? dir = null, channel = null, dateStr = null, firm = null, host = null, token = null;
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--matching-fills-dir": dir = Next(args, ref i); break;
+                case "--channel": channel = Next(args, ref i); break;
+                case "--date": dateStr = Next(args, ref i); break;
+                case "--firm": firm = Next(args, ref i); break;
+                case "--trading-host": host = Next(args, ref i); break;
+                case "--auth-token": token = Next(args, ref i); break;
+                default: throw new CliException($"unknown argument: {args[i]}");
+            }
+        }
+        if (dir is null || channel is null || dateStr is null || firm is null || host is null || token is null)
+            throw new CliException("missing required argument(s).");
+        if (!DateOnly.TryParseExact(dateStr, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var date))
+            throw new CliException($"invalid --date '{dateStr}'; expected YYYY-MM-DD.");
+        return new CliArgs(dir, channel, date, firm, host, token);
+    }
+
+    private static string Next(string[] args, ref int i)
+    {
+        if (i + 1 >= args.Length) throw new CliException($"missing value for {args[i]}.");
+        return args[++i];
+    }
+}

--- a/backend/tools/B3.Trading.Reconciliation/README.md
+++ b/backend/tools/B3.Trading.Reconciliation/README.md
@@ -1,0 +1,81 @@
+# B3 Trading-Host Reconciliation Tool
+
+D+1 reconciliation between the matching platform's EOD fills CSV
+([B3MatchingPlatform#330](https://github.com/pedrosakuma/B3MatchingPlatform/issues/330))
+and the trading-host's daily statement
+(`GET /statement/{date}.csv`). Closes the trading-host side of
+[B3TradingPlatform#274](https://github.com/pedrosakuma/B3TradingPlatform/issues/274).
+
+## Inputs
+
+* **Matching CSV drop** — produced by `EodFillsExporter` at
+  `{dropRoot}/{channel}/{yyyy-MM-dd}/fills.csv` (consumer-visible
+  when the `.done` sidecar appears). Columns (frozen by ADR-0001):
+
+  ```
+  tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm
+  ```
+
+  The tool verifies the SHA-256 declared in `.done` matches the
+  file bytes and rejects partial / corrupt drops.
+
+* **Trading-host statement** — fetched via
+  `GET {tradingHostUrl}/statement/{date}.csv` with a Bearer token.
+  Multi-section CSV; only the *fills* section is consumed.
+
+## What it checks
+
+Compares **(symbol, firm-relative side)** aggregates between the two
+sources:
+
+* count of fills
+* sum of fill quantity
+* sum of fill notional (qty × price)
+
+The matching exporter emits one row per trade with both firms on the
+same row; the tool projects the firm-relative view by:
+
+* expanding internal crosses (`buyFirm == sellFirm == ourFirm`) into a
+  Buy + Sell pair, mirroring the host's per-ER `FillRowDto` shape;
+* skipping rows where neither side matches the requested firm.
+
+A per-trade join on `tradeId` is intentionally **not** done — the
+trading-host's `executionId` is synthesised as `{clOrdId}:{cumQty}`
+and is not the venue tradeId.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | All buckets aligned. |
+| 2    | At least one bucket differs — see stdout for the diff report. |
+| 1    | Argument / IO / integrity error. |
+
+## Usage
+
+```bash
+b3-reconcile \
+  --matching-fills-dir /var/post-trade/drops \
+  --channel 1 \
+  --date 2026-05-19 \
+  --firm FIRM01 \
+  --trading-host https://trading.local \
+  --auth-token "$TRADING_HOST_TOKEN"
+```
+
+## Wiring this into D+1 operations (suggested)
+
+1. Wait for the matching `.done` sidecar to appear (filesystem watch
+   or polling).
+2. Wait for the trading-host's daily reset to flush in-flight WAL events
+   (host emits a metric on the snapshot boundary).
+3. Run `b3-reconcile` per firm. Page on exit code 2.
+
+## Out of scope (filed as follow-ups)
+
+* End-to-end CI scenario (real matching → real trading-host → diff = 0)
+  — depends on B3MatchingPlatform#330 PR-3 (DailyResetScheduler hook)
+  and a docker-compose harness; filed as a follow-up to #274.
+* Per-trade audit (matching every host fill ER to a venue trade row)
+  — requires the trading-host to start carrying the venue tradeId on
+  the ER, which today is dropped by the SDK.

--- a/backend/tools/B3.Trading.Reconciliation/TradingHostStatementParser.cs
+++ b/backend/tools/B3.Trading.Reconciliation/TradingHostStatementParser.cs
@@ -1,0 +1,137 @@
+using System.Globalization;
+
+namespace B3.Trading.Reconciliation;
+
+/// <summary>
+/// Parser for the fills section of the trading-host statement CSV
+/// emitted by <c>GET /statement/{dayKey}.csv</c>. The CSV is
+/// multi-section (positions, fills, fees, pnl, ir-day-trade) separated
+/// by blank lines and re-headered for each section. We only care about
+/// the fills section here; we identify it by header text and tolerate
+/// the others changing shape.
+/// </summary>
+public static class TradingHostStatementParser
+{
+    private const string FillsHeader =
+        "executionId,clOrdId,orderId,symbol,side,quantity,price,timestampUtc,subAccountId";
+
+    public static IReadOnlyList<HostFillRow> ParseFills(string csvBody)
+    {
+        ArgumentNullException.ThrowIfNull(csvBody);
+        var rows = new List<HostFillRow>();
+        var inFills = false;
+        var lineNo = 0;
+        foreach (var raw in csvBody.Split('\n'))
+        {
+            lineNo++;
+            var line = raw.TrimEnd('\r');
+            if (line.Length == 0)
+            {
+                inFills = false;
+                continue;
+            }
+            if (string.Equals(NoWhitespace(line), FillsHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                inFills = true;
+                continue;
+            }
+            if (!inFills) continue;
+            rows.Add(ParseFillRow(line, lineNo));
+        }
+        return rows;
+    }
+
+    private static string NoWhitespace(string s) =>
+        string.Concat(s.Where(c => !char.IsWhiteSpace(c)));
+
+    private static HostFillRow ParseFillRow(string line, int lineNo)
+    {
+        var cols = SplitCsv(line);
+        if (cols.Count < 8)
+            throw new InvalidDataException(
+                $"Trading-host statement fill row at line {lineNo} has {cols.Count} columns, expected at least 8: '{line}'.");
+        try
+        {
+            return new HostFillRow(
+                ExecutionId: cols[0],
+                ClOrdId: cols[1],
+                OrderId: cols[2],
+                Symbol: cols[3],
+                Side: cols[4],
+                Quantity: long.Parse(cols[5], CultureInfo.InvariantCulture),
+                Price: decimal.Parse(cols[6], CultureInfo.InvariantCulture),
+                TimestampUtc: DateTimeOffset.Parse(cols[7], CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                SubAccountId: cols.Count >= 9 ? NullIfEmpty(cols[8]) : null);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidDataException(
+                $"Malformed trading-host statement fill row at line {lineNo}: '{line}'. {ex.Message}", ex);
+        }
+    }
+
+    private static string? NullIfEmpty(string s) => string.IsNullOrEmpty(s) ? null : s;
+
+    private static List<string> SplitCsv(string line)
+    {
+        // Statement CSV quotes only when the value needs it (commas /
+        // double-quotes inside a field). Match the writer in
+        // StatementEndpoints.RenderCsv: double-quote wrap + "" escape.
+        var cols = new List<string>();
+        var sb = new System.Text.StringBuilder();
+        var inQuotes = false;
+        for (var i = 0; i < line.Length; i++)
+        {
+            var c = line[i];
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < line.Length && line[i + 1] == '"')
+                    {
+                        sb.Append('"');
+                        i++;
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                    }
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            else
+            {
+                if (c == ',')
+                {
+                    cols.Add(sb.ToString());
+                    sb.Clear();
+                }
+                else if (c == '"' && sb.Length == 0)
+                {
+                    inQuotes = true;
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+        }
+        cols.Add(sb.ToString());
+        return cols;
+    }
+}
+
+public sealed record HostFillRow(
+    string ExecutionId,
+    string ClOrdId,
+    string OrderId,
+    string Symbol,
+    string Side,
+    long Quantity,
+    decimal Price,
+    DateTimeOffset TimestampUtc,
+    string? SubAccountId);


### PR DESCRIPTION
Refs #274.

Adds `backend/tools/B3.Trading.Reconciliation` (assembly: `b3-reconcile`) — a D+1 reconciliation tool that diffs the matching platform's EOD fills CSV drop (B3MatchingPlatform#330, ADR-0001 frozen schema) against the trading-host's daily statement for a `firm + UTC date`.

### What's in

| Piece | Purpose |
|---|---|
| `MatchingFillsReader` | Validates the matching atomic drop via `.done` sidecar (presence + declared SHA-256 + row count) before yielding rows. Refuses partial/corrupt drops. |
| `TradingHostStatementParser` | Section-aware parser that extracts only the fills section from our multi-section statement CSV; tolerates other sections changing shape. |
| `FillsComparator` | Aggregate-first comparator on `(symbol, side)` buckets — count, sum of qty, sum of notional. Projects matching-side rows into the host's per-ER shape, expanding internal crosses (same firm on both legs) into Buy + Sell. |
| `Program.cs` | CLI: fetches `/statement/{date}.csv` with Bearer auth, glues reader + parser + comparator, exits `0` (clean) / `2` (drift) / `1` (arg/IO/integrity). |
| `README.md` | Usage, contract, exit codes, D+1 ops wiring suggestion. |

### Why aggregate-first

Per-trade joining is intentionally **not** done — the trading-host execution id is synthesised as `{clOrdId}:{cumQty}` (see `StatementProjection.cs:141`) and is therefore not joinable against the matching `tradeId`. Aggregate diff on `(symbol, side)` is the strongest invariant we can assert today; per-trade audit will require carrying the venue tradeId on the ER (separate follow-up).

### Tests

12 unit tests, all green:
- **Reader:** canonical-contract parse, wrong header rejected, SHA-256 verified vs `.done`, SHA mismatch rejected, missing `.done` refuses to consume.
- **Parser:** extracts fills section from multi-section CSV ignoring positions/fees, handles quoted fields with commas.
- **Comparator:** clean alignment, internal-cross fan-out, qty drift surfaces per-bucket, other-firm rows filtered out, missing host-side bucket surfaces.

Full solution build clean.

### Out of scope (follow-ups)

- **E2E CI scenario** (real matching → trading-host → diff = 0): depends on B3MatchingPlatform#330 PR-3 (auto-trigger via DailyResetScheduler) and a docker-compose harness — will file a follow-up under #274 when PR-3 lands.
- **Per-trade audit**: needs venue tradeId carried on ER (SDK gap).
