### PR TITLE
ops: pin matching-platform image to immutable digest (#352)

### DIFF
--- a/.github/workflows/matching-image-bump.yml
+++ b/.github/workflows/matching-image-bump.yml
@@ -1,0 +1,75 @@
+name: Matching image bump
+
+# Watches the upstream ghcr.io/pedrosakuma/b3-matching:latest digest
+# and opens an automated PR bumping docker/docker-compose.yml when it
+# advances. Bumping is a reviewable, CI-validated event — not a silent
+# pull on every build. See scripts/matching-image/check-upstream.sh and
+# B3TradingPlatform#352.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — early enough to land in a Monday review cycle.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Upstream tag to resolve (default: latest)'
+        required: false
+        default: 'latest'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve upstream digest and detect drift
+        id: drift
+        run: |
+          set +e
+          out=$(scripts/matching-image/check-upstream.sh "${{ github.event.inputs.tag || 'latest' }}")
+          code=$?
+          echo "$out"
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          if [[ $code -eq 2 ]]; then
+            new_digest=$(echo "$out" | tail -n1)
+            echo "new_digest=${new_digest}" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Apply bump
+        if: steps.drift.outputs.exit_code == '2'
+        run: |
+          old=$(grep -oE 'b3-matching@sha256:[0-9a-f]{64}' docker/docker-compose.yml | head -n1 | sed 's/.*@//')
+          new="${{ steps.drift.outputs.new_digest }}"
+          sed -i "s|${old}|${new}|g" docker/docker-compose.yml
+          git diff --stat
+
+      - name: Open pull request
+        if: steps.drift.outputs.exit_code == '2'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: bot/matching-image-bump
+          commit-message: |
+            ops: bump matching-platform image pin
+
+            Resolved by scripts/matching-image/check-upstream.sh.
+            Tag: ${{ github.event.inputs.tag || 'latest' }}
+            New digest: ${{ steps.drift.outputs.new_digest }}
+          title: 'ops: bump matching-platform image pin'
+          body: |
+            Automated bump of the matching-platform image pin in
+            `docker/docker-compose.yml`.
+
+            - Tag watched: `${{ github.event.inputs.tag || 'latest' }}`
+            - New digest: `${{ steps.drift.outputs.new_digest }}`
+
+            CI (including `real-stack-conformance`) will validate this
+            digest before merge. Refs #352.
+          labels: |
+            ops
+            dependencies

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,7 +60,12 @@ name: b3trading
 
 services:
   matching-platform:
-    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching:latest}
+    # NB: pinned to an immutable digest, not :latest. See
+    # scripts/matching-image/check-upstream.sh and the
+    # matching-image-bump workflow for the bump cadence.
+    # Devs can still override (e.g. MATCHING_IMAGE=ghcr.io/pedrosakuma/b3-matching:latest)
+    # to test the bleeding edge locally.
+    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching@sha256:0a5f6e77ec5895b0fd88ae49f7b3e051613ab77e20dc28c8f1f20e027bbbfda1}
     container_name: b3-matching-platform
     restart: unless-stopped
     networks:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -33,7 +33,7 @@ docker compose \
 
 | Service | Image | Port (host) | Purpose |
 |---|---|---|---|
-| `matching-platform` | `ghcr.io/pedrosakuma/b3-matching:latest` | (internal `:9876`, `:8080`) | FIXP TCP listener + UMDF unicast publisher + `/admin/channels/*` snapshot ops |
+| `matching-platform` | `ghcr.io/pedrosakuma/b3-matching@sha256:…` (pinned — see [Bumping the matching image](#bumping-the-matching-image)) | (internal `:9876`, `:8080`) | FIXP TCP listener + UMDF unicast publisher + `/admin/channels/*` snapshot ops |
 | `marketdata` | `ghcr.io/pedrosakuma/b3-marketdata:latest` | `8081` | UMDF unicast consumer (`30084/30184/31084 udp`) + WebSocket fanout (`:8080`) |
 | `trading-host` | `ghcr.io/pedrosakuma/b3-trading-host:latest` | `5000` | REST + WebSocket; `Mode=Real`, FIRM01 session against matching, live `IReferencePrice` wired through marketdata WS |
 | `frontend` | `ghcr.io/pedrosakuma/b3-trading-frontend:latest` | `8080` | nginx serving the static UI + reverse-proxy to trading-host |
@@ -441,3 +441,48 @@ ports:
 
 See the full [FIXP listener operations guide](operations/fixp-listener.md) for
 TLS setup, rate-limit tuning, and monitoring.
+
+## Bumping the matching image
+
+The `matching-platform` service is pinned to an **immutable image
+digest** (`ghcr.io/pedrosakuma/b3-matching@sha256:…`) in
+`docker/docker-compose.yml`. We deliberately do **not** track
+`:latest` — every bump is a reviewable, CI-validated PR. This
+mitigates the class of flake where upstream churn lands on our builds
+without warning (e.g. #332, #345, #347).
+
+### Daily local override
+
+Devs who want the bleeding edge for a one-off run can override:
+
+```bash
+MATCHING_IMAGE=ghcr.io/pedrosakuma/b3-matching:latest \
+  docker compose -f docker/docker-compose.yml up matching-platform
+```
+
+### Detecting drift
+
+```bash
+scripts/matching-image/check-upstream.sh           # tag=latest
+scripts/matching-image/check-upstream.sh v1.2.3    # specific tag
+```
+
+Exit `0` means the pin matches upstream; `2` means upstream has
+advanced and a bump is due; `1` means an IO / argument error. The new
+digest is printed on the last stdout line when drift is detected.
+
+### Automated bump cadence
+
+The [`matching-image-bump`](../.github/workflows/matching-image-bump.yml)
+workflow runs the script on a weekly cron (Mondays 06:00 UTC) **and**
+on `workflow_dispatch`. When drift is detected it opens a PR bumping
+the pin; the standard CI matrix (`real-stack-conformance` included)
+validates the new digest before a human merges.
+
+### Manual bump (one-liner)
+
+```bash
+new=$(scripts/matching-image/check-upstream.sh | tail -n1)
+old=$(grep -oE 'b3-matching@sha256:[0-9a-f]{64}' docker/docker-compose.yml | head -n1 | sed 's/.*@//')
+sed -i "s|${old}|${new}|g" docker/docker-compose.yml
+```

--- a/scripts/matching-image/check-upstream.sh
+++ b/scripts/matching-image/check-upstream.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Resolves the current sha256 digest of the upstream
+# ghcr.io/pedrosakuma/b3-matching image for a given tag (default
+# `latest`) and prints a human-readable diff against the digest pinned
+# in docker/docker-compose.yml.
+#
+# Exit codes:
+#   0 — pinned digest already matches upstream (no action needed)
+#   1 — usage / IO error
+#   2 — drift detected (caller should open a bump PR)
+#
+# Usage:
+#   scripts/matching-image/check-upstream.sh                 # tag=latest
+#   scripts/matching-image/check-upstream.sh v1.2.3          # specific tag
+#   IMAGE=ghcr.io/other/img scripts/matching-image/check-upstream.sh
+set -euo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/pedrosakuma/b3-matching}"
+TAG="${1:-latest}"
+COMPOSE_FILE="${COMPOSE_FILE:-$(dirname "$0")/../../docker/docker-compose.yml}"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "error: compose file not found at $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+REPO="${IMAGE#ghcr.io/}"
+
+echo "Resolving ${IMAGE}:${TAG} via ghcr.io registry API..."
+TOKEN=$(curl -fsSL "https://ghcr.io/token?scope=repository:${REPO}:pull" \
+  | python3 -c "import json,sys;print(json.load(sys.stdin)['token'])")
+
+UPSTREAM_DIGEST=$(curl -fsSL -I \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json" \
+  "https://ghcr.io/v2/${REPO}/manifests/${TAG}" \
+  | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}' \
+  | tr -d '\r\n')
+
+if [[ -z "$UPSTREAM_DIGEST" ]]; then
+  echo "error: could not resolve upstream digest for ${IMAGE}:${TAG}" >&2
+  exit 1
+fi
+
+PINNED_DIGEST=$(grep -oE 'b3-matching@sha256:[0-9a-f]{64}' "$COMPOSE_FILE" \
+  | head -n1 \
+  | sed 's/.*@//')
+
+if [[ -z "$PINNED_DIGEST" ]]; then
+  echo "error: no @sha256:... digest pin found in $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+echo "pinned  : ${PINNED_DIGEST}"
+echo "upstream: ${UPSTREAM_DIGEST}"
+
+if [[ "$PINNED_DIGEST" == "$UPSTREAM_DIGEST" ]]; then
+  echo "✔ pin is current — no bump needed."
+  exit 0
+fi
+
+echo "✗ upstream has advanced. Run the matching-image-bump workflow (or"
+echo "  bump manually): sed -i \"s|${PINNED_DIGEST}|${UPSTREAM_DIGEST}|g\" $COMPOSE_FILE"
+echo "${UPSTREAM_DIGEST}"
+exit 2


### PR DESCRIPTION
Closes #352.

The `matching-platform` service in `docker/docker-compose.yml` used to default to `ghcr.io/pedrosakuma/b3-matching:latest`, meaning every CI build (`real-stack-conformance`) and every local `docker compose up` pulled the head of upstream — **any breaking change merged upstream landed on our builds without warning.** Several recent flakes (#332, #345, #347) correlated with upstream churn we couldn't see.

### Changes

- **`docker-compose.yml`** — replace `:latest` default with the current upstream digest (`@sha256:0a5f6e…fda1`). Devs can still override via `MATCHING_IMAGE=...` to test the bleeding edge locally.
- **`scripts/matching-image/check-upstream.sh`** — resolves the upstream digest via ghcr.io registry API; exits `0` when the pin is current, `2` when upstream has advanced (emits the new digest on the last stdout line), `1` on IO error.
- **`.github/workflows/matching-image-bump.yml`** — weekly cron (Mondays 06:00 UTC) + `workflow_dispatch`. Runs the script; on drift, applies the bump and opens a PR via `peter-evans/create-pull-request`. The standard CI matrix (including `real-stack-conformance`) validates the new digest before a human merges.
- **`docs/DOCKER.md`** — _Bumping the matching image_ section explaining override / detection / cadence / manual bump.

### Verified locally

- `scripts/matching-image/check-upstream.sh` exits `0` and confirms _pin is current_.
- `docker compose -f docker/docker-compose.yml config` resolves `matching-platform.image` to the pinned digest.

### Acceptance (from the issue)

- [x] `docker-compose.yml` no longer points to `:latest` by default.
- [x] README / ops docs explain how to bump.
- [x] Upstream-bump automation file (workflow + script) present.
- [ ] Green CI run on the pinned digest — pending this PR's checks (`real-stack-conformance` is in the matrix).
