### PR TITLE
feat(modify): emit OrderReplaceRejectedEvent on risk/margin reject (#337)

### DIFF
--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -452,6 +452,39 @@ public static class HistoryEndpoints
                     ownerByClOrdId[rr.NewClOrdId] = (rr.EndClientId, rr.Symbol, rr.Side);
                     replaceLinks[rr.NewClOrdId] = new ReplaceIntent(rr.OriginalClOrdId, rr.NewQuantity);
                     break;
+                case OrderReplaceRejectedEvent rrj:
+                    // #337 — surface the rejected modify so it shows up
+                    // in the trader's executions log alongside the
+                    // submit-side rejects. The original order's
+                    // owner/symbol/side are already in the side-table
+                    // (registered by the matching OrderSubmittedEvent
+                    // when the original was created); look them up so
+                    // the firm-isolation + owner filters apply
+                    // correctly. If we can't resolve the original
+                    // (truncated WAL window) we drop the row — same
+                    // posture as the ER branch below.
+                    if (rrj.TimestampUtc < from || rrj.TimestampUtc > to) break;
+                    if (!ownerByClOrdId.TryGetValue(rrj.OriginalClOrdId, out var origMeta)) break;
+                    if (!OwnerMatches(origMeta.Owner, owner)) break;
+                    if (symbol is not null && !origMeta.Symbol.Equals(symbol, StringComparison.Ordinal)) break;
+                    result.Add(new ExecutionProjection(
+                        Seq: seq,
+                        // Surface the burned NewClOrdId so the row is
+                        // unique against any other reject on the same
+                        // original (multiple modify attempts) — the
+                        // FE blotter already keys executions by
+                        // ClOrdId+Seq.
+                        ClOrdId: rrj.NewClOrdId,
+                        Symbol: origMeta.Symbol,
+                        Side: origMeta.Side,
+                        Kind: nameof(ExecKind.Rejected),
+                        LeavesQuantity: 0,
+                        CumulativeQuantity: 0,
+                        LastQuantity: 0,
+                        LastPrice: 0m,
+                        RejectReason: rrj.Reason,
+                        TimestampUtc: rrj.TimestampUtc));
+                    break;
                 case OrderCancelRequestedEvent cr:
                     cancelLinks[cr.CancelClOrdId] = cr.OriginalClOrdId;
                     break;

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -231,18 +231,23 @@ public sealed class OrderModifyService
             SubAccountId: orig.SubAccountId);
 
         // Ordering note (RFC docs/rfcs/risk-pipeline-ordering-v0.md, #262):
-        // risk evaluation runs *pre-WAL* on the modify path. A rejected
-        // modify leaves no WAL footprint today — an asymmetry vs.
-        // OrderSubmissionService that the RFC tracks as an open audit gap
-        // (Option B follow-up: emit OrderReplaceRejectedEvent here).
+        // risk evaluation runs *pre-WAL* on the modify path. #337 closed
+        // the audit gap below: a rejected modify dispatches an
+        // OrderReplaceRejectedEvent so /executions/history, the CVM /
+        // drop-copy / touch consumers and the FE blotter all observe
+        // the burned ClOrdId + reason. Replay treats the event as a
+        // pure no-op for book/ownership/margin state (advances the
+        // ClOrdId watermark only).
         var decision = _risk.Evaluate(riskCtx);
         if (!decision.Approved)
         {
+            var reason = decision.Reason ?? "risk_rejected";
             MetricsRegistry.OrdersRejectedByRisk.Add(1,
-                new KeyValuePair<string, object?>("reason", decision.Reason ?? "risk_rejected"),
+                new KeyValuePair<string, object?>("reason", reason),
                 new KeyValuePair<string, object?>("path", "modify"),
                 new KeyValuePair<string, object?>("firmId", orig.FirmId));
-            return OrderModifyResult.RiskRejected(decision.Reason ?? "risk_rejected");
+            PublishReplaceRejected(req, orig, newClOrdId, "risk", reason);
+            return OrderModifyResult.RiskRejected(reason);
         }
 
         // Margin Prepare: reserve only the upsize delta. The
@@ -256,11 +261,13 @@ public sealed class OrderModifyService
             req.OriginalClOrdId, newClOrdId, req.Owner, newRemainingNotional, ct);
         if (!marginDecision.Approved)
         {
+            var reason = marginDecision.Reason ?? "margin_rejected";
             MetricsRegistry.OrdersRejectedByRisk.Add(1,
-                new KeyValuePair<string, object?>("reason", marginDecision.Reason ?? "margin_rejected"),
+                new KeyValuePair<string, object?>("reason", reason),
                 new KeyValuePair<string, object?>("path", "modify"),
                 new KeyValuePair<string, object?>("firmId", orig.FirmId));
-            return OrderModifyResult.RiskRejected(marginDecision.Reason ?? "margin_rejected");
+            PublishReplaceRejected(req, orig, newClOrdId, "margin", reason);
+            return OrderModifyResult.RiskRejected(reason);
         }
 
         var intent = new OrderReplacementIntent(
@@ -356,6 +363,70 @@ public sealed class OrderModifyService
             new KeyValuePair<string, object?>("firmId", orig.FirmId));
 
         return OrderModifyResult.Accepted(newClOrdId);
+    }
+
+    /// <summary>
+    /// #337 — durable audit row for a modify rejected pre-WAL by the
+    /// risk pipeline or margin coordinator. Mirrors the submit-side
+    /// <c>OrderSubmissionService.PublishSyntheticRejection</c> shape:
+    /// dispatch the structured WAL event, and in the same commit
+    /// callback emit the live <see cref="ExecutionEvent"/> the FE
+    /// blotter listens on. WAL backpressure falls back to a sink-only
+    /// publish so the trader still observes the reject even when WAL
+    /// append is degraded (same posture as the submit path).
+    /// </summary>
+    private void PublishReplaceRejected(
+        OrderModifyRequest req,
+        Order orig,
+        ulong newClOrdId,
+        string source,
+        string reason)
+    {
+        var evt = new OrderReplaceRejectedEvent
+        {
+            OriginalClOrdId = req.OriginalClOrdId,
+            NewClOrdId = newClOrdId,
+            EndClientId = req.Owner.Value,
+            FirmId = orig.FirmId,
+            Symbol = orig.Symbol,
+            SecurityId = orig.SecurityId,
+            Side = orig.Side.ToString(),
+            Type = orig.Type.ToString(),
+            RequestedQuantity = req.NewQuantity,
+            RequestedPrice = req.NewPrice,
+            RequestedTimeInForce = req.NewTimeInForce?.ToString(),
+            RequestedStopPrice = req.NewStopPrice,
+            RequestedGoodTillDate = req.NewGoodTillDate,
+            Source = source,
+            Reason = reason,
+            ParentAlgoId = orig.ParentAlgoId,
+            AlgoSliceSeq = orig.AlgoSliceSeq,
+        };
+
+        Action publishLive = () => _sink.Publish(new ExecutionEvent(
+            req.Owner, newClOrdId, orig.Symbol, orig.Side,
+            // Status is the ORIGINAL order's current status — the
+            // replace was rejected; the original keeps Working /
+            // PartiallyFilled / etc.
+            orig.Status, ExecKind.Rejected,
+            LeavesQuantity: orig.LeavesQuantity,
+            CumulativeQuantity: orig.CumulativeQuantity,
+            LastQuantity: 0, LastPrice: 0m,
+            RejectReason: reason,
+            TimestampUtc: DateTimeOffset.UtcNow,
+            FirmId: orig.FirmId));
+
+        try
+        {
+            _dispatcher.Dispatch(evt, publishLive);
+        }
+        catch (WalBackpressureException)
+        {
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "orders.modify.reject"),
+                new KeyValuePair<string, object?>("firmId", orig.FirmId));
+            publishLive();
+        }
     }
 }
 

--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -30,6 +30,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(OrderSubmittedEvent))]
 [JsonSerializable(typeof(OrderCancelRequestedEvent))]
 [JsonSerializable(typeof(OrderReplaceRequestedEvent))]
+[JsonSerializable(typeof(OrderReplaceRejectedEvent))]
 [JsonSerializable(typeof(ExecutionReportReceivedEvent))]
 [JsonSerializable(typeof(KillSwitchToggledEvent))]
 [JsonSerializable(typeof(SymbolHaltToggledEvent))]

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -26,6 +26,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
 [JsonDerivedType(typeof(OrderSubmittedEvent), "order.submitted")]
 [JsonDerivedType(typeof(OrderReplaceRequestedEvent), "order.replace-requested")]
+[JsonDerivedType(typeof(OrderReplaceRejectedEvent), "order.replace-rejected")]
 [JsonDerivedType(typeof(OrderReplaceAmbiguousMarginHeldEvent), "order.replace-ambiguous-margin-held")]
 [JsonDerivedType(typeof(ExecutionReportReceivedEvent), "er.received")]
 [JsonDerivedType(typeof(KillSwitchToggledEvent), "killswitch.toggled")]
@@ -235,6 +236,78 @@ public sealed record OrderReplaceRequestedEvent : WalEvent
     public string? RequestedTimeInForce { get; init; }
     public decimal? RequestedStopPrice { get; init; }
     public DateTimeOffset? RequestedGoodTillDate { get; init; }
+}
+
+/// <summary>
+/// #337 — pre-trade reject on the modify (cancel-replace) pipeline.
+/// Recorded when <see cref="B3.Trading.Application.OrderModifyService"/>
+/// rejects a replace request via the risk pipeline OR the margin
+/// coordinator, before any gateway dispatch. Closes the audit gap
+/// flagged by the risk-pipeline-ordering RFC (#262): without this
+/// event the rejected modify left zero WAL footprint — invisible to
+/// <c>/executions/history</c>, the FE blotter, the CVM 35/505 export
+/// (#308), the drop-copy feed (#306) and the best-exec touch capture
+/// (#307). The companion <see cref="OrderReplaceRequestedEvent"/> is
+/// NOT emitted on the reject path (no intent registration, no
+/// new-ClOrdId watermark advance needed downstream), so this record
+/// is the sole durable trace of the burned ClOrdId.
+///
+/// <para>
+/// <b>Replay semantics.</b> Pure audit — replay does NOT mutate the
+/// working book, ownership map, replacement registry, margin or
+/// position state. The <see cref="NewClOrdId"/> is recorded so the
+/// ClOrdId watermark advances during replay (consistent with the
+/// successful-replace path), preventing the same ID from being
+/// re-issued post-restart. See
+/// <c>StateSnapshotter.ApplyWalEventDuringRecovery</c>.
+/// </para>
+///
+/// <para>
+/// <b>Additive payload.</b> Older binaries skip the unknown
+/// discriminator with a structured warning (see <see cref="WalEvent"/>
+/// schema evolution rule), so segments produced with this event remain
+/// readable by pre-#337 readers.
+/// </para>
+/// </summary>
+public sealed record OrderReplaceRejectedEvent : WalEvent
+{
+    public required ulong OriginalClOrdId { get; init; }
+    /// <summary>
+    /// ClOrdId that was generated and burned by the reject. Recorded
+    /// so the post-restart watermark replay advances past it; never
+    /// reused for a live order.
+    /// </summary>
+    public required ulong NewClOrdId { get; init; }
+    public required string EndClientId { get; init; }
+    public required string FirmId { get; init; }
+    public required string Symbol { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required string Side { get; init; }
+    public required string Type { get; init; }
+    public required long RequestedQuantity { get; init; }
+    public decimal? RequestedPrice { get; init; }
+    public string? RequestedTimeInForce { get; init; }
+    public decimal? RequestedStopPrice { get; init; }
+    public DateTimeOffset? RequestedGoodTillDate { get; init; }
+    /// <summary>
+    /// Origin of the reject: <c>"risk"</c> for a pre-WAL
+    /// <see cref="B3.Trading.Application.Risk.RiskPipeline"/> decline,
+    /// <c>"margin"</c> for an
+    /// <see cref="B3.Trading.Application.Risk.Accounting.IReplaceMarginCoordinator"/>
+    /// decline. Mirrors the <c>path=modify</c> +
+    /// <c>reason=…</c> tags on <c>trading.orders.rejected.by_risk</c>.
+    /// </summary>
+    public required string Source { get; init; }
+    /// <summary>
+    /// Human-readable / machine-parsable reason string from the
+    /// rejecting check (e.g. <c>"position_limit_exceeded"</c>,
+    /// <c>"margin_insufficient"</c>). Same field the synthetic
+    /// <see cref="ExecutionReportReceivedEvent.RejectReason"/> carries
+    /// on the submit-side reject.
+    /// </summary>
+    public required string Reason { get; init; }
+    public ulong? ParentAlgoId { get; init; }
+    public int? AlgoSliceSeq { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -970,6 +970,17 @@ public sealed class EventReplayer
                 // intent itself wasn't re-registered (orig already gone).
                 _clOrdIds.AdvanceCounterTo(new EndClientId(rr.EndClientId), rr.NewClOrdId);
                 break;
+            case OrderReplaceRejectedEvent rrj:
+                // #337 — pure-audit event. Replay does NOT mutate the
+                // book / ownership / replacement registry / margin —
+                // none of those were touched on the live path either
+                // (reject happens BEFORE intent registration and
+                // BEFORE the gateway dispatch). The only durable
+                // effect to recover is the burned ClOrdId watermark
+                // so the same ID is never re-issued post-restart,
+                // matching the successful-replace branch above.
+                _clOrdIds.AdvanceCounterTo(new EndClientId(rrj.EndClientId), rrj.NewClOrdId);
+                break;
             case OrderReplaceAmbiguousMarginHeldEvent amh:
                 // Pass-5 review (#299) P1. Re-establish the held
                 // margin reservation a pre-crash modify left in

--- a/backend/tests/B3.Trading.Application.Tests/OrderReplaceRejectedEventTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderReplaceRejectedEventTests.cs
@@ -1,0 +1,215 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #337 — coverage for the OrderReplaceRejectedEvent audit row the
+/// modify pipeline now writes when the risk pipeline or the margin
+/// coordinator rejects a cancel-replace pre-WAL. Closes the audit gap
+/// flagged by the risk-pipeline-ordering RFC (#262).
+/// </summary>
+public class OrderReplaceRejectedEventTests
+{
+    [Fact]
+    public async Task RiskReject_writes_OrderReplaceRejectedEvent_with_source_risk_and_burned_clordid()
+    {
+        var (svc, store, sink, _, seed) = Build(riskRejects: true, marginRejects: false);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(seed.Owner, seed.ClOrdId, NewQuantity: 200, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.RiskRejected, result.Kind);
+
+        var rejected = store.Recorded
+            .Select(t => t.Event)
+            .OfType<OrderReplaceRejectedEvent>()
+            .Single();
+        Assert.Equal(seed.ClOrdId, rejected.OriginalClOrdId);
+        Assert.NotEqual(0UL, rejected.NewClOrdId);
+        Assert.Equal("risk", rejected.Source);
+        Assert.Equal("test_risk_reject", rejected.Reason);
+        Assert.Equal(seed.FirmId, rejected.FirmId);
+        Assert.Equal(seed.Owner.Value, rejected.EndClientId);
+        Assert.Equal(seed.Symbol, rejected.Symbol);
+        Assert.Equal(seed.SecurityId, rejected.SecurityId);
+        Assert.Equal(200, rejected.RequestedQuantity);
+        Assert.Equal(30m, rejected.RequestedPrice);
+
+        // Live FE notification mirrors submit-side: ExecKind.Rejected
+        // under the burned ClOrdId.
+        var live = Assert.Single(sink.Events);
+        Assert.Equal(ExecKind.Rejected, live.Kind);
+        Assert.Equal(rejected.NewClOrdId, live.ClOrdId);
+        Assert.Equal("test_risk_reject", live.RejectReason);
+    }
+
+    [Fact]
+    public async Task MarginReject_writes_OrderReplaceRejectedEvent_with_source_margin()
+    {
+        var (svc, store, _, _, seed) = Build(riskRejects: false, marginRejects: true);
+
+        var result = await svc.ModifyAsync(
+            new OrderModifyRequest(seed.Owner, seed.ClOrdId, NewQuantity: 200, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Equal(OrderModifyResultKind.RiskRejected, result.Kind);
+        var rejected = store.Recorded
+            .Select(t => t.Event)
+            .OfType<OrderReplaceRejectedEvent>()
+            .Single();
+        Assert.Equal("margin", rejected.Source);
+        Assert.Equal("test_margin_reject", rejected.Reason);
+    }
+
+    [Fact]
+    public async Task RiskReject_does_not_write_OrderReplaceRequestedEvent_or_advance_intent()
+    {
+        // The rejected ClOrdId must NOT appear as an OrderReplaceRequestedEvent
+        // (no intent registration, no gateway dispatch). Only the
+        // OrderReplaceRejectedEvent audit row exists for it.
+        var (svc, store, _, _, seed) = Build(riskRejects: true, marginRejects: false);
+
+        await svc.ModifyAsync(
+            new OrderModifyRequest(seed.Owner, seed.ClOrdId, NewQuantity: 200, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Empty(store.Recorded.Select(t => t.Event).OfType<OrderReplaceRequestedEvent>());
+        Assert.Single(store.Recorded.Select(t => t.Event).OfType<OrderReplaceRejectedEvent>());
+    }
+
+    [Fact]
+    public async Task RiskReject_gateway_is_not_called()
+    {
+        var (svc, _, _, gw, seed) = Build(riskRejects: true, marginRejects: false);
+
+        await svc.ModifyAsync(
+            new OrderModifyRequest(seed.Owner, seed.ClOrdId, NewQuantity: 200, NewPrice: 30m),
+            CancellationToken.None);
+
+        Assert.Empty(gw.Replaces);
+    }
+
+    [Fact]
+    public async Task RiskReject_preserves_requested_optionals_on_event()
+    {
+        var (svc, store, _, _, seed) = Build(riskRejects: true, marginRejects: false);
+
+        var gtd = DateTimeOffset.UtcNow.AddHours(2);
+        await svc.ModifyAsync(
+            new OrderModifyRequest(
+                seed.Owner, seed.ClOrdId, NewQuantity: 150, NewPrice: 31m,
+                NewTimeInForce: TimeInForce.GTD, NewStopPrice: null, NewGoodTillDate: gtd),
+            CancellationToken.None);
+
+        var evt = store.Recorded.Select(t => t.Event).OfType<OrderReplaceRejectedEvent>().Single();
+        Assert.Equal("GTD", evt.RequestedTimeInForce);
+        Assert.Equal(gtd, evt.RequestedGoodTillDate);
+        Assert.Null(evt.RequestedStopPrice);
+    }
+
+    // ----------------------------------------------------------------
+    // Builders / fakes
+    // ----------------------------------------------------------------
+
+    private static (OrderModifyService Svc, RecordingEventStore Store, CapturingSink Sink,
+        CapturingGateway Gw, Order Seed) Build(bool riskRejects, bool marginRejects)
+    {
+        var owner = new EndClientId("alice");
+        var seed = new Order(
+            1_337_001UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM01");
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        Assert.True(book.TryAdd(seed));
+        ownership.Register(seed.ClOrdId, owner);
+        var gateway = new CapturingGateway();
+        var sink = new CapturingSink();
+        var checks = riskRejects
+            ? new IRiskCheck[] { new AlwaysRejectingCheck("test_risk_reject") }
+            : Array.Empty<IRiskCheck>();
+        var risk = new RiskPipeline(checks);
+        var margin = marginRejects
+            ? (IReplaceMarginCoordinator)new AlwaysRejectingReplaceMargin("test_margin_reject")
+            : new NoOpReplaceMargin();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var svc = new OrderModifyService(
+            clOrdIds, ownership, book, gateway, sink, risk, margin,
+            new PendingReplacementRegistry(), dispatcher,
+            new NeverDrain(), NullLogger<OrderModifyService>.Instance);
+        return (svc, store, sink, gateway, seed);
+    }
+
+    private sealed class AlwaysRejectingCheck(string reason) : IRiskCheck
+    {
+        public int Order => 0;
+        public string Name => "AlwaysReject";
+        public RiskDecision Check(RiskContext ctx) => RiskDecision.Reject(reason);
+    }
+
+    private sealed class AlwaysRejectingReplaceMargin(string reason) : IReplaceMarginCoordinator
+    {
+        public Task<RiskDecision> PrepareReplaceAsync(ulong _, ulong __, EndClientId ___, decimal ____, CancellationToken _____)
+            => Task.FromResult(RiskDecision.Reject(reason));
+        public void CommitReplace(ulong _, ulong __, decimal ___) { }
+        public void AbortReplace(ulong _) { }
+    }
+
+    private sealed class NoOpReplaceMargin : IReplaceMarginCoordinator
+    {
+        public Task<RiskDecision> PrepareReplaceAsync(ulong _, ulong __, EndClientId ___, decimal ____, CancellationToken _____)
+            => Task.FromResult(RiskDecision.Approve);
+        public void CommitReplace(ulong _, ulong __, decimal ___) { }
+        public void AbortReplace(ulong _) { }
+    }
+
+    private sealed class CapturingSink : IExecutionEventSink
+    {
+        public readonly List<ExecutionEvent> Events = new();
+        public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    private sealed class CapturingGateway : IExchangeGateway
+    {
+        public readonly List<(ulong NewClOrdId, long Qty, decimal? Px, TimeInForce? Tif, decimal? Stop, DateTimeOffset? Gtd)> Replaces = new();
+        public Task SubmitAsync(Order o, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelAsync(Order o, ulong cancelClOrdId, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelReplaceAsync(Order o, ulong newClOrdId, long newQty, decimal? newPx,
+            TimeInForce? tif, decimal? stop, DateTimeOffset? gtd, CancellationToken ct)
+        {
+            Replaces.Add((newClOrdId, newQty, newPx, tif, stop, gtd));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NeverDrain : Lifecycle.IDrainGate { public bool IsDraining => false; }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        public ConcurrentQueue<(long Seq, WalEvent Event)> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+        public long Append(WalEvent evt)
+        {
+            var s = Interlocked.Increment(ref _seq);
+            Recorded.Enqueue((s, evt));
+            return s;
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> _) => Append(evt);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/docs/rfcs/risk-pipeline-ordering-v0.md
+++ b/docs/rfcs/risk-pipeline-ordering-v0.md
@@ -236,6 +236,17 @@ Rationale:
 > "modify: emit `OrderReplaceRejectedEvent` on risk reject" to close the
 > audit gap without touching the submit path's invariants.
 
+**Status update (#337 — modify audit gap closed):** the modify pipeline now
+dispatches an `OrderReplaceRejectedEvent` WAL row on both the risk-reject and
+the margin-reject branches (with `Source="risk"` / `Source="margin"`) and
+publishes a synthetic `ExecKind.Rejected` `ExecutionEvent` to the live sink
+for the FE blotter. Replay treats the event as audit-only (advances the
+ClOrdId watermark; no book/ownership/margin mutation), and
+`/executions/history` projects the row with `Kind="Rejected"`. The
+modify-side row of the asymmetry table in §1.3 (the three rows tagged "no
+WAL row / no FE notification / no /executions/history row") is therefore now
+on parity with the submit path.
+
 ## 6. Out of scope
 
 - Reworking `IRiskCheck` to be async — no current check needs I/O.


### PR DESCRIPTION
Closes #337.

Closes the modify-side audit gap flagged by the risk-pipeline-ordering RFC (#262). When `OrderModifyService` rejects a cancel-replace pre-WAL (risk pipeline or margin coordinator), the burned `newClOrdId` now leaves a single WAL audit row **and** a synthetic `ExecKind.Rejected` `ExecutionEvent` on the live sink — same posture as submit-side `PublishSyntheticRejection`.

## Acceptance
- [x] New `OrderReplaceRejectedEvent` WAL row defined and persisted (`Source` = `risk` or `margin`).
- [x] Replay treats it as audit-only (advances ClOrdId watermark; no book/ownership/margin mutation).
- [x] `OrderModifyService` writes the audit row on both risk- and margin-reject branches with WAL-backpressure fallback to sink-only publish.
- [x] `/executions/history` projects the row as `Kind="Rejected"` under the original order's owner/symbol.
- [x] 5 new unit tests (`OrderReplaceRejectedEventTests`): risk source, margin source, no spurious `OrderReplaceRequestedEvent`, no gateway dispatch, optionals round-trip.
- [x] RFC `risk-pipeline-ordering-v0.md` status block notes the gap closed.

## Test results
- `B3.Trading.Application.Tests`: 1065/1065 ✅
- `B3.Trading.Api.Tests`: 484/484 ✅

FE: existing executions blotter already renders `Rejected` rows with the rejection badge — no FE change required.