### PR TITLE
chore(deps): bump B3.MarketData.WebSocketClient 0.1.0 → 0.2.0 (#286)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.3" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
-    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.2.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />


### PR DESCRIPTION
Refs #286.

Pure dependency bump. v0.2.0 of `B3.MarketData.WebSocketClient` surfaces the data classes that were missing in v0.1.0:

- `SubscribeFlags.Book` (MBO / L3 order-by-order) → `BookSnapshot`, `OrderAdded`, `OrderUpdated`, `OrderDeleted`, `BookCleared`, `MarketTierUpdate`.
- `SubscribeFlags.Mbp` (L2 aggregated price levels) → `LevelSnapshot`, `LevelUpdate`, `LevelDeleted`.
- `SubscribeFlags.News`.

This unblocks the SDK-surface gap noted in #286 / mirror upstream `pedrosakuma/B3MarketDataPlatform#41` (now resolved).

## Scope

- Single line change in `backend/Directory.Packages.props`.
- No consumer wired yet: `SdkMarketDataSubscriber` still subscribes with `Trades | Info` only.
- Existing `TradeEvent` / `InfoSnapshotEvent` / `ServerStatusEvent` / `ServerHelloEvent` shapes are source-compat — no breaking changes hit the build.

## Follow-up (not in this PR — remains tracked under #286)

- Extend `IMarketDataSubscriber` seam with Book/Mbp events.
- Adopt MBO-only on the wire per the design discussion (host derives L2 view internally; FE gets it through the WS hub).
- Wire `SubscribeFlags.Book` in `SdkMarketDataSubscriber.SubscribeAsync`.
- Plumb depth into pegged (#283 → #287), collar v2, FE depth ladder (#293), surveillance (#312).

## Tests

- `dotnet build B3TradingPlatform.slnx`: 0 warnings, 0 errors.
- Full test suite: 1683/1684 — only failure is the known #325 GtdScheduler backpressure flake (passes on rerun; unrelated to this change).