### PR TITLE
feat(marketdata): Stage A in-host MBO store + L2 view (#286)

### DIFF
--- a/backend/src/B3.Trading.Application/MarketData/IL2BookView.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IL2BookView.cs
@@ -1,0 +1,38 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.6 Stage A (#286). Read-only L2 view derived from the L3 / MBO
+/// book maintained by <see cref="MboBookStore"/>. Consumers that only
+/// need top-of-book (pegging v2, collar v2, depth-ladder FE channel)
+/// take a dependency on this seam instead of the full L3 store so the
+/// MBO implementation can change without rippling.
+/// </summary>
+public interface IL2BookView
+{
+    /// <summary>
+    /// Returns the current best bid + best ask + the aggregated qty /
+    /// order count on each top level, or <c>null</c> when the store
+    /// has not seen any orders for <paramref name="symbol"/> yet (no
+    /// snapshot delivered or both sides emptied via
+    /// <see cref="MarketBookCleared"/>).
+    /// </summary>
+    L2TopOfBook? GetTopOfBook(string symbol);
+}
+
+/// <summary>
+/// Top-of-book aggregate derived from the per-order MBO book. Either
+/// side may be a "missing" (price = 0, qty = 0, count = 0) tuple when
+/// the corresponding side is empty — callers should check
+/// <see cref="L2Side.OrderCount"/> &gt; 0 before consuming the price.
+/// </summary>
+public readonly record struct L2TopOfBook(
+    string Symbol,
+    L2Side Bid,
+    L2Side Ask,
+    DateTimeOffset UpdatedUtc);
+
+/// <summary>Aggregate of one side of one price level.</summary>
+public readonly record struct L2Side(
+    decimal Price,
+    long TotalQty,
+    int OrderCount);

--- a/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
@@ -54,6 +54,21 @@ public interface IMarketDataSubscriber : IAsyncDisposable
     event Action<MarketAuctionImbalance>? AuctionImbalance;
     event Action<MarketAuctionPrint>? AuctionPrint;
 
+    // -------------------------------------------------------------
+    // L3 / MBO book (Q3.6 Stage A, #286). Raised only when the
+    // adapter is configured with EnableBook=true; otherwise these
+    // stay silent (existing consumers pay nothing). The events fire
+    // in the order the SDK delivers them; consumers MUST treat
+    // BookSnapshot as a state-reset marker and apply subsequent
+    // OrderAdded/Updated/Deleted in delivery order.
+    // -------------------------------------------------------------
+
+    event Action<MarketBookSnapshot>? BookSnapshot;
+    event Action<MarketOrderAdded>? OrderAdded;
+    event Action<MarketOrderUpdated>? OrderUpdated;
+    event Action<MarketOrderDeleted>? OrderDeleted;
+    event Action<MarketBookCleared>? BookCleared;
+
     Task ConnectAsync(CancellationToken ct = default);
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataEvents.cs
@@ -41,3 +41,87 @@ public enum MarketDataConnectionState
     Reconnecting,
     Faulted,
 }
+
+// ── L3 / MBO book events (Q3.6 Stage A, #286) ───────────────────────
+
+/// <summary>App-owned mirror of the SDK's <c>BookSide</c> enum.
+/// Same wire bytes (0 = Bid, 1 = Ask). Kept here so consumers below
+/// the host adapter don't reference the SDK.</summary>
+public enum MarketBookSide : byte
+{
+    Bid = 0,
+    Ask = 1,
+}
+
+/// <summary>App-owned mirror of the SDK's <c>BookClearSide</c> enum
+/// (0 = Both, 1 = Bid, 2 = Ask).</summary>
+public enum MarketBookClearSide : byte
+{
+    Both = 0,
+    Bid = 1,
+    Ask = 2,
+}
+
+/// <summary>One MBO order inside a <see cref="MarketBookSnapshot"/>.
+/// Price is already scaled by the SDK.</summary>
+public readonly record struct MarketBookOrder(
+    ulong OrderId,
+    decimal Price,
+    long Qty);
+
+/// <summary>
+/// L3 / order-by-order snapshot. Consumers MUST clear any prior per-
+/// symbol L3 state on receipt and then rebuild from <see cref="Bids"/>
+/// / <see cref="Asks"/> (which may be empty if the server sends the
+/// snapshot as an empty marker followed by <see cref="MarketOrderAdded"/>
+/// frames in the same packet). <see cref="RptSeq"/> matches the
+/// per-symbol sequence the next incremental will carry.
+/// </summary>
+public sealed class MarketBookSnapshot
+{
+    public required string Symbol { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required uint RptSeq { get; init; }
+    public IReadOnlyList<MarketBookOrder> Bids { get; init; } = Array.Empty<MarketBookOrder>();
+    public IReadOnlyList<MarketBookOrder> Asks { get; init; } = Array.Empty<MarketBookOrder>();
+    public required DateTimeOffset ReceivedUtc { get; init; }
+}
+
+/// <summary>Per-order Add. Price is already scaled by the SDK.</summary>
+public readonly record struct MarketOrderAdded(
+    string Symbol,
+    ulong SecurityId,
+    ulong OrderId,
+    MarketBookSide Side,
+    decimal Price,
+    long Qty,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>Per-order Update (qty / price change). Consumers SHOULD
+/// upsert by <see cref="OrderId"/>.</summary>
+public readonly record struct MarketOrderUpdated(
+    string Symbol,
+    ulong SecurityId,
+    ulong OrderId,
+    MarketBookSide Side,
+    decimal Price,
+    long Qty,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>Per-order Delete. Consumers MUST drop
+/// <see cref="OrderId"/> on <see cref="Side"/>.</summary>
+public readonly record struct MarketOrderDeleted(
+    string Symbol,
+    ulong SecurityId,
+    ulong OrderId,
+    MarketBookSide Side,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>Mass-delete of one or both sides. A follow-up snapshot is
+/// NOT guaranteed; consumers MUST drop every order on the affected
+/// side(s).</summary>
+public readonly record struct MarketBookCleared(
+    string Symbol,
+    ulong SecurityId,
+    MarketBookClearSide ClearSide,
+    DateTimeOffset ReceivedUtc);

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
@@ -43,4 +43,22 @@ public sealed class MarketDataOptions
     /// (cache wins forever as long as it has a value).
     /// </summary>
     public TimeSpan MaxStaleness { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Q3.6 Stage A (#286). Opt-in flag to subscribe to the L3 / MBO
+    /// book stream (<c>SubscribeFlags.Book</c>) in addition to
+    /// <c>Trades | Info</c>. When <c>true</c>, every symbol passed to
+    /// <see cref="IMarketDataSubscriber.SubscribeAsync"/> receives the
+    /// per-order add/update/delete + book-snapshot stream, which the
+    /// in-host <c>MboBookStore</c> assembles into both an L3 view and a
+    /// derived L2 top-of-book.
+    /// <para>
+    /// Default <c>false</c> so existing deployments (which only need
+    /// trades + info for the collar / VWAP estimator) pay nothing for
+    /// the MBO bandwidth + per-order CPU cost. Set to <c>true</c> once
+    /// a consumer (pegging v2, depth UI, surveillance) needs the
+    /// book.
+    /// </para>
+    /// </summary>
+    public bool EnableBook { get; set; } = false;
 }

--- a/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
@@ -1,0 +1,170 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.6 Stage A (#286). In-host L3 (MBO) book store + derived L2 view.
+/// Applies the per-symbol stream of
+/// <see cref="MarketBookSnapshot"/> + <see cref="MarketOrderAdded"/> /
+/// <see cref="MarketOrderUpdated"/> / <see cref="MarketOrderDeleted"/> /
+/// <see cref="MarketBookCleared"/> frames the
+/// <see cref="IMarketDataSubscriber"/> raises (when
+/// <c>MarketDataOptions.EnableBook</c> is on) and exposes the aggregate
+/// top-of-book via <see cref="IL2BookView"/>.
+///
+/// <para>
+/// <b>Design choice (MBO-only on the wire).</b> The server also exposes
+/// an L2 / MBP stream, but we deliberately subscribe to MBO only and
+/// derive L2 internally — one feed, one source of truth, no L2/L3
+/// divergence bugs. See <c>docs/rfcs/</c> design notes; tracking
+/// issue #286.
+/// </para>
+///
+/// <para>
+/// <b>Thread safety.</b> Each per-symbol state is mutated under its
+/// own lock. The outer <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// handles concurrent symbol upserts. Reads (<see cref="GetTopOfBook"/>)
+/// take the same per-symbol lock to publish a consistent aggregate.
+/// The SDK delivers per-symbol events on a single dispatch thread so
+/// contention is limited to readers vs. that thread.
+/// </para>
+/// </summary>
+public sealed class MboBookStore : IL2BookView
+{
+    private readonly ConcurrentDictionary<string, SymbolState> _bySymbol =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public void ApplySnapshot(MarketBookSnapshot snap)
+    {
+        var state = _bySymbol.GetOrAdd(snap.Symbol, _ => new SymbolState(snap.Symbol));
+        lock (state.Gate)
+        {
+            state.Bids.Clear();
+            state.Asks.Clear();
+            foreach (var o in snap.Bids)
+                state.Bids[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+            foreach (var o in snap.Asks)
+                state.Asks[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+            state.UpdatedUtc = snap.ReceivedUtc;
+        }
+    }
+
+    public void ApplyAdded(MarketOrderAdded ev)
+    {
+        if (ev.Qty <= 0) return;
+        var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
+        lock (state.Gate)
+        {
+            SideMap(state, ev.Side)[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
+            state.UpdatedUtc = ev.ReceivedUtc;
+        }
+    }
+
+    public void ApplyUpdated(MarketOrderUpdated ev)
+    {
+        var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
+        lock (state.Gate)
+        {
+            var map = SideMap(state, ev.Side);
+            if (ev.Qty <= 0)
+            {
+                map.Remove(ev.OrderId);
+            }
+            else
+            {
+                map[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
+            }
+            state.UpdatedUtc = ev.ReceivedUtc;
+        }
+    }
+
+    public void ApplyDeleted(MarketOrderDeleted ev)
+    {
+        if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
+        lock (state.Gate)
+        {
+            SideMap(state, ev.Side).Remove(ev.OrderId);
+            state.UpdatedUtc = ev.ReceivedUtc;
+        }
+    }
+
+    public void ApplyCleared(MarketBookCleared ev)
+    {
+        if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
+        lock (state.Gate)
+        {
+            switch (ev.ClearSide)
+            {
+                case MarketBookClearSide.Both:
+                    state.Bids.Clear();
+                    state.Asks.Clear();
+                    break;
+                case MarketBookClearSide.Bid:
+                    state.Bids.Clear();
+                    break;
+                case MarketBookClearSide.Ask:
+                    state.Asks.Clear();
+                    break;
+            }
+            state.UpdatedUtc = ev.ReceivedUtc;
+        }
+    }
+
+    public L2TopOfBook? GetTopOfBook(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return null;
+        if (!_bySymbol.TryGetValue(symbol.Trim(), out var state)) return null;
+        lock (state.Gate)
+        {
+            // Bid side: best = highest price; Ask side: best = lowest price.
+            var bid = TopOfSide(state.Bids, ascending: false);
+            var ask = TopOfSide(state.Asks, ascending: true);
+            if (bid.OrderCount == 0 && ask.OrderCount == 0) return null;
+            return new L2TopOfBook(state.Symbol, bid, ask, state.UpdatedUtc);
+        }
+    }
+
+    /// <summary>Test/diagnostic hook: per-side live order count.</summary>
+    public (int Bids, int Asks) GetOrderCounts(string symbol)
+    {
+        if (!_bySymbol.TryGetValue(symbol, out var state)) return (0, 0);
+        lock (state.Gate) return (state.Bids.Count, state.Asks.Count);
+    }
+
+    private static L2Side TopOfSide(Dictionary<ulong, OrderEntry> side, bool ascending)
+    {
+        if (side.Count == 0) return new L2Side(0m, 0, 0);
+        decimal best = ascending ? decimal.MaxValue : decimal.MinValue;
+        foreach (var e in side.Values)
+        {
+            if (ascending ? e.Price < best : e.Price > best)
+                best = e.Price;
+        }
+        long qty = 0;
+        int count = 0;
+        foreach (var e in side.Values)
+        {
+            if (e.Price == best)
+            {
+                qty += e.Qty;
+                count++;
+            }
+        }
+        return new L2Side(best, qty, count);
+    }
+
+    private static Dictionary<ulong, OrderEntry> SideMap(SymbolState s, MarketBookSide side) =>
+        side == MarketBookSide.Bid ? s.Bids : s.Asks;
+
+    private readonly record struct OrderEntry(decimal Price, long Qty);
+
+    private sealed class SymbolState
+    {
+        public SymbolState(string symbol) { Symbol = symbol; }
+        public string Symbol { get; }
+        public Dictionary<ulong, OrderEntry> Bids { get; } = new();
+        public Dictionary<ulong, OrderEntry> Asks { get; } = new();
+        public DateTimeOffset UpdatedUtc { get; set; }
+        public object Gate { get; } = new();
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/MboBookStorePump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MboBookStorePump.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Hosting;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.6 Stage A (#286). Wires the L3 / MBO events raised by
+/// <see cref="IMarketDataSubscriber"/> into <see cref="MboBookStore"/>.
+/// Same hosted-service lifecycle as <see cref="MarketDataPegBookPump"/>
+/// so DI guarantees the handlers are attached before the subscriber
+/// connects.
+///
+/// <para>
+/// When <c>MarketDataOptions.EnableBook</c> is off the subscriber never
+/// raises the Book* events; this pump is still wired (so the store can
+/// be resolved as a singleton) but stays silent.
+/// </para>
+/// </summary>
+public sealed class MboBookStorePump : IHostedService
+{
+    private readonly IMarketDataSubscriber _subscriber;
+    private readonly MboBookStore _store;
+
+    public MboBookStorePump(IMarketDataSubscriber subscriber, MboBookStore store)
+    {
+        _subscriber = subscriber;
+        _store = store;
+        _subscriber.BookSnapshot += OnSnapshot;
+        _subscriber.OrderAdded += OnAdded;
+        _subscriber.OrderUpdated += OnUpdated;
+        _subscriber.OrderDeleted += OnDeleted;
+        _subscriber.BookCleared += OnCleared;
+    }
+
+    private void OnSnapshot(MarketBookSnapshot s) => _store.ApplySnapshot(s);
+    private void OnAdded(MarketOrderAdded e) => _store.ApplyAdded(e);
+    private void OnUpdated(MarketOrderUpdated e) => _store.ApplyUpdated(e);
+    private void OnDeleted(MarketOrderDeleted e) => _store.ApplyDeleted(e);
+    private void OnCleared(MarketBookCleared e) => _store.ApplyCleared(e);
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscriber.BookSnapshot -= OnSnapshot;
+        _subscriber.OrderAdded -= OnAdded;
+        _subscriber.OrderUpdated -= OnUpdated;
+        _subscriber.OrderDeleted -= OnDeleted;
+        _subscriber.BookCleared -= OnCleared;
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/NullMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Application/MarketData/NullMarketDataSubscriber.cs
@@ -18,6 +18,11 @@ public sealed class NullMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<MarketAuctionImbalance>? AuctionImbalance;
     public event Action<MarketAuctionPrint>? AuctionPrint;
+    public event Action<MarketBookSnapshot>? BookSnapshot;
+    public event Action<MarketOrderAdded>? OrderAdded;
+    public event Action<MarketOrderUpdated>? OrderUpdated;
+    public event Action<MarketOrderDeleted>? OrderDeleted;
+    public event Action<MarketBookCleared>? BookCleared;
 #pragma warning restore CS0067
 
     public MarketDataConnectionState State => MarketDataConnectionState.Disconnected;

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -222,6 +222,18 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<B3.Trading.Application.MarketData.MarketDataPegBookPump>();
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.MarketDataPegBookPump>());
+        // Q3.6 Stage A (#286). In-host L3/MBO book store + pump. Off by
+        // default — events only flow when MarketDataOptions.EnableBook
+        // is true, in which case SdkMarketDataSubscriber subscribes to
+        // SubscribeFlags.Book and the SDK raises the Book* events the
+        // pump bridges into the store. L2 view is derived from the L3
+        // state and exposed via IL2BookView for downstream consumers.
+        services.AddSingleton<B3.Trading.Application.MarketData.MboBookStore>();
+        services.AddSingleton<B3.Trading.Application.MarketData.IL2BookView>(
+            sp => sp.GetRequiredService<B3.Trading.Application.MarketData.MboBookStore>());
+        services.AddSingleton<B3.Trading.Application.MarketData.MboBookStorePump>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.MarketData.MboBookStorePump>());
         services.AddSingleton<AlgoEngine>();
         services.AddHostedService(sp => sp.GetRequiredService<AlgoEngine>());
         services.AddHostedService<AlgoScheduler>();

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -1,6 +1,7 @@
 using B3.MarketData.WebSocketClient;
 using B3.Trading.Application.MarketData;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using AppConnState = B3.Trading.Application.MarketData.MarketDataConnectionState;
 using AppTrade = B3.Trading.Application.MarketData.MarketTrade;
 using AppInfoSnapshot = B3.Trading.Application.MarketData.MarketInfoSnapshot;
@@ -21,9 +22,17 @@ namespace B3.Trading.Host.MarketData;
 ///         already scaled by the SDK (1e-4).</item>
 ///   <item>SDK <c>InfoSnapshotEvent</c> → <see cref="AppInfoSnapshot"/>
 ///         keeping only the two prices the collar consumes today.</item>
-///   <item><see cref="SubscribeAsync(string, CancellationToken)"/> always asks for
-///         <c>Trades | Info</c> so a fresh subscription seeds the cache
-///         immediately from the snapshot frame.</item>
+///   <item>SDK MBO events (<c>BookSnapshot</c>, <c>OrderAdded</c>,
+///         <c>OrderUpdated</c>, <c>OrderDeleted</c>,
+///         <c>BookCleared</c>) → app-owned <c>Market*</c> records
+///         (Q3.6 Stage A, #286). Hooked only when
+///         <see cref="MarketDataOptions.EnableBook"/> is true; when
+///         off the SDK still surfaces them but we deliberately don't
+///         subscribe to <c>SubscribeFlags.Book</c> so the server
+///         never streams them.</item>
+///   <item><see cref="SubscribeAsync(string, CancellationToken)"/> asks for
+///         <c>Trades | Info</c> by default and adds <c>Book</c> when
+///         <see cref="MarketDataOptions.EnableBook"/> is true.</item>
 /// </list>
 /// </para>
 /// </summary>
@@ -31,32 +40,56 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
 {
     private readonly MarketDataClient _client;
     private readonly ILogger<SdkMarketDataSubscriber> _logger;
+    private readonly SubscribeFlags _subscribeFlags;
+    private readonly bool _bookEnabled;
 
     public event Action<AppTrade>? Trade;
     public event Action<AppInfoSnapshot>? InfoSnapshot;
     public event Action<AppConnState>? ConnectionStateChanged;
     public event Action<MarketSubscribeError>? SubscribeError;
 
-    // SDK gap: B3.MarketData.WebSocketClient 0.1.0 does not surface
+    // SDK gap: B3.MarketData.WebSocketClient 0.2.0 still does not surface
     // dedicated auction events. We declare the events on the seam so
     // AuctionStateStore + WS channels are wired end-to-end; they
     // simply never fire under the live SDK today. Tests inject a fake
-    // subscriber that raises them. Tracking: B3MatchingPlatform#321/#322.
+    // subscriber that raises them. Tracking: B3MarketDataPlatform#40.
 #pragma warning disable CS0067 // event never used — see SDK-gap note above.
     public event Action<B3.Trading.Application.MarketData.MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<B3.Trading.Application.MarketData.MarketAuctionImbalance>? AuctionImbalance;
     public event Action<B3.Trading.Application.MarketData.MarketAuctionPrint>? AuctionPrint;
 #pragma warning restore CS0067
 
-    public SdkMarketDataSubscriber(MarketDataClient client, ILogger<SdkMarketDataSubscriber> logger)
+    public event Action<MarketBookSnapshot>? BookSnapshot;
+    public event Action<MarketOrderAdded>? OrderAdded;
+    public event Action<MarketOrderUpdated>? OrderUpdated;
+    public event Action<MarketOrderDeleted>? OrderDeleted;
+    public event Action<MarketBookCleared>? BookCleared;
+
+    public SdkMarketDataSubscriber(
+        MarketDataClient client,
+        ILogger<SdkMarketDataSubscriber> logger,
+        IOptions<MarketDataOptions> options)
     {
         _client = client;
         _logger = logger;
+        _bookEnabled = options.Value.EnableBook;
+        _subscribeFlags = _bookEnabled
+            ? SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Book
+            : SubscribeFlags.Trades | SubscribeFlags.Info;
 
         _client.Trade += OnSdkTrade;
         _client.InfoSnapshot += OnSdkInfo;
         _client.ConnectionStateChanged += OnSdkConn;
         _client.SubscribeError += OnSdkSubErr;
+
+        if (_bookEnabled)
+        {
+            _client.BookSnapshot += OnSdkBookSnapshot;
+            _client.OrderAdded += OnSdkOrderAdded;
+            _client.OrderUpdated += OnSdkOrderUpdated;
+            _client.OrderDeleted += OnSdkOrderDeleted;
+            _client.BookCleared += OnSdkBookCleared;
+        }
     }
 
     public AppConnState State => Translate(_client.State);
@@ -67,7 +100,7 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
 
     public async ValueTask SubscribeAsync(string symbol, CancellationToken ct = default)
     {
-        await _client.SubscribeAsync(symbol, SubscribeFlags.Trades | SubscribeFlags.Info, ct)
+        await _client.SubscribeAsync(symbol, _subscribeFlags, ct)
             .ConfigureAwait(false);
 
         if (_client.TryGetSecurityId(symbol, out var securityId))
@@ -86,6 +119,14 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         _client.InfoSnapshot -= OnSdkInfo;
         _client.ConnectionStateChanged -= OnSdkConn;
         _client.SubscribeError -= OnSdkSubErr;
+        if (_bookEnabled)
+        {
+            _client.BookSnapshot -= OnSdkBookSnapshot;
+            _client.OrderAdded -= OnSdkOrderAdded;
+            _client.OrderUpdated -= OnSdkOrderUpdated;
+            _client.OrderDeleted -= OnSdkOrderDeleted;
+            _client.BookCleared -= OnSdkBookCleared;
+        }
         return _client.DisposeAsync();
     }
 
@@ -114,6 +155,65 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
 
     private void OnSdkSubErr(SubscribeErrorEvent ev) =>
         SubscribeError?.Invoke(new MarketSubscribeError(ev.Symbol, ev.ErrorCode.ToString()));
+
+    // ── Q3.6 Stage A (#286) MBO translation ─────────────────────────
+
+    private void OnSdkBookSnapshot(BookSnapshotEvent ev)
+    {
+        var bids = ev.Bids.Count == 0
+            ? (IReadOnlyList<MarketBookOrder>)Array.Empty<MarketBookOrder>()
+            : ev.Bids.Select(o => new MarketBookOrder(o.OrderId, o.Price, o.Qty)).ToArray();
+        var asks = ev.Asks.Count == 0
+            ? (IReadOnlyList<MarketBookOrder>)Array.Empty<MarketBookOrder>()
+            : ev.Asks.Select(o => new MarketBookOrder(o.OrderId, o.Price, o.Qty)).ToArray();
+        BookSnapshot?.Invoke(new MarketBookSnapshot
+        {
+            Symbol = ev.Symbol,
+            SecurityId = ev.SecurityId,
+            RptSeq = ev.RptSeq,
+            Bids = bids,
+            Asks = asks,
+            ReceivedUtc = AsOffset(ev.ReceivedUtc),
+        });
+    }
+
+    private void OnSdkOrderAdded(OrderAddedEvent ev) =>
+        OrderAdded?.Invoke(new MarketOrderAdded(
+            ev.Symbol, ev.SecurityId, ev.OrderId, TranslateSide(ev.Side),
+            ev.Price, ev.Qty, AsOffset(ev.ReceivedUtc)));
+
+    private void OnSdkOrderUpdated(OrderUpdatedEvent ev) =>
+        OrderUpdated?.Invoke(new MarketOrderUpdated(
+            ev.Symbol, ev.SecurityId, ev.OrderId, TranslateSide(ev.Side),
+            ev.Price, ev.Qty, AsOffset(ev.ReceivedUtc)));
+
+    private void OnSdkOrderDeleted(OrderDeletedEvent ev) =>
+        OrderDeleted?.Invoke(new MarketOrderDeleted(
+            ev.Symbol, ev.SecurityId, ev.OrderId, TranslateSide(ev.Side),
+            AsOffset(ev.ReceivedUtc)));
+
+    private void OnSdkBookCleared(BookClearedEvent ev) =>
+        BookCleared?.Invoke(new MarketBookCleared(
+            ev.Symbol, ev.SecurityId, TranslateClearSide(ev.ClearSide),
+            AsOffset(ev.ReceivedUtc)));
+
+    private static DateTimeOffset AsOffset(DateTime dt) =>
+        new(DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+
+    private static MarketBookSide TranslateSide(BookSide s) => s switch
+    {
+        BookSide.Bid => MarketBookSide.Bid,
+        BookSide.Ask => MarketBookSide.Ask,
+        _ => MarketBookSide.Bid,
+    };
+
+    private static MarketBookClearSide TranslateClearSide(BookClearSide s) => s switch
+    {
+        BookClearSide.Both => MarketBookClearSide.Both,
+        BookClearSide.Bid => MarketBookClearSide.Bid,
+        BookClearSide.Ask => MarketBookClearSide.Ask,
+        _ => MarketBookClearSide.Both,
+    };
 
     private static AppConnState Translate(SdkConnState s) => s switch
     {

--- a/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
@@ -192,7 +192,8 @@ public class AuctionWebSocketChannelTests
     private sealed class FakeMdSubscriber : IMarketDataSubscriber
     {
 #pragma warning disable CS0067
-        public event Action<MarketTrade>? Trade;
+        #pragma warning disable CS0067
+    public event Action<MarketTrade>? Trade;
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
         public event Action<MarketSubscribeError>? SubscribeError;
@@ -200,6 +201,13 @@ public class AuctionWebSocketChannelTests
         public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
+#pragma warning disable CS0067
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+        public event Action<MarketBookCleared>? BookCleared;
+    #pragma warning restore CS0067
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;
         public long DroppedEventCount => 0;

--- a/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
@@ -192,8 +192,8 @@ public class AuctionWebSocketChannelTests
     private sealed class FakeMdSubscriber : IMarketDataSubscriber
     {
 #pragma warning disable CS0067
-        #pragma warning disable CS0067
-    public event Action<MarketTrade>? Trade;
+#pragma warning disable CS0067
+        public event Action<MarketTrade>? Trade;
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
         public event Action<MarketSubscribeError>? SubscribeError;
@@ -207,7 +207,7 @@ public class AuctionWebSocketChannelTests
         public event Action<MarketOrderUpdated>? OrderUpdated;
         public event Action<MarketOrderDeleted>? OrderDeleted;
         public event Action<MarketBookCleared>? BookCleared;
-    #pragma warning restore CS0067
+#pragma warning restore CS0067
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;
         public long DroppedEventCount => 0;

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -24,8 +24,8 @@ public class PnlRefPriceFanOutTests
 
     private sealed class FakeSubscriber : IMarketDataSubscriber
     {
-        #pragma warning disable CS0067
-    public event Action<MarketTrade>? Trade;
+#pragma warning disable CS0067
+        public event Action<MarketTrade>? Trade;
 #pragma warning disable CS0067
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -38,7 +38,7 @@ public class PnlRefPriceFanOutTests
         public event Action<MarketOrderUpdated>? OrderUpdated;
         public event Action<MarketOrderDeleted>? OrderDeleted;
         public event Action<MarketBookCleared>? BookCleared;
-    #pragma warning restore CS0067
+#pragma warning restore CS0067
 #pragma warning restore CS0067
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -24,7 +24,8 @@ public class PnlRefPriceFanOutTests
 
     private sealed class FakeSubscriber : IMarketDataSubscriber
     {
-        public event Action<MarketTrade>? Trade;
+        #pragma warning disable CS0067
+    public event Action<MarketTrade>? Trade;
 #pragma warning disable CS0067
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -32,6 +33,12 @@ public class PnlRefPriceFanOutTests
         public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+        public event Action<MarketBookCleared>? BookCleared;
+    #pragma warning restore CS0067
 #pragma warning restore CS0067
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -184,7 +184,8 @@ public class MarketDataVolumePumpTests
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;
         public long DroppedEventCount => 0;
-        public event Action<MarketTrade>? Trade;
+        #pragma warning disable CS0067
+    public event Action<MarketTrade>? Trade;
 #pragma warning disable CS0067 // unused in this test
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -192,6 +193,12 @@ public class MarketDataVolumePumpTests
         public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+        public event Action<MarketBookCleared>? BookCleared;
+    #pragma warning restore CS0067
 #pragma warning restore CS0067
 
         public void RaiseTrade(MarketTrade t) => Trade?.Invoke(t);

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -184,8 +184,8 @@ public class MarketDataVolumePumpTests
 
         public MarketDataConnectionState State => MarketDataConnectionState.Connected;
         public long DroppedEventCount => 0;
-        #pragma warning disable CS0067
-    public event Action<MarketTrade>? Trade;
+#pragma warning disable CS0067
+        public event Action<MarketTrade>? Trade;
 #pragma warning disable CS0067 // unused in this test
         public event Action<MarketInfoSnapshot>? InfoSnapshot;
         public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -198,7 +198,7 @@ public class MarketDataVolumePumpTests
         public event Action<MarketOrderUpdated>? OrderUpdated;
         public event Action<MarketOrderDeleted>? OrderDeleted;
         public event Action<MarketBookCleared>? BookCleared;
-    #pragma warning restore CS0067
+#pragma warning restore CS0067
 #pragma warning restore CS0067
 
         public void RaiseTrade(MarketTrade t) => Trade?.Invoke(t);

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MboBookStoreTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MboBookStoreTests.cs
@@ -1,0 +1,259 @@
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// Q3.6 Stage A (#286). Unit tests for MboBookStore (L3 maintenance +
+/// derived L2 top-of-book).
+/// </summary>
+public class MboBookStoreTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 5, 19, 14, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void TopOfBook_returns_null_for_unknown_symbol()
+    {
+        var s = new MboBookStore();
+        Assert.Null(s.GetTopOfBook("UNKN"));
+    }
+
+    [Fact]
+    public void Snapshot_seeds_book_and_top_picks_best_bid_and_best_ask()
+    {
+        var s = new MboBookStore();
+        s.ApplySnapshot(new MarketBookSnapshot
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321,
+            RptSeq = 1,
+            Bids = new[]
+            {
+                new MarketBookOrder(101, 30.10m, 100),
+                new MarketBookOrder(102, 30.20m, 200), // best
+                new MarketBookOrder(103, 30.20m, 50),  // ties on best
+            },
+            Asks = new[]
+            {
+                new MarketBookOrder(201, 30.40m, 300), // best
+                new MarketBookOrder(202, 30.50m, 100),
+            },
+            ReceivedUtc = T0,
+        });
+
+        var top = Assert.NotNull(s.GetTopOfBook("PETR4"));
+        Assert.Equal(30.20m, top.Bid.Price);
+        Assert.Equal(250, top.Bid.TotalQty);
+        Assert.Equal(2, top.Bid.OrderCount);
+        Assert.Equal(30.40m, top.Ask.Price);
+        Assert.Equal(300, top.Ask.TotalQty);
+        Assert.Equal(1, top.Ask.OrderCount);
+    }
+
+    [Fact]
+    public void OrderAdded_appends_and_can_become_new_best()
+    {
+        var s = SeedSimple();
+        s.ApplyAdded(new MarketOrderAdded("PETR4", 4321, 999, MarketBookSide.Bid, 30.30m, 80, T0.AddSeconds(1)));
+
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(30.30m, top.Bid.Price);
+        Assert.Equal(80, top.Bid.TotalQty);
+        Assert.Equal(1, top.Bid.OrderCount);
+    }
+
+    [Fact]
+    public void OrderUpdated_zero_qty_is_treated_as_delete()
+    {
+        var s = SeedSimple();
+        // Existing best bid (102 @ 30.20 / 200). Update to qty=0 should remove it.
+        s.ApplyUpdated(new MarketOrderUpdated("PETR4", 4321, 102, MarketBookSide.Bid, 30.20m, 0, T0.AddSeconds(1)));
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        // Remaining bids: 101 @ 30.10 / 100 and 103 @ 30.20 / 50 → best still 30.20 / 50 / 1.
+        Assert.Equal(30.20m, top.Bid.Price);
+        Assert.Equal(50, top.Bid.TotalQty);
+        Assert.Equal(1, top.Bid.OrderCount);
+    }
+
+    [Fact]
+    public void OrderUpdated_qty_change_aggregates_in_top()
+    {
+        var s = SeedSimple();
+        s.ApplyUpdated(new MarketOrderUpdated("PETR4", 4321, 103, MarketBookSide.Bid, 30.20m, 150, T0.AddSeconds(1)));
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        // 102 (200) + 103 (150) = 350 at 30.20.
+        Assert.Equal(30.20m, top.Bid.Price);
+        Assert.Equal(350, top.Bid.TotalQty);
+        Assert.Equal(2, top.Bid.OrderCount);
+    }
+
+    [Fact]
+    public void OrderDeleted_drops_and_recomputes_top()
+    {
+        var s = SeedSimple();
+        s.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321, 102, MarketBookSide.Bid, T0.AddSeconds(1)));
+        s.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321, 103, MarketBookSide.Bid, T0.AddSeconds(1)));
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(30.10m, top.Bid.Price);
+        Assert.Equal(100, top.Bid.TotalQty);
+        Assert.Equal(1, top.Bid.OrderCount);
+    }
+
+    [Fact]
+    public void BookCleared_both_empties_state_and_top_returns_null()
+    {
+        var s = SeedSimple();
+        s.ApplyCleared(new MarketBookCleared("PETR4", 4321, MarketBookClearSide.Both, T0.AddSeconds(1)));
+        Assert.Null(s.GetTopOfBook("PETR4"));
+        var (b, a) = s.GetOrderCounts("PETR4");
+        Assert.Equal(0, b);
+        Assert.Equal(0, a);
+    }
+
+    [Fact]
+    public void BookCleared_single_side_keeps_other()
+    {
+        var s = SeedSimple();
+        s.ApplyCleared(new MarketBookCleared("PETR4", 4321, MarketBookClearSide.Bid, T0.AddSeconds(1)));
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(0, top.Bid.OrderCount);
+        Assert.Equal(30.40m, top.Ask.Price);
+    }
+
+    [Fact]
+    public void Snapshot_replaces_prior_state()
+    {
+        var s = SeedSimple();
+        s.ApplySnapshot(new MarketBookSnapshot
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321,
+            RptSeq = 5,
+            Bids = new[] { new MarketBookOrder(500, 31.00m, 10) },
+            Asks = new[] { new MarketBookOrder(501, 31.05m, 20) },
+            ReceivedUtc = T0.AddSeconds(2),
+        });
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(31.00m, top.Bid.Price);
+        Assert.Equal(10, top.Bid.TotalQty);
+        Assert.Equal(1, top.Bid.OrderCount);
+        Assert.Equal(31.05m, top.Ask.Price);
+        var (b, a) = s.GetOrderCounts("PETR4");
+        Assert.Equal(1, b);
+        Assert.Equal(1, a);
+    }
+
+    [Fact]
+    public void OrderAdded_with_nonpositive_qty_is_ignored()
+    {
+        var s = new MboBookStore();
+        s.ApplyAdded(new MarketOrderAdded("PETR4", 4321, 1, MarketBookSide.Bid, 30m, 0, T0));
+        s.ApplyAdded(new MarketOrderAdded("PETR4", 4321, 2, MarketBookSide.Bid, 30m, -5, T0));
+        Assert.Null(s.GetTopOfBook("PETR4"));
+    }
+
+    [Fact]
+    public void Top_unknown_symbol_after_only_one_side_present_returns_value_with_empty_other()
+    {
+        var s = new MboBookStore();
+        s.ApplyAdded(new MarketOrderAdded("PETR4", 4321, 1, MarketBookSide.Ask, 30m, 100, T0));
+        var top = s.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(30m, top.Ask.Price);
+        Assert.Equal(100, top.Ask.TotalQty);
+        Assert.Equal(1, top.Ask.OrderCount);
+        Assert.Equal(0, top.Bid.OrderCount);
+    }
+
+    [Fact]
+    public void Symbol_lookup_is_case_insensitive_and_trims_whitespace()
+    {
+        var s = SeedSimple();
+        Assert.NotNull(s.GetTopOfBook("petr4"));
+        Assert.NotNull(s.GetTopOfBook("  PETR4  "));
+    }
+
+    [Fact]
+    public async Task Pump_bridges_subscriber_events_into_store()
+    {
+        var sub = new FakeBookSubscriber();
+        var store = new MboBookStore();
+        var pump = new MboBookStorePump(sub, store);
+        await pump.StartAsync(CancellationToken.None);
+        sub.RaiseSnapshot("PETR4", new[] { new MarketBookOrder(1, 30m, 100) }, Array.Empty<MarketBookOrder>(), T0);
+        sub.RaiseAdded("PETR4", 2, MarketBookSide.Ask, 30.10m, 50, T0);
+        var top = store.GetTopOfBook("PETR4")!.Value;
+        Assert.Equal(30m, top.Bid.Price);
+        Assert.Equal(30.10m, top.Ask.Price);
+        await pump.StopAsync(CancellationToken.None);
+        sub.RaiseDeleted("PETR4", 1, MarketBookSide.Bid, T0.AddSeconds(1));
+        Assert.Equal(30m, store.GetTopOfBook("PETR4")!.Value.Bid.Price);
+    }
+
+    private static MboBookStore SeedSimple()
+    {
+        var s = new MboBookStore();
+        s.ApplySnapshot(new MarketBookSnapshot
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321,
+            RptSeq = 1,
+            Bids = new[]
+            {
+                new MarketBookOrder(101, 30.10m, 100),
+                new MarketBookOrder(102, 30.20m, 200),
+                new MarketBookOrder(103, 30.20m, 50),
+            },
+            Asks = new[]
+            {
+                new MarketBookOrder(201, 30.40m, 300),
+                new MarketBookOrder(202, 30.50m, 100),
+            },
+            ReceivedUtc = T0,
+        });
+        return s;
+    }
+
+    private sealed class FakeBookSubscriber : IMarketDataSubscriber
+    {
+#pragma warning disable CS0067
+        public event Action<MarketTrade>? Trade;
+        public event Action<MarketInfoSnapshot>? InfoSnapshot;
+        public event Action<MarketDataConnectionState>? ConnectionStateChanged;
+        public event Action<MarketSubscribeError>? SubscribeError;
+        public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
+        public event Action<MarketAuctionImbalance>? AuctionImbalance;
+        public event Action<MarketAuctionPrint>? AuctionPrint;
+#pragma warning restore CS0067
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+#pragma warning disable CS0067
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+#pragma warning restore CS0067
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+#pragma warning disable CS0067
+        public event Action<MarketBookCleared>? BookCleared;
+#pragma warning restore CS0067
+
+        public MarketDataConnectionState State => MarketDataConnectionState.Connected;
+        public long DroppedEventCount => 0;
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void RaiseSnapshot(string symbol, IReadOnlyList<MarketBookOrder> bids, IReadOnlyList<MarketBookOrder> asks, DateTimeOffset ts) =>
+            BookSnapshot?.Invoke(new MarketBookSnapshot
+            {
+                Symbol = symbol,
+                SecurityId = 0,
+                RptSeq = 1,
+                Bids = bids,
+                Asks = asks,
+                ReceivedUtc = ts,
+            });
+
+        public void RaiseAdded(string sym, ulong id, MarketBookSide side, decimal px, long qty, DateTimeOffset ts) =>
+            OrderAdded?.Invoke(new MarketOrderAdded(sym, 0, id, side, px, qty, ts));
+
+        public void RaiseDeleted(string sym, ulong id, MarketBookSide side, DateTimeOffset ts) =>
+            OrderDeleted?.Invoke(new MarketOrderDeleted(sym, 0, id, side, ts));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
@@ -203,6 +203,7 @@ internal sealed class StaticFallback : IReferencePrice
 
 internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
 {
+    #pragma warning disable CS0067
     public event Action<MarketTrade>? Trade;
     public event Action<MarketInfoSnapshot>? InfoSnapshot;
     public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -210,6 +211,12 @@ internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<MarketAuctionImbalance>? AuctionImbalance;
     public event Action<MarketAuctionPrint>? AuctionPrint;
+    public event Action<MarketBookSnapshot>? BookSnapshot;
+    public event Action<MarketOrderAdded>? OrderAdded;
+    public event Action<MarketOrderUpdated>? OrderUpdated;
+    public event Action<MarketOrderDeleted>? OrderDeleted;
+    public event Action<MarketBookCleared>? BookCleared;
+    #pragma warning restore CS0067
 
     public MarketDataConnectionState State { get; private set; } = MarketDataConnectionState.Disconnected;
     public long DroppedEventCount => 0;

--- a/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
@@ -203,7 +203,7 @@ internal sealed class StaticFallback : IReferencePrice
 
 internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
 {
-    #pragma warning disable CS0067
+#pragma warning disable CS0067
     public event Action<MarketTrade>? Trade;
     public event Action<MarketInfoSnapshot>? InfoSnapshot;
     public event Action<MarketDataConnectionState>? ConnectionStateChanged;
@@ -216,7 +216,7 @@ internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketOrderUpdated>? OrderUpdated;
     public event Action<MarketOrderDeleted>? OrderDeleted;
     public event Action<MarketBookCleared>? BookCleared;
-    #pragma warning restore CS0067
+#pragma warning restore CS0067
 
     public MarketDataConnectionState State { get; private set; } = MarketDataConnectionState.Disconnected;
     public long DroppedEventCount => 0;


### PR DESCRIPTION
## What
Stage A of #286: host-side scaffolding to consume MBO/L3 from `B3.MarketData.WebSocketClient` 0.2.0 (PR #357 unblocked the SDK surface). No downstream consumer is wired yet.

## Design (MBO-only on the wire)
- Subscribe only to `SubscribeFlags.Book` when `MarketDataOptions.EnableBook=true`.
- Derive L2 top-of-book in-host from the L3 store — one source of truth, no two-feed divergence (ITCH/Nasdaq convention).
- Default off: existing deployments (trades+info only) pay zero cost.

## Surface
- `IMarketDataSubscriber` gains 5 Book events.
- `SdkMarketDataSubscriber` conditionally OR's `SubscribeFlags.Book` and translates the SDK events into app records.
- `MboBookStore` (per-symbol L3, per-side dict, per-symbol lock) + `IL2BookView` for downstream readers.
- `MboBookStorePump` (IHostedService) bridges subscriber → store.
- DI registered alongside `PegBookTopCache`/`MarketDataPegBookPump`.

## Tests
- New `MboBookStoreTests`: snapshot, add/update/delete/clear, L2 derivation (max-price bid, min-price ask, tie aggregation), `qty<=0` delete semantics, side-scoped clear, case-insensitive symbol lookup, pump bridge round-trip.
- 4 existing fake subscribers extended with Book events under CS0067 pragma.
- Full `dotnet test` green locally.

## Out of scope
- Stage B: WS hub channel `book.{symbol}` + FE depth ladder (#293).
- Stage C: pegging v2 (#283/#287), surveillance #312, queue-position metric.

Refs #286.