### PR TITLE
feat(risk): stable reject codes on pre-trade rejections (#288)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -146,7 +146,7 @@ public static class OrdersEndpoints
                     Results.Accepted($"/orders/{result.ClOrdId}", new { ClOrdId = result.ClOrdId.ToString() }),
                 OrderSubmissionResultKind.Rejected =>
                     Results.Accepted($"/orders/{result.ClOrdId}",
-                        new { ClOrdId = result.ClOrdId.ToString(), Status = "Rejected", Reason = result.Reason }),
+                        new { ClOrdId = result.ClOrdId.ToString(), Status = "Rejected", Reason = result.Reason, Code = result.Code }),
                 OrderSubmissionResultKind.GatewayFailed =>
                     Results.Json(
                         new { error = "gateway unavailable", clOrdId = result.ClOrdId.ToString() },
@@ -213,7 +213,7 @@ public static class OrdersEndpoints
                 OrderModifyResultKind.BadRequest =>
                     Results.BadRequest(new { error = result.Reason }),
                 OrderModifyResultKind.RiskRejected =>
-                    Results.UnprocessableEntity(new { error = result.Reason }),
+                    Results.UnprocessableEntity(new { error = result.Reason, code = result.Code }),
                 OrderModifyResultKind.GatewayFailed =>
                     Results.Json(
                         new { error = "gateway unavailable", clOrdId = result.NewClOrdId.ToString() },

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -242,12 +242,14 @@ public sealed class OrderModifyService
         if (!decision.Approved)
         {
             var reason = decision.Reason ?? "risk_rejected";
+            var code = decision.Code ?? "risk_rejected";
             MetricsRegistry.OrdersRejectedByRisk.Add(1,
                 new KeyValuePair<string, object?>("reason", reason),
+                new KeyValuePair<string, object?>("code", code),
                 new KeyValuePair<string, object?>("path", "modify"),
                 new KeyValuePair<string, object?>("firmId", orig.FirmId));
             PublishReplaceRejected(req, orig, newClOrdId, "risk", reason);
-            return OrderModifyResult.RiskRejected(reason);
+            return OrderModifyResult.RiskRejected(reason, code);
         }
 
         // Margin Prepare: reserve only the upsize delta. The
@@ -262,12 +264,14 @@ public sealed class OrderModifyService
         if (!marginDecision.Approved)
         {
             var reason = marginDecision.Reason ?? "margin_rejected";
+            var code = marginDecision.Code ?? "margin_rejected";
             MetricsRegistry.OrdersRejectedByRisk.Add(1,
                 new KeyValuePair<string, object?>("reason", reason),
+                new KeyValuePair<string, object?>("code", code),
                 new KeyValuePair<string, object?>("path", "modify"),
                 new KeyValuePair<string, object?>("firmId", orig.FirmId));
             PublishReplaceRejected(req, orig, newClOrdId, "margin", reason);
-            return OrderModifyResult.RiskRejected(reason);
+            return OrderModifyResult.RiskRejected(reason, code);
         }
 
         var intent = new OrderReplacementIntent(
@@ -475,32 +479,38 @@ public sealed class OrderModifyResult
     public OrderModifyResultKind Kind { get; }
     public ulong NewClOrdId { get; }
     public string? Reason { get; }
+    /// <summary>
+    /// #288 — stable machine-readable code (e.g. <c>min_tick_size</c>,
+    /// <c>price_collar</c>) on risk-rejection paths. Null on accept.
+    /// </summary>
+    public string? Code { get; }
     public Exception? GatewayException { get; }
 
-    private OrderModifyResult(OrderModifyResultKind kind, ulong newClOrdId, string? reason, Exception? ex)
+    private OrderModifyResult(OrderModifyResultKind kind, ulong newClOrdId, string? reason, string? code, Exception? ex)
     {
         Kind = kind;
         NewClOrdId = newClOrdId;
         Reason = reason;
+        Code = code;
         GatewayException = ex;
     }
 
     public static OrderModifyResult Accepted(ulong newClOrdId) =>
-        new(OrderModifyResultKind.Accepted, newClOrdId, null, null);
-    public static OrderModifyResult RiskRejected(string reason) =>
-        new(OrderModifyResultKind.RiskRejected, 0, reason, null);
+        new(OrderModifyResultKind.Accepted, newClOrdId, null, null, null);
+    public static OrderModifyResult RiskRejected(string reason, string? code = null) =>
+        new(OrderModifyResultKind.RiskRejected, 0, reason, code, null);
     public static OrderModifyResult GatewayFailed(ulong newClOrdId, Exception ex) =>
-        new(OrderModifyResultKind.GatewayFailed, newClOrdId, "gateway_unavailable", ex);
+        new(OrderModifyResultKind.GatewayFailed, newClOrdId, "gateway_unavailable", "gateway_unavailable", ex);
     public static OrderModifyResult WalBackpressure(string detail) =>
-        new(OrderModifyResultKind.WalBackpressure, 0, detail, null);
+        new(OrderModifyResultKind.WalBackpressure, 0, detail, "wal_backpressure", null);
     public static OrderModifyResult BadRequest(string reason) =>
-        new(OrderModifyResultKind.BadRequest, 0, reason, null);
+        new(OrderModifyResultKind.BadRequest, 0, reason, "bad_request", null);
     public static OrderModifyResult Conflict(string reason) =>
-        new(OrderModifyResultKind.Conflict, 0, reason, null);
+        new(OrderModifyResultKind.Conflict, 0, reason, "conflict", null);
     public static OrderModifyResult NotFound { get; } =
-        new(OrderModifyResultKind.NotFound, 0, null, null);
+        new(OrderModifyResultKind.NotFound, 0, null, null, null);
     public static OrderModifyResult Drained { get; } =
-        new(OrderModifyResultKind.Drained, 0, "service draining", null);
+        new(OrderModifyResultKind.Drained, 0, "service draining", "service_draining", null);
     /// <summary>
     /// #108 — DuplicateClOrdID guard. The just-allocated new ClOrdID
     /// already exists in <see cref="WorkingOrderBook"/> or
@@ -508,7 +518,7 @@ public sealed class OrderModifyResult
     /// no WAL event, no gateway call. Endpoints map to <c>409 Conflict</c>.
     /// </summary>
     public static OrderModifyResult DuplicateClOrdId(ulong newClOrdId) =>
-        new(OrderModifyResultKind.DuplicateClOrdId, newClOrdId, "duplicate_clordid", null);
+        new(OrderModifyResultKind.DuplicateClOrdId, newClOrdId, "duplicate_clordid", "duplicate_clordid", null);
 }
 
 public enum OrderModifyResultKind

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -254,11 +254,14 @@ public sealed class OrderSubmissionService
         }
         if (!decision.Approved)
         {
+            var reason = decision.Reason ?? "risk_rejected";
+            var code = decision.Code ?? "risk_rejected";
             MetricsRegistry.OrdersRejectedByRisk.Add(1,
-                new KeyValuePair<string, object?>("reason", decision.Reason ?? "risk_rejected"),
+                new KeyValuePair<string, object?>("reason", reason),
+                new KeyValuePair<string, object?>("code", code),
                 new KeyValuePair<string, object?>("firmId", req.FirmId));
-            PublishSyntheticRejection(order, decision.Reason ?? "risk_rejected");
-            return OrderSubmissionResult.Rejected(clOrdId, decision.Reason ?? "risk_rejected");
+            PublishSyntheticRejection(order, reason);
+            return OrderSubmissionResult.Rejected(clOrdId, reason, code);
         }
 
         _accountant.RecordAccepted(riskCtx);
@@ -417,28 +420,34 @@ public sealed class OrderSubmissionResult
     public OrderSubmissionResultKind Kind { get; }
     public ulong ClOrdId { get; }
     public string? Reason { get; }
+    /// <summary>
+    /// #288 — stable machine-readable code (e.g. <c>min_tick_size</c>,
+    /// <c>kill_switch</c>) on rejection paths. Null on accept.
+    /// </summary>
+    public string? Code { get; }
     public Exception? GatewayException { get; }
 
-    private OrderSubmissionResult(OrderSubmissionResultKind kind, ulong clOrdId, string? reason, Exception? ex)
+    private OrderSubmissionResult(OrderSubmissionResultKind kind, ulong clOrdId, string? reason, string? code, Exception? ex)
     {
         Kind = kind;
         ClOrdId = clOrdId;
         Reason = reason;
+        Code = code;
         GatewayException = ex;
     }
 
     public static OrderSubmissionResult Accepted(ulong clOrdId) =>
-        new(OrderSubmissionResultKind.Accepted, clOrdId, null, null);
-    public static OrderSubmissionResult Rejected(ulong clOrdId, string reason) =>
-        new(OrderSubmissionResultKind.Rejected, clOrdId, reason, null);
+        new(OrderSubmissionResultKind.Accepted, clOrdId, null, null, null);
+    public static OrderSubmissionResult Rejected(ulong clOrdId, string reason, string? code = null) =>
+        new(OrderSubmissionResultKind.Rejected, clOrdId, reason, code, null);
     public static OrderSubmissionResult GatewayFailed(ulong clOrdId, Exception ex) =>
-        new(OrderSubmissionResultKind.GatewayFailed, clOrdId, "gateway_unavailable", ex);
+        new(OrderSubmissionResultKind.GatewayFailed, clOrdId, "gateway_unavailable", "gateway_unavailable", ex);
     public static OrderSubmissionResult WalBackpressure(string detail) =>
-        new(OrderSubmissionResultKind.WalBackpressure, 0, detail, null);
+        new(OrderSubmissionResultKind.WalBackpressure, 0, detail, "wal_backpressure", null);
     public static OrderSubmissionResult BadRequest(string reason) =>
-        new(OrderSubmissionResultKind.BadRequest, 0, reason, null);
+        new(OrderSubmissionResultKind.BadRequest, 0, reason, "bad_request", null);
     public static OrderSubmissionResult Drained { get; } =
-        new(OrderSubmissionResultKind.Drained, 0, "service draining", null);
+        new(OrderSubmissionResultKind.Drained, 0, "service draining", "service_draining", null);
     /// <summary>
     /// #108 — DuplicateClOrdID guard. The just-allocated ClOrdID
     /// already exists in the <see cref="WorkingOrderBook"/>. No WAL
@@ -448,7 +457,7 @@ public sealed class OrderSubmissionResult
     /// failures and so operators can spot the invariant breach.
     /// </summary>
     public static OrderSubmissionResult DuplicateClOrdId(ulong clOrdId) =>
-        new(OrderSubmissionResultKind.DuplicateClOrdId, clOrdId, "duplicate_clordid", null);
+        new(OrderSubmissionResultKind.DuplicateClOrdId, clOrdId, "duplicate_clordid", "duplicate_clordid", null);
 }
 
 public enum OrderSubmissionResultKind

--- a/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
@@ -44,6 +44,7 @@ public sealed class MinTickSizeCheck : IRiskCheck
         // that would bite a double-based modulus.
         if (decimal.Remainder(ctx.Price.Value, tick) != 0m)
             return RiskDecision.Reject(
+                RiskRejectCodes.MinTickSize,
                 $"price {ctx.Price.Value} is not a multiple of tick size {tick} for {ctx.Symbol}");
         return RiskDecision.Approve;
     }
@@ -70,6 +71,7 @@ public sealed class MinLotSizeCheck : IRiskCheck
 
         if (ctx.Quantity % lot != 0)
             return RiskDecision.Reject(
+                RiskRejectCodes.MinLotSize,
                 $"quantity {ctx.Quantity} is not a multiple of lot size {lot} for {ctx.Symbol}");
         return RiskDecision.Approve;
     }

--- a/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
@@ -46,10 +46,22 @@ public sealed record RiskContext(
     /// </summary>
     SubAccountId? SubAccountId = null);
 
-public sealed record RiskDecision(bool Approved, string? Reason)
+public sealed record RiskDecision(bool Approved, string? Reason, string? Code = null)
 {
-    public static readonly RiskDecision Approve = new(true, null);
-    public static RiskDecision Reject(string reason) => new(false, reason);
+    public static readonly RiskDecision Approve = new(true, null, null);
+    public static RiskDecision Reject(string reason) => new(false, reason, null);
+
+    /// <summary>
+    /// #288 — stable machine-readable code. Preferred over the legacy
+    /// <c>Reject(reason)</c> overload so the REST surface and the FE
+    /// can branch on a fixed identifier instead of parsing the
+    /// human-readable reason. <see cref="RiskPipeline.Evaluate"/> falls
+    /// back to the rejecting check's <see cref="IRiskCheck.Name"/> when
+    /// a check rejects without supplying its own code, so every
+    /// pipeline rejection surfaces a non-null code without each check
+    /// having to opt in.
+    /// </summary>
+    public static RiskDecision Reject(string code, string reason) => new(false, reason, code);
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Risk/RiskPipeline.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskPipeline.cs
@@ -23,7 +23,17 @@ public sealed class RiskPipeline
         {
             var decision = check.Check(ctx);
             if (!decision.Approved)
-                return decision;
+            {
+                // #288 — every pipeline rejection must surface a stable
+                // code. Most checks today only call
+                // RiskDecision.Reject(reason); fall back to the check
+                // Name (already a stable lower_snake_case identifier
+                // per the IRiskCheck contract) so the REST surface and
+                // the FE never see a null code on a pipeline reject.
+                return decision.Code is null
+                    ? decision with { Code = check.Name }
+                    : decision;
+            }
         }
         return RiskDecision.Approve;
     }

--- a/backend/src/B3.Trading.Application/Risk/RiskRejectCodes.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskRejectCodes.cs
@@ -1,0 +1,35 @@
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Stable canonical machine-readable codes for pre-trade risk
+/// rejections (#288). Surfaced on <see cref="RiskDecision.Code"/> and
+/// propagated through <c>OrderSubmissionResult.Code</c> /
+/// <c>OrderModifyResult.Code</c> and into the REST surface so the FE
+/// and CVM / drop-copy / observability consumers can branch on a fixed
+/// identifier instead of parsing the human-readable reason.
+///
+/// <para>
+/// The default fallback inside <see cref="RiskPipeline.Evaluate"/> is
+/// the rejecting <see cref="IRiskCheck.Name"/> (lower_snake_case), so
+/// new checks automatically surface a non-null code even when they
+/// only call <c>RiskDecision.Reject(reason)</c>. The constants here
+/// document the canonical spelling used by the checks that have been
+/// audited and stabilised — the FE / clients should depend on these
+/// rather than on the free-text reason.
+/// </para>
+/// </summary>
+public static class RiskRejectCodes
+{
+    /// <summary>
+    /// <see cref="Checks.MinTickSizeCheck"/> — price is not a whole
+    /// multiple of the instrument's tick size. Maps to FIX-44
+    /// <c>OrderExceedsTickSize</c> rejection family.
+    /// </summary>
+    public const string MinTickSize = "min_tick_size";
+
+    /// <summary>
+    /// <see cref="Checks.MinLotSizeCheck"/> — quantity is not a whole
+    /// multiple of the instrument's round lot.
+    /// </summary>
+    public const string MinLotSize = "min_lot_size";
+}

--- a/backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/Q12RiskEndpointTests.cs
@@ -237,5 +237,5 @@ public class Q12RiskEndpointTests
         return ack!;
     }
 
-    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason);
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason, string? Code);
 }

--- a/backend/tests/B3.Trading.Api.Tests/RiskRejectionCodeSurfaceTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/RiskRejectionCodeSurfaceTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// #288 — REST surface emits a stable machine-readable <c>code</c>
+/// (e.g. <c>min_tick_size</c>) alongside the human-readable
+/// <c>reason</c>/<c>error</c>, on both <c>POST /orders</c>
+/// (<c>Status="Rejected"</c>, 202) and <c>PUT /orders/{id}</c>
+/// (<c>422 UnprocessableEntity</c>) risk-rejection paths.
+///
+/// <para>
+/// The wire field is the lower_snake_case <see cref="IRiskCheck.Name"/>
+/// of the rejecting check (the pipeline fall-back), with explicit
+/// canonical values listed in <c>RiskRejectCodes</c>. Tests target the
+/// tick-size check because it's the smallest unambiguous trigger.
+/// </para>
+/// </summary>
+public class RiskRejectionCodeSurfaceTests
+{
+    [Fact]
+    public async Task POST_TickSizeViolation_Surfaces_MinTickSize_Code()
+    {
+        // Seed PETR4 with a 0.01 tick; submit a price that is not a
+        // whole multiple (0.005) to trigger MinTickSizeCheck.
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:SymbolDirectory:Specs:PETR4:TickSize"] = "0.01",
+        });
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var resp = await PostOrder(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            TimeInForce = "Day",
+            Quantity = 100,
+            Price = 30.005m,
+        });
+
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var ack = await ReadAck(resp);
+        Assert.Equal("Rejected", ack.Status);
+        Assert.Equal("min_tick_size", ack.Code);
+        // Reason still carries the existing human-readable detail.
+        Assert.Contains("tick size", ack.Reason);
+    }
+
+    [Fact]
+    public async Task PUT_ModifyToOffTick_Surfaces_MinTickSize_Code_AsUnprocessable()
+    {
+        using var f = TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:SymbolDirectory:Specs:PETR4:TickSize"] = "0.01",
+        });
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        // Submit an on-tick order first.
+        var posted = await PostOrder(http, token, new
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            Side = "Buy",
+            Type = "Limit",
+            TimeInForce = "Day",
+            Quantity = 100,
+            Price = 29.90m,
+        });
+        Assert.Equal(HttpStatusCode.Accepted, posted.StatusCode);
+        var origAck = await ReadAck(posted);
+        Assert.Null(origAck.Status); // Accepted (not "Rejected")
+
+        // Modify to an off-tick price (0.005 increment).
+        var put = new HttpRequestMessage(HttpMethod.Put, $"/orders/{origAck.ClOrdId}")
+        {
+            Content = JsonContent.Create(new
+            {
+                Quantity = 100,
+                Price = 29.905m,
+            }),
+        };
+        put.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(put);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        var err = JsonSerializer.Deserialize<ErrCode>(body,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.NotNull(err);
+        Assert.Equal("min_tick_size", err!.Code);
+        Assert.Contains("tick size", err.Error);
+    }
+
+    private static async Task<HttpResponseMessage> PostOrder(HttpClient http, string token, object payload)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/orders")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await http.SendAsync(req);
+    }
+
+    private static async Task<OrderAck> ReadAck(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        var ack = JsonSerializer.Deserialize<OrderAck>(body,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.NotNull(ack);
+        return ack!;
+    }
+
+    private sealed record OrderAck(string ClOrdId, string? Status, string? Reason, string? Code);
+    private sealed record ErrCode(string? Error, string? Code);
+}

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -445,7 +445,11 @@ public class RiskPipelineTests
         var check = new MinTickSizeCheck(dir);
         Assert.True(check.Check(Ctx(price: 30.01m)).Approved);
         Assert.True(check.Check(Ctx(price: 30.00m)).Approved);
-        Assert.False(check.Check(Ctx(price: 30.001m)).Approved);
+        var rejected = check.Check(Ctx(price: 30.001m));
+        Assert.False(rejected.Approved);
+        // #288 — stable code on the decision itself (independent of the
+        // pipeline fallback) so direct callers also see it.
+        Assert.Equal(RiskRejectCodes.MinTickSize, rejected.Code);
     }
 
     [Fact]
@@ -469,8 +473,50 @@ public class RiskPipelineTests
         var check = new MinLotSizeCheck(dir);
         Assert.True(check.Check(Ctx(qty: 100)).Approved);
         Assert.True(check.Check(Ctx(qty: 300)).Approved);
-        Assert.False(check.Check(Ctx(qty: 150)).Approved);
+        var rejected = check.Check(Ctx(qty: 150));
+        Assert.False(rejected.Approved);
+        Assert.Equal(RiskRejectCodes.MinLotSize, rejected.Code);
         Assert.False(check.Check(Ctx(qty: 1)).Approved);
+    }
+
+    [Fact]
+    public void Pipeline_AttachesCheckName_AsCode_WhenCheckDidNotSetOne()
+    {
+        // KillSwitchCheck rejects with RiskDecision.Reject(reason) only
+        // (no explicit code), so the pipeline must fall back to its
+        // Name property. Any future check that adopts the explicit
+        // overload keeps its own code untouched (covered by the tick
+        // and lot tests above).
+        var pipeline = new RiskPipeline(new IRiskCheck[] { new AlwaysRejectNoCodeCheck("custom_name") });
+        var decision = pipeline.Evaluate(Ctx(price: 10m));
+        Assert.False(decision.Approved);
+        Assert.Equal("custom_name", decision.Code);
+    }
+
+    [Fact]
+    public void Pipeline_PreservesExplicitCode_WhenCheckSetOne()
+    {
+        var pipeline = new RiskPipeline(new IRiskCheck[] { new AlwaysRejectWithCodeCheck("custom_name", "EXPLICIT_CODE") });
+        var decision = pipeline.Evaluate(Ctx(price: 10m));
+        Assert.False(decision.Approved);
+        Assert.Equal("EXPLICIT_CODE", decision.Code);
+    }
+
+    private sealed class AlwaysRejectNoCodeCheck : IRiskCheck
+    {
+        public AlwaysRejectNoCodeCheck(string name) => Name = name;
+        public int Order => 0;
+        public string Name { get; }
+        public RiskDecision Check(RiskContext ctx) => RiskDecision.Reject("nope");
+    }
+
+    private sealed class AlwaysRejectWithCodeCheck : IRiskCheck
+    {
+        private readonly string _code;
+        public AlwaysRejectWithCodeCheck(string name, string code) { Name = name; _code = code; }
+        public int Order => 0;
+        public string Name { get; }
+        public RiskDecision Check(RiskContext ctx) => RiskDecision.Reject(_code, "nope");
     }
 
     [Fact]


### PR DESCRIPTION
## What
First slice of #288: every pre-trade risk rejection now surfaces a stable, machine-readable `code` alongside the existing human-readable `reason`, so the FE, FIXP bot, drop-copy and observability consumers can branch on a fixed identifier without parsing the prose.

## Why
- Today `RiskDecision` is `(Approved, Reason)` only — REST callers substring-match `"tick size"` / `"kill-switch"` to know what happened.
- The pre-trade-risk-v2 RFC §4.7 already promised reason codes (`MARGIN_INSUFFICIENT`, tick/lot violations, absolute collar).

## How
- `RiskDecision` gains a nullable `Code` field. New `Reject(code, reason)` overload; legacy `Reject(reason)` keeps working.
- `RiskPipeline.Evaluate` falls back to the rejecting `IRiskCheck.Name` (already lower_snake_case) when the check did not set a code — so **every** pipeline rejection surfaces a non-null code, even before checks are individually audited.
- `MinTickSizeCheck` and `MinLotSizeCheck` adopt explicit canonical codes via new `RiskRejectCodes` (`min_tick_size`, `min_lot_size`) — these are the smallest unambiguous triggers and the natural FIX `OrderExceedsTickSize` family mapping.

## REST surface (additive)
- `POST /orders` Rejected ack: `{ ClOrdId, Status, Reason, Code }` (new `Code` field).
- `PUT /orders/{id}` 422 risk reject: `{ error, code }` (new `code` field).
- `OrdersRejectedByRisk` OTel counter gains a `code` tag (submit + modify) so Grafana panels can group by stable identifier.
- Other terminal kinds (BadRequest / WalBackpressure / GatewayFailed / Drained / DuplicateClOrdId) get stable codes too, plumbed through `OrderSubmissionResult.Code` / `OrderModifyResult.Code`.

## Tests
- `RiskPipelineTests`: explicit code preserved; missing code falls back to check Name; `MinTickSize` / `MinLotSize` emit their canonical codes.
- New `RiskRejectionCodeSurfaceTests`: end-to-end that `min_tick_size` surfaces on both POST (202 Rejected) and PUT (422) paths, seeding PETR4 with a 0.01 tick via `TestAppFactory.WithOverrides`.
- Full suite green locally (1080+485+134+... ; the known `MetricsFirmTagTests` flake passed on rerun).

## Out of scope (tracked separately)
- **Tiered tick sizes (CVM ladder per price bucket)** — defer; today's flat `decimal? TickSize` per symbol stays.
- **Upstream B3MatchingPlatform tick-size enforcement audit** — upstream tracker.
- Migrating the other ~20 checks to explicit `RiskRejectCodes` constants. They surface their Name as fallback already; can adopt the explicit overload incrementally.

Refs #288, #251.