### PR TITLE
feat(ws): public book.{symbol} top-of-book channel (#286 Stage B)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -25,6 +25,14 @@ public static class Channels
     public const string AuctionPrefix = "auction.";
 
     /// <summary>
+    /// Q3.6 Stage B (#286). Public per-symbol top-of-book channel
+    /// (<c>book.${symbol}</c>) fed by the in-host MBO store
+    /// (<c>MboBookStore</c>). Same auth posture as the auction/phases
+    /// channels: authenticated bearer required, no per-firm filter.
+    /// </summary>
+    public const string BookPrefix = "book.";
+
+    /// <summary>
     /// Per-owner channel names (validated against an exact set).
     /// Per-symbol public channels (<see cref="PhasesPrefix"/> /
     /// <see cref="AuctionPrefix"/>) are validated separately via
@@ -56,6 +64,11 @@ public static class Channels
             kind = PublicChannelKind.Auction;
             raw = channel[AuctionPrefix.Length..];
         }
+        else if (channel.StartsWith(BookPrefix, StringComparison.Ordinal))
+        {
+            kind = PublicChannelKind.Book;
+            raw = channel[BookPrefix.Length..];
+        }
         else
         {
             return false;
@@ -76,6 +89,7 @@ public static class Channels
 
     public static string PhasesFor(string symbol) => PhasesPrefix + symbol;
     public static string AuctionFor(string symbol) => AuctionPrefix + symbol;
+    public static string BookFor(string symbol) => BookPrefix + symbol;
 }
 
 public enum PublicChannelKind
@@ -83,7 +97,33 @@ public enum PublicChannelKind
     None,
     Phases,
     Auction,
+    Book,
 }
+
+/// <summary>
+/// Q3.6 Stage B (#286). Wire shape for the public
+/// <c>book.${symbol}</c> top-of-book channel. Fields are nullable so
+/// an empty-state snapshot (no MBO frame seen for this symbol yet, or
+/// the side was cleared) ships a stable shape with <c>null</c>s rather
+/// than zeroes that look like real prices. Mirrors
+/// <see cref="L2TopOfBook"/> from the application layer.
+/// </summary>
+public sealed record L2TopOfBookDto(
+    string Symbol,
+    L2SideDto? Bid,
+    L2SideDto? Ask,
+    DateTimeOffset? UpdatedUtc)
+{
+    public static L2TopOfBookDto Empty(string symbol) => new(symbol, null, null, null);
+
+    public static L2TopOfBookDto From(L2TopOfBook t) => new(
+        t.Symbol,
+        t.Bid.OrderCount > 0 ? new L2SideDto(t.Bid.Price, t.Bid.TotalQty, t.Bid.OrderCount) : null,
+        t.Ask.OrderCount > 0 ? new L2SideDto(t.Ask.Price, t.Ask.TotalQty, t.Ask.OrderCount) : null,
+        t.UpdatedUtc);
+}
+
+public sealed record L2SideDto(decimal Price, long TotalQty, int OrderCount);
 
 /// <summary>Inbound command from a connected client.</summary>
 public sealed record InboundCommand(string Type, string[]? Channels);

--- a/backend/src/B3.Trading.Api/WebSockets/IPublicChannelSnapshots.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/IPublicChannelSnapshots.cs
@@ -28,3 +28,31 @@ public sealed class NullPublicChannelSnapshots : IPublicChannelSnapshots
 {
     public object? GetSnapshot(PublicChannelKind kind, string symbol) => null;
 }
+
+/// <summary>
+/// Q3.6 Stage B (#286). Composite snapshot provider that delegates to
+/// each inner provider in order, returning the first non-null result.
+/// Used to multiplex independent sinks (auction, book, …) behind the
+/// single <see cref="IPublicChannelSnapshots"/> the WS hub depends on
+/// — each sink owns one or more <see cref="PublicChannelKind"/> values
+/// and returns <c>null</c> for kinds it does not handle.
+/// </summary>
+public sealed class CompositePublicChannelSnapshots : IPublicChannelSnapshots
+{
+    private readonly IPublicChannelSnapshots[] _inner;
+
+    public CompositePublicChannelSnapshots(params IPublicChannelSnapshots[] inner)
+    {
+        _inner = inner ?? Array.Empty<IPublicChannelSnapshots>();
+    }
+
+    public object? GetSnapshot(PublicChannelKind kind, string symbol)
+    {
+        foreach (var provider in _inner)
+        {
+            var snap = provider.GetSnapshot(kind, symbol);
+            if (snap is not null) return snap;
+        }
+        return null;
+    }
+}

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
@@ -1,0 +1,90 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.MarketData;
+using Microsoft.Extensions.Hosting;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// Q3.6 Stage B (#286). WebSocket fan-out for the public per-symbol
+/// top-of-book channel (<c>book.${symbol}</c>). Listens to
+/// <see cref="MboBookStore.TopChanged"/> and broadcasts deltas to all
+/// subscribed clients; snapshot bootstrap is served through
+/// <see cref="IPublicChannelSnapshots"/> so a newly-subscribed client
+/// always sees the current top before the next delta lands.
+///
+/// <para>
+/// Coalesces no-op updates: an apply that did not change the derived
+/// top-of-book (e.g. a deep-book add that did not affect the best
+/// price/qty/order-count) is dropped so quiet symbols stay quiet on
+/// the wire. The "last sent" snapshot is kept per symbol; the first
+/// observed update for a symbol is always emitted.
+/// </para>
+///
+/// <para>
+/// Same auth posture as the other public per-symbol channels
+/// (authenticated bearer required; no per-firm filter). When
+/// <c>MarketDataOptions.EnableBook=false</c> the underlying store
+/// stays empty so this sink is a no-op (snapshots return the empty
+/// shape; no deltas fire). Registration is unconditional to keep DI
+/// composition simple — the cost is one event handler and an empty
+/// dictionary.
+/// </para>
+/// </summary>
+public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedService
+{
+    private readonly SubscriptionManager _subs;
+    private readonly MboBookStore _store;
+
+    // Last DTO we put on the wire for each symbol — used to coalesce
+    // identical updates (no-op deep-book mutations). Keyed
+    // case-insensitively to match the store.
+    private readonly ConcurrentDictionary<string, L2TopOfBookDto> _lastSent =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public WebSocketBookEventSink(SubscriptionManager subs, MboBookStore store)
+    {
+        _subs = subs;
+        _store = store;
+    }
+
+    // ---------------- IPublicChannelSnapshots ----------------
+
+    public object? GetSnapshot(PublicChannelKind kind, string symbol) => kind switch
+    {
+        PublicChannelKind.Book => _store.GetTopOfBook(symbol) is { } top
+            ? L2TopOfBookDto.From(top)
+            : L2TopOfBookDto.Empty(symbol),
+        _ => null,
+    };
+
+    // ---------------- IHostedService ----------------
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _store.TopChanged += OnTopChanged;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _store.TopChanged -= OnTopChanged;
+        return Task.CompletedTask;
+    }
+
+    // ---------------- Event handlers ----------------
+
+    private void OnTopChanged(L2TopOfBook? top)
+    {
+        if (top is null) return; // nothing to broadcast when both sides went empty
+        var dto = L2TopOfBookDto.From(top.Value);
+        // Coalesce: skip if best bid+ask are identical to last sent for
+        // this symbol — UpdatedUtc is intentionally excluded so a
+        // deep-book mutation that bumped the store's timestamp but did
+        // not move the top stays off the wire.
+        if (_lastSent.TryGetValue(dto.Symbol, out var prev) &&
+            Equals(prev.Bid, dto.Bid) && Equals(prev.Ask, dto.Ask))
+            return;
+        _lastSent[dto.Symbol] = dto;
+        _subs.BroadcastPublic(Channels.BookFor(dto.Symbol), dto);
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
@@ -34,9 +34,22 @@ public sealed class MboBookStore : IL2BookView
     private readonly ConcurrentDictionary<string, SymbolState> _bySymbol =
         new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Q3.6 Stage B (#286). Raised after every applied frame, with the
+    /// derived top-of-book at that instant — <c>null</c> when the frame
+    /// emptied both sides. The event fires <b>outside</b> the per-symbol
+    /// lock so a slow subscriber cannot stall the apply path; producers
+    /// must therefore tolerate stale reads racing newer updates (the
+    /// derived snapshot is point-in-time and self-contained, so this is
+    /// safe). Used by <c>WebSocketBookEventSink</c> to fan out to
+    /// <c>book.${symbol}</c> subscribers.
+    /// </summary>
+    public event Action<L2TopOfBook?>? TopChanged;
+
     public void ApplySnapshot(MarketBookSnapshot snap)
     {
         var state = _bySymbol.GetOrAdd(snap.Symbol, _ => new SymbolState(snap.Symbol));
+        L2TopOfBook? top;
         lock (state.Gate)
         {
             state.Bids.Clear();
@@ -46,23 +59,29 @@ public sealed class MboBookStore : IL2BookView
             foreach (var o in snap.Asks)
                 state.Asks[o.OrderId] = new OrderEntry(o.Price, o.Qty);
             state.UpdatedUtc = snap.ReceivedUtc;
+            top = ComputeTopLocked(state);
         }
+        TopChanged?.Invoke(top);
     }
 
     public void ApplyAdded(MarketOrderAdded ev)
     {
         if (ev.Qty <= 0) return;
         var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
+        L2TopOfBook? top;
         lock (state.Gate)
         {
             SideMap(state, ev.Side)[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
             state.UpdatedUtc = ev.ReceivedUtc;
+            top = ComputeTopLocked(state);
         }
+        TopChanged?.Invoke(top);
     }
 
     public void ApplyUpdated(MarketOrderUpdated ev)
     {
         var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
+        L2TopOfBook? top;
         lock (state.Gate)
         {
             var map = SideMap(state, ev.Side);
@@ -75,22 +94,28 @@ public sealed class MboBookStore : IL2BookView
                 map[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
             }
             state.UpdatedUtc = ev.ReceivedUtc;
+            top = ComputeTopLocked(state);
         }
+        TopChanged?.Invoke(top);
     }
 
     public void ApplyDeleted(MarketOrderDeleted ev)
     {
         if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
+        L2TopOfBook? top;
         lock (state.Gate)
         {
             SideMap(state, ev.Side).Remove(ev.OrderId);
             state.UpdatedUtc = ev.ReceivedUtc;
+            top = ComputeTopLocked(state);
         }
+        TopChanged?.Invoke(top);
     }
 
     public void ApplyCleared(MarketBookCleared ev)
     {
         if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
+        L2TopOfBook? top;
         lock (state.Gate)
         {
             switch (ev.ClearSide)
@@ -107,21 +132,24 @@ public sealed class MboBookStore : IL2BookView
                     break;
             }
             state.UpdatedUtc = ev.ReceivedUtc;
+            top = ComputeTopLocked(state);
         }
+        TopChanged?.Invoke(top);
     }
 
     public L2TopOfBook? GetTopOfBook(string symbol)
     {
         if (string.IsNullOrWhiteSpace(symbol)) return null;
         if (!_bySymbol.TryGetValue(symbol.Trim(), out var state)) return null;
-        lock (state.Gate)
-        {
-            // Bid side: best = highest price; Ask side: best = lowest price.
-            var bid = TopOfSide(state.Bids, ascending: false);
-            var ask = TopOfSide(state.Asks, ascending: true);
-            if (bid.OrderCount == 0 && ask.OrderCount == 0) return null;
-            return new L2TopOfBook(state.Symbol, bid, ask, state.UpdatedUtc);
-        }
+        lock (state.Gate) return ComputeTopLocked(state);
+    }
+
+    private static L2TopOfBook? ComputeTopLocked(SymbolState state)
+    {
+        var bid = TopOfSide(state.Bids, ascending: false);
+        var ask = TopOfSide(state.Asks, ascending: true);
+        if (bid.OrderCount == 0 && ask.OrderCount == 0) return null;
+        return new L2TopOfBook(state.Symbol, bid, ask, state.UpdatedUtc);
     }
 
     /// <summary>Test/diagnostic hook: per-side live order count.</summary>

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -152,9 +152,20 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.AuctionStateStore>());
         services.AddSingleton<WebSocketAuctionEventSink>();
-        services.AddSingleton<IPublicChannelSnapshots>(sp =>
-            sp.GetRequiredService<WebSocketAuctionEventSink>());
         services.AddHostedService(sp => sp.GetRequiredService<WebSocketAuctionEventSink>());
+
+        // Q3.6 Stage B (#286). Public per-symbol book.${symbol} fan-out.
+        // Listens to MboBookStore.TopChanged (raised only when EnableBook
+        // is true and the SDK feeds MBO frames) and broadcasts derived
+        // L2 top-of-book deltas. Doubles as the snapshot provider for
+        // PublicChannelKind.Book; composed with the auction sink below.
+        services.AddSingleton<WebSocketBookEventSink>();
+        services.AddHostedService(sp => sp.GetRequiredService<WebSocketBookEventSink>());
+
+        services.AddSingleton<IPublicChannelSnapshots>(sp =>
+            new CompositePublicChannelSnapshots(
+                sp.GetRequiredService<WebSocketAuctionEventSink>(),
+                sp.GetRequiredService<WebSocketBookEventSink>()));
 
         services.AddSingleton<ExecutionReportProcessor>();
         services.AddSingleton<OrderSubmissionService>();

--- a/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
@@ -1,0 +1,137 @@
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+public class BookWebSocketChannelTests
+{
+    private static (SubscriptionManager subs, MboBookStore store, WebSocketBookEventSink sink) Build()
+    {
+        var store = new MboBookStore();
+        var subs = new SubscriptionManager(new WorkingOrderBook(), new PositionKeeper(), new AlgoBook());
+        var sink = new WebSocketBookEventSink(subs, store);
+        sink.StartAsync(default).GetAwaiter().GetResult();
+        return (subs, store, sink);
+    }
+
+    private static MarketOrderAdded Add(string sym, ulong id, MarketBookSide side, decimal price, long qty) =>
+        new(sym, 4321UL, id, side, price, qty, DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void TryParsePublic_recognises_book_with_valid_symbol()
+    {
+        Assert.True(Channels.TryParsePublic("book.PETR4", out var k, out var s));
+        Assert.Equal(PublicChannelKind.Book, k);
+        Assert.Equal("PETR4", s);
+    }
+
+    [Theory]
+    [InlineData("book.")]
+    [InlineData("book.PETR 4")]
+    [InlineData("book.PETR-4")]
+    [InlineData("book.thisistoolongasymbolname")]
+    public void TryParsePublic_rejects_invalid_book_inputs(string ch)
+    {
+        Assert.False(Channels.TryParsePublic(ch, out var k, out _));
+        Assert.Equal(PublicChannelKind.None, k);
+    }
+
+    [Fact]
+    public void Book_subscribe_emits_empty_snapshot_when_no_frame_seen()
+    {
+        var (subs, _, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        Assert.Equal("snapshot", msg!.Type);
+        Assert.Equal("book.PETR4", msg.Channel);
+        var dto = Assert.IsType<L2TopOfBookDto>(msg.Data);
+        Assert.Equal("PETR4", dto.Symbol);
+        Assert.Null(dto.Bid);
+        Assert.Null(dto.Ask);
+        Assert.Null(dto.UpdatedUtc);
+    }
+
+    [Fact]
+    public void Book_subscribe_then_OrderAdded_pushes_delta_with_new_top()
+    {
+        var (subs, store, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // discard cold snapshot
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+
+        Assert.True(client.Reader.TryRead(out var delta));
+        Assert.Equal("delta", delta!.Type);
+        Assert.Equal("book.PETR4", delta.Channel);
+        Assert.Equal(1, delta.Seq);
+        var dto = Assert.IsType<L2TopOfBookDto>(delta.Data);
+        Assert.Equal("PETR4", dto.Symbol);
+        Assert.NotNull(dto.Bid);
+        Assert.Equal(30.10m, dto.Bid!.Price);
+        Assert.Equal(100, dto.Bid.TotalQty);
+        Assert.Equal(1, dto.Bid.OrderCount);
+        Assert.Null(dto.Ask);
+    }
+
+    [Fact]
+    public void Book_subscribe_after_OrderAdded_serves_populated_snapshot()
+    {
+        var (subs, store, sink) = Build();
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Ask, 30.20m, 50));
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        Assert.Equal("snapshot", msg!.Type);
+        var dto = Assert.IsType<L2TopOfBookDto>(msg.Data);
+        Assert.Equal(30.10m, dto.Bid!.Price);
+        Assert.Equal(30.20m, dto.Ask!.Price);
+        Assert.Equal(50, dto.Ask.TotalQty);
+    }
+
+    [Fact]
+    public void Book_coalesces_deep_book_updates_that_do_not_change_top()
+    {
+        var (subs, store, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // snapshot
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+        Assert.True(client.Reader.TryRead(out _)); // first delta
+
+        // Deeper bid at lower price — top of book unchanged.
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.00m, 500));
+
+        Assert.False(client.Reader.TryRead(out var maybe),
+            $"expected coalesced (no delta) but got {maybe?.Type} {maybe?.Data}");
+    }
+
+    [Fact]
+    public void Book_emits_only_to_subscribed_clients()
+    {
+        var (subs, store, sink) = Build();
+        var alice = new SubscribedClient(new EndClientId("alice"), "TEST");
+        var bob = new SubscribedClient(new EndClientId("bob"), "TEST");
+        subs.SubscribePublicWithSnapshot(alice, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        alice.Reader.TryRead(out _);
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+
+        Assert.True(alice.Reader.TryRead(out _));
+        Assert.False(bob.Reader.TryRead(out _));
+    }
+}


### PR DESCRIPTION
## Summary

Stage B of #286: exposes the in-host derived L2 top-of-book over the trading-host's authenticated WebSocket hub as the public per-symbol channel `book.${symbol}`. Trader UI (and other internal consumers) can now subscribe without depending directly on the market-data SDK.

## Changes

- **`MboBookStore.TopChanged`** — new event raised after every applied frame (outside the per-symbol lock) carrying the freshly-computed `L2TopOfBook?` (`null` when both sides went empty).
- **`Channels.BookPrefix` + `PublicChannelKind.Book`** — new channel kind alongside `phases` / `auction`; same symbol validation (≤16 chars, ASCII alphanumeric).
- **`L2TopOfBookDto` + `L2SideDto`** — wire shape; nullable sides so the empty-state snapshot ships a stable shape rather than zeroes that look like real prices. Mirrors the eventual `IBookFeed` SDK contract so the swap will not break clients.
- **`WebSocketBookEventSink`** (`IHostedService` + `IPublicChannelSnapshots`) — listens to `TopChanged`, coalesces no-op deep-book updates (compares best bid/ask only; `UpdatedUtc` excluded so quiet symbols stay quiet), fans out deltas, serves cold snapshots.
- **`CompositePublicChannelSnapshots`** — multiplexes auction + book sinks behind the single `IPublicChannelSnapshots` the hub consumes.

## Feature-flag posture

Sink is registered unconditionally for DI simplicity. When `MarketDataOptions.EnableBook=false` (default) the underlying `MboBookStore` stays empty, `TopChanged` never fires, and snapshots return the empty shape. **No behavioural change** for existing deployments until the flag flips.

## Tests

New `BookWebSocketChannelTests` (10 cases): parser positive/negative, cold-snapshot (empty and populated), delta-on-update, coalesce of deep-book mutations, per-client isolation. Full suite green except the known #345 pegged-algo race-flake (rerun usually passes).

## Follow-ups

- FE consumer for `book.${symbol}` is tracked under #293 (Q3.13 depth MBO toggle); split intentionally to keep this PR backend-only.
- When `IBookFeed` from B3MarketDataPlatform v0.3.0 lands, the in-host derivation (`MboBookStore` + `MboBookStorePump` + `IL2BookView`) gets removed but `L2TopOfBookDto` stays — wire-stable across the swap.