### PR TITLE
feat(book): depth ladder over WS + FE swap to trading-host channel (#286)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -102,25 +102,36 @@ public enum PublicChannelKind
 
 /// <summary>
 /// Q3.6 Stage B (#286). Wire shape for the public
-/// <c>book.${symbol}</c> top-of-book channel. Fields are nullable so
-/// an empty-state snapshot (no MBO frame seen for this symbol yet, or
-/// the side was cleared) ships a stable shape with <c>null</c>s rather
-/// than zeroes that look like real prices. Mirrors
-/// <see cref="L2TopOfBook"/> from the application layer.
+/// <c>book.${symbol}</c> top-N depth channel. Each side lists
+/// aggregated price levels sorted best-to-worst (bids descending,
+/// asks ascending), capped to <c>MarketDataOptions.BookChannelMaxLevels</c>.
+/// Empty array on a side means "no liquidity" (either never seen, or
+/// cleared). <c>UpdatedUtc</c> is <c>null</c> only on the empty-state
+/// cold snapshot served before any MBO frame lands.
 /// </summary>
-public sealed record L2TopOfBookDto(
+public sealed record L2LadderDto(
     string Symbol,
-    L2SideDto? Bid,
-    L2SideDto? Ask,
+    IReadOnlyList<L2SideDto> Bids,
+    IReadOnlyList<L2SideDto> Asks,
     DateTimeOffset? UpdatedUtc)
 {
-    public static L2TopOfBookDto Empty(string symbol) => new(symbol, null, null, null);
+    public static L2LadderDto Empty(string symbol) =>
+        new(symbol, Array.Empty<L2SideDto>(), Array.Empty<L2SideDto>(), null);
 
-    public static L2TopOfBookDto From(L2TopOfBook t) => new(
-        t.Symbol,
-        t.Bid.OrderCount > 0 ? new L2SideDto(t.Bid.Price, t.Bid.TotalQty, t.Bid.OrderCount) : null,
-        t.Ask.OrderCount > 0 ? new L2SideDto(t.Ask.Price, t.Ask.TotalQty, t.Ask.OrderCount) : null,
-        t.UpdatedUtc);
+    public static L2LadderDto From(L2Ladder l) => new(
+        l.Symbol,
+        Map(l.Bids),
+        Map(l.Asks),
+        l.UpdatedUtc);
+
+    private static IReadOnlyList<L2SideDto> Map(IReadOnlyList<L2Side> src)
+    {
+        if (src.Count == 0) return Array.Empty<L2SideDto>();
+        var arr = new L2SideDto[src.Count];
+        for (var i = 0; i < src.Count; i++)
+            arr[i] = new L2SideDto(src[i].Price, src[i].TotalQty, src[i].OrderCount);
+        return arr;
+    }
 }
 
 public sealed record L2SideDto(decimal Price, long TotalQty, int OrderCount);

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
@@ -1,23 +1,28 @@
 using System.Collections.Concurrent;
 using B3.Trading.Application.MarketData;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Api.WebSockets;
 
 /// <summary>
 /// Q3.6 Stage B (#286). WebSocket fan-out for the public per-symbol
-/// top-of-book channel (<c>book.${symbol}</c>). Listens to
-/// <see cref="MboBookStore.TopChanged"/> and broadcasts deltas to all
-/// subscribed clients; snapshot bootstrap is served through
+/// depth ladder channel (<c>book.${symbol}</c>). Listens to
+/// <see cref="MboBookStore.BookChanged"/>; on each event pulls the
+/// top-N ladder from the store at the configured depth
+/// (<c>MarketDataOptions.BookChannelMaxLevels</c>) and broadcasts a
+/// <see cref="L2LadderDto"/> delta to all subscribed clients.
+/// Snapshot bootstrap is served through
 /// <see cref="IPublicChannelSnapshots"/> so a newly-subscribed client
-/// always sees the current top before the next delta lands.
+/// always sees the current ladder before the next delta lands.
 ///
 /// <para>
 /// Coalesces no-op updates: an apply that did not change the derived
-/// top-of-book (e.g. a deep-book add that did not affect the best
-/// price/qty/order-count) is dropped so quiet symbols stay quiet on
-/// the wire. The "last sent" snapshot is kept per symbol; the first
-/// observed update for a symbol is always emitted.
+/// top-N ladder (e.g. a level beyond <c>BookChannelMaxLevels</c>
+/// changed, or a deeper-than-top update that left the visible window
+/// untouched) is dropped so quiet symbols stay quiet on the wire.
+/// The last-sent DTO is kept per symbol; the first observed update
+/// for a symbol is always emitted.
 /// </para>
 ///
 /// <para>
@@ -34,26 +39,31 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
 {
     private readonly SubscriptionManager _subs;
     private readonly MboBookStore _store;
+    private readonly int _maxLevels;
 
-    // Last DTO we put on the wire for each symbol — used to coalesce
-    // identical updates (no-op deep-book mutations). Keyed
-    // case-insensitively to match the store.
-    private readonly ConcurrentDictionary<string, L2TopOfBookDto> _lastSent =
+    // Last DTO put on the wire per symbol — used to coalesce identical
+    // updates. Keyed case-insensitively to match the store.
+    private readonly ConcurrentDictionary<string, L2LadderDto> _lastSent =
         new(StringComparer.OrdinalIgnoreCase);
 
-    public WebSocketBookEventSink(SubscriptionManager subs, MboBookStore store)
+    public WebSocketBookEventSink(
+        SubscriptionManager subs,
+        MboBookStore store,
+        IOptions<MarketDataOptions> options)
     {
         _subs = subs;
         _store = store;
+        var max = options.Value.BookChannelMaxLevels;
+        _maxLevels = max > 0 ? max : 10;
     }
 
     // ---------------- IPublicChannelSnapshots ----------------
 
     public object? GetSnapshot(PublicChannelKind kind, string symbol) => kind switch
     {
-        PublicChannelKind.Book => _store.GetTopOfBook(symbol) is { } top
-            ? L2TopOfBookDto.From(top)
-            : L2TopOfBookDto.Empty(symbol),
+        PublicChannelKind.Book => _store.GetLadder(symbol, _maxLevels) is { } ladder
+            ? L2LadderDto.From(ladder)
+            : L2LadderDto.Empty(symbol),
         _ => null,
     };
 
@@ -61,30 +71,41 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _store.TopChanged += OnTopChanged;
+        _store.BookChanged += OnBookChanged;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _store.TopChanged -= OnTopChanged;
+        _store.BookChanged -= OnBookChanged;
         return Task.CompletedTask;
     }
 
     // ---------------- Event handlers ----------------
 
-    private void OnTopChanged(L2TopOfBook? top)
+    private void OnBookChanged(string symbol)
     {
-        if (top is null) return; // nothing to broadcast when both sides went empty
-        var dto = L2TopOfBookDto.From(top.Value);
-        // Coalesce: skip if best bid+ask are identical to last sent for
-        // this symbol — UpdatedUtc is intentionally excluded so a
-        // deep-book mutation that bumped the store's timestamp but did
-        // not move the top stays off the wire.
-        if (_lastSent.TryGetValue(dto.Symbol, out var prev) &&
-            Equals(prev.Bid, dto.Bid) && Equals(prev.Ask, dto.Ask))
+        var ladder = _store.GetLadder(symbol, _maxLevels);
+        if (ladder is null) return; // nothing to broadcast when both sides went empty
+        var dto = L2LadderDto.From(ladder.Value);
+        // Coalesce: skip if bid/ask ladders are identical to last sent
+        // for this symbol — UpdatedUtc is intentionally excluded so a
+        // deep-book mutation that bumped the store's timestamp but
+        // did not move the visible window stays off the wire.
+        if (_lastSent.TryGetValue(dto.Symbol, out var prev) && SidesEqual(prev, dto))
             return;
         _lastSent[dto.Symbol] = dto;
         _subs.BroadcastPublic(Channels.BookFor(dto.Symbol), dto);
+    }
+
+    private static bool SidesEqual(L2LadderDto a, L2LadderDto b) =>
+        SideEqual(a.Bids, b.Bids) && SideEqual(a.Asks, b.Asks);
+
+    private static bool SideEqual(IReadOnlyList<L2SideDto> a, IReadOnlyList<L2SideDto> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (var i = 0; i < a.Count; i++)
+            if (!Equals(a[i], b[i])) return false;
+        return true;
     }
 }

--- a/backend/src/B3.Trading.Application/MarketData/IL2BookView.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IL2BookView.cs
@@ -16,6 +16,15 @@ public interface IL2BookView
     /// snapshot delivered or both sides emptied via
     /// <see cref="MarketBookCleared"/>).
     /// </summary>
+    /// <summary>
+    /// Q3.6 Stage B (#286). Returns the top-<paramref name="maxLevels"/>
+    /// aggregated depth ladder per side (bids descending by price, asks
+    /// ascending). Returns <c>null</c> when the store has not seen any
+    /// orders for <paramref name="symbol"/> yet, or both sides are
+    /// empty. <paramref name="maxLevels"/> must be &gt; 0.
+    /// </summary>
+    L2Ladder? GetLadder(string symbol, int maxLevels);
+
     L2TopOfBook? GetTopOfBook(string symbol);
 }
 
@@ -36,3 +45,17 @@ public readonly record struct L2Side(
     decimal Price,
     long TotalQty,
     int OrderCount);
+
+/// <summary>
+/// Q3.6 Stage B (#286). Top-N depth ladder derived from the L3 / MBO
+/// store: per-side list of aggregated price levels, sorted best-to-
+/// worst (bids descending, asks ascending). Used by the FE depth
+/// view via the <c>book.${symbol}</c> WS channel. Same null/empty
+/// semantics as <see cref="L2TopOfBook"/> — sides may be empty when
+/// the store has not seen any orders on that side yet.
+/// </summary>
+public readonly record struct L2Ladder(
+    string Symbol,
+    IReadOnlyList<L2Side> Bids,
+    IReadOnlyList<L2Side> Asks,
+    DateTimeOffset UpdatedUtc);

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
@@ -61,4 +61,14 @@ public sealed class MarketDataOptions
     /// </para>
     /// </summary>
     public bool EnableBook { get; set; } = false;
+
+    /// <summary>
+    /// Q3.6 Stage B (#286). Depth of the per-symbol ladder fanned out
+    /// over the public <c>book.${symbol}</c> WebSocket channel. Each
+    /// side is capped to this many price levels (best-to-worst). 10 is
+    /// the depth the FE depth view consumes today; raise carefully
+    /// (bandwidth grows linearly per update). Ignored when
+    /// <see cref="EnableBook"/> is false.
+    /// </summary>
+    public int BookChannelMaxLevels { get; set; } = 10;
 }

--- a/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MboBookStore.cs
@@ -35,21 +35,20 @@ public sealed class MboBookStore : IL2BookView
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Q3.6 Stage B (#286). Raised after every applied frame, with the
-    /// derived top-of-book at that instant — <c>null</c> when the frame
-    /// emptied both sides. The event fires <b>outside</b> the per-symbol
-    /// lock so a slow subscriber cannot stall the apply path; producers
-    /// must therefore tolerate stale reads racing newer updates (the
-    /// derived snapshot is point-in-time and self-contained, so this is
-    /// safe). Used by <c>WebSocketBookEventSink</c> to fan out to
-    /// <c>book.${symbol}</c> subscribers.
+    /// Q3.6 Stage B (#286). Raised after every applied frame with the
+    /// symbol whose state changed. Listeners pull the derived view they
+    /// want (top-of-book or top-N ladder) at their preferred depth so
+    /// the store does not pay aggregation cost when nobody is
+    /// listening. Fires <b>outside</b> the per-symbol lock so a slow
+    /// subscriber cannot stall the apply path; producers must
+    /// therefore tolerate stale reads racing newer updates (the
+    /// derived snapshot is point-in-time and self-contained).
     /// </summary>
-    public event Action<L2TopOfBook?>? TopChanged;
+    public event Action<string>? BookChanged;
 
     public void ApplySnapshot(MarketBookSnapshot snap)
     {
         var state = _bySymbol.GetOrAdd(snap.Symbol, _ => new SymbolState(snap.Symbol));
-        L2TopOfBook? top;
         lock (state.Gate)
         {
             state.Bids.Clear();
@@ -59,29 +58,25 @@ public sealed class MboBookStore : IL2BookView
             foreach (var o in snap.Asks)
                 state.Asks[o.OrderId] = new OrderEntry(o.Price, o.Qty);
             state.UpdatedUtc = snap.ReceivedUtc;
-            top = ComputeTopLocked(state);
         }
-        TopChanged?.Invoke(top);
+        BookChanged?.Invoke(snap.Symbol);
     }
 
     public void ApplyAdded(MarketOrderAdded ev)
     {
         if (ev.Qty <= 0) return;
         var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
-        L2TopOfBook? top;
         lock (state.Gate)
         {
             SideMap(state, ev.Side)[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
             state.UpdatedUtc = ev.ReceivedUtc;
-            top = ComputeTopLocked(state);
         }
-        TopChanged?.Invoke(top);
+        BookChanged?.Invoke(ev.Symbol);
     }
 
     public void ApplyUpdated(MarketOrderUpdated ev)
     {
         var state = _bySymbol.GetOrAdd(ev.Symbol, _ => new SymbolState(ev.Symbol));
-        L2TopOfBook? top;
         lock (state.Gate)
         {
             var map = SideMap(state, ev.Side);
@@ -94,28 +89,24 @@ public sealed class MboBookStore : IL2BookView
                 map[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
             }
             state.UpdatedUtc = ev.ReceivedUtc;
-            top = ComputeTopLocked(state);
         }
-        TopChanged?.Invoke(top);
+        BookChanged?.Invoke(ev.Symbol);
     }
 
     public void ApplyDeleted(MarketOrderDeleted ev)
     {
         if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
-        L2TopOfBook? top;
         lock (state.Gate)
         {
             SideMap(state, ev.Side).Remove(ev.OrderId);
             state.UpdatedUtc = ev.ReceivedUtc;
-            top = ComputeTopLocked(state);
         }
-        TopChanged?.Invoke(top);
+        BookChanged?.Invoke(ev.Symbol);
     }
 
     public void ApplyCleared(MarketBookCleared ev)
     {
         if (!_bySymbol.TryGetValue(ev.Symbol, out var state)) return;
-        L2TopOfBook? top;
         lock (state.Gate)
         {
             switch (ev.ClearSide)
@@ -132,9 +123,8 @@ public sealed class MboBookStore : IL2BookView
                     break;
             }
             state.UpdatedUtc = ev.ReceivedUtc;
-            top = ComputeTopLocked(state);
         }
-        TopChanged?.Invoke(top);
+        BookChanged?.Invoke(ev.Symbol);
     }
 
     public L2TopOfBook? GetTopOfBook(string symbol)
@@ -144,12 +134,56 @@ public sealed class MboBookStore : IL2BookView
         lock (state.Gate) return ComputeTopLocked(state);
     }
 
+    public L2Ladder? GetLadder(string symbol, int maxLevels)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return null;
+        if (maxLevels <= 0) throw new ArgumentOutOfRangeException(nameof(maxLevels));
+        if (!_bySymbol.TryGetValue(symbol.Trim(), out var state)) return null;
+        lock (state.Gate)
+        {
+            if (state.Bids.Count == 0 && state.Asks.Count == 0) return null;
+            var bids = LadderSideLocked(state.Bids, ascending: false, maxLevels);
+            var asks = LadderSideLocked(state.Asks, ascending: true, maxLevels);
+            return new L2Ladder(state.Symbol, bids, asks, state.UpdatedUtc);
+        }
+    }
+
     private static L2TopOfBook? ComputeTopLocked(SymbolState state)
     {
         var bid = TopOfSide(state.Bids, ascending: false);
         var ask = TopOfSide(state.Asks, ascending: true);
         if (bid.OrderCount == 0 && ask.OrderCount == 0) return null;
         return new L2TopOfBook(state.Symbol, bid, ask, state.UpdatedUtc);
+    }
+
+    // Aggregates the per-order side map into top-N price levels, sorted
+    // best-to-worst. Caller MUST hold the per-symbol gate.
+    private static IReadOnlyList<L2Side> LadderSideLocked(
+        Dictionary<ulong, OrderEntry> side, bool ascending, int maxLevels)
+    {
+        if (side.Count == 0) return Array.Empty<L2Side>();
+        // Aggregate by price first (qty + count). Capacity hint is a
+        // mild over-estimate to avoid resizes for the common case.
+        var byPrice = new Dictionary<decimal, (long Qty, int Count)>(side.Count);
+        foreach (var e in side.Values)
+        {
+            if (byPrice.TryGetValue(e.Price, out var agg))
+                byPrice[e.Price] = (agg.Qty + e.Qty, agg.Count + 1);
+            else
+                byPrice[e.Price] = (e.Qty, 1);
+        }
+        // Sort then trim to maxLevels. Ascending = ask side (best = lowest),
+        // descending = bid side (best = highest).
+        var ordered = ascending
+            ? byPrice.OrderBy(kv => kv.Key)
+            : byPrice.OrderByDescending(kv => kv.Key);
+        var result = new List<L2Side>(Math.Min(maxLevels, byPrice.Count));
+        foreach (var kv in ordered)
+        {
+            if (result.Count >= maxLevels) break;
+            result.Add(new L2Side(kv.Key, kv.Value.Qty, kv.Value.Count));
+        }
+        return result;
     }
 
     /// <summary>Test/diagnostic hook: per-side live order count.</summary>

--- a/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
@@ -2,17 +2,19 @@ using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace B3.Trading.Api.Tests;
 
 public class BookWebSocketChannelTests
 {
-    private static (SubscriptionManager subs, MboBookStore store, WebSocketBookEventSink sink) Build()
+    private static (SubscriptionManager subs, MboBookStore store, WebSocketBookEventSink sink) Build(int maxLevels = 10)
     {
         var store = new MboBookStore();
         var subs = new SubscriptionManager(new WorkingOrderBook(), new PositionKeeper(), new AlgoBook());
-        var sink = new WebSocketBookEventSink(subs, store);
+        var opts = Options.Create(new MarketDataOptions { BookChannelMaxLevels = maxLevels });
+        var sink = new WebSocketBookEventSink(subs, store, opts);
         sink.StartAsync(default).GetAwaiter().GetResult();
         return (subs, store, sink);
     }
@@ -50,10 +52,10 @@ public class BookWebSocketChannelTests
         Assert.True(client.Reader.TryRead(out var msg));
         Assert.Equal("snapshot", msg!.Type);
         Assert.Equal("book.PETR4", msg.Channel);
-        var dto = Assert.IsType<L2TopOfBookDto>(msg.Data);
+        var dto = Assert.IsType<L2LadderDto>(msg.Data);
         Assert.Equal("PETR4", dto.Symbol);
-        Assert.Null(dto.Bid);
-        Assert.Null(dto.Ask);
+        Assert.Empty(dto.Bids);
+        Assert.Empty(dto.Asks);
         Assert.Null(dto.UpdatedUtc);
     }
 
@@ -72,13 +74,93 @@ public class BookWebSocketChannelTests
         Assert.Equal("delta", delta!.Type);
         Assert.Equal("book.PETR4", delta.Channel);
         Assert.Equal(1, delta.Seq);
-        var dto = Assert.IsType<L2TopOfBookDto>(delta.Data);
+        var dto = Assert.IsType<L2LadderDto>(delta.Data);
         Assert.Equal("PETR4", dto.Symbol);
-        Assert.NotNull(dto.Bid);
-        Assert.Equal(30.10m, dto.Bid!.Price);
-        Assert.Equal(100, dto.Bid.TotalQty);
-        Assert.Equal(1, dto.Bid.OrderCount);
-        Assert.Null(dto.Ask);
+        var bid = Assert.Single(dto.Bids);
+        Assert.Equal(30.10m, bid.Price);
+        Assert.Equal(100, bid.TotalQty);
+        Assert.Equal(1, bid.OrderCount);
+        Assert.Empty(dto.Asks);
+    }
+
+    [Fact]
+    public void Book_ladder_aggregates_orders_at_same_price()
+    {
+        var (subs, store, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // snapshot
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+        client.Reader.TryRead(out _); // first delta
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.10m, 200));
+
+        Assert.True(client.Reader.TryRead(out var delta));
+        var dto = Assert.IsType<L2LadderDto>(delta!.Data);
+        var bid = Assert.Single(dto.Bids);
+        Assert.Equal(30.10m, bid.Price);
+        Assert.Equal(300, bid.TotalQty);
+        Assert.Equal(2, bid.OrderCount);
+    }
+
+    [Fact]
+    public void Book_ladder_sorts_bids_descending_and_asks_ascending()
+    {
+        var (subs, store, sink) = Build();
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.05m, 200));
+        store.ApplyAdded(Add("PETR4", 3UL, MarketBookSide.Bid, 30.20m, 150));
+        store.ApplyAdded(Add("PETR4", 4UL, MarketBookSide.Ask, 30.40m, 50));
+        store.ApplyAdded(Add("PETR4", 5UL, MarketBookSide.Ask, 30.30m, 75));
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<L2LadderDto>(msg!.Data);
+        Assert.Equal(new[] { 30.20m, 30.10m, 30.05m }, dto.Bids.Select(b => b.Price));
+        Assert.Equal(new[] { 30.30m, 30.40m }, dto.Asks.Select(a => a.Price));
+    }
+
+    [Fact]
+    public void Book_ladder_respects_BookChannelMaxLevels()
+    {
+        var (subs, store, sink) = Build(maxLevels: 3);
+        for (var i = 0; i < 5; i++)
+            store.ApplyAdded(Add("PETR4", (ulong)(100 + i), MarketBookSide.Bid, 30m + i * 0.01m, 10));
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<L2LadderDto>(msg!.Data);
+        // Best 3 levels (highest prices): 30.04, 30.03, 30.02.
+        Assert.Equal(new[] { 30.04m, 30.03m, 30.02m }, dto.Bids.Select(b => b.Price));
+    }
+
+    [Fact]
+    public void Book_coalesces_updates_beyond_visible_depth()
+    {
+        var (subs, store, sink) = Build(maxLevels: 2);
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // snapshot
+
+        // Build top-2 first; each emission is a real delta.
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.20m, 100));
+        Assert.True(client.Reader.TryRead(out _));
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.10m, 100));
+        Assert.True(client.Reader.TryRead(out _));
+
+        // Add an order at level 3 (below visible window) — coalesced.
+        store.ApplyAdded(Add("PETR4", 3UL, MarketBookSide.Bid, 30.00m, 500));
+
+        Assert.False(client.Reader.TryRead(out var maybe),
+            $"expected coalesced (no delta) but got {maybe?.Type} {maybe?.Data}");
     }
 
     [Fact]
@@ -94,29 +176,10 @@ public class BookWebSocketChannelTests
 
         Assert.True(client.Reader.TryRead(out var msg));
         Assert.Equal("snapshot", msg!.Type);
-        var dto = Assert.IsType<L2TopOfBookDto>(msg.Data);
-        Assert.Equal(30.10m, dto.Bid!.Price);
-        Assert.Equal(30.20m, dto.Ask!.Price);
-        Assert.Equal(50, dto.Ask.TotalQty);
-    }
-
-    [Fact]
-    public void Book_coalesces_deep_book_updates_that_do_not_change_top()
-    {
-        var (subs, store, sink) = Build();
-        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
-        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
-            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
-        client.Reader.TryRead(out _); // snapshot
-
-        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
-        Assert.True(client.Reader.TryRead(out _)); // first delta
-
-        // Deeper bid at lower price — top of book unchanged.
-        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.00m, 500));
-
-        Assert.False(client.Reader.TryRead(out var maybe),
-            $"expected coalesced (no delta) but got {maybe?.Type} {maybe?.Data}");
+        var dto = Assert.IsType<L2LadderDto>(msg.Data);
+        Assert.Equal(30.10m, dto.Bids[0].Price);
+        Assert.Equal(30.20m, dto.Asks[0].Price);
+        Assert.Equal(50, dto.Asks[0].TotalQty);
     }
 
     [Fact]
@@ -133,5 +196,16 @@ public class BookWebSocketChannelTests
 
         Assert.True(alice.Reader.TryRead(out _));
         Assert.False(bob.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public void GetLadder_returns_null_for_unseen_symbol_and_empty_state()
+    {
+        var (_, store, _) = Build();
+        Assert.Null(store.GetLadder("UNKNOWN", 10));
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30m, 1));
+        store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 1UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
+        Assert.Null(store.GetLadder("PETR4", 10));
     }
 }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -141,12 +141,13 @@ function init() {
     onCvmDownload:     handleCvmDownload,
   });
 
-  // Q1.6 (#258). Whenever the watchlist or auctionPanelSymbol slice
-  // changes, re-diff the public WS subscription set so phase badges
-  // stay in sync with the watchlist and auction.${symbol} is only
-  // subscribed while the panel is open.
+  // Q1.6 (#258) + Q3.6 Stage B (#286). Whenever the watchlist,
+  // auctionPanelSymbol or selectedSymbol slice changes, re-diff the
+  // public WS subscription set so phase badges stay in sync,
+  // auction.${symbol} is only subscribed while the panel is open, and
+  // book.${symbol} tracks the currently selected DOB symbol.
   state.subscribe((slice) => {
-    if (slice === "watchlist" || slice === "auctionPanelSymbol" || slice === "all") {
+    if (slice === "watchlist" || slice === "auctionPanelSymbol" || slice === "selectedSymbol" || slice === "all") {
       syncPublicChannels();
     }
   });
@@ -571,6 +572,10 @@ function syncPublicChannels() {
   const channels = [];
   for (const sym of st.watchlist) channels.push("phases." + sym);
   if (st.auctionPanelSymbol) channels.push("auction." + st.auctionPanelSymbol);
+  // Q3.6 Stage B (#286). Depth ladder only flows for the currently
+  // selected symbol — the DOB renders one symbol at a time. Keeps WS
+  // fan-out cost predictable as the watchlist grows.
+  if (st.selectedSymbol) channels.push("book." + st.selectedSymbol);
   try { worker.postMessage({ type: "setPublicChannels", channels }); }
   catch { /* worker not ready yet — replayed by next slice notify */ }
 }
@@ -619,13 +624,10 @@ function startMdWorker() {
 
   mdWorker = new Worker(new URL("./mdWorker.js", import.meta.url), { type: "module" });
   mdWorker.onmessage = (ev) => onMdWorkerMessage(ev.data);
-  // Subscribe with MBP from the start. DOB is always rendered, so the
-  // book channel needs to populate without waiting for the user to
-  // explicitly pick a symbol from the topbar selector. Keeping MBP off
-  // by default would leave the DOB stuck on "awaiting book snapshot…"
-  // for users who accept the default-selected symbol.
-  const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
-  mbpEnabled = true;
+  // Q3.6 Stage B (#286): trading-host owns the book channel now, so
+  // mdWorker drops MBP — trades + info only. Depth comes from the
+  // authenticated `book.${symbol}` WS sub managed in syncPublicChannels.
+  const flags = FLAGS.TRADES | FLAGS.INFO;
   mdWorker.postMessage({
     type: "start",
     url: mdConfig.url,
@@ -659,7 +661,6 @@ function handleApplyMd({ url, symbols }) {
     state.clearAllCandles();
     state.clearAllTape();
     state.clearAllHeatmap();
-    mbpEnabled = false;
     startMdWorker();
   } else {
     mdWorker.postMessage({ type: "setSymbols", symbols });
@@ -672,18 +673,20 @@ function handleApplyMd({ url, symbols }) {
   ui.setMdFeedback(`watching ${symbols.length} symbol(s)`, "ok");
 }
 
-// MBP is sticky: once enabled in a session, we leave the flag on even
-// if the trader closes the DOB panel. Toggling MBP re-subscribes every
-// symbol (server allocates fresh securityIds per flag set), which would
-// briefly blank market-data and trade-tape — not worth it.
+// Q3.6 Stage B (#286). MBP retired from the direct marketdata path —
+// depth ladder is fanned out by the trading host via book.${symbol}.
+// `mbpEnabled` is left as a no-op flag during the deprecation window
+// so any in-flight call sites stay structurally valid; the next pass
+// removes it together with the dead mdWorker book code paths.
 let mbpEnabled = false;
 let lastAutoFilledTicketSymbol = null;
 let _successToastTimer = null;
 
 function handleSelectSymbol(symbol) {
-  // Single global selector drives DOB, chart and tape. As soon as the
-  // user picks anything we promote the MD subscription to MBP so the
-  // book panel can render depth (the default is TRADES|INFO only).
+  // Single global selector drives DOB, chart and tape. The depth view
+  // for `symbol` is now wired through the trading-host `book.${symbol}`
+  // sub (added by syncPublicChannels on the next selectedSymbol slice
+  // notify), so we no longer need to promote the mdWorker bitmask.
   state.setSelectedSymbol(symbol || null);
   // Auto-fill the ticket-symbol input when it's empty or still tracking
   // a previously auto-filled symbol. We never clobber a value the trader
@@ -699,10 +702,6 @@ function handleSelectSymbol(symbol) {
       }
     }
   }
-  if (!symbol || !mdWorker || mbpEnabled) return;
-  const flags = FLAGS.TRADES | FLAGS.INFO | FLAGS.MBP;
-  mdWorker.postMessage({ type: "setFlags", flags });
-  mbpEnabled = true;
 }
 
 function onMdWorkerMessage(msg) {
@@ -729,11 +728,6 @@ function onMdWorkerMessage(msg) {
       state.removeBookSymbol(msg.symbol);
       state.removeCandlesSymbol(msg.symbol);
       break;
-    case "md.book.snapshot":   state.applyMdBookSnapshot(msg); break;
-    case "md.book.cleared":    state.applyMdBookCleared(msg); break;
-    case "md.level.snapshot":  state.applyMdLevelSnapshot(msg); break;
-    case "md.level.update":    state.applyMdLevelUpdate(msg); break;
-    case "md.level.deleted":   state.applyMdLevelDeleted(msg); break;
     case "md.candle.snapshot": state.applyMdCandleSnapshot(msg); break;
     case "md.candle.update":   state.applyMdCandleUpdate(msg); break;
     case "md.error":    console.warn("[md]", msg); break;
@@ -757,6 +751,7 @@ function onWorkerMessage(msg) {
     case "pnl.delta":           state.applyPnlDelta(msg.data); break;
     case "phases.frame":        state.applyPhaseFrame(msg.data); break;
     case "auction.frame":       state.applyAuctionFrame(msg.data); break;
+    case "book.frame":          state.applyBookFrame(msg.data); break;
     case "error":
       // A frame-level error from the server (e.g., unknown_channel,
       // bad subscribe args, channel auth). #342: surface it as a

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -427,6 +427,31 @@ export function applyMdBookSnapshot({ symbol }) {
   notify("book");
 }
 
+/// <summary>
+/// Q3.6 Stage B (#286). Apply a `book.${symbol}` frame coming from the
+/// trading-host WS (replaces both sides with the server's coalesced
+/// top-N ladder). Snapshot and delta share the same shape, so a single
+/// reducer handles both — the server already replays the latest
+/// ladder as a `snapshot` frame on subscribe.
+/// </summary>
+export function applyBookFrame(frame) {
+  if (!frame || typeof frame.Symbol !== "string") return;
+  const entry = ensureBook(frame.Symbol);
+  entry.bids.clear();
+  entry.asks.clear();
+  for (const lv of frame.Bids ?? []) {
+    entry.bids.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  }
+  for (const lv of frame.Asks ?? []) {
+    entry.asks.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  }
+  // Empty-state snapshot (UpdatedUtc=null) keeps ready=false so the
+  // DOB shows its "waiting" affordance instead of an empty ladder.
+  entry.ready = frame.UpdatedUtc != null;
+  entry.updatedAt = Date.now();
+  notify("book");
+}
+
 export function applyMdLevelSnapshot({ symbol, bids, asks }) {
   const entry = ensureBook(symbol);
   entry.bids.clear();

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -154,6 +154,11 @@ function handleFrame(frame) {
         post({ type: "phases.frame", data: frame.data });
       } else if (frame.channel.startsWith("auction.")) {
         post({ type: "auction.frame", data: frame.data });
+      } else if (frame.channel.startsWith("book.")) {
+        // Q3.6 Stage B (#286). Depth ladder fan-out from the trading
+        // host. Snapshot + delta share the same payload shape, so the
+        // main-thread reducer handles both identically.
+        post({ type: "book.frame", data: frame.data });
       }
       break;
   }

--- a/frontend/test/state-book-frame.test.mjs
+++ b/frontend/test/state-book-frame.test.mjs
@@ -1,0 +1,72 @@
+// Frontend reducer tests for the new trading-host `book.${symbol}` WS
+// channel (Q3.6 Stage B, #286). Runs with
+// `node --test frontend/test/state-book-frame.test.mjs`.
+//
+// Coverage: snapshot replaces both sides, empty snapshot keeps
+// ready=false, defensive null guards, watchlist trimming still
+// evicts the entry.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust-bookframe=${n}`);
+}
+
+const frame = (overrides = {}) => ({
+  Symbol: 'PETR4',
+  Bids: [
+    { Price: 30.20, TotalQty: 100, OrderCount: 1 },
+    { Price: 30.10, TotalQty: 250, OrderCount: 3 },
+  ],
+  Asks: [
+    { Price: 30.30, TotalQty: 50, OrderCount: 1 },
+  ],
+  UpdatedUtc: '2026-05-19T20:00:00Z',
+  ...overrides,
+});
+
+test('applyBookFrame populates both sides with priceKey-bucketed levels and flips ready=true', async () => {
+  const s = await freshState();
+  s.applyBookFrame(frame());
+  const entry = s.getState().book.get('PETR4');
+  assert.equal(entry.ready, true);
+  assert.equal(entry.bids.size, 2);
+  assert.equal(entry.asks.size, 1);
+  assert.deepEqual(entry.bids.get('30.2000'), { qty: 100, count: 1 });
+  assert.deepEqual(entry.bids.get('30.1000'), { qty: 250, count: 3 });
+  assert.deepEqual(entry.asks.get('30.3000'), { qty: 50, count: 1 });
+});
+
+test('applyBookFrame empty-state snapshot leaves ready=false', async () => {
+  const s = await freshState();
+  s.applyBookFrame({ Symbol: 'VALE3', Bids: [], Asks: [], UpdatedUtc: null });
+  const entry = s.getState().book.get('VALE3');
+  assert.equal(entry.ready, false);
+  assert.equal(entry.bids.size, 0);
+  assert.equal(entry.asks.size, 0);
+});
+
+test('applyBookFrame replaces the prior ladder rather than merging', async () => {
+  const s = await freshState();
+  s.applyBookFrame(frame());
+  s.applyBookFrame(frame({
+    Bids: [{ Price: 31.00, TotalQty: 999, OrderCount: 7 }],
+    Asks: [],
+  }));
+  const entry = s.getState().book.get('PETR4');
+  assert.equal(entry.bids.size, 1);
+  assert.equal(entry.asks.size, 0);
+  assert.deepEqual(entry.bids.get('31.0000'), { qty: 999, count: 7 });
+});
+
+test('applyBookFrame ignores malformed payloads', async () => {
+  const s = await freshState();
+  s.applyBookFrame(null);
+  s.applyBookFrame(undefined);
+  s.applyBookFrame({});
+  s.applyBookFrame({ Symbol: 42 });
+  assert.equal(s.getState().book.size, 0);
+});


### PR DESCRIPTION
## Resumo

Stage B do #286 promovido a depth ladder e FE migrado para consumir o canal do trading-host. Auth/entitlement unificado na hub autenticada — direto-marketdata fica restrito a trades+info.

## Backend

- **`MboBookStore.GetLadder(symbol, maxLevels)`** — agrega por preço, ordena best-to-worst, trunca em N.
- **`BookChanged(symbol)`** substitui `TopChanged(L2TopOfBook?)`. Fired fora do lock; consumidores puxam a view que querem.
- **`L2LadderDto { Bids[], Asks[], UpdatedUtc }`** substitui `L2TopOfBookDto` no canal `book.${symbol}`. Nada consumia ainda — quebra de wire sem impacto.
- **`MarketDataOptions.BookChannelMaxLevels`** (default 10).
- Coalesce de no-op compara só janela visível (`UpdatedUtc` excluído).

## Frontend

- `worker.js` roteia `book.${sym}` → `book.frame`.
- `state.applyBookFrame(frame)` substitui ambos os lados da entry (snapshot + delta same shape). Empty-state mantém `ready=false`.
- `syncPublicChannels` adiciona `book.${selectedSymbol}` — DOB renderiza um símbolo por vez, custo de fan-out previsível.
- `mdWorker` perde MBP do bitmask inicial; `md.book.*`/`md.level.*` saem do roteador do app. Reducers `applyMd*Book*`/`applyMd*Level*` ficam no `state.js` durante a janela de depreciação (tests antigos continuam cobrindo a forma; remoção completa em PR follow-up).

## Tests

- Backend: 14 casos (parser, agregação, ordenação, truncamento por MaxLevels, deep-coalesce, snapshot vs delta, isolamento entre clients, empty-state, `GetLadder` null on unseen/empty).
- FE: 4 novos casos para `applyBookFrame` (populate, empty-state ready=false, replace-not-merge, null guards). Suíte FE 297/297.
- Backend sweep verde exceto flake conhecida #332 (`MetricsFirmTagTests`).