### PR TITLE
feat(pegged): wire MBO-derived BBO into pegged book-top cache (#286 Stage C)

### DIFF
--- a/backend/src/B3.Trading.Application/MarketData/MarketDataPegBookPump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataPegBookPump.cs
@@ -22,10 +22,12 @@ namespace B3.Trading.Application.MarketData;
 /// </para>
 ///
 /// <para>
-/// <b>SDK gap.</b> Today only <c>Trade</c> and <c>InfoSnapshot.LastTradePrice</c>
-/// drive the cache; the BBO legs in <see cref="BookTop"/> stay null
-/// until the SDK surfaces book-top frames. See
-/// <see cref="PegBookTopCache"/> for the fallback contract.
+/// <b>BBO source.</b> This pump only writes <c>Last</c> (from Trade /
+/// InfoSnapshot). The BBO legs in <see cref="BookTop"/> are populated
+/// by <see cref="MboPegBookPump"/> off <see cref="MboBookStore"/>
+/// when <c>MarketDataOptions.EnableBook</c> is on (Q3.6 Stage C,
+/// #286). When MBO is off, BBO stays null and the cache falls back
+/// to last-trade per the contract in <see cref="PegBookTopCache"/>.
 /// </para>
 /// </summary>
 public sealed class MarketDataPegBookPump : IHostedService

--- a/backend/src/B3.Trading.Application/MarketData/MboPegBookPump.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MboPegBookPump.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Q3.6 Stage C (#286). Bridges the in-host MBO book
+/// (<see cref="MboBookStore"/>) into the Pegged-algo BBO cache
+/// (<see cref="PegBookTopCache"/>) so <c>PegRef.Mid</c> and
+/// <c>PegRef.Best</c> resolve to real best-bid/best-ask instead of
+/// transparently falling back to last-trade.
+///
+/// <para>
+/// Closes the "SDK gap" originally noted on
+/// <see cref="MarketDataPegBookPump"/> and <see cref="PegBookTopCache"/>:
+/// while the broker-side SDK still does not raise standalone BBO frames,
+/// the MBO feed already exposes a per-order book that
+/// <see cref="MboBookStore"/> aggregates into a top-of-book — we just
+/// pump that derived view into the same cache the Pegged engine reads.
+/// </para>
+///
+/// <para>
+/// <b>Gating.</b> <see cref="MboBookStore.BookChanged"/> only fires
+/// when <c>MarketDataOptions.EnableBook</c> is true and the SDK feeds
+/// MBO frames. When MBO is off, this pump silently no-ops and the
+/// engine falls back to last-trade exactly as before — no behavioral
+/// regression in the configuration the legacy v1 path was tested on.
+/// </para>
+///
+/// <para>
+/// <b>Thread-safety.</b> <see cref="MboBookStore"/> raises
+/// <see cref="MboBookStore.BookChanged"/> outside its per-symbol lock,
+/// so the <see cref="MboBookStore.GetTopOfBook"/> read here races
+/// newer mutations. That is intentional and correct: each callback
+/// publishes a self-consistent snapshot to the cache; the most recent
+/// writer wins, ordering preserved because the SDK delivers
+/// per-symbol events on a single dispatch thread.
+/// </para>
+/// </summary>
+public sealed class MboPegBookPump : IHostedService
+{
+    private readonly MboBookStore _store;
+    private readonly PegBookTopCache _cache;
+    private readonly ILogger<MboPegBookPump>? _logger;
+
+    public MboPegBookPump(
+        MboBookStore store,
+        PegBookTopCache cache,
+        ILogger<MboPegBookPump>? logger = null)
+    {
+        _store = store;
+        _cache = cache;
+        _logger = logger;
+        _store.BookChanged += OnBookChanged;
+    }
+
+    private void OnBookChanged(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        try
+        {
+            var top = _store.GetTopOfBook(symbol);
+            if (top is not { } t) return;
+            // L2Side.OrderCount > 0 distinguishes a "real" side from
+            // the sentinel (0,0,0) tuple GetTopOfBook returns when one
+            // side is empty. We pass null for an empty side so the
+            // cache's existing-value-preserving merge does not clobber
+            // a previously-known BBO leg with zero.
+            decimal? bid = t.Bid.OrderCount > 0 ? t.Bid.Price : (decimal?)null;
+            decimal? ask = t.Ask.OrderCount > 0 ? t.Ask.Price : (decimal?)null;
+            if (bid is null && ask is null) return;
+            _cache.UpdateBookTop(symbol, bid, ask, t.UpdatedUtc);
+        }
+        catch (Exception ex)
+        {
+            // BookChanged is invoked from the SDK dispatch thread; an
+            // unhandled exception here would propagate into the store
+            // and starve all other listeners (auction sink, WS book
+            // sink). Swallow + log so a Pegged-cache hiccup never
+            // breaks the wider book pipeline.
+            _logger?.LogWarning(ex,
+                "MboPegBookPump failed to propagate BBO for {Symbol}; cache leg left at previous value.",
+                symbol);
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _store.BookChanged -= OnBookChanged;
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/PegBookTopCache.cs
+++ b/backend/src/B3.Trading.Application/MarketData/PegBookTopCache.cs
@@ -9,16 +9,16 @@ namespace B3.Trading.Application.MarketData;
 /// layer so tests can inject prices directly without a real MD feed.
 ///
 /// <para>
-/// <b>SDK gap.</b> The current <c>B3.MarketData.WebSocketClient</c> 0.1.0
-/// only surfaces <c>Trade</c> + <c>InfoSnapshot</c> events; BBO frames
-/// are not raised end-to-end (tracked alongside the auction-event SDK
-/// gap — see <c>IMarketDataSubscriber</c>). Until the SDK ships BBO,
-/// <see cref="MarketDataPegBookPump"/> only writes the <c>Last</c>
-/// field. For <see cref="PegRef.Mid"/> / <see cref="PegRef.Best"/>
-/// callers therefore transparently fall back to last-trade — same
-/// price for all three pegRefs in v0. Tests that need to exercise
-/// distinct mid/best/last paths use the in-memory cache directly via
-/// <see cref="UpdateBookTop"/>.
+/// <b>BBO source (Q3.6 Stage C, #286).</b> Best-bid / best-ask are
+/// populated by <see cref="MboPegBookPump"/> off the in-host
+/// <see cref="MboBookStore"/> when <c>MarketDataOptions.EnableBook</c>
+/// is on — the SDK still does not raise standalone BBO frames, but
+/// the MBO feed already carries the per-order book we aggregate. When
+/// MBO is disabled, the BBO legs stay null and <see cref="BookTop"/>
+/// transparently falls back to last-trade for all three pegRefs
+/// (legacy v1 behavior). Last-trade itself is fed by
+/// <see cref="MarketDataPegBookPump"/> off <c>Trade</c> /
+/// <c>InfoSnapshot</c> events as before.
 /// </para>
 /// </summary>
 public sealed class PegBookTopCache

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -245,6 +245,15 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<B3.Trading.Application.MarketData.MboBookStorePump>();
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.MboBookStorePump>());
+        // Q3.6 Stage C (#286). Bridges MboBookStore-derived BBO into
+        // the Pegged book-top cache. Closes the v1 SDK gap where
+        // PegRef.Mid / PegRef.Best transparently fell back to last-
+        // trade because no BBO source existed. No-op when EnableBook
+        // is false (the legacy v1 last-trade fallback then kicks in
+        // unchanged).
+        services.AddSingleton<B3.Trading.Application.MarketData.MboPegBookPump>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.MarketData.MboPegBookPump>());
         services.AddSingleton<AlgoEngine>();
         services.AddHostedService(sp => sp.GetRequiredService<AlgoEngine>());
         services.AddHostedService<AlgoScheduler>();

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MboPegBookPumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MboPegBookPumpTests.cs
@@ -1,0 +1,152 @@
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// Q3.6 Stage C (#286). Unit tests for <see cref="MboPegBookPump"/> —
+/// bridges <see cref="MboBookStore.BookChanged"/> into
+/// <see cref="PegBookTopCache.UpdateBookTop"/>.
+/// </summary>
+public class MboPegBookPumpTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 5, 19, 14, 0, 0, TimeSpan.Zero);
+
+    private static MarketBookSnapshot Snap(ulong bidOrderId, decimal bidPx, ulong askOrderId, decimal askPx) =>
+        new()
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321,
+            RptSeq = 1,
+            Bids = new[] { new MarketBookOrder(bidOrderId, bidPx, 100) },
+            Asks = new[] { new MarketBookOrder(askOrderId, askPx, 100) },
+            ReceivedUtc = T0,
+        };
+
+    [Fact]
+    public async Task BookChanged_pushes_top_of_book_into_cache()
+    {
+        var store = new MboBookStore();
+        var cache = new PegBookTopCache();
+        var pump = new MboPegBookPump(store, cache);
+        try
+        {
+            store.ApplySnapshot(Snap(101UL, 30.20m, 201UL, 30.40m));
+
+            var top = cache.TryGet("PETR4");
+            Assert.NotNull(top);
+            Assert.Equal(30.20m, top.Value.BestBid);
+            Assert.Equal(30.40m, top.Value.BestAsk);
+            Assert.Equal(30.30m, top.Value.Mid);
+        }
+        finally
+        {
+            await pump.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Subsequent_updates_replace_cached_bbo()
+    {
+        var store = new MboBookStore();
+        var cache = new PegBookTopCache();
+        var pump = new MboPegBookPump(store, cache);
+        try
+        {
+            store.ApplySnapshot(Snap(101UL, 30.20m, 201UL, 30.40m));
+            // Replace the bid with a higher one — top of book moves.
+            store.ApplyAdded(new MarketOrderAdded(
+                Symbol: "PETR4",
+                SecurityId: 4321,
+                OrderId: 102UL,
+                Side: MarketBookSide.Bid,
+                Price: 30.25m,
+                Qty: 50,
+                ReceivedUtc: T0.AddSeconds(1)));
+
+            var top = cache.TryGet("PETR4");
+            Assert.NotNull(top);
+            Assert.Equal(30.25m, top.Value.BestBid);
+            Assert.Equal(30.40m, top.Value.BestAsk);
+        }
+        finally
+        {
+            await pump.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Empty_side_preserves_known_leg_via_cache_merge()
+    {
+        var store = new MboBookStore();
+        var cache = new PegBookTopCache();
+        // Pre-seed both legs via a direct cache write so we can prove
+        // the pump's "empty side -> null" path does not clobber the
+        // existing value.
+        cache.UpdateBookTop("PETR4", bestBid: 30.10m, bestAsk: 30.40m, receivedUtc: T0);
+
+        var pump = new MboPegBookPump(store, cache);
+        try
+        {
+            // Snapshot with only an ask side — GetTopOfBook returns a
+            // sentinel (0,0,0) for the bid leg; the pump should send
+            // null for that side, not zero.
+            store.ApplySnapshot(new MarketBookSnapshot
+            {
+                Symbol = "PETR4",
+                SecurityId = 4321,
+                RptSeq = 5,
+                Bids = Array.Empty<MarketBookOrder>(),
+                Asks = new[] { new MarketBookOrder(201UL, 30.45m, 100) },
+                ReceivedUtc = T0.AddSeconds(2),
+            });
+
+            var top = cache.TryGet("PETR4");
+            Assert.NotNull(top);
+            Assert.Equal(30.10m, top.Value.BestBid); // preserved
+            Assert.Equal(30.45m, top.Value.BestAsk); // updated
+        }
+        finally
+        {
+            await pump.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_unsubscribes_from_BookChanged()
+    {
+        var store = new MboBookStore();
+        var cache = new PegBookTopCache();
+        var pump = new MboPegBookPump(store, cache);
+
+        await pump.StopAsync(CancellationToken.None);
+
+        // After Stop, further store mutations must not touch the cache.
+        store.ApplySnapshot(Snap(101UL, 30.20m, 201UL, 30.40m));
+        Assert.Null(cache.TryGet("PETR4"));
+    }
+
+    [Fact]
+    public async Task Both_sides_empty_yields_no_cache_write()
+    {
+        var store = new MboBookStore();
+        var cache = new PegBookTopCache();
+        var pump = new MboPegBookPump(store, cache);
+        try
+        {
+            store.ApplySnapshot(new MarketBookSnapshot
+            {
+                Symbol = "ZZZZ",
+                SecurityId = 1,
+                RptSeq = 1,
+                Bids = Array.Empty<MarketBookOrder>(),
+                Asks = Array.Empty<MarketBookOrder>(),
+                ReceivedUtc = T0,
+            });
+            Assert.Null(cache.TryGet("ZZZZ"));
+        }
+        finally
+        {
+            await pump.StopAsync(CancellationToken.None);
+        }
+    }
+}


### PR DESCRIPTION
Stage C of the #286 in-host MBO rollout. Closes the v1 SDK gap on `PegBookTopCache` (where the BBO legs stayed null and PegRef.Mid/Best transparently fell back to last-trade).

## What
- New `MboPegBookPump` (`IHostedService`) subscribes to `MboBookStore.BookChanged` and pushes `GetTopOfBook(symbol)` into `PegBookTopCache.UpdateBookTop`.
- Empty side → `null` leg so the cache's existing-value-preserving merge does not clobber a previously-known BBO with the `(0,0,0)` sentinel `GetTopOfBook` returns for an empty side.
- Listener errors swallowed + logged: the same `BookChanged` event drives the WS book sink and (transitively) the auction sink — a Pegged-cache hiccup must not starve the wider book pipeline.
- DI: concrete singleton + hosted service registered right after `MboBookStorePump` in `TradingApplicationCoreServiceCollectionExtensions`.
- Refreshed the `PegBookTopCache` / `MarketDataPegBookPump` "SDK gap" doc comments so they point at the new BBO source instead of saying it doesn't exist.

## Gating
No behavioral change when `MarketDataOptions.EnableBook` is false: `BookChanged` simply never fires, the pump no-ops, and the engine sees the legacy last-trade fallback exactly as the v1 path tested today.

## Verification
- 5 new unit tests for `MboPegBookPumpTests` cover: BookChanged populates BBO; subsequent `ApplyAdded` shifts the cached top; empty bid side preserves a previously-known `BestBid`; `StopAsync` unsubscribes; both-sides-empty snapshot leaves the cache untouched.
- Full backend sweep green: 1085 Application + 500 Api + 134 EntryPointListener + 12 Reconciliation. `dotnet format` clean.

## Follow-ups (separate PRs)
- #287 (server-side pegged): still blocked upstream — this PR keeps client-side emulation fed by a real BBO in the meantime.
- Optional collar v2 (#312 family) could also adopt `IL2BookView` for the same reason.