### PR TITLE
feat(risk): tiered tick-size ladder per instrument (closes #360)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
@@ -13,6 +13,16 @@ namespace B3.Trading.Application.Risk.Checks;
 /// </para>
 ///
 /// <para>
+/// #360. Supports the CVM-style tiered tick ladder via
+/// <see cref="InstrumentSpec.TickLadder"/>: the active tick is
+/// resolved per-price (binary-style scan over canonicalized bands).
+/// When no ladder is configured the legacy flat
+/// <see cref="InstrumentSpec.TickSize"/> still applies, so symbols
+/// not yet migrated to the ladder schema keep the prior behavior
+/// and message verbatim.
+/// </para>
+///
+/// <para>
 /// <b>Fail-open:</b> symbols missing from
 /// <see cref="SymbolDirectory.TryGetSpec"/> approve. The fat-finger
 /// checks are additive — never blocking on a symbol whose spec wasn't
@@ -35,17 +45,27 @@ public sealed class MinTickSizeCheck : IRiskCheck
     public RiskDecision Check(RiskContext ctx)
     {
         if (!ctx.Price.HasValue) return RiskDecision.Approve;
-        if (!_directory.TryGetSpec(ctx.Symbol, out var spec) || spec.TickSize is not { } tick || tick <= 0m)
-            return RiskDecision.Approve;
+        if (!_directory.TryGetSpec(ctx.Symbol, out var spec)) return RiskDecision.Approve;
+
+        var price = ctx.Price.Value;
+        var tick = spec.ResolveTick(price);
+        if (tick is not { } t || t <= 0m) return RiskDecision.Approve;
 
         // decimal arithmetic is exact for the values we care about
         // (tick sizes are 0.01 / 0.001 etc., prices have at most 4-6
         // decimals). decimal.Remainder avoids the FP precision trap
         // that would bite a double-based modulus.
-        if (decimal.Remainder(ctx.Price.Value, tick) != 0m)
-            return RiskDecision.Reject(
-                RiskRejectCodes.MinTickSize,
-                $"price {ctx.Price.Value} is not a multiple of tick size {tick} for {ctx.Symbol}");
+        if (decimal.Remainder(price, t) != 0m)
+        {
+            // #360. When a ladder is in play surface the band in the
+            // reject reason so the trader sees *why* the tick changed
+            // ("...in band [10,100)" vs the global flat "...0.05").
+            var band = spec.ResolveBand(price);
+            var reason = band is { } b
+                ? $"price {price} is not a multiple of tick size {t} (band [{b.LowerInclusive},{(b.UpperExclusive?.ToString() ?? "+inf")})) for {ctx.Symbol}"
+                : $"price {price} is not a multiple of tick size {t} for {ctx.Symbol}";
+            return RiskDecision.Reject(RiskRejectCodes.MinTickSize, reason);
+        }
         return RiskDecision.Approve;
     }
 }

--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -62,16 +62,42 @@ public sealed class SymbolDirectory
         foreach (var kv in options.Specs)
         {
             if (string.IsNullOrWhiteSpace(kv.Key) || kv.Value is null) continue;
-            // Drop entries that wouldn't constrain anything — keeps
-            // TryGetSpec callers from having to special-case zero/negative.
             var t = kv.Value.TickSize;
             var l = kv.Value.LotSize;
-            if ((t is null or <= 0m) && (l is null or <= 0)) continue;
+            var ladder = NormalizeLadder(kv.Value.TickLadder);
+            // Drop entries that wouldn't constrain anything — keeps
+            // TryGetSpec callers from having to special-case zero/negative.
+            if ((t is null or <= 0m) && (l is null or <= 0) && ladder is null) continue;
             specs[kv.Key] = new InstrumentSpec(
                 t is > 0m ? t : null,
-                l is > 0 ? l : null);
+                l is > 0 ? l : null,
+                ladder);
         }
         _specs = specs;
+    }
+
+    // #360. Validate and canonicalize the optional CVM-style tick
+    // ladder: drop malformed rows (non-positive tick, NaN), de-dup by
+    // MinPriceInclusive (last-write-wins per band), sort ascending so
+    // ResolveTick can do a binary search. Returns null when the
+    // resulting ladder is empty so MinTickSizeCheck can treat
+    // "ladder present" as a positive signal.
+    private static IReadOnlyList<TickBand>? NormalizeLadder(IReadOnlyList<TickBandOptions>? rows)
+    {
+        if (rows is null || rows.Count == 0) return null;
+        var sorted = new SortedDictionary<decimal, decimal>();
+        foreach (var r in rows)
+        {
+            if (r is null) continue;
+            if (r.Tick <= 0m) continue;
+            if (r.MinPriceInclusive < 0m) continue;
+            sorted[r.MinPriceInclusive] = r.Tick;
+        }
+        if (sorted.Count == 0) return null;
+        var list = new TickBand[sorted.Count];
+        var i = 0;
+        foreach (var kv in sorted) list[i++] = new TickBand(kv.Key, kv.Value);
+        return list;
     }
 
     public int Count => _byName.Count;
@@ -133,11 +159,92 @@ public sealed class SymbolDirectory
 /// Per-instrument trading constraints that don't fit in
 /// <see cref="Risk.RiskOptions"/> because they describe the
 /// instrument itself, not the firm/end-client risk policy. Both
-/// fields are optional — a null/missing value means "no constraint",
-/// so partial entries are valid (e.g. a TickSize-only spec for a
-/// symbol whose lot size is 1).
+/// flat fields are optional — a null/missing value means "no
+/// constraint", so partial entries are valid (e.g. a TickSize-only
+/// spec for a symbol whose lot size is 1).
+///
+/// <para>
+/// #360. <see cref="TickLadder"/> is an optional CVM-style tiered
+/// tick schedule (price-band → tick) for venues where the tick
+/// varies by price bucket. When present it overrides
+/// <see cref="TickSize"/> on a per-price basis; <see cref="TickSize"/>
+/// (when also set) acts as a fallback for prices below the lowest
+/// band's <c>MinPriceInclusive</c> and as backwards-compatible
+/// metadata. The ladder is canonicalized at construction time
+/// (sorted ascending by <c>MinPriceInclusive</c>, malformed rows
+/// dropped); see <see cref="ResolveTick(decimal)"/>.
+/// </para>
 /// </summary>
-public readonly record struct InstrumentSpec(decimal? TickSize, long? LotSize);
+public readonly record struct InstrumentSpec(
+    decimal? TickSize,
+    long? LotSize,
+    IReadOnlyList<TickBand>? TickLadder = null)
+{
+    /// <summary>
+    /// #360. Returns the tick that applies at <paramref name="price"/>:
+    /// the largest band whose <c>MinPriceInclusive &lt;= price</c>
+    /// when <see cref="TickLadder"/> is set, otherwise the flat
+    /// <see cref="TickSize"/>. Returns null when neither resolves
+    /// (price below the lowest band and no flat fallback) — the
+    /// caller treats that as fail-open consistent with the existing
+    /// "unconfigured symbol" posture.
+    /// </summary>
+    public decimal? ResolveTick(decimal price)
+    {
+        if (TickLadder is { Count: > 0 } ladder)
+        {
+            decimal? match = null;
+            // Linear scan is fine — production ladders are <10 rows.
+            // Bands are sorted ascending so we keep the latest match.
+            for (int i = 0; i < ladder.Count; i++)
+            {
+                if (ladder[i].MinPriceInclusive <= price) match = ladder[i].Tick;
+                else break;
+            }
+            if (match.HasValue) return match;
+        }
+        return TickSize is > 0m ? TickSize : null;
+    }
+
+    /// <summary>
+    /// #360. Returns the band index and tick that applied at
+    /// <paramref name="price"/>, or null when no ladder is set or
+    /// the price is below every band. Used by the reject reason in
+    /// <c>MinTickSizeCheck</c> to surface the band range to the
+    /// trader.
+    /// </summary>
+    public TickBandMatch? ResolveBand(decimal price)
+    {
+        if (TickLadder is not { Count: > 0 } ladder) return null;
+        int idx = -1;
+        for (int i = 0; i < ladder.Count; i++)
+        {
+            if (ladder[i].MinPriceInclusive <= price) idx = i;
+            else break;
+        }
+        if (idx < 0) return null;
+        var lo = ladder[idx].MinPriceInclusive;
+        decimal? hi = idx + 1 < ladder.Count ? ladder[idx + 1].MinPriceInclusive : null;
+        return new TickBandMatch(lo, hi, ladder[idx].Tick);
+    }
+}
+
+/// <summary>
+/// #360. One row of the CVM-style tiered tick ladder: the tick that
+/// applies from <see cref="MinPriceInclusive"/> up to the next
+/// band's <c>MinPriceInclusive</c> (exclusive) or +infinity.
+/// </summary>
+public readonly record struct TickBand(decimal MinPriceInclusive, decimal Tick);
+
+/// <summary>
+/// #360. Result of <see cref="InstrumentSpec.ResolveBand(decimal)"/>
+/// — the half-open price range that produced the resolved tick.
+/// <see cref="UpperExclusive"/> is null on the topmost band.
+/// </summary>
+public readonly record struct TickBandMatch(
+    decimal LowerInclusive,
+    decimal? UpperExclusive,
+    decimal Tick);
 
 /// <summary>
 /// Bound from <c>Trading:SymbolDirectory</c>.
@@ -172,4 +279,22 @@ public sealed class InstrumentSpecOptions
 {
     public decimal? TickSize { get; set; }
     public long? LotSize { get; set; }
+
+    /// <summary>
+    /// #360. Optional CVM-style tiered tick schedule. Bound from
+    /// <c>Trading:SymbolDirectory:Specs:&lt;SYMBOL&gt;:TickLadder</c>.
+    /// Order in JSON does not matter — <see cref="SymbolDirectory"/>
+    /// canonicalizes (sort + dedup + drop malformed) at startup.
+    /// </summary>
+    public List<TickBandOptions>? TickLadder { get; set; }
+}
+
+/// <summary>
+/// #360. Mutable counterpart of <see cref="TickBand"/> for
+/// configuration binding.
+/// </summary>
+public sealed class TickBandOptions
+{
+    public decimal MinPriceInclusive { get; set; }
+    public decimal Tick { get; set; }
 }

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -466,6 +466,119 @@ public class RiskPipelineTests
         Assert.True(new MinTickSizeCheck(dir).Check(Ctx(price: null, type: OrderType.Market)).Approved);
     }
 
+    // ── #360 tiered tick-ladder coverage ──────────────────────────────
+
+    [Fact]
+    public void MinTickSize_Ladder_appliesPerBand()
+    {
+        var dir = BuildDirectory(specs: new()
+        {
+            ["PETR4"] = new()
+            {
+                TickLadder = new()
+                {
+                    new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                    new TickBandOptions { MinPriceInclusive = 1m,   Tick = 0.05m },
+                    new TickBandOptions { MinPriceInclusive = 10m,  Tick = 0.10m },
+                    new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.50m },
+                },
+            },
+        });
+        var check = new MinTickSizeCheck(dir);
+
+        // 0.01 band [0,1): 0.50 valid, 0.501 rejects.
+        Assert.True(check.Check(Ctx(price: 0.50m)).Approved);
+        Assert.False(check.Check(Ctx(price: 0.501m)).Approved);
+
+        // 0.05 band [1,10): 5.05 valid, 5.07 rejects.
+        Assert.True(check.Check(Ctx(price: 5.05m)).Approved);
+        Assert.False(check.Check(Ctx(price: 5.07m)).Approved);
+
+        // 0.10 band [10,100): 50.10 valid, 50.05 rejects.
+        Assert.True(check.Check(Ctx(price: 50.10m)).Approved);
+        Assert.False(check.Check(Ctx(price: 50.05m)).Approved);
+
+        // 0.50 band [100,+inf): 150.50 valid, 150.10 rejects.
+        Assert.True(check.Check(Ctx(price: 150.50m)).Approved);
+        Assert.False(check.Check(Ctx(price: 150.10m)).Approved);
+    }
+
+    [Fact]
+    public void MinTickSize_Ladder_rejectReason_surfacesBandRange()
+    {
+        var dir = BuildDirectory(specs: new()
+        {
+            ["PETR4"] = new()
+            {
+                TickLadder = new()
+                {
+                    new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                    new TickBandOptions { MinPriceInclusive = 10m,  Tick = 0.10m },
+                    new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.50m },
+                },
+            },
+        });
+        var check = new MinTickSizeCheck(dir);
+
+        var midBand = check.Check(Ctx(price: 50.05m));
+        Assert.False(midBand.Approved);
+        Assert.Equal(RiskRejectCodes.MinTickSize, midBand.Code);
+        Assert.Contains("band [10,100)", midBand.Reason);
+        Assert.Contains("tick size 0.10", midBand.Reason);
+
+        var topBand = check.Check(Ctx(price: 200.10m));
+        Assert.False(topBand.Approved);
+        Assert.Contains("band [100,+inf)", topBand.Reason);
+    }
+
+    [Fact]
+    public void MinTickSize_Ladder_belowLowestBand_fallsBackToFlatTick()
+    {
+        // Operator declares a ladder starting at price 1 plus a flat
+        // 0.01 tick — sub-real prices use the flat fallback; the
+        // reject reason on the flat path keeps the legacy message
+        // (no "band" suffix) so the format only changes when ladder
+        // actually applied.
+        var dir = BuildDirectory(specs: new()
+        {
+            ["MGLU3"] = new()
+            {
+                TickSize = 0.01m,
+                TickLadder = new()
+                {
+                    new TickBandOptions { MinPriceInclusive = 1m,  Tick = 0.05m },
+                    new TickBandOptions { MinPriceInclusive = 10m, Tick = 0.10m },
+                },
+            },
+        });
+        var check = new MinTickSizeCheck(dir);
+
+        // Sub-real: flat 0.01 fallback approves valid + reject reason omits band.
+        Assert.True(check.Check(Ctx(symbol: "MGLU3", price: 0.50m)).Approved);
+        var rej = check.Check(Ctx(symbol: "MGLU3", price: 0.505m));
+        Assert.False(rej.Approved);
+        Assert.DoesNotContain("band", rej.Reason);
+
+        // In-band: ladder applies — message carries band suffix.
+        var rejBand = check.Check(Ctx(symbol: "MGLU3", price: 5.07m));
+        Assert.False(rejBand.Approved);
+        Assert.Contains("band [1,10)", rejBand.Reason);
+    }
+
+    [Fact]
+    public void MinTickSize_legacyFlatOnly_reasonUnchanged()
+    {
+        // Pre-#360 behavior preserved for symbols that never opt in to
+        // the ladder schema — surface the exact same reject text the
+        // earlier tests asserted.
+        var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
+        var rej = new MinTickSizeCheck(dir).Check(Ctx(price: 30.001m));
+        Assert.False(rej.Approved);
+        Assert.Equal(
+            "price 30.001 is not a multiple of tick size 0.01 for PETR4",
+            rej.Reason);
+    }
+
     [Fact]
     public void MinLotSize_RejectsNonMultiple()
     {

--- a/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
@@ -240,4 +240,164 @@ public class SymbolDirectoryTests
         // dictionary enumeration is implementation defined.
         Assert.Contains(symbol, new[] { "PETR4", "PETR3" });
     }
+
+    // ── #360 tick-ladder coverage ─────────────────────────────────────
+
+    [Fact]
+    public void TickLadder_ResolveTick_picksBandByPrice()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETR4"] = new InstrumentSpecOptions
+                {
+                    TickLadder = new()
+                    {
+                        new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                        new TickBandOptions { MinPriceInclusive = 1m,   Tick = 0.05m },
+                        new TickBandOptions { MinPriceInclusive = 10m,  Tick = 0.10m },
+                        new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.50m },
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.01m, spec.ResolveTick(0.50m));
+        Assert.Equal(0.05m, spec.ResolveTick(1m));     // boundary inclusive
+        Assert.Equal(0.05m, spec.ResolveTick(9.99m));
+        Assert.Equal(0.10m, spec.ResolveTick(10m));
+        Assert.Equal(0.10m, spec.ResolveTick(50m));
+        Assert.Equal(0.50m, spec.ResolveTick(100m));
+        Assert.Equal(0.50m, spec.ResolveTick(9999m));
+    }
+
+    [Fact]
+    public void TickLadder_isCanonicalized_outOfOrder_andDeduped()
+    {
+        // Operator writes the ladder in any order; the directory must
+        // sort ascending and dedup (last-write-wins per MinPriceInclusive).
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["VALE3"] = new InstrumentSpecOptions
+                {
+                    TickLadder = new()
+                    {
+                        new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.50m },
+                        new TickBandOptions { MinPriceInclusive = 1m,   Tick = 0.05m },
+                        new TickBandOptions { MinPriceInclusive = 1m,   Tick = 0.99m }, // dup -> wins
+                        new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("VALE3", out var spec));
+        Assert.Equal(0.01m, spec.ResolveTick(0.50m));
+        Assert.Equal(0.99m, spec.ResolveTick(5m));   // dedup last-write-wins
+        Assert.Equal(0.50m, spec.ResolveTick(100m));
+    }
+
+    [Fact]
+    public void TickLadder_dropsMalformedRows()
+    {
+        // Non-positive tick or negative MinPriceInclusive are dropped.
+        // Spec with ONLY malformed rows yields null ladder; combined
+        // with no flat TickSize the entry is dropped (matches the
+        // existing "no constraint = no spec" rule).
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["JUNK"] = new InstrumentSpecOptions
+                {
+                    TickLadder = new()
+                    {
+                        new TickBandOptions { MinPriceInclusive = 0m,  Tick = 0m },
+                        new TickBandOptions { MinPriceInclusive = 0m,  Tick = -1m },
+                        new TickBandOptions { MinPriceInclusive = -5m, Tick = 0.01m },
+                    },
+                },
+            },
+        });
+
+        Assert.False(sut.TryGetSpec("JUNK", out _));
+    }
+
+    [Fact]
+    public void TickLadder_fallsBackToFlatTickSize_belowLowestBand()
+    {
+        // A ladder that starts at price 1 plus a flat TickSize of 0.01
+        // — prices below 1 fall back to the flat tick (preserves the
+        // legacy behavior for symbols whose operator opts in to the
+        // ladder schema only for higher bands).
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["MGLU3"] = new InstrumentSpecOptions
+                {
+                    TickSize = 0.01m,
+                    TickLadder = new()
+                    {
+                        new TickBandOptions { MinPriceInclusive = 1m,  Tick = 0.05m },
+                        new TickBandOptions { MinPriceInclusive = 10m, Tick = 0.10m },
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("MGLU3", out var spec));
+        Assert.Equal(0.01m, spec.ResolveTick(0.50m));
+        Assert.Equal(0.05m, spec.ResolveTick(1m));
+        Assert.Equal(0.10m, spec.ResolveTick(20m));
+    }
+
+    [Fact]
+    public void TickLadder_ResolveBand_reportsHalfOpenRange()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETR4"] = new InstrumentSpecOptions
+                {
+                    TickLadder = new()
+                    {
+                        new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                        new TickBandOptions { MinPriceInclusive = 1m,   Tick = 0.05m },
+                        new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.50m },
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("PETR4", out var spec));
+
+        var b0 = spec.ResolveBand(0.50m);
+        Assert.NotNull(b0);
+        Assert.Equal(0m, b0.Value.LowerInclusive);
+        Assert.Equal(1m, b0.Value.UpperExclusive);
+
+        var bMid = spec.ResolveBand(50m);
+        Assert.NotNull(bMid);
+        Assert.Equal(1m, bMid.Value.LowerInclusive);
+        Assert.Equal(100m, bMid.Value.UpperExclusive);
+
+        var bTop = spec.ResolveBand(500m);
+        Assert.NotNull(bTop);
+        Assert.Equal(100m, bTop.Value.LowerInclusive);
+        Assert.Null(bTop.Value.UpperExclusive);
+
+        // Spec with no ladder -> null match.
+        var flat = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs = { ["X"] = new InstrumentSpecOptions { TickSize = 0.01m } },
+        });
+        Assert.True(flat.TryGetSpec("X", out var flatSpec));
+        Assert.Null(flatSpec.ResolveBand(1m));
+    }
 }


### PR DESCRIPTION
Closes #360. Follow-up to #288 (PR #359).

## What
Extends `InstrumentSpec` with an optional CVM/B3-style tiered tick schedule so `MinTickSizeCheck` can validate prices against per-price-band ticks (R$0.01 below R$1, R$0.05 in `[1,10)`, R$0.10 in `[10,100)`, R$0.50 above R$100 — typical CVM equities schema) instead of a single flat tick per symbol.

### Domain
- `InstrumentSpec` gains `IReadOnlyList<TickBand>? TickLadder` plus `ResolveTick(price)` / `ResolveBand(price)` helpers.
- `TickBand(decimal MinPriceInclusive, decimal Tick)` + `TickBandMatch(LowerInclusive, UpperExclusive, Tick)` records.
- Bands are canonicalized at `SymbolDirectory` construction: sorted ascending by `MinPriceInclusive`, deduped last-write-wins, rows with non-positive tick or negative floor dropped.

### Config binding
- `InstrumentSpecOptions.TickLadder` (List of `TickBandOptions`) — bound from `Trading:SymbolDirectory:Specs:<SYMBOL>:TickLadder`.
- Order in JSON doesn't matter; operator can list bands in any order.

### Risk check
- `MinTickSizeCheck` now resolves the active tick per-price.
- Reject reason surfaces the half-open band range when a ladder applied: `price 50.05 is not a multiple of tick size 0.10 (band [10,100)) for PETR4`.
- Same stable code (`min_tick_size`, since #288) — only the reason detail changes.

### Backwards compatibility
- Flat `TickSize` is retained as a backwards-compatible field and as the fallback when a price falls below the lowest ladder band.
- Flat-only specs (no ladder) keep the legacy reason verbatim (`price X is not a multiple of tick size Y for SYM`) — no regression for symbols that haven't opted in.

## Verification
Full backend sweep green: **1094 Application + 500 Api + 134 EntryPointListener + 23 SimulatorBot + 12 Reconciliation**. `dotnet format` clean.

New tests (+9):
- `SymbolDirectoryTests`: `ResolveTick` picks correct band; ladder canonicalized (out-of-order + dedup); malformed rows dropped; flat fallback for sub-floor prices; `ResolveBand` reports half-open range incl. `+inf` on topmost band.
- `RiskPipelineTests`: `MinTickSizeCheck` approves/rejects across all four bands; reject reason carries `band [lo,hi)`; flat fallback path keeps legacy reason format.

## Out of scope
- Populating the live ladder in `docker/real/instruments-eqt.json` — left to a separate ops PR per the issue ("Idealmente popular a partir da tabela CVM/B3 oficial").