### PR TITLE
docs(market-data): document MBO subscriber + config (closes #286)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,10 +194,15 @@ replay on (re)connect. Revisit when the matching side does.
 - **Platform ↔ exchange.** FIXP credentials per firm, in config, mirrors
   `B3EntryPointClient`'s API. Lands when that lib is wired in.
 
-### 5. Market data for the trader UI
+### 5. Market data
 
-Three options on the table (see issue #1 §5). Not committed yet. The
-bootstrap is order-only; market data will arrive in a follow-up.
+The host consumes `B3.MarketData.WebSocketClient` (SDK) through
+`SdkMarketDataSubscriber` and exposes events via the
+application-side `IMarketDataSubscriber` seam. Trade + info events
+are always on; the opt-in `Trading:MarketData:EnableBook` flag adds
+the MBO (L3) stream consumed by `MboBookStore` and bridged to
+Pegged BBO by `MboPegBookPump`. See [`MARKET-DATA.md`](MARKET-DATA.md)
+for configuration, event flow and the SDK→app DTO mapping.
 
 ## Pre-trade risk (Phase 4)
 

--- a/docs/MARKET-DATA.md
+++ b/docs/MARKET-DATA.md
@@ -1,0 +1,109 @@
+# Market data
+
+This document describes how the trading-host consumes the
+`B3.MarketData.WebSocketClient` SDK and how MBO (Market-by-Order /
+L3) events flow through the application after PR #286 (Stages A–C).
+
+## SDK version
+
+`B3.MarketData.WebSocketClient` is pinned in
+`backend/Directory.Packages.props`. The current version exposes:
+
+- `SubscribeFlags.Info` — instrument metadata / snapshots
+- `SubscribeFlags.Trades` — public trade prints
+- `SubscribeFlags.Book` — MBO order-by-order events
+  (`OrderAdded` / `OrderUpdated` / `OrderDeleted` /
+  `BookSnapshot` / `BookCleared`)
+
+The book flag is opt-in; the trading-host subscribes to it only
+when `Trading:MarketData:EnableBook` is `true`. With the flag off
+the host runs in legacy mode: no MBO events, Pegged algos fall
+back to last-trade for `PegRef.Mid`/`Best`.
+
+## Configuration
+
+```jsonc
+{
+  "Trading": {
+    "MarketData": {
+      // Live SDK endpoint. Set to empty to fall back to
+      // NullMarketDataSubscriber (offline mode for dev/tests).
+      "Endpoint": "wss://marketdata.example/ws",
+
+      // Symbols to subscribe at startup. Live additions go through
+      // IMarketDataSubscriber.SubscribeAsync at runtime.
+      "Symbols": ["PETR4", "VALE3"],
+
+      // When true, includes SubscribeFlags.Book in the SDK
+      // subscribe call so MBO events flow into MboBookStore.
+      // Default: false.
+      "EnableBook": true
+    }
+  }
+}
+```
+
+## Event flow
+
+```
+B3.MarketData.WebSocketClient (SDK)
+        │
+        ▼
+SdkMarketDataSubscriber  (Host)             ← adapter: SDK types → app DTOs
+        │ raises events on the IMarketDataSubscriber interface
+        ▼
+IMarketDataSubscriber  (Application)
+   ├── Trade ─────────► MarketDataVolumePump ──► VolumeCurveEstimator
+   ├── Trade ─────────► MarketDataPegBookPump ─► PegBookTopCache (Last leg)
+   ├── InfoSnapshot ──► MarketDataReferencePrice, AuctionStateStore
+   └── Book* (gated on EnableBook)
+        │
+        ▼
+   MboBookStorePump ──► MboBookStore  (L3, in-process)
+        │                  │
+        │                  └─ BookChanged(symbol) event
+        ▼                         │
+   WS book sink                   ▼
+                          MboPegBookPump ──► PegBookTopCache (Bid/Ask legs)
+```
+
+`MboBookStore` keeps a per-symbol order-by-order side map; reads
+expose `GetTopOfBook(symbol)` and `GetView(symbol)` (L2-aggregated
+view derived from the L3 store). All apply methods are serialised
+per symbol; `BookChanged` is raised outside the lock so subscribers
+cannot deadlock the apply path.
+
+## Subscriber surface
+
+`IMarketDataSubscriber` is the seam between Host (which owns the
+SDK lifetime) and Application (pumps + stores + algos):
+
+- `Trade`, `InfoSnapshot`, `Imbalance`, `AuctionUpdate` — pre-MBO
+  events available regardless of `EnableBook`.
+- `OrderAdded`, `OrderUpdated`, `OrderDeleted`, `BookSnapshot`,
+  `BookCleared` — raised only when `EnableBook` is `true`.
+
+The application **never** references SDK types directly; only
+`SdkMarketDataSubscriber` (in `B3.Trading.Host`) does the SDK→DTO
+mapping. Swapping the SDK or running offline against
+`NullMarketDataSubscriber` is a Host concern.
+
+## Smoke / round-trip
+
+- `MboBookStorePumpTests` / `MboBookStoreTests` cover snapshot,
+  add/update/delete, cleared, top-of-book, side-aggregation.
+- `MboPegBookPumpTests` covers the BBO bridge into
+  `PegBookTopCache`.
+- The integration-real-stack workflow exercises a live subscribe
+  end-to-end when the upstream marketdata-platform image is
+  present.
+
+## See also
+
+- [`docs/rfcs/perf-hardening-v0.md`](rfcs/perf-hardening-v0.md) —
+  load-test methodology (the same MBO path is exercised under load).
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) §5 — high-level view.
+- Issue [#286](https://github.com/pedrosakuma/B3TradingPlatform/issues/286) —
+  MBO feed tracking (this doc is the closing artefact for criterion 4).
+- Issue [#293](https://github.com/pedrosakuma/B3TradingPlatform/issues/293) —
+  follow-up: surface MBO over the trader-UI WS protocol.


### PR DESCRIPTION
Closes #286.

Adds `docs/MARKET-DATA.md` — the last open criterion of #286 was 'configuration documentation'. The technical work (SDK 0.2.0 upgrade, MBO adapter, MboBookStore + Pump, MboPegBookPump bridge, smoke tests) landed across Stages A–C (PRs #358, #361, #362, #364); this PR just makes the channel discoverable.

Coverage:
- SDK version + `SubscribeFlags` surface (Info/Trades/Book)
- `Trading:MarketData` config schema (`EnableBook` opt-in)
- End-to-end event flow diagram (SDK → adapter → `IMarketDataSubscriber` → pumps → `MboBookStore` → consumers)
- Subscriber surface contract (Host owns SDK types; Application sees only DTOs)
- Smoke / round-trip pointers
- Cross-ref to #293 (FE MBO toggle, the natural follow-up)

Also updates `ARCHITECTURE.md §5` to replace the placeholder 'market data will arrive in a follow-up' with a short pointer to the new doc.

Docs-only, no code change.