### PR TITLE
chore(entrypoint-listener): remove obsolete RouterChannelCapacity shim

### DIFF
--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_Bench.cs
@@ -80,7 +80,7 @@ public class BotErRouter_RouteOne_Bench
         var coord = new BotOutboundCoordinator(sessions, opts.Value);
         _coord = coord;
         _mux = new BotErMultiplexer(_mappings, sessions, directory, coord,
-            NullLogger<BotErMultiplexer>.Instance, opts);
+            NullLogger<BotErMultiplexer>.Instance);
 
         _cts = new CancellationTokenSource();
         await _mux.StartAsync(_cts.Token).ConfigureAwait(false);

--- a/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_LiveSocket_Bench.cs
+++ b/backend/bench/B3.Trading.Benchmarks/Benches/BotErRouter_RouteOne_LiveSocket_Bench.cs
@@ -144,7 +144,7 @@ public class BotErRouter_RouteOne_LiveSocket_Bench
         });
         _coord = new BotOutboundCoordinator(sessions, opts.Value);
         _mux = new BotErMultiplexer(_mappings, sessions, directory, _coord,
-            NullLogger<BotErMultiplexer>.Instance, opts);
+            NullLogger<BotErMultiplexer>.Instance);
 
         _cts = new CancellationTokenSource();
         await _mux.StartAsync(_cts.Token).ConfigureAwait(false);

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -5,7 +5,6 @@ using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace B3.Trading.EntryPointListener.Hosting;
 
@@ -79,15 +78,13 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
         IUserBotSessionRegistry sessions,
         IBotSessionConnectionDirectory directory,
         BotOutboundCoordinator outbound,
-        ILogger<BotErMultiplexer> logger,
-        IOptions<BotErMultiplexerOptions>? options = null)
+        ILogger<BotErMultiplexer> logger)
     {
         _mappings = mappings;
         _sessions = sessions;
         _directory = directory;
         _outbound = outbound;
         _logger = logger;
-        _ = options; // P9 (F4) removed the global router channel; RouterChannelCapacity is retained on the options type only for backwards-compatible config binding (see BotErMultiplexerOptions).
 
         // CredentialId-only overflow signal channel. Unbounded is safe
         // here because the message is a 16-byte Guid and the post rate

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexerOptions.cs
@@ -18,21 +18,6 @@ public sealed class BotErMultiplexerOptions
     public int OutboundBufferMaxMessages { get; set; } = BotOutboundBuffer.DefaultMaxMessages;
 
     /// <summary>
-    /// <b>Deprecated (P9 / RFC §5.4).</b> Pre-P9, this sized the global
-    /// <c>Channel&lt;ExecutionEvent&gt;</c> between the dispatcher and
-    /// the multiplexer drain thread. P9 / F4 removed that channel —
-    /// credential resolve is now synchronous in the fan-out path and
-    /// the per-credential <see cref="BotOutboundBuffer"/> is the sole
-    /// bounded layer (with <see cref="OutboundBufferMaxMessages"/> the
-    /// only knob for ER-rate backpressure). The property is retained
-    /// solely for backwards-compatible binding of existing
-    /// <c>appsettings.json</c> sections so deployment configs do not
-    /// fail to load; the value is ignored.
-    /// </summary>
-    [Obsolete("Removed in P9 / RFC §5.4 — synchronous credential resolve eliminated the global router channel. Tune OutboundBufferMaxMessages instead.")]
-    public int RouterChannelCapacity { get; set; } = 16_384;
-
-    /// <summary>
     /// Checkpoint cadence (RFC §4.8): every N seconds OR every M
     /// messages, whichever comes first. Either both at default (5s,
     /// 100msg) or operator-tuned.

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErMultiplexerTests.cs
@@ -109,7 +109,7 @@ public class BotErMultiplexerTests
         });
         var coord = new BotOutboundCoordinator(sessions, opts.Value);
         var mux = new BotErMultiplexer(mappings, sessions, directory, coord,
-            NullLogger<BotErMultiplexer>.Instance, opts);
+            NullLogger<BotErMultiplexer>.Instance);
         // Start the BackgroundService manually so Tests don't need a host.
         var cts = new CancellationTokenSource();
         await mux.StartAsync(cts.Token);

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/BotErRouterSyncResolveTests.cs
@@ -245,7 +245,7 @@ public class BotErRouterSyncResolveTests
         });
         var coord = new BotOutboundCoordinator(sessions, opts.Value);
         var mux = new BotErMultiplexer(mappings, sessions, directory, coord,
-            NullLogger<BotErMultiplexer>.Instance, opts);
+            NullLogger<BotErMultiplexer>.Instance);
         var cts = new CancellationTokenSource();
         await mux.StartAsync(cts.Token);
         return (mux, new MuxCtx(sessions, mappings, directory, coord));


### PR DESCRIPTION
Removes the back-compat `RouterChannelCapacity` shim that has lived on `BotErMultiplexerOptions` since P9 / RFC §5.4 dropped the global router channel. Discovered during a dead-code/observability audit.

**Verified safe:**
- No deployment config under `docker/` or `docs/` references the key.
- No strict-binder (`ErrorOnUnknownConfiguration`) is enabled anywhere → a stale `RouterChannelCapacity` line in a downstream `appsettings.json` is silently ignored, not a startup failure.
- `BotErMultiplexer` itself never read the value (constructor only did `_ = options;` to silence the unused-param warning).

**Drops** (-21 lines net):
- `BotErMultiplexerOptions.RouterChannelCapacity` property + obsolete attribute + 12-line XML doc
- `BotErMultiplexer` ctor's `IOptions<BotErMultiplexerOptions>? options = null` param + the `_ = options;` line + matching using directive
- `opts` positional argument from the two test call sites that were threading it through purely to satisfy the dead parameter

EntryPointListener tests 134/134 pass locally; `dotnet format` clean.