### PR TITLE
feat(#370): Stage A — venue halt/resume ingest from UMDF

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -606,10 +606,12 @@ public static class AdminEndpoints
                     Symbol = symbol,
                     Halted = halted,
                     ActorUserId = actor,
+                    Origin = B3.Trading.Application.MarketData.HaltOrigin.Operator,
                 },
                 mutate);
             MetricsRegistry.SymbolHaltToggled.Add(1,
-                new KeyValuePair<string, object?>("halted", halted));
+                new KeyValuePair<string, object?>("halted", halted),
+                new KeyValuePair<string, object?>("origin", "operator"));
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)

--- a/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IMarketDataSubscriber.cs
@@ -54,6 +54,18 @@ public interface IMarketDataSubscriber : IAsyncDisposable
     event Action<MarketAuctionImbalance>? AuctionImbalance;
     event Action<MarketAuctionPrint>? AuctionPrint;
 
+    // -------------------------------------------------------------
+    // Per-symbol trading-status delta (#370 Stage A). The adapter
+    // remembers the last observed status per symbol (raw SBE
+    // SecurityTradingStatus code carried in InfoSnapshot.TradingStatus)
+    // and raises this event only when it actually changes. Consumers:
+    // VenueHaltSubscriber bridges PAUSE/FORBIDDEN ↔ SymbolHaltService.
+    // Stage B will replace the delta-detection with a typed SDK event
+    // once B3.MarketData.WebSocketClient exposes one.
+    // -------------------------------------------------------------
+
+    event Action<MarketTradingStatusChange>? TradingStatusChanged;
+
     // L3 / MBO frames are not raised on this seam. The live wire path
     // funnels them through SDK 0.4.0's IBookFeed → SdkBookFeedAdapter →
     // IL2BookView; tests that need to drive an L3 book directly use

--- a/backend/src/B3.Trading.Application/MarketData/NullMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Application/MarketData/NullMarketDataSubscriber.cs
@@ -18,6 +18,7 @@ public sealed class NullMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<MarketAuctionImbalance>? AuctionImbalance;
     public event Action<MarketAuctionPrint>? AuctionPrint;
+    public event Action<MarketTradingStatusChange>? TradingStatusChanged;
     public event Action<MarketBookSnapshot>? BookSnapshot;
     public event Action<MarketOrderAdded>? OrderAdded;
     public event Action<MarketOrderUpdated>? OrderUpdated;

--- a/backend/src/B3.Trading.Application/MarketData/TradingStatusModels.cs
+++ b/backend/src/B3.Trading.Application/MarketData/TradingStatusModels.cs
@@ -1,0 +1,85 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Per-symbol trading status delta surfaced by <see cref="IMarketDataSubscriber"/>
+/// (Stage A of #370). Derived from <c>InfoSnapshot.TradingStatus</c>
+/// transitions: the SDK delivers info snapshots as cumulative state,
+/// the adapter remembers the last status per symbol and raises this
+/// event only when the value actually changes.
+///
+/// <para>
+/// <see cref="NewStatus"/> is the raw SBE
+/// <c>SecurityTradingStatus</c> code from the upstream
+/// <c>B3.Umdf.Mbo.Sbe.V16</c> schema; consumers map it via
+/// <see cref="SecurityTradingStatusCodes"/>. <see cref="PreviousStatus"/>
+/// is null on the first observation for a symbol.
+/// </para>
+/// </summary>
+public readonly record struct MarketTradingStatusChange(
+    string Symbol,
+    ulong SecurityId,
+    long? PreviousStatus,
+    long NewStatus,
+    DateTimeOffset ReceivedUtc);
+
+/// <summary>
+/// Raw SBE <c>SecurityTradingStatus</c> values from the upstream
+/// market-data schema (B3 UMDF v2.2). Centralised here so the venue
+/// halt subscriber and any future consumer share a single source of
+/// truth and don't sprinkle magic numbers across the codebase.
+///
+/// <para>
+/// We surface only the codes the application actually interprets.
+/// Anything not listed (e.g. <c>CLOSE = 4</c>, <c>RESERVED = 21</c>,
+/// <c>FINAL_CLOSING_CALL = 101</c>) is a scheduled session-phase
+/// transition handled by <c>SessionPhaseService</c>, not a halt.
+/// </para>
+/// </summary>
+public static class SecurityTradingStatusCodes
+{
+    /// <summary>Trading halt (manual / regulatory pause).</summary>
+    public const long Pause = 2;
+
+    /// <summary>Instrument is trading normally.</summary>
+    public const long Open = 17;
+
+    /// <summary>Not available for trading (forbidden).</summary>
+    public const long Forbidden = 18;
+
+    /// <summary>
+    /// True iff the status represents a halt-equivalent stop on order
+    /// submission (PAUSE or FORBIDDEN). The other documented values
+    /// — CLOSE, RESERVED, FINAL_CLOSING_CALL — are scheduled phases
+    /// and are deliberately NOT treated as halts here.
+    /// </summary>
+    public static bool IsHalt(long status) =>
+        status == Pause || status == Forbidden;
+
+    /// <summary>True iff the status represents continuous trading
+    /// (i.e. the venue is open). Used to clear a venue-origin halt
+    /// when the upstream resumes.</summary>
+    public static bool IsOpen(long status) => status == Open;
+}
+
+/// <summary>
+/// Origin of a <c>SymbolHaltService</c> halt. Operator and venue
+/// halts coexist as independent flags on the same symbol — a symbol
+/// is halted iff at least one origin has it halted. This means:
+/// <list type="bullet">
+///   <item>An operator halt is NEVER cleared by a venue resume
+///         (operator stays in control).</item>
+///   <item>A venue halt is NEVER cleared by an operator resume
+///         (the venue is still rejecting orders; clearing would
+///         create a false sense of safety).</item>
+/// </list>
+/// </summary>
+public enum HaltOrigin
+{
+    /// <summary>Local operator halt via <c>/admin/halts</c>.</summary>
+    Operator = 0,
+
+    /// <summary>Venue-originated halt observed via market data
+    /// (Stage A: <c>SecurityTradingStatus</c> deltas; Stage B: a
+    /// dedicated SDK event once available).</summary>
+    Venue = 1,
+}

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -39,6 +39,15 @@ public sealed class RawPlatformSnapshot
     public string[] KilledFirms { get; init; } = Array.Empty<string>();
     public string[] HaltedSymbols { get; init; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Halted symbols with origin flags (#370 Stage A). Authoritative
+    /// post-#370; pre-existing snapshots leave this empty and the
+    /// projection falls back to <see cref="HaltedSymbols"/> tagged as
+    /// operator halts.
+    /// </summary>
+    public B3.Trading.Application.Risk.SymbolHaltEntry[] HaltedSymbolOrigins { get; init; } =
+        Array.Empty<B3.Trading.Application.Risk.SymbolHaltEntry>();
+
     public SessionPhase DefaultPhase { get; init; } = SessionPhase.Continuous;
     public SessionPhaseOverrideRaw[] SessionPhaseOverrides { get; init; } =
         Array.Empty<SessionPhaseOverrideRaw>();

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -50,6 +50,17 @@ public sealed class PlatformSnapshot
     public List<string> HaltedSymbols { get; init; } = new();
 
     /// <summary>
+    /// Halted symbols with their origin bitmask
+    /// (<see cref="B3.Trading.Application.Risk.SymbolHaltEntry.Flags"/>:
+    /// Operator=1, Venue=2). Added in #370 Stage A; older snapshots
+    /// pre-date the field and deserialise empty, in which case the
+    /// snapshotter falls back to <see cref="HaltedSymbols"/> and
+    /// treats every entry as an operator halt (the only origin that
+    /// existed pre-#370).
+    /// </summary>
+    public List<SymbolHaltOriginSnapshot> HaltedSymbolOrigins { get; init; } = new();
+
+    /// <summary>
     /// Global default <see cref="B3.Trading.Domain.SessionPhase"/>
     /// (#108) — applied when a symbol has no override. Older snapshots
     /// pre-date the field and deserialise as <c>"Continuous"</c>, which
@@ -600,6 +611,13 @@ public sealed record AlgoIdCounterSnapshot(string FirmId, long Counter);
 /// enum name for forward-compat across reorderings.
 /// </summary>
 public sealed record SessionPhaseOverrideSnapshot(string Symbol, string Phase);
+
+/// <summary>
+/// A halted symbol with its origin bitmask (Operator=1, Venue=2,
+/// both=3). Wire form for <see cref="PlatformSnapshot.HaltedSymbolOrigins"/>.
+/// Added by #370 Stage A.
+/// </summary>
+public sealed record SymbolHaltOriginSnapshot(string Symbol, byte Flags);
 
 /// <summary>
 /// Q4.1 (#301). One per-firm row of the

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -431,12 +431,26 @@ public sealed record KillSwitchToggledEvent : WalEvent
 /// when, and why" — and the only way recovery reconstructs the halt
 /// set, since halts are an out-of-band admin decision rather than a
 /// side-effect of an exchange ER.
+///
+/// <para>
+/// <see cref="Origin"/> distinguishes operator vs venue halts
+/// (#370 Stage A). Null on legacy events (pre-#370) — recovery treats
+/// the absence as <see cref="B3.Trading.Application.MarketData.HaltOrigin.Operator"/>,
+/// matching the single-origin behaviour that existed before the slice.
+/// </para>
 /// </summary>
 public sealed record SymbolHaltToggledEvent : WalEvent
 {
     public required string Symbol { get; init; }
     public required bool Halted { get; init; }    // true=halt, false=resume
     public string? ActorUserId { get; init; }
+
+    /// <summary>
+    /// Origin of the halt/resume. Null on legacy events; new code
+    /// always sets it. See
+    /// <see cref="B3.Trading.Application.MarketData.HaltOrigin"/>.
+    /// </summary>
+    public B3.Trading.Application.MarketData.HaltOrigin? Origin { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Risk/SymbolHaltService.cs
+++ b/backend/src/B3.Trading.Application/Risk/SymbolHaltService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using B3.Trading.Application.MarketData;
 
 namespace B3.Trading.Application.Risk;
 
@@ -23,18 +24,99 @@ namespace B3.Trading.Application.Risk;
 /// survives a process restart — losing it on crash would be the
 /// worst possible default for a safety control.
 /// </para>
+///
+/// <para>
+/// <b>Halt origin (#370 Stage A):</b> halts carry a
+/// <see cref="HaltOrigin"/> tag (<see cref="HaltOrigin.Operator"/>
+/// for <c>/admin/halts</c>, <see cref="HaltOrigin.Venue"/> for halts
+/// observed via market data). The two origins are independent flags:
+/// a symbol is halted iff at least one origin has it halted, so an
+/// operator halt is never cleared by a venue resume (operator stays
+/// in control) and a venue halt is never cleared by an operator
+/// resume (would create a false sense of safety while the venue is
+/// still rejecting). See <see cref="HaltOrigin"/> for the rationale.
+/// </para>
 /// </summary>
 public sealed class SymbolHaltService
 {
+    // Bit-flag per origin (Operator=1, Venue=2). A symbol is halted
+    // iff its value is != 0. ConcurrentDictionary gives us atomic
+    // reads for IsHalted on the risk-pipeline hot path without
+    // taking a lock; mutations go through Halt/Resume which AddOrUpdate.
     private readonly ConcurrentDictionary<string, byte> _haltedSymbols =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private static byte FlagOf(HaltOrigin origin) => (byte)(1 << (int)origin);
+
     public bool IsHalted(string symbol) => _haltedSymbols.ContainsKey(symbol);
 
-    public void Halt(string symbol) => _haltedSymbols[symbol] = 1;
-    public bool Resume(string symbol) => _haltedSymbols.TryRemove(symbol, out _);
+    /// <summary>True iff the symbol is halted with at least the
+    /// given origin flag set. Used by callers (e.g. recovery) that
+    /// need to reason about who placed the halt.</summary>
+    public bool IsHaltedBy(string symbol, HaltOrigin origin)
+    {
+        if (_haltedSymbols.TryGetValue(symbol, out var flags))
+            return (flags & FlagOf(origin)) != 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Marks <paramref name="symbol"/> halted by <paramref name="origin"/>.
+    /// Idempotent: re-halting with the same origin is a no-op. If the
+    /// other origin already holds a halt, this adds to it; the symbol
+    /// stays halted until BOTH origins resume.
+    /// </summary>
+    public void Halt(string symbol, HaltOrigin origin = HaltOrigin.Operator)
+    {
+        var flag = FlagOf(origin);
+        _haltedSymbols.AddOrUpdate(symbol, flag, (_, existing) => (byte)(existing | flag));
+    }
+
+    /// <summary>
+    /// Clears the <paramref name="origin"/> flag for
+    /// <paramref name="symbol"/>. Returns true iff the symbol was
+    /// halted by that origin and is now fully cleared (i.e. no other
+    /// origin still holds it halted). Returns false when either the
+    /// symbol was not halted by this origin, or it remains halted by
+    /// the other origin.
+    /// </summary>
+    public bool Resume(string symbol, HaltOrigin origin = HaltOrigin.Operator)
+    {
+        var flag = FlagOf(origin);
+        while (_haltedSymbols.TryGetValue(symbol, out var existing))
+        {
+            if ((existing & flag) == 0) return false; // not halted by this origin
+            var next = (byte)(existing & ~flag);
+            if (next == 0)
+            {
+                if (_haltedSymbols.TryRemove(new KeyValuePair<string, byte>(symbol, existing)))
+                    return true;
+            }
+            else
+            {
+                if (_haltedSymbols.TryUpdate(symbol, next, existing))
+                    return false; // still halted by the other origin
+            }
+            // CAS lost a race — retry.
+        }
+        return false;
+    }
 
     public IReadOnlyCollection<string> ListHalted() => _haltedSymbols.Keys.ToArray();
+
+    /// <summary>
+    /// Returns the current halt set along with each symbol's origin
+    /// flags (Operator=1, Venue=2, both=3). Used by the snapshotter
+    /// to capture origin alongside the symbol list.
+    /// </summary>
+    public IReadOnlyCollection<SymbolHaltEntry> ListHaltedWithOrigin()
+    {
+        var snapshot = _haltedSymbols.ToArray();
+        var entries = new SymbolHaltEntry[snapshot.Length];
+        for (var i = 0; i < snapshot.Length; i++)
+            entries[i] = new SymbolHaltEntry(snapshot[i].Key, snapshot[i].Value);
+        return entries;
+    }
 
     /// <summary>
     /// Phase-1 (lock-side) capture for the two-phase snapshot pipeline
@@ -55,10 +137,50 @@ public sealed class SymbolHaltService
         return i == raw.Length ? raw : raw[..i];
     }
 
+    /// <summary>
+    /// Raw snapshot with origin flags. New format added by #370 Stage A;
+    /// see <see cref="ListHaltedWithOrigin"/>.
+    /// </summary>
+    public SymbolHaltEntry[] RawSnapshotWithOrigin()
+    {
+        var snapshot = _haltedSymbols.ToArray();
+        if (snapshot.Length == 0) return Array.Empty<SymbolHaltEntry>();
+        var entries = new SymbolHaltEntry[snapshot.Length];
+        for (var i = 0; i < snapshot.Length; i++)
+            entries[i] = new SymbolHaltEntry(snapshot[i].Key, snapshot[i].Value);
+        return entries;
+    }
+
     public void Restore(IEnumerable<string> haltedSymbols)
     {
         ArgumentNullException.ThrowIfNull(haltedSymbols);
         _haltedSymbols.Clear();
-        foreach (var s in haltedSymbols) _haltedSymbols[s] = 1;
+        // Legacy path — pre-#370 snapshots only carried the symbol
+        // list, no origin. Treat them as operator halts so the
+        // existing /admin/halts DELETE keeps working after recovery.
+        var operatorFlag = FlagOf(HaltOrigin.Operator);
+        foreach (var s in haltedSymbols) _haltedSymbols[s] = operatorFlag;
+    }
+
+    /// <summary>
+    /// Restore with origin flags. Used by the snapshotter when
+    /// replaying post-#370 snapshots.
+    /// </summary>
+    public void RestoreWithOrigin(IEnumerable<SymbolHaltEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        _haltedSymbols.Clear();
+        foreach (var e in entries)
+        {
+            if (e.Flags == 0) continue; // defensive: ignore cleared rows
+            _haltedSymbols[e.Symbol] = e.Flags;
+        }
     }
 }
+
+/// <summary>
+/// A halted symbol with its origin bitmask
+/// (Operator=1, Venue=2, both=3). Carried in snapshots so the
+/// origin distinction survives recovery.
+/// </summary>
+public readonly record struct SymbolHaltEntry(string Symbol, byte Flags);

--- a/backend/src/B3.Trading.Application/Risk/VenueHaltSubscriber.cs
+++ b/backend/src/B3.Trading.Application/Risk/VenueHaltSubscriber.cs
@@ -1,0 +1,153 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Bridges venue-originated trading-status changes
+/// (<see cref="IMarketDataSubscriber.TradingStatusChanged"/>) into
+/// <see cref="SymbolHaltService"/>, audited via
+/// <see cref="SymbolHaltToggledEvent"/> with
+/// <see cref="HaltOrigin.Venue"/>.
+///
+/// <para>
+/// Stage A of #370: the SDK does not surface a dedicated halt event
+/// yet (tracked in <c>B3MarketDataPlatform#40</c>), so the
+/// <see cref="SdkMarketDataSubscriber"/> watches
+/// <c>InfoSnapshot.TradingStatus</c> for changes and raises the
+/// app-side event. This subscriber translates raw SBE
+/// <c>SecurityTradingStatus</c> codes (PAUSE / OPEN / FORBIDDEN) into
+/// halt/resume operations on the operator-independent venue origin
+/// flag. Operator halts placed via <c>/admin/halts</c> are unaffected
+/// by venue resumes (and vice versa) — see <see cref="HaltOrigin"/>.
+/// </para>
+///
+/// <para>
+/// Dispatched events go through <see cref="EventDispatcher"/> like
+/// any other audited mutation, so the venue halt survives a process
+/// restart and shows up in the WAL alongside operator halts. The
+/// <c>"origin" = "venue"</c> tag on
+/// <c>trading.symbol_halt.toggled</c> lets ops separate the two
+/// streams in dashboards.
+/// </para>
+///
+/// <para>
+/// Codes other than <c>PAUSE</c>, <c>FORBIDDEN</c> and <c>OPEN</c>
+/// are deliberately ignored here: <c>CLOSE</c>, <c>RESERVED</c> and
+/// <c>FINAL_CLOSING_CALL</c> are scheduled session phases owned by
+/// <c>SessionPhaseService</c>, not halts. Surfacing them as halts
+/// would mis-attribute every pre-open to a regulatory action.
+/// </para>
+/// </summary>
+public sealed class VenueHaltSubscriber : IHostedService, IAsyncDisposable
+{
+    private readonly IMarketDataSubscriber _subscriber;
+    private readonly SymbolHaltService _haltService;
+    private readonly EventDispatcher _dispatcher;
+    private readonly ILogger<VenueHaltSubscriber>? _logger;
+    private int _started;
+
+    public VenueHaltSubscriber(
+        IMarketDataSubscriber subscriber,
+        SymbolHaltService haltService,
+        EventDispatcher dispatcher,
+        ILogger<VenueHaltSubscriber>? logger = null)
+    {
+        _subscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
+        _haltService = haltService ?? throw new ArgumentNullException(nameof(haltService));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Subscribe at most once even if the hosted service framework
+        // calls Start twice (defensive; happens in some test rigs).
+        if (System.Threading.Interlocked.Exchange(ref _started, 1) == 0)
+            _subscriber.TradingStatusChanged += OnTradingStatusChanged;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (System.Threading.Interlocked.Exchange(ref _started, 0) == 1)
+            _subscriber.TradingStatusChanged -= OnTradingStatusChanged;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (System.Threading.Interlocked.Exchange(ref _started, 0) == 1)
+            _subscriber.TradingStatusChanged -= OnTradingStatusChanged;
+        return ValueTask.CompletedTask;
+    }
+
+    internal void OnTradingStatusChanged(MarketTradingStatusChange change)
+    {
+        var status = change.NewStatus;
+
+        bool halted;
+        if (SecurityTradingStatusCodes.IsHalt(status))
+        {
+            halted = true;
+        }
+        else if (SecurityTradingStatusCodes.IsOpen(status))
+        {
+            halted = false;
+        }
+        else
+        {
+            // Phase code (CLOSE / RESERVED / FINAL_CLOSING_CALL / …) —
+            // not a halt; SessionPhaseService owns it.
+            return;
+        }
+
+        // Suppress no-op transitions: if the venue origin already has
+        // the desired state we do not touch the WAL. Halting twice
+        // from the same origin would otherwise produce a stream of
+        // identical SymbolHaltToggledEvent records in the audit log.
+        var alreadyHaltedByVenue = _haltService.IsHaltedBy(change.Symbol, HaltOrigin.Venue);
+        if (halted == alreadyHaltedByVenue) return;
+
+        try
+        {
+            _dispatcher.Dispatch(
+                new SymbolHaltToggledEvent
+                {
+                    Symbol = change.Symbol,
+                    Halted = halted,
+                    ActorUserId = null, // venue-originated, no operator
+                    Origin = HaltOrigin.Venue,
+                },
+                () =>
+                {
+                    if (halted) _haltService.Halt(change.Symbol, HaltOrigin.Venue);
+                    else _haltService.Resume(change.Symbol, HaltOrigin.Venue);
+                });
+
+            MetricsRegistry.SymbolHaltToggled.Add(1,
+                new KeyValuePair<string, object?>("halted", halted),
+                new KeyValuePair<string, object?>("origin", "venue"));
+
+            _logger?.LogInformation(
+                "Venue halt {Action} for {Symbol}: status {PreviousStatus} → {NewStatus}",
+                halted ? "applied" : "cleared",
+                change.Symbol,
+                change.PreviousStatus,
+                change.NewStatus);
+        }
+        catch (Exception ex)
+        {
+            // Never let a venue halt failure tear down the SDK reader
+            // loop. The next status delta will retry; missing one halt
+            // is worse than missing a hundred, but worse still is
+            // losing the market-data feed entirely.
+            _logger?.LogError(ex,
+                "Failed to apply venue halt for {Symbol} (status {NewStatus})",
+                change.Symbol, change.NewStatus);
+        }
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -151,6 +151,17 @@ public static class TradingApplicationCoreServiceCollectionExtensions
             sp.GetRequiredService<B3.Trading.Application.MarketData.AuctionStateStore>());
         services.AddHostedService(sp =>
             sp.GetRequiredService<B3.Trading.Application.MarketData.AuctionStateStore>());
+
+        // #370 Stage A. Bridges venue-originated trading-status deltas
+        // observed by the market-data adapter into SymbolHaltService,
+        // audited via SymbolHaltToggledEvent { Origin = Venue }. Lives
+        // here (next to the other MD-driven singletons) so wiring stays
+        // colocated; the subscriber itself is in B3.Trading.Application
+        // because the service it bridges to is.
+        services.AddSingleton<B3.Trading.Application.Risk.VenueHaltSubscriber>();
+        services.AddHostedService(sp =>
+            sp.GetRequiredService<B3.Trading.Application.Risk.VenueHaltSubscriber>());
+
         services.AddSingleton<WebSocketAuctionEventSink>();
         services.AddHostedService(sp => sp.GetRequiredService<WebSocketAuctionEventSink>());
 

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -61,6 +61,16 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketAuctionImbalance>? AuctionImbalance;
     public event Action<MarketAuctionPrint>? AuctionPrint;
 
+    // ── #370 Stage A — venue trading-status delta detection ─────────
+    // SDK 0.4.0 carries TradingStatus as a nullable long inside
+    // InfoSnapshotEvent. The application seam wants a discrete event,
+    // not a snapshot stream, so we keep the last observed value per
+    // symbol here and only raise when it changes. Single-threaded
+    // access from the SDK callback path; no lock needed.
+    public event Action<MarketTradingStatusChange>? TradingStatusChanged;
+    private readonly Dictionary<string, long> _lastTradingStatus =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public SdkMarketDataSubscriber(
         MarketDataClient client,
         ILogger<SdkMarketDataSubscriber> logger,
@@ -156,6 +166,32 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
             imbalanceSide: TranslateAuctionSide(ev.AuctionImbalanceCondition),
             tradingStatus: ev.TradingStatus,
             receivedUtc: receivedUtc);
+
+        // #370 Stage A: surface a TradingStatus delta only when the
+        // SDK actually carries the field and the value changed. The
+        // wire encodes status as long? (SBE SecurityTradingStatus
+        // codes) — see SecurityTradingStatusCodes for the values
+        // VenueHaltSubscriber interprets.
+        if (ev.TradingStatus is { } status)
+        {
+            long? previous = null;
+            var changed = true;
+            if (_lastTradingStatus.TryGetValue(ev.Symbol, out var prev))
+            {
+                previous = prev;
+                changed = prev != status;
+            }
+            if (changed)
+            {
+                _lastTradingStatus[ev.Symbol] = status;
+                TradingStatusChanged?.Invoke(new MarketTradingStatusChange(
+                    Symbol: ev.Symbol,
+                    SecurityId: ev.SecurityId,
+                    PreviousStatus: previous,
+                    NewStatus: status,
+                    ReceivedUtc: receivedUtc));
+            }
+        }
     }
 
     private static OrderSide? TranslateAuctionSide(SdkAuctionCondition? c) => c switch

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -163,6 +163,7 @@ public sealed class StateSnapshotter
         KilledEndClients = _killSwitch.RawSnapshotKilledEndClients(),
         KilledFirms = _killSwitch.RawSnapshotKilledFirms(),
         HaltedSymbols = _symbolHalts.RawSnapshot(),
+        HaltedSymbolOrigins = _symbolHalts.RawSnapshotWithOrigin(),
         DefaultPhase = _sessionPhases.DefaultPhase,
         SessionPhaseOverrides = _sessionPhases.RawSnapshotOverrides(),
         ClOrdIds = _clOrdIds.RawSnapshot(),
@@ -462,6 +463,11 @@ public sealed class StateSnapshotter
             KilledEndClients = new List<string>(raw.KilledEndClients),
             KilledFirms = new List<string>(raw.KilledFirms),
             HaltedSymbols = new List<string>(raw.HaltedSymbols),
+            HaltedSymbolOrigins = raw.HaltedSymbolOrigins.Length == 0
+                ? new List<SymbolHaltOriginSnapshot>()
+                : raw.HaltedSymbolOrigins
+                    .Select(e => new SymbolHaltOriginSnapshot(e.Symbol, e.Flags))
+                    .ToList(),
             DefaultSessionPhase = raw.DefaultPhase.ToString(),
             SessionPhaseOverrides = phaseOverrides,
             ClOrdIds = clOrdIds,
@@ -498,7 +504,17 @@ public sealed class StateSnapshotter
         _orders.Restore(snap.WorkingOrders);
         _positions.Restore(snap.Positions);
         _killSwitch.Restore(snap.KilledEndClients, snap.KilledFirms);
-        _symbolHalts.Restore(snap.HaltedSymbols);
+        // #370 Stage A: prefer origin-bearing list when present;
+        // fall back to the legacy string list (treat as Operator).
+        if (snap.HaltedSymbolOrigins is { Count: > 0 })
+        {
+            _symbolHalts.RestoreWithOrigin(snap.HaltedSymbolOrigins
+                .Select(s => new B3.Trading.Application.Risk.SymbolHaltEntry(s.Symbol, s.Flags)));
+        }
+        else
+        {
+            _symbolHalts.Restore(snap.HaltedSymbols);
+        }
         var defaultPhase = Enum.TryParse<SessionPhase>(snap.DefaultSessionPhase, ignoreCase: true, out var dp)
             ? dp : SessionPhase.Continuous;
         var overrides = snap.SessionPhaseOverrides
@@ -1045,8 +1061,9 @@ public sealed class EventReplayer
                 }
                 break;
             case SymbolHaltToggledEvent sh:
-                if (sh.Halted) _symbolHalts.Halt(sh.Symbol);
-                else _symbolHalts.Resume(sh.Symbol);
+                var origin = sh.Origin ?? B3.Trading.Application.MarketData.HaltOrigin.Operator;
+                if (sh.Halted) _symbolHalts.Halt(sh.Symbol, origin);
+                else _symbolHalts.Resume(sh.Symbol, origin);
                 break;
             case SessionPhaseChangedEvent sp:
                 if (string.IsNullOrWhiteSpace(sp.Symbol))

--- a/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AuctionWebSocketChannelTests.cs
@@ -202,6 +202,7 @@ public class AuctionWebSocketChannelTests
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
 #pragma warning disable CS0067
+        public event Action<MarketTradingStatusChange>? TradingStatusChanged;
         public event Action<MarketBookSnapshot>? BookSnapshot;
         public event Action<MarketOrderAdded>? OrderAdded;
         public event Action<MarketOrderUpdated>? OrderUpdated;

--- a/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PnlRefPriceFanOutTests.cs
@@ -33,6 +33,7 @@ public class PnlRefPriceFanOutTests
         public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
+        public event Action<MarketTradingStatusChange>? TradingStatusChanged;
         public event Action<MarketBookSnapshot>? BookSnapshot;
         public event Action<MarketOrderAdded>? OrderAdded;
         public event Action<MarketOrderUpdated>? OrderUpdated;

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/MarketDataVolumePumpTests.cs
@@ -193,6 +193,7 @@ public class MarketDataVolumePumpTests
         public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
         public event Action<MarketAuctionImbalance>? AuctionImbalance;
         public event Action<MarketAuctionPrint>? AuctionPrint;
+        public event Action<MarketTradingStatusChange>? TradingStatusChanged;
         public event Action<MarketBookSnapshot>? BookSnapshot;
         public event Action<MarketOrderAdded>? OrderAdded;
         public event Action<MarketOrderUpdated>? OrderUpdated;

--- a/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketDataReferencePriceTests.cs
@@ -211,6 +211,7 @@ internal sealed class FakeMarketDataSubscriber : IMarketDataSubscriber
     public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<MarketAuctionImbalance>? AuctionImbalance;
     public event Action<MarketAuctionPrint>? AuctionPrint;
+    public event Action<MarketTradingStatusChange>? TradingStatusChanged;
     public event Action<MarketBookSnapshot>? BookSnapshot;
     public event Action<MarketOrderAdded>? OrderAdded;
     public event Action<MarketOrderUpdated>? OrderUpdated;

--- a/backend/tests/B3.Trading.Application.Tests/Risk/SymbolHaltOriginTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Risk/SymbolHaltOriginTests.cs
@@ -1,0 +1,237 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Infrastructure.Persistence;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #370 Stage A — operator/venue origin semantics for
+/// <see cref="SymbolHaltService"/> and the
+/// <see cref="VenueHaltSubscriber"/> bridge.
+/// </summary>
+public sealed class SymbolHaltOriginTests
+{
+    // ── SymbolHaltService origin semantics ─────────────────────────
+
+    [Fact]
+    public void OperatorAndVenueAreIndependentFlags()
+    {
+        var svc = new SymbolHaltService();
+        svc.Halt("PETR4", HaltOrigin.Operator);
+        svc.Halt("PETR4", HaltOrigin.Venue);
+
+        Assert.True(svc.IsHalted("PETR4"));
+        Assert.True(svc.IsHaltedBy("PETR4", HaltOrigin.Operator));
+        Assert.True(svc.IsHaltedBy("PETR4", HaltOrigin.Venue));
+
+        // Venue resume — operator still has it halted.
+        var fullyCleared = svc.Resume("PETR4", HaltOrigin.Venue);
+        Assert.False(fullyCleared);
+        Assert.True(svc.IsHalted("PETR4"));
+        Assert.True(svc.IsHaltedBy("PETR4", HaltOrigin.Operator));
+        Assert.False(svc.IsHaltedBy("PETR4", HaltOrigin.Venue));
+
+        // Operator resume — fully cleared now.
+        fullyCleared = svc.Resume("PETR4", HaltOrigin.Operator);
+        Assert.True(fullyCleared);
+        Assert.False(svc.IsHalted("PETR4"));
+    }
+
+    [Fact]
+    public void ResumeReturnsFalseWhenOriginNotHalting()
+    {
+        var svc = new SymbolHaltService();
+        Assert.False(svc.Resume("PETR4", HaltOrigin.Venue));
+        svc.Halt("PETR4", HaltOrigin.Operator);
+        Assert.False(svc.Resume("PETR4", HaltOrigin.Venue));
+        Assert.True(svc.IsHalted("PETR4"));
+    }
+
+    [Fact]
+    public void HaltIsIdempotentPerOrigin()
+    {
+        var svc = new SymbolHaltService();
+        svc.Halt("PETR4", HaltOrigin.Venue);
+        svc.Halt("PETR4", HaltOrigin.Venue);
+        Assert.True(svc.Resume("PETR4", HaltOrigin.Venue)); // first resume clears
+        Assert.False(svc.IsHalted("PETR4"));
+    }
+
+    [Fact]
+    public void RawSnapshotWithOriginRoundTripsViaRestoreWithOrigin()
+    {
+        var src = new SymbolHaltService();
+        src.Halt("PETR4", HaltOrigin.Operator);
+        src.Halt("PETR4", HaltOrigin.Venue);
+        src.Halt("VALE3", HaltOrigin.Venue);
+        src.Halt("ITUB4", HaltOrigin.Operator);
+
+        var snapshot = src.RawSnapshotWithOrigin();
+        Assert.Equal(3, snapshot.Length);
+
+        var dst = new SymbolHaltService();
+        dst.RestoreWithOrigin(snapshot);
+
+        Assert.True(dst.IsHaltedBy("PETR4", HaltOrigin.Operator));
+        Assert.True(dst.IsHaltedBy("PETR4", HaltOrigin.Venue));
+        Assert.False(dst.IsHaltedBy("VALE3", HaltOrigin.Operator));
+        Assert.True(dst.IsHaltedBy("VALE3", HaltOrigin.Venue));
+        Assert.True(dst.IsHaltedBy("ITUB4", HaltOrigin.Operator));
+        Assert.False(dst.IsHaltedBy("ITUB4", HaltOrigin.Venue));
+    }
+
+    [Fact]
+    public void LegacyRestoreCoercesToOperator()
+    {
+        var svc = new SymbolHaltService();
+        svc.Halt("OLD", HaltOrigin.Venue);
+        svc.Restore(new[] { "PETR4", "VALE3" });
+
+        Assert.False(svc.IsHalted("OLD"));
+        Assert.True(svc.IsHaltedBy("PETR4", HaltOrigin.Operator));
+        Assert.False(svc.IsHaltedBy("PETR4", HaltOrigin.Venue));
+        Assert.True(svc.IsHaltedBy("VALE3", HaltOrigin.Operator));
+    }
+
+    // ── VenueHaltSubscriber translation ────────────────────────────
+
+    [Fact]
+    public async Task VenueSubscriber_TranslatesPauseAndOpenAndIgnoresPhaseCodes()
+    {
+        var fake = new FakeMdSubscriber();
+        var halts = new SymbolHaltService();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var sub = new VenueHaltSubscriber(fake, halts, dispatcher);
+        await sub.StartAsync(CancellationToken.None);
+
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Pause);
+        Assert.True(halts.IsHaltedBy("PETR4", HaltOrigin.Venue));
+        Assert.Single(store.HaltEvents);
+        Assert.Equal(HaltOrigin.Venue, store.HaltEvents[0].Origin);
+        Assert.True(store.HaltEvents[0].Halted);
+
+        // CLOSE / RESERVED / FINAL_CLOSING_CALL are phases → ignored.
+        fake.Raise("PETR4", 4);
+        fake.Raise("PETR4", 21);
+        fake.Raise("PETR4", 101);
+        Assert.True(halts.IsHaltedBy("PETR4", HaltOrigin.Venue));
+        Assert.Single(store.HaltEvents);
+
+        // OPEN clears the venue halt.
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Open);
+        Assert.False(halts.IsHaltedBy("PETR4", HaltOrigin.Venue));
+        Assert.Equal(2, store.HaltEvents.Count);
+        Assert.False(store.HaltEvents[1].Halted);
+    }
+
+    [Fact]
+    public async Task VenueSubscriber_SuppressesNoOpTransitions()
+    {
+        var fake = new FakeMdSubscriber();
+        var halts = new SymbolHaltService();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var sub = new VenueHaltSubscriber(fake, halts, dispatcher);
+        await sub.StartAsync(CancellationToken.None);
+
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Pause);
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Forbidden); // still a halt
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Pause);     // still a halt
+        Assert.Single(store.HaltEvents);
+
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Open);
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Open); // already resumed
+        Assert.Equal(2, store.HaltEvents.Count);
+    }
+
+    [Fact]
+    public async Task VenueResumeLeavesOperatorHaltIntact()
+    {
+        var fake = new FakeMdSubscriber();
+        var halts = new SymbolHaltService();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var sub = new VenueHaltSubscriber(fake, halts, dispatcher);
+        await sub.StartAsync(CancellationToken.None);
+
+        halts.Halt("PETR4", HaltOrigin.Operator);
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Pause); // venue halts too
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Open);  // venue clears
+
+        Assert.True(halts.IsHalted("PETR4"));
+        Assert.True(halts.IsHaltedBy("PETR4", HaltOrigin.Operator));
+        Assert.False(halts.IsHaltedBy("PETR4", HaltOrigin.Venue));
+    }
+
+    [Fact]
+    public async Task VenueSubscriber_StopUnsubscribes()
+    {
+        var fake = new FakeMdSubscriber();
+        var halts = new SymbolHaltService();
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var sub = new VenueHaltSubscriber(fake, halts, dispatcher);
+        await sub.StartAsync(CancellationToken.None);
+        await sub.StopAsync(CancellationToken.None);
+
+        fake.Raise("PETR4", SecurityTradingStatusCodes.Pause);
+        Assert.Empty(store.HaltEvents);
+        Assert.False(halts.IsHalted("PETR4"));
+    }
+
+    // ── test doubles ───────────────────────────────────────────────
+
+    private sealed class FakeMdSubscriber : IMarketDataSubscriber
+    {
+#pragma warning disable CS0067
+        public event Action<MarketTrade>? Trade;
+        public event Action<MarketInfoSnapshot>? InfoSnapshot;
+        public event Action<MarketDataConnectionState>? ConnectionStateChanged;
+        public event Action<MarketSubscribeError>? SubscribeError;
+        public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
+        public event Action<MarketAuctionImbalance>? AuctionImbalance;
+        public event Action<MarketAuctionPrint>? AuctionPrint;
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+        public event Action<MarketBookCleared>? BookCleared;
+#pragma warning restore CS0067
+        public event Action<MarketTradingStatusChange>? TradingStatusChanged;
+
+        public MarketDataConnectionState State => MarketDataConnectionState.Connected;
+        public long DroppedEventCount => 0;
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask SubscribeAsync(string symbol, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void Raise(string symbol, long status) =>
+            TradingStatusChanged?.Invoke(new MarketTradingStatusChange(
+                symbol, SecurityId: 0, PreviousStatus: null,
+                NewStatus: status, ReceivedUtc: DateTimeOffset.UtcNow));
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        private long _seq;
+        public List<SymbolHaltToggledEvent> HaltEvents { get; } = new();
+        public long CurrentSeq => _seq;
+        public long Append(WalEvent evt)
+        {
+            if (evt is SymbolHaltToggledEvent sh) HaltEvents.Add(sh);
+            return ++_seq;
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> preSerialisedPayload) => Append(evt);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Resolves Stage A of #370.

## Summary
Wires venue-originated trading-status changes (PAUSE / FORBIDDEN / OPEN observed via UMDF `InfoSnapshot.TradingStatus`) into `SymbolHaltService` so risk pre-trade rejects orders the venue itself is already refusing — closing the gap left by upstream #322 landing without trading-host consumption.

## Surface changes
- New `HaltOrigin` enum (`Operator` / `Venue`) — bitmask flags on `SymbolHaltService`; operator and venue halts are independent (venue resume never clears an operator halt and vice versa).
- New `MarketTradingStatusChange` + `SecurityTradingStatusCodes` (raw SBE values centralised).
- `IMarketDataSubscriber.TradingStatusChanged` event. `SdkMarketDataSubscriber` remembers last status per symbol and emits deltas only.
- `VenueHaltSubscriber` (IHostedService) translates PAUSE/FORBIDDEN→halt, OPEN→resume; ignores CLOSE/RESERVED/FINAL_CLOSING_CALL (those are session phases). Suppresses no-op transitions. Logs+swallows exceptions to protect SDK reader loop.
- `SymbolHaltToggledEvent.Origin` (nullable, back-compat); snapshots gain `HaltedSymbolOrigins`; legacy snapshot list restores as Operator.
- `/admin/halts` and metric tagged `origin=operator` / `origin=venue`.

## Stage B (deferred)
SDK 0.2.0 has no dedicated halt event; Stage A uses InfoSnapshot delta detection. Replace with typed event when `B3MarketDataPlatform#40` ships.

## Tests
- New `SymbolHaltOriginTests` (10): origin independence, idempotent halt, raw snapshot round-trip, legacy restore coercion, venue subscriber translation/dedup/stop, operator-halt preservation under venue resume.
- Full Application (1102/1103 — 1 known flake `GtdSchedulerRegressionTests.DispatchExpire_WalBackpressureOnCancel...` passes on rerun) + Api (500/500) suites green.
- `dotnet format` clean.