### PR TITLE
chore(deps): bump B3.MarketData.WebSocketClient 0.2.0 → 0.4.0

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.3" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
-    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.2.0" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.4.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />


### PR DESCRIPTION
## Summary
Bumps `B3.MarketData.WebSocketClient` from 0.2.0 to 0.4.0. Single-file diff in `backend/Directory.Packages.props`.

## Upstream content (all additive over 0.2.0)
- **#42** — full server parity surface (MBO/MBP/News/Candles/Rankings).
- **#44** (closes upstream #43) — opt-in `IBookFeed`/`IBookView` Phase 1.
- **#45** (closes upstream #40) — auction fields surfaced in `InfoSnapshot`.
- **#47** — `AuctionPrint` flag end-to-end.
- **#53** — `IBookFeed` Phase 2: depth-N + auto-evict on Unsubscribe.

We consume **none** of the new surface in this PR — it's a pure pin bump to unblock the follow-ups.

## Follow-ups (separate PRs)
1. **Auction wiring** — wire `TheoreticalOpening`/`AuctionImbalance`/`AuctionPrint` in `SdkMarketDataSubscriber` (#263/upstream #40 surface).
2. **`MboBookStore` → `IBookFeed` migration** — delete ~250 LOC and consume `IBookFeed` directly. Phase 2's depth-N + auto-evict covers our use.
3. **Stage B of #370 (venue halt typed event)** still deferred — upstream has no dedicated event in this drop.

## Validation
- `dotnet build B3TradingPlatform.slnx` → clean.
- `dotnet test` → 1094/1094 Application, 134/134 EntryPointListener, 499/500 Api (1 known flake: `MetricsFirmTagTests.OrdersSubmittedCounter_CarriesFirmIdTag` — MeterListener race; passes on rerun).