### PR TITLE
feat(md): wire SDK 0.4.0 auction events end-to-end (#263)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.3" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
-    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.2.0" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.4.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/backend/src/B3.Trading.Application/MarketData/AuctionProjector.cs
+++ b/backend/src/B3.Trading.Application/MarketData/AuctionProjector.cs
@@ -1,0 +1,163 @@
+using System.Collections.Concurrent;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Pure projection of upstream market-data auction fields into the
+/// application-side <see cref="MarketTheoreticalOpening"/>,
+/// <see cref="MarketAuctionImbalance"/> and <see cref="MarketAuctionPrint"/>
+/// deltas. Stateful in the small: it remembers the last value emitted per
+/// symbol so cumulative snapshots from the SDK (re-published with every
+/// frame) collapse into change events only.
+///
+/// <para>Lives in <c>B3.Trading.Application</c> on purpose — the host
+/// adapter (<c>SdkMarketDataSubscriber</c>) translates SDK enums into
+/// primitives + <see cref="OrderSide"/> and hands them here, so the
+/// projector stays free of any SDK package reference and is
+/// directly unit-testable.</para>
+///
+/// <para><b>Trading-status codes</b>: <see cref="ReservedTradingStatus"/>
+/// (21) and <see cref="FinalClosingCallTradingStatus"/> (101) come from the
+/// B3 UMDF SBE schema 2.2.0 (<c>SecurityTradingStatus</c>). They drive
+/// <see cref="MarketAuctionPrint.Kind"/>: an auction cross emitted while
+/// the venue reports <c>FINAL_CLOSING_CALL</c> is a closing print; everything
+/// else (opening / reopening) is an opening print.</para>
+/// </summary>
+public sealed class AuctionProjector
+{
+    /// <summary>B3 SBE <c>SecurityTradingStatus</c> code for pre-open / reserved.</summary>
+    public const long ReservedTradingStatus = 21;
+
+    /// <summary>B3 SBE <c>SecurityTradingStatus</c> code for the final closing call.</summary>
+    public const long FinalClosingCallTradingStatus = 101;
+
+    private readonly ConcurrentDictionary<string, SymbolState> _bySymbol = new(StringComparer.Ordinal);
+
+    /// <summary>Fires when the theoretical-opening (price, qty) pair changes for a symbol.</summary>
+    public event Action<MarketTheoreticalOpening>? TheoreticalOpening;
+
+    /// <summary>Fires when the auction imbalance (qty + pending side) changes for a symbol.</summary>
+    public event Action<MarketAuctionImbalance>? AuctionImbalance;
+
+    /// <summary>Fires for every trade flagged as an auction print.</summary>
+    public event Action<MarketAuctionPrint>? AuctionPrint;
+
+    /// <summary>
+    /// Ingest one info snapshot. <paramref name="theoreticalOpeningPrice"/> and
+    /// <paramref name="theoreticalOpeningSize"/> are paired — both must be present
+    /// for a theoretical-opening delta to fire. <paramref name="imbalanceSide"/>
+    /// is <c>null</c> when the venue reports a balanced book or has not yet
+    /// published an imbalance; in that case no imbalance delta fires.
+    /// <paramref name="tradingStatus"/> is remembered so a subsequent auction
+    /// print can be classified as opening vs closing.
+    /// </summary>
+    public void OnInfoSnapshot(
+        string symbol,
+        ulong securityId,
+        decimal? theoreticalOpeningPrice,
+        long? theoreticalOpeningSize,
+        long? imbalanceSize,
+        OrderSide? imbalanceSide,
+        long? tradingStatus,
+        DateTimeOffset receivedUtc)
+    {
+        if (string.IsNullOrEmpty(symbol)) return;
+        var state = _bySymbol.GetOrAdd(symbol, _ => new SymbolState());
+
+        MarketTheoreticalOpening? topDelta = null;
+        MarketAuctionImbalance? imbDelta = null;
+
+        lock (state.Sync)
+        {
+            if (tradingStatus.HasValue)
+            {
+                state.LastTradingStatus = tradingStatus.Value;
+            }
+
+            if (theoreticalOpeningPrice.HasValue && theoreticalOpeningSize.HasValue)
+            {
+                var price = theoreticalOpeningPrice.Value;
+                var qty = theoreticalOpeningSize.Value;
+                if (!state.HasTop || state.LastTopPrice != price || state.LastTopQty != qty)
+                {
+                    state.HasTop = true;
+                    state.LastTopPrice = price;
+                    state.LastTopQty = qty;
+                    topDelta = new MarketTheoreticalOpening(symbol, securityId, price, qty, receivedUtc);
+                }
+            }
+
+            if (imbalanceSize.HasValue && imbalanceSide.HasValue)
+            {
+                var qty = imbalanceSize.Value;
+                var side = imbalanceSide.Value;
+                if (!state.HasImbalance || state.LastImbalanceQty != qty || state.LastImbalanceSide != side)
+                {
+                    state.HasImbalance = true;
+                    state.LastImbalanceQty = qty;
+                    state.LastImbalanceSide = side;
+                    imbDelta = new MarketAuctionImbalance(symbol, securityId, qty, side, receivedUtc);
+                }
+            }
+        }
+
+        if (topDelta is { } t) TheoreticalOpening?.Invoke(t);
+        if (imbDelta is { } i) AuctionImbalance?.Invoke(i);
+    }
+
+    /// <summary>
+    /// Ingest one trade that the SDK has flagged as an auction print
+    /// (<c>TradeFlags.AuctionPrint</c>). The print's
+    /// <see cref="AuctionPrintKind"/> is decided from the last
+    /// <c>TradingStatus</c> observed on the same symbol via
+    /// <see cref="OnInfoSnapshot"/>: <c>FINAL_CLOSING_CALL</c> ⇒ closing,
+    /// anything else (including never-observed) ⇒ opening.
+    /// </summary>
+    public void OnAuctionTrade(
+        string symbol,
+        ulong securityId,
+        decimal price,
+        long qty,
+        DateTimeOffset receivedUtc)
+    {
+        if (string.IsNullOrEmpty(symbol)) return;
+        var state = _bySymbol.GetOrAdd(symbol, _ => new SymbolState());
+
+        AuctionPrintKind kind;
+        bool clearTop;
+        lock (state.Sync)
+        {
+            kind = state.LastTradingStatus == FinalClosingCallTradingStatus
+                ? AuctionPrintKind.Closing
+                : AuctionPrintKind.Opening;
+
+            // The cross has happened: any retained TheoreticalOpening / imbalance
+            // for this symbol is now stale. Drop the memo so the next snapshot
+            // (or a re-auction) re-publishes from scratch instead of being
+            // suppressed as a duplicate.
+            clearTop = state.HasTop || state.HasImbalance;
+            state.HasTop = false;
+            state.HasImbalance = false;
+            state.LastTopPrice = default;
+            state.LastTopQty = default;
+            state.LastImbalanceQty = default;
+            state.LastImbalanceSide = default;
+        }
+
+        _ = clearTop; // documented behavior; nothing else to do under the lock.
+        AuctionPrint?.Invoke(new MarketAuctionPrint(symbol, securityId, kind, price, qty, receivedUtc));
+    }
+
+    private sealed class SymbolState
+    {
+        public readonly object Sync = new();
+        public long? LastTradingStatus;
+        public bool HasTop;
+        public decimal LastTopPrice;
+        public long LastTopQty;
+        public bool HasImbalance;
+        public long LastImbalanceQty;
+        public OrderSide LastImbalanceSide;
+    }
+}

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -1,11 +1,13 @@
 using B3.MarketData.WebSocketClient;
 using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using AppConnState = B3.Trading.Application.MarketData.MarketDataConnectionState;
 using AppTrade = B3.Trading.Application.MarketData.MarketTrade;
 using AppInfoSnapshot = B3.Trading.Application.MarketData.MarketInfoSnapshot;
 using SdkConnState = B3.MarketData.WebSocketClient.ConnectionState;
+using SdkAuctionCondition = B3.MarketData.WebSocketClient.AuctionImbalanceCondition;
 
 namespace B3.Trading.Host.MarketData;
 
@@ -42,22 +44,22 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
     private readonly ILogger<SdkMarketDataSubscriber> _logger;
     private readonly SubscribeFlags _subscribeFlags;
     private readonly bool _bookEnabled;
+    private readonly AuctionProjector _auctionProjector;
 
     public event Action<AppTrade>? Trade;
     public event Action<AppInfoSnapshot>? InfoSnapshot;
     public event Action<AppConnState>? ConnectionStateChanged;
     public event Action<MarketSubscribeError>? SubscribeError;
 
-    // SDK gap: B3.MarketData.WebSocketClient 0.2.0 still does not surface
-    // dedicated auction events. We declare the events on the seam so
-    // AuctionStateStore + WS channels are wired end-to-end; they
-    // simply never fire under the live SDK today. Tests inject a fake
-    // subscriber that raises them. Tracking: B3MarketDataPlatform#40.
-#pragma warning disable CS0067 // event never used — see SDK-gap note above.
+    // Auction events: surfaced by SDK 0.4.0 as cumulative fields on
+    // InfoSnapshotEvent (TheoreticalOpening / AuctionImbalance) and as a
+    // TradeFlags bit on TradeEvent (AuctionPrint). The host adapter funnels
+    // those into AuctionProjector, which collapses cumulative snapshots into
+    // delta events and decides opening vs closing kind from the last
+    // TradingStatus observed for the symbol. Upstream B3MarketDataPlatform#40.
     public event Action<B3.Trading.Application.MarketData.MarketTheoreticalOpening>? TheoreticalOpening;
     public event Action<B3.Trading.Application.MarketData.MarketAuctionImbalance>? AuctionImbalance;
     public event Action<B3.Trading.Application.MarketData.MarketAuctionPrint>? AuctionPrint;
-#pragma warning restore CS0067
 
     public event Action<MarketBookSnapshot>? BookSnapshot;
     public event Action<MarketOrderAdded>? OrderAdded;
@@ -76,6 +78,11 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         _subscribeFlags = _bookEnabled
             ? SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Book
             : SubscribeFlags.Trades | SubscribeFlags.Info;
+
+        _auctionProjector = new AuctionProjector();
+        _auctionProjector.TheoreticalOpening += ev => TheoreticalOpening?.Invoke(ev);
+        _auctionProjector.AuctionImbalance += ev => AuctionImbalance?.Invoke(ev);
+        _auctionProjector.AuctionPrint += ev => AuctionPrint?.Invoke(ev);
 
         _client.Trade += OnSdkTrade;
         _client.InfoSnapshot += OnSdkInfo;
@@ -132,23 +139,48 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
 
     private void OnSdkTrade(TradeEvent ev)
     {
+        var receivedUtc = new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc));
         Trade?.Invoke(new AppTrade(
             Symbol: ev.Symbol,
             SecurityId: ev.SecurityId,
             Price: ev.Price,
             Qty: ev.Qty,
-            ReceivedUtc: new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc))));
+            ReceivedUtc: receivedUtc));
+
+        if ((ev.Flags & TradeFlags.AuctionPrint) != 0)
+        {
+            _auctionProjector.OnAuctionTrade(ev.Symbol, ev.SecurityId, ev.Price, ev.Qty, receivedUtc);
+        }
     }
 
     private void OnSdkInfo(InfoSnapshotEvent ev)
     {
+        var receivedUtc = new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc));
         InfoSnapshot?.Invoke(new AppInfoSnapshot(
             Symbol: ev.Symbol,
             SecurityId: ev.SecurityId,
             LastTradePrice: ev.LastTradePrice,
             TradingReferencePrice: ev.TradingReferencePrice,
-            ReceivedUtc: new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc))));
+            ReceivedUtc: receivedUtc));
+
+        _auctionProjector.OnInfoSnapshot(
+            symbol: ev.Symbol,
+            securityId: ev.SecurityId,
+            theoreticalOpeningPrice: ev.TheoreticalOpeningPrice,
+            theoreticalOpeningSize: ev.TheoreticalOpeningSize,
+            imbalanceSize: ev.AuctionImbalanceSize,
+            imbalanceSide: TranslateAuctionSide(ev.AuctionImbalanceCondition),
+            tradingStatus: ev.TradingStatus,
+            receivedUtc: receivedUtc);
     }
+
+    private static OrderSide? TranslateAuctionSide(SdkAuctionCondition? c) => c switch
+    {
+        SdkAuctionCondition.MoreBuyers => OrderSide.Buy,
+        SdkAuctionCondition.MoreSellers => OrderSide.Sell,
+        // Balanced / Unknown / null → no pending side → no imbalance delta.
+        _ => null,
+    };
 
     private void OnSdkConn(ConnectionStateChangedEvent ev) =>
         ConnectionStateChanged?.Invoke(Translate(ev.State));

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/AuctionProjectorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/AuctionProjectorTests.cs
@@ -1,0 +1,194 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+public class AuctionProjectorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 19, 13, 30, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void TheoreticalOpening_fires_on_first_snapshot_with_price_and_size()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketTheoreticalOpening>();
+        p.TheoreticalOpening += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", securityId: 100, theoreticalOpeningPrice: 30.5m,
+            theoreticalOpeningSize: 1_000, imbalanceSize: null, imbalanceSide: null,
+            tradingStatus: null, receivedUtc: Now);
+
+        var ev = Assert.Single(hits);
+        Assert.Equal("PETR4", ev.Symbol);
+        Assert.Equal(100ul, ev.SecurityId);
+        Assert.Equal(30.5m, ev.Price);
+        Assert.Equal(1_000L, ev.Qty);
+        Assert.Equal(Now, ev.ReceivedUtc);
+    }
+
+    [Fact]
+    public void TheoreticalOpening_does_not_fire_when_only_price_present()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketTheoreticalOpening>();
+        p.TheoreticalOpening += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, theoreticalOpeningPrice: 30.5m,
+            theoreticalOpeningSize: null, imbalanceSize: null, imbalanceSide: null,
+            tradingStatus: null, receivedUtc: Now);
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void TheoreticalOpening_collapses_unchanged_snapshots()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketTheoreticalOpening>();
+        p.TheoreticalOpening += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, null, null, null, Now);
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, null, null, null, Now.AddSeconds(1));
+
+        Assert.Single(hits);
+    }
+
+    [Fact]
+    public void TheoreticalOpening_fires_again_on_price_or_qty_change()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketTheoreticalOpening>();
+        p.TheoreticalOpening += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, null, null, null, Now);
+        p.OnInfoSnapshot("PETR4", 100, 30.6m, 1_000, null, null, null, Now.AddSeconds(1));
+        p.OnInfoSnapshot("PETR4", 100, 30.6m, 1_200, null, null, null, Now.AddSeconds(2));
+
+        Assert.Equal(3, hits.Count);
+        Assert.Equal(30.6m, hits[1].Price);
+        Assert.Equal(1_200L, hits[2].Qty);
+    }
+
+    [Fact]
+    public void AuctionImbalance_fires_with_buy_side_when_more_buyers()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionImbalance>();
+        p.AuctionImbalance += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, null, null, imbalanceSize: 500,
+            imbalanceSide: OrderSide.Buy, tradingStatus: null, receivedUtc: Now);
+
+        var ev = Assert.Single(hits);
+        Assert.Equal(OrderSide.Buy, ev.Side);
+        Assert.Equal(500L, ev.Quantity);
+    }
+
+    [Fact]
+    public void AuctionImbalance_suppressed_when_side_null()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionImbalance>();
+        p.AuctionImbalance += hits.Add;
+
+        // Balanced book or null condition → no delta fires.
+        p.OnInfoSnapshot("PETR4", 100, null, null, imbalanceSize: 0,
+            imbalanceSide: null, tradingStatus: null, receivedUtc: Now);
+
+        Assert.Empty(hits);
+    }
+
+    [Fact]
+    public void AuctionImbalance_collapses_unchanged_and_fires_on_side_flip()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionImbalance>();
+        p.AuctionImbalance += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, null, null, 500, OrderSide.Buy, null, Now);
+        p.OnInfoSnapshot("PETR4", 100, null, null, 500, OrderSide.Buy, null, Now.AddSeconds(1));
+        p.OnInfoSnapshot("PETR4", 100, null, null, 500, OrderSide.Sell, null, Now.AddSeconds(2));
+
+        Assert.Equal(2, hits.Count);
+        Assert.Equal(OrderSide.Buy, hits[0].Side);
+        Assert.Equal(OrderSide.Sell, hits[1].Side);
+    }
+
+    [Fact]
+    public void AuctionPrint_defaults_to_opening_kind_when_no_trading_status_seen()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionPrint>();
+        p.AuctionPrint += hits.Add;
+
+        p.OnAuctionTrade("PETR4", 100, price: 30.0m, qty: 5_000, Now);
+
+        var ev = Assert.Single(hits);
+        Assert.Equal(AuctionPrintKind.Opening, ev.Kind);
+        Assert.Equal(30.0m, ev.Price);
+        Assert.Equal(5_000L, ev.Qty);
+    }
+
+    [Fact]
+    public void AuctionPrint_is_closing_when_last_status_is_final_closing_call()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionPrint>();
+        p.AuctionPrint += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, null, null, null, null,
+            tradingStatus: AuctionProjector.FinalClosingCallTradingStatus, receivedUtc: Now);
+        p.OnAuctionTrade("PETR4", 100, 30.0m, 5_000, Now.AddSeconds(1));
+
+        Assert.Equal(AuctionPrintKind.Closing, Assert.Single(hits).Kind);
+    }
+
+    [Fact]
+    public void AuctionPrint_is_opening_when_last_status_is_reserved()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketAuctionPrint>();
+        p.AuctionPrint += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, null, null, null, null,
+            tradingStatus: AuctionProjector.ReservedTradingStatus, receivedUtc: Now);
+        p.OnAuctionTrade("PETR4", 100, 30.0m, 5_000, Now.AddSeconds(1));
+
+        Assert.Equal(AuctionPrintKind.Opening, Assert.Single(hits).Kind);
+    }
+
+    [Fact]
+    public void AuctionPrint_resets_memoized_top_and_imbalance()
+    {
+        var p = new AuctionProjector();
+        var tops = new List<MarketTheoreticalOpening>();
+        var imbs = new List<MarketAuctionImbalance>();
+        p.TheoreticalOpening += tops.Add;
+        p.AuctionImbalance += imbs.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, 500, OrderSide.Buy, null, Now);
+        p.OnAuctionTrade("PETR4", 100, 30.5m, 5_000, Now.AddSeconds(1));
+        // Same top + imbalance values: would normally collapse, but the cross
+        // dropped the memo so both should re-publish.
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, 500, OrderSide.Buy, null, Now.AddSeconds(2));
+
+        Assert.Equal(2, tops.Count);
+        Assert.Equal(2, imbs.Count);
+    }
+
+    [Fact]
+    public void Symbols_are_tracked_independently()
+    {
+        var p = new AuctionProjector();
+        var hits = new List<MarketTheoreticalOpening>();
+        p.TheoreticalOpening += hits.Add;
+
+        p.OnInfoSnapshot("PETR4", 100, 30.5m, 1_000, null, null, null, Now);
+        p.OnInfoSnapshot("VALE3", 200, 30.5m, 1_000, null, null, null, Now);
+
+        Assert.Equal(2, hits.Count);
+        Assert.Contains(hits, h => h.Symbol == "PETR4");
+        Assert.Contains(hits, h => h.Symbol == "VALE3");
+    }
+}


### PR DESCRIPTION
Closes (part of) #263 — projects the auction surface that landed in `B3.MarketData.WebSocketClient` 0.4.0 (upstream B3MarketDataPlatform #40 / #45 / #47) into the application-side `MarketTheoreticalOpening` / `MarketAuctionImbalance` / `MarketAuctionPrint` events that `AuctionStateStore`, `IPhaseProvider`, and the `auction.${symbol}` WS channel have been wired against since #257.

### Stack
- **Base**: `chore/sdk-marketdata-0.4.0` (PR #373 — SDK bump).
- Will retarget to `main` once #373 merges.

### What changed
- New `AuctionProjector` in `B3.Trading.Application.MarketData`:
  - Collapses cumulative `InfoSnapshotEvent` fields into delta events — `TheoreticalOpening` only fires when (price, qty) actually change; `AuctionImbalance` only when (qty, side) change. Balanced / unknown condition ⇒ no imbalance delta.
  - Remembers per-symbol `TradingStatus` so an `AuctionPrint` trade can be classified Opening vs Closing (`FINAL_CLOSING_CALL`=101 ⇒ Closing; `RESERVED`=21 / never-observed ⇒ Opening, matching `AuctionStateStore`'s Open/Close transitions).
  - On `AuctionPrint`, drops the memoized top + imbalance so a re-auction re-publishes instead of being suppressed.
  - No SDK reference — unit-testable from `Application.Tests`.
- `SdkMarketDataSubscriber` instantiates the projector, translates the SDK's `AuctionImbalanceCondition` into `OrderSide?` (Balanced/Unknown→null), and pipes `InfoSnapshotEvent` fields + `TradeFlags.AuctionPrint` trades through it. Removes the `#pragma warning disable CS0067` block that flagged the three events as never-raised.

### Tests
- 12 new unit tests covering: delta detection, suppressed unchanged snapshots, side flips, opening-vs-closing kind decision (incl. default), reset on cross, per-symbol isolation.
- Full suite: 1106/1106 Application, 134/134 EPL, 499/500 Api (single failure is the known `MetricsFirmTagTests.OrdersSubmittedCounter_CarriesFirmIdTag` MeterListener flake; passes on rerun).

### Out of scope
- `MboBookStore` → `IBookFeed` migration (next PR in this sequence).
- `TradingStatus` delta event (PR #371 / #370 Stage A) — that branch tracks the same field for a different purpose; once #371 merges this branch will rebase cleanly because both touch `OnSdkInfo` additively but in different shapes (the projector approach here ignores the delta event surface).