### PR TITLE
feat(#372): expose public WS L3 channel `bookmbo.${symbol}`

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -33,6 +33,17 @@ public static class Channels
     public const string BookPrefix = "book.";
 
     /// <summary>
+    /// #372 / #293. Public per-symbol L3 (order-by-order) channel
+    /// (<c>bookmbo.${symbol}</c>) fed by the raw MBO frames from the
+    /// market-data SDK (<c>IMboBookEventSource</c>). Independent of
+    /// <see cref="BookPrefix"/>: <c>book.</c> coalesces a derived L2
+    /// top-N ladder for chart-style consumers, <c>bookmbo.</c> ships
+    /// every per-order event for L3-aware front-ends. Same auth
+    /// posture (authenticated bearer required, no per-firm filter).
+    /// </summary>
+    public const string BookMboPrefix = "bookmbo.";
+
+    /// <summary>
     /// Per-owner channel names (validated against an exact set).
     /// Per-symbol public channels (<see cref="PhasesPrefix"/> /
     /// <see cref="AuctionPrefix"/>) are validated separately via
@@ -64,6 +75,11 @@ public static class Channels
             kind = PublicChannelKind.Auction;
             raw = channel[AuctionPrefix.Length..];
         }
+        else if (channel.StartsWith(BookMboPrefix, StringComparison.Ordinal))
+        {
+            kind = PublicChannelKind.BookMbo;
+            raw = channel[BookMboPrefix.Length..];
+        }
         else if (channel.StartsWith(BookPrefix, StringComparison.Ordinal))
         {
             kind = PublicChannelKind.Book;
@@ -90,6 +106,7 @@ public static class Channels
     public static string PhasesFor(string symbol) => PhasesPrefix + symbol;
     public static string AuctionFor(string symbol) => AuctionPrefix + symbol;
     public static string BookFor(string symbol) => BookPrefix + symbol;
+    public static string BookMboFor(string symbol) => BookMboPrefix + symbol;
 }
 
 public enum PublicChannelKind
@@ -98,6 +115,7 @@ public enum PublicChannelKind
     Phases,
     Auction,
     Book,
+    BookMbo,
 }
 
 /// <summary>
@@ -135,6 +153,47 @@ public sealed record L2LadderDto(
 }
 
 public sealed record L2SideDto(decimal Price, long TotalQty, int OrderCount);
+
+// ── L3 / MBO depth channel (#372 / #293) ────────────────────────────
+
+/// <summary>
+/// Wire shape for the <c>bookmbo.${symbol}</c> snapshot frame.
+/// Lists every order known to the host per side, sorted server-side
+/// (best price first). <c>UpdatedUtc</c> is <c>null</c> on the cold
+/// snapshot served before any MBO frame has landed for the symbol.
+/// <c>Sequence</c> is the last applied <c>RptSeq</c> (opaque to the
+/// client — used only for debug + ops correlation).
+/// </summary>
+public sealed record MboBookSnapshotDto(
+    string Symbol,
+    long? Sequence,
+    IReadOnlyList<MboOrderDto> Bids,
+    IReadOnlyList<MboOrderDto> Asks,
+    DateTimeOffset? UpdatedUtc)
+{
+    public static MboBookSnapshotDto Empty(string symbol) =>
+        new(symbol, null, Array.Empty<MboOrderDto>(), Array.Empty<MboOrderDto>(), null);
+}
+
+/// <summary>One MBO order inside a snapshot.</summary>
+public sealed record MboOrderDto(string OrderId, decimal Price, long Qty);
+
+/// <summary>
+/// Wire shape for one per-order delta on <c>bookmbo.${symbol}</c>.
+/// <c>Kind</c> is one of <c>added</c> / <c>updated</c> / <c>deleted</c>
+/// / <c>cleared</c>. Fields not relevant for <c>kind</c> are null:
+/// <c>cleared</c> carries only <c>Symbol</c> + <c>Side</c> (the side
+/// being cleared — null means both sides).
+/// </summary>
+public sealed record MboBookDeltaDto(
+    string Kind,
+    string Symbol,
+    string? OrderId,
+    string? Side,
+    decimal? Price,
+    long? Qty,
+    DateTimeOffset Ts);
+
 
 /// <summary>Inbound command from a connected client.</summary>
 public sealed record InboundCommand(string Type, string[]? Channels);

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketMboBookEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketMboBookEventSink.cs
@@ -1,0 +1,280 @@
+using System.Collections.Concurrent;
+using B3.Trading.Application.MarketData;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// #372 / #293. WebSocket fan-out for the public per-symbol L3 (MBO)
+/// depth channel (<c>bookmbo.${symbol}</c>). Listens to the raw MBO
+/// events on <see cref="IMboBookEventSource"/> (snapshot / order
+/// add / update / delete / book cleared) and broadcasts one
+/// <see cref="MboBookDeltaDto"/> per event to subscribed clients.
+/// Doubles as the snapshot provider for <see cref="PublicChannelKind.BookMbo"/>:
+/// new subscribers receive a <see cref="MboBookSnapshotDto"/> of
+/// the current per-symbol L3 state before the next delta lands.
+///
+/// <para>
+/// State model: per <c>Symbol</c> we keep a pair of dictionaries
+/// (bids / asks) keyed by <c>OrderId</c>. The dictionary is rebuilt
+/// from each <c>BookSnapshot</c>, mutated by add/update/delete, and
+/// emptied (per side or both) by <c>BookCleared</c>. Snapshot reads
+/// take the per-symbol lock; the same lock guards mutation so an
+/// in-flight subscribe never sees a torn state.
+/// </para>
+///
+/// <para>
+/// No coalescing: an L3 channel exists precisely so consumers see
+/// every per-order event. Back-pressure is handled by the existing
+/// <see cref="SubscriptionManager"/> bounded channel (drop-with-counter
+/// on slow socket).
+/// </para>
+///
+/// <para>
+/// When the live feed is off (no <c>WsUrl</c> or
+/// <c>MarketDataOptions.EnableBook=false</c>) the registered
+/// <see cref="IMboBookEventSource"/> is the no-op implementation;
+/// this sink stays idle and snapshots return the empty shape — same
+/// posture as <see cref="WebSocketBookEventSink"/> in that mode.
+/// </para>
+/// </summary>
+public sealed class WebSocketMboBookEventSink : IPublicChannelSnapshots, IHostedService
+{
+    private readonly SubscriptionManager _subs;
+    private readonly IMboBookEventSource _source;
+    private readonly bool _enabled;
+
+    // Per-symbol L3 state. Each PerSymbol entry is independently
+    // locked: snapshot reads + mutations on the same symbol serialize
+    // through it; cross-symbol events run lock-free.
+    private readonly ConcurrentDictionary<string, PerSymbol> _state =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public WebSocketMboBookEventSink(
+        SubscriptionManager subs,
+        IMboBookEventSource source,
+        IOptions<MarketDataOptions> options)
+    {
+        _subs = subs;
+        _source = source;
+        _enabled = options.Value.EnableBook;
+    }
+
+    // ---------------- IPublicChannelSnapshots ----------------
+
+    public object? GetSnapshot(PublicChannelKind kind, string symbol)
+    {
+        if (kind != PublicChannelKind.BookMbo) return null;
+        if (string.IsNullOrEmpty(symbol)) return MboBookSnapshotDto.Empty(symbol);
+        if (!_state.TryGetValue(symbol, out var per))
+            return MboBookSnapshotDto.Empty(symbol);
+        return per.Snapshot();
+    }
+
+    // ---------------- IHostedService ----------------
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Even when EnableBook is false we attach handlers — the
+        // registered NullMboBookEventSource never raises them, so this
+        // costs nothing and keeps the wire-up symmetric with the L2
+        // sink which is also unconditional.
+        _source.BookSnapshot += OnBookSnapshot;
+        _source.OrderAdded += OnOrderAdded;
+        _source.OrderUpdated += OnOrderUpdated;
+        _source.OrderDeleted += OnOrderDeleted;
+        _source.BookCleared += OnBookCleared;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _source.BookSnapshot -= OnBookSnapshot;
+        _source.OrderAdded -= OnOrderAdded;
+        _source.OrderUpdated -= OnOrderUpdated;
+        _source.OrderDeleted -= OnOrderDeleted;
+        _source.BookCleared -= OnBookCleared;
+        return Task.CompletedTask;
+    }
+
+    // ---------------- Event handlers ----------------
+
+    private void OnBookSnapshot(MarketBookSnapshot ev)
+    {
+        if (!_enabled) return;
+        var per = _state.GetOrAdd(ev.Symbol, _ => new PerSymbol(ev.Symbol));
+        per.ApplySnapshot(ev);
+        // Snapshots are also surfaced as a snapshot frame on the wire
+        // — but only late joiners use them; existing subscribers
+        // already had per-order deltas. We don't broadcast the
+        // snapshot as a delta to avoid double-counting state.
+    }
+
+    private void OnOrderAdded(MarketOrderAdded ev)
+    {
+        if (!_enabled) return;
+        var per = _state.GetOrAdd(ev.Symbol, _ => new PerSymbol(ev.Symbol));
+        per.ApplyAdded(ev);
+        _subs.BroadcastPublic(
+            Channels.BookMboFor(ev.Symbol),
+            new MboBookDeltaDto("added", ev.Symbol, ev.OrderId.ToString(),
+                SideToWire(ev.Side), ev.Price, ev.Qty, ev.ReceivedUtc));
+    }
+
+    private void OnOrderUpdated(MarketOrderUpdated ev)
+    {
+        if (!_enabled) return;
+        var per = _state.GetOrAdd(ev.Symbol, _ => new PerSymbol(ev.Symbol));
+        per.ApplyUpdated(ev);
+        _subs.BroadcastPublic(
+            Channels.BookMboFor(ev.Symbol),
+            new MboBookDeltaDto("updated", ev.Symbol, ev.OrderId.ToString(),
+                SideToWire(ev.Side), ev.Price, ev.Qty, ev.ReceivedUtc));
+    }
+
+    private void OnOrderDeleted(MarketOrderDeleted ev)
+    {
+        if (!_enabled) return;
+        if (_state.TryGetValue(ev.Symbol, out var per))
+            per.ApplyDeleted(ev);
+        _subs.BroadcastPublic(
+            Channels.BookMboFor(ev.Symbol),
+            new MboBookDeltaDto("deleted", ev.Symbol, ev.OrderId.ToString(),
+                SideToWire(ev.Side), null, null, ev.ReceivedUtc));
+    }
+
+    private void OnBookCleared(MarketBookCleared ev)
+    {
+        if (!_enabled) return;
+        if (_state.TryGetValue(ev.Symbol, out var per))
+            per.ApplyCleared(ev);
+        _subs.BroadcastPublic(
+            Channels.BookMboFor(ev.Symbol),
+            new MboBookDeltaDto("cleared", ev.Symbol, null,
+                ClearSideToWire(ev.ClearSide), null, null, ev.ReceivedUtc));
+    }
+
+    private static string SideToWire(MarketBookSide s) => s switch
+    {
+        MarketBookSide.Bid => "bid",
+        MarketBookSide.Ask => "ask",
+        _ => "bid",
+    };
+
+    // null = both sides cleared (matches the SDK semantics).
+    private static string? ClearSideToWire(MarketBookClearSide s) => s switch
+    {
+        MarketBookClearSide.Bid => "bid",
+        MarketBookClearSide.Ask => "ask",
+        MarketBookClearSide.Both => null,
+        _ => null,
+    };
+
+    // ---------------- Per-symbol L3 state ----------------
+
+    private sealed class PerSymbol
+    {
+        private readonly string _symbol;
+        private readonly object _lock = new();
+        private readonly SortedDictionary<ulong, MarketBookOrder> _bids = new();
+        private readonly SortedDictionary<ulong, MarketBookOrder> _asks = new();
+        private long? _seq;
+        private DateTimeOffset? _updatedUtc;
+
+        public PerSymbol(string symbol) => _symbol = symbol;
+
+        public void ApplySnapshot(MarketBookSnapshot ev)
+        {
+            lock (_lock)
+            {
+                _bids.Clear();
+                _asks.Clear();
+                foreach (var o in ev.Bids) _bids[o.OrderId] = o;
+                foreach (var o in ev.Asks) _asks[o.OrderId] = o;
+                _seq = ev.RptSeq;
+                _updatedUtc = ev.ReceivedUtc;
+            }
+        }
+
+        public void ApplyAdded(MarketOrderAdded ev)
+        {
+            lock (_lock)
+            {
+                var dict = ev.Side == MarketBookSide.Bid ? _bids : _asks;
+                dict[ev.OrderId] = new MarketBookOrder(ev.OrderId, ev.Price, ev.Qty);
+                _updatedUtc = ev.ReceivedUtc;
+            }
+        }
+
+        public void ApplyUpdated(MarketOrderUpdated ev)
+        {
+            lock (_lock)
+            {
+                var dict = ev.Side == MarketBookSide.Bid ? _bids : _asks;
+                dict[ev.OrderId] = new MarketBookOrder(ev.OrderId, ev.Price, ev.Qty);
+                _updatedUtc = ev.ReceivedUtc;
+            }
+        }
+
+        public void ApplyDeleted(MarketOrderDeleted ev)
+        {
+            lock (_lock)
+            {
+                var dict = ev.Side == MarketBookSide.Bid ? _bids : _asks;
+                dict.Remove(ev.OrderId);
+                _updatedUtc = ev.ReceivedUtc;
+            }
+        }
+
+        public void ApplyCleared(MarketBookCleared ev)
+        {
+            lock (_lock)
+            {
+                switch (ev.ClearSide)
+                {
+                    case MarketBookClearSide.Bid: _bids.Clear(); break;
+                    case MarketBookClearSide.Ask: _asks.Clear(); break;
+                    case MarketBookClearSide.Both:
+                    default:
+                        _bids.Clear();
+                        _asks.Clear();
+                        break;
+                }
+                _updatedUtc = ev.ReceivedUtc;
+            }
+        }
+
+        public MboBookSnapshotDto Snapshot()
+        {
+            lock (_lock)
+            {
+                return new MboBookSnapshotDto(
+                    _symbol,
+                    _seq,
+                    Project(_bids, bids: true),
+                    Project(_asks, bids: false),
+                    _updatedUtc);
+            }
+        }
+
+        // Best-first ordering: bids descending price, asks ascending.
+        // Ties broken by OrderId ascending (deterministic + matches the
+        // SDK's snapshot ordering).
+        private static IReadOnlyList<MboOrderDto> Project(
+            SortedDictionary<ulong, MarketBookOrder> src, bool bids)
+        {
+            if (src.Count == 0) return Array.Empty<MboOrderDto>();
+            var arr = new MboOrderDto[src.Count];
+            var i = 0;
+            foreach (var o in src.Values)
+                arr[i++] = new MboOrderDto(o.OrderId.ToString(), o.Price, o.Qty);
+            Array.Sort(arr, (a, b) =>
+            {
+                var cmp = bids ? b.Price.CompareTo(a.Price) : a.Price.CompareTo(b.Price);
+                return cmp != 0 ? cmp : string.CompareOrdinal(a.OrderId, b.OrderId);
+            });
+            return arr;
+        }
+    }
+}

--- a/backend/src/B3.Trading.Application/MarketData/IMboBookEventSource.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IMboBookEventSource.cs
@@ -1,0 +1,66 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// Application-side seam over the raw L3 / MBO frames the upstream
+/// market-data SDK exposes. Separate from <see cref="IL2BookView"/>
+/// (which is a derived, aggregated view): consumers that need
+/// per-order fidelity (e.g. the public <c>bookmbo.${symbol}</c> WS
+/// channel, #372 / #293) subscribe here instead of asking the L2
+/// view for ladder deltas.
+///
+/// <para>
+/// Implementations MUST raise events in the order they arrive from
+/// the wire so consumers can rebuild a deterministic per-symbol L3
+/// state by applying snapshot → add/update/delete deltas. Events
+/// MAY race across symbols on different threads, but per-symbol
+/// ordering MUST be preserved.
+/// </para>
+///
+/// <para>
+/// The host-side <c>SdkMboBookEventSource</c> wires this seam to
+/// <c>B3.MarketData.WebSocketClient.MarketDataClient</c>'s
+/// <c>BookSnapshot</c> / <c>OrderAdded</c> / <c>OrderUpdated</c> /
+/// <c>OrderDeleted</c> / <c>BookCleared</c> events. Tests use a fake
+/// implementation that raises the events synchronously.
+/// </para>
+///
+/// <para>
+/// When the live market-data feed is off (no <c>WsUrl</c> or
+/// <c>EnableBook=false</c>) this seam is registered as a no-op (no
+/// events ever raised); WS subscribers to <c>bookmbo.${symbol}</c>
+/// still receive the empty cold snapshot and then sit idle.
+/// </para>
+/// </summary>
+public interface IMboBookEventSource
+{
+    event Action<MarketBookSnapshot>? BookSnapshot;
+    event Action<MarketOrderAdded>? OrderAdded;
+    event Action<MarketOrderUpdated>? OrderUpdated;
+    event Action<MarketOrderDeleted>? OrderDeleted;
+    event Action<MarketBookCleared>? BookCleared;
+}
+
+/// <summary>
+/// Default no-op implementation. Used when the live wire path is
+/// disabled so the WS sink can resolve through DI without conditional
+/// registration on consumer side.
+/// </summary>
+public sealed class NullMboBookEventSource : IMboBookEventSource
+{
+    public event Action<MarketBookSnapshot>? BookSnapshot;
+    public event Action<MarketOrderAdded>? OrderAdded;
+    public event Action<MarketOrderUpdated>? OrderUpdated;
+    public event Action<MarketOrderDeleted>? OrderDeleted;
+    public event Action<MarketBookCleared>? BookCleared;
+
+    // Suppress "field is never used" — the events exist only to satisfy
+    // the contract for consumers that may attach handlers.
+    private void _suppress()
+    {
+        _ = BookSnapshot;
+        _ = OrderAdded;
+        _ = OrderUpdated;
+        _ = OrderDeleted;
+        _ = BookCleared;
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -174,10 +174,20 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<WebSocketBookEventSink>();
         services.AddHostedService(sp => sp.GetRequiredService<WebSocketBookEventSink>());
 
+        // #372 / #293. Public per-symbol bookmbo.${symbol} L3 fan-out.
+        // Listens to IMboBookEventSource (raw MBO events from the SDK
+        // adapter when live, no-op otherwise) and broadcasts one
+        // per-order delta per event. Doubles as the snapshot provider
+        // for PublicChannelKind.BookMbo; composed below alongside the
+        // L2 + auction sinks.
+        services.AddSingleton<WebSocketMboBookEventSink>();
+        services.AddHostedService(sp => sp.GetRequiredService<WebSocketMboBookEventSink>());
+
         services.AddSingleton<IPublicChannelSnapshots>(sp =>
             new CompositePublicChannelSnapshots(
                 sp.GetRequiredService<WebSocketAuctionEventSink>(),
-                sp.GetRequiredService<WebSocketBookEventSink>()));
+                sp.GetRequiredService<WebSocketBookEventSink>(),
+                sp.GetRequiredService<WebSocketMboBookEventSink>()));
 
         services.AddSingleton<ExecutionReportProcessor>();
         services.AddSingleton<OrderSubmissionService>();

--- a/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
+++ b/backend/src/B3.Trading.Host/MarketData/MarketDataRegistration.cs
@@ -63,6 +63,13 @@ public static class MarketDataRegistration
         services.TryAddSingleton<InMemoryL2BookView>();
         services.TryAddSingleton<IL2BookView>(sp => sp.GetRequiredService<InMemoryL2BookView>());
 
+        // IMboBookEventSource is registered unconditionally as a no-op
+        // so WebSocketMboBookEventSink resolves in DI even when MD is
+        // off. The live wire-path adapter (SdkMboBookEventSource)
+        // replaces this singleton further down when WsUrl + EnableBook
+        // are both on.
+        services.TryAddSingleton<IMboBookEventSource, NullMboBookEventSource>();
+
         if (string.IsNullOrWhiteSpace(opts.WsUrl))
         {
             services.AddSingleton<IReferencePrice>(sp =>
@@ -98,6 +105,16 @@ public static class MarketDataRegistration
                 new SdkBookFeedAdapter(sp.GetRequiredService<IBookFeed>()));
             services.Replace(ServiceDescriptor.Singleton<IL2BookView>(sp =>
                 sp.GetRequiredService<SdkBookFeedAdapter>()));
+
+            // #372 / #293. Raw L3 MBO event source for the public
+            // bookmbo.${symbol} WS channel. Subscribes to the SAME
+            // MarketDataClient instance the BookFeed uses — both
+            // handlers run on every Book*/Order* event; no duplicate
+            // network traffic.
+            services.AddSingleton<SdkMboBookEventSource>(sp =>
+                new SdkMboBookEventSource(sp.GetRequiredService<MarketDataClient>()));
+            services.Replace(ServiceDescriptor.Singleton<IMboBookEventSource>(sp =>
+                sp.GetRequiredService<SdkMboBookEventSource>()));
         }
 
         services.AddSingleton<IMarketDataSubscriber, SdkMarketDataSubscriber>();

--- a/backend/src/B3.Trading.Host/MarketData/SdkMboBookEventSource.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMboBookEventSource.cs
@@ -1,0 +1,125 @@
+using B3.MarketData.WebSocketClient;
+using B3.Trading.Application.MarketData;
+using AppMarketBookSnapshot = B3.Trading.Application.MarketData.MarketBookSnapshot;
+using AppMarketBookOrder = B3.Trading.Application.MarketData.MarketBookOrder;
+using AppMarketOrderAdded = B3.Trading.Application.MarketData.MarketOrderAdded;
+using AppMarketOrderUpdated = B3.Trading.Application.MarketData.MarketOrderUpdated;
+using AppMarketOrderDeleted = B3.Trading.Application.MarketData.MarketOrderDeleted;
+using AppMarketBookCleared = B3.Trading.Application.MarketData.MarketBookCleared;
+using AppMarketBookSide = B3.Trading.Application.MarketData.MarketBookSide;
+using AppMarketBookClearSide = B3.Trading.Application.MarketData.MarketBookClearSide;
+using SdkBookSide = B3.MarketData.WebSocketClient.BookSide;
+using SdkBookClearSide = B3.MarketData.WebSocketClient.BookClearSide;
+
+namespace B3.Trading.Host.MarketData;
+
+/// <summary>
+/// Adapter from <see cref="MarketDataClient"/> raw MBO frames
+/// (<c>BookSnapshot</c>, <c>OrderAdded</c>, <c>OrderUpdated</c>,
+/// <c>OrderDeleted</c>, <c>BookCleared</c>) to the application-side
+/// <see cref="IMboBookEventSource"/> seam consumed by
+/// <c>WebSocketMboBookEventSink</c> (#372 / #293).
+///
+/// <para>
+/// Subscribes in parallel to SDK 0.4.0's <see cref="IBookFeed"/> — the
+/// BookFeed maintains a derived L2 view (used by
+/// <see cref="SdkBookFeedAdapter"/>); this adapter forwards the raw
+/// L3 events untouched so the WS L3 channel sees every per-order
+/// delta. Both subscribers attach to the SAME <see cref="MarketDataClient"/>
+/// instance — the SDK fans events out to every handler, no duplicate
+/// network traffic.
+/// </para>
+///
+/// <para>
+/// Registered only when <c>MarketDataOptions.EnableBook</c> AND
+/// <c>WsUrl</c> are both set (same gate as the L2 BookFeed). When the
+/// live feed is off, <see cref="NullMboBookEventSource"/> is wired
+/// instead — the sink resolves through DI either way.
+/// </para>
+/// </summary>
+internal sealed class SdkMboBookEventSource : IMboBookEventSource, IDisposable
+{
+    private readonly MarketDataClient _client;
+
+    public event Action<AppMarketBookSnapshot>? BookSnapshot;
+    public event Action<AppMarketOrderAdded>? OrderAdded;
+    public event Action<AppMarketOrderUpdated>? OrderUpdated;
+    public event Action<AppMarketOrderDeleted>? OrderDeleted;
+    public event Action<AppMarketBookCleared>? BookCleared;
+
+    public SdkMboBookEventSource(MarketDataClient client)
+    {
+        _client = client;
+        _client.BookSnapshot += OnBookSnapshot;
+        _client.OrderAdded += OnOrderAdded;
+        _client.OrderUpdated += OnOrderUpdated;
+        _client.OrderDeleted += OnOrderDeleted;
+        _client.BookCleared += OnBookCleared;
+    }
+
+    public void Dispose()
+    {
+        _client.BookSnapshot -= OnBookSnapshot;
+        _client.OrderAdded -= OnOrderAdded;
+        _client.OrderUpdated -= OnOrderUpdated;
+        _client.OrderDeleted -= OnOrderDeleted;
+        _client.BookCleared -= OnBookCleared;
+    }
+
+    private void OnBookSnapshot(BookSnapshotEvent ev)
+    {
+        var bids = new AppMarketBookOrder[ev.Bids.Count];
+        for (var i = 0; i < ev.Bids.Count; i++)
+            bids[i] = new AppMarketBookOrder(ev.Bids[i].OrderId, ev.Bids[i].Price, ev.Bids[i].Qty);
+        var asks = new AppMarketBookOrder[ev.Asks.Count];
+        for (var i = 0; i < ev.Asks.Count; i++)
+            asks[i] = new AppMarketBookOrder(ev.Asks[i].OrderId, ev.Asks[i].Price, ev.Asks[i].Qty);
+        BookSnapshot?.Invoke(new AppMarketBookSnapshot
+        {
+            Symbol = ev.Symbol,
+            SecurityId = ev.SecurityId,
+            RptSeq = ev.RptSeq,
+            Bids = bids,
+            Asks = asks,
+            ReceivedUtc = NormalizeUtc(ev.ReceivedUtc),
+        });
+    }
+
+    private void OnOrderAdded(OrderAddedEvent ev) =>
+        OrderAdded?.Invoke(new AppMarketOrderAdded(
+            ev.Symbol, ev.SecurityId, ev.OrderId, ToAppSide(ev.Side),
+            ev.Price, ev.Qty, NormalizeUtc(ev.ReceivedUtc)));
+
+    private void OnOrderUpdated(OrderUpdatedEvent ev) =>
+        OrderUpdated?.Invoke(new AppMarketOrderUpdated(
+            ev.Symbol, ev.SecurityId, ev.OrderId, ToAppSide(ev.Side),
+            ev.Price, ev.Qty, NormalizeUtc(ev.ReceivedUtc)));
+
+    private void OnOrderDeleted(OrderDeletedEvent ev) =>
+        OrderDeleted?.Invoke(new AppMarketOrderDeleted(
+            ev.Symbol, ev.SecurityId, ev.OrderId, ToAppSide(ev.Side),
+            NormalizeUtc(ev.ReceivedUtc)));
+
+    private void OnBookCleared(BookClearedEvent ev) =>
+        BookCleared?.Invoke(new AppMarketBookCleared(
+            ev.Symbol, ev.SecurityId, ToAppClearSide(ev.ClearSide),
+            NormalizeUtc(ev.ReceivedUtc)));
+
+    private static AppMarketBookSide ToAppSide(SdkBookSide s) => s switch
+    {
+        SdkBookSide.Bid => AppMarketBookSide.Bid,
+        SdkBookSide.Ask => AppMarketBookSide.Ask,
+        _ => AppMarketBookSide.Bid,
+    };
+
+    private static AppMarketBookClearSide ToAppClearSide(SdkBookClearSide s) => s switch
+    {
+        SdkBookClearSide.Bid => AppMarketBookClearSide.Bid,
+        SdkBookClearSide.Ask => AppMarketBookClearSide.Ask,
+        SdkBookClearSide.Both => AppMarketBookClearSide.Both,
+        _ => AppMarketBookClearSide.Both,
+    };
+
+    private static DateTimeOffset NormalizeUtc(DateTime utc) =>
+        new(DateTime.SpecifyKind(utc, DateTimeKind.Utc));
+}

--- a/backend/tests/B3.Trading.Api.Tests/MboBookWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/MboBookWebSocketChannelTests.cs
@@ -1,0 +1,318 @@
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+public class MboBookWebSocketChannelTests
+{
+    private sealed class FakeMboSource : IMboBookEventSource
+    {
+        public event Action<MarketBookSnapshot>? BookSnapshot;
+        public event Action<MarketOrderAdded>? OrderAdded;
+        public event Action<MarketOrderUpdated>? OrderUpdated;
+        public event Action<MarketOrderDeleted>? OrderDeleted;
+        public event Action<MarketBookCleared>? BookCleared;
+
+        public void RaiseSnapshot(MarketBookSnapshot s) => BookSnapshot?.Invoke(s);
+        public void RaiseAdded(MarketOrderAdded a) => OrderAdded?.Invoke(a);
+        public void RaiseUpdated(MarketOrderUpdated u) => OrderUpdated?.Invoke(u);
+        public void RaiseDeleted(MarketOrderDeleted d) => OrderDeleted?.Invoke(d);
+        public void RaiseCleared(MarketBookCleared c) => BookCleared?.Invoke(c);
+    }
+
+    private static (SubscriptionManager subs, FakeMboSource src, WebSocketMboBookEventSink sink) Build(bool enableBook = true)
+    {
+        var src = new FakeMboSource();
+        var subs = new SubscriptionManager(new WorkingOrderBook(), new PositionKeeper(), new AlgoBook());
+        var opts = Options.Create(new MarketDataOptions { EnableBook = enableBook });
+        var sink = new WebSocketMboBookEventSink(subs, src, opts);
+        sink.StartAsync(default).GetAwaiter().GetResult();
+        return (subs, src, sink);
+    }
+
+    private static MarketOrderAdded Add(string sym, ulong id, MarketBookSide side, decimal price, long qty) =>
+        new(sym, 4321UL, id, side, price, qty, DateTimeOffset.UtcNow);
+
+    // ── Channel parsing ────────────────────────────────────────────
+
+    [Fact]
+    public void TryParsePublic_recognises_bookmbo_with_valid_symbol()
+    {
+        Assert.True(Channels.TryParsePublic("bookmbo.PETR4", out var k, out var s));
+        Assert.Equal(PublicChannelKind.BookMbo, k);
+        Assert.Equal("PETR4", s);
+    }
+
+    [Theory]
+    [InlineData("bookmbo.")]
+    [InlineData("bookmbo.PETR 4")]
+    [InlineData("bookmbo.PETR-4")]
+    [InlineData("bookmbo.thisistoolongasymbolname")]
+    public void TryParsePublic_rejects_invalid_bookmbo_inputs(string ch)
+    {
+        Assert.False(Channels.TryParsePublic(ch, out var k, out _));
+        Assert.Equal(PublicChannelKind.None, k);
+    }
+
+    [Fact]
+    public void TryParsePublic_does_not_confuse_bookmbo_with_book()
+    {
+        // bookmbo.X must NOT parse as Book("mbo.X") — explicit prefix
+        // discrimination is what makes the two channels coexist.
+        Assert.True(Channels.TryParsePublic("bookmbo.PETR4", out var k1, out _));
+        Assert.Equal(PublicChannelKind.BookMbo, k1);
+
+        Assert.True(Channels.TryParsePublic("book.PETR4", out var k2, out _));
+        Assert.Equal(PublicChannelKind.Book, k2);
+    }
+
+    // ── Cold snapshot ──────────────────────────────────────────────
+
+    [Fact]
+    public void Subscribe_emits_empty_snapshot_when_no_frame_seen()
+    {
+        var (subs, _, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        Assert.Equal("snapshot", msg!.Type);
+        Assert.Equal("bookmbo.PETR4", msg.Channel);
+        var dto = Assert.IsType<MboBookSnapshotDto>(msg.Data);
+        Assert.Equal("PETR4", dto.Symbol);
+        Assert.Empty(dto.Bids);
+        Assert.Empty(dto.Asks);
+        Assert.Null(dto.UpdatedUtc);
+        Assert.Null(dto.Sequence);
+    }
+
+    // ── Deltas: add/update/delete/cleared ──────────────────────────
+
+    [Fact]
+    public void OrderAdded_pushes_added_delta_per_order()
+    {
+        var (subs, src, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _); // discard cold snapshot
+
+        src.RaiseAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30.10m, 100));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        Assert.Equal("delta", msg!.Type);
+        Assert.Equal("bookmbo.PETR4", msg.Channel);
+        Assert.Equal(1, msg.Seq);
+        var dto = Assert.IsType<MboBookDeltaDto>(msg.Data);
+        Assert.Equal("added", dto.Kind);
+        Assert.Equal("PETR4", dto.Symbol);
+        Assert.Equal("1", dto.OrderId);
+        Assert.Equal("bid", dto.Side);
+        Assert.Equal(30.10m, dto.Price);
+        Assert.Equal(100, dto.Qty);
+    }
+
+    [Fact]
+    public void OrderUpdated_pushes_updated_delta()
+    {
+        var (subs, src, sink) = Build();
+        src.RaiseAdded(Add("PETR4", 7UL, MarketBookSide.Ask, 31m, 50));
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _); // snapshot has the original order
+
+        src.RaiseUpdated(new MarketOrderUpdated("PETR4", 4321UL, 7UL,
+            MarketBookSide.Ask, 31m, 30, DateTimeOffset.UtcNow));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookDeltaDto>(msg!.Data);
+        Assert.Equal("updated", dto.Kind);
+        Assert.Equal("7", dto.OrderId);
+        Assert.Equal("ask", dto.Side);
+        Assert.Equal(30, dto.Qty);
+    }
+
+    [Fact]
+    public void OrderDeleted_pushes_deleted_delta_with_no_price_qty()
+    {
+        var (subs, src, sink) = Build();
+        src.RaiseAdded(Add("PETR4", 9UL, MarketBookSide.Bid, 29m, 200));
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _);
+
+        src.RaiseDeleted(new MarketOrderDeleted("PETR4", 4321UL, 9UL,
+            MarketBookSide.Bid, DateTimeOffset.UtcNow));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookDeltaDto>(msg!.Data);
+        Assert.Equal("deleted", dto.Kind);
+        Assert.Equal("9", dto.OrderId);
+        Assert.Null(dto.Price);
+        Assert.Null(dto.Qty);
+    }
+
+    [Fact]
+    public void BookCleared_both_sides_emits_null_side()
+    {
+        var (subs, src, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _);
+
+        src.RaiseCleared(new MarketBookCleared("PETR4", 4321UL,
+            MarketBookClearSide.Both, DateTimeOffset.UtcNow));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookDeltaDto>(msg!.Data);
+        Assert.Equal("cleared", dto.Kind);
+        Assert.Null(dto.Side);
+    }
+
+    [Fact]
+    public void BookCleared_bid_only_emits_bid_side()
+    {
+        var (subs, src, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _);
+
+        src.RaiseCleared(new MarketBookCleared("PETR4", 4321UL,
+            MarketBookClearSide.Bid, DateTimeOffset.UtcNow));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookDeltaDto>(msg!.Data);
+        Assert.Equal("cleared", dto.Kind);
+        Assert.Equal("bid", dto.Side);
+    }
+
+    // ── Snapshot semantics ─────────────────────────────────────────
+
+    [Fact]
+    public void Snapshot_reflects_applied_state_after_add_update_delete()
+    {
+        var (subs, src, sink) = Build();
+        src.RaiseAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30m, 100));
+        src.RaiseAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 30.10m, 200));
+        src.RaiseAdded(Add("PETR4", 3UL, MarketBookSide.Ask, 30.20m, 50));
+        src.RaiseUpdated(new MarketOrderUpdated("PETR4", 4321UL, 1UL,
+            MarketBookSide.Bid, 30m, 80, DateTimeOffset.UtcNow));
+        src.RaiseDeleted(new MarketOrderDeleted("PETR4", 4321UL, 3UL,
+            MarketBookSide.Ask, DateTimeOffset.UtcNow));
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookSnapshotDto>(msg!.Data);
+        Assert.Equal(2, dto.Bids.Count);
+        // Bids sorted best-first (descending price).
+        Assert.Equal(30.10m, dto.Bids[0].Price);
+        Assert.Equal(200, dto.Bids[0].Qty);
+        Assert.Equal("2", dto.Bids[0].OrderId);
+        Assert.Equal(30m, dto.Bids[1].Price);
+        Assert.Equal(80, dto.Bids[1].Qty); // updated from 100 to 80
+        Assert.Empty(dto.Asks); // order 3 was deleted
+    }
+
+    [Fact]
+    public void Snapshot_after_BookSnapshot_rebuilds_state()
+    {
+        var (subs, src, sink) = Build();
+        // Establish some prior state…
+        src.RaiseAdded(Add("PETR4", 99UL, MarketBookSide.Bid, 10m, 10));
+        // …then a fresh snapshot must wipe it.
+        src.RaiseSnapshot(new MarketBookSnapshot
+        {
+            Symbol = "PETR4",
+            SecurityId = 4321UL,
+            RptSeq = 42,
+            Bids = new[] { new MarketBookOrder(1UL, 30m, 100) },
+            Asks = new[] { new MarketBookOrder(2UL, 31m, 50) },
+            ReceivedUtc = DateTimeOffset.UtcNow,
+        });
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookSnapshotDto>(msg!.Data);
+        Assert.Equal(42L, dto.Sequence);
+        Assert.Single(dto.Bids);
+        Assert.Equal("1", dto.Bids[0].OrderId);
+        Assert.Single(dto.Asks);
+        Assert.Equal("2", dto.Asks[0].OrderId);
+    }
+
+    [Fact]
+    public void Snapshot_after_BookCleared_is_empty_for_that_side()
+    {
+        var (subs, src, sink) = Build();
+        src.RaiseAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30m, 100));
+        src.RaiseAdded(Add("PETR4", 2UL, MarketBookSide.Ask, 31m, 50));
+        src.RaiseCleared(new MarketBookCleared("PETR4", 4321UL,
+            MarketBookClearSide.Ask, DateTimeOffset.UtcNow));
+
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<MboBookSnapshotDto>(msg!.Data);
+        Assert.Single(dto.Bids);
+        Assert.Empty(dto.Asks);
+    }
+
+    // ── EnableBook=false ───────────────────────────────────────────
+
+    [Fact]
+    public void When_EnableBook_off_deltas_are_dropped()
+    {
+        var (subs, src, sink) = Build(enableBook: false);
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        client.Reader.TryRead(out _); // snapshot (empty)
+
+        src.RaiseAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30m, 100));
+
+        Assert.False(client.Reader.TryRead(out _));
+    }
+
+    // ── Multi-subscriber fan-out ───────────────────────────────────
+
+    [Fact]
+    public void Multiple_subscribers_each_receive_the_same_delta()
+    {
+        var (subs, src, sink) = Build();
+        var c1 = new SubscribedClient(new EndClientId("alice"), "A");
+        var c2 = new SubscribedClient(new EndClientId("bob"), "B");
+        subs.SubscribePublicWithSnapshot(c1, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        subs.SubscribePublicWithSnapshot(c2, "bookmbo.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.BookMbo, "PETR4"));
+        c1.Reader.TryRead(out _);
+        c2.Reader.TryRead(out _);
+
+        src.RaiseAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 30m, 100));
+
+        Assert.True(c1.Reader.TryRead(out var m1));
+        Assert.True(c2.Reader.TryRead(out var m2));
+        var d1 = Assert.IsType<MboBookDeltaDto>(m1!.Data);
+        var d2 = Assert.IsType<MboBookDeltaDto>(m2!.Data);
+        Assert.Equal("added", d1.Kind);
+        Assert.Equal("added", d2.Kind);
+        Assert.Equal(d1.OrderId, d2.OrderId);
+    }
+}


### PR DESCRIPTION
Closes #372. Backend prerequisite for #293 (FE depth view MBO toggle).

## Summary

Adds the per-symbol L3 (order-by-order) WebSocket channel `bookmbo.${symbol}` next to the existing L2 `book.${symbol}`. Front-ends that want per-order rendering plug into `bookmbo.`; chart-style consumers stay on `book.`.

## Wire shape

```jsonc
// snapshot
{ "kind": "snapshot", "symbol": "PETR4", "sequence": 12345,
  "bids": [{"orderId":"…","price":"30.50","qty":100}, …],
  "asks": [ … ],
  "updatedUtc": "…" }

// deltas (one per per-order event)
{ "kind": "added",   "symbol": "PETR4", "orderId":"…", "side":"bid", "price":"30.50", "qty":100, "ts":"…" }
{ "kind": "updated", "symbol": "PETR4", "orderId":"…", "side":"bid", "price":"30.50", "qty": 50, "ts":"…" }
{ "kind": "deleted", "symbol": "PETR4", "orderId":"…", "side":"bid", "ts":"…" }
{ "kind": "cleared", "symbol": "PETR4", "side":"bid"|"ask"|null, "ts":"…" }
```

## Implementation

* **`IMboBookEventSource`** — new Application seam with 5 events (BookSnapshot / OrderAdded / OrderUpdated / OrderDeleted / BookCleared) using the existing app-owned `Market*` records. `NullMboBookEventSource` is the default.
* **`SdkMboBookEventSource`** (Host) — subscribes to `MarketDataClient.Book*/Order*` events in parallel with SDK 0.4.0's `IBookFeed` (the L2 aggregator). Both handlers fan out from the SAME SDK client, so there's no duplicate network traffic.
* **`WebSocketMboBookEventSink`** (Api) — per-symbol L3 state (`SortedDictionary<orderId, order>` per side) under a per-symbol lock; broadcasts via `SubscriptionManager`; serves snapshots for `PublicChannelKind.BookMbo`. No coalescing (L3 = every event matters); back-pressure handled by the existing bounded channel.
* Channel parsing: new `bookmbo.` prefix branch in `Channels.TryParsePublic` (ordered before `book.` to avoid prefix collision).
* DI gating: `SdkMboBookEventSource` registered only when `MarketDataOptions.EnableBook` + `WsUrl` are both set — same gate as the L2 BookFeed.

## Tests

14 new tests in `MboBookWebSocketChannelTests` covering:
- Channel parsing (valid/invalid + no collision with `book.`)
- Cold snapshot (empty)
- Each delta kind (added/updated/deleted/cleared with both/bid/ask)
- Snapshot state after applied mutations
- BookSnapshot rebuilds prior state
- `EnableBook=false` ⇒ deltas dropped
- Multi-subscriber fan-out

Full suite green: 1114 + 517 + 134 + 12 = **1777 tests / 0 failures**.

## Closes
- #372

## Unblocks
- #293 (FE depth view MBO toggle — the frontend can now subscribe to `bookmbo.${symbol}`)