### PR TITLE
fix(#382): enable Book subscription by default in real-stack compose

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
@@ -86,7 +86,24 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
     private void OnBookChanged(string symbol)
     {
         var ladder = _store.GetLadder(symbol, _maxLevels);
-        if (ladder is null) return; // nothing to broadcast when both sides went empty
+        if (ladder is null)
+        {
+            // Book emptied (last resting order on both sides was filled,
+            // cancelled, or expired). Without an explicit empty frame on
+            // the wire the FE keeps rendering the last populated ladder
+            // forever (#382 follow-up: bid lingered after fill — only a
+            // hard refresh re-fetched the cold-start snapshot and cleared
+            // the DOB). Broadcast Empty(symbol) once on the populated →
+            // empty edge so the FE reducer clears both sides; coalesce
+            // subsequent empty-events by tracking the empty as the new
+            // _lastSent so a steady-state empty book stays off the wire.
+            if (_lastSent.TryGetValue(symbol, out var prevEmpty) && IsEmptyLadder(prevEmpty))
+                return;
+            var emptyDto = L2LadderDto.Empty(symbol);
+            _lastSent[symbol] = emptyDto;
+            _subs.BroadcastPublic(Channels.BookFor(symbol), emptyDto);
+            return;
+        }
         var dto = L2LadderDto.From(ladder.Value);
         // Coalesce: skip if bid/ask ladders are identical to last sent
         // for this symbol — UpdatedUtc is intentionally excluded so a
@@ -97,6 +114,9 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
         _lastSent[dto.Symbol] = dto;
         _subs.BroadcastPublic(Channels.BookFor(dto.Symbol), dto);
     }
+
+    private static bool IsEmptyLadder(L2LadderDto dto) =>
+        dto.Bids.Count == 0 && dto.Asks.Count == 0;
 
     private static bool SidesEqual(L2LadderDto a, L2LadderDto b) =>
         SideEqual(a.Bids, b.Bids) && SideEqual(a.Asks, b.Asks);

--- a/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
@@ -208,4 +208,74 @@ public class BookWebSocketChannelTests
         store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 1UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
         Assert.Null(store.GetLadder("PETR4", 10));
     }
+
+    /// <summary>
+    /// #382 follow-up regression. Until this fix, OnBookChanged early-returned
+    /// when <see cref="IL2BookView.GetLadder"/> returned null on the populated →
+    /// empty edge (last resting order filled / cancelled). The FE never got the
+    /// "book emptied" frame and the DOB kept rendering the last populated
+    /// ladder until a hard refresh refetched the cold-start snapshot.
+    /// </summary>
+    [Fact]
+    public void Book_emptied_after_fill_broadcasts_empty_dto()
+    {
+        var (subs, store, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // cold snapshot
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 32.50m, 100));
+        Assert.True(client.Reader.TryRead(out var populatedDelta));
+        var populated = Assert.IsType<L2LadderDto>(populatedDelta!.Data);
+        Assert.Single(populated.Bids);
+
+        // Last resting order gone → store returns null ladder.
+        store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 1UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
+
+        Assert.True(client.Reader.TryRead(out var emptyDelta), "FE must receive a delta when the book empties");
+        Assert.Equal("delta", emptyDelta!.Type);
+        var emptyDto = Assert.IsType<L2LadderDto>(emptyDelta.Data);
+        Assert.Equal("PETR4", emptyDto.Symbol);
+        Assert.Empty(emptyDto.Bids);
+        Assert.Empty(emptyDto.Asks);
+        // Empty-state marker matches the cold-start snapshot shape so the FE
+        // reducer's `ready = updatedUtc != null` branch flips ready=false and
+        // the DOB drops back to the waiting affordance instead of carrying
+        // stale levels.
+        Assert.Null(emptyDto.UpdatedUtc);
+    }
+
+    /// <summary>
+    /// #382 follow-up. Empty-state broadcasts must coalesce: a steady-state
+    /// empty book (e.g. nobody trading the symbol) should not spam a delta
+    /// every time the store fires BookChanged.
+    /// </summary>
+    [Fact]
+    public void Book_empty_steady_state_coalesces_subsequent_empty_events()
+    {
+        var (subs, store, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        client.Reader.TryRead(out _); // cold snapshot
+
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 32.50m, 100));
+        client.Reader.TryRead(out _); // populated delta
+
+        store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 1UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
+        Assert.True(client.Reader.TryRead(out _)); // first empty delta
+
+        // Second populated → empty cycle exercises the coalesce gate: the
+        // store's empty state hasn't moved since the prior broadcast, so no
+        // new delta hits the wire.
+        store.ApplyAdded(Add("PETR4", 2UL, MarketBookSide.Bid, 32.40m, 50));
+        Assert.True(client.Reader.TryRead(out _)); // re-populated delta
+        store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 2UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
+        Assert.True(client.Reader.TryRead(out _)); // empty delta after second cycle
+
+        // No further deltas: any extra BookChanged that resolves to empty
+        // must be swallowed.
+        Assert.False(client.Reader.TryRead(out _));
+    }
 }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -66,3 +66,11 @@ TRADING_MARKETDATA_SYMBOL_0=PETR4
 # DEMO_INJECT_RATE_HZ=0.3
 # DEMO_MAX_OPEN_ORDERS=50
 # DEMO_MODE=auto-detect
+
+# ── MarketData Book subscription (#382) ─────────────────────────────
+# The real-stack compose defaults this to true so the DOB / book.${symbol}
+# WS channel populates from MBO out of the box. Override to false to
+# disable the SDK Book subscription (e.g. when debugging MD cost or
+# reproducing a Book-feed regression in isolation). No-op under the
+# unavailable / e2e overlays — they pin the flag off explicitly.
+# TRADING_MARKETDATA_ENABLE_BOOK=true

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -18,3 +18,10 @@ services:
       # symbol into a SecurityId so the validator does not 400.
       Trading__SymbolDirectory__SecurityIds__PETR4: "4321"
       Trading__SymbolDirectory__SecurityIds__VALE3: "1234"
+      # #382. The smoke E2E uses the in-process StubExchangeGateway and
+      # the matching/marketdata services are suppressed via profiles;
+      # the SDK has nothing to subscribe to. Clear the inherited WsUrl
+      # and pin EnableBook off so the trading-host stays quiet on the
+      # MD side (no reconnect churn, no SDK Book subscription).
+      Trading__MarketData__WsUrl: ""
+      Trading__MarketData__EnableBook: "false"

--- a/docker/docker-compose.unavailable.yml
+++ b/docker/docker-compose.unavailable.yml
@@ -93,6 +93,12 @@ services:
       # Static fallback Trading:Risk:ReferencePrices map (still set by
       # base) keeps the price-collar happy if any code path consults it.
       Trading__MarketData__WsUrl: ""
+      # #382. Belt-and-suspenders: WsUrl="" already short-circuits the
+      # MD registration before EnableBook is read, but pin the flag off
+      # explicitly so a future change that wires a stub MD URL under
+      # this overlay does not accidentally re-enable the Book
+      # subscription.
+      Trading__MarketData__EnableBook: "false"
 
   matching-platform:
     profiles: ["never-on"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -300,6 +300,18 @@ services:
       Trading__MarketData__Symbols__0: PETR4
       Trading__MarketData__Symbols__1: VALE3
       Trading__MarketData__Symbols__2: ITUB4
+      # #382. EnableBook flips two switches in lockstep:
+      #   - SdkMarketDataSubscriber adds SubscribeFlags.Book to the SDK
+      #     subscription so marketdata streams MBO frames to trading-host.
+      #   - MarketDataRegistration replaces the no-op InMemoryL2BookView
+      #     with SdkBookFeedAdapter (backed by SDK 0.4.0 IBookFeed) so
+      #     WebSocketBookEventSink and MboPegBookPump see real depth.
+      # MarketDataOptions defaults to false to keep the application
+      # surface honest when MD is wired but the SDK Book extension is
+      # not desired; for the real-stack compose, depth IS the headline
+      # feature so we flip it on by default. Override via .env when
+      # debugging MD cost or chasing a Book-feed regression.
+      Trading__MarketData__EnableBook: ${TRADING_MARKETDATA_ENABLE_BOOK:-true}
     volumes:
       - trading-data:/var/lib/b3trading
     networks:

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -411,21 +411,25 @@ function ensureBook(symbol) {
 /// top-N ladder). Snapshot and delta share the same shape, so a single
 /// reducer handles both — the server already replays the latest
 /// ladder as a `snapshot` frame on subscribe.
+///
+/// Wire shape is camelCase: `WebSocketHub` serializes outbound frames
+/// with `JsonSerializerDefaults.Web`, so `L2LadderDto.Symbol` lands on
+/// the wire as `symbol`, `Bids[i].Price` as `price`, etc. (#382 follow-up.)
 /// </summary>
 export function applyBookFrame(frame) {
-  if (!frame || typeof frame.Symbol !== "string") return;
-  const entry = ensureBook(frame.Symbol);
+  if (!frame || typeof frame.symbol !== "string") return;
+  const entry = ensureBook(frame.symbol);
   entry.bids.clear();
   entry.asks.clear();
-  for (const lv of frame.Bids ?? []) {
-    entry.bids.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  for (const lv of frame.bids ?? []) {
+    entry.bids.set(priceKey(lv.price), { qty: lv.totalQty, count: lv.orderCount });
   }
-  for (const lv of frame.Asks ?? []) {
-    entry.asks.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  for (const lv of frame.asks ?? []) {
+    entry.asks.set(priceKey(lv.price), { qty: lv.totalQty, count: lv.orderCount });
   }
-  // Empty-state snapshot (UpdatedUtc=null) keeps ready=false so the
+  // Empty-state snapshot (updatedUtc=null) keeps ready=false so the
   // DOB shows its "waiting" affordance instead of an empty ladder.
-  entry.ready = frame.UpdatedUtc != null;
+  entry.ready = frame.updatedUtc != null;
   entry.updatedAt = Date.now();
   notify("book");
 }

--- a/frontend/test/state-book-frame.test.mjs
+++ b/frontend/test/state-book-frame.test.mjs
@@ -5,6 +5,15 @@
 // Coverage: snapshot replaces both sides, empty snapshot keeps
 // ready=false, defensive null guards, watchlist trimming still
 // evicts the entry.
+//
+// IMPORTANT: WebSocketHub serializes outbound frames with
+// JsonSerializerDefaults.Web, so the wire payload is camelCase
+// (`symbol`, `bids`, `asks`, `updatedUtc`, level fields `price`,
+// `totalQty`, `orderCount`). Fixtures here must match the wire
+// shape — early test fixtures used PascalCase and silently masked
+// a real bug where the reducer dropped every live frame (#382
+// follow-up: DOB stayed empty even with EnableBook=true and a
+// populated book on the wire).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -16,15 +25,15 @@ async function freshState() {
 }
 
 const frame = (overrides = {}) => ({
-  Symbol: 'PETR4',
-  Bids: [
-    { Price: 30.20, TotalQty: 100, OrderCount: 1 },
-    { Price: 30.10, TotalQty: 250, OrderCount: 3 },
+  symbol: 'PETR4',
+  bids: [
+    { price: 30.20, totalQty: 100, orderCount: 1 },
+    { price: 30.10, totalQty: 250, orderCount: 3 },
   ],
-  Asks: [
-    { Price: 30.30, TotalQty: 50, OrderCount: 1 },
+  asks: [
+    { price: 30.30, totalQty: 50, orderCount: 1 },
   ],
-  UpdatedUtc: '2026-05-19T20:00:00Z',
+  updatedUtc: '2026-05-19T20:00:00Z',
   ...overrides,
 });
 
@@ -42,7 +51,7 @@ test('applyBookFrame populates both sides with priceKey-bucketed levels and flip
 
 test('applyBookFrame empty-state snapshot leaves ready=false', async () => {
   const s = await freshState();
-  s.applyBookFrame({ Symbol: 'VALE3', Bids: [], Asks: [], UpdatedUtc: null });
+  s.applyBookFrame({ symbol: 'VALE3', bids: [], asks: [], updatedUtc: null });
   const entry = s.getState().book.get('VALE3');
   assert.equal(entry.ready, false);
   assert.equal(entry.bids.size, 0);
@@ -53,8 +62,8 @@ test('applyBookFrame replaces the prior ladder rather than merging', async () =>
   const s = await freshState();
   s.applyBookFrame(frame());
   s.applyBookFrame(frame({
-    Bids: [{ Price: 31.00, TotalQty: 999, OrderCount: 7 }],
-    Asks: [],
+    bids: [{ price: 31.00, totalQty: 999, orderCount: 7 }],
+    asks: [],
   }));
   const entry = s.getState().book.get('PETR4');
   assert.equal(entry.bids.size, 1);
@@ -67,6 +76,10 @@ test('applyBookFrame ignores malformed payloads', async () => {
   s.applyBookFrame(null);
   s.applyBookFrame(undefined);
   s.applyBookFrame({});
-  s.applyBookFrame({ Symbol: 42 });
+  s.applyBookFrame({ symbol: 42 });
+  // Pascal-case shape (pre-#382 wire mismatch) is also rejected so a
+  // future serializer regression surfaces in tests instead of silently
+  // emptying the DOB.
+  s.applyBookFrame({ Symbol: 'PETR4', Bids: [], Asks: [], UpdatedUtc: '2026-05-19T20:00:00Z' });
   assert.equal(s.getState().book.size, 0);
 });


### PR DESCRIPTION
Fixes #382.

## Context

`MarketDataOptions.EnableBook` defaults to `false`. The base `docker/docker-compose.yml` wires every other live-MD env var for `trading-host` (`WsUrl`, `Symbols`) but never sets `Trading__MarketData__EnableBook`, so the SDK subscription comes up with `Trades|Info` only and `IL2BookView` stays on the no-op `InMemoryL2BookView`. End result: vanilla `docker compose up` ships an empty DOB.

Caught during manual validation — a fresh order accepted/working never produced book frames; only after setting `EnableBook=true` did `book.PETR4` populate with real depth.

## Changes

- **`docker/docker-compose.yml`** — set `Trading__MarketData__EnableBook: ${TRADING_MARKETDATA_ENABLE_BOOK:-true}` next to the WsUrl/Symbols block. Variable form lets operators flip the switch from `.env` without forking the compose.
- **`docker/docker-compose.unavailable.yml`** — pin `EnableBook=false` explicitly. WsUrl=\"\" already short-circuits MD registration, but the explicit flag protects against a future overlay that wires a stub URL.
- **`docker/docker-compose.e2e.yml`** — clear inherited `WsUrl` and pin `EnableBook=false`. The smoke E2E suppresses matching/marketdata via profiles; the inherited `ws://marketdata:8080/ws` would churn reconnect attempts otherwise.
- **`docker/.env.example`** — document the opt-out switch.

## Out of scope

- Flipping `MarketDataOptions.EnableBook` default to `true` in code (#382 bonus). Wider blast radius; left as a follow-up RFC.
- DOB false-negative \"check MD settings\" alert for empty-but-live books (tracked separately in #379).
- The base compose also lacks `Trading:Reports:Cvm:OwnerHashSalt` and trips the boot guard in non-Development envs — separate adjacent gap, not bundled here.

## Validation

Clean reboot (volumes wiped) using only the base compose + the CVM-salt overlay required to boot:

```
$ docker exec b3-trading-host printenv | grep EnableBook
Trading__MarketData__EnableBook=true

$ # submit one resting Buy
$ curl -X POST .../orders -d '{... PETR4 Buy 100 @ 32.50 Limit Day ...}'
{\"clOrdId\":\"1\"}

$ # subscribe book.PETR4 over WS
snapshot book.PETR4 seq=0:
  bids=[{price:32.5, totalQty:100, orderCount:1}], asks=[]
  updatedUtc=2026-05-22T14:14:36.99…
```

DOB renders depth instead of \"no book — check MD settings\".