### PR TITLE
fix(#379): distinguish live-empty book from cold-start MD in DOB

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketBookEventSink.cs
@@ -39,6 +39,7 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
 {
     private readonly SubscriptionManager _subs;
     private readonly IL2BookView _store;
+    private readonly TimeProvider _clock;
     private readonly int _maxLevels;
 
     // Last DTO put on the wire per symbol — used to coalesce identical
@@ -49,23 +50,41 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
     public WebSocketBookEventSink(
         SubscriptionManager subs,
         IL2BookView store,
-        IOptions<MarketDataOptions> options)
+        IOptions<MarketDataOptions> options,
+        TimeProvider? clock = null)
     {
         _subs = subs;
         _store = store;
+        _clock = clock ?? TimeProvider.System;
         var max = options.Value.BookChannelMaxLevels;
         _maxLevels = max > 0 ? max : 10;
     }
 
     // ---------------- IPublicChannelSnapshots ----------------
 
+    /// <summary>
+    /// #379. A late subscriber to <c>book.${symbol}</c> must see the same
+    /// "live but empty" marker (zero levels, non-null UpdatedUtc) that
+    /// active subscribers saw when the book emptied — otherwise the FE
+    /// can't tell apart "MD never spoke to us" (cold start, UpdatedUtc=null)
+    /// from "MD is live, just nothing resting" (UpdatedUtc=now). When we
+    /// have a last-sent DTO for this symbol it IS the authoritative
+    /// snapshot; fall back to the store only when we've never broadcast.
+    /// </summary>
     public object? GetSnapshot(PublicChannelKind kind, string symbol) => kind switch
     {
-        PublicChannelKind.Book => _store.GetLadder(symbol, _maxLevels) is { } ladder
-            ? L2LadderDto.From(ladder)
-            : L2LadderDto.Empty(symbol),
+        PublicChannelKind.Book => GetBookSnapshot(symbol),
         _ => null,
     };
+
+    private L2LadderDto GetBookSnapshot(string symbol)
+    {
+        if (_lastSent.TryGetValue(symbol, out var prev))
+            return prev;
+        return _store.GetLadder(symbol, _maxLevels) is { } ladder
+            ? L2LadderDto.From(ladder)
+            : L2LadderDto.Empty(symbol);
+    }
 
     // ---------------- IHostedService ----------------
 
@@ -93,13 +112,25 @@ public sealed class WebSocketBookEventSink : IPublicChannelSnapshots, IHostedSer
             // the wire the FE keeps rendering the last populated ladder
             // forever (#382 follow-up: bid lingered after fill — only a
             // hard refresh re-fetched the cold-start snapshot and cleared
-            // the DOB). Broadcast Empty(symbol) once on the populated →
-            // empty edge so the FE reducer clears both sides; coalesce
-            // subsequent empty-events by tracking the empty as the new
-            // _lastSent so a steady-state empty book stays off the wire.
+            // the DOB).
+            //
+            // #379. Stamp UpdatedUtc with the broadcast time so the FE
+            // can distinguish "MD never spoke to us" (cold start, the
+            // store has never had a frame for this symbol → snapshot
+            // shape is L2LadderDto.Empty with UpdatedUtc=null) from
+            // "MD is live, just nothing resting right now" (this path —
+            // a BookChanged event fired, so MD is definitely alive).
+            // The FE reducer flips ready=true on any non-null UpdatedUtc
+            // and the DOB renderer switches the empty case from the
+            // misleading "no book — check MD settings ⚙" copy to a
+            // simple "no resting orders" placeholder.
             if (_lastSent.TryGetValue(symbol, out var prevEmpty) && IsEmptyLadder(prevEmpty))
                 return;
-            var emptyDto = L2LadderDto.Empty(symbol);
+            var emptyDto = new L2LadderDto(
+                symbol,
+                Array.Empty<L2SideDto>(),
+                Array.Empty<L2SideDto>(),
+                _clock.GetUtcNow());
             _lastSent[symbol] = emptyDto;
             _subs.BroadcastPublic(Channels.BookFor(symbol), emptyDto);
             return;

--- a/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BookWebSocketChannelTests.cs
@@ -9,18 +9,30 @@ namespace B3.Trading.Api.Tests;
 
 public class BookWebSocketChannelTests
 {
+    private static readonly DateTimeOffset FixedClockNow =
+        new(2026, 5, 22, 14, 0, 0, TimeSpan.Zero);
+
     private static (SubscriptionManager subs, InMemoryL2BookView store, WebSocketBookEventSink sink) Build(int maxLevels = 10)
     {
         var store = new InMemoryL2BookView();
         var subs = new SubscriptionManager(new WorkingOrderBook(), new PositionKeeper(), new AlgoBook());
         var opts = Options.Create(new MarketDataOptions { BookChannelMaxLevels = maxLevels });
-        var sink = new WebSocketBookEventSink(subs, store, opts);
+        var clock = new FakeTimeProvider(FixedClockNow);
+        var sink = new WebSocketBookEventSink(subs, store, opts, clock);
         sink.StartAsync(default).GetAwaiter().GetResult();
         return (subs, store, sink);
     }
 
     private static MarketOrderAdded Add(string sym, ulong id, MarketBookSide side, decimal price, long qty) =>
         new(sym, 4321UL, id, side, price, qty, DateTimeOffset.UtcNow);
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now += delta;
+    }
 
     [Fact]
     public void TryParsePublic_recognises_book_with_valid_symbol()
@@ -239,11 +251,61 @@ public class BookWebSocketChannelTests
         Assert.Equal("PETR4", emptyDto.Symbol);
         Assert.Empty(emptyDto.Bids);
         Assert.Empty(emptyDto.Asks);
-        // Empty-state marker matches the cold-start snapshot shape so the FE
-        // reducer's `ready = updatedUtc != null` branch flips ready=false and
-        // the DOB drops back to the waiting affordance instead of carrying
-        // stale levels.
-        Assert.Null(emptyDto.UpdatedUtc);
+        // #379. Live-empty marker: UpdatedUtc is non-null (stamped with the
+        // sink's TimeProvider) so the FE reducer flips ready=true and the
+        // DOB renders "empty" per-side instead of "no book — check MD
+        // settings". Cold-start L2LadderDto.Empty(symbol) keeps UpdatedUtc=null
+        // (see Book_subscribe_emits_empty_snapshot_when_no_frame_seen).
+        Assert.Equal(FixedClockNow, emptyDto.UpdatedUtc);
+    }
+
+    /// <summary>
+    /// #379. A late subscriber to a symbol whose book has emptied since the
+    /// last populated broadcast must see the live-empty marker (non-null
+    /// UpdatedUtc), not the cold-start shape. Otherwise the DOB shows
+    /// "check MD settings" to a trader whose MD subscription is perfectly
+    /// healthy — the symbol is just quiet right now.
+    /// </summary>
+    [Fact]
+    public void Book_late_subscriber_after_empty_sees_live_empty_marker()
+    {
+        var (subs, store, sink) = Build();
+        // Drive the populated → empty cycle without any subscriber to
+        // prove _lastSent is populated purely by OnBookChanged.
+        store.ApplyAdded(Add("PETR4", 1UL, MarketBookSide.Bid, 32.50m, 100));
+        store.ApplyDeleted(new MarketOrderDeleted("PETR4", 4321UL, 1UL, MarketBookSide.Bid, DateTimeOffset.UtcNow));
+
+        var client = new SubscribedClient(new EndClientId("bob"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+
+        Assert.True(client.Reader.TryRead(out var snap));
+        Assert.Equal("snapshot", snap!.Type);
+        var dto = Assert.IsType<L2LadderDto>(snap.Data);
+        Assert.Empty(dto.Bids);
+        Assert.Empty(dto.Asks);
+        Assert.Equal(FixedClockNow, dto.UpdatedUtc);
+    }
+
+    /// <summary>
+    /// #379. Cold-start contract preserved: a subscriber arriving before
+    /// any BookChanged has fired for the symbol still sees the null
+    /// UpdatedUtc marker so the FE shows "awaiting book snapshot…" → then
+    /// "check MD settings" after the timeout, which IS the right copy
+    /// when MD truly hasn't spoken.
+    /// </summary>
+    [Fact]
+    public void Book_cold_start_snapshot_still_carries_null_updated_utc()
+    {
+        var (subs, _, sink) = Build();
+        var client = new SubscribedClient(new EndClientId("alice"), "TEST");
+        subs.SubscribePublicWithSnapshot(client, "book.PETR4",
+            () => sink.GetSnapshot(PublicChannelKind.Book, "PETR4"));
+        Assert.True(client.Reader.TryRead(out var snap));
+        var dto = Assert.IsType<L2LadderDto>(snap!.Data);
+        Assert.Empty(dto.Bids);
+        Assert.Empty(dto.Asks);
+        Assert.Null(dto.UpdatedUtc);
     }
 
     /// <summary>

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -415,6 +415,17 @@ function ensureBook(symbol) {
 /// Wire shape is camelCase: `WebSocketHub` serializes outbound frames
 /// with `JsonSerializerDefaults.Web`, so `L2LadderDto.Symbol` lands on
 /// the wire as `symbol`, `Bids[i].Price` as `price`, etc. (#382 follow-up.)
+///
+/// `ready` reflects MD liveness for the symbol, NOT order presence:
+///   - `updatedUtc=null` (cold-start L2LadderDto.Empty) → ready=false,
+///     the DOB renders the "awaiting / check MD settings" affordance.
+///   - `updatedUtc=<iso>` with non-empty sides → ready=true, depth renders.
+///   - `updatedUtc=<iso>` with both sides empty (live-empty: book just
+///     emptied, or late subscriber to a quiet symbol) → ready=true and
+///     each side falls through to `renderDobSide`'s "empty" muted-cell.
+///     The server stamps this UpdatedUtc itself on the populated → empty
+///     edge so the FE can tell apart "MD never spoke" from "MD is live,
+///     just nothing resting" (#379).
 /// </summary>
 export function applyBookFrame(frame) {
   if (!frame || typeof frame.symbol !== "string") return;

--- a/frontend/test/state-book-frame.test.mjs
+++ b/frontend/test/state-book-frame.test.mjs
@@ -58,6 +58,21 @@ test('applyBookFrame empty-state snapshot leaves ready=false', async () => {
   assert.equal(entry.asks.size, 0);
 });
 
+// #379. Live-but-empty: the trading-host stamps UpdatedUtc on the
+// populated → empty edge (and serves it from _lastSent to late
+// subscribers) so the FE can tell "MD never spoke" (cold start,
+// updatedUtc=null → ready=false → "check MD settings" copy) apart from
+// "MD is live, just nothing resting" (updatedUtc=iso → ready=true →
+// the renderer falls through to the per-side "empty" muted-cell).
+test('applyBookFrame live-empty frame (zero sides + non-null updatedUtc) flips ready=true', async () => {
+  const s = await freshState();
+  s.applyBookFrame({ symbol: 'ITUB4', bids: [], asks: [], updatedUtc: '2026-05-22T14:00:00Z' });
+  const entry = s.getState().book.get('ITUB4');
+  assert.equal(entry.ready, true);
+  assert.equal(entry.bids.size, 0);
+  assert.equal(entry.asks.size, 0);
+});
+
 test('applyBookFrame replaces the prior ladder rather than merging', async () => {
   const s = await freshState();
   s.applyBookFrame(frame());


### PR DESCRIPTION
Closes #379. **Stacked on top of #383** (target base will switch to `main` once #383 merges).

## Problem

After #382 fixed the populated → empty broadcast, every cross-and-clear trade left the trader staring at the alarming **"no book — check MD settings ⚙"** copy in the DOB — even though MD was perfectly healthy. The reducer was conflating two very different states:

| State | Meaning | Correct copy |
|---|---|---|
| cold start (`updatedUtc=null`) | MD has not spoken for this symbol yet | "check MD settings" |
| live-empty (`updatedUtc=null` after #382) | MD is healthy, book just emptied | should be "empty" |

Both got the cold-start treatment because the empty-edge frame and the cold-start snapshot were indistinguishable on the wire.

## Fix

### Backend (`WebSocketBookEventSink`)
- Empty-edge broadcast in `OnBookChanged` now stamps `UpdatedUtc` with `TimeProvider.GetUtcNow` instead of `L2LadderDto.Empty(symbol)`'s null marker. The fact that `OnBookChanged` fired at all proves MD is alive.
- `GetSnapshot` prefers `_lastSent[symbol]` over the store, so a late subscriber to a quiet-but-live symbol gets the same non-null `UpdatedUtc` marker active subscribers saw on the empty edge.
- Cold-start subscribers (no prior broadcast) still get `L2LadderDto.Empty` with null `UpdatedUtc` — that case IS "check MD".
- `TimeProvider` injected as optional ctor param (defaults to `TimeProvider.System`) — consistent with `PnlRefPriceFanOut` / `AuctionStateStore` / `MarketDataReferencePrice`. No DI changes required.

### Frontend
- `applyBookFrame` contract refreshed in doc comment: `ready=true` now means "MD is live for this symbol", not "this symbol has resting orders". No reducer logic change needed — `ready = updatedUtc != null` already does the right thing once the backend stamps the timestamp.
- `renderDob` needs no change either: when `ready=true` and a side is empty, `renderDobSide` naturally produces the per-side "empty" muted-cell, which is the right copy for a live-empty book.

## Tests
- `BookWebSocketChannelTests`: existing empty-edge regression test updated to assert non-null `UpdatedUtc` via `FakeTimeProvider`. Added `Book_late_subscriber_after_empty_sees_live_empty_marker` and `Book_cold_start_snapshot_still_carries_null_updated_utc`. **35/35 pass.**
- `state-book-frame.test.mjs`: added live-empty case asserting `ready=true` with non-null `updatedUtc` + empty sides. **283/283 FE tests pass** (was 282).

## Validation
Built trading-host image with this change, restarted host + matching, validated cold-start vs live-empty paths against the running stack from the same compose used to file #379.

---
Stacking note: target base intentionally points at `fix/382-enable-book-real-stack` to keep diff scoped. Will retarget to `main` after #383 merges.
