### PR TITLE
Debit fees from CashLedger Available (#387)

### DIFF
--- a/backend/src/B3.Trading.Application/CashLedger.cs
+++ b/backend/src/B3.Trading.Application/CashLedger.cs
@@ -49,6 +49,33 @@ public sealed class CashLedger
     }
 
     /// <summary>
+    /// #387. Debit a brokerage / settlement fee from <see cref="CashBalance.Available"/>.
+    /// Called by <see cref="FeeKeeper.Apply"/> after the seen-set
+    /// guard succeeds, so this method itself is NOT idempotent — it
+    /// always debits the supplied <paramref name="amount"/>. Replay
+    /// idempotency lives in the keeper (FeeAccruedEvent.ExecutionId
+    /// dedup); from there it's the same byte-identical recovery
+    /// contract as <see cref="ApplyFill"/>.
+    /// <para>
+    /// <paramref name="amount"/> is a positive fee total (the
+    /// <see cref="Persistence.FeeAccruedEvent.Total"/> field is always
+    /// non-negative). Zero amounts are a no-op so a fee-free symbol
+    /// does not materialise a balance row.
+    /// </para>
+    /// </summary>
+    public void ApplyFee(EndClientId owner, decimal amount)
+    {
+        if (amount < 0m)
+            throw new ArgumentOutOfRangeException(nameof(amount), "fee must be non-negative");
+        if (amount == 0m) return;
+        var balance = GetOrCreate(owner);
+        lock (balance)
+        {
+            balance.ApplyFee(amount);
+        }
+    }
+
+    /// <summary>
     /// Read-only convenience for risk / API callers. Returns <c>0</c> for
     /// an unknown owner without materialising an entry, so probing the
     /// balance can't pollute the dictionary.

--- a/backend/src/B3.Trading.Application/FeeKeeper.cs
+++ b/backend/src/B3.Trading.Application/FeeKeeper.cs
@@ -32,6 +32,20 @@ public sealed class FeeKeeper
     private readonly ConcurrentDictionary<(string EndClient, DateOnly Day), decimal> _totals = new();
     private readonly ConcurrentDictionary<string, byte> _seenExecutionIds = new();
     /// <summary>
+    /// #387. Optional cash sink: when wired, every successful (non-
+    /// duplicate) fee application also debits the end-client's free
+    /// cash via <see cref="CashLedger.ApplyFee"/>. Optional so tests
+    /// and the daily-statement projection (which only consumes the
+    /// keeper's totals) can construct a FeeKeeper without a cash
+    /// dependency.
+    /// </summary>
+    private readonly CashLedger? _cash;
+
+    public FeeKeeper(CashLedger? cash = null)
+    {
+        _cash = cash;
+    }
+    /// <summary>
     /// Pass-3 review (#277). Holds ER-synthesised fee placeholders
     /// during a replay run. The WAL sequencing guarantees a durable
     /// <see cref="FeeAccruedEvent"/> (if it exists) follows its ER, so
@@ -86,6 +100,12 @@ public sealed class FeeKeeper
         var day = DateOnly.FromDateTime(evt.TimestampUtc.UtcDateTime);
         var key = (evt.EndClientId, day);
         _totals.AddOrUpdate(key, evt.Total, (_, current) => current + evt.Total);
+        // #387. Mirror the fee debit into CashLedger so the trader's
+        // Available reflects post-fee cash. Gated by the seen-set above,
+        // so replay (FeeAccruedEvent re-applied on WAL drain) is a
+        // no-op for cash too. Optional dep — when null, only totals
+        // advance (test contexts / statement-only deployments).
+        _cash?.ApplyFee(new B3.Trading.Domain.EndClientId(evt.EndClientId), evt.Total);
         return true;
     }
 
@@ -143,6 +163,12 @@ public sealed class FeeKeeper
             var day = DateOnly.FromDateTime(p.TimestampUtc.UtcDateTime);
             var key = (p.EndClientId, day);
             _totals.AddOrUpdate(key, breakdown.Total, (_, current) => current + breakdown.Total);
+            // #387. Same cash-debit hook as Apply, executed only for
+            // ER-then-crash window survivors. The seen-set TryAdd above
+            // is the idempotency gate — a fee that was already in the
+            // snapshot (loaded via Restore + seen-set) never reaches
+            // here.
+            _cash?.ApplyFee(new B3.Trading.Domain.EndClientId(p.EndClientId), breakdown.Total);
             Observability.MetricsRegistry.FeeReplaySynth.Add(1,
                 new KeyValuePair<string, object?>("reconciled", false));
             materialised++;

--- a/backend/src/B3.Trading.Domain/CashBalance.cs
+++ b/backend/src/B3.Trading.Domain/CashBalance.cs
@@ -40,6 +40,19 @@ public sealed class CashBalance
     }
 
     /// <summary>
+    /// #387. Debit a brokerage / settlement fee from <see cref="Available"/>.
+    /// Fees are always a cost — the sign is fixed (debit). Caller
+    /// (CashLedger.ApplyFee, gated by FeeKeeper's seen-set) is
+    /// responsible for replay idempotency.
+    /// </summary>
+    public void ApplyFee(decimal amount)
+    {
+        if (amount < 0m)
+            throw new ArgumentOutOfRangeException(nameof(amount), "fee must be non-negative");
+        Available -= amount;
+    }
+
+    /// <summary>
     /// Recovery / seed-only constructor used by snapshot replay and
     /// startup seeding. Skips the ApplyFill arithmetic so a snapshot
     /// loaded with a negative or zero balance round-trips exactly.

--- a/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
@@ -103,4 +103,39 @@ public class CashLedgerTests
         Assert.Equal(src.GetAvailable(new EndClientId("alice")), dst.GetAvailable(new EndClientId("alice")));
         Assert.Equal(src.GetAvailable(new EndClientId("bob")), dst.GetAvailable(new EndClientId("bob")));
     }
+
+    // #387. Cash debit hook used by FeeKeeper.Apply after the seen-set
+    // gate succeeds. Idempotency lives in the keeper; from the ledger's
+    // point of view ApplyFee is just an unconditional debit.
+    [Fact]
+    public void ApplyFee_DebitsAvailable()
+    {
+        var ledger = new CashLedger();
+        var alice = new EndClientId("alice");
+        ledger.SeedIfAbsent(alice, 1_000m);
+
+        ledger.ApplyFee(alice, 0.50m);
+        ledger.ApplyFee(alice, 0.25m);
+
+        Assert.Equal(999.25m, ledger.GetAvailable(alice));
+    }
+
+    [Fact]
+    public void ApplyFee_ZeroAmount_DoesNotMaterialiseRow()
+    {
+        var ledger = new CashLedger();
+        var ghost = new EndClientId("ghost");
+
+        ledger.ApplyFee(ghost, 0m);
+
+        Assert.Empty(ledger.Snapshot());
+    }
+
+    [Fact]
+    public void ApplyFee_NegativeAmount_Throws()
+    {
+        var ledger = new CashLedger();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ledger.ApplyFee(new EndClientId("alice"), -1m));
+    }
 }

--- a/backend/tests/B3.Trading.Application.Tests/FeeKeeperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/FeeKeeperTests.cs
@@ -115,4 +115,95 @@ public class FeeKeeperTests
         Assert.Equal("alice", ec);
         Assert.Equal(new DateOnly(2025, 1, 15), d);
     }
+
+    // ----- #387: cash debit wired through FeeKeeper.Apply -----
+
+    [Fact]
+    public void Apply_WithCashLedger_DebitsAvailable_OnFirstSeen()
+    {
+        var cash = new CashLedger();
+        cash.SeedIfAbsent(new B3.Trading.Domain.EndClientId("alice"), 1_000m);
+        var keeper = new FeeKeeper(cash);
+        var t = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.True(keeper.Apply(Evt("1", 10, "alice", 0.50m, t)));
+
+        Assert.Equal(999.50m, cash.GetAvailable(new B3.Trading.Domain.EndClientId("alice")));
+    }
+
+    [Fact]
+    public void Apply_WithCashLedger_DedupesByExecutionId_NoDoubleDebit()
+    {
+        var cash = new CashLedger();
+        cash.SeedIfAbsent(new B3.Trading.Domain.EndClientId("alice"), 1_000m);
+        var keeper = new FeeKeeper(cash);
+        var t = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        var evt = Evt("1", 10, "alice", 0.50m, t);
+
+        Assert.True(keeper.Apply(evt));
+        Assert.False(keeper.Apply(evt));   // replay / retransmit
+
+        Assert.Equal(999.50m, cash.GetAvailable(new B3.Trading.Domain.EndClientId("alice")));
+    }
+
+    [Fact]
+    public void Apply_WithoutCashLedger_AdvancesTotalsButDebitsNothing()
+    {
+        // Statement-only / test contexts construct FeeKeeper without
+        // a CashLedger — totals must still advance.
+        var keeper = new FeeKeeper(cash: null);
+        var t = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.True(keeper.Apply(Evt("1", 10, "alice", 5m, t)));
+
+        Assert.Equal(5m, keeper.GetDayTotal("alice", new DateOnly(2025, 1, 15)));
+    }
+
+    // #387. WAL replay (snapshot-before-fee path): Restore loads
+    // seen-set + totals; subsequent FeeAccruedEvent replay must be a
+    // no-op for BOTH totals and cash.
+    [Fact]
+    public void Apply_AfterRestoreWithSeenId_NoDoubleDebit()
+    {
+        var cash = new CashLedger();
+        cash.SeedIfAbsent(new B3.Trading.Domain.EndClientId("alice"), 1_000m);
+        // Pretend a previous run already debited the fee → snapshot
+        // captured Available=999.50 and seen-set={"1:10"}.
+        cash.ApplyFee(new B3.Trading.Domain.EndClientId("alice"), 0.50m);
+        var keeper = new FeeKeeper(cash);
+        keeper.Restore(new Dictionary<string, decimal>(), new[] { "1:10" });
+
+        var t = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        Assert.False(keeper.Apply(Evt("1", 10, "alice", 0.50m, t)));
+
+        Assert.Equal(999.50m, cash.GetAvailable(new B3.Trading.Domain.EndClientId("alice")));
+    }
+
+    // #387. FinalizeReplay path: ER-then-crash window. No durable fee
+    // event came through but the ER did. Materialise + debit cash.
+    [Fact]
+    public void FinalizeReplay_MaterialisesFee_AndDebitsCash()
+    {
+        var cash = new CashLedger();
+        cash.SeedIfAbsent(new B3.Trading.Domain.EndClientId("alice"), 1_000m);
+        var keeper = new FeeKeeper(cash);
+        var t = new DateTimeOffset(2025, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        keeper.RegisterPendingReplaySynth("1:10", "alice", "PETR4",
+            B3.Trading.Domain.OrderSide.Buy, 10, 30m, t);
+
+        var calc = new StaticFeeCalculator(0.75m);
+        var n = keeper.FinalizeReplay(calc);
+
+        Assert.Equal(1, n);
+        Assert.Equal(0.75m, keeper.GetDayTotal("alice", new DateOnly(2025, 1, 15)));
+        Assert.Equal(999.25m, cash.GetAvailable(new B3.Trading.Domain.EndClientId("alice")));
+    }
+
+    private sealed class StaticFeeCalculator : IFeeCalculator
+    {
+        private readonly decimal _total;
+        public StaticFeeCalculator(decimal total) { _total = total; }
+        public FeeBreakdown Compute(string symbol, B3.Trading.Domain.OrderSide side, long quantity, decimal price)
+            => new(_total, 0m, 0m, _total);
+    }
 }


### PR DESCRIPTION
Closes #387.

## What
Wire `FeeKeeper` into `CashLedger` so per-fill brokerage/emolumentos/liquidação are debited from Available, not just accumulated on the (display-only) totals map.

## How
- `CashBalance.ApplyFee(decimal)` – pure debit, throws on negative.
- `CashLedger.ApplyFee(EndClientId, decimal)` – per-balance lock; zero-amount no-op (doesn't materialise a row for end-clients with no balance yet).
- `FeeKeeper` gains an optional `CashLedger?` ctor param (DI auto-resolves since both are `AddSingleton`'d). The cash debit is fired **inside** `Apply` and `FinalizeReplay`, **after** the existing `_seenExecutionIds.TryAdd` succeeds — so it inherits the same dedup that protects fee totals from double-application on retransmits, snapshot+tail recovery, and the ER-then-crash replay path.

## Replay safety
`RawSnapshotSeenIds` already persists the dedup set; restoring it then replaying the tail will skip duplicates, including the cash debit. No new snapshot field needed.

## Tests
- +3 CashLedger (debit / zero no-op / negative throws)
- +5 FeeKeeper (debit on first seen / dedup / no-ledger back-compat / restore+seen no double-debit / FinalizeReplay materialises + debits)
- Full suite green: 517 + 1122 + 81 + 134 + 12 + 23 = 1889 tests pass.