### PR TITLE
Live balance.me WS channel (#386)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -15,6 +15,16 @@ public static class Channels
     public const string PnlMe = "pnl.me";
 
     /// <summary>
+    /// #386. Per-end-client live cash balance projection. Snapshot is
+    /// a single <see cref="BalanceDto"/> at subscribe time; deltas are
+    /// pushed by <c>WebSocketBalanceFanOut</c> whenever
+    /// <see cref="CashLedger.BalanceChanged"/> fires (fills, fees,
+    /// opening-balance seed). Not firm-scoped — the underlying
+    /// <see cref="CashLedger"/> is keyed only by end-client owner.
+    /// </summary>
+    public const string BalanceMe = "balance.me";
+
+    /// <summary>
     /// Q1.5 (#257). Public per-symbol market-data channels of the form
     /// <c>phases.${symbol}</c> and <c>auction.${symbol}</c> — fed off
     /// the UMDF auction listener via <c>AuctionStateStore</c>. They are
@@ -50,7 +60,7 @@ public static class Channels
     /// <see cref="TryParsePublic"/>.
     /// </summary>
     public static readonly IReadOnlySet<string> All =
-        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe, AlgoMe, PnlMe };
+        new HashSet<string>(StringComparer.Ordinal) { OrdersMe, ExecutionsMe, PositionsMe, AlgoMe, PnlMe, BalanceMe };
 
     /// <summary>
     /// Recognises <c>phases.SYMBOL</c> / <c>auction.SYMBOL</c> and

--- a/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
@@ -33,19 +33,22 @@ public sealed class SubscriptionManager
     private readonly AlgoBook _algos;
     private readonly PnlKeeper? _pnl;
     private readonly Application.Risk.IReferencePrice? _refPrice;
+    private readonly CashLedger? _cash;
 
     public SubscriptionManager(
         WorkingOrderBook orders,
         PositionKeeper positions,
         AlgoBook algos,
         PnlKeeper? pnl = null,
-        Application.Risk.IReferencePrice? refPrice = null)
+        Application.Risk.IReferencePrice? refPrice = null,
+        CashLedger? cash = null)
     {
         _orders = orders;
         _positions = positions;
         _algos = algos;
         _pnl = pnl;
         _refPrice = refPrice;
+        _cash = cash;
     }
 
     private object LockFor(EndClientId owner) =>
@@ -93,6 +96,7 @@ public sealed class SubscriptionManager
                 Channels.PnlMe => (_pnl is not null && _refPrice is not null)
                     ? PnlProjection.Build(client.Owner, client.FirmId, _pnl, _positions, _refPrice)
                     : null,
+                Channels.BalanceMe => new BalanceDto(_cash?.GetAvailable(client.Owner) ?? 0m),
                 _ => null,
             };
 

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketBalanceFanOut.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketBalanceFanOut.cs
@@ -1,0 +1,133 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Api.WebSockets;
+
+/// <summary>
+/// #386. Bridges <see cref="CashLedger.BalanceChanged"/> to the
+/// <c>balance.me</c> WS channel. One delta per (owner, Available)
+/// change reaches subscribed clients; repeated mutations that leave
+/// <c>Available</c> unchanged are coalesced out so a fee that debits
+/// 0 (which is a no-op in the ledger anyway) cannot trigger a
+/// redundant publish.
+///
+/// <para>
+/// <b>Lock ordering.</b> The keeper raises the event while holding
+/// the per-balance lock (so subscribers observe a consistent value).
+/// To avoid the WS hub's per-owner publish lock nesting under the
+/// ledger lock, the handler only ENQUEUES (owner, available) onto a
+/// channel; a dedicated drain task pumps the queue and calls
+/// <see cref="SubscriptionManager.Publish(EndClientId, string?, string, object)"/>
+/// out from under the keeper lock.
+/// </para>
+///
+/// <para>
+/// <b>Firm scope.</b> <see cref="CashLedger"/> is keyed only by
+/// <see cref="EndClientId"/>; the balance for a given owner is the
+/// same regardless of which firm authenticated the WS session. The
+/// publish therefore passes <c>firmId: null</c> and fans out to every
+/// subscribed client of the owner.
+/// </para>
+/// </summary>
+public sealed class WebSocketBalanceFanOut : IHostedService, IAsyncDisposable
+{
+    private readonly CashLedger _cash;
+    private readonly SubscriptionManager _subs;
+    private readonly ILogger<WebSocketBalanceFanOut>? _logger;
+
+    private readonly ConcurrentDictionary<EndClientId, decimal> _lastSent = new();
+
+    private readonly Channel<(EndClientId Owner, decimal Available)> _channel =
+        Channel.CreateUnbounded<(EndClientId, decimal)>(
+            new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _drainTask;
+    private int _stopped;
+
+    public WebSocketBalanceFanOut(
+        CashLedger cash,
+        SubscriptionManager subs,
+        ILogger<WebSocketBalanceFanOut>? logger = null)
+    {
+        _cash = cash;
+        _subs = subs;
+        _logger = logger;
+        _cash.BalanceChanged += OnBalanceChanged;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _drainTask = Task.Run(DrainAsync);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0) return;
+        _cash.BalanceChanged -= OnBalanceChanged;
+        _cts.Cancel();
+        _channel.Writer.TryComplete();
+        if (_drainTask is not null)
+        {
+            try { await _drainTask.ConfigureAwait(false); } catch { /* best-effort */ }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private void OnBalanceChanged(EndClientId owner, decimal available)
+    {
+        // Enqueue under the keeper lock; the drain runs outside it.
+        _channel.Writer.TryWrite((owner, available));
+    }
+
+    private async Task DrainAsync()
+    {
+        var reader = _channel.Reader;
+        try
+        {
+            while (await reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var item))
+                {
+                    try { PublishIfChanged(item.Owner, item.Available); }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning(ex,
+                            "balance.me fan-out failed for owner={Owner}", item.Owner.Value);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private void PublishIfChanged(EndClientId owner, decimal available)
+    {
+        // Coalesce: skip when the most recently published Available for
+        // this owner is identical. Decimals compare by value (not scale),
+        // which is what we want — 0 == 0.00.
+        if (_lastSent.TryGetValue(owner, out var prev) && prev == available)
+            return;
+
+        if (_subs.CountFor(owner) == 0)
+        {
+            // No subscribers — still update _lastSent so the first publish
+            // after a subscriber attaches reflects the snapshot baseline.
+            _lastSent[owner] = available;
+            return;
+        }
+
+        _subs.Publish(owner, firmId: null, Channels.BalanceMe, new BalanceDto(available));
+        _lastSent[owner] = available;
+    }
+}

--- a/backend/src/B3.Trading.Application/CashLedger.cs
+++ b/backend/src/B3.Trading.Application/CashLedger.cs
@@ -20,6 +20,24 @@ public sealed class CashLedger
     private readonly ConcurrentDictionary<EndClientId, CashBalance> _balances = new();
 
     /// <summary>
+    /// #386. Fired AFTER every mutation that changes
+    /// <see cref="CashBalance.Available"/> for an owner — fills, fees,
+    /// and the opening-balance seed. Invoked under the per-balance
+    /// lock so subscribers observe a consistent (owner, newAvailable)
+    /// pair, in mutation order. Listeners must NOT block (the lock is
+    /// held); the WS fan-out enqueues onto a channel and returns.
+    /// </summary>
+    public event Action<EndClientId, decimal>? BalanceChanged;
+
+    private void RaiseBalanceChanged(EndClientId owner, decimal newAvailable)
+    {
+        var handler = BalanceChanged;
+        if (handler is null) return;
+        try { handler(owner, newAvailable); }
+        catch { /* one bad subscriber must not poison the keeper */ }
+    }
+
+    /// <summary>
     /// Returns the existing balance or creates a fresh one at zero. Used
     /// by ER processor to fold fills lazily — accounts that never fill
     /// stay out of memory.
@@ -36,15 +54,23 @@ public sealed class CashLedger
     public bool SeedIfAbsent(EndClientId owner, decimal initialAvailable)
     {
         var seeded = CashBalance.Hydrate(owner, initialAvailable);
-        return _balances.TryAdd(owner, seeded);
+        if (_balances.TryAdd(owner, seeded))
+        {
+            RaiseBalanceChanged(owner, initialAvailable);
+            return true;
+        }
+        return false;
     }
 
     public void ApplyFill(EndClientId owner, OrderSide side, long quantity, decimal price)
     {
         var balance = GetOrCreate(owner);
+        decimal newAvailable;
         lock (balance)
         {
             balance.ApplyFill(side, quantity, price);
+            newAvailable = balance.Available;
+            RaiseBalanceChanged(owner, newAvailable);
         }
     }
 
@@ -72,6 +98,7 @@ public sealed class CashLedger
         lock (balance)
         {
             balance.ApplyFee(amount);
+            RaiseBalanceChanged(owner, balance.Available);
         }
     }
 

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -92,6 +92,14 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<IUserBotOrderMappingRegistry>(sp =>
             sp.GetRequiredService<InMemoryUserBotOrderMappingRegistry>());
         services.AddSingleton<SubscriptionManager>();
+
+        // #386. balance.me WS fan-out — bridges CashLedger.BalanceChanged
+        // (fills + fees + opening seed) to subscribed clients. Singleton +
+        // hosted service so the drain task starts/stops with the host;
+        // the event subscription itself attaches in the ctor so deltas
+        // queued before StartAsync run are picked up at start.
+        services.AddSingleton<WebSocketBalanceFanOut>();
+        services.AddHostedService(sp => sp.GetRequiredService<WebSocketBalanceFanOut>());
         // RFC §5.2 (F2). The WS hub sink is channel-backed and runs as
         // a hosted service so its drain task starts/stops with the host.
         // Both the IExecutionEventSink (synthetic publishes from

--- a/backend/tests/B3.Trading.Api.Tests/BalanceWebSocketChannelTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/BalanceWebSocketChannelTests.cs
@@ -1,0 +1,185 @@
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// #386. Coverage for the <c>balance.me</c> WS channel: snapshot on
+/// subscribe + live deltas pushed by <see cref="WebSocketBalanceFanOut"/>.
+/// </summary>
+public class BalanceWebSocketChannelTests
+{
+    [Fact]
+    public void Subscribe_EnqueuesBalanceSnapshot_ReflectingCurrentAvailable()
+    {
+        var cash = new CashLedger();
+        var owner = new EndClientId("alice");
+        cash.SeedIfAbsent(owner, 1_000m);
+
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook(), cash: cash);
+        var client = new SubscribedClient(owner, "FIRM01");
+        subs.Add(client);
+
+        subs.SubscribeWithSnapshot(client, Channels.BalanceMe);
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        Assert.Equal("snapshot", msg!.Type);
+        Assert.Equal(Channels.BalanceMe, msg.Channel);
+        var dto = Assert.IsType<BalanceDto>(msg.Data);
+        Assert.Equal(1_000m, dto.Available);
+    }
+
+    [Fact]
+    public void Subscribe_NoLedger_StillReturnsZeroSnapshot()
+    {
+        var owner = new EndClientId("alice");
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook());
+        var client = new SubscribedClient(owner, "FIRM01");
+        subs.Add(client);
+
+        subs.SubscribeWithSnapshot(client, Channels.BalanceMe);
+
+        Assert.True(client.Reader.TryRead(out var msg));
+        var dto = Assert.IsType<BalanceDto>(msg!.Data);
+        Assert.Equal(0m, dto.Available);
+    }
+
+    [Fact]
+    public async Task FanOut_PublishesDelta_OnFill()
+    {
+        var cash = new CashLedger();
+        var owner = new EndClientId("alice");
+        cash.SeedIfAbsent(owner, 10_000m);
+
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook(), cash: cash);
+        await using var fan = new WebSocketBalanceFanOut(cash, subs);
+        await fan.StartAsync(CancellationToken.None);
+
+        var client = new SubscribedClient(owner, "FIRM01");
+        subs.Add(client);
+        subs.SubscribeWithSnapshot(client, Channels.BalanceMe);
+        client.Reader.TryRead(out _); // discard snapshot
+
+        cash.ApplyFill(owner, OrderSide.Buy, 100, 30m); // -3000
+
+        var delta = await ReadWithTimeoutAsync(client);
+        Assert.Equal("delta", delta!.Type);
+        Assert.Equal(Channels.BalanceMe, delta.Channel);
+        Assert.Equal(1, delta.Seq);
+        var dto = Assert.IsType<BalanceDto>(delta.Data);
+        Assert.Equal(7_000m, dto.Available);
+
+        await fan.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task FanOut_PublishesDelta_OnFee()
+    {
+        var cash = new CashLedger();
+        var owner = new EndClientId("alice");
+        cash.SeedIfAbsent(owner, 500m);
+
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook(), cash: cash);
+        await using var fan = new WebSocketBalanceFanOut(cash, subs);
+        await fan.StartAsync(CancellationToken.None);
+
+        var client = new SubscribedClient(owner, "FIRM01");
+        subs.Add(client);
+        subs.SubscribeWithSnapshot(client, Channels.BalanceMe);
+        client.Reader.TryRead(out _); // snapshot
+
+        cash.ApplyFee(owner, 12.34m);
+
+        var delta = await ReadWithTimeoutAsync(client);
+        var dto = Assert.IsType<BalanceDto>(delta!.Data);
+        Assert.Equal(487.66m, dto.Available);
+
+        await fan.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task FanOut_CoalescesIdenticalAvailable_NoRedundantDelta()
+    {
+        var cash = new CashLedger();
+        var owner = new EndClientId("alice");
+        cash.SeedIfAbsent(owner, 100m);
+
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook(), cash: cash);
+        await using var fan = new WebSocketBalanceFanOut(cash, subs);
+        await fan.StartAsync(CancellationToken.None);
+
+        var client = new SubscribedClient(owner, "FIRM01");
+        subs.Add(client);
+        subs.SubscribeWithSnapshot(client, Channels.BalanceMe);
+        client.Reader.TryRead(out _); // snapshot
+
+        // Same buy + sell at same price returns Available to 100, but
+        // every fill raises BalanceChanged. We expect a delta for the
+        // intermediate state (Buy: 90) and another back to 100 — both
+        // distinct Available values so neither is coalesced. To test the
+        // coalesce path, fire two mutations that DO collapse: two
+        // ApplyFee(0) calls (no-op, no event) followed by one real fee.
+        cash.ApplyFee(owner, 0m);
+        cash.ApplyFee(owner, 0m);
+        cash.ApplyFee(owner, 25m);
+
+        var delta = await ReadWithTimeoutAsync(client);
+        Assert.Equal(75m, ((BalanceDto)delta!.Data!).Available);
+
+        // No extra delta should arrive
+        await Task.Delay(100);
+        Assert.False(client.Reader.TryRead(out _));
+
+        await fan.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task FanOut_OwnerScoped_DoesNotLeakAcrossOwners()
+    {
+        var cash = new CashLedger();
+        var alice = new EndClientId("alice");
+        var bob = new EndClientId("bob");
+        cash.SeedIfAbsent(alice, 1_000m);
+        cash.SeedIfAbsent(bob, 2_000m);
+
+        var subs = new SubscriptionManager(
+            new WorkingOrderBook(), new PositionKeeper(), new AlgoBook(), cash: cash);
+        await using var fan = new WebSocketBalanceFanOut(cash, subs);
+        await fan.StartAsync(CancellationToken.None);
+
+        var bobClient = new SubscribedClient(bob, "FIRM01");
+        subs.Add(bobClient);
+        subs.SubscribeWithSnapshot(bobClient, Channels.BalanceMe);
+        bobClient.Reader.TryRead(out _); // snapshot
+
+        cash.ApplyFee(alice, 50m); // alice mutates; bob must not see it
+
+        await Task.Delay(100);
+        Assert.False(bobClient.Reader.TryRead(out _));
+
+        await fan.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void Channels_BalanceMe_IsRecognised()
+    {
+        Assert.Contains(Channels.BalanceMe, Channels.All);
+    }
+
+    private static async Task<OutboundMessage?> ReadWithTimeoutAsync(SubscribedClient client)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (client.Reader.TryRead(out var msg)) return msg;
+            await Task.Delay(10);
+        }
+        return null;
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/CashLedgerTests.cs
@@ -138,4 +138,79 @@ public class CashLedgerTests
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             ledger.ApplyFee(new EndClientId("alice"), -1m));
     }
+
+    // ── #386 BalanceChanged event ────────────────────────────────────
+
+    [Fact]
+    public void BalanceChanged_FiresOnSeed_WithSeededAmount()
+    {
+        var ledger = new CashLedger();
+        var owner = new EndClientId("alice");
+        (EndClientId Owner, decimal Available)? observed = null;
+        ledger.BalanceChanged += (o, a) => observed = (o, a);
+
+        ledger.SeedIfAbsent(owner, 1_000m);
+
+        Assert.NotNull(observed);
+        Assert.Equal(owner, observed!.Value.Owner);
+        Assert.Equal(1_000m, observed.Value.Available);
+    }
+
+    [Fact]
+    public void BalanceChanged_FiresOnFill_WithPostMutationAvailable()
+    {
+        var ledger = new CashLedger();
+        var owner = new EndClientId("alice");
+        ledger.SeedIfAbsent(owner, 500m);
+        var captured = new List<decimal>();
+        ledger.BalanceChanged += (_, a) => captured.Add(a);
+
+        ledger.ApplyFill(owner, OrderSide.Buy, 10, 25m); // -250
+
+        Assert.Single(captured);
+        Assert.Equal(250m, captured[0]);
+    }
+
+    [Fact]
+    public void BalanceChanged_FiresOnFee_WithPostMutationAvailable()
+    {
+        var ledger = new CashLedger();
+        var owner = new EndClientId("alice");
+        ledger.SeedIfAbsent(owner, 100m);
+        var captured = new List<decimal>();
+        ledger.BalanceChanged += (_, a) => captured.Add(a);
+
+        ledger.ApplyFee(owner, 7.50m);
+
+        Assert.Single(captured);
+        Assert.Equal(92.50m, captured[0]);
+    }
+
+    [Fact]
+    public void BalanceChanged_DoesNotFire_OnZeroFee()
+    {
+        var ledger = new CashLedger();
+        var owner = new EndClientId("alice");
+        ledger.SeedIfAbsent(owner, 100m);
+        var fireCount = 0;
+        ledger.BalanceChanged += (_, _) => fireCount++;
+
+        ledger.ApplyFee(owner, 0m);
+
+        Assert.Equal(0, fireCount);
+    }
+
+    [Fact]
+    public void BalanceChanged_ThrowingSubscriber_DoesNotPoisonLedger()
+    {
+        var ledger = new CashLedger();
+        var owner = new EndClientId("alice");
+        ledger.BalanceChanged += (_, _) => throw new InvalidOperationException("bad subscriber");
+
+        // Must not throw out of the ledger.
+        ledger.SeedIfAbsent(owner, 100m);
+        ledger.ApplyFill(owner, OrderSide.Sell, 5, 10m); // +50
+
+        Assert.Equal(150m, ledger.GetAvailable(owner));
+    }
 }


### PR DESCRIPTION
Closes #386. Stacked on #387.

## What
Adds a per-end-client live cash balance projection over WS: `balance.me` channel with snapshot on subscribe + delta on every `Available` change.

## How
- `CashLedger.BalanceChanged` event fires under the per-balance lock on every mutation (`SeedIfAbsent` / `ApplyFill` / `ApplyFee`). Subscribers observe a consistent `(owner, newAvailable)` pair in mutation order.
- `WebSocketBalanceFanOut` (`IHostedService`) attaches the event in its ctor, enqueues onto an unbounded channel from the keeper lock, and runs a dedicated drain task that calls `SubscriptionManager.Publish` out from under the lock — keeper hot path stays tight and there's no nested-lock risk between keeper-lock and WS publish-lock.
- Coalesces by `_lastSent`: identical `Available` values are dropped. Zero-fee no-ops never trigger the event in the first place.
- Owner-scoped publish (`firmId: null`) — `CashLedger` is keyed only by `EndClientId`, so the balance for a given owner is the same regardless of authenticated firm.
- Channel registered in `Channels.All`; snapshot served via the existing `SubscribeWithSnapshot` switch using a new optional `CashLedger` ctor param on `SubscriptionManager` (DI auto-resolves).

## Tests
- +5 `CashLedger` event tests (seed/fill/fee/zero-fee/throwing-subscriber-isolation)
- +7 WS channel tests (snapshot reflects Available; fallback to 0 with no ledger; delta on fill; delta on fee; coalesce; owner isolation; channel registered in `Channels.All`)
- Full suite: 524 (api) + 1127 (app) + 81 + 134 + 12 + 23 = 1901 pass.

## Stacking
Branched off `fix/387-fees-in-cashledger` so the fan-out also fires on fee debits without a merge race. Will retarget to `main` once #388 lands.