### PR TITLE
Cash balance pill in trader UI topbar (#385)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -100,6 +100,23 @@ body {
    the in-progress `connecting` tone. */
 .status-not_ready    { background: rgba(217,122,74,.18); color: #d97a4a; }
 .user-label { color: var(--muted); }
+/* #385. Live cash balance pill in the topbar. Same muted palette as
+   the other status badges so it doesn't fight for attention with the
+   WS / market-data pills; switches to a warning tone when the
+   available balance goes negative. */
+.user-balance {
+  display: inline-flex; align-items: center;
+  padding: .15rem .5rem;
+  border: 1px solid var(--border); border-radius: 4px;
+  background: var(--panel-2); color: var(--text);
+  font-variant-numeric: tabular-nums;
+  font-size: .85rem;
+}
+.user-balance.balance-negative {
+  background: rgba(217,122,74,.18);
+  color: #d97a4a;
+  border-color: rgba(217,122,74,.35);
+}
 .symbol-select {
   display: inline-flex; align-items: center; gap: .35rem;
   font-size: .72rem; color: var(--muted); text-transform: uppercase;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,6 +110,11 @@
         <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
         <span id="user-label" class="user-label"></span>
         <span id="user-role" class="role-badge" hidden></span>
+        <!-- #385. Live cash balance for the logged-in end-client.
+             Hidden when no session is mounted. Updated by `balance.me`
+             WS frames (see WebSocketBalanceFanOut / #386). -->
+        <span id="user-balance" class="user-balance" role="status" aria-live="polite"
+              aria-label="Saldo disponível" title="Saldo disponível" hidden>R$ —</span>
         <button id="bot-credentials-open" class="link-button" type="button"
                 aria-label="Bot credentials">Bot credentials</button>
         <button id="security-open" class="link-button" type="button"

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -743,6 +743,7 @@ function onWorkerMessage(msg) {
     case "executions.delta":    state.applyExecutionsDelta(msg.data); break;
     case "pnl.snapshot":        state.applyPnlDelta(msg.data); break;
     case "pnl.delta":           state.applyPnlDelta(msg.data); break;
+    case "balance.frame":       state.applyBalanceFrame(msg.data); break;
     case "phases.frame":        state.applyPhaseFrame(msg.data); break;
     case "auction.frame":       state.applyAuctionFrame(msg.data); break;
     case "book.frame":          state.applyBookFrame(msg.data); break;

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -173,6 +173,14 @@ const state = {
   // accounting client-side. `null` until the first fetch/frame lands;
   // readers render a "no data yet" placeholder in the meantime.
   pnl: null,                // PnlTodayDto | null
+  // #385 / #386. Live cash balance for the logged-in end-client. Mirrors
+  // the GET /balance projection (BalanceDto = { Available }) and is kept
+  // fresh by the `balance.me` WS channel — snapshot on subscribe, delta
+  // on every CashLedger mutation (fills, fees, opening-balance seed).
+  // `null` until the first frame lands; the header widget renders an
+  // "R$ —" placeholder in the meantime so a slow first frame doesn't
+  // freeze a stale number from a prior session.
+  balance: null,            // { available: number } | null
   // Q2.6 (#273). History tab slices. Cursor-based pagination: each
   // append() preserves accumulated items so "load more" feels stable.
   // `nextCursor === null` means the server has no further pages.
@@ -311,6 +319,10 @@ export function clearAll() {
   // or trader-WS reconnect so the next session can't read the previous
   // user's data while waiting for its own snapshot.
   state.pnl = null;
+  // #385. Cash balance is per-session — drop on logout / WS reconnect
+  // so the next session can't render the previous user's number while
+  // waiting for its own snapshot.
+  state.balance = null;
   state.historyOrders     = { items: [], nextCursor: null, loading: false };
   state.historyExecutions = { items: [], nextCursor: null, loading: false };
   state.historyFilters    = { from: "", to: "", symbol: "" };
@@ -982,6 +994,22 @@ export function clearPnl() {
   if (state.pnl == null) return;
   state.pnl = null;
   notify("pnl");
+}
+
+// ── #385. Cash balance frame ──────────────────────────────────────
+// Snapshot and delta on `balance.me` share the same payload
+// (`BalanceDto { Available }`) — the wire is the full value, never a
+// diff — so a single reducer handles both. The decimal is serialised
+// by STJ as a JSON number; we coerce to Number once here so renderers
+// can format with Intl.NumberFormat without re-parsing.
+export function applyBalanceFrame(dto) {
+  if (dto == null) return;
+  const raw = dto.available ?? dto.Available;
+  if (raw == null) return;
+  const available = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(available)) return;
+  state.balance = { available };
+  notify("balance");
 }
 
 // ── Q2.6 (#273). History tab slices ───────────────────────────────

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -1388,6 +1388,44 @@ export function setUserLabel(user) {
   setViewToggleVisible(isAdmin, getState().currentView);
 }
 
+// #385. Render the live cash balance in the topbar. The widget shows
+// "R$ —" until the first `balance.me` frame lands (or when the user
+// logs out / WS reconnects clears the slice). Negative balances are
+// rendered with a `balance-negative` class so the trader notices they
+// are underwater. Format uses pt-BR thousands/decimal separators to
+// match the rest of the trader UI (price ticket, P&L panel).
+const BALANCE_FORMATTER = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function renderBalance() {
+  const el = $("user-balance");
+  if (!el) return;
+  const st = getState();
+  if (!st.user?.username) {
+    // Logged out — hide the badge entirely so the topbar collapses
+    // back to the login layout.
+    el.hidden = true;
+    el.textContent = "";
+    el.classList.remove("balance-negative");
+    return;
+  }
+  el.hidden = false;
+  const bal = st.balance;
+  if (bal == null || !Number.isFinite(bal.available)) {
+    el.textContent = "R$ —";
+    el.classList.remove("balance-negative");
+    el.title = "Saldo disponível — aguardando dados";
+    return;
+  }
+  el.textContent = BALANCE_FORMATTER.format(bal.available);
+  el.classList.toggle("balance-negative", bal.available < 0);
+  el.title = `Saldo disponível: ${BALANCE_FORMATTER.format(bal.available)}`;
+}
+
 function applyCurrentView(view) {
   const trader = $("trader-view");
   const admin = $("admin-view");
@@ -1587,6 +1625,7 @@ export function renderForSlice(slice) {
     renderStaleness("ws");
   }
   if (slice === "user")   setUserLabel(getState().user);
+  if (slice === "balance" || slice === "user" || slice === "all") renderBalance();
   if (slice === "marketData" || slice === "all") renderMarketData();
   if (slice === "marketDataStatus") {
     setMdStatusPill(getState().marketDataStatus);

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -26,7 +26,7 @@ let stopped = false;
 // only useful while the P&L panel is mounted, so the main thread
 // dynamically (un)subscribes via setPnlSubscribed when the user
 // enters / leaves the history view.
-const CHANNELS = ["orders.me", "executions.me", "positions.me"];
+const CHANNELS = ["orders.me", "executions.me", "positions.me", "balance.me"];
 
 // Q2.6 (#273). Tracks whether the main thread wants pnl.me subscribed
 // right now. Held across reconnects so a flap doesn't drop the
@@ -142,6 +142,12 @@ function handleFrame(frame) {
       // PnlTodayDto — the main thread reducer treats them identically,
       // so we forward a single event type per direction.
       post({ type: frame.type === "snapshot" ? "pnl.snapshot" : "pnl.delta", data: frame.data });
+      break;
+    case "balance.me":
+      // #385 / #386. Snapshot + delta carry the full BalanceDto, so a
+      // single forwarded event type is enough — the main thread reducer
+      // (applyBalanceFrame) replaces wholesale either way.
+      post({ type: "balance.frame", data: frame.data });
       break;
     default:
       // Q1.6 (#258). Public per-symbol channels — phases.${symbol} and

--- a/frontend/test/state-balance-frame.test.mjs
+++ b/frontend/test/state-balance-frame.test.mjs
@@ -1,0 +1,70 @@
+// Frontend reducer tests for the new `balance.me` WS channel
+// (issue #385, fed by #386 fan-out). Runs with
+// `node --test frontend/test/state-balance-frame.test.mjs`.
+//
+// Coverage: snapshot + delta share the same reducer; both casing
+// variants (`Available` PascalCase vs `available` camelCase) supported
+// since STJ defaults to PascalCase but a future client-cased shape
+// shouldn't break the widget; null/garbage frames are no-ops; clearAll
+// (logout / WS reconnect) drops the slice so the next session can't
+// inherit it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+let n = 0;
+async function freshState() {
+  n += 1;
+  return await import(`../js/state.js?bust-balance=${n}`);
+}
+
+test('applyBalanceFrame stores Available from a PascalCase wire frame', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ Available: 1234.56 });
+  assert.deepEqual(s.getState().balance, { available: 1234.56 });
+});
+
+test('applyBalanceFrame accepts camelCase `available` too', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ available: 99.99 });
+  assert.deepEqual(s.getState().balance, { available: 99.99 });
+});
+
+test('applyBalanceFrame supports string-encoded decimals (defensive)', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ Available: '500.25' });
+  assert.deepEqual(s.getState().balance, { available: 500.25 });
+});
+
+test('applyBalanceFrame treats null / missing / NaN as a no-op (keeps prior value)', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ Available: 100 });
+  s.applyBalanceFrame(null);
+  s.applyBalanceFrame({ Available: null });
+  s.applyBalanceFrame({ Available: 'not-a-number' });
+  assert.deepEqual(s.getState().balance, { available: 100 });
+});
+
+test('applyBalanceFrame replaces wholesale on each frame (snapshot + delta share shape)', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ Available: 100 });
+  s.applyBalanceFrame({ Available: 87.66 }); // post-fee delta
+  s.applyBalanceFrame({ Available: 0 });
+  assert.deepEqual(s.getState().balance, { available: 0 });
+});
+
+test('clearAll drops the balance slice (logout / WS reconnect boundary)', async () => {
+  const s = await freshState();
+  s.applyBalanceFrame({ Available: 7500 });
+  s.clearAll();
+  assert.equal(s.getState().balance, null);
+});
+
+test('applyBalanceFrame notifies the "balance" slice', async () => {
+  const s = await freshState();
+  const slices = [];
+  s.subscribe((slice) => slices.push(slice));
+  s.applyBalanceFrame({ Available: 1 });
+  assert.ok(slices.includes('balance'),
+    `expected "balance" notification, got: ${JSON.stringify(slices)}`);
+});


### PR DESCRIPTION
Closes #385. Stacked on #386 → #387.

## What
Surface the live cash balance in the trader UI so the user can see remaining buying power without leaving the trading view.

## How
- **Worker**: `balance.me` added to the always-on `CHANNELS` set alongside `orders.me` / `positions.me` / `executions.me`. Snapshot + delta both forward as a single `balance.frame` message — the wire shape is the full `BalanceDto` either way (no diff accounting).
- **State**: new `state.balance` slice (`null` until the first frame); `applyBalanceFrame` accepts both PascalCase (STJ default) and camelCase shapes, coerces string-encoded decimals defensively, and bails on `null` / `NaN` so a malformed frame can't blank the pill. `clearAll` (logout / WS reconnect) drops it so the next session can't render the previous user's number.
- **UI**: `#user-balance` pill next to the user label, formatted with `Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' })`. Hidden when logged out. Shows "R$ —" placeholder while waiting for the first frame. Goes to a warning tone (`balance-negative` class) when the available balance is negative so the trader notices they're underwater.

## Tests
- +7 frontend reducer tests in `state-balance-frame.test.mjs` (both casings, string decimal, null/NaN no-op, replace-on-delta semantics, clearAll boundary, slice notification).
- Full FE suite green: 288/288.

## Stacking
Branched off `fix/386-balance-ws-channel` (which itself stacks on `fix/387-fees-in-cashledger`). Will retarget to `main` after #388 + #389 land.