### PR TITLE
fix(frontend): book.${symbol} reducer reads camelCase wire shape

### DIFF
--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -425,19 +425,33 @@ function ensureBook(symbol) {
 /// ladder as a `snapshot` frame on subscribe.
 /// </summary>
 export function applyBookFrame(frame) {
-  if (!frame || typeof frame.Symbol !== "string") return;
-  const entry = ensureBook(frame.Symbol);
+  if (!frame) return;
+  // The trading-host WS serializes DTOs with JsonSerializerDefaults.Web
+  // (camelCase). Tolerate PascalCase too for forward-compat with any
+  // older sink or test fixture.
+  const symbol = frame.symbol ?? frame.Symbol;
+  if (typeof symbol !== "string") return;
+  const bids = frame.bids ?? frame.Bids ?? [];
+  const asks = frame.asks ?? frame.Asks ?? [];
+  const updatedUtc = frame.updatedUtc ?? frame.UpdatedUtc ?? null;
+  const entry = ensureBook(symbol);
   entry.bids.clear();
   entry.asks.clear();
-  for (const lv of frame.Bids ?? []) {
-    entry.bids.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  for (const lv of bids) {
+    const price = lv.price ?? lv.Price;
+    const qty = lv.totalQty ?? lv.TotalQty;
+    const count = lv.orderCount ?? lv.OrderCount;
+    entry.bids.set(priceKey(price), { qty, count });
   }
-  for (const lv of frame.Asks ?? []) {
-    entry.asks.set(priceKey(lv.Price), { qty: lv.TotalQty, count: lv.OrderCount });
+  for (const lv of asks) {
+    const price = lv.price ?? lv.Price;
+    const qty = lv.totalQty ?? lv.TotalQty;
+    const count = lv.orderCount ?? lv.OrderCount;
+    entry.asks.set(priceKey(price), { qty, count });
   }
-  // Empty-state snapshot (UpdatedUtc=null) keeps ready=false so the
+  // Empty-state snapshot (updatedUtc=null) keeps ready=false so the
   // DOB shows its "waiting" affordance instead of an empty ladder.
-  entry.ready = frame.UpdatedUtc != null;
+  entry.ready = updatedUtc != null;
   entry.updatedAt = Date.now();
   notify("book");
 }

--- a/frontend/test/state-book-frame.test.mjs
+++ b/frontend/test/state-book-frame.test.mjs
@@ -68,5 +68,36 @@ test('applyBookFrame ignores malformed payloads', async () => {
   s.applyBookFrame(undefined);
   s.applyBookFrame({});
   s.applyBookFrame({ Symbol: 42 });
+  s.applyBookFrame({ symbol: 42 });
   assert.equal(s.getState().book.size, 0);
+});
+
+test('applyBookFrame accepts the camelCase wire shape produced by JsonSerializerDefaults.Web', async () => {
+  // Real wire shape served by trading-host (System.Text.Json web defaults
+  // camelCase the L2LadderDto / L2SideDto record properties).
+  const s = await freshState();
+  s.applyBookFrame({
+    symbol: 'PETR4',
+    bids: [
+      { price: 30.20, totalQty: 100, orderCount: 1 },
+      { price: 30.10, totalQty: 250, orderCount: 3 },
+    ],
+    asks: [
+      { price: 30.30, totalQty: 50, orderCount: 1 },
+    ],
+    updatedUtc: '2026-05-22T18:47:00Z',
+  });
+  const entry = s.getState().book.get('PETR4');
+  assert.equal(entry.ready, true);
+  assert.equal(entry.bids.size, 2);
+  assert.equal(entry.asks.size, 1);
+  assert.deepEqual(entry.bids.get('30.2000'), { qty: 100, count: 1 });
+  assert.deepEqual(entry.asks.get('30.3000'), { qty: 50, count: 1 });
+});
+
+test('applyBookFrame camelCase empty-state snapshot keeps ready=false', async () => {
+  const s = await freshState();
+  s.applyBookFrame({ symbol: 'VALE3', bids: [], asks: [], updatedUtc: null });
+  const entry = s.getState().book.get('VALE3');
+  assert.equal(entry.ready, false);
 });


### PR DESCRIPTION
Discovered during manual validation of the post-#388/#391/#392 stack: `book.${symbol}` snapshots/deltas landed in the WS network tab but the DOB stayed stuck on "no book — check MD settings".

## Root cause
Trading-host WS hub serializes with `JsonSerializerDefaults.Web` (camelCase) — see `backend/src/B3.Trading.Api/WebSockets/WebSocketHub.cs:17`. But `applyBookFrame` in `frontend/js/state.js` was added in #286 reading PascalCase keys (`frame.Symbol`, `frame.Bids`, `lv.Price`, …) which never match the wire. The frame was silently dropped every time.

The original tests in `frontend/test/state-book-frame.test.mjs` fed PascalCase fixtures and were green, hiding the bug.

## Fix
- `applyBookFrame` now reads camelCase (matching the wire) while tolerating PascalCase for forward-compat with any older fixture (same pattern as `applyBalanceFrame` and `applyAuctionFrame`).
- Added 2 tests exercising the real camelCase wire shape; existing PascalCase tests still pass.

## Verification
`node --test frontend/test/state-book-frame.test.mjs` → 6/6 pass.
Manual end-to-end will be done after deploy.