### PR TITLE
Fase 1: FE shell + tablist primária + hash router (#397)

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -24,8 +24,18 @@ body {
   background: var(--bg);
   color: var(--text);
   font: 13px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  /* Fase 1 (#397). The app-shell (topbar + tablist) is now a body-level
+     sibling of each view, not nested inside trader-view. Stack them so
+     the shell pins to the top and the active view fills the remaining
+     viewport height. */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
-.view { min-height: 100vh; }
+.view { flex: 1 1 auto; min-height: 0; }
+/* App-shell topbar pinned at the top; views render below it. */
+#app-shell { flex: 0 0 auto; }
+.trader-view { display: flex; flex-direction: column; }
 
 /* ---------- Login ---------- */
 .login-view { display: grid; place-items: center; }
@@ -73,7 +83,8 @@ body {
    trapping content under the topbar. The previous `height: 100vh;
    overflow: hidden` swallowed the bottom row (Executions Log + Market
    Data) and let the Tape panel paint over the Blotter. */
-.trader-view { display: flex; flex-direction: column; min-height: 100vh; }
+/* `.trader-view` flex layout moved earlier (next to body shell rules)
+   in Fase 1 (#397) — keep the comment above for context. */
 .topbar {
   display: flex; justify-content: space-between; align-items: center;
   padding: .6rem 1rem; background: var(--panel); border-bottom: 1px solid var(--border);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -88,49 +88,58 @@
     </form>
   </section>
 
+  <!-- APP SHELL --------------------------------------------------------
+       Fase 1 (#397). The topbar lives outside any individual view so
+       the primary tablist + global status pills + logout are always
+       visible while a session is mounted. `app-shell` is hidden until
+       login completes and re-hidden on logout. -->
+  <header id="app-shell" class="app-shell topbar" hidden>
+    <div class="brand">B3TradingPlatform <span class="pill">trader</span></div>
+    <div class="status">
+      <nav id="view-toggle" class="view-toggle" role="tablist" aria-label="Primary navigation">
+        <button type="button" data-view="trader" class="active" role="tab"
+                aria-selected="true" aria-controls="trader-view" id="tab-trader">Trading</button>
+        <button type="button" data-view="algos" role="tab"
+                aria-selected="false" aria-controls="algos-view" id="tab-algos"
+                disabled title="Em breve (Fase 2)">Algos</button>
+        <button type="button" data-view="history" role="tab"
+                aria-selected="false" aria-controls="history-view" id="tab-history">History</button>
+        <button type="button" data-view="settings" role="tab"
+                aria-selected="false" aria-controls="settings-view" id="tab-settings">Settings</button>
+        <button type="button" data-view="compliance" role="tab"
+                aria-selected="false" aria-controls="compliance-view" id="tab-compliance" hidden>Compliance</button>
+        <button type="button" data-view="admin" role="tab"
+                aria-selected="false" aria-controls="admin-view" id="tab-admin" hidden>Admin</button>
+      </nav>
+      <label class="symbol-select" for="selected-symbol">
+        Symbol
+        <select id="selected-symbol" aria-label="Selected symbol (DOB / chart / tape)">
+          <option value="">— select —</option>
+        </select>
+      </label>
+      <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
+      <span id="gateway-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Exchange gateway: unknown" title="Exchange gateway session state (FIXP)" hidden>gateway</span>
+      <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
+      <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
+      <span id="user-label" class="user-label"></span>
+      <span id="user-role" class="role-badge" hidden></span>
+      <!-- #385. Live cash balance for the logged-in end-client.
+           Hidden when no session is mounted. Updated by `balance.me`
+           WS frames (see WebSocketBalanceFanOut / #386). -->
+      <span id="user-balance" class="user-balance" role="status" aria-live="polite"
+            aria-label="Saldo disponível" title="Saldo disponível" hidden>R$ —</span>
+      <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
+    </div>
+  </header>
+
+  <!-- #342: Transient toast for WebSocket frame-level errors (e.g.,
+       unknown_channel, channel auth failure). Lives between the shell
+       and the active view so it's visible from any panel without taking
+       up persistent screen real estate. Auto-dismissed after a few seconds. -->
+  <div id="ws-error-toast" class="ws-error-toast" role="status" aria-live="polite" hidden></div>
+
   <!-- TRADER VIEW ------------------------------------------------------ -->
-  <section id="trader-view" class="view trader-view" hidden>
-    <header class="topbar">
-      <div class="brand">B3TradingPlatform <span class="pill">trader</span></div>
-      <div class="status">
-        <span id="view-toggle" class="view-toggle" role="tablist" aria-label="View" hidden>
-          <button type="button" data-view="trader" class="active" role="tab" aria-selected="true">Trader</button>
-          <button type="button" data-view="admin" role="tab" aria-selected="false">Admin</button>
-          <button type="button" data-view="compliance" role="tab" aria-selected="false" hidden>Compliance</button>
-        </span>
-        <label class="symbol-select" for="selected-symbol">
-          Symbol
-          <select id="selected-symbol" aria-label="Selected symbol (DOB / chart / tape)">
-            <option value="">— select —</option>
-          </select>
-        </label>
-        <span id="firms-health" class="firms-health" role="status" aria-live="polite" aria-label="Firms health" hidden></span>
-        <span id="gateway-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="Exchange gateway: unknown" title="Exchange gateway session state (FIXP)" hidden>gateway</span>
-        <span id="ws-status" class="status-pill status-disconnected" role="status" aria-live="polite" aria-label="WebSocket: disconnected" title="WebSocket connection">disconnected</span>
-        <span id="ws-reconnect" class="reconnect-countdown" hidden></span>
-        <span id="user-label" class="user-label"></span>
-        <span id="user-role" class="role-badge" hidden></span>
-        <!-- #385. Live cash balance for the logged-in end-client.
-             Hidden when no session is mounted. Updated by `balance.me`
-             WS frames (see WebSocketBalanceFanOut / #386). -->
-        <span id="user-balance" class="user-balance" role="status" aria-live="polite"
-              aria-label="Saldo disponível" title="Saldo disponível" hidden>R$ —</span>
-        <button id="bot-credentials-open" class="link-button" type="button"
-                aria-label="Bot credentials">Bot credentials</button>
-        <button id="security-open" class="link-button" type="button"
-                aria-label="Security (two-factor authentication)">Security</button>
-        <button id="history-open" class="link-button" type="button"
-                aria-label="History, P&amp;L and statement">History</button>
-        <button id="logout" class="link-button" type="button" aria-label="Logout">Logout</button>
-      </div>
-    </header>
-
-    <!-- #342: Transient toast for WebSocket frame-level errors (e.g.,
-         unknown_channel, channel auth failure). Lives between the topbar
-         and the grid so it's visible from any panel without taking up
-         persistent screen real estate. Auto-dismissed after a few seconds. -->
-    <div id="ws-error-toast" class="ws-error-toast" role="status" aria-live="polite" hidden></div>
-
+  <section id="trader-view" class="view trader-view" role="tabpanel" aria-labelledby="tab-trader" hidden>
     <main class="grid">
       <!-- ORDER TICKET ----------------------------------------------- -->
       <section class="panel ticket">
@@ -440,7 +449,7 @@
   </section>
 
   <!-- ADMIN VIEW ------------------------------------------------------- -->
-  <section id="admin-view" class="view admin-view" hidden>
+  <section id="admin-view" class="view admin-view" role="tabpanel" aria-labelledby="tab-admin" hidden>
     <header class="admin-subbar">
       <h2>Operator console — mode: <span id="admin-mode">—</span></h2>
       <div class="admin-actions">
@@ -615,7 +624,7 @@
   <!-- BOT CREDENTIALS VIEW (sub-issue #169 of user-bot-fixp-listener-v0)
        Manage user-issued PATs that authenticate external FIXP bots.
        Visible to every authenticated user (no admin gate). -->
-  <section id="bot-credentials-view" class="view bot-credentials-view" hidden>
+  <section id="bot-credentials-view" class="view bot-credentials-view" role="region" aria-label="Bot credentials" hidden>
     <header class="admin-subbar">
       <h2>Bot credentials</h2>
       <div class="admin-actions">
@@ -692,7 +701,7 @@
        downloader (CSV blob + JSON modal). Mirrors the bot-credentials
        view layout — a sibling top-level <section> toggled via the
        header link, not a child of the trader grid. -->
-  <section id="history-view" class="view history-view" hidden>
+  <section id="history-view" class="view history-view" role="tabpanel" aria-labelledby="tab-history" hidden>
     <header class="admin-subbar">
       <h2>History · P&amp;L · Statement</h2>
       <div class="admin-actions">
@@ -888,7 +897,7 @@
        unless currentView === "compliance". The drop-copy feed
        attaches to /ws/dropcopy on view-enter and closes on leave;
        all other panels are pure REST. -->
-  <section id="compliance-view" class="view compliance-view" hidden>
+  <section id="compliance-view" class="view compliance-view" role="tabpanel" aria-labelledby="tab-compliance" hidden>
     <header class="admin-subbar">
       <h2>Compliance console</h2>
       <div class="admin-actions"></div>
@@ -982,6 +991,45 @@
         <button id="compliance-cvm-505" type="button">Download model 505</button>
       </div>
       <p id="compliance-cvm-feedback" class="feedback" role="status" aria-live="polite" hidden></p>
+    </section>
+  </section>
+
+  <!-- ALGOS VIEW (Fase 2 #398 placeholder) ----------------------------
+       Stub panel rendered when #algos tab is active. Real list / boleta
+       / detail UI lands in #398; for now the tab itself is disabled and
+       this section is unreachable through the tablist, but kept so the
+       hash router has a target. -->
+  <section id="algos-view" class="view algos-view" role="tabpanel" aria-labelledby="tab-algos" hidden>
+    <header class="admin-subbar">
+      <h2>Algos</h2>
+    </header>
+    <section class="panel admin-panel">
+      <p class="muted-line">Em construção — chega na Fase 2 (#398).</p>
+    </section>
+  </section>
+
+  <!-- SETTINGS VIEW (Fase 3 #399 placeholder) -------------------------
+       Fase 1 lands the tab + a thin shell that exposes Bot credentials
+       + Security (2FA) entry points. Fase 3 replaces this body with
+       sub-tabs (Bot creds / Security / Market data / Preferences). -->
+  <section id="settings-view" class="view settings-view" role="tabpanel" aria-labelledby="tab-settings" hidden>
+    <header class="admin-subbar">
+      <h2>Settings</h2>
+    </header>
+    <section class="panel admin-panel">
+      <h3>Bot credentials</h3>
+      <p class="muted-line">Gerencie tokens de acesso programático (PATs).</p>
+      <button id="settings-open-bot-credentials" type="button" class="link-button">Abrir Bot credentials →</button>
+    </section>
+    <section class="panel admin-panel">
+      <h3>Security (2FA)</h3>
+      <p class="muted-line">Configure autenticação de dois fatores (TOTP).</p>
+      <button id="settings-open-security" type="button" class="link-button">Abrir Security →</button>
+    </section>
+    <section class="panel admin-panel">
+      <h3>Market data</h3>
+      <p class="muted-line">Endpoint do WebSocket de market data e watchlist.</p>
+      <button id="settings-open-md" type="button" class="link-button">Abrir Market data settings →</button>
     </section>
   </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -87,6 +87,20 @@ function init() {
   });
   document.getElementById("security-confirm")?.addEventListener("click", onSecurityEnrollConfirm);
   document.getElementById("security-disable")?.addEventListener("click", onSecurityDisable);
+  // Fase 1 (#397): Settings tab is a placeholder shell exposing entry
+  // points to the now-removed standalone topbar buttons (Bot creds,
+  // Security, Market data). Fase 3 (#399) folds these into proper
+  // sub-tabs.
+  document.getElementById("settings-open-bot-credentials")
+    ?.addEventListener("click", () => handleSwitchView("bot-credentials"));
+  document.getElementById("settings-open-security")
+    ?.addEventListener("click", openSecurityPanel);
+  document.getElementById("settings-open-md")
+    ?.addEventListener("click", () => {
+      // Reuse the existing MD-settings popover trigger; the actual
+      // modal/open logic lives in ui.js and is wired to #md-settings-open.
+      document.getElementById("md-settings-open")?.click();
+    });
   ui.bindUi();
   adminUi.bindAdminUi();
   botCredentialsUi.bindBotCredentialsUi();
@@ -150,6 +164,19 @@ function init() {
     if (slice === "watchlist" || slice === "auctionPanelSymbol" || slice === "all") {
       syncPublicChannels();
     }
+  });
+
+  // Fase 1 (#397). URL hash navigation. The tablist click handler
+  // itself lives in ui.js (which already dispatches through the
+  // shared `onSwitchView` handler we wired below); here we just keep
+  // the browser back/forward buttons walking the tab history.
+  // Avoid loops: handleSwitchView only pushes a hash entry when the
+  // active view actually changes, so reapplying the current hash
+  // here is a no-op.
+  window.addEventListener("popstate", () => {
+    if (!session) return;
+    const view = tabFromHash();
+    if (view) handleSwitchView(view);
   });
 
   const stored = readSession();
@@ -463,14 +490,27 @@ function startSession(next) {
   // visible. showTrader() runs first so the brief flash is the
   // trader scaffold, never login-into-compliance.
   ui.showTrader();
-  const initialView = defaultViewForRole(next.role);
+  // Fase 1 (#397). Resolve the landing tab in priority order:
+  //   1. URL hash (deep-link / refresh after navigation),
+  //   2. sessionStorage (last tab in this browser tab),
+  //   3. role default (compliance lands on its own console; everyone
+  //      else lands on trader).
+  // Each candidate must pass the same role-gate as handleSwitchView,
+  // otherwise we fall through to the next candidate.
+  const allowed = new Set(tabsForRole(next.role));
+  const candidates = [tabFromHash(), readPersistedTab(), defaultViewForRole(next.role)];
+  const initialView = candidates.find((v) => v && (allowed.has(v) || v === "bot-credentials"))
+    || defaultViewForRole(next.role);
   state.setCurrentView(initialView);
+  persistActiveTab(initialView);
+  syncUrlHash(initialView, /*replace*/ true);
   if (initialView === "compliance") {
     // Compliance users land directly on the compliance console — no
     // trader view, no admin polls. Open the drop-copy socket so the
     // live feed has data the moment the panel renders.
     openComplianceDropCopy();
   }
+  syncPnlSubscription(initialView);
 
   startWorker();
   startMdWorker();
@@ -1046,6 +1086,10 @@ function logout() {
   closeComplianceDropCopy();
   clearSession();
   clearMdConfig();
+  // Fase 1 (#397). Drop the persisted tab so the next sign-in lands
+  // on the role-default rather than reviving the previous user's
+  // navigation state.
+  try { sessionStorage.removeItem(ACTIVE_TAB_KEY); } catch { /* private mode */ }
   state.setUser(null);
   state.setStatus("disconnected");
   state.setMarketDataStatus("disconnected");
@@ -1166,16 +1210,88 @@ async function pollGatewayOnce() {
 
 // ── Admin view + actions ───────────────────────────────────────────
 
+// ── Primary tab routing ────────────────────────────────────────────
+//
+// Fase 1 (#397). Single seam for activating any of the top-level
+// tabs (`trader`, `algos`, `history`, `settings`, `admin`,
+// `compliance`) plus the `bot-credentials` sub-view (still reached
+// from inside Settings).
+//
+// Side-effects:
+//   * gates by role via `tabsForRole`;
+//   * persists the active tab in sessionStorage (`fe.activeTab`)
+//     so a refresh lands on the same tab;
+//   * syncs the URL hash via pushState so the browser back/forward
+//     buttons walk the tab history;
+//   * lifts/drops the per-view subscriptions (drop-copy WS, pnl.me).
+
+const ACTIVE_TAB_KEY = "fe.activeTab";
+// Map of view → URL hash; views without a hash here aren't deep-linked
+// (e.g. bot-credentials shares its hash with Settings since it's an
+// inner navigation target).
+const HASH_FOR_VIEW = Object.freeze({
+  trader: "#trading",
+  algos: "#algos",
+  history: "#history",
+  settings: "#settings",
+  admin: "#admin",
+  compliance: "#compliance",
+});
+// Reverse map + a few legacy aliases for back-compat with bookmarked
+// hashes that used the old standalone-button names.
+const VIEW_FOR_HASH = Object.freeze({
+  "#trading": "trader",
+  "#trader": "trader",
+  "#algos": "algos",
+  "#history": "history",
+  "#settings": "settings",
+  "#admin": "admin",
+  "#compliance": "compliance",
+  "#bot-credentials": "settings",  // legacy deep-link → Settings shell
+});
+
+function tabFromHash() {
+  const hash = (typeof window !== "undefined" && window.location?.hash) || "";
+  return VIEW_FOR_HASH[hash] || null;
+}
+
+function persistActiveTab(view) {
+  try { sessionStorage.setItem(ACTIVE_TAB_KEY, view); } catch { /* private mode */ }
+}
+
+function readPersistedTab() {
+  try { return sessionStorage.getItem(ACTIVE_TAB_KEY); } catch { return null; }
+}
+
+function syncUrlHash(view, replace) {
+  if (typeof window === "undefined" || !window.history) return;
+  const hash = HASH_FOR_VIEW[view];
+  if (!hash) return; // bot-credentials et al — don't pollute the URL
+  if (window.location.hash === hash) return;
+  const url = window.location.pathname + window.location.search + hash;
+  if (replace) window.history.replaceState(null, "", url);
+  else window.history.pushState(null, "", url);
+}
+
 function handleSwitchView(view) {
   if (!session) return;
-  // Role-gate the target view. Plain users can only see trader /
-  // bot-credentials / history. Admin sees everything. Compliance is
-  // pinned to its own console.
+  // Fase 1 (#397). Algos tab is a disabled placeholder until Fase 2
+  // (#398) — drop the activation silently.
+  if (view === "algos") return;
+  // Role-gate the target view. Plain users see trader / algos /
+  // history / settings; admin sees everything; compliance is pinned
+  // to its own console. `bot-credentials` is an inner-navigation
+  // target reached from Settings, not a primary tab — allow it for
+  // any role that already has Settings access.
   const allowed = tabsForRole(session.role);
-  // history is reachable from every role via the header link — keep it
-  // available even though it doesn't appear in the nav tabs list.
-  if (view !== "history" && !allowed.includes(view)) return;
+  if (view === "bot-credentials") {
+    if (!allowed.includes("settings")) return;
+  } else if (!allowed.includes(view)) {
+    return;
+  }
   state.setCurrentView(view);
+  persistActiveTab(view);
+  syncUrlHash(view, /*replace*/ false);
   // Drop-copy WS lifecycle: open on enter, close on leave. Cheap to
   // re-open; we don't pay the cost of holding the socket while the
   // user is parked on a different view.

--- a/frontend/js/complianceUi.js
+++ b/frontend/js/complianceUi.js
@@ -343,10 +343,18 @@ export function yesterdayBrt() {
 
 // Returns the role → views map so app.js (and the unit test) share a
 // single source of truth for nav-tab gating.
+//
+// Fase 1 (#397) reshape: every signed-in role gets Trading + History +
+// Settings + Algos (Algos is disabled in the UI until Fase 2 lands but
+// still belongs to the nav set — `handleSwitchView` blocks the actual
+// activation). Admin layers on Admin + Compliance. Compliance role is
+// pinned to its own console plus History so the user can audit their
+// own session activity. `bot-credentials` is no longer a primary tab —
+// it's reached from the Settings view.
 export function tabsForRole(role) {
-  if (role === "admin")      return ["trader", "admin", "bot-credentials", "compliance"];
-  if (role === "compliance") return ["compliance"];
-  return ["trader", "bot-credentials"];
+  if (role === "admin")      return ["trader", "algos", "history", "settings", "admin", "compliance"];
+  if (role === "compliance") return ["compliance", "history"];
+  return ["trader", "algos", "history", "settings"];
 }
 
 export function defaultViewForRole(role) {

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -104,7 +104,7 @@ const state = {
   killStatus: null,        // { endClients: [], firms: [], fetchedAt } | null — admin-only
   haltStatus: null,        // { symbols: [], fetchedAt } | null — admin-only
   eodReport: null,         // { ranAt, report } | null — last EOD response in this session
-  currentView: "trader",   // "trader" | "admin" | "bot-credentials" | "compliance" — which view is mounted
+  currentView: "trader",   // "trader" | "algos" | "history" | "settings" | "admin" | "compliance" | "bot-credentials" — which view is mounted
   // Q4.14 (#314). Rolling drop-copy feed surfaced on the compliance
   // view. The buffer is capped at COMPLIANCE_FEED_CAP so the table
   // can render every entry without virtualising. `paused` halts

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -8,6 +8,7 @@ import {
   computeHeatmapVolumes, HEATMAP_WINDOW_MS,
 } from "./state.js";
 import { rulesFor } from "./validation.js";
+import { tabsForRole } from "./complianceUi.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -127,6 +128,8 @@ export function setHandlers(handlers) {
 
 export function showLogin() {
   $("login-view").hidden = false;
+  const shell = $("app-shell");
+  if (shell) shell.hidden = true;
   $("trader-view").hidden = true;
   $("admin-view").hidden = true;
   const cred = $("bot-credentials-view");
@@ -135,6 +138,10 @@ export function showLogin() {
   if (hist) hist.hidden = true;
   const compliance = $("compliance-view");
   if (compliance) compliance.hidden = true;
+  const settings = $("settings-view");
+  if (settings) settings.hidden = true;
+  const algos = $("algos-view");
+  if (algos) algos.hidden = true;
   // Default to the login card; a user that previously toggled to the
   // signup card and was bumped back to login (e.g. logout, expiry)
   // shouldn't land staring at the signup form.
@@ -147,6 +154,8 @@ export function showLogin() {
 
 export function showTrader() {
   $("login-view").hidden = true;
+  const shell = $("app-shell");
+  if (shell) shell.hidden = false;
   $("trader-view").hidden = false;
   $("admin-view").hidden = true;
   const cred = $("bot-credentials-view");
@@ -155,23 +164,26 @@ export function showTrader() {
   if (hist) hist.hidden = true;
   const compliance = $("compliance-view");
   if (compliance) compliance.hidden = true;
+  const settings = $("settings-view");
+  if (settings) settings.hidden = true;
+  const algos = $("algos-view");
+  if (algos) algos.hidden = true;
 }
 
 function setViewToggleVisible(visible, current) {
   const wrap = $("view-toggle");
   if (!wrap) return;
+  // Fase 1 (#397). The tablist itself is always visible while logged
+  // in — only the per-role gating decides which tab buttons render.
+  // `visible=false` is now the logged-out signal coming from showLogin.
   wrap.hidden = !visible;
-  // Q4.14 (#314). The Compliance tab is gated independently — show
-  // it for admin (who sees every tab) and hide it otherwise. The
-  // wider toggle row is itself driven by the caller (admin-only
-  // today, since compliance lands directly on the compliance view
-  // with no sibling tabs to switch to).
   const role = getState().user?.role;
-  const complianceTab = wrap.querySelector('button[data-view="compliance"]');
-  if (complianceTab) complianceTab.hidden = !(role === "admin");
+  const allowed = visible ? new Set(tabsForRole(role)) : new Set();
   for (const btn of wrap.querySelectorAll("button[data-view]")) {
-    btn.classList.toggle("active", btn.dataset.view === current);
-    btn.setAttribute("aria-selected", btn.dataset.view === current ? "true" : "false");
+    const view = btn.dataset.view;
+    btn.hidden = !allowed.has(view);
+    btn.classList.toggle("active", view === current);
+    btn.setAttribute("aria-selected", view === current ? "true" : "false");
   }
 }
 
@@ -1383,9 +1395,10 @@ export function setUserLabel(user) {
       roleEl.hidden = true;
     }
   }
-  // Toggle visibility of the trader/admin view switch based on role.
-  const isAdmin = user?.role === "admin";
-  setViewToggleVisible(isAdmin, getState().currentView);
+  // Fase 1 (#397). The tablist is visible whenever a user is signed
+  // in; per-button gating is computed inside setViewToggleVisible.
+  const loggedIn = !!user?.username;
+  setViewToggleVisible(loggedIn, getState().currentView);
 }
 
 // #385. Render the live cash balance in the topbar. The widget shows
@@ -1432,29 +1445,35 @@ function applyCurrentView(view) {
   const credentials = $("bot-credentials-view");
   const history = $("history-view");
   const compliance = $("compliance-view");
+  const settings = $("settings-view");
+  const algos = $("algos-view");
   if (!trader || !admin) return;
   const showTraderView = view === "trader";
   const showAdminView = view === "admin";
   const showCredentialsView = view === "bot-credentials";
   const showHistoryView = view === "history";
   const showComplianceView = view === "compliance";
+  const showSettingsView = view === "settings";
+  const showAlgosView = view === "algos";
   trader.hidden = !showTraderView;
   admin.hidden = !showAdminView;
   if (credentials) credentials.hidden = !showCredentialsView;
   if (history)     history.hidden     = !showHistoryView;
   if (compliance)  compliance.hidden  = !showComplianceView;
-  // The trader/admin pill toggle stays hidden when the credentials /
-  // history views are up — they're self-contained sub-pages reached
-  // via the header link, not siblings of trader/admin. For compliance
-  // the toggle stays visible (admin can hop between admin / trader /
-  // compliance via the tabs); a pure-compliance principal has no
-  // sibling tabs so the toggle hides itself via the visible flag.
-  if (showCredentialsView || showHistoryView) {
-    setViewToggleVisible(false, view);
-  } else {
-    const role = getState().user?.role;
-    setViewToggleVisible(role === "admin", view);
-  }
+  if (settings)    settings.hidden    = !showSettingsView;
+  if (algos)       algos.hidden       = !showAlgosView;
+  // Fase 1 (#397): the primary tablist now persists across every view.
+  // `setViewToggleVisible(true, …)` runs whenever a user is signed in;
+  // the logged-out path (showLogin) is the only caller that passes
+  // `false`. We highlight the active tab — when the active view is
+  // `bot-credentials` (reached from Settings) we keep the Settings tab
+  // highlighted to communicate the user is still "inside" Settings.
+  const highlight = view === "bot-credentials" ? "settings" : view;
+  setViewToggleVisible(true, highlight);
+  // Trader-specific topbar controls (symbol selector) are only
+  // meaningful while the trading view is mounted.
+  const symbolWrap = $("selected-symbol")?.closest("label.symbol-select");
+  if (symbolWrap) symbolWrap.hidden = !showTraderView;
 }
 
 // Periodic UI tick for time-based elements (in-flight elapsed, reconnect

--- a/frontend/test/compliance-ui.test.mjs
+++ b/frontend/test/compliance-ui.test.mjs
@@ -70,15 +70,19 @@ const protocol = await import("../js/protocol.js");
 const state = await import("../js/state.js");
 
 test("tabsForRole gates the nav tabs per JWT role", () => {
+  // Fase 1 (#397): primary tablist is Trading / Algos / History /
+  // Settings (+ Admin / Compliance for admin; Compliance + History
+  // for the compliance role). `bot-credentials` is no longer a
+  // primary tab — it's reached from inside Settings.
   assert.deepEqual(compliance.tabsForRole("user"),
-    ["trader", "bot-credentials"]);
+    ["trader", "algos", "history", "settings"]);
   assert.deepEqual(compliance.tabsForRole("admin"),
-    ["trader", "admin", "bot-credentials", "compliance"]);
+    ["trader", "algos", "history", "settings", "admin", "compliance"]);
   assert.deepEqual(compliance.tabsForRole("compliance"),
-    ["compliance"]);
+    ["compliance", "history"]);
   // Unknown role defaults to plain-user surface (least privilege).
   assert.deepEqual(compliance.tabsForRole(undefined),
-    ["trader", "bot-credentials"]);
+    ["trader", "algos", "history", "settings"]);
 });
 
 test("defaultViewForRole lands compliance on its own console", () => {


### PR DESCRIPTION
Closes #397. Parte do epic #396 (Fase 1 — pura plumbing).

## O que muda

- **Topbar lifted** para um \`<header id=\"app-shell\">\` de nível body, sempre visível enquanto logado.
- **\`#view-toggle\` vira tablist primária** com 6 tabs:
  - Trading | Algos (disabled, Fase 2) | History | Settings | Compliance (gated) | Admin (gated)
- **Removidos** os 3 botões soltos do topbar (\`bot-credentials-open\`, \`security-open\`, \`history-open\`).
- **Hash routing** \`#trading\`/\`#algos\`/\`#history\`/\`#settings\`/\`#admin\`/\`#compliance\` com pushState (back-button navega entre tabs); legacy \`#bot-credentials\` redireciona para Settings.
- **sessionStorage** \`fe.activeTab\` mantém a tab ativa após refresh; limpa no logout.
- **\`tabsForRole\` reshape**:
  | role | tabs |
  |---|---|
  | user | trader, algos, history, settings |
  | admin | trader, algos, history, settings, admin, compliance |
  | compliance | compliance, history |
- **Placeholders** \`algos-view\` (vazio) e \`settings-view\` (3 botões para Bot creds / Security / MD config — Fase 3 consolida em sub-tabs).
- **CSS**: \`body\` vira flex-column; views ocupam o restante da viewport abaixo do shell.
- **ARIA**: \`role=\"tab\"\`, \`aria-controls\`, \`role=\"tabpanel\"\`, \`aria-labelledby\` em todas as views.

## Validação

- \`node --test frontend/test/\` → 300/300 ✅
- Sem mudança de contrato com o backend.
- Bindings legados (\`#bot-credentials-open\`, \`#history-open\` etc) virram \`?.\`-guarded no-ops na produção, mantendo os DOM stubs dos testes válidos.

## Fora de escopo (fases seguintes)

- UI de Algos → #398 (Fase 2)
- Settings consolidado em sub-tabs → #399 (Fase 3)
- Reflow do Trading em sub-tabs → #400 (Fase 4)
- Polish / responsive / a11y → #401 (Fase 5)