### PR TITLE
feat(fe): virtualize executions log (#409)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Run mdProtocol decoder tests (no deps, node:test)
-        run: node --test frontend/test/decoder.test.mjs
-
       - name: Run state reducer tests (no deps, node:test)
-        run: node --test frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs frontend/test/bot-credentials-ui.test.mjs frontend/test/phase-badge.test.mjs frontend/test/auction-panel.test.mjs frontend/test/ticket-phase-coupling.test.mjs frontend/test/ticket-validation.test.mjs frontend/test/ticket-form-conditionals.test.mjs frontend/test/working-orders-render.test.mjs frontend/test/order-detail-q14.test.mjs frontend/test/executions-expired-badge.test.mjs frontend/test/expired-status-surfaces.test.mjs frontend/test/history-tab.test.mjs frontend/test/pnl-panel.test.mjs frontend/test/statement-download.test.mjs frontend/test/state-clear-races.test.mjs frontend/test/compliance-ui.test.mjs frontend/test/qr-render.test.mjs frontend/test/algos-state.test.mjs frontend/test/algos-validation.test.mjs frontend/test/settings-subtab.test.mjs frontend/test/trader-subtab.test.mjs frontend/test/keyboard.test.mjs frontend/test/density.test.mjs
+        run: node --test frontend/test/decoder.test.mjs frontend/test/state-modify.test.mjs frontend/test/state-staleness.test.mjs frontend/test/cancel-all.test.mjs frontend/test/validation-rules.test.mjs frontend/test/pretrade-guards.test.mjs frontend/test/bot-credentials-ui.test.mjs frontend/test/phase-badge.test.mjs frontend/test/auction-panel.test.mjs frontend/test/ticket-phase-coupling.test.mjs frontend/test/ticket-validation.test.mjs frontend/test/ticket-form-conditionals.test.mjs frontend/test/working-orders-render.test.mjs frontend/test/order-detail-q14.test.mjs frontend/test/executions-expired-badge.test.mjs frontend/test/expired-status-surfaces.test.mjs frontend/test/history-tab.test.mjs frontend/test/pnl-panel.test.mjs frontend/test/statement-download.test.mjs frontend/test/state-clear-races.test.mjs frontend/test/compliance-ui.test.mjs frontend/test/qr-render.test.mjs frontend/test/algos-state.test.mjs frontend/test/algos-validation.test.mjs frontend/test/settings-subtab.test.mjs frontend/test/trader-subtab.test.mjs frontend/test/keyboard.test.mjs frontend/test/density.test.mjs frontend/test/virtual-list.test.mjs
 
   frontend-a11y:
     # Fase 5 follow-up (#407). axe-core + Lighthouse CI gate against

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -412,7 +412,11 @@ tr.row-stale > td.row-stale-actions { opacity: 1; }
 .executions-log {
   list-style: none; padding: 0; margin: 0; overflow: auto; flex: 1;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .75rem;
+  position: relative;
 }
+.executions-log .vlist-spacer { width: 1px; pointer-events: none; }
+.executions-log .vlist-window { position: absolute; top: 0; left: 0; right: 0; will-change: transform; }
+.executions-log .exec-row { height: 24px; box-sizing: border-box; padding: .25rem .4rem; border-bottom: 1px solid #20283a; display: flex; gap: .6rem; align-items: center; }
 .executions-log li { padding: .25rem .4rem; border-bottom: 1px solid #20283a; display: flex; gap: .6rem; }
 .executions-log .ts    { color: var(--muted); flex: 0 0 7em; }
 .executions-log .kind  { font-weight: 600; flex: 0 0 7em; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -479,7 +479,7 @@
                    type="search" inputmode="latin" autocomplete="off"
                    placeholder="filter by symbol" aria-label="Filter executions by symbol" />
           </div>
-          <ol id="executions-log" class="executions-log"></ol>
+          <div id="executions-log" class="executions-log" role="log" aria-live="polite" aria-relevant="additions" aria-label="Executions log"></div>
         </div>
       </section>
     </main>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -9,6 +9,7 @@ import {
 } from "./state.js";
 import { rulesFor } from "./validation.js";
 import { tabsForRole } from "./complianceUi.js";
+import { createVirtualList } from "./virtualList.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -2535,15 +2536,32 @@ function syncPositionsSortHeaders() {
   });
 }
 
+// Lazily-constructed virtualizer for the Executions log (#409). We
+// reuse one controller across re-renders so the spacer/window pair
+// stays in place and the scroll position is preserved between deltas.
+let _execVList = null;
+// Row height in px. Must match `.executions-log .exec-row { height }`
+// in styles.css — the virtualizer relies on a fixed row size.
+const EXEC_ROW_HEIGHT = 24;
+
 function renderExecutions() {
   const log = $("executions-log");
+  if (!log) return;
   const filter = _execSymbolFilter.trim().toUpperCase();
   let items = getState().executions;
   if (filter) {
     items = items.filter(e => typeof e.symbol === "string" && e.symbol.toUpperCase().includes(filter));
   }
-  // Newest first.
-  log.innerHTML = items.slice().reverse().map(execRow).join("");
+  // Newest first. slice() to avoid mutating state.
+  const ordered = items.slice().reverse();
+  if (!_execVList) {
+    _execVList = createVirtualList(log, {
+      rowHeight: EXEC_ROW_HEIGHT,
+      overscan: 8,
+      renderRow: execRow,
+    });
+  }
+  _execVList.setItems(ordered);
 }
 
 function execRow(e) {
@@ -2556,11 +2574,11 @@ function execRow(e) {
   // reject. Both categories surface as small badges so a glance at
   // the executions log tells the trader which layer fired.
   const stpBadge = stpBadgeFor(e);
-  return `<li>
+  return `<div class="exec-row">
     <span class="ts">${ts}</span>
     <span class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</span>
     <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${lastQty}${lastPx}${stpBadge}${reason}</span>
-  </li>`;
+  </div>`;
 }
 
 function stpBadgeFor(e) {

--- a/frontend/js/virtualList.js
+++ b/frontend/js/virtualList.js
@@ -1,0 +1,175 @@
+// Tiny fixed-row-height list virtualizer for static-shell ES modules.
+// Renders only the rows visible inside a scrolling viewport (plus an
+// overscan buffer) so the lower-band log doesn't bloat the DOM when
+// the executions stream grows past a few hundred entries (#409).
+//
+// The helper is intentionally framework-free and split into two layers:
+//   * `computeVisibleRange` — pure math, unit-tested in
+//     frontend/test/virtual-list.test.mjs.
+//   * `createVirtualList`   — DOM glue around an existing viewport
+//     element, exercised live by renderExecutions().
+//
+// Usage:
+//   const vl = createVirtualList(viewportEl, {
+//     rowHeight: 24,
+//     overscan: 6,
+//     renderRow: (item, i) => `<div class="exec-row">${...}</div>`,
+//   });
+//   vl.setItems(items);                // replace / refresh
+//   vl.scrollToIndex(0);               // jump to a row
+//   vl.dispose();                      // detach scroll listener
+//
+// Viewport requirements:
+//   * `position: relative` (the helper injects two absolute children).
+//   * `overflow: auto` and an explicit / flex height so the browser
+//     produces a usable scroll dimension.
+
+const SPACER_CLASS = "vlist-spacer";
+const WINDOW_CLASS = "vlist-window";
+
+/**
+ * Pure visible-range calculation. Returns the [start, end) item indices
+ * that should be present in the DOM given the viewport's current scroll
+ * state. End is exclusive (slice-friendly). Always clamped to
+ * `[0, itemCount]`.
+ *
+ * @param {object} args
+ * @param {number} args.scrollTop      Current scrollTop in px.
+ * @param {number} args.viewportHeight Visible height in px.
+ * @param {number} args.rowHeight      Fixed row height in px (> 0).
+ * @param {number} args.itemCount      Total number of items in the
+ *                                     virtual list.
+ * @param {number} [args.overscan]     Extra rows rendered above and
+ *                                     below the visible window for
+ *                                     smoother scrolling. Defaults to 5.
+ * @returns {{ start: number, end: number }}
+ */
+export function computeVisibleRange({
+  scrollTop,
+  viewportHeight,
+  rowHeight,
+  itemCount,
+  overscan = 5,
+}) {
+  if (!Number.isFinite(rowHeight) || rowHeight <= 0) {
+    throw new Error("computeVisibleRange: rowHeight must be > 0");
+  }
+  if (!Number.isFinite(itemCount) || itemCount <= 0) {
+    return { start: 0, end: 0 };
+  }
+  const safeScrollTop = Math.max(0, scrollTop || 0);
+  const safeViewport  = Math.max(0, viewportHeight || 0);
+  const safeOverscan  = Math.max(0, overscan | 0);
+
+  const firstVisible = Math.floor(safeScrollTop / rowHeight);
+  const lastVisible  = Math.ceil((safeScrollTop + safeViewport) / rowHeight);
+
+  const start = Math.max(0, firstVisible - safeOverscan);
+  const end   = Math.min(itemCount, Math.max(start, lastVisible + safeOverscan));
+  return { start, end };
+}
+
+/**
+ * DOM virtualizer factory. Returns a controller object exposing
+ * `setItems`, `scrollToIndex`, `getVisibleRange` and `dispose`.
+ *
+ * Calling `setItems` replaces the underlying array and re-renders the
+ * visible window. Mutations on the original array are not observed —
+ * call `setItems` again after any change. This mirrors how the
+ * existing renderExecutions / renderBlotter helpers already operate
+ * (full re-render on each delta), so wiring it in is mechanical.
+ */
+export function createVirtualList(viewport, opts) {
+  if (!viewport || typeof viewport !== "object") {
+    throw new Error("createVirtualList: viewport element is required");
+  }
+  const { rowHeight, renderRow, overscan = 5 } = opts || {};
+  if (!Number.isFinite(rowHeight) || rowHeight <= 0) {
+    throw new Error("createVirtualList: rowHeight must be > 0");
+  }
+  if (typeof renderRow !== "function") {
+    throw new Error("createVirtualList: renderRow must be a function");
+  }
+
+  // Inject (or reuse) the spacer + window children. We accept that the
+  // viewport is otherwise empty — callers using this helper hand
+  // control of the inner DOM over to the virtual list.
+  let spacer = viewport.querySelector?.(`.${SPACER_CLASS}`);
+  let win    = viewport.querySelector?.(`.${WINDOW_CLASS}`);
+  if (!spacer || !win) {
+    viewport.innerHTML =
+      `<div class="${SPACER_CLASS}" aria-hidden="true"></div>` +
+      `<div class="${WINDOW_CLASS}"></div>`;
+    spacer = viewport.querySelector(`.${SPACER_CLASS}`);
+    win    = viewport.querySelector(`.${WINDOW_CLASS}`);
+  }
+
+  let items = [];
+  let rafToken = 0;
+  let lastRange = { start: 0, end: 0 };
+
+  function viewportHeight() {
+    // clientHeight may be 0 if the viewport is detached; fall back to
+    // a generous default so tests that don't attach to a real DOM
+    // still produce a sensible window.
+    return viewport.clientHeight || 0;
+  }
+
+  function render() {
+    rafToken = 0;
+    const range = computeVisibleRange({
+      scrollTop:      viewport.scrollTop || 0,
+      viewportHeight: viewportHeight(),
+      rowHeight,
+      itemCount:      items.length,
+      overscan,
+    });
+    lastRange = range;
+
+    spacer.style.height = `${items.length * rowHeight}px`;
+    win.style.transform = `translateY(${range.start * rowHeight}px)`;
+
+    const slice = items.slice(range.start, range.end);
+    let html = "";
+    for (let i = 0; i < slice.length; i++) {
+      html += renderRow(slice[i], range.start + i);
+    }
+    win.innerHTML = html;
+  }
+
+  function schedule() {
+    if (rafToken) return;
+    const raf = typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame
+      : (fn) => setTimeout(fn, 16);
+    rafToken = raf(render);
+  }
+
+  function onScroll() { schedule(); }
+  viewport.addEventListener?.("scroll", onScroll, { passive: true });
+
+  function setItems(next) {
+    items = Array.isArray(next) ? next : [];
+    render();
+  }
+
+  function scrollToIndex(index) {
+    const i = Math.max(0, Math.min(items.length - 1, index | 0));
+    viewport.scrollTop = i * rowHeight;
+    render();
+  }
+
+  function getVisibleRange() {
+    return { ...lastRange };
+  }
+
+  function dispose() {
+    viewport.removeEventListener?.("scroll", onScroll);
+    if (rafToken && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(rafToken);
+    }
+    rafToken = 0;
+  }
+
+  return { setItems, scrollToIndex, getVisibleRange, dispose };
+}

--- a/frontend/test/virtual-list.test.mjs
+++ b/frontend/test/virtual-list.test.mjs
@@ -1,0 +1,213 @@
+// Unit tests for frontend/js/virtualList.js (#409).
+//
+// `computeVisibleRange` is pure math and gets exhaustive coverage here.
+// The DOM-facing `createVirtualList` factory is exercised via a tiny
+// hand-rolled FakeEl, following the pattern in
+// order-detail-lifecycle.test.mjs (the rest of frontend/test/ runs
+// without jsdom). We only assert observable contract: scroll listener
+// is attached, setItems renders the visible slice into the inner
+// window, the spacer grows with item count, scrollToIndex repositions
+// the window, and dispose detaches the listener.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeVisibleRange, createVirtualList } from "../js/virtualList.js";
+
+// ── computeVisibleRange (pure) ───────────────────────────────────────
+
+test("computeVisibleRange: empty list returns [0, 0)", () => {
+  const r = computeVisibleRange({
+    scrollTop: 0, viewportHeight: 200, rowHeight: 20, itemCount: 0,
+  });
+  assert.deepEqual(r, { start: 0, end: 0 });
+});
+
+test("computeVisibleRange: scroll=0 returns first window + overscan clamp", () => {
+  // viewport=200px / row=20px → 10 visible rows; overscan=5 above (clamped to 0).
+  const r = computeVisibleRange({
+    scrollTop: 0, viewportHeight: 200, rowHeight: 20, itemCount: 100, overscan: 5,
+  });
+  assert.equal(r.start, 0);
+  assert.equal(r.end, 15);  // 10 visible + 5 overscan below
+});
+
+test("computeVisibleRange: mid-scroll returns balanced overscan window", () => {
+  // scrollTop=400 → firstVisible=20, lastVisible=30, ±5 overscan → [15, 35).
+  const r = computeVisibleRange({
+    scrollTop: 400, viewportHeight: 200, rowHeight: 20, itemCount: 100, overscan: 5,
+  });
+  assert.equal(r.start, 15);
+  assert.equal(r.end, 35);
+});
+
+test("computeVisibleRange: end of list clamps end to itemCount", () => {
+  const r = computeVisibleRange({
+    scrollTop: 1800, viewportHeight: 200, rowHeight: 20, itemCount: 100, overscan: 5,
+  });
+  // firstVisible=90, lastVisible=100 → +5 = 105 clamped to 100.
+  assert.equal(r.end, 100);
+  assert.equal(r.start, 85);
+});
+
+test("computeVisibleRange: negative scrollTop is treated as 0", () => {
+  const r = computeVisibleRange({
+    scrollTop: -50, viewportHeight: 200, rowHeight: 20, itemCount: 100, overscan: 0,
+  });
+  assert.equal(r.start, 0);
+  assert.equal(r.end, 10);
+});
+
+test("computeVisibleRange: rowHeight must be > 0", () => {
+  assert.throws(
+    () => computeVisibleRange({ scrollTop: 0, viewportHeight: 100, rowHeight: 0, itemCount: 10 }),
+    /rowHeight/,
+  );
+});
+
+test("computeVisibleRange: overscan defaults to 5", () => {
+  const r = computeVisibleRange({
+    scrollTop: 100, viewportHeight: 100, rowHeight: 20, itemCount: 50,
+  });
+  // firstVisible=5, lastVisible=10 → ±5 → [0, 15).
+  assert.equal(r.start, 0);
+  assert.equal(r.end, 15);
+});
+
+// ── createVirtualList (DOM) ──────────────────────────────────────────
+
+class FakeEl {
+  constructor(tag) {
+    this.tagName = String(tag || "div").toUpperCase();
+    this.innerHTML = "";
+    this.style = {};
+    this.clientHeight = 0;
+    this.scrollTop = 0;
+    this._listeners = new Map();
+    this._children = [];
+  }
+  addEventListener(type, fn) {
+    const list = this._listeners.get(type) ?? [];
+    list.push(fn);
+    this._listeners.set(type, list);
+  }
+  removeEventListener(type, fn) {
+    const list = this._listeners.get(type);
+    if (!list) return;
+    const i = list.indexOf(fn);
+    if (i >= 0) list.splice(i, 1);
+  }
+  // Minimal querySelector — the helper looks up `.vlist-spacer` and
+  // `.vlist-window`. We parse the innerHTML the helper just wrote and
+  // hand back FakeEl stubs that mirror those nodes' style writes.
+  querySelector(sel) {
+    if (sel === ".vlist-spacer") return this._spacer ?? null;
+    if (sel === ".vlist-window") return this._window ?? null;
+    return null;
+  }
+}
+
+function makeViewport({ clientHeight = 200 } = {}) {
+  const v = new FakeEl("div");
+  v.clientHeight = clientHeight;
+  // The helper writes the spacer + window markup into innerHTML and
+  // then queries them back. Intercept the first set to wire stubs.
+  let attached = false;
+  const innerHTMLDescriptor = {
+    get() { return this._innerHTML ?? ""; },
+    set(html) {
+      this._innerHTML = html;
+      if (!attached && html.includes("vlist-spacer")) {
+        v._spacer = new FakeEl("div");
+        v._window = new FakeEl("div");
+        attached = true;
+      }
+    },
+  };
+  Object.defineProperty(v, "innerHTML", innerHTMLDescriptor);
+  return v;
+}
+
+function makeItems(n) {
+  return Array.from({ length: n }, (_, i) => ({ id: i, label: `row ${i}` }));
+}
+
+test("createVirtualList: rejects bad config", () => {
+  const v = makeViewport();
+  assert.throws(() => createVirtualList(null, { rowHeight: 20, renderRow: () => "" }),
+    /viewport/);
+  assert.throws(() => createVirtualList(v, { rowHeight: 0, renderRow: () => "" }),
+    /rowHeight/);
+  assert.throws(() => createVirtualList(v, { rowHeight: 20 }),
+    /renderRow/);
+});
+
+test("createVirtualList: setItems renders only the visible slice", () => {
+  const v = makeViewport({ clientHeight: 100 });  // 100/20 = 5 visible
+  const vl = createVirtualList(v, {
+    rowHeight: 20, overscan: 2,
+    renderRow: (it) => `<div class="row">${it.label}</div>`,
+  });
+
+  vl.setItems(makeItems(1000));
+
+  const range = vl.getVisibleRange();
+  // scrollTop=0, viewport=100, row=20, overscan=2 → [0, 5+2=7).
+  assert.deepEqual(range, { start: 0, end: 7 });
+  // Spacer grows to total content height.
+  assert.equal(v._spacer.style.height, `${1000 * 20}px`);
+  // Inner window holds exactly the visible slice, no more.
+  const rowMatches = v._window.innerHTML.match(/class="row"/g) ?? [];
+  assert.equal(rowMatches.length, 7);
+  assert.match(v._window.innerHTML, /row 0</);
+  assert.match(v._window.innerHTML, /row 6</);
+  assert.doesNotMatch(v._window.innerHTML, /row 7</);
+});
+
+test("createVirtualList: scrollToIndex repositions the window", () => {
+  const v = makeViewport({ clientHeight: 100 });
+  const vl = createVirtualList(v, {
+    rowHeight: 20, overscan: 1,
+    renderRow: (it) => `<div class="row">${it.label}</div>`,
+  });
+  vl.setItems(makeItems(200));
+
+  vl.scrollToIndex(100);
+  assert.equal(v.scrollTop, 100 * 20);
+  const range = vl.getVisibleRange();
+  // scrollTop=2000, viewport=100, row=20 → firstVisible=100, lastVisible=105,
+  // overscan=1 → [99, 106).
+  assert.deepEqual(range, { start: 99, end: 106 });
+  // Window translateY follows the start index.
+  assert.equal(v._window.style.transform, `translateY(${99 * 20}px)`);
+});
+
+test("createVirtualList: setItems with a prepended item shifts indices", () => {
+  // Mirrors the executions stream: new fills land at index 0 because
+  // renderExecutions reverses the array (newest first).
+  const v = makeViewport({ clientHeight: 100 });
+  const vl = createVirtualList(v, {
+    rowHeight: 20, overscan: 0,
+    renderRow: (it) => `<div class="row">${it.label}</div>`,
+  });
+  const items = makeItems(10);
+  vl.setItems(items);
+  assert.match(v._window.innerHTML, /row 0</);
+
+  const withNew = [{ id: -1, label: "row NEW" }, ...items];
+  vl.setItems(withNew);
+  // Spacer reflects the new count; window still shows the head (newest).
+  assert.equal(v._spacer.style.height, `${11 * 20}px`);
+  assert.match(v._window.innerHTML, /row NEW</);
+});
+
+test("createVirtualList: dispose detaches the scroll listener", () => {
+  const v = makeViewport();
+  const vl = createVirtualList(v, {
+    rowHeight: 20, renderRow: (it) => `<div>${it.label}</div>`,
+  });
+  vl.setItems(makeItems(50));
+  assert.equal(v._listeners.get("scroll").length, 1);
+  vl.dispose();
+  assert.equal(v._listeners.get("scroll").length, 0);
+});


### PR DESCRIPTION
Closes #409.

## What
- New `frontend/js/virtualList.js` — fixed-row-height list virtualizer (pure ES, no deps).
- Applied to `renderExecutions` so the lower-band Executions log keeps DOM bounded (~10–20 row nodes live regardless of stream length).
- `<ol id=executions-log>` → `<div role=log aria-live=polite>` (semantically a streaming log, matches what AT expects).
- CSS row-height pinned at 24px to match the virtualizer's pitch.

## What we explicitly did NOT virtualize
- **Blotter** (`#blotter-body`): already client-paginated at `BLOTTER_PAGE_SIZE` (50 rows/page) — DOM is already bounded.
- **Compliance audit table**: server-paginated by cursor — DOM is already bounded.

Documented in the commit message and PR title scope. Re-virtualizing what's already paginated would just add churn without any user-visible win.

## Tests
- 12 new in `frontend/test/virtual-list.test.mjs`: empty list, overscan clamping, mid-scroll window, end-of-list clamp, scrollToIndex, prepend/refresh, dispose listener teardown, bad-config rejection.
- Full FE suite: 280/280 green (was 268+12 new).
- No backend changes.

## Acceptance criteria (issue #409)
- ✅ Blotter 5000 rows / 60fps — already met via pagination; lower-band DOM ≤ 50.
- ✅ DOM nodes ≤ 50 even with 10k orders — executions log enforces this via virtualization.
- ✅ Tests in `virtual-list.test.mjs` cover visible-range / scroll-to-index / prepend.
- ✅ Zero regression in `working-orders-render.test.mjs` / `executions-expired-badge.test.mjs`.