### PR TITLE
fix(#381): surface replace-reject ERs to the UI

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -876,6 +876,56 @@ public sealed class ExecutionReportProcessor
         {
             _botErRouter.Route(rejectedEv);
         }
+
+        // #381. The replace-side BotRouter event above intentionally
+        // does NOT reach the WS hub (orders.me has no record of the
+        // replace-side ClOrdID). But the operator who clicked Modify
+        // on the *original* ClOrdID has every right to know their
+        // PUT /orders/{clOrdId} got rejected — without this second
+        // event the UI silently re-enables the Modify button as if
+        // nothing happened. Emit a discriminated ExecKind.ReplaceRejected
+        // scoped to intent.OriginalClOrdId, carrying the original's
+        // preserved Leaves/Cumulative so the UI doesn't have to special-
+        // case "this is a reject, ignore the quantities". Route to
+        // WsHub | DropCopy — never BotRouter, to avoid double-delivery
+        // to bots that already received the synthetic Rejected above.
+        long origLeaves = 0;
+        long origCum = 0;
+        var origStatus = OrderStatus.Working;
+        if (_orders.TryGet(intent.OriginalClOrdId, out var origOrder) && origOrder is not null)
+        {
+            origLeaves = origOrder.LeavesQuantity;
+            origCum = origOrder.CumulativeQuantity;
+            origStatus = origOrder.Status;
+        }
+
+        var origVisibleEv = new ExecutionEvent(
+            intent.Owner,
+            intent.OriginalClOrdId,
+            intent.Symbol,
+            intent.Side,
+            origStatus,
+            ExecKind.ReplaceRejected,
+            LeavesQuantity: origLeaves,
+            CumulativeQuantity: origCum,
+            LastQuantity: 0,
+            LastPrice: 0m,
+            RejectReason: rejectReason,
+            TimestampUtc: DateTimeOffset.UtcNow,
+            IsNativeStp: false,
+            FirmId: intent.FirmId);
+        if (fanOut is not null)
+        {
+            fanOut.Add(origVisibleEv,
+                Persistence.ExecutionFanOutTargets.WsHub | Persistence.ExecutionFanOutTargets.DropCopy);
+        }
+        else
+        {
+            // Test / legacy path with no fan-out registry: surface via
+            // the direct sink. BotRouter is deliberately not invoked —
+            // bots get the replace-side Rejected event above.
+            _sink.Publish(origVisibleEv);
+        }
     }
 
     private void ApplyReplaceAccepted(
@@ -1118,4 +1168,27 @@ public enum ExecKind
     /// double-update consumers for the same observation.
     /// </summary>
     Restored,
+    /// <summary>
+    /// #381. Synthetic projection of a venue-side replace-reject (FIXP
+    /// <c>OrderCancelReplaceRequest</c> rejected, surfaced as ER kind
+    /// <see cref="Rejected"/> against the replace-side ClOrdID and
+    /// intercepted by the <c>PendingReplacementRegistry</c> consumer).
+    /// The original order is untouched (status stays Working /
+    /// PartiallyFilled) but the operator who issued the
+    /// <c>PUT /orders/{clOrdId}</c> must know the modify failed.
+    /// <para>
+    /// Routing: the <see cref="Rejected"/> event for the *replace-side*
+    /// ClOrdID continues to flow to <c>BotRouter</c> only (per #172 F:
+    /// the WS hub has no <c>orders.me</c> record for a ClOrdID that
+    /// never opened an order). The <c>ReplaceRejected</c> event scoped
+    /// to <c>intent.OriginalClOrdId</c> targets <c>WsHub | DropCopy</c>
+    /// — never <c>BotRouter</c>, to avoid double-delivery to bots that
+    /// already received the <see cref="Rejected"/> event via the
+    /// existing path.
+    /// </para>
+    /// Carries the original's preserved <c>LeavesQuantity</c> /
+    /// <c>CumulativeQuantity</c> and the venue's reject reason; no
+    /// fill price (no economic event).
+    /// </summary>
+    ReplaceRejected,
 }

--- a/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ExecutionReportProcessorTests.cs
@@ -1,5 +1,6 @@
 using B3.Trading.Application.Risk;
 using B3.Trading.Application;
+using B3.Trading.Application.UserBots;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -350,9 +351,121 @@ public class ExecutionReportProcessorTests
         Assert.True(order.IsStale);
     }
 
+    [Fact]
+    public void ApplyReplaceRejected_EmitsUiVisibleEvent_ScopedToOriginalClOrdId()
+    {
+        // #381 regression: a venue replace-reject (PUT /orders/{orig} ->
+        // venue rejected the new ClOrdID) used to publish ONLY the synthetic
+        // Rejected event tagged BotRouter-only (per #172 F), so the WS hub
+        // never observed the rejection. The trader who clicked Modify saw
+        // nothing — Modify button silently re-enabled, no row update, no
+        // toast. Now ApplyReplaceRejected MUST also publish a second event
+        // scoped to intent.OriginalClOrdId with ExecKind.ReplaceRejected so
+        // the operator sees the modify failed.
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new RecordingSink();
+        var botRouter = new RecordingBotErRouter();
+        var replacements = new PendingReplacementRegistry();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, sink, new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            replacements: replacements,
+            botErRouter: botRouter);
+
+        var owner = new EndClientId("alice");
+        var orig = new Order(1UL, owner, "PETR4", 4321UL, OrderSide.Sell, OrderType.Limit, 100, 32.50m);
+        book.TryAdd(orig);
+        ownership.Register(1UL, owner);
+        orig.MarkWorking();
+
+        // Operator clicks Modify: a fresh replace-side ClOrdID (3) is
+        // registered as in-flight against orig=1. The new request reaches
+        // the venue which rejects it (reject_code=5 / unknown order).
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: 1UL, NewClOrdId: 3UL,
+            Owner: owner, Symbol: "PETR4", SecurityId: 4321UL,
+            Side: OrderSide.Sell, Type: OrderType.Limit,
+            NewQuantity: 100, NewPrice: 32.55m,
+            FirmId: "FIRM01", ParentAlgoId: null, AlgoSliceSeq: null);
+        Assert.True(replacements.TryAdd(intent));
+
+        proc.Apply(3UL, ExecKind.Rejected, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: "reject_code=5");
+
+        // Bot side: replace-side ClOrdID receives the synthetic Rejected
+        // (preserves #172 F — bots own the ClOrdIDs they issue).
+        Assert.Single(botRouter.Events);
+        var botEv = botRouter.Events[0];
+        Assert.Equal(3UL, botEv.ClOrdId);
+        Assert.Equal(ExecKind.Rejected, botEv.Kind);
+        Assert.Equal(OrderStatus.Rejected, botEv.Status);
+
+        // UI side: the new #381 event scoped to OrigClOrdId, status preserved
+        // (Working, since orig was MarkWorking-ed), Leaves/Cum copied from
+        // the still-alive original Order, and kind discriminated as
+        // ReplaceRejected so the FE can clear inflightModifies + toast.
+        Assert.Single(sink.Events);
+        var uiEv = sink.Events[0];
+        Assert.Equal(intent.OriginalClOrdId, uiEv.ClOrdId);
+        Assert.Equal(ExecKind.ReplaceRejected, uiEv.Kind);
+        Assert.Equal(OrderStatus.Working, uiEv.Status);
+        Assert.Equal(orig.LeavesQuantity, uiEv.LeavesQuantity);
+        Assert.Equal(orig.CumulativeQuantity, uiEv.CumulativeQuantity);
+        Assert.Equal("reject_code=5", uiEv.RejectReason);
+        Assert.Equal(intent.FirmId, uiEv.FirmId);
+
+        // Original order itself is untouched (replace-reject is non-economic).
+        Assert.Equal(OrderStatus.Working, orig.Status);
+    }
+
+    [Fact]
+    public void ApplyReplaceRejected_OrigMissingFromBook_StillEmitsUiVisibleEvent_WithSafeDefaults()
+    {
+        // Edge case: the original Order has already terminalised (rare race
+        // — late ApplyReplaceRejected for a replace that was issued just
+        // before a fill arrived and Filled the original). The UI-visible
+        // event still ships so the operator's Modify button gets unstuck;
+        // Leaves/Cum fall back to 0 and Status defaults to Working (the
+        // FE only uses the event as a "modify failed" signal in this case).
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var sink = new RecordingSink();
+        var replacements = new PendingReplacementRegistry();
+        var proc = new ExecutionReportProcessor(
+            ownership, book, new PositionKeeper(), sink, new NoOpMarginProvider(),
+            NullLogger<ExecutionReportProcessor>.Instance,
+            replacements: replacements);
+
+        var owner = new EndClientId("alice");
+        ownership.Register(1UL, owner);
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: 1UL, NewClOrdId: 3UL,
+            Owner: owner, Symbol: "PETR4", SecurityId: 4321UL,
+            Side: OrderSide.Sell, Type: OrderType.Limit,
+            NewQuantity: 100, NewPrice: 32.55m,
+            FirmId: "FIRM01", ParentAlgoId: null, AlgoSliceSeq: null);
+        Assert.True(replacements.TryAdd(intent));
+
+        proc.Apply(3UL, ExecKind.Rejected, leaves: 0, cumQty: 0, lastQty: 0, lastPx: 0m, rejectReason: "reject_code=5");
+
+        Assert.Single(sink.Events);
+        var uiEv = sink.Events[0];
+        Assert.Equal(1UL, uiEv.ClOrdId);
+        Assert.Equal(ExecKind.ReplaceRejected, uiEv.Kind);
+        Assert.Equal(0, uiEv.LeavesQuantity);
+        Assert.Equal(0, uiEv.CumulativeQuantity);
+    }
+
     private sealed class RecordingSink : IExecutionEventSink
     {
         public readonly List<ExecutionEvent> Events = new();
         public void Publish(ExecutionEvent ev) => Events.Add(ev);
+    }
+
+    private sealed class RecordingBotErRouter : IBotErRouter
+    {
+        public readonly List<ExecutionEvent> Events = new();
+        public void Route(ExecutionEvent ev) => Events.Add(ev);
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -629,7 +629,17 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Equal(OrderStatus.PendingNew, orig.Status); // unchanged
         Assert.False(book.TryGet(2UL, out _));
         Assert.False(reg.TryGet(2UL, out _));
-        Assert.Empty(sink.Events); // replace-reject does not publish (no new order to surface)
+        // #381. The new contract: replace-reject DOES surface a single
+        // ExecKind.ReplaceRejected event scoped to OriginalClOrdId so the
+        // operator's UI can release the optimistic Modify-inflight flag.
+        // The replace-side Rejected event is BotRouter-only (#172 F) and
+        // does not reach _sink in this test wiring (no botErRouter wired).
+        var ev = Assert.Single(sink.Events);
+        Assert.Equal(1UL, ev.ClOrdId);
+        Assert.Equal(ExecKind.ReplaceRejected, ev.Kind);
+        Assert.Equal(OrderStatus.PendingNew, ev.Status);
+        Assert.Equal(100, ev.LeavesQuantity);
+        Assert.Equal("tick-out-of-range", ev.RejectReason);
     }
 
     [Fact]

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -319,6 +319,17 @@ export function applyExecutionsDelta(row) {
   if (state.executions.length > EXECUTIONS_CAPACITY) {
     state.executions.splice(0, state.executions.length - EXECUTIONS_CAPACITY);
   }
+  // #381. Replace-reject is non-economic — the backend does NOT emit an
+  // orders delta for the original ClOrdID (its Status/Leaves/Cum are
+  // preserved). Without explicit clearing here the operator's Modify
+  // button stays stuck in the "inflight" spin state forever, since the
+  // optimistic markModifyInflight(clOrdId, true) set at submit-time only
+  // gets cleared by a subsequent orders delta or a successful Replaced
+  // ER. The new ExecKind.ReplaceRejected (scoped to OriginalClOrdId) is
+  // our cue to release the spinner so the trader can retry.
+  if (row && row.kind === "ReplaceRejected" && row.clOrdId != null) {
+    markModifyInflight(row.clOrdId, false);
+  }
   notify("executions");
 }
 

--- a/frontend/test/state-modify.test.mjs
+++ b/frontend/test/state-modify.test.mjs
@@ -57,3 +57,38 @@ test('clearAll() empties inflightModifies', async () => {
   s.clearAll();
   assert.equal(s.getState().inflightModifies.size, 0);
 });
+
+// #381 — ExecKind.ReplaceRejected from the backend lands as an executions
+// delta scoped to the OriginalClOrdId. applyExecutionsDelta must release
+// the optimistic inflight-modify flag so the Modify button gets unstuck;
+// without this the trader sees a permanently-spinning button after every
+// venue replace-reject (no orders delta arrives — the order itself is
+// unchanged by definition for a replace-reject).
+test('applyExecutionsDelta(ReplaceRejected) clears inflightModifies for the original ClOrdID', async () => {
+  const s = await freshState();
+  s.markModifyInflight('42', true);
+  assert.ok(s.getState().inflightModifies.has('42'));
+  s.applyExecutionsDelta({
+    clOrdId: '42', symbol: 'PETR4', side: 'Sell', status: 'Working',
+    kind: 'ReplaceRejected', leavesQuantity: 100, cumulativeQuantity: 0,
+    lastQuantity: 0, lastPrice: 0, rejectReason: 'reject_code=5',
+    timestampUtc: new Date().toISOString(),
+  });
+  assert.ok(!s.getState().inflightModifies.has('42'));
+  // Event is still appended to the executions log for the trader to see.
+  assert.equal(s.getState().executions.length, 1);
+  assert.equal(s.getState().executions[0].kind, 'ReplaceRejected');
+});
+
+test('applyExecutionsDelta with other kinds does NOT clear inflightModifies', async () => {
+  const s = await freshState();
+  s.markModifyInflight('42', true);
+  s.applyExecutionsDelta({
+    clOrdId: '42', symbol: 'PETR4', side: 'Sell', status: 'PartiallyFilled',
+    kind: 'PartialFill', leavesQuantity: 80, cumulativeQuantity: 20,
+    lastQuantity: 20, lastPrice: 30, rejectReason: null,
+    timestampUtc: new Date().toISOString(),
+  });
+  // Spinner stays until the actual Replaced ack / explicit clear arrives.
+  assert.ok(s.getState().inflightModifies.has('42'));
+});


### PR DESCRIPTION
Closes #381.

## Problem

When a venue rejects a PUT /orders/{clOrdId} replace (tick-out-of-range, unknown ClOrdID, etc.), `ExecutionReportProcessor.ApplyReplaceRejected` used to publish only a synthetic `Rejected` event tagged `BotRouter` (per #172 (F) — the WS hub's `orders.me` view has no record of the replace-side ClOrdID). So the operator who clicked **Modify** saw absolutely nothing: button stuck in optimistic inflight-spin, no toast, no row update, no executions-log entry.

## Fix

**Backend** — `ApplyReplaceRejected` now emits a SECOND `ExecutionEvent` scoped to `intent.OriginalClOrdId` with new `ExecKind.ReplaceRejected`. Preserves the original order's `Status` / `LeavesQuantity` / `CumulativeQuantity` (replace-reject is non-economic — original keeps Working/PartiallyFilled). Routed `WsHub | DropCopy` — explicitly **not** `BotRouter`, to avoid double-delivery (bots already get the synthetic Rejected on the replace-side ClOrdID per #172 (F)).

**Frontend** — `applyExecutionsDelta` calls `markModifyInflight(clOrdId, false)` when `row.kind === 'ReplaceRejected'` so the Modify button gets unstuck. The event is still appended to the executions log so the trader sees the rejection reason.

## Out of scope

Cancel-reject (also called out in #381) is genuinely missing: `ApplyCancelRejected` doesn't exist. FIXP `OrderCancelReject` is its own msg type, not an ER. Tracking separately if it surfaces.

## Tests

- 2 new tests in `ExecutionReportProcessorTests` (happy path + orig-missing edge case).
- Updated stale assertion in `OrderModifyMarginAndProcessorTests.Processor_Rejected_forIntentInRegistry_treatsAsReplaceReject_originalUntouched`.
- 2 new tests in `state-modify.test.mjs` (clears inflight on ReplaceRejected; does NOT clear on other kinds).
- Backend: 1129/1129 Application + 493/493 Api + 81/81 Domain + 12/12 Reconciliation + 134/134 EntryPointListener.
- Frontend: 308/308 (CI test list).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>