### PR TITLE
#380 path B: session-version guard on snapshot recovery

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -191,6 +191,24 @@ public static class MetricsRegistry
     public static readonly Counter<long> RecoveryEventsReplayed =
         Meter.CreateCounter<long>("trading.recovery.events_replayed");
 
+    // #380 path B. Session-version guard. Fires once per firm whose
+    // gateway SessionVerId has advanced past the verId recorded in the
+    // loaded snapshot — i.e. the venue rolled the session while the
+    // process was down. Tag `firm` carries the FirmId. A non-zero rate
+    // outside known dev-bridge data-wipe scenarios indicates the venue
+    // is dropping our session more often than expected.
+    public static readonly Counter<long> RecoverySessionRolledFirms =
+        Meter.CreateCounter<long>("trading.recovery.session_rolled_firms");
+
+    // #380 path B. Number of WorkingOrderBook entries eagerly retired
+    // (MarkCancelled) by the session-version guard. Tag `firm` carries
+    // the FirmId. Burst on a single restart is expected when a real
+    // session roll happens; a steady drip across restarts means the
+    // snapshot is not being refreshed often enough relative to gateway
+    // reconnect frequency.
+    public static readonly Counter<long> RecoverySessionRolledOrdersDropped =
+        Meter.CreateCounter<long>("trading.recovery.session_rolled_orders_dropped");
+
     // Q2.3 (#270). Fee-keeper deterministic replay synth — surfaces the
     // crash window between ER append (seq N) and FeeAccruedEvent append
     // (seq N+1). Tag `reconciled` is true when a durable FeeAccruedEvent

--- a/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/RawSnapshots.cs
@@ -193,6 +193,15 @@ public sealed class RawPlatformSnapshot
     /// </summary>
     public IReadOnlyList<SubAccountPnlBasisSnapshot> SubAccountPnlBasis { get; init; } =
         Array.Empty<SubAccountPnlBasisSnapshot>();
+
+    /// <summary>
+    /// #380 path B. Per-firm last-observed FIXP <c>SessionVerId</c> at
+    /// snapshot capture time. Empty on snapshots pre-dating the field
+    /// or in compositions without an <c>IFirmSessionStatusProvider</c>
+    /// (e.g. Mock/Stub/Unavailable exchange modes).
+    /// </summary>
+    public IReadOnlyDictionary<string, uint> FirmSessionVerIds { get; init; } =
+        new Dictionary<string, uint>();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -299,6 +299,24 @@ public sealed class PlatformSnapshot
     /// empty basis map (best-effort, see record doc).
     /// </summary>
     public List<SubAccountPnlBasisSnapshot> SubAccountPnlBasis { get; init; } = new();
+
+    /// <summary>
+    /// #380 path B. Per-firm last-observed FIXP <c>SessionVerId</c> at
+    /// snapshot capture time, sourced from each
+    /// <see cref="B3.Trading.Infrastructure.IFirmSessionStatusProvider"/>
+    /// entry. Empty on snapshots pre-dating the field (additive). When
+    /// present, <see cref="B3.Trading.Infrastructure.Persistence.PersistenceRecovery"/>
+    /// compares each firm's current gateway <c>SessionVerId</c> against
+    /// the stored value after replay and eagerly retires every
+    /// <see cref="B3.Trading.Application.WorkingOrderBook"/> entry
+    /// attached to a firm whose verId has advanced past the snapshot
+    /// (the venue rolled the session — orders attached to the prior
+    /// version are ghosts and would otherwise poison STP, modify, and
+    /// margin checks until the next ER ack that never comes).
+    /// Restore is a no-op for the snapshot itself; the dict is read
+    /// straight off the loaded snapshot by the recovery path.
+    /// </summary>
+    public Dictionary<string, uint> FirmSessionVerIds { get; init; } = new();
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
@@ -39,6 +39,15 @@ public sealed class PersistenceRecovery
     private readonly FillProjection? _fillProjection;
     private readonly WorkingOrderBook? _orders;
     private readonly OrderOwnershipMap? _ownership;
+    // #380 path B. Optional. When wired AND the loaded snapshot carries
+    // per-firm SessionVerIds, recovery compares each firm's current
+    // gateway SessionVerId against the stored value after WAL replay.
+    // For any firm whose verId has advanced past the snapshot, every
+    // working order attached to that firm is eagerly retired
+    // (MarkCancelled) — those orders cannot exist at the venue under
+    // the new session version and would otherwise poison STP, modify,
+    // and margin checks until the next ER ack that never comes.
+    private readonly IFirmSessionStatusProvider? _firmSessionStatus;
 
     public PersistenceRecovery(
         IEventStore store,
@@ -49,7 +58,8 @@ public sealed class PersistenceRecovery
         AuditLogKeeper? auditKeeper = null,
         FillProjection? fillProjection = null,
         WorkingOrderBook? orders = null,
-        OrderOwnershipMap? ownership = null)
+        OrderOwnershipMap? ownership = null,
+        IFirmSessionStatusProvider? firmSessionStatus = null)
     {
         _store = store;
         _snapshotter = snapshotter;
@@ -60,6 +70,7 @@ public sealed class PersistenceRecovery
         _fillProjection = fillProjection;
         _orders = orders;
         _ownership = ownership;
+        _firmSessionStatus = firmSessionStatus;
     }
 
     public async Task RunAsync(CancellationToken ct = default)
@@ -162,6 +173,69 @@ public sealed class PersistenceRecovery
         }
         MetricsRegistry.RecoveryEventsReplayed.Add(replayed);
         _logger.LogInformation("Persistence recovery: replayed {Count} events past seq={Since}.", replayed, since);
+
+        // #380 path B. Session-version guard. Compares the snapshot's
+        // per-firm SessionVerId record against each gateway's current
+        // live verId; for any firm whose verId has advanced past the
+        // snapshot, every WorkingOrderBook entry attached to that firm
+        // is retired (MarkCancelled). Skipped silently when either side
+        // is absent: legacy snapshots have no FirmSessionVerIds, Mock /
+        // Stub / Unavailable exchange modes have no IFirmSessionStatusProvider.
+        if (snap is not null && _firmSessionStatus is not null && _orders is not null)
+        {
+            ReconcileFirmSessionVerIds(snap);
+        }
+    }
+
+    private void ReconcileFirmSessionVerIds(PlatformSnapshot snap)
+    {
+        if (snap.FirmSessionVerIds is null || snap.FirmSessionVerIds.Count == 0)
+        {
+            // Pre-#380 snapshot — no recorded baseline. Cannot
+            // distinguish "venue rolled" from "first restart since
+            // the field was added"; skip rather than retire blindly.
+            return;
+        }
+
+        var currentByFirm = _firmSessionStatus!.Snapshot();
+        foreach (var status in currentByFirm)
+        {
+            if (!snap.FirmSessionVerIds.TryGetValue(status.FirmId, out var storedVerId)
+                || storedVerId == 0)
+            {
+                // No baseline for this firm — first snapshot after the
+                // firm was added, or capture happened before the firm
+                // ever Established. Skip.
+                continue;
+            }
+            if (status.SessionVerId <= storedVerId)
+            {
+                // Same or earlier session — orders attached at the
+                // stored verId are still valid at the venue.
+                continue;
+            }
+
+            // Session-version advanced past the snapshot. Every working
+            // order attached to this firm at snapshot capture (and
+            // anything the WAL tail re-confirmed) is a ghost on the
+            // venue side. Retire each one.
+            var dropped = 0;
+            foreach (var order in _orders!.EnumerateForFirm(status.FirmId, includeTerminal: false))
+            {
+                order.MarkCancelled();
+                if (order.Status == B3.Trading.Domain.OrderStatus.Cancelled)
+                {
+                    dropped++;
+                }
+            }
+            _logger.LogWarning(
+                "event=recovery.session-rolled firm={Firm} from={From} to={To} dropped={Dropped}",
+                status.FirmId, storedVerId, status.SessionVerId, dropped);
+            MetricsRegistry.RecoverySessionRolledFirms.Add(1,
+                new KeyValuePair<string, object?>("firm", status.FirmId));
+            MetricsRegistry.RecoverySessionRolledOrdersDropped.Add(dropped,
+                new KeyValuePair<string, object?>("firm", status.FirmId));
+        }
     }
 }
 

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -78,6 +78,12 @@ public sealed class StateSnapshotter
     private readonly SubAccountsRegistry? _subAccounts;
     private readonly SubAccountPositionKeeper? _subAccountPositions;
     private readonly SubAccountPnlKeeper? _subAccountPnl;
+    // #380 path B. Optional. When wired (Real exchange mode), capture
+    // each firm gateway's live SessionVerId so the recovery path can
+    // detect a session-version roll and retire ghost orders. Null in
+    // Mock/Stub modes — capture writes an empty dict, recovery skips
+    // the reconcile.
+    private readonly IFirmSessionStatusProvider? _firmSessionStatus;
 
     public StateSnapshotter(
         WorkingOrderBook orders,
@@ -103,7 +109,8 @@ public sealed class StateSnapshotter
         IReplaceMarginCoordinator? replaceMargin = null,
         SubAccountsRegistry? subAccounts = null,
         SubAccountPositionKeeper? subAccountPositions = null,
-        SubAccountPnlKeeper? subAccountPnl = null)
+        SubAccountPnlKeeper? subAccountPnl = null,
+        IFirmSessionStatusProvider? firmSessionStatus = null)
     {
         _orders = orders;
         _positions = positions;
@@ -129,6 +136,7 @@ public sealed class StateSnapshotter
         _subAccounts = subAccounts;
         _subAccountPositions = subAccountPositions;
         _subAccountPnl = subAccountPnl;
+        _firmSessionStatus = firmSessionStatus;
     }
 
     public PlatformSnapshot Capture(long seq) => Project(CaptureRaw(seq));
@@ -226,6 +234,13 @@ public sealed class StateSnapshotter
         SubAccountPositions = _subAccountPositions?.Snapshot() ?? Array.Empty<SubAccountPositionSnapshot>(),
         SubAccountPnl = _subAccountPnl?.Snapshot() ?? Array.Empty<SubAccountPnlSnapshot>(),
         SubAccountPnlBasis = _subAccountPnl?.SnapshotBasis() ?? Array.Empty<SubAccountPnlBasisSnapshot>(),
+        // #380 path B. Each firm's live SessionVerId at capture time so
+        // recovery can detect a session-roll between snapshot and restart.
+        // Empty when the provider is null (Mock/Stub modes).
+        FirmSessionVerIds = _firmSessionStatus is null
+            ? new Dictionary<string, uint>()
+            : _firmSessionStatus.Snapshot()
+                .ToDictionary(s => s.FirmId, s => s.SessionVerId, StringComparer.Ordinal),
     };
 
     /// <summary>
@@ -495,6 +510,9 @@ public sealed class StateSnapshotter
             SubAccountPositions = raw.SubAccountPositions.ToList(),
             SubAccountPnl = raw.SubAccountPnl.ToList(),
             SubAccountPnlBasis = raw.SubAccountPnlBasis.ToList(),
+            FirmSessionVerIds = raw.FirmSessionVerIds.Count == 0
+                ? new Dictionary<string, uint>()
+                : new Dictionary<string, uint>(raw.FirmSessionVerIds, StringComparer.Ordinal),
         };
     }
 

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/PersistenceRecoverySessionVerGuardTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/PersistenceRecoverySessionVerGuardTests.cs
@@ -1,0 +1,284 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Persistence;
+
+/// <summary>
+/// #380 path B — session-version guard on recovery. Verifies that
+/// <see cref="PersistenceRecovery"/> retires WorkingOrderBook entries
+/// whose firm's live FIXP SessionVerId has advanced past the verId the
+/// snapshot recorded. Catches the dev-bridge case where the matching
+/// layer's volume was wiped while trading-host's was kept: every order
+/// the snapshot restored is a ghost on the venue side; STP, modify, and
+/// margin checks would otherwise treat them as live until ER replies
+/// that never come.
+/// </summary>
+public class PersistenceRecoverySessionVerGuardTests : IDisposable
+{
+    private readonly string _root;
+
+    public PersistenceRecoverySessionVerGuardTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "b3tp-380-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private PersistenceOptions Opts() => new()
+    {
+        DataDirectory = _root,
+        FirmId = "test",
+        ChannelCapacity = 1024,
+        GroupCommitMaxRecords = 8,
+        GroupCommitWindow = TimeSpan.FromMilliseconds(5),
+        FsyncOnFlush = false,
+    };
+
+    private sealed class FakeFirmSessionStatusProvider(IReadOnlyList<FirmSessionStatus> snap)
+        : IFirmSessionStatusProvider
+    {
+        public IReadOnlyList<FirmSessionStatus> Snapshot() => snap;
+    }
+
+    [Fact]
+    public async Task RolledForward_RetiresAllWorkingOrdersForThatFirm()
+    {
+        // Phase 1: snapshot 2 firms with verId 5 each, 2 working orders each.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) =
+                BuildState(store, new FakeFirmSessionStatusProvider(new[]
+                {
+                    new FirmSessionStatus("FIRM01", "established", false, 5u),
+                    new FirmSessionStatus("FIRM02", "established", false, 5u),
+                }));
+
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "FIRM01", "PETR4");
+            DispatchSubmit(dispatcher, book, ownership, 2UL, "alice", "FIRM01", "VALE3");
+            DispatchSubmit(dispatcher, book, ownership, 10UL, "bob", "FIRM02", "PETR4");
+            DispatchSubmit(dispatcher, book, ownership, 11UL, "bob", "FIRM02", "VALE3");
+
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+
+            // Sanity: dict captured per-firm verIds.
+            Assert.Equal(5u, snap!.FirmSessionVerIds["FIRM01"]);
+            Assert.Equal(5u, snap.FirmSessionVerIds["FIRM02"]);
+
+            await store.FlushAsync();
+        }
+
+        // Phase 2: cold boot — provider reports FIRM01 advanced to 8,
+        // FIRM02 still at 5. FIRM01 must lose all its orders; FIRM02
+        // must keep them.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var provider = new FakeFirmSessionStatusProvider(new[]
+            {
+                new FirmSessionStatus("FIRM01", "established", false, 8u),
+                new FirmSessionStatus("FIRM02", "established", false, 5u),
+            });
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) =
+                BuildState(store, provider);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance,
+                orders: book, ownership: ownership, firmSessionStatus: provider);
+
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out var o1) && o1!.Status == OrderStatus.Cancelled);
+            Assert.True(book.TryGet(2UL, out var o2) && o2!.Status == OrderStatus.Cancelled);
+            Assert.True(book.TryGet(10UL, out var o10) && o10!.Status == OrderStatus.PendingNew);
+            Assert.True(book.TryGet(11UL, out var o11) && o11!.Status == OrderStatus.PendingNew);
+
+            // Retired orders disappear from the "working" view.
+            Assert.Empty(book.EnumerateForFirm("FIRM01"));
+            Assert.Equal(2, book.EnumerateForFirm("FIRM02").Count);
+        }
+    }
+
+    [Fact]
+    public async Task EqualVerId_NoRetirement()
+    {
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) =
+                BuildState(store, new FakeFirmSessionStatusProvider(new[]
+                {
+                    new FirmSessionStatus("FIRM01", "established", false, 5u),
+                }));
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "FIRM01", "PETR4");
+
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var provider = new FakeFirmSessionStatusProvider(new[]
+            {
+                new FirmSessionStatus("FIRM01", "established", false, 5u),
+            });
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) =
+                BuildState(store, provider);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance,
+                orders: book, ownership: ownership, firmSessionStatus: provider);
+
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out var o1) && o1!.Status == OrderStatus.PendingNew);
+        }
+    }
+
+    [Fact]
+    public async Task NoProvider_NoRetirement()
+    {
+        // Mock/Stub composition: no IFirmSessionStatusProvider. Guard
+        // must silently no-op rather than wipe the book.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) = BuildState(store, null);
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "FIRM01", "PETR4");
+
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+
+            Assert.Empty(snap!.FirmSessionVerIds);
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) =
+                BuildState(store, null);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance,
+                orders: book, ownership: ownership, firmSessionStatus: null);
+
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out var o1) && o1!.Status == OrderStatus.PendingNew);
+        }
+    }
+
+    [Fact]
+    public async Task PreFieldSnapshot_NoRetirement()
+    {
+        // Legacy snapshot has no FirmSessionVerIds entry for the firm
+        // (simulated by capturing without a provider). On warm restart
+        // with a provider now wired, stored=0 baseline must NOT retire
+        // anything — we can't distinguish a fresh session from "first
+        // boot since the field was added".
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) = BuildState(store, null);
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "FIRM01", "PETR4");
+
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var provider = new FakeFirmSessionStatusProvider(new[]
+            {
+                new FirmSessionStatus("FIRM01", "established", false, 99u),
+            });
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) =
+                BuildState(store, provider);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance,
+                orders: book, ownership: ownership, firmSessionStatus: provider);
+
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out var o1) && o1!.Status == OrderStatus.PendingNew);
+        }
+    }
+
+    private sealed class TestSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent evt) { }
+    }
+
+    private (
+        WorkingOrderBook,
+        PositionKeeper,
+        KillSwitchService,
+        OrderOwnershipMap,
+        StateSnapshotter,
+        EventDispatcher,
+        ExecutionReportProcessor,
+        TestSink,
+        AlgoBook) BuildState(IEventStore store, IFirmSessionStatusProvider? provider)
+    {
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var killSwitch = new KillSwitchService();
+        var ownership = new OrderOwnershipMap();
+        var clOrdIds = new ClOrdIdPrefixRegistry();
+        var algos = new AlgoBook();
+        var sink = new TestSink();
+        var processor = new ExecutionReportProcessor(ownership, book, positions, sink,
+            new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var snapshotter = new StateSnapshotter(book, positions, killSwitch, new SymbolHaltService(),
+            new SessionPhaseService(), clOrdIds, ownership, algos, new AlgoIdRegistry(), new CashLedger(),
+            firmSessionStatus: provider);
+        var dispatcher = new EventDispatcher(store);
+        return (book, positions, killSwitch, ownership, snapshotter, dispatcher, processor, sink, algos);
+    }
+
+    private static void DispatchSubmit(
+        EventDispatcher d, WorkingOrderBook book, OrderOwnershipMap ownership,
+        ulong clOrdId, string endClient, string firmId, string symbol)
+    {
+        var owner = new EndClientId(endClient);
+        d.Dispatch(
+            new OrderSubmittedEvent
+            {
+                ClOrdId = clOrdId,
+                EndClientId = endClient,
+                FirmId = firmId,
+                Symbol = symbol,
+                SecurityId = 4321UL,
+                Side = OrderSide.Buy.ToString(),
+                Type = "Limit",
+                Quantity = 100,
+                Price = 30m,
+            },
+            () =>
+            {
+                book.TryAdd(new Order(clOrdId, owner, symbol, 4321UL, OrderSide.Buy, OrderType.Limit,
+                    100, 30m, firmId: firmId));
+                ownership.Register(clOrdId, owner);
+            });
+    }
+}


### PR DESCRIPTION
Closes part of #380 (path B only — the cheap snapshot-side guard).

## Problem
Dev-bridge teardown wipes `b3-matching-data` while keeping `b3-trading-data`. `PersistenceRecovery` restores orders the venue knows nothing about → STP local-rejects, modify/cancel hit `reject_code=5 (unknown)`, fat-finger overcounts exposure.

## Path B design
- Snapshot now records each firm's live FIXP `SessionVerId` at capture time.
- On startup recovery, compare against gateway's current verId.
- For any firm whose verId **advanced** past the stored value, `MarkCancelled` every `WorkingOrderBook` entry attached to that firm.
- `MarkCancelled` is idempotent and STP/modify/margin checks already exclude terminal — retired orders disappear from the working view without any new remove-by-firm API.
- Idempotent on crash: re-runs same compare on next restart → no new WAL events needed.

## Out of scope
Path A (post-Establish `MassStatusRequest` reconcile, ~2000 LOC). Tracked separately in #380 for a future PR.

## Changes
- `PlatformSnapshot` + `RawPlatformSnapshot`: new `FirmSessionVerIds` dict (empty on pre-#380 snapshots / Mock/Stub modes).
- `StateSnapshotter`: optional `IFirmSessionStatusProvider` ctor param; `CaptureRaw` populates dict; `Project` copies through. DI auto-resolves the existing `FirmGatewayRegistry` singleton.
- `PersistenceRecovery`: optional provider + `WorkingOrderBook` params; after WAL replay, calls `ReconcileFirmSessionVerIds(snap)`. Logs `event=recovery.session-rolled firm=… from=… to=… dropped=…`.
- `MetricsRegistry`: new counters `trading.recovery.session_rolled_firms` and `trading.recovery.session_rolled_orders_dropped` (both tagged `firm`).
- New `PersistenceRecoverySessionVerGuardTests` with 4 cases: rolled-forward retires; equal-verId no-op; no-provider no-op; pre-#380 snapshot (stored=0) no-op.

## Test results (local)
- B3.Trading.Application.Tests: 1133/1133 (+4 new)
- B3.Trading.Api.Tests: 493/493
- B3.Trading.EntryPointListener.Tests: 134/134
- B3.Trading.Domain.Tests: 81/81
- B3.Trading.Reconciliation.Tests: 12/12

## Edge cases covered in code
- Provider absent → silent no-op (Mock/Stub modes).
- Snapshot pre-dates field (`stored == 0`) → no retirement (can't distinguish "fresh session" from "first restart since field was added").
- `current <= stored` (same or earlier session) → no retirement.
- Other firms' orders never touched.