### PR TITLE
Split Replaced into Replaced+ReplacedNew, keep FIXP wire-faithful (#417)

### DIFF
--- a/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
+++ b/backend/src/B3.Trading.Application/ExecutionReportProcessor.cs
@@ -987,9 +987,16 @@ public sealed class ExecutionReportProcessor
         else
         {
             _sink.Publish(origEv);
-            // Sub-issue #172 (F): the bot must observe the original's
-            // terminalisation as part of the replace ack stream.
-            _botErRouter?.Route(origEv);
+            // #417. The orig-leg ExecutionEvent is a state-transition
+            // projection for internal WS consumers (executions.me /
+            // orders.me / drop-copy). It is NOT routed to the FIXP
+            // outbound bot — FIX/FIXP/SBE semantics dictate ONE
+            // ExecutionReport with ExecType=Replace per cancel-replace
+            // ack, carrying both new ClOrdID and OrigClOrdID. Emitting
+            // a second OrderModified frame for the orig leg would
+            // violate that contract and confuse bot replay state
+            // machines. The new-leg event below is the wire-faithful
+            // one and is the only one routed to _botErRouter.
         }
 
         // 2) Hydrate the replacement with intent metadata + venue's
@@ -1076,7 +1083,12 @@ public sealed class ExecutionReportProcessor
             newOrder.Symbol,
             newOrder.Side,
             newOrder.Status,
-            ExecKind.Replaced,
+            // #417. New-leg face of the replace ack. The orig-leg
+            // event above stays as Replaced (terminal); this one is
+            // ReplacedNew (replacement entering Working) so the
+            // executions blotter can render the two legs distinctly
+            // instead of two indistinguishable "Replaced" rows.
+            ExecKind.ReplacedNew,
             newOrder.LeavesQuantity,
             newOrder.CumulativeQuantity,
             0,
@@ -1191,4 +1203,32 @@ public enum ExecKind
     /// fill price (no economic event).
     /// </summary>
     ReplaceRejected,
+    /// <summary>
+    /// #417. Companion of <see cref="Replaced"/>. A successful venue
+    /// cancel-replace ack produces TWO internal <c>ExecutionEvent</c>s
+    /// from <c>ExecutionReportProcessor.ApplyReplaceAccepted</c>: one
+    /// <see cref="Replaced"/> against the original ClOrdID (which
+    /// terminalises) and one <see cref="ReplacedNew"/> against the
+    /// new ClOrdID (which enters Working / PartiallyFilled). Before
+    /// #417 both events carried <see cref="Replaced"/>, which made the
+    /// executions blotter render two indistinguishable "Replaced"
+    /// rows for a single modify.
+    /// <para>
+    /// <b>Wire fidelity (FIX/FIXP/SBE).</b> FIX semantics specify ONE
+    /// ExecutionReport with <c>ExecType=Replace</c> per cancel-replace
+    /// ack, carrying both the new <c>ClOrdID</c> and <c>OrigClOrdID</c>.
+    /// The split into two internal events is a projection convenience
+    /// for our WebSocket consumers (executions.me / orders.me) and
+    /// drop-copy compliance only — bot-bound traffic via
+    /// <c>BotErRouter</c> stays wire-faithful: only the
+    /// <see cref="ReplacedNew"/> leg is routed (it carries
+    /// OrigClOrdID through the FIXP encoder), the
+    /// <see cref="Replaced"/> orig-leg event is NOT routed to bots.
+    /// </para>
+    /// Carries the replacement's seeded <c>LeavesQuantity</c> /
+    /// <c>CumulativeQuantity</c> baseline and the ER's <c>LastPrice</c>
+    /// (0 for plain replace; non-zero only on priority-lost replace
+    /// with concurrent fill — see issue #241 / #299 P1).
+    /// </summary>
+    ReplacedNew,
 }

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/BotErMultiplexer.cs
@@ -194,7 +194,10 @@ public sealed class BotErMultiplexer : BackgroundService, IBotErRouter, IExecuti
         // not yet correlate the raw cancel-side id (sub-issue G when
         // raw side-channel lands), so we omit it for cancel/replace
         // and the bot reads OrigClOrdID = its original ClOrdID.
-        ulong externalOrig = (ev.Kind is ExecKind.Canceled or ExecKind.Replaced)
+        // #417: ReplacedNew is the new-leg companion of Replaced;
+        // same externalOrig treatment so the bot sees a consistent
+        // OrigClOrdID across both legs of the cancel-replace ack.
+        ulong externalOrig = (ev.Kind is ExecKind.Canceled or ExecKind.Replaced or ExecKind.ReplacedNew)
             ? mapping.ExternalClOrdId
             : 0UL;
 

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/OutboundExecutionReportEncoder.cs
@@ -65,6 +65,9 @@ internal static class OutboundExecutionReportEncoder
             ExecKind.PartialFill or ExecKind.Fill => EncodeTrade(ev, externalClOrdId),
             ExecKind.Canceled => EncodeCancel(ev, externalClOrdId, externalOrigClOrdId),
             ExecKind.Replaced => EncodeModify(ev, externalClOrdId, externalOrigClOrdId),
+            // #417. New-leg face of the same FIX ExecType=Replace ack;
+            // wire-encoded identically.
+            ExecKind.ReplacedNew => EncodeModify(ev, externalClOrdId, externalOrigClOrdId),
             ExecKind.Rejected => EncodeReject(ev, externalClOrdId, externalOrigClOrdId),
             _ => throw new NotSupportedException(
                 $"ExecKind {ev.Kind} has no SBE ExecutionReport mapping in v0."),

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -773,13 +773,17 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Single(replaceCoord.Commits);
         Assert.Empty(replaceCoord.Aborts);
         Assert.Equal((777UL, 778UL, 32.50m * 100), replaceCoord.Commits[0]);
-        // Replace-fanout: orig + new ExecutionEvent (kind=Replaced) on the sink.
+        // Replace-fanout: orig (kind=Replaced) + new (kind=ReplacedNew, #417) on the sink.
         Assert.Equal(2, sink.Events.Count);
-        Assert.All(sink.Events, e => Assert.Equal(ExecKind.Replaced, e.Kind));
-        Assert.Contains(sink.Events, e => e.ClOrdId == 777UL);
-        Assert.Contains(sink.Events, e => e.ClOrdId == 778UL);
-        // Bot router saw both replace ERs.
-        Assert.Equal(2, botRouter.Events.Count);
+        Assert.Equal(ExecKind.Replaced,    sink.Events.Single(e => e.ClOrdId == 777UL).Kind);
+        Assert.Equal(ExecKind.ReplacedNew, sink.Events.Single(e => e.ClOrdId == 778UL).Kind);
+        // #417: bot router is wire-faithful — sees ONE ExecutionReport
+        // for the replace ack (the new leg, carrying OrigClOrdID via
+        // the FIXP encoder), not two. The orig-leg terminalisation is
+        // an internal WS projection only.
+        Assert.Single(botRouter.Events);
+        Assert.Equal(778UL, botRouter.Events[0].ClOrdId);
+        Assert.Equal(ExecKind.ReplacedNew, botRouter.Events[0].Kind);
 
         // 4) Subsequent Trade ER on the new ClOrdID (orig=0 in priority-lost trade).
         proc.Apply(778UL, ExecKind.Fill, leaves: 0, cumQty: 100, lastQty: 100, lastPx: 32.50m, rejectReason: null, origClOrdId: 0);
@@ -798,7 +802,8 @@ public class OrderModifyMarginAndProcessorTests
         var fillEv = sink.Events[2];
         Assert.Equal(ExecKind.Fill, fillEv.Kind);
         Assert.Equal(778UL, fillEv.ClOrdId);
-        Assert.Equal(3, botRouter.Events.Count);
+        // #417: bot saw 1 replace ER (new leg only) + 1 fill = 2 total.
+        Assert.Equal(2, botRouter.Events.Count);
     }
 
     [Fact]

--- a/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/OrderModifyMarginAndProcessorTests.cs
@@ -775,7 +775,7 @@ public class OrderModifyMarginAndProcessorTests
         Assert.Equal((777UL, 778UL, 32.50m * 100), replaceCoord.Commits[0]);
         // Replace-fanout: orig (kind=Replaced) + new (kind=ReplacedNew, #417) on the sink.
         Assert.Equal(2, sink.Events.Count);
-        Assert.Equal(ExecKind.Replaced,    sink.Events.Single(e => e.ClOrdId == 777UL).Kind);
+        Assert.Equal(ExecKind.Replaced, sink.Events.Single(e => e.ClOrdId == 777UL).Kind);
         Assert.Equal(ExecKind.ReplacedNew, sink.Events.Single(e => e.ClOrdId == 778UL).Kind);
         // #417: bot router is wire-faithful — sees ONE ExecutionReport
         // for the replace ack (the new leg, carrying OrigClOrdID via


### PR DESCRIPTION
A successful venue cancel-replace ack used to fan out as TWO
ExecutionEvents both carrying kind=Replaced — one on the orig
ClOrdID (terminal) and one on the new ClOrdID (working). The
frontend executions blotter renders kind verbatim, so a single
modify surfaced as two indistinguishable "Replaced" rows.

Design decision:

- Wire (FIX/FIXP/SBE) is strict: ExecType=Replace is ONE
  ExecutionReport with both ClOrdID and OrigClOrdID. The bot
  outbound path (BotErRouter -> OutboundExecutionReportEncoder)
  must emit exactly one OrderModified per ack. Only the new-leg
  event is routed; the orig-leg event is suppressed for bots.
  This reverts the over-fan-out introduced by sub-issue #172 F.

- Internal messaging (WS executions.me / orders.me / drop-copy)
  is allowed to be more verbose: the orig-leg Replaced event is
  still published to _sink so subscribers see the original
  terminalise distinctly from the replacement entering Working.
  The new ExecKind.ReplacedNew makes the two legs unambiguous
  in the blotter without inferring from Status.

Changes:
- ExecKind.ReplacedNew added (new enum value, with XML doc)
- ApplyReplaceAccepted: new-leg event uses ReplacedNew; orig-leg
  event no longer routed to _botErRouter
- OutboundExecutionReportEncoder: ReplacedNew -> EncodeModify
  (same SBE OrderModified shape as Replaced, kept for safety
  even though only ReplacedNew now reaches the encoder)
- BotErMultiplexer: ReplacedNew included in the kind check that
  populates externalOrig with the original ClOrdID

Tests:
- OrderModifyMarginAndProcessorTests priority-lost replace test:
  asserts sink has Replaced (orig) + ReplacedNew (new), bot
  router has exactly one event (the new-leg ReplacedNew, NOT
  two). Follow-up fill bumps bot count to 2 (was 3).

Application + Api + EntryPointListener test suites all green.

Refs #417

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
