### PR TITLE
fix(#419): stale-mark working orders on session-roll instead of cancelling

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -202,12 +202,22 @@ public static class MetricsRegistry
 
     // #380 path B. Number of WorkingOrderBook entries eagerly retired
     // (MarkCancelled) by the session-version guard. Tag `firm` carries
-    // the FirmId. Burst on a single restart is expected when a real
-    // session roll happens; a steady drip across restarts means the
-    // snapshot is not being refreshed often enough relative to gateway
-    // reconnect frequency.
+    // the FirmId. Post-#419, this counter only ticks for PendingNew
+    // orders (never acked by the venue → safe to cancel); confirmed
+    // working orders go through the staleness overlay instead — see
+    // <see cref="RecoverySessionRolledOrdersStaled"/>.
     public static readonly Counter<long> RecoverySessionRolledOrdersDropped =
         Meter.CreateCounter<long>("trading.recovery.session_rolled_orders_dropped");
+
+    // #419. Number of Working / PartiallyFilled orders flagged stale
+    // (Order.MarkStale) by the session-version guard. Tag `firm`
+    // carries the FirmId. The venue may still hold these orders
+    // (B3 persists the book across FIXP session rolls), so we keep
+    // them visible in the blotter and accounting but gate
+    // Cancel/Modify at the API until a real ER (or a future
+    // OrderMassStatusRequest reconciliation) confirms their fate.
+    public static readonly Counter<long> RecoverySessionRolledOrdersStaled =
+        Meter.CreateCounter<long>("trading.recovery.session_rolled_orders_staled");
 
     // Q2.3 (#270). Fee-keeper deterministic replay synth — surfaces the
     // crash window between ER append (seq N) and FeeAccruedEvent append

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
@@ -39,14 +39,18 @@ public sealed class PersistenceRecovery
     private readonly FillProjection? _fillProjection;
     private readonly WorkingOrderBook? _orders;
     private readonly OrderOwnershipMap? _ownership;
-    // #380 path B. Optional. When wired AND the loaded snapshot carries
-    // per-firm SessionVerIds, recovery compares each firm's current
-    // gateway SessionVerId against the stored value after WAL replay.
-    // For any firm whose verId has advanced past the snapshot, every
-    // working order attached to that firm is eagerly retired
-    // (MarkCancelled) — those orders cannot exist at the venue under
-    // the new session version and would otherwise poison STP, modify,
-    // and margin checks until the next ER ack that never comes.
+    // #380 path B (refined by #419). Optional. When wired AND the
+    // loaded snapshot carries per-firm SessionVerIds, recovery compares
+    // each firm's current gateway SessionVerId against the stored value
+    // after WAL replay. For any firm whose verId has advanced past the
+    // snapshot, every confirmed working order attached to that firm is
+    // flagged stale (Order.MarkStale) — Cancel/Modify is blocked at the
+    // API until a real ER lifts the flag, but the order stays visible
+    // in the blotter and accounting because the venue (B3 and the local
+    // matching) persists orders across FIXP session rolls. Only
+    // never-acked PendingNew orders are retired outright (MarkCancelled):
+    // an order whose first ER never returned to us cannot have a
+    // matching record on the venue side under any session version.
     private readonly IFirmSessionStatusProvider? _firmSessionStatus;
 
     public PersistenceRecovery(
@@ -215,25 +219,50 @@ public sealed class PersistenceRecovery
                 continue;
             }
 
-            // Session-version advanced past the snapshot. Every working
-            // order attached to this firm at snapshot capture (and
-            // anything the WAL tail re-confirmed) is a ghost on the
-            // venue side. Retire each one.
-            var dropped = 0;
+            // Session-version advanced past the snapshot. Per #419, this
+            // does NOT imply the venue purged the firm's orders — B3 (and
+            // our local matching-platform) persist the order book across
+            // FIXP session rolls; cancel-on-disconnect is opt-in per
+            // session, not default. Mark each Working / PartiallyFilled
+            // order stale instead of cancelling: Cancel/Modify is gated
+            // (409 at the API) so we don't fire wasted requests against
+            // a possibly-still-live order, but the order stays visible
+            // in /orders + executions blotter + positions/cash so
+            // operators see what the venue might still be matching. Real
+            // ERs (or a future OrderMassStatusRequest reconciliation —
+            // out of scope here) lift the flag automatically.
+            //
+            // PendingNew is the one exception: the venue never acked
+            // those, so a session roll guarantees they cannot exist
+            // under any session version. Fall back to MarkCancelled for
+            // those — same behaviour as PR #415.
+            var staled = 0;
+            var cancelled = 0;
+            var now = DateTimeOffset.UtcNow;
+            var reason = $"recovery.session-rolled:{storedVerId}->{status.SessionVerId}";
             foreach (var order in _orders!.EnumerateForFirm(status.FirmId, includeTerminal: false))
             {
-                order.MarkCancelled();
-                if (order.Status == B3.Trading.Domain.OrderStatus.Cancelled)
+                if (order.MarkStale(reason, now))
                 {
-                    dropped++;
+                    staled++;
+                }
+                else if (order.Status == B3.Trading.Domain.OrderStatus.PendingNew)
+                {
+                    order.MarkCancelled();
+                    if (order.Status == B3.Trading.Domain.OrderStatus.Cancelled)
+                    {
+                        cancelled++;
+                    }
                 }
             }
             _logger.LogWarning(
-                "event=recovery.session-rolled firm={Firm} from={From} to={To} dropped={Dropped}",
-                status.FirmId, storedVerId, status.SessionVerId, dropped);
+                "event=recovery.session-rolled firm={Firm} from={From} to={To} staled={Staled} cancelled={Cancelled}",
+                status.FirmId, storedVerId, status.SessionVerId, staled, cancelled);
             MetricsRegistry.RecoverySessionRolledFirms.Add(1,
                 new KeyValuePair<string, object?>("firm", status.FirmId));
-            MetricsRegistry.RecoverySessionRolledOrdersDropped.Add(dropped,
+            MetricsRegistry.RecoverySessionRolledOrdersStaled.Add(staled,
+                new KeyValuePair<string, object?>("firm", status.FirmId));
+            MetricsRegistry.RecoverySessionRolledOrdersDropped.Add(cancelled,
                 new KeyValuePair<string, object?>("firm", status.FirmId));
         }
     }

--- a/backend/tests/B3.Trading.Application.Tests/Persistence/PersistenceRecoverySessionVerGuardTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Persistence/PersistenceRecoverySessionVerGuardTests.cs
@@ -10,13 +10,18 @@ namespace B3.Trading.Application.Tests.Persistence;
 
 /// <summary>
 /// #380 path B — session-version guard on recovery. Verifies that
-/// <see cref="PersistenceRecovery"/> retires WorkingOrderBook entries
-/// whose firm's live FIXP SessionVerId has advanced past the verId the
-/// snapshot recorded. Catches the dev-bridge case where the matching
-/// layer's volume was wiped while trading-host's was kept: every order
-/// the snapshot restored is a ghost on the venue side; STP, modify, and
-/// margin checks would otherwise treat them as live until ER replies
-/// that never come.
+/// <see cref="PersistenceRecovery"/> reacts to a firm whose live FIXP
+/// SessionVerId has advanced past the verId the snapshot recorded.
+///
+/// <para>
+/// Per <see href="https://github.com/pedrosakuma/B3TradingPlatform/issues/419">#419</see>
+/// the reaction is two-tier: <see cref="Order.MarkStale"/> for
+/// confirmed Working / PartiallyFilled orders (the venue typically
+/// persists the book across FIXP session rolls — keep them visible
+/// but gate Cancel/Modify until reconciliation), <see cref="Order.MarkCancelled"/>
+/// for never-acked PendingNew orders (no venue record possible under
+/// any session version).
+/// </para>
 /// </summary>
 public class PersistenceRecoverySessionVerGuardTests : IDisposable
 {
@@ -52,7 +57,8 @@ public class PersistenceRecoverySessionVerGuardTests : IDisposable
     [Fact]
     public async Task RolledForward_RetiresAllWorkingOrdersForThatFirm()
     {
-        // Phase 1: snapshot 2 firms with verId 5 each, 2 working orders each.
+        // Phase 1: snapshot 2 firms with verId 5 each, 2 PendingNew orders each.
+        // PendingNew = no venue ack ever received → cancel-fallback path.
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) =
@@ -80,8 +86,9 @@ public class PersistenceRecoverySessionVerGuardTests : IDisposable
         }
 
         // Phase 2: cold boot — provider reports FIRM01 advanced to 8,
-        // FIRM02 still at 5. FIRM01 must lose all its orders; FIRM02
-        // must keep them.
+        // FIRM02 still at 5. FIRM01 PendingNew orders take the
+        // cancel-fallback (#419) since they were never acked; FIRM02
+        // keeps everything.
         await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
         {
             var provider = new FakeFirmSessionStatusProvider(new[]
@@ -99,14 +106,77 @@ public class PersistenceRecoverySessionVerGuardTests : IDisposable
 
             await recovery.RunAsync();
 
+            // PendingNew + session-roll → cancelled (no possible venue record).
             Assert.True(book.TryGet(1UL, out var o1) && o1!.Status == OrderStatus.Cancelled);
+            Assert.False(o1!.IsStale);
             Assert.True(book.TryGet(2UL, out var o2) && o2!.Status == OrderStatus.Cancelled);
+            Assert.False(o2!.IsStale);
             Assert.True(book.TryGet(10UL, out var o10) && o10!.Status == OrderStatus.PendingNew);
             Assert.True(book.TryGet(11UL, out var o11) && o11!.Status == OrderStatus.PendingNew);
 
-            // Retired orders disappear from the "working" view.
+            // Cancelled orders drop out of the "working" view.
             Assert.Empty(book.EnumerateForFirm("FIRM01"));
             Assert.Equal(2, book.EnumerateForFirm("FIRM02").Count);
+        }
+    }
+
+    [Fact]
+    public async Task RolledForward_ConfirmedOrders_AreStaled_NotCancelled()
+    {
+        // #419. Confirmed (Working / PartiallyFilled) orders survive a
+        // session roll — the venue persists the book — but get the
+        // staleness overlay so Cancel/Modify is gated at the API until
+        // a real ER lifts the flag. Verifies the order stays visible
+        // and keeps its pre-roll status.
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var (book, _, _, ownership, snapshotter, dispatcher, _, _, _) =
+                BuildState(store, new FakeFirmSessionStatusProvider(new[]
+                {
+                    new FirmSessionStatus("FIRM01", "established", false, 5u),
+                }));
+            DispatchSubmit(dispatcher, book, ownership, 1UL, "alice", "FIRM01", "PETR4");
+            // Confirm at the venue so the order transitions PendingNew → Working
+            // (mirrors what an inbound OrderConfirmed ER would do during normal
+            // operation, captured into the snapshot we're about to write).
+            dispatcher.WithSnapshotLock(_ =>
+            {
+                Assert.True(book.TryGet(1UL, out var order));
+                order!.MarkWorking();
+            });
+
+            var snapStore = new SnapshotStore(_root, "test");
+            PlatformSnapshot? snap = null;
+            dispatcher.WithSnapshotLock(seq => snap = snapshotter.Capture(seq));
+            snapStore.Write(snap!);
+            await store.FlushAsync();
+        }
+
+        await using (var store = new FileEventStore(Opts(), NullLogger<FileEventStore>.Instance))
+        {
+            var provider = new FakeFirmSessionStatusProvider(new[]
+            {
+                new FirmSessionStatus("FIRM01", "established", false, 8u),
+            });
+            var (book, _, killSwitch, ownership, snapshotter, _, processor, _, algos) =
+                BuildState(store, provider);
+            var replayer = new EventReplayer(book, ownership, killSwitch, new SymbolHaltService(),
+                new SessionPhaseService(), processor, algos, new ClOrdIdPrefixRegistry(), new AlgoIdRegistry());
+            var recovery = new PersistenceRecovery(store, snapshotter, replayer,
+                new SnapshotStore(_root, "test"), NullLogger<PersistenceRecovery>.Instance,
+                orders: book, ownership: ownership, firmSessionStatus: provider);
+
+            await recovery.RunAsync();
+
+            Assert.True(book.TryGet(1UL, out var o1));
+            Assert.Equal(OrderStatus.Working, o1!.Status);
+            Assert.True(o1.IsStale);
+            Assert.Contains("session-rolled", o1.StaleReason ?? "");
+            Assert.NotNull(o1.StaledAtUtc);
+
+            // Stale orders MUST remain enumerable so positions/cash/blotter
+            // reflect the live venue state until reconciliation completes.
+            Assert.Single(book.EnumerateForFirm("FIRM01"));
         }
     }
 


### PR DESCRIPTION
Closes #419.

## Problem

PR #415 (#380 path B), merged earlier today, cancels every working order
attached to a firm whose FIXP SessionVerId advanced past the snapshot
on recovery. Reproduced live this session: alice's PETR4 working order
present in matching-platform's book disappeared from trading-host's
blotter after a matching+host restart.

The premise PR #415 used ("session-roll ⇒ venue purged orders") is
wrong for B3 and our local matching — order books persist across FIXP
session rolls; cancel-on-disconnect is opt-in per session, not default.

## Fix

Two-tier reaction in `SnapshotService.ReconcileFirmSessionVerIds`:

| Pre-roll status | Pre-#419 | Post-#419 |
|---|---|---|
| Working / PartiallyFilled | MarkCancelled (wrong — venue may still hold) | **MarkStale** (#132 overlay, gates Cancel/Modify, stays visible) |
| PendingNew | MarkCancelled | MarkCancelled (unchanged — no possible venue record) |
| Terminal | n/a (already filtered) | n/a (already filtered) |

`Order.MarkStale` was designed in #132 slice 1 for exactly this case
("matching engine restarted with a fresh book while trading-host
retained its WAL/snapshot state"), and `ExecutionReportProcessor`
already auto-clears the overlay on any genuine terminal ER from the
venue — false positives self-heal on the next reconnect.

A future PR can add OrderMassStatusRequest reconciliation (the path A
of the original #380 design, deferred at the time) on top of this
without changing the staleness semantics.

## New metric

`trading.recovery.session_rolled_orders_staled{firm}` — count of
orders flagged stale per firm per recovery. The existing
`...orders_dropped` counter now only ticks for the PendingNew bucket.

Log line is now:
`event=recovery.session-rolled firm=X from=N to=M staled=A cancelled=B`

## Tests

- Existing `RolledForward_RetiresAllWorkingOrdersForThatFirm` keeps
  asserting `OrderStatus.Cancelled` for PendingNew orders (now also
  explicit about `IsStale=false`).
- New `RolledForward_ConfirmedOrders_AreStaled_NotCancelled` covers
  the Working path: status preserved, `IsStale=true`, reason includes
  `session-rolled`, order still enumerable from `EnumerateForFirm`.
- Full suite: 1134 (Application) + 493 (Api) tests green locally.

## Refs

PR #415 · #380 · #132