### PR TITLE
feat(#421): show submit-accepted feedback as a top-of-shell toast

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -665,6 +665,27 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
   font-size: .8rem; font-variant-numeric: tabular-nums;
 }
 
+/* #421: Transient success/info toast for order submits. Same slot as
+ * .ws-error-toast (lives between the topbar and the panel grid, takes
+ * no space when hidden) but green-tinted by default. Kind modifiers
+ * (.warn / .error) let the same surface carry a fat-finger warning or
+ * a submit failure when we want them above the fold rather than buried
+ * under the ticket form. */
+.order-toast {
+  margin: .35rem 1rem 0; padding: .35rem .7rem;
+  background: rgba(38,166,154,.14); color: var(--green, #26a69a);
+  border: 1px solid rgba(38,166,154,.35); border-radius: 4px;
+  font-size: .8rem; font-variant-numeric: tabular-nums;
+}
+.order-toast.warn {
+  background: rgba(255,167,38,.14); color: var(--yellow, #ffa726);
+  border-color: rgba(255,167,38,.35);
+}
+.order-toast.error {
+  background: rgba(239,83,80,.14); color: var(--red);
+  border-color: rgba(239,83,80,.35);
+}
+
 /* ---------- Session-expiry modal + helpers (section 4 of #30) ---------- */
 .muted-cell { color: var(--muted); }
 .muted-line { color: var(--muted); margin: 0 0 .4rem; font-size: .8rem; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -154,6 +154,13 @@
        up persistent screen real estate. Auto-dismissed after a few seconds. -->
   <div id="ws-error-toast" class="ws-error-toast" role="status" aria-live="polite" hidden></div>
 
+  <!-- #421: Transient toast for successful order submits. Lives next to
+       the ws-error-toast so success and failure surfaces share the same
+       visual region (top of the shell, no layout shift when hidden).
+       Replaces the inline "accepted: …" text that used to live under the
+       ticket form and was easy to miss while scrolling the blotter. -->
+  <div id="order-toast" class="order-toast" role="status" aria-live="polite" hidden></div>
+
   <!-- TRADER VIEW ------------------------------------------------------ -->
   <section id="trader-view" class="view trader-view" role="tabpanel" aria-labelledby="tab-trader" hidden>
     <main class="trader-layout">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -843,7 +843,6 @@ function handleApplyMd({ url, symbols }) {
 // per-selection promotion needed; selectedSymbol just drives which
 // ladder the DOB renders.
 let lastAutoFilledTicketSymbol = null;
-let _successToastTimer = null;
 
 function handleSelectSymbol(symbol) {
   // Single global selector drives DOB, chart and tape. The DOB reads
@@ -991,16 +990,12 @@ async function handleSubmitOrder(payload) {
   state.setSubmitInflight({ startedAt: Date.now() });
   try {
     const resp = await submitOrder(session.backend, session.token, payload);
+    // #421: success surface is the standalone toast above the panel
+    // grid — easier to notice than the previous inline text under the
+    // ticket form, and doesn't fight for space with the next submit.
     const msg = `accepted: ${resp.clOrdId}${resp.status ? ` (${resp.status})` : ""}`;
-    ui.setTicketFeedback(msg, "ok");
+    ui.showOrderToast(msg, "ok");
     ui.clearTicket();
-    // Auto-dismiss the success toast after 5s, but only if the message
-    // hasn't been replaced (e.g. by a later submit's warning/error).
-    if (_successToastTimer) clearTimeout(_successToastTimer);
-    _successToastTimer = setTimeout(() => {
-      _successToastTimer = null;
-      ui.setTicketFeedbackIfMatches(msg, null);
-    }, 5000);
   } catch (err) {
     if (err.status === 401) { logout(); return; }
     ui.setTicketFeedback(err.message || "submit failed", "error");

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -1273,14 +1273,35 @@ export function showWsErrorToast(message) {
   }, WS_ERROR_TOAST_MS);
 }
 
-// Clear the ticket feedback only if it still shows `expected`. Used by
-// the success-toast auto-dismiss so a later warning/error message that
-// landed before the timer fires isn't accidentally erased.
-export function setTicketFeedbackIfMatches(expected, replacement) {
-  const el = $("ticket-feedback");
-  if (!el || el.hidden) return;
-  if (el.textContent !== expected) return;
-  setTicketFeedback(replacement, null);
+// #421: Transient toast for order-submit feedback. Replaces the
+// "accepted: …" text that used to sit under the ticket form (easy to
+// miss when the trader's eyes were on the blotter). `kind` is one of
+// "ok" (default — green), "warn" (yellow), "error" (red). Auto-dismisses
+// after ORDER_TOAST_MS; successive calls restart the timer. Pass
+// `null` to hide immediately.
+const ORDER_TOAST_MS = 5_000;
+let _orderToastTimer = null;
+export function showOrderToast(message, kind) {
+  const el = $("order-toast");
+  if (!el) return;
+  if (!message) {
+    if (_orderToastTimer) { clearTimeout(_orderToastTimer); _orderToastTimer = null; }
+    el.hidden = true;
+    el.textContent = "";
+    el.className = "order-toast";
+    return;
+  }
+  el.hidden = false;
+  el.textContent = message;
+  const cls = kind === "warn" ? "warn" : kind === "error" ? "error" : "";
+  el.className = cls ? `order-toast ${cls}` : "order-toast";
+  if (_orderToastTimer) clearTimeout(_orderToastTimer);
+  _orderToastTimer = setTimeout(() => {
+    _orderToastTimer = null;
+    el.hidden = true;
+    el.textContent = "";
+    el.className = "order-toast";
+  }, ORDER_TOAST_MS);
 }
 
 // Submit button disabled-state is the OR of two independent conditions


### PR DESCRIPTION
Closes #421.

## What

Move the 'accepted: <clOrdId>' success message from the inline form-feedback element (`#ticket-feedback`) to a dedicated top-of-shell toast (`#order-toast`) that mirrors the existing #342 `#ws-error-toast` slot.

## Why

Surfaced during manual validation today: the success line lived under the ticket form, easy to miss when the trader's eyes were on the blotter / DOB. The new placement sits between the topbar and the panel grid so the confirmation is visible from any view without occupying layout space when hidden.

## Design

| Surface | Element | Used for |
|---|---|---|
| Top-of-shell toast (new) | `#order-toast` | success accepted (this PR) + future kind=warn/error if we choose |
| Top-of-shell toast (existing #342) | `#ws-error-toast` | WS frame errors |
| Inline under form (kept) | `#ticket-feedback` | fat-finger 'click submit again to override' warn + submit error (sticky, tied to form) |

`showOrderToast(message, kind)` supports three kinds (`ok` default, `warn`, `error`) so future call sites can use the same surface for warn/error if needed. Auto-dismisses after 5s, restartable on successive calls.

## Cleanup

The old ad-hoc `setTimeout` + `setTicketFeedbackIfMatches` dance in `app.js` exists only because the form-feedback element was shared between success and warn/error surfaces — needed to avoid clobbering a later warn. With a separate toast element the dance is unnecessary; the toast owns its own dismissal.

- Removed `setTicketFeedbackIfMatches` (`ui.js`) — only caller was the success path.
- Removed `_successToastTimer` (`app.js`).

## Tests

- All 389 frontend node:test pass.
- No existing test referenced the removed helpers (verified via grep).

## A11y

`role='status' aria-live='polite'` on the new element — same contract as `#ws-error-toast` (non-interruptive announcement, screen reader announces on update without stealing focus).