### PR TITLE
feat(#423): modify modal pre-fills with remaining (leaves), wire stays FIX-correct

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -720,6 +720,20 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 }
 .modal-actions button[type="submit"]:hover { filter: brightness(1.1); }
 
+/*
+ * Modify-modal helper line.
+ *
+ * The qty input on the modify modal represents the **new remaining**
+ * (leaves) quantity the trader wants the order to keep working — this
+ * is more intuitive after a partial fill than "new total". The wire
+ * (FIX OrderCancelReplaceRequest.OrderQty / our equivalent) is always
+ * the new total = cum + remaining, computed at submit time. The hint
+ * below the qty input shows the trader exactly what total the wire
+ * will carry so there is no ambiguity between UX and protocol.
+ */
+.modify-hint { margin: -.4rem 0 0; color: var(--muted); font-size: .75rem; }
+.modify-hint.error { color: var(--red); }
+
 /* ---------- Bot credentials view (sub-issue #169) ---------- */
 .bot-credentials-view {
   display: flex; flex-direction: column; height: 100vh; overflow: auto;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -599,9 +599,10 @@
       <h2 id="modify-modal-title">Modify order</h2>
       <p id="modify-modal-summary" class="muted-line"></p>
       <label>
-        <span>New quantity</span>
+        <span>New remaining quantity</span>
         <input id="modify-modal-qty" type="number" min="1" step="1" required inputmode="numeric" />
       </label>
+      <p id="modify-modal-wire-hint" class="modify-hint" aria-live="polite"></p>
       <label>
         <span>New price</span>
         <input id="modify-modal-price" type="number" min="0" step="any" inputmode="decimal" />

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -276,6 +276,51 @@ export function setSessionModalError(message) {
 }
 
 // ── Modify-order modal (slice 5 of #122) ───────────────────────────
+//
+// UX-vs-wire contract (#421 follow-up):
+//
+//   The "New quantity" field shown to the trader represents the
+//   **new remaining (leaves)** quantity they want to keep working.
+//   After a partial fill, "leaves" is the number the trader
+//   actually thinks about ("I have 100 still working — change it
+//   to 80"); pre-filling the field with the original total qty
+//   would force the trader to mentally re-add the cum, which is
+//   easy to get wrong (esp. on a busy book).
+//
+//   The wire, however, MUST stay 100% FIX-conformant:
+//   OrderCancelReplaceRequest.OrderQty (38) is always the
+//   **new total** = cumQty + newLeaves, with the invariant
+//   OrderQty ≥ CumQty. The conversion happens at submit time
+//   inside `computeWireOrderQty`, and a live hint under the input
+//   ("→ total wire = cum 100 + remaining 80 = 180") makes the
+//   translation visible to the trader so the UX abstraction never
+//   hides what we are actually sending.
+//
+//   See `modifyModalDefaultLeaves` / `computeWireOrderQty` for the
+//   pure helpers exercised by frontend/test/modify-modal-leaves.
+
+// Pure helper: choose the input default for the modify modal.
+// Falls back to the order's total quantity for orders that never
+// touched a fill (cum=0 ⇒ leaves==quantity anyway).
+export function modifyModalDefaultLeaves(order) {
+  if (!order) return "";
+  const leaves = Number(order.leavesQuantity);
+  if (Number.isFinite(leaves) && leaves > 0) return leaves;
+  const qty = Number(order.quantity);
+  if (Number.isFinite(qty) && qty > 0) return qty;
+  return "";
+}
+
+// Pure helper: translate the UX-level "new leaves" back into the
+// wire-level OrderQty. Returns NaN on bad input so callers can
+// short-circuit with a validation error.
+export function computeWireOrderQty(newLeaves, cumQty) {
+  const lv = Number(newLeaves);
+  const cum = Number(cumQty);
+  if (!Number.isFinite(lv) || !Number.isInteger(lv) || lv <= 0) return NaN;
+  if (!Number.isFinite(cum) || cum < 0) return NaN;
+  return cum + lv;
+}
 
 // The modal stores its "current target" on the form element via
 // dataset so the submit handler doesn't depend on UI state churn
@@ -295,11 +340,18 @@ function openModifyModal(clOrdId) {
   const qty   = $("modify-modal-qty");
   const price = $("modify-modal-price");
   const summary = $("modify-modal-summary");
+  const hint  = $("modify-modal-wire-hint");
   const error = $("modify-modal-error");
   if (!modal || !form || !qty) return;
 
+  // Snapshot cumQty on the form so the submit handler converts
+  // leaves→wire against the exact value the trader saw when the
+  // modal opened, even if a background ER bumps cum mid-edit.
   form.dataset.clordid = clOrdId;
-  qty.value = order.quantity ?? "";
+  const cumSnapshot = Number(order.cumulativeQuantity) || 0;
+  form.dataset.cumqty = String(cumSnapshot);
+
+  qty.value = modifyModalDefaultLeaves(order);
   if (price) {
     if (order.price == null) {
       price.value = "";
@@ -315,6 +367,7 @@ function openModifyModal(clOrdId) {
       `Order ${order.clOrdId} — ${order.symbol} ${order.side} ${order.type} ` +
       `(qty ${order.quantity}, leaves ${order.leavesQuantity}, cum ${order.cumulativeQuantity}, px ${px})`;
   }
+  refreshModifyWireHint();
   if (error) { error.hidden = true; error.textContent = ""; }
   rememberFocusForModal("modify-modal");
   modal.hidden = false;
@@ -323,12 +376,42 @@ function openModifyModal(clOrdId) {
   setTimeout(() => qty.focus(), 0);
 }
 
+// Recompute the "→ wire total = cum + remaining = N" hint shown
+// under the qty input. Called on open and on every input change so
+// the trader always sees the OrderQty that will hit the wire.
+function refreshModifyWireHint() {
+  const form  = $("modify-modal-form");
+  const qty   = $("modify-modal-qty");
+  const hint  = $("modify-modal-wire-hint");
+  if (!form || !qty || !hint) return;
+  const cum = Number(form.dataset.cumqty) || 0;
+  const raw = qty.value.trim();
+  if (raw === "") {
+    hint.textContent = `Wire OrderQty = cum ${cum} + remaining ?`;
+    hint.classList.remove("error");
+    return;
+  }
+  const wire = computeWireOrderQty(raw, cum);
+  if (!Number.isFinite(wire)) {
+    hint.textContent = "Remaining must be a positive integer.";
+    hint.classList.add("error");
+    return;
+  }
+  hint.textContent = `Wire OrderQty = cum ${cum} + remaining ${Number(raw)} = ${wire}`;
+  hint.classList.remove("error");
+}
+
 export function closeModifyModal() {
   const modal = $("modify-modal");
   const form  = $("modify-modal-form");
+  const hint  = $("modify-modal-wire-hint");
   if (!modal) return;
   modal.hidden = true;
-  if (form) delete form.dataset.clordid;
+  if (form) {
+    delete form.dataset.clordid;
+    delete form.dataset.cumqty;
+  }
+  if (hint) { hint.textContent = ""; hint.classList.remove("error"); }
   setModifyModalError(null);
   setModifyModalSubmitting(false);
   restoreFocusForModal("modify-modal");
@@ -607,9 +690,15 @@ function submitModifyForm() {
   if (!clOrdId) return;
 
   const qtyRaw = qtyEl.value.trim();
-  const qty = Number(qtyRaw);
-  if (!Number.isFinite(qty) || qty <= 0 || !Number.isInteger(qty)) {
-    setModifyModalError("Quantity must be a positive integer.");
+  const newLeaves = Number(qtyRaw);
+  if (!Number.isFinite(newLeaves) || newLeaves <= 0 || !Number.isInteger(newLeaves)) {
+    setModifyModalError("Remaining quantity must be a positive integer.");
+    return;
+  }
+  const cumSnapshot = Number(form.dataset.cumqty) || 0;
+  const wireQty = computeWireOrderQty(newLeaves, cumSnapshot);
+  if (!Number.isFinite(wireQty)) {
+    setModifyModalError("Remaining quantity must be a positive integer.");
     return;
   }
   let price = null;
@@ -625,7 +714,10 @@ function submitModifyForm() {
     }
   }
   setModifyModalError(null);
-  onModifyOrder(clOrdId, { quantity: qty, price });
+  // Wire-level: OrderCancelReplaceRequest.OrderQty = cum + newLeaves
+  // (FIX invariant OrderQty ≥ CumQty); see the "UX-vs-wire" comment
+  // block above openModifyModal.
+  onModifyOrder(clOrdId, { quantity: wireQty, price });
 }
 
 // ── Cancel-all modal (T3) ──────────────────────────────────────────
@@ -940,6 +1032,13 @@ export function bindUi() {
       e.preventDefault();
       submitModifyForm();
     });
+  }
+  // Live wire-OrderQty hint: refresh on every qty edit so the trader
+  // always sees the FIX OrderQty = cum + remaining that will hit the
+  // wire (UX-vs-wire contract above openModifyModal).
+  const modifyQtyInput = $("modify-modal-qty");
+  if (modifyQtyInput) {
+    modifyQtyInput.addEventListener("input", () => refreshModifyWireHint());
   }
   if (modifyCancelBtn) {
     modifyCancelBtn.addEventListener("click", () => closeModifyModal());

--- a/frontend/test/modify-modal-leaves.test.mjs
+++ b/frontend/test/modify-modal-leaves.test.mjs
@@ -1,0 +1,92 @@
+// Modify-modal UX-vs-wire conversion (#421 follow-up).
+//
+// The modal exposes "new remaining quantity" to the trader (much
+// more intuitive after a partial fill than "new total"), but the
+// wire OrderCancelReplaceRequest still carries the FIX-conformant
+// OrderQty (38) = cumQty + newLeaves with the invariant
+// OrderQty ≥ CumQty. These pure helpers own that translation; the
+// modal UI just shells out to them, so locking them down here
+// guards both "what shows up in the input" and "what hits the wire"
+// without needing a DOM harness.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  modifyModalDefaultLeaves,
+  computeWireOrderQty,
+} from "../js/ui.js";
+
+function order(over = {}) {
+  return {
+    clOrdId: "1",
+    symbol: "PETR4",
+    side: "Buy",
+    type: "Limit",
+    status: "New",
+    quantity: 200,
+    leavesQuantity: 200,
+    cumulativeQuantity: 0,
+    price: 32.5,
+    ...over,
+  };
+}
+
+test("modifyModalDefaultLeaves: fresh order ⇒ leaves == quantity", () => {
+  assert.equal(modifyModalDefaultLeaves(order()), 200);
+});
+
+test("modifyModalDefaultLeaves: partially-filled order ⇒ leaves (not total)", () => {
+  // This is the #421 case in the screenshot: order qty=200 with
+  // cum=100 should pre-fill the input with 100, not 200.
+  const o = order({ status: "PartiallyFilled", leavesQuantity: 100, cumulativeQuantity: 100 });
+  assert.equal(modifyModalDefaultLeaves(o), 100);
+});
+
+test("modifyModalDefaultLeaves: falls back to quantity when leaves is missing/zero", () => {
+  assert.equal(modifyModalDefaultLeaves(order({ leavesQuantity: 0 })), 200);
+  assert.equal(modifyModalDefaultLeaves(order({ leavesQuantity: null })), 200);
+  assert.equal(modifyModalDefaultLeaves(order({ leavesQuantity: undefined })), 200);
+});
+
+test("modifyModalDefaultLeaves: returns empty string for missing input", () => {
+  assert.equal(modifyModalDefaultLeaves(null), "");
+  assert.equal(modifyModalDefaultLeaves(undefined), "");
+  assert.equal(modifyModalDefaultLeaves({}), "");
+});
+
+test("computeWireOrderQty: fresh order, cum=0 ⇒ wire == new leaves", () => {
+  assert.equal(computeWireOrderQty(150, 0), 150);
+});
+
+test("computeWireOrderQty: partial fill ⇒ wire = cum + new leaves (FIX invariant)", () => {
+  // cum=100 already filled; trader wants 80 still working ⇒ wire OrderQty = 180.
+  assert.equal(computeWireOrderQty(80, 100), 180);
+  // Growing the remaining ⇒ wire grows too.
+  assert.equal(computeWireOrderQty(500, 100), 600);
+});
+
+test("computeWireOrderQty: returns NaN on invalid new-leaves input", () => {
+  assert.ok(Number.isNaN(computeWireOrderQty(0, 100)));     // not positive
+  assert.ok(Number.isNaN(computeWireOrderQty(-5, 100)));    // negative
+  assert.ok(Number.isNaN(computeWireOrderQty(1.5, 100)));   // non-integer
+  assert.ok(Number.isNaN(computeWireOrderQty("abc", 100))); // not a number
+  assert.ok(Number.isNaN(computeWireOrderQty(null, 100)));
+  assert.ok(Number.isNaN(computeWireOrderQty(undefined, 100)));
+});
+
+test("computeWireOrderQty: returns NaN on invalid cum input", () => {
+  assert.ok(Number.isNaN(computeWireOrderQty(50, -1)));
+  assert.ok(Number.isNaN(computeWireOrderQty(50, "abc")));
+  // null/undefined cum is permissive: a missing cum from state
+  // safely defaults to 0 at the call site (form.dataset.cumqty),
+  // so the pure helper only rejects actively-bad numbers.
+});
+
+test("computeWireOrderQty: wire qty always ≥ cum (FIX invariant by construction)", () => {
+  for (const [lv, cum] of [[1, 0], [1, 100], [100, 50], [200, 200]]) {
+    const wire = computeWireOrderQty(lv, cum);
+    assert.ok(wire >= cum, `wire ${wire} must be ≥ cum ${cum}`);
+    assert.equal(wire, cum + lv);
+  }
+});


### PR DESCRIPTION
After a partial fill the modify modal pre-filled "New quantity" with
the order's total qty (200 for cum=100+leaves=100). The trader thinks
in terms of "what's still working", so:

* Re-label to "New remaining quantity" and pre-fill with
  leavesQuantity (falls back to quantity when cum=0).
* Add a live hint under the input showing the wire translation:
  "Wire OrderQty = cum N + remaining M = N+M". The trader always
  sees the FIX OrderQty that will actually hit the wire — the UX
  abstraction never hides protocol.
* Wire stays 100% FIX-conformant: OrderCancelReplaceRequest.OrderQty
  (38) = cum + newLeaves, so OrderQty ≥ CumQty by construction.
* Snapshot the cum on form open so a background ER doesn't shift
  the translation mid-edit.

Two pure helpers — modifyModalDefaultLeaves / computeWireOrderQty —
own the UX-to-wire translation; they're covered by a new
frontend/test/modify-modal-leaves test (9 cases). 398 frontend tests
green.

Refs #423.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
