### PR TITLE
feat(gateway): graceful FIXP Terminate(Finished) on host shutdown

### DIFF
--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -34,6 +34,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private readonly SemaphoreSlim _reconnectLock = new(1, 1);
     private readonly TimeSpan _initialReconnectDelay;
     private readonly TimeSpan _maxReconnectDelay;
+    private readonly TimeSpan _gracefulTerminateTimeout;
     private readonly TimeProvider _clock;
     private readonly OrderEntryLatencyProbe _latencyProbe;
     private Task? _eventLoop;
@@ -66,7 +67,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         TimeSpan? maxReconnectDelay = null,
         TimeProvider? clock = null,
         OrderEntryLatencyProbe? latencyProbe = null,
-        IVenueDisconnectReactor? venueDisconnectReactor = null)
+        IVenueDisconnectReactor? venueDisconnectReactor = null,
+        TimeSpan? gracefulTerminateTimeout = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -74,6 +76,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _currentSessionVerId = initialSessionVerId;
         _initialReconnectDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(1);
         _maxReconnectDelay = maxReconnectDelay ?? TimeSpan.FromSeconds(30);
+        _gracefulTerminateTimeout = gracefulTerminateTimeout ?? TimeSpan.FromSeconds(2);
         _clock = clock ?? TimeProvider.System;
         _latencyProbe = latencyProbe ?? new OrderEntryLatencyProbe(_clock);
         _reactor = venueDisconnectReactor;
@@ -702,6 +705,42 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         {
             try { await _eventLoop.ConfigureAwait(false); } catch { /* event loop swallows, but be defensive */ }
         }
+
+        // Graceful FIXP Terminate(Finished) before tearing down the SDK so the
+        // peer flushes our session promptly and our next boot doesn't trip
+        // DUPLICATE_SESSION_CONNECTION. The SDK's own DisposeAsync also sends
+        // Terminate(Finished) internally as a last-resort fallback, but it
+        // swallows IOException silently and doesn't emit the
+        // `entrypoint.terminate` activity + counter that the public
+        // TerminateAsync surfaces — so we call it explicitly here for both
+        // observability (one log line per firm shutdown) and protocol-level
+        // determinism (bounded timeout so a stuck peer can't hang shutdown).
+        //
+        // OnTerminated is intentionally still attached at this point: the SDK
+        // raises Terminated(InitiatedByClient=true) from inside TerminateAsync,
+        // and we want the existing handler to record the metric / log line
+        // (the _disposed guard on line 527 ensures it skips the reconnect loop).
+        if (Volatile.Read(ref _connectedState) == 1)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(_gracefulTerminateTimeout);
+                await _client.TerminateAsync(Up.TerminationCode.Finished, cts.Token).ConfigureAwait(false);
+                _logger.LogInformation(
+                    "Sent graceful FIXP Terminate(Finished) for firm {Firm} on shutdown.", _firmId);
+            }
+            catch (InvalidOperationException)
+            {
+                // SDK throws this if the session was torn down between our
+                // connected-state check and the call (race with peer Terminate).
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Graceful FIXP Terminate failed for firm {Firm}; proceeding with dispose.", _firmId);
+            }
+        }
+
         _client.Terminated -= OnTerminated;
         _client.InboundGapAtReconnect -= OnInboundGapAtReconnect;
         await _client.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Why

When trading-host receives SIGTERM (docker stop, k8s rollout, manual restart), we want matching to release our FIXP session promptly so the next boot doesn't trip `DUPLICATE_SESSION_CONNECTION` while the peer still considers the prior session alive.

Currently the SDK's own `EntryPointClient.DisposeAsync → StopActiveSessionAsync → FixpClientSession.DisposeAsync` does call `TerminateAsync(Finished)` at the FixpClientSession layer as a last-resort fallback. But:

- it swallows `IOException` silently with no log signal — an operator has no way to confirm the graceful path ran;
- it doesn't emit the public `entrypoint.terminate` activity nor the terminations counter (those only fire from `IEntryPointClient.TerminateAsync`);
- it has no dedicated short timeout, so a stuck peer can block shutdown up to `SessionTeardownTimeout` (5s default) inside dispose.

## What

`B3EntryPointClientGateway.DisposeAsync` now calls `_client.TerminateAsync(TerminationCode.Finished, ct)` explicitly **before** invoking `_client.DisposeAsync`:

- one INFO log line per firm on graceful shutdown (or WARN with exception on failure)
- the SDK telemetry hooks fire (`entrypoint.terminate` activity + terminations counter, `direction=outbound`, `code=Finished`)
- a bounded 2s timeout via the new optional ctor param `gracefulTerminateTimeout` (default 2s, leaves headroom inside the 5s SDK teardown window)

Existing `OnTerminated` handler is intentionally left attached during the call so it still records `EntryPointConnected -1` and the `EntryPointTerminated` counter with `initiated_by_client=true`. The `_disposed` guard on the handler ensures the reconnect loop does **not** fire on this self-initiated termination.

Gated on `Volatile.Read(ref _connectedState) == 1` so we don't throw `InvalidOperationException` ("Client is not connected") when dispose runs after a cold-start failure or a peer-initiated terminate that hasn't been followed by a reattach.

## Tests

Build clean (0 warnings). 1761 tests green:
- Application: 1134
- Api: 493
- EntryPointListener: 134

The SDK's `EntryPointClient` is sealed and requires a real TCP peer, so a dedicated unit test for the Terminate-on-dispose path would require a FIXP test peer that the SDK does not currently ship. The change is small (one new ctor param + a new block in `DisposeAsync` guarded by try/catch with bounded timeout) and follows existing patterns. Manual verification is straightforward: on next docker restart the host log will show one `Sent graceful FIXP Terminate(Finished) for firm {Firm} on shutdown.` line per firm before the SDK tears the TCP down.

## Risk

Low. Wrapped in try/catch — any failure logs WARN and falls through to the existing `_client.DisposeAsync` path (which still sends Terminate(Finished) at the FixpClientSession layer as before). Bounded 2s timeout caps the worst case. No behaviour change on the connect / reconnect hot paths.

Closes follow-up item from PR #426 / plan.md.