### PR TITLE
FE: label ExecKind.ReplacedNew as 'Replacement'

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -426,6 +426,7 @@ tr.row-stale > td.row-stale-actions { opacity: 1; }
 .executions-log .Canceled    { color: var(--gray); }
 .executions-log .New         { color: var(--accent); }
 .executions-log .Replaced    { color: var(--gray); }
+.executions-log .ReplacedNew { color: var(--accent); }
 .executions-log .Expired     { color: #888; }
 .executions-log .meta { color: var(--muted); }
 .executions-log .badge {

--- a/frontend/js/historyUi.js
+++ b/frontend/js/historyUi.js
@@ -21,7 +21,7 @@
 // the renderers via dom-stub.mjs — same pattern as bot-credentials.
 
 import { getState, subscribe } from "./state.js";
-import { fmtQty, fmtPx } from "./ui.js";
+import { fmtQty, fmtPx, execKindLabel } from "./ui.js";
 
 const $ = (id) => document.getElementById(id);
 
@@ -275,7 +275,7 @@ function executionRow(e) {
     <td>${escapeHtml(e.clOrdId ?? "")}</td>
     <td>${escapeHtml(e.symbol ?? "")}</td>
     <td>${escapeHtml(e.side ?? "")}</td>
-    <td>${escapeHtml(e.kind ?? "")}</td>
+    <td>${escapeHtml(execKindLabel(e.kind))}</td>
     <td class="num">${fmtQty(e.lastQuantity)}</td>
     <td class="num">${e.lastPrice == null ? "—" : fmtPx(e.lastPrice)}</td>
     <td class="num">${fmtQty(e.cumulativeQuantity)}</td>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -636,7 +636,7 @@ function execDetailRow(e) {
   const notes = [reason, stp].filter(Boolean).join(" ");
   return `<tr>
     <td>${ts}</td>
-    <td class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</td>
+    <td class="kind ${escapeHtml(e.kind)}">${escapeHtml(execKindLabel(e.kind))}</td>
     <td class="num">${lastQty}</td>
     <td class="num">${lastPx}</td>
     <td class="num">${fmtQty(e.cumulativeQuantity)}</td>
@@ -2734,7 +2734,7 @@ function execRow(e) {
   const stpBadge = stpBadgeFor(e);
   return `<div class="exec-row">
     <span class="ts">${ts}</span>
-    <span class="kind ${escapeHtml(e.kind)}">${escapeHtml(e.kind)}</span>
+    <span class="kind ${escapeHtml(e.kind)}">${escapeHtml(execKindLabel(e.kind))}</span>
     <span class="meta">${escapeHtml(e.clOrdId)} ${escapeHtml(e.symbol)} ${lastQty}${lastPx}${stpBadge}${reason}</span>
   </div>`;
 }
@@ -2802,6 +2802,23 @@ export function typeChipHtml(type) {
   const meta = ORDER_TYPE_CHIP[type];
   if (!meta) return escapeHtml(type ?? "");
   return `<span class="type-chip ${meta.cls}" title="${escapeHtml(type)}">${meta.label}</span>`;
+}
+
+// Map ExecKind enum strings (as emitted by the backend `executions.me`
+// stream) to user-friendly display labels. PR #418 split the legacy
+// `Replaced` into two events: the original ClOrdID terminalises as
+// `Replaced` (still labeled "Replaced") and the replacement entering
+// Working surfaces as `ReplacedNew` — which would render literally as
+// "ReplacedNew" without this mapping. All other kinds keep their raw
+// enum spelling so a future ExecKind addition stays visible while the
+// label table catches up. Returns the raw input (escape-safe) when no
+// mapping is registered.
+const EXEC_KIND_LABELS = Object.freeze({
+  ReplacedNew: "Replacement",
+});
+export function execKindLabel(kind) {
+  if (kind == null) return "";
+  return EXEC_KIND_LABELS[kind] ?? kind;
 }
 
 // Format an ISO timestamp for the order-detail GTD field. Returns "—"

--- a/frontend/test/exec-kind-label.test.mjs
+++ b/frontend/test/exec-kind-label.test.mjs
@@ -1,0 +1,39 @@
+// PR #418 split the legacy `Replaced` ExecKind into two events: the
+// original ClOrdID terminalises as `Replaced` and the replacement
+// entering Working surfaces as `ReplacedNew`. The raw enum spelling
+// would render literally as "ReplacedNew" in the executions log —
+// `execKindLabel()` in ui.js rewrites it to the user-friendly
+// "Replacement" while leaving every other kind untouched (so a
+// future ExecKind addition stays visible while the label table
+// catches up).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { execKindLabel } from "../js/ui.js";
+
+test("execKindLabel maps ReplacedNew to 'Replacement'", () => {
+  assert.equal(execKindLabel("ReplacedNew"), "Replacement");
+});
+
+test("execKindLabel passes through known kinds unchanged", () => {
+  for (const k of ["New", "PartialFill", "Fill", "Cancelled", "Rejected",
+                   "Replaced", "Expired", "ReplaceRejected"]) {
+    assert.equal(execKindLabel(k), k);
+  }
+});
+
+test("execKindLabel passes through unknown kinds (forward-compat)", () => {
+  assert.equal(execKindLabel("SomeFutureKind"), "SomeFutureKind");
+});
+
+test("execKindLabel coerces null/undefined to empty string", () => {
+  assert.equal(execKindLabel(null), "");
+  assert.equal(execKindLabel(undefined), "");
+});
+
+test("styles.css ships an .executions-log .ReplacedNew rule", async () => {
+  const fs = await import("node:fs/promises");
+  const css = await fs.readFile(new URL("../css/styles.css", import.meta.url), "utf8");
+  assert.match(css, /\.executions-log\s+\.ReplacedNew\s*\{[^}]*color:/);
+});


### PR DESCRIPTION
Follow-up polish for PR #418.

## Problem
PR #418 split the legacy `ExecKind.Replaced` into two events:
- **`Replaced`** — original ClOrdID terminalises (display unchanged)
- **`ReplacedNew`** — replacement entering Working

The new value rendered literally as "ReplacedNew" in three FE views (order-detail modal, live executions log, history panel).

## Change
- Add `execKindLabel(kind)` helper to `frontend/js/ui.js` with a minimal mapping table `{ ReplacedNew: 'Replacement' }`. Unknown / unmapped kinds pass through verbatim (forward-compat).
- Apply at the three render sites — CSS classes still use the raw enum so color coding stays decoupled from display text.
- New `.executions-log .ReplacedNew { color: var(--accent); }` rule distinguishes the new working leg from the gray terminal `.Replaced`.

## Tests
- New `frontend/test/exec-kind-label.test.mjs` covers the mapping, pass-through, null/undefined coercion, and asserts the CSS rule ships.
- Full FE suite: **404/404 green**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>