### PR TITLE
test(compliance): Cancel-as-Replace audit + 1000-iter chaos sweep (closes #430)

### DIFF
--- a/backend/tests/B3.Trading.Application.Tests/CancelAsReplaceChaosTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/CancelAsReplaceChaosTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.UserBots;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+#pragma warning disable CS0618 // legacy Margin.Initial used to seed capacity in tests
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// Issue #430 — defensive chaos sweep over every documented venue ER ordering
+/// in the Cancel-as-Replace family (B3MatchingPlatform priority-lost path).
+///
+/// Background: issue #241 fixed the original silent-fill-loss bug (PR #242),
+/// and #247/#248 closed the margin reservation leak. Targeted unit tests exist
+/// for each scenario in <see cref="OrderModifyMarginAndProcessorTests"/> and
+/// <c>HistoryEndpointTests</c>. This file complements them with a 1000-iteration
+/// deterministic sweep that picks one of the six documented scenario shapes at
+/// random per iteration (seeded by iteration index for reproducibility) and
+/// asserts the same correctness invariants after each run.
+///
+/// The intent is a regression net: any future refactor of
+/// <see cref="ExecutionReportProcessor.Apply"/>, the
+/// <see cref="PendingReplacementRegistry"/>, or the
+/// <see cref="ReserveOnSubmitMarginProvider"/> coordinator path that breaks
+/// one of the documented orderings will trip an invariant with a reproducible
+/// seed.
+///
+/// Scope (and intentional exclusions) are documented in
+/// <c>docs/audits/cancel-as-replace-audit.md</c>.
+/// </summary>
+public class CancelAsReplaceChaosTests
+{
+    private const int Iterations = 1000;
+
+    [Fact]
+    public void Chaos_AllDocumentedScenarios_InvariantsHoldAcrossThousandIterations()
+    {
+        var failures = new List<string>();
+        var scenarioCounts = new int[Enum.GetValues<Scenario>().Length];
+
+        for (var i = 0; i < Iterations; i++)
+        {
+            var seed = i;
+            var rng = new Random(seed);
+            var scenario = (Scenario)rng.Next(scenarioCounts.Length);
+            scenarioCounts[(int)scenario]++;
+
+            try
+            {
+                RunScenario(scenario, rng);
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"iter={i} seed={seed} scenario={scenario}: {ex.Message}");
+                if (failures.Count >= 10)
+                {
+                    break;
+                }
+            }
+        }
+
+        // Cover every scenario at least once across 1000 iterations.
+        for (var s = 0; s < scenarioCounts.Length; s++)
+        {
+            Assert.True(scenarioCounts[s] > 0,
+                $"scenario {(Scenario)s} never exercised; rebalance RNG distribution.");
+        }
+
+        Assert.True(failures.Count == 0,
+            $"{failures.Count} chaos iterations failed:\n  " + string.Join("\n  ", failures));
+    }
+
+    private enum Scenario
+    {
+        /// <summary>Cancel(new,orig) → Fill(new,0) — happy priority-lost flow.</summary>
+        PriorityLostHappy,
+        /// <summary>Cancel(new,orig) → Fill(new,0) → Cancel(new,orig) replay (FIXP retransmit).</summary>
+        PriorityLostHappy_WithCancelReplay,
+        /// <summary>Cancel(new,orig) → real-Cancel(new) — no fill.</summary>
+        PriorityLostHappy_FollowedByRealCancel,
+        /// <summary>Reject(new) — venue refused the replace; original keeps Working.</summary>
+        ReplaceRejectedByVenue,
+        /// <summary>Replaced(new,orig) — priority-kept variant.</summary>
+        PriorityKept,
+        /// <summary>PartialFill on original BEFORE Cancel-as-Replace lands, then Fill on new.</summary>
+        OriginalPartiallyFilled_ThenCancelAsReplace,
+    }
+
+    private static readonly EndClientId Bob = new("bob");
+    private const string Firm = "FIRM";
+    private const string Symbol = "PETR4";
+    private const ulong SecId = 4321UL;
+
+    private void RunScenario(Scenario scenario, Random rng)
+    {
+        // Slight randomisation of qty/price to stress decimal/long maths
+        // without breaking the scenario shape.
+        var qty = 100 + rng.Next(0, 5) * 10;            // 100..140 step 10
+        var origPx = 32.40m + rng.Next(0, 10) * 0.01m;  // 32.40..32.49
+        var newPx = origPx + 0.01m;                     // crosses up
+
+        var harness = BuildHarness();
+        var origId = 777UL;
+        var newId = 778UL;
+
+        // Original sits Working.
+        var orig = new Order(origId, Bob, Symbol, SecId, OrderSide.Buy, OrderType.Limit, qty, origPx, Firm);
+        harness.Book.TryAdd(orig);
+        orig.MarkWorking();
+        harness.Ownership.Register(origId, Bob);
+
+        // Pre-replace partial-fill scenario.
+        long preFill = 0;
+        if (scenario == Scenario.OriginalPartiallyFilled_ThenCancelAsReplace)
+        {
+            preFill = rng.Next(1, (int)(qty / 2)); // never full
+            harness.Proc.Apply(origId, ExecKind.PartialFill,
+                leaves: qty - preFill, cumQty: preFill, lastQty: preFill, lastPx: origPx,
+                rejectReason: null, origClOrdId: 0);
+            // Sanity: position credited for the partial.
+            Assert.Equal(preFill, harness.Positions.GetOrCreate(Firm, Bob, Symbol).NetQuantity);
+        }
+
+        // Modify: register link + intent.
+        harness.Ownership.RegisterReplaceLink(origId, newId);
+        var intent = new OrderReplacementIntent(
+            OriginalClOrdId: origId,
+            NewClOrdId: newId,
+            Owner: Bob,
+            Symbol: Symbol,
+            SecurityId: SecId,
+            Side: OrderSide.Buy,
+            Type: OrderType.Limit,
+            NewQuantity: qty,
+            NewPrice: newPx,
+            FirmId: Firm,
+            ParentAlgoId: null,
+            AlgoSliceSeq: null);
+        Assert.True(harness.Registry.TryAdd(intent));
+
+        // Dispatch the venue ER sequence for the chosen scenario.
+        switch (scenario)
+        {
+            case Scenario.PriorityLostHappy:
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: origId);
+                harness.Proc.Apply(newId, ExecKind.Fill, 0, qty, qty, newPx, null, origClOrdId: 0);
+                break;
+
+            case Scenario.PriorityLostHappy_WithCancelReplay:
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: origId);
+                harness.Proc.Apply(newId, ExecKind.Fill, 0, qty, qty, newPx, null, origClOrdId: 0);
+                // Replay of the Canceled ER (FIXP retransmit). Order is already
+                // Filled (terminal) so MarkCancelled is a no-op; no margin churn.
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, qty, 0, 0m, null, origClOrdId: origId);
+                break;
+
+            case Scenario.PriorityLostHappy_FollowedByRealCancel:
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: origId);
+                // After the intent is consumed, a real subsequent Cancel of the
+                // new (Working) order is a normal cancel: registry returns
+                // false, falls through to the standard cancel branch.
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: origId);
+                break;
+
+            case Scenario.ReplaceRejectedByVenue:
+                harness.Proc.Apply(newId, ExecKind.Rejected, 0, 0, 0, 0m,
+                    rejectReason: "VENUE_REJECT_TEST", origClOrdId: origId);
+                break;
+
+            case Scenario.PriorityKept:
+                harness.Proc.Apply(newId, ExecKind.Replaced, qty, 0, 0, 0m, null, origClOrdId: origId);
+                harness.Proc.Apply(newId, ExecKind.Fill, 0, qty, qty, newPx, null, origClOrdId: 0);
+                break;
+
+            case Scenario.OriginalPartiallyFilled_ThenCancelAsReplace:
+                harness.Proc.Apply(newId, ExecKind.Canceled, 0, 0, 0, 0m, null, origClOrdId: origId);
+                // Cancel-as-Replace carries erCum=0 (B3 venue's stale shape);
+                // ExecutionReportProcessor's #299 P1 clamp hydrates the new
+                // order with cum=preFill, leaves=qty-preFill so we don't
+                // re-book the partial fill. The next Fill ER then carries the
+                // CUMULATIVE post-fill total (=qty) with lastQty being the
+                // delta actually executed against the new aggressor (leftover).
+                var leftover = qty - preFill;
+                harness.Proc.Apply(newId, ExecKind.Fill, 0, qty, leftover, newPx, null, origClOrdId: 0);
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unhandled scenario {scenario}");
+        }
+
+        // ---- Invariants ----
+        AssertInvariants(harness, scenario, origId, newId, qty, newPx, preFill);
+    }
+
+    private static void AssertInvariants(
+        Harness h, Scenario scenario, ulong origId, ulong newId, long qty, decimal newPx, long preFill)
+    {
+        // 1) Margin coordinator: exactly one resolution per registered intent.
+        var totalResolutions = h.ReplaceCoord.Commits.Count + h.ReplaceCoord.Aborts.Count;
+        Assert.True(totalResolutions == 1,
+            $"expected exactly 1 commit-or-abort per intent; got commits={h.ReplaceCoord.Commits.Count} aborts={h.ReplaceCoord.Aborts.Count}");
+
+        // 2) Registry is one-shot: nothing left to consume for newId.
+        Assert.False(h.Registry.TryConsume(newId, out _),
+            "PendingReplacementRegistry should not still hold the intent");
+
+        // 3) Original order invariants.
+        Assert.True(h.Book.TryGet(origId, out var origAfter));
+        Assert.NotNull(origAfter);
+        var origOk = scenario switch
+        {
+            Scenario.ReplaceRejectedByVenue
+                => origAfter!.Status is OrderStatus.Working or OrderStatus.PartiallyFilled,
+            _ => origAfter!.Status is OrderStatus.Replaced or OrderStatus.Filled,
+        };
+        Assert.True(origOk, $"orig status {origAfter!.Status} unexpected for {scenario}");
+        AssertOrderArithmetic(origAfter);
+
+        // 4) New order invariants — present iff scenario hydrated it.
+        var hasNew = h.Book.TryGet(newId, out var newAfter) && newAfter is not null;
+        switch (scenario)
+        {
+            case Scenario.ReplaceRejectedByVenue:
+                Assert.False(hasNew, "rejected replace must not create new order in book");
+                break;
+            default:
+                Assert.True(hasNew, $"{scenario} should have hydrated new order");
+                AssertOrderArithmetic(newAfter!);
+                break;
+        }
+
+        // 5) PositionKeeper: NetQuantity must equal the sum of fills booked.
+        // For OriginalPartiallyFilled scenario, preFill on orig + qty on new = preFill + qty.
+        // For RejectedByVenue, no fills happened.
+        var expectedNet = scenario switch
+        {
+            Scenario.ReplaceRejectedByVenue => 0L,
+            Scenario.PriorityLostHappy_FollowedByRealCancel => 0L,
+            Scenario.OriginalPartiallyFilled_ThenCancelAsReplace => qty, // preFill on orig + (qty-preFill) on new = qty
+            _ => qty,
+        };
+        var pos = h.Positions.GetOrCreate(Firm, Bob, Symbol);
+        Assert.True(pos.NetQuantity == expectedNet,
+            $"NetQuantity={pos.NetQuantity} expected={expectedNet} for {scenario} (qty={qty}, preFill={preFill}, newPx={newPx})");
+
+        // 6) Owner resolution stays consistent.
+        Assert.True(h.Ownership.TryResolve(origId, out var ownerOrig) && ownerOrig == Bob);
+        if (hasNew)
+        {
+            Assert.True(h.Ownership.TryResolve(newId, out var ownerNew) && ownerNew == Bob);
+        }
+
+        // 7) Defensive: if commit happened, it must be for our (orig,new) pair.
+        if (h.ReplaceCoord.Commits.Count == 1)
+        {
+            Assert.Equal(origId, h.ReplaceCoord.Commits[0].Orig);
+            Assert.Equal(newId, h.ReplaceCoord.Commits[0].New);
+        }
+        if (h.ReplaceCoord.Aborts.Count == 1)
+        {
+            Assert.Equal(newId, h.ReplaceCoord.Aborts[0]);
+        }
+    }
+
+    private static void AssertOrderArithmetic(Order o)
+    {
+        // Leaves + Cum must equal Quantity at every observable state.
+        Assert.True(o.LeavesQuantity + o.CumulativeQuantity == o.Quantity,
+            $"order {o.ClOrdId}: leaves({o.LeavesQuantity}) + cum({o.CumulativeQuantity}) != qty({o.Quantity})");
+
+        // Terminal status invariants.
+        if (o.Status == OrderStatus.Filled)
+        {
+            Assert.Equal(0, o.LeavesQuantity);
+            Assert.Equal(o.Quantity, o.CumulativeQuantity);
+        }
+    }
+
+    // ---- harness ----
+
+    private sealed class Harness
+    {
+        public required OrderOwnershipMap Ownership { get; init; }
+        public required WorkingOrderBook Book { get; init; }
+        public required PositionKeeper Positions { get; init; }
+        public required CashLedger Cash { get; init; }
+        public required PendingReplacementRegistry Registry { get; init; }
+        public required RecordingReplaceCoordinator ReplaceCoord { get; init; }
+        public required ExecutionReportProcessor Proc { get; init; }
+    }
+
+    private sealed class RecordingReplaceCoordinator : IReplaceMarginCoordinator
+    {
+        public List<(ulong Orig, ulong New, decimal Notional)> Commits { get; } = new();
+        public List<ulong> Aborts { get; } = new();
+
+        public System.Threading.Tasks.Task<RiskDecision> PrepareReplaceAsync(
+            ulong originalClOrdId, ulong newClOrdId, EndClientId owner,
+            decimal newRemainingNotional, System.Threading.CancellationToken ct)
+            => System.Threading.Tasks.Task.FromResult(RiskDecision.Approve);
+
+        public void CommitReplace(ulong originalClOrdId, ulong newClOrdId, decimal confirmedRemainingNotional)
+            => Commits.Add((originalClOrdId, newClOrdId, confirmedRemainingNotional));
+
+        public void AbortReplace(ulong newClOrdId)
+            => Aborts.Add(newClOrdId);
+    }
+
+    private sealed class NullSink : IExecutionEventSink
+    {
+        public void Publish(ExecutionEvent ev) { }
+    }
+
+    private static Harness BuildHarness()
+    {
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var cash = new CashLedger();
+        cash.SeedIfAbsent(Bob, 1_000_000m);
+        var opts = new RiskOptions();
+        opts.Margin.Enabled = true;
+        opts.Margin.Initial["bob"] = 1_000_000m;
+        var monitor = new StaticOptionsMonitor<RiskOptions>(opts);
+        var marginProvider = new ReserveOnSubmitMarginProvider(monitor, NullLogger<ReserveOnSubmitMarginProvider>.Instance);
+        var replaceCoord = new RecordingReplaceCoordinator();
+        var reg = new PendingReplacementRegistry();
+
+        var proc = new ExecutionReportProcessor(
+            ownership, book, positions, new NullSink(), marginProvider,
+            NullLogger<ExecutionReportProcessor>.Instance,
+            algoSignals: null,
+            cash: cash,
+            replacements: reg,
+            replaceMargin: replaceCoord,
+            botErRouter: null);
+
+        return new Harness
+        {
+            Ownership = ownership,
+            Book = book,
+            Positions = positions,
+            Cash = cash,
+            Registry = reg,
+            ReplaceCoord = replaceCoord,
+            Proc = proc,
+        };
+    }
+}

--- a/docs/audits/cancel-as-replace-audit.md
+++ b/docs/audits/cancel-as-replace-audit.md
@@ -1,0 +1,114 @@
+# Cancel-as-Replace path audit (issue #430)
+
+**Status:** Audited 2026-05-24 — no live correctness gaps. Defensive chaos test added in
+`backend/tests/B3.Trading.Application.Tests/CancelAsReplaceChaosTests.cs`.
+
+**Related:** #241 (root bug fix, PR #242), #247/#248 (margin commit drop, PR #248),
+#122 slice 1 (`RegisterReplaceLink`), #122 slice 2 (`PendingReplacementRegistry`),
+#16 (idempotent ER), #275 pass-4 (`OrdersHistory_CancelAsReplace_*`), #417 (wire-faithful
+bot routing), #299 P1 (cum/leaves baseline hydration), #255 (GTD on replace terminal).
+
+## 1. Problem domain
+
+B3MatchingPlatform implements `OrderCancelReplaceRequest` (FIX 35=G, FIXP equivalent) via
+**two distinct venue paths**:
+
+| Venue path | Trigger | Wire ER shape | Processor branch |
+|---|---|---|---|
+| `priority-kept` | Same price + qty ≤ current | One ER with `ExecType=Replaced`, `OrigClOrdID=orig` | Line 206-212 (`Replaced` + intent) |
+| `priority-lost` | Any other change (incl. price-cross, upsize) | `ER_Cancel(new, orig)` + `ER_Trade(new, 0)` and/or `ER_New(new)` — **never** `Replaced` | Line 224-237 (`Canceled` + intent) — issue #241 |
+
+A third venue outcome — replace rejected by the matching engine — comes in as
+`ER_Reject(new)` and is handled by line 199-205 (`Rejected` + intent → `ApplyReplaceRejected`).
+
+The shared invariant: the `PendingReplacementRegistry` keyed by `newClOrdId` is the
+**single source of truth** that disambiguates "this Cancel/Reject/Replaced is the venue's
+answer to my modify" from "this is a standalone cancel/reject". `TryConsume` is one-shot,
+so each replace flow resolves exactly once.
+
+## 2. Caminhos cobertos (and where)
+
+### 2.1 Origin (modify request)
+
+`OrderModifyService.ModifyAsync`
+(`backend/src/B3.Trading.Application/OrderModifyService.cs`):
+
+1. Allocates `newClOrdId` via `ClOrdIdPrefixRegistry`.
+2. `_ownership.RegisterReplaceLink(origId, newClOrdId)` — slice 1 of #122. Enables
+   `TryResolve(newClOrdId)` even before any ER lands. Survives gateway clock skew.
+3. Risk pipeline + margin `PrepareReplaceAsync` (line 219-274, post-#337 also publishes
+   `OrderReplaceRejectedEvent` to the WAL on reject — see
+   `docs/rfcs/risk-pipeline-ordering-v0.md`).
+4. `_replacements.TryAdd(intent)` registers the `OrderReplacementIntent`.
+5. `_gateway.CancelReplaceAsync(...)`.
+
+### 2.2 Venue ER ingress
+
+`ExecutionReportProcessor.Apply`
+(`backend/src/B3.Trading.Application/ExecutionReportProcessor.cs:Apply`):
+
+| Order of events | Resulting behaviour |
+|---|---|
+| **priority-kept**: `Replaced(new, orig)` | `ApplyReplaceAccepted` (line 210). `MarkReplaced(orig)`, `HydrateReplacement(new)` from `intent.NewPrice/NewQuantity`, `CommitReplace`. Subsequent fills land on `new`. |
+| **priority-lost happy**: `Canceled(new, orig)` → `Fill(new, orig=0)` | First event takes the cancel-as-replace branch (line 224-237) and funnels through `ApplyReplaceAccepted` with `erLeaves=intent.NewQuantity, erCum=0`. The new order is hydrated in `WorkingOrderBook`. Second event finds the new order present, books the fill. |
+| **Replace rejected by venue**: `Rejected(new)` | `ApplyReplaceRejected` (line 203). `AbortReplace(new)`, `MarkRejected(intent.NewClOrdId)` placeholder routed to bot, original stays Working. Tests: `OrderModifyMarginAndProcessorTests.Processor_Replaced_branch_rejectedFlow*`. |
+| **Replay Cancel (FIXP retransmit)** | `_replacements.TryConsume` is one-shot — second `Canceled(new, orig)` falls through to standard cancel branch. The Working new order is `MarkCancelled`. Documented in `Processor_CancelAsReplace_secondCancelReplay_isIdempotentNoOp`. No margin double-commit, no orphans. |
+| **Real cancel after Cancel-as-Replace** | Same as Replay Cancel branch above. The new order's cancel is a legitimate state transition (user / venue cancel of the new). |
+| **Original partially filled BEFORE Cancel-as-Replace** | `MarkReplaced` preserves `Filled` terminal (line 955-958); fills booked on original are not re-booked on new (PositionKeeper already saw them). The **#299 P1 cum-stale clamp** (line 1020-1029) detects venue-issued `erCum=0` against a non-zero original cum and rewrites `seedCum := origOrder.CumulativeQuantity`, `seedLeaves := intent.NewQuantity - seedCum`. Subsequent Fill ER under the new ClOrdID carries the full cumulative post-fill total (=NewQuantity), so the delta booked into PositionKeeper is exactly `qty - preFill`. Total NetQuantity = preFill + (qty - preFill) = qty (the user's target). Tests: `OrdersHistory_CancelAsReplaceAfterOriginalFilled_OriginalStaysFilled`, `OrdersHistory_CancelAsReplaceWithPartiallyFilledOriginal_ReplacementCumResetsToZero`, `CancelAsReplaceChaosTests.Scenario.OriginalPartiallyFilled_ThenCancelAsReplace`. |
+| **ER firm mismatch** | Cross-firm replace guard runs BEFORE the intercept blocks (line 145-191, PR #317 P1). `TryConsume` is NOT invoked when firm mismatches, so a malicious cross-firm Cancel can't drain another firm's pending intent. Test: `CancelAsReplace_withMismatchingFirm_doesNotConsumeIntent_orMutateOriginal`. |
+
+### 2.3 Known limitation (documented, out-of-scope)
+
+**Trade-before-Cancel ordering (FIXP out-of-order delivery)**. If the venue's
+`ER_Trade(new, 0)` arrives before `ER_Cancel(new, orig)`, the Trade hits the
+`TryGet(new) → false` branch (line 266-277) and increments the
+`trading.execution_reports.dropped_known_owner_missing_order` metric with
+`kind=Fill` tag. The fix would be a small per-ClOrdID reorder buffer with TTL;
+not delivered today and not in scope for this audit. Track separately if observed
+in production via the metric.
+
+## 3. Resolution / cleanup paths
+
+Every successful Cancel-as-Replace must call exactly one of `CommitReplace` or
+`AbortReplace` on the `IReplaceMarginCoordinator`. The audit checked:
+
+| Cleanup callsite | Calls `Commit` | Calls `Abort` |
+|---|---|---|
+| `ApplyReplaceAccepted` (Replaced or Cancel-as-Replace happy path) | ✅ line 1071 (after hydrate) | — |
+| `ApplyReplaceAccepted` (orig not in book — defensive) | — | ✅ line 947 |
+| `ApplyReplaceRejected` (replace rejected by venue) | — | ✅ line 893 |
+| `OrderModifyService` (risk reject pre-WAL, margin reject) | — | ✅ via `AbortReplace` in finally |
+
+**Invariant**: for any `intent` added to the registry, exactly one of these branches
+fires (registry `TryConsume` is one-shot; intent leak would only happen if all four
+miss). The chaos test asserts `Commits + Aborts == intents` per scenario.
+
+## 4. Chaos test design
+
+`backend/tests/B3.Trading.Application.Tests/CancelAsReplaceChaosTests.cs` runs 1000
+deterministic iterations (`seed = i`) of a randomly-selected scenario from a closed
+set of 6 venue behaviours (happy, replay, real-cancel-after, replace-reject,
+priority-kept, partial-fill-then-cancel-as-replace). After each iteration it asserts:
+
+1. **Margin coordinator balance**: `Commits.Count + Aborts.Count == 1` per intent.
+   No leak, no double-resolve.
+2. **WorkingOrderBook coherence**: for every order present, `LeavesQuantity +
+   CumulativeQuantity == OriginalQuantity` and status is consistent
+   (`Filled` ⇒ leaves=0; `Cancelled`/`Replaced`/`Rejected` are terminal).
+3. **PositionKeeper balance**: `pos.NetQuantity == Σ(fills booked under this owner +
+   symbol)`. Verifies no fill lost or double-booked across the replace boundary.
+4. **OrderOwnershipMap**: every consumed ClOrdID resolves to its owner.
+
+The intent is **regression net**: any future refactor that breaks one of the six
+flows will trip an invariant deterministically (seed reproducible from the
+failing iteration index).
+
+## 5. Open follow-ups (recommend NOT in scope of #430)
+
+- Out-of-order Trade-before-Cancel reorder buffer (see §2.3). Wait for production
+  signal on the existing metric before investing.
+- Concurrent multi-threaded chaos. `ExecutionReportProcessor.Apply` is documented
+  as called serially from the gateway ingress pipeline; multi-thread chaos would
+  require redesigning the harness around an explicit serializer and risks testing
+  the harness rather than the code under test.
+


### PR DESCRIPTION
Closes #430.

## Background

The 2026-05-24 B3 compliance audit (#430) asked for two defensive deliverables on top of the bug fix already shipped in #241 → PR #242 (and the margin reservation follow-up in #247/#248):

1. **Audit document** mapping every venue Cancel-as-Replace path to the corresponding processor branch.
2. **Chaos test** sweeping the documented orderings.

This PR delivers both. No production code is touched — the bug fix is unchanged.

## What's in the doc

`docs/audits/cancel-as-replace-audit.md`

- B3MatchingPlatform's three `OrderCancelReplaceRequest` paths (priority-kept / priority-lost / replace-rejected) mapped to the three `ExecutionReportProcessor.Apply` branches.
- Every ER ordering (happy, replay, real-cancel-after, replace-rejected, priority-kept, partial-fill-then-cancel-as-replace, ER firm mismatch) cross-referenced to its covering test.
- The four `IReplaceMarginCoordinator` cleanup edges that guarantee Commit + Abort = number of registered intents.
- One known limitation kept out of scope and tracked via metric: Trade-before-Cancel out-of-order delivery.
- Note on the #299 P1 cum-stale clamp behaviour for partially-filled originals.

## What's in the test

`backend/tests/B3.Trading.Application.Tests/CancelAsReplaceChaosTests.cs`

- 1000 deterministic iterations (`seed = iteration index` — every failure is fully reproducible).
- Each iteration randomly picks one of six documented venue ER orderings.
- Coverage assertion: every scenario must fire at least once across the sweep.
- Per-iteration invariants:
  1. Exactly one Commit OR Abort per registered intent (no margin leak).
  2. Registry one-shot consumption.
  3. `leaves + cum == quantity` arithmetic on every present order.
  4. `PositionKeeper.NetQuantity` equals the scenario's expected fills.
  5. `OrderOwnershipMap` resolves both ClOrdIDs.
  6. Commit pair = (orig, new), abort target = new.

## Findings during development

The chaos sweep caught a real test-modelling bug in the partial-fill scenario: the first draft sent the wrong cumQty shape on the Fill ER and revealed the **#299 P1 cum-stale clamp** (`ExecutionReportProcessor.cs:1020-1029`) in action. The clamp rewrites `seedCum := origOrder.CumulativeQuantity` when the venue issues `erCum=0` against a partially-filled original — without it, the subsequent fill would re-book the partial and over-credit position. The test now reflects the real venue wire shape (Cancel-as-Replace with erCum=0 → Fill ER with cumulative post-fill total = NewQuantity).

This is exactly the kind of regression net the audit asked for: any future refactor that breaks the clamp will deterministically trip the partial-fill scenario.

## Test results

```
Passed!  - Failed:     0, Passed:  1135, Skipped:     0, Total:  1135
Duration: 11 s (full Application.Tests)
```

The chaos test itself runs in ~260ms for 1000 iterations.

## Out of scope (intentional)

Documented in §5 of the audit doc and worth restating here:

- Out-of-order Trade-before-Cancel reorder buffer. Wait for production signal on `trading.execution_reports.dropped_known_owner_missing_order` before investing.
- Multi-threaded concurrent chaos. `ExecutionReportProcessor.Apply` is documented as serialized by the gateway ingress pipeline; multi-thread chaos would test the harness, not the code under test.