### PR TITLE
compliance: thread FIXP listener FirmId through credential creation (#431)

### DIFF
--- a/backend/src/B3.Trading.Api/UserBotCredentialsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/UserBotCredentialsEndpoints.cs
@@ -43,7 +43,8 @@ public static class UserBotCredentialsEndpoints
             if (label.Length > MaxLabelLength)
                 return Results.BadRequest(new { error = $"Label exceeds {MaxLabelLength} characters." });
 
-            var created = await registry.CreateAsync(sub, label, ct);
+            var created = await registry.CreateAsync(sub, label, ct,
+                firmId: ctx.User.FindFirstValue(Auth.JwtIssuer.FirmClaim) ?? "default");
             var dto = new CreatedUserBotCredentialDto(
                 Id: created.Credential.Id,
                 Label: created.Credential.Label,

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -365,7 +365,8 @@ public sealed record UserBotCredentialSnapshot(
     string Label,
     string SecretHash,
     DateTimeOffset CreatedAtUtc,
-    DateTimeOffset? RevokedAtUtc);
+    DateTimeOffset? RevokedAtUtc,
+    string? FirmId = null);
 
 public sealed record OrderSnapshot(
     ulong ClOrdId,

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -808,6 +808,13 @@ public sealed record UserBotCredentialCreatedEvent : WalEvent
     public required string Label { get; init; }
     public required string SecretHash { get; init; }
     public required DateTimeOffset CreatedAtUtc { get; init; }
+    /// <summary>
+    /// #431 — firm scope inherited from the JWT <c>firm</c> claim of the
+    /// human user at credential creation time. Nullable so events minted
+    /// by older builds (pre-#431) replay as the legacy <c>"default"</c>
+    /// sentinel — see <c>StateSnapshotter</c> apply step.
+    /// </summary>
+    public string? FirmId { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotCredentialRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotCredentialRegistry.cs
@@ -17,7 +17,8 @@ public interface IUserBotCredentialRegistry
     Task<CreatedUserBotCredential> CreateAsync(
         string userId,
         string label,
-        CancellationToken ct);
+        CancellationToken ct,
+        string firmId = "default");
 
     /// <summary>
     /// Soft-revoke (sets <c>RevokedAtUtc</c>). Returns <c>false</c>

--- a/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/IUserBotSessionRegistry.cs
@@ -16,7 +16,8 @@ public sealed record BotSessionPrincipal(
     string UserId,
     Guid CredentialId,
     string CredShortId,
-    string Label);
+    string Label,
+    string FirmId = "default");
 
 /// <summary>
 /// Persistent per-credential state managed by

--- a/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotCredentialRegistry.cs
+++ b/backend/src/B3.Trading.Application/UserBots/InMemoryUserBotCredentialRegistry.cs
@@ -44,10 +44,11 @@ public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegist
     }
 
     public Task<CreatedUserBotCredential> CreateAsync(
-        string userId, string label, CancellationToken ct)
+        string userId, string label, CancellationToken ct, string firmId = "default")
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
         ArgumentException.ThrowIfNullOrWhiteSpace(label);
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
 
         var shortId = MintShortId();
         var secret = MintSecret();
@@ -60,7 +61,8 @@ public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegist
             Label: label.Trim(),
             SecretHash: hash,
             CreatedAtUtc: DateTimeOffset.UtcNow,
-            RevokedAtUtc: null);
+            RevokedAtUtc: null,
+            FirmId: firmId);
 
         var evt = new UserBotCredentialCreatedEvent
         {
@@ -70,6 +72,7 @@ public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegist
             Label = credential.Label,
             SecretHash = credential.SecretHash,
             CreatedAtUtc = credential.CreatedAtUtc,
+            FirmId = credential.FirmId,
         };
 
         if (_dispatcher is not null)
@@ -171,7 +174,7 @@ public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegist
                 .ThenBy(c => c.Id)
                 .Select(c => new UserBotCredentialSnapshot(
                     c.Id, c.UserId, c.CredShortId, c.Label, c.SecretHash,
-                    c.CreatedAtUtc, c.RevokedAtUtc))
+                    c.CreatedAtUtc, c.RevokedAtUtc, c.FirmId))
                 .ToList();
         }
     }
@@ -208,7 +211,11 @@ public sealed class InMemoryUserBotCredentialRegistry : IUserBotCredentialRegist
             {
                 var c = new UserBotCredential(
                     s.Id, s.UserId, s.CredShortId, s.Label, s.SecretHash,
-                    s.CreatedAtUtc, s.RevokedAtUtc);
+                    s.CreatedAtUtc, s.RevokedAtUtc,
+                    // #431 — pre-existing snapshots have no FirmId; replay
+                    // to the legacy "default" sentinel so attribution stays
+                    // aligned with the old listener behavior.
+                    FirmId: string.IsNullOrEmpty(s.FirmId) ? "default" : s.FirmId);
                 _byId[c.Id] = c;
                 _byShortId[c.CredShortId] = c;
             }

--- a/backend/src/B3.Trading.Application/UserBots/UserBotCredential.cs
+++ b/backend/src/B3.Trading.Application/UserBots/UserBotCredential.cs
@@ -19,6 +19,12 @@ namespace B3.Trading.Application.UserBots;
 /// other per-user surface (cash ledger, positions, kill-switch).
 /// Sub-issue D's listener must look up the human owner via this field.
 /// </remarks>
+/// <param name="FirmId">
+/// Firm scope inherited from the JWT <c>firm</c> claim of the human user
+/// at credential creation time (#431). Snapshots / WAL events minted by
+/// older builds replay with the legacy <c>"default"</c> sentinel so the
+/// pre-existing single-firm deployments keep their attribution.
+/// </param>
 public sealed record UserBotCredential(
     Guid Id,
     string UserId,
@@ -26,7 +32,8 @@ public sealed record UserBotCredential(
     string Label,
     string SecretHash,
     DateTimeOffset CreatedAtUtc,
-    DateTimeOffset? RevokedAtUtc = null);
+    DateTimeOffset? RevokedAtUtc = null,
+    string FirmId = "default");
 
 /// <summary>
 /// One-shot DTO returned by <see cref="IUserBotCredentialRegistry.CreateAsync"/>.

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpOrderAdapter.cs
@@ -181,7 +181,10 @@ internal sealed class FixpOrderAdapter
 
         var req = new OrderSubmissionRequest(
             Owner: owner,
-            FirmId: "default",
+            // #431 — firm scope flows from the authenticated FIXP credential
+            // (set at credential creation time from the JWT firm claim);
+            // legacy credentials hydrate as "default" via the registry.
+            FirmId: scope.Principal.FirmId,
             Symbol: symbol,
             SecurityId: securityId,
             Side: side,

--- a/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
+++ b/backend/src/B3.Trading.EntryPointListener/Hosting/FixpSessionConnection.cs
@@ -542,7 +542,8 @@ internal sealed class FixpSessionConnection : IBotSessionOutboundSender, IDispos
         // scope without re-querying the registry.
         var sessionState = await _sessions.GetOrCreateAsync(credential.Id, ct).ConfigureAwait(false);
         var principal = new BotSessionPrincipal(
-            credential.UserId, credential.Id, credential.CredShortId, credential.Label);
+            credential.UserId, credential.Id, credential.CredShortId, credential.Label,
+            credential.FirmId);
         _scope = new FixpConnectionScope(_connectionId, principal, sessionState);
 
         _logger.LogInformation(

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -1169,7 +1169,10 @@ public sealed class EventReplayer
             case UserBotCredentialCreatedEvent ubc:
                 _userBotCredentials?.ApplyCreated(new UserBotCredential(
                     ubc.Id, ubc.UserId, ubc.CredShortId, ubc.Label, ubc.SecretHash,
-                    ubc.CreatedAtUtc, RevokedAtUtc: null));
+                    ubc.CreatedAtUtc, RevokedAtUtc: null,
+                    // #431 — events emitted before firm attribution rolled out
+                    // hydrate as the legacy "default" sentinel.
+                    FirmId: string.IsNullOrEmpty(ubc.FirmId) ? "default" : ubc.FirmId));
                 break;
             case UserBotCredentialRevokedEvent ubr:
                 _userBotCredentials?.ApplyRevoked(ubr.Id, ubr.RevokedAtUtc);

--- a/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/UserBots/InMemoryUserBotCredentialRegistryTests.cs
@@ -245,6 +245,128 @@ public class InMemoryUserBotCredentialRegistryTests
         Assert.NotNull(await consumer.TryAuthenticateAsync(c2.PlainToken, default));
     }
 
+    // ───────────────────────── #431 firm attribution ─────────────────────────
+
+    [Fact]
+    public async Task CreateAsync_DefaultFirmId_IsLegacyDefaultSentinel()
+    {
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default);
+        // Pre-#431 callers (and the omitted-argument case) must keep
+        // attributing to the legacy "default" sentinel — that is what
+        // the listener has always emitted and what PositionKeeper
+        // bookkeeping expects when only one firm is configured.
+        Assert.Equal("default", c.Credential.FirmId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ExplicitFirmId_PropagatesIntoCredentialAndEvent()
+    {
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var r = new InMemoryUserBotCredentialRegistry(dispatcher);
+
+        var c = await r.CreateAsync("alice", "x", default, firmId: "alpha");
+        Assert.Equal("alpha", c.Credential.FirmId);
+
+        var created = Assert.IsType<UserBotCredentialCreatedEvent>(Assert.Single(store.Events));
+        Assert.Equal("alpha", created.FirmId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public async Task CreateAsync_BlankFirmId_Rejected(string? firmId)
+    {
+        var r = Reg();
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            r.CreateAsync("alice", "x", default, firmId: firmId!));
+    }
+
+    [Fact]
+    public async Task SnapshotRoundTrip_PreservesFirmId_AndHydratesLegacyAsDefault()
+    {
+        var src = Reg();
+        var alpha = await src.CreateAsync("alice", "a", default, firmId: "alpha");
+        var beta = await src.CreateAsync("bob", "b", default, firmId: "beta");
+
+        var snap = src.Snapshot().ToList();
+        Assert.All(snap, row => Assert.NotNull(row.FirmId));
+
+        // Splice in a legacy snapshot row (FirmId=null) and ensure the
+        // restored credential hydrates as the legacy "default" sentinel
+        // — the back-compat invariant for pre-#431 builds.
+        snap.Add(new UserBotCredentialSnapshot(
+            Id: Guid.NewGuid(),
+            UserId: "carol",
+            CredShortId: "LEGACY1234",
+            Label: "legacy",
+            SecretHash: "$2a$12$" + new string('a', 53),
+            CreatedAtUtc: DateTimeOffset.UtcNow,
+            RevokedAtUtc: null,
+            FirmId: null));
+
+        var dst = Reg();
+        dst.Restore(snap);
+
+        Assert.Equal("alpha", Assert.Single(dst.ListByUser("alice")).FirmId);
+        Assert.Equal("beta", Assert.Single(dst.ListByUser("bob")).FirmId);
+        Assert.Equal("default", Assert.Single(dst.ListByUser("carol")).FirmId);
+    }
+
+    [Fact]
+    public async Task EventReplay_PreservesExplicitFirmId_AndHydratesLegacyNullAsDefault()
+    {
+        var store = new RecordingEventStore();
+        var dispatcher = new EventDispatcher(store);
+        var producer = new InMemoryUserBotCredentialRegistry(dispatcher);
+
+        var modern = await producer.CreateAsync("alice", "a", default, firmId: "alpha");
+
+        // Synthesize a legacy WAL event whose FirmId field was never set
+        // (the persisted JSON wouldn't carry the property at all).
+        var legacy = new UserBotCredentialCreatedEvent
+        {
+            Id = Guid.NewGuid(),
+            UserId = "bob",
+            CredShortId = "LEGACY9999",
+            Label = "legacy",
+            SecretHash = modern.Credential.SecretHash,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+            FirmId = null,
+        };
+
+        var consumer = new InMemoryUserBotCredentialRegistry();
+        foreach (var e in store.Events.Concat(new WalEvent[] { legacy }))
+        {
+            if (e is UserBotCredentialCreatedEvent c)
+            {
+                consumer.ApplyCreated(new UserBotCredential(
+                    c.Id, c.UserId, c.CredShortId, c.Label, c.SecretHash,
+                    c.CreatedAtUtc, RevokedAtUtc: null,
+                    FirmId: string.IsNullOrEmpty(c.FirmId) ? "default" : c.FirmId));
+            }
+        }
+
+        Assert.Equal("alpha", Assert.Single(consumer.ListByUser("alice")).FirmId);
+        Assert.Equal("default", Assert.Single(consumer.ListByUser("bob")).FirmId);
+    }
+
+    [Fact]
+    public async Task TryAuthenticate_RestoresFirmIdOnReturnedCredential()
+    {
+        // Sanity: the listener fishes BotSessionPrincipal.FirmId out of
+        // the row returned by TryAuthenticateAsync — that row must carry
+        // the firmId chosen at creation time, not the "default" sentinel.
+        var r = Reg();
+        var c = await r.CreateAsync("alice", "x", default, firmId: "alpha");
+
+        var resolved = await r.TryAuthenticateAsync(c.PlainToken, default);
+        Assert.NotNull(resolved);
+        Assert.Equal("alpha", resolved!.FirmId);
+    }
+
     private sealed class RecordingEventStore : IEventStore
     {
         public List<WalEvent> Events { get; } = new();


### PR DESCRIPTION
Closes #431.

## Problema

`FixpOrderAdapter.HandleNewOrderSingleAsync` construía `OrderSubmissionRequest` com `FirmId: "default"` hardcoded — toda ordem submetida via FIXP por user-bots era atribuída à mesma firm independente de qual firm o usuário criador da credencial pertencia. Quebra de isolamento multi-tenant no wire inbound (caminho REST já fazia certo via JWT `firm` claim).

## Solução

`FirmId` é capturado **no momento da criação da credencial** (a partir do `firm` claim do JWT do humano que criou) e flui:

```
JWT.firm → POST /api/user-bot-credentials → UserBotCredential.FirmId
        → UserBotCredentialCreatedEvent.FirmId (WAL)
        → UserBotCredentialSnapshot.FirmId
        → BotSessionPrincipal.FirmId (post-Negotiate)
        → OrderSubmissionRequest.FirmId (FixpOrderAdapter)
```

## Back-compat

WALs e snapshots pré-#431 não carregam `FirmId`. Replay hidrata como `"default"` (mesmo sentinel que `PositionKeeper` usa) tanto em `Restore()` quanto em `StateSnapshotter`. Deployments single-firm mantêm comportamento idêntico.

`IUserBotCredentialRegistry.CreateAsync` adiciona `firmId` como parâmetro **opcional** (default `"default"`), preservando todos os ~25 call-sites de teste sem modificação.

## Testes

- 7 testes novos em `InMemoryUserBotCredentialRegistryTests` cobrindo:
  - `CreateAsync` default sentinel
  - `CreateAsync` explicit firmId propaga p/ credential + WAL event
  - `CreateAsync` rejeita firmId blank/null/whitespace
  - Snapshot round-trip preserva FirmId; row legacy com `FirmId=null` hidrata como `"default"`
  - Event replay preserva FirmId explícito; legacy null hidrata como `"default"`
  - `TryAuthenticate` retorna credencial com FirmId correto (caminho consumido pelo listener)
- 1142 application + 134 listener + 493 api tests verdes

## Arquivos

| Camada | Arquivo |
|---|---|
| Domain | `UserBotCredential.cs`, `IUserBotCredentialRegistry.cs`, `IUserBotSessionRegistry.cs` (BotSessionPrincipal) |
| Persistence | `WalEvents.cs`, `Snapshots.cs`, `StateSnapshotter.cs` |
| Registry | `InMemoryUserBotCredentialRegistry.cs` |
| REST | `UserBotCredentialsEndpoints.cs` |
| Listener | `FixpSessionConnection.cs`, `FixpOrderAdapter.cs` |
| Tests | `InMemoryUserBotCredentialRegistryTests.cs` |

## Roadmap compliance B3

PR 3/13 do roadmap. Já merged: #442 (#429), #443 (#430). Próximo: #432 (BusinessReject envelope).
