### PR TITLE
compliance: persist BusinessReject envelopes to WAL (#432)

### DIFF
--- a/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEventJsonContext.cs
@@ -58,6 +58,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonSerializable(typeof(SubAccountCreatedEvent))]
 [JsonSerializable(typeof(SubAccountDeactivatedEvent))]
 [JsonSerializable(typeof(AuditLogEvent))]
+[JsonSerializable(typeof(BusinessRejectReceivedEvent))]
 [JsonSerializable(typeof(MarketData.BookTouchSnapshot))]
 public sealed partial class WalEventJsonContext : JsonSerializerContext
 {

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -56,6 +56,7 @@ namespace B3.Trading.Application.Persistence;
 [JsonDerivedType(typeof(SubAccountCreatedEvent), "sub-account.created")]
 [JsonDerivedType(typeof(SubAccountDeactivatedEvent), "sub-account.deactivated")]
 [JsonDerivedType(typeof(AuditLogEvent), "audit.log")]
+[JsonDerivedType(typeof(BusinessRejectReceivedEvent), "business-reject.received")]
 public abstract record WalEvent
 {
     public DateTimeOffset TimestampUtc { get; init; } = DateTimeOffset.UtcNow;
@@ -1181,4 +1182,35 @@ public sealed record AuditLogEvent : WalEvent
 
     /// <summary>Free-form per-capture-site context — endpoint args, before/after summaries, target user, etc. Bounded to small string values by convention so the WAL record stays compact.</summary>
     public Dictionary<string, string>? Details { get; init; }
+}
+
+/// <summary>
+/// #432. Records a venue <c>BusinessReject</c> — a structural rejection
+/// of an inbound message (malformed payload, unknown <c>SecurityID</c>,
+/// outside trading hours, etc.) that never produces an
+/// <see cref="ExecutionReportReceivedEvent"/>. Persisted so the operator
+/// can reconcile "request sent but no ER" gaps without log scraping and
+/// so the WAL replay reconstructs the audit trail.
+///
+/// <para>
+/// Has no ClOrdID anchor — the venue references the inbound seqnum
+/// (<see cref="RefSeqNum"/>) rather than a business identifier. The
+/// event is replay-inert: it does not mutate order state. It exists
+/// purely for audit / history visibility.
+/// </para>
+/// </summary>
+public sealed record BusinessRejectReceivedEvent : WalEvent
+{
+    /// <summary>Firm the reject arrived on (gateway-stamped).</summary>
+    public required string FirmId { get; init; }
+    /// <summary>FIX <c>RefSeqNum</c> — session seqnum of the rejected inbound message.</summary>
+    public required ulong RefSeqNum { get; init; }
+    /// <summary>FIX <c>BusinessRejectReason</c> code as emitted by the venue.</summary>
+    public required int RejectReason { get; init; }
+    /// <summary>Free-form detail string from the venue.</summary>
+    public string? Text { get; init; }
+    /// <summary>Venue session inbound seqnum of the reject message itself.</summary>
+    public required ulong SeqNum { get; init; }
+    /// <summary>Venue <c>SendingTime</c> from the reject envelope.</summary>
+    public required DateTimeOffset SendingTime { get; init; }
 }

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -126,6 +126,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     public bool IsReconnecting => Volatile.Read(ref _reconnectingState) == 1;
 
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
+    public event Action<BusinessRejectEnvelope>? BusinessRejectReceived;
 
     /// <summary>
     /// Establish the FIXP session and start the inbound event loop. Idempotent;
@@ -399,6 +400,33 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
                 {
                     MetricsRegistry.EntryPointTranslationErrors.Add(1, FirmTag());
                     _logger.LogError(ex, "Failed to translate upstream event {Event} for firm {Firm}", ev.GetType().Name, _firmId);
+                    continue;
+                }
+
+                // #432 — BusinessReject has no ClOrdID anchor and therefore
+                // no ExecutionReportEnvelope, but it must NOT be silently
+                // discarded: it indicates a structural rejection (malformed
+                // payload / unknown SecurityID / outside trading hours) for
+                // which the order request never produced an ER. Route via
+                // its own event channel + metric so the downstream router
+                // can persist it to the WAL for operator audit.
+                if (ev is UpModels.BusinessReject br)
+                {
+                    RecordBusinessReject(_firmId, br);
+                    try
+                    {
+                        BusinessRejectReceived?.Invoke(new BusinessRejectEnvelope(
+                            FirmId: _firmId,
+                            RefSeqNum: br.RefSeqNum,
+                            RejectReason: br.RejectReason,
+                            Text: br.Text,
+                            SeqNum: br.SeqNum,
+                            SendingTime: br.SendingTime));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "BusinessReject subscriber threw for firm {Firm}; continuing.", _firmId);
+                    }
                     continue;
                 }
 

--- a/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointExecutionReportRouter.cs
@@ -19,6 +19,11 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
     private readonly ExecutionReportProcessor _processor;
     private readonly EventDispatcher _dispatcher;
     private readonly Action<ExecutionReportEnvelope> _handler;
+    // #432 — second subscription on the gateway: BusinessReject envelopes
+    // travel on their own channel because they lack a ClOrdID anchor; the
+    // router persists them to the WAL for operator audit but does not
+    // hand them to the ExecutionReportProcessor (no order state changes).
+    private readonly Action<BusinessRejectEnvelope> _businessRejectHandler;
     // Q4.7 (#307). Both optional so the legacy two-arg test ctor keeps
     // working. When wired, the router captures a top-of-book snapshot
     // for every Fill / PartialFill and threads it through both the WAL
@@ -47,10 +52,16 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
         _orders = orders;
         _bookTop = bookTop;
         _handler = OnExecutionReport;
+        _businessRejectHandler = OnBusinessReject;
         _client.ExecutionReportReceived += _handler;
+        _client.BusinessRejectReceived += _businessRejectHandler;
     }
 
-    public void Dispose() => _client.ExecutionReportReceived -= _handler;
+    public void Dispose()
+    {
+        _client.ExecutionReportReceived -= _handler;
+        _client.BusinessRejectReceived -= _businessRejectHandler;
+    }
 
     private void OnExecutionReport(ExecutionReportEnvelope er)
     {
@@ -141,6 +152,37 @@ public sealed class EntryPointExecutionReportRouter : IDisposable
             _dispatcher.RunExclusive(() =>
                 _processor.Apply(er.ClOrdId, kind, er.LeavesQuantity, er.CumulativeQuantity,
                     er.LastQuantity, er.LastPrice, er.RejectReason, er.OrigClOrdId, envelopeFirmId: er.FirmId, bookTouch: bookTouch));
+        }
+    }
+
+    // #432. BusinessReject is replay-inert (no order state mutation), so the
+    // router just persists it to the WAL and lets the dispatcher fan it out
+    // to any subscribers (history projection, WS fan-out — both deferred to
+    // follow-up issues). The dispatcher lock isn't needed because nothing
+    // downstream consumes the in-memory ordering against ER right now;
+    // ordering vs ER is preserved by the WAL seqnum anyway.
+    private void OnBusinessReject(BusinessRejectEnvelope br)
+    {
+        var walEvent = new BusinessRejectReceivedEvent
+        {
+            FirmId = br.FirmId ?? "default",
+            RefSeqNum = br.RefSeqNum,
+            RejectReason = br.RejectReason,
+            Text = br.Text,
+            SeqNum = br.SeqNum,
+            SendingTime = br.SendingTime,
+        };
+
+        try
+        {
+            _dispatcher.Dispatch(walEvent, _ => { });
+        }
+        catch (WalBackpressureException)
+        {
+            // BR is an audit signal, not a state mutation — losing it on
+            // backpressure is acceptable. The metric makes the loss visible.
+            MetricsRegistry.WalBackpressure.Add(1,
+                new KeyValuePair<string, object?>("call_site", "business_reject.router"));
         }
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
+++ b/backend/src/B3.Trading.Infrastructure/FirmGatewayRegistry.cs
@@ -19,6 +19,7 @@ public sealed class FirmGatewayRegistry : IEntryPointClient, IFirmSessionStatusP
 {
     private readonly Dictionary<string, B3EntryPointClientGateway> _gateways;
     private readonly Action<ExecutionReportEnvelope> _bridge;
+    private readonly Action<BusinessRejectEnvelope> _brBridge;
 
     public FirmGatewayRegistry(IEnumerable<B3EntryPointClientGateway> gateways)
     {
@@ -26,8 +27,12 @@ public sealed class FirmGatewayRegistry : IEntryPointClient, IFirmSessionStatusP
         if (_gateways.Count == 0)
             throw new InvalidOperationException("FirmGatewayRegistry requires at least one configured firm.");
         _bridge = e => ExecutionReportReceived?.Invoke(e);
+        _brBridge = e => BusinessRejectReceived?.Invoke(e);
         foreach (var g in _gateways.Values)
+        {
             g.ExecutionReportReceived += _bridge;
+            g.BusinessRejectReceived += _brBridge;
+        }
     }
 
     public IReadOnlyDictionary<string, B3EntryPointClientGateway> Gateways => _gateways;
@@ -68,6 +73,7 @@ public sealed class FirmGatewayRegistry : IEntryPointClient, IFirmSessionStatusP
     }
 
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
+    public event Action<BusinessRejectEnvelope>? BusinessRejectReceived;
 
     // Submit-side surface unused — OrdersEndpoints injects IExchangeGateway,
     // which resolves to MultiFirmExchangeGateway (which dispatches by firmId).
@@ -81,7 +87,10 @@ public sealed class FirmGatewayRegistry : IEntryPointClient, IFirmSessionStatusP
     public async ValueTask DisposeAsync()
     {
         foreach (var g in _gateways.Values)
+        {
             g.ExecutionReportReceived -= _bridge;
+            g.BusinessRejectReceived -= _brBridge;
+        }
         foreach (var g in _gateways.Values)
             await g.DisposeAsync().ConfigureAwait(false);
     }

--- a/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
@@ -22,6 +22,18 @@ public interface IEntryPointClient
     /// implementation contract; consumers do not have to lock.
     /// </summary>
     event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
+
+    /// <summary>
+    /// #432 — raised whenever the exchange pushes a <c>BusinessReject</c>
+    /// (structural rejection: malformed message, unknown SecurityID,
+    /// outside trading hours, etc.). These have no ClOrdID anchor so
+    /// they cannot piggy-back on the ER pipeline, but the platform must
+    /// still surface them: a venue BusinessReject means an order request
+    /// never produced an ExecutionReport, and the operator/trader needs
+    /// the audit trail to reconcile. Single-threaded by implementation
+    /// contract.
+    /// </summary>
+    event Action<BusinessRejectEnvelope>? BusinessRejectReceived;
 }
 
 public enum EpSide
@@ -113,3 +125,34 @@ public sealed record ExecutionReportEnvelope(
     /// unchanged — a null envelope FirmId skips the cross-firm check.
     /// </summary>
     string? FirmId = null);
+
+/// <summary>
+/// #432. Wire-layer envelope for a venue <c>BusinessReject</c> — a
+/// structural rejection of an inbound message that never produced an
+/// ExecutionReport (e.g. malformed payload, unknown <c>SecurityID</c>,
+/// outside trading hours). No ClOrdID anchor (the reject references the
+/// session seqnum, not a business id), so it travels on its own event
+/// channel rather than as a degraded
+/// <see cref="ExecutionReportEnvelope"/>.
+/// </summary>
+/// <param name="FirmId">Source firm the reject arrived on. Always
+/// populated by the gateway/mock; nullable only to stay symmetric with
+/// <see cref="ExecutionReportEnvelope"/>.</param>
+/// <param name="RefSeqNum">FIX <c>RefSeqNum</c> — session seqnum of the
+/// rejected inbound message. Anchors the reject to a request when the
+/// caller correlates by seqnum (see RFC outbound seqnum reservation).</param>
+/// <param name="RejectReason">FIX <c>BusinessRejectReason</c> code as
+/// emitted by the venue.</param>
+/// <param name="Text">Human-readable detail string from the venue —
+/// preserved verbatim for operator audit / log scraping.</param>
+/// <param name="SeqNum">Venue session inbound seqnum of the reject
+/// message itself.</param>
+/// <param name="SendingTime">Venue <c>SendingTime</c> from the reject
+/// envelope.</param>
+public sealed record BusinessRejectEnvelope(
+    string? FirmId,
+    ulong RefSeqNum,
+    int RejectReason,
+    string? Text,
+    ulong SeqNum,
+    DateTimeOffset SendingTime);

--- a/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/MockEntryPointClient.cs
@@ -41,6 +41,7 @@ public sealed class MockEntryPointClient : IEntryPointClient
     public Func<OrderCancelRequest, Task>? CancelDelayInjector { get; set; }
 
     public event Action<ExecutionReportEnvelope>? ExecutionReportReceived;
+    public event Action<BusinessRejectEnvelope>? BusinessRejectReceived;
 
     public Task SubmitNewOrderAsync(NewOrderSingle request, CancellationToken cancellationToken)
     {
@@ -117,4 +118,11 @@ public sealed class MockEntryPointClient : IEntryPointClient
     /// </summary>
     public void EmitExecutionReport(ExecutionReportEnvelope er) =>
         ExecutionReportReceived?.Invoke(er);
+
+    /// <summary>
+    /// #432 — test/host hook to push a <c>BusinessReject</c> through the
+    /// exchange-side event channel.
+    /// </summary>
+    public void EmitBusinessReject(BusinessRejectEnvelope reject) =>
+        BusinessRejectReceived?.Invoke(reject);
 }

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -121,6 +121,97 @@ public class EntryPointGatewayAndRouterTests
         Assert.Single(sink.Events);
     }
 
+    [Fact]
+    public void Router_OnBusinessReject_AppendsWalEvent_WithGatewayStampedFirm()
+    {
+        // #432. BusinessReject from the venue must reach the WAL so the
+        // operator can reconcile "request sent but no ER" gaps and so the
+        // history projection / replay can surface it. The router stamps
+        // FirmId from the envelope (which the gateway itself stamps from
+        // its own configured firm) — defending against a future refactor
+        // that forgets to plumb FirmId through.
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new TestSink();
+        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var client = new MockEntryPointClient();
+        var store = new BrRecordingStore();
+        var dispatcher = new EventDispatcher(store, Array.Empty<IExecutionFanOutSink>());
+        using var router = new EntryPointExecutionReportRouter(client, proc, dispatcher);
+
+        var sendingTime = new DateTimeOffset(2026, 5, 24, 14, 30, 0, TimeSpan.Zero);
+        client.EmitBusinessReject(new BusinessRejectEnvelope(
+            FirmId: "FIRM-A",
+            RefSeqNum: 4242UL,
+            RejectReason: 3,
+            Text: "Unknown SecurityID",
+            SeqNum: 5000UL,
+            SendingTime: sendingTime));
+
+        var (_, evt) = Assert.Single(store.Recorded);
+        var br = Assert.IsType<BusinessRejectReceivedEvent>(evt);
+        Assert.Equal("FIRM-A", br.FirmId);
+        Assert.Equal(4242UL, br.RefSeqNum);
+        Assert.Equal(3, br.RejectReason);
+        Assert.Equal("Unknown SecurityID", br.Text);
+        Assert.Equal(5000UL, br.SeqNum);
+        Assert.Equal(sendingTime, br.SendingTime);
+
+        // BR is replay-inert — it must not touch order state.
+        Assert.Empty(sink.Events);
+    }
+
+    [Fact]
+    public void Router_OnBusinessReject_NullFirm_DefaultsToDefaultFirm()
+    {
+        // Back-compat: legacy gateways / mocks that don't stamp FirmId
+        // still produce a recoverable WAL row rather than crashing.
+        var ownership = new OrderOwnershipMap();
+        var book = new WorkingOrderBook();
+        var positions = new PositionKeeper();
+        var sink = new TestSink();
+        var proc = new ExecutionReportProcessor(ownership, book, positions, sink, new NoOpMarginProvider(), NullLogger<ExecutionReportProcessor>.Instance);
+        var client = new MockEntryPointClient();
+        var store = new BrRecordingStore();
+        var dispatcher = new EventDispatcher(store, Array.Empty<IExecutionFanOutSink>());
+        using var router = new EntryPointExecutionReportRouter(client, proc, dispatcher);
+
+        client.EmitBusinessReject(new BusinessRejectEnvelope(
+            FirmId: null,
+            RefSeqNum: 1UL,
+            RejectReason: 0,
+            Text: null,
+            SeqNum: 2UL,
+            SendingTime: DateTimeOffset.UtcNow));
+
+        var (_, evt) = Assert.Single(store.Recorded);
+        var br = Assert.IsType<BusinessRejectReceivedEvent>(evt);
+        Assert.Equal("default", br.FirmId);
+    }
+
+    private sealed class BrRecordingStore : IEventStore
+    {
+        public System.Collections.Concurrent.ConcurrentQueue<(long Seq, WalEvent Event)> Recorded { get; } = new();
+        private long _seq;
+        public long CurrentSeq => Interlocked.Read(ref _seq);
+        public long Append(WalEvent evt)
+        {
+            var s = Interlocked.Increment(ref _seq);
+            Recorded.Enqueue((s, evt));
+            return s;
+        }
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> _) => Append(evt);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async System.Collections.Generic.IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
     private sealed class TestSink : IExecutionEventSink, IExecutionFanOutSink
     {
         public readonly List<ExecutionEvent> Events = new();


### PR DESCRIPTION
Closes #432.

Venue `BusinessReject` (BR) was **100% silent** in the gateway path:
`B3EntryPointClientGateway.Translate` returned `null` for `UpModels.BusinessReject`, the (already-declared) `RecordBusinessReject` metric helper was **dead code**, and there was no event channel for downstream observers. Operators had no way to reconcile a "request sent but no ER" gap without log scraping, and WAL replay never reconstructed the reject — a compliance gap for audit / `/executions/history` paridade.

## What changed

Wire seam → router → WAL:

- `IEntryPointClient` gains `BusinessRejectReceived` event + `BusinessRejectEnvelope` record (`FirmId?`, `RefSeqNum`, `RejectReason`, `Text?`, `SeqNum`, `SendingTime`).
- `B3EntryPointClientGateway` now raises the event (FirmId-stamped from its own configured firm) **and** finally invokes the existing `EntryPointBusinessRejects` counter.
- `FirmGatewayRegistry` bridges per-firm BR streams onto the aggregate event so the single registered `EntryPointExecutionReportRouter` sees every firm.
- `EntryPointExecutionReportRouter` subscribes to BR and persists each one as a new `BusinessRejectReceivedEvent` WAL row. **Replay-inert**: no order state mutation, no `ExecutionReportProcessor.Apply` call — BR has no ClOrdID anchor (it references the rejected message by inbound `RefSeqNum`).
- New WAL event registered in `WalEvents.cs` discriminator + `WalEventJsonContext`.
- `MockEntryPointClient` gains an `EmitBusinessReject` test seam.

## What is intentionally deferred

The issue acceptance criteria mentions surfacing BR in `/executions/history` and the WS `executions.me` (or new `business.me`) channel + e2e FE test. **Punted to a follow-up issue** — the channel decision needs UI alignment, and these are additive consumers of the already-persisted WAL row (no further changes to the wire/audit critical path).

## Tests

- `Router_OnBusinessReject_AppendsWalEvent_WithGatewayStampedFirm` — happy path; asserts every BR field round-trips into the WAL, and that order state stays untouched.
- `Router_OnBusinessReject_NullFirm_DefaultsToDefaultFirm` — back-compat for callers/mocks that don't stamp FirmId.
- Existing `BusinessReject_TranslatesToNullEnvelope` kept — documents that `Translate` intentionally returns null for BR (it's not an ER and never was).
- Full suite green: 1136 Application + 134 EntryPointListener + 493 Api + Domain/Reconciliation/SimulatorBot.

## Risk

- Additive on the wire and in the WAL (new discriminator key `business-reject.received`). Replay tolerates unknown keys, and FirmId defaults to `"default"` for legacy rows.
- No state-mutation surface touched.
