### PR TITLE
compliance: cross-firm beneficial-owner STP scope (#433)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -762,6 +762,20 @@ public static class MetricsRegistry
     public static readonly Counter<long> StopCheckSkippedNoRef =
         Meter.CreateCounter<long>("trading.risk.stop_check_skipped_no_ref");
 
+    // #433. Self-trade rejections at the pre-trade gate. Tagged with:
+    //   - scope: same_firm | cross_firm
+    //     same_firm: the contra order belongs to the same (firm, owner)
+    //     cross_firm: the contra order belongs to a different firm
+    //                 mapped to the same beneficial owner via the
+    //                 BeneficialOwners registry (CVM 168 práticas
+    //                 equitativas guard rail).
+    //   - mode: block (the only mode supported today; CancelOldest /
+    //                  CancelBoth wait on B3.EntryPoint SDK exposing
+    //                  SelfTradePreventionInstruction — see RFC
+    //                  pre-trade-risk-v2 §STP).
+    public static readonly Counter<long> SelfTradeRejected =
+        Meter.CreateCounter<long>("trading.risk.stp.rejected_total");
+
     // Per-symbol age (seconds) of the last live MD update held in the
     // MarketDataReferencePrice cache. Sourced from a callback registered
     // by the provider on construction (singleton). Symbols that have

--- a/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SelfTradePreventionCheck.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Options;
 
@@ -67,11 +68,27 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly WorkingOrderBook _orders;
+    private readonly IBeneficialOwnerResolver _beneficialOwners;
 
-    public SelfTradePreventionCheck(IOptionsMonitor<RiskOptions> options, WorkingOrderBook orders)
+    public SelfTradePreventionCheck(
+        IOptionsMonitor<RiskOptions> options,
+        WorkingOrderBook orders,
+        IBeneficialOwnerResolver beneficialOwners)
     {
         _options = options;
         _orders = orders;
+        _beneficialOwners = beneficialOwners;
+    }
+
+    // Back-compat ctor for tests + legacy DI that don't wire the
+    // beneficial-owner resolver yet. Cross-firm scope is unreachable
+    // when constructed this way (the resolver collapses BO == owner
+    // and only ever returns the input owner from OwnersFor).
+    public SelfTradePreventionCheck(
+        IOptionsMonitor<RiskOptions> options,
+        WorkingOrderBook orders)
+        : this(options, orders, new DefaultBeneficialOwnerResolver())
+    {
     }
 
     // Ordered just after no_naked_short (180) and before position
@@ -90,29 +107,75 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
         if (allow == true) return RiskDecision.Approve;
 
         var oppositeSide = ctx.Side == OrderSide.Buy ? OrderSide.Sell : OrderSide.Buy;
+
+        // Phase 1 — same-firm scope (pre-#433 behavior, unchanged).
         // PR #316 P2: scope the contra-order scan to the caller's firm
         // so an opposite-side working order in FIRM02 cannot reject a
         // FIRM01 order from the same JWT sub. Self-trading is a venue-
         // session concern (the matching engine groups orders by firm
-        // session, not by end-client), so cross-firm pairs of the same
-        // owner can never wash-trade through this platform.
+        // session, not by end-client), so same-firm same-owner pairs
+        // ARE the wash trade.
         foreach (var existing in _orders.ForEndClientAndFirm(ctx.FirmId, ctx.Owner))
         {
             if (existing.Side != oppositeSide) continue;
             if (!string.Equals(existing.Symbol, ctx.Symbol, StringComparison.Ordinal)) continue;
             if (!IsStillRestable(existing)) continue;
 
-            // Presence-based: do NOT consult prices. Any opposite-side
-            // working order in the same symbol is enough to reject.
-            return RiskDecision.Reject(
-                $"self_trade_prevention: own opposite-side {existing.Side} order " +
-                $"{existing.LeavesQuantity}@" +
-                $"{(existing.Price.HasValue ? existing.Price.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "MKT")} " +
-                $"is working on {ctx.Symbol} (clOrdId={existing.ClOrdId}); " +
-                $"set AllowSelfTrade=true to opt out");
+            MetricsRegistry.SelfTradeRejected.Add(1,
+                new KeyValuePair<string, object?>("scope", "same_firm"),
+                new KeyValuePair<string, object?>("mode", "block"));
+            return RiskDecision.Reject(BuildReason("same_firm", existing, ctx));
+        }
+
+        // Phase 2 — cross-firm beneficial-owner scope (#433).
+        // CVM 168 práticas equitativas: a single beneficial owner cannot
+        // wash-trade across firms. Opt-in via EnforceCrossFirmStp so
+        // single-firm and same-BO-on-purpose deployments retain the
+        // pre-existing semantics. The matching engine on B3 isolates by
+        // firm session, so a cross-firm contra pair is allowed to fill
+        // at the venue — which is exactly the wash-trade vector the
+        // platform must close on its side.
+        var enforceCrossFirm = RiskLimitsResolver.Resolve(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.EnforceCrossFirmStp);
+        if (enforceCrossFirm != true) return RiskDecision.Approve;
+
+        var beneficialOwnerId = _beneficialOwners.Resolve(ctx.Owner);
+        foreach (var siblingOwner in _beneficialOwners.OwnersFor(beneficialOwnerId))
+        {
+            foreach (var existing in _orders.ForEndClient(siblingOwner))
+            {
+                if (string.Equals(existing.FirmId, ctx.FirmId, StringComparison.Ordinal)
+                    && existing.Owner == ctx.Owner)
+                {
+                    // Already covered by Phase 1.
+                    continue;
+                }
+                if (existing.Side != oppositeSide) continue;
+                if (!string.Equals(existing.Symbol, ctx.Symbol, StringComparison.Ordinal)) continue;
+                if (!IsStillRestable(existing)) continue;
+
+                MetricsRegistry.SelfTradeRejected.Add(1,
+                    new KeyValuePair<string, object?>("scope", "cross_firm"),
+                    new KeyValuePair<string, object?>("mode", "block"));
+                return RiskDecision.Reject(BuildReason("cross_firm", existing, ctx, beneficialOwnerId));
+            }
         }
 
         return RiskDecision.Approve;
+    }
+
+    private static string BuildReason(string scope, Order existing, RiskContext ctx, string? beneficialOwnerId = null)
+    {
+        var price = existing.Price.HasValue
+            ? existing.Price.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : "MKT";
+        var boHint = beneficialOwnerId is null
+            ? ""
+            : $" (beneficial_owner={beneficialOwnerId}, contra_firm={existing.FirmId})";
+        return
+            $"self_trade_prevention[{scope}]: own opposite-side {existing.Side} order " +
+            $"{existing.LeavesQuantity}@{price} is working on {ctx.Symbol} " +
+            $"(clOrdId={existing.ClOrdId}){boHint}; set AllowSelfTrade=true to opt out";
     }
 
     // "Still restable" = order is on the book and has unfilled quantity.
@@ -125,4 +188,15 @@ public sealed class SelfTradePreventionCheck : IRiskCheck
                        and not OrderStatus.Cancelled
                        and not OrderStatus.Rejected
                        and not OrderStatus.Replaced;
+
+    // Used only by the legacy two-arg ctor for back-compat: collapses
+    // every owner to its own BO so cross-firm scope can't fire even
+    // if EnforceCrossFirmStp is set, when wired through a host that
+    // didn't register the real resolver yet.
+    private sealed class DefaultBeneficialOwnerResolver : IBeneficialOwnerResolver
+    {
+        public string Resolve(EndClientId owner) => owner.Value;
+        public IReadOnlyCollection<EndClientId> OwnersFor(string beneficialOwnerId) =>
+            new[] { new EndClientId(beneficialOwnerId) };
+    }
 }

--- a/backend/src/B3.Trading.Application/Risk/IBeneficialOwnerResolver.cs
+++ b/backend/src/B3.Trading.Application/Risk/IBeneficialOwnerResolver.cs
@@ -1,0 +1,87 @@
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// #433. Maps an <see cref="EndClientId"/> (platform-level "owner") to
+/// its <em>beneficial owner</em> — the real-world legal person / entity
+/// whose interest the order represents. A single beneficial owner can
+/// hold multiple platform owners (e.g. one CPF traded via two different
+/// firms registered on this trading host), and self-trade prevention
+/// (CVM 168 práticas equitativas) must cover wash-trades across that
+/// fan-out.
+///
+/// <para>
+/// Default policy when no mapping is configured: beneficial owner ==
+/// owner id. This is back-compat with every existing deployment — the
+/// cross-firm STP scope is opt-in via
+/// <see cref="RiskLimits.EnforceCrossFirmStp"/> AND requires explicit
+/// configuration of overlapping owner→BO entries to take effect.
+/// </para>
+/// </summary>
+public interface IBeneficialOwnerResolver
+{
+    /// <summary>Resolves the beneficial-owner id of a platform owner.</summary>
+    string Resolve(EndClientId owner);
+
+    /// <summary>
+    /// Returns every platform owner registered for the given beneficial
+    /// owner — including the queried owner itself when its mapping (or
+    /// implicit self-mapping) hits the same beneficial owner. The
+    /// returned list always contains at least the input owner.
+    /// </summary>
+    IReadOnlyCollection<EndClientId> OwnersFor(string beneficialOwnerId);
+}
+
+/// <summary>
+/// Options-backed implementation. Bound from
+/// <c>Trading:Risk:BeneficialOwners</c>: a flat
+/// <c>owner_id → beneficial_owner_id</c> dictionary. Lookups for owners
+/// not in the map collapse to <c>owner_id == beneficial_owner_id</c>,
+/// preserving the pre-#433 semantics.
+/// </summary>
+public sealed class OptionsBeneficialOwnerResolver : IBeneficialOwnerResolver
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+
+    public OptionsBeneficialOwnerResolver(IOptionsMonitor<RiskOptions> options)
+    {
+        _options = options;
+    }
+
+    public string Resolve(EndClientId owner)
+    {
+        var map = _options.CurrentValue.BeneficialOwners;
+        return map.TryGetValue(owner.Value, out var bo) && !string.IsNullOrWhiteSpace(bo)
+            ? bo
+            : owner.Value;
+    }
+
+    public IReadOnlyCollection<EndClientId> OwnersFor(string beneficialOwnerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(beneficialOwnerId);
+        var map = _options.CurrentValue.BeneficialOwners;
+        var owners = new List<EndClientId>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kv in map)
+        {
+            if (string.Equals(kv.Value, beneficialOwnerId, StringComparison.OrdinalIgnoreCase)
+                && seen.Add(kv.Key))
+            {
+                owners.Add(new EndClientId(kv.Key));
+            }
+        }
+
+        // Self-mapping fallback: when the BO id is not in the values of
+        // the map, it is implicitly the owner of the same name (the
+        // default-policy collapse described in <see cref="Resolve"/>).
+        if (owners.Count == 0 && seen.Add(beneficialOwnerId))
+        {
+            owners.Add(new EndClientId(beneficialOwnerId));
+        }
+
+        return owners;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -49,6 +49,15 @@ public sealed class RiskOptions
     /// only, no per-symbol override.
     /// </summary>
     public OrderRateOptions OrderRate { get; set; } = new();
+
+    /// <summary>
+    /// #433. Optional <c>owner_id → beneficial_owner_id</c> mapping for
+    /// cross-firm self-trade prevention. See
+    /// <see cref="IBeneficialOwnerResolver"/> for semantics. Unset
+    /// entries collapse to <c>BO == owner</c> (back-compat).
+    /// </summary>
+    public Dictionary<string, string> BeneficialOwners { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>
@@ -222,6 +231,21 @@ public sealed class RiskLimits
     public bool? AllowSelfTrade { get; set; }
 
     /// <summary>
+    /// #433. When <c>true</c>, the self-trade prevention check also
+    /// scans working orders that belong to <em>other firms</em> of the
+    /// same beneficial owner (as resolved by
+    /// <see cref="B3.Trading.Application.Risk.IBeneficialOwnerResolver"/>).
+    /// Compliance gap covered by Instrução CVM 168 (práticas equitativas):
+    /// a single beneficial owner trading through two firms on this
+    /// platform must not wash-trade across them. Default semantics
+    /// when unset everywhere in the precedence chain are conservative:
+    /// cross-firm STP is <b>off</b> (same-firm scope only) — opt in by
+    /// setting <c>true</c> per-firm / per-end-client. Has no effect when
+    /// <see cref="AllowSelfTrade"/> is <c>true</c> (the latter wins).
+    /// </summary>
+    public bool? EnforceCrossFirmStp { get; set; }
+
+    /// <summary>
     /// Slice of #108. When <c>true</c>, Market orders are rejected
     /// unless the reference-price lookup returns
     /// <see cref="ReferencePriceSource.Live"/> — i.e. the live MD feed
@@ -338,6 +362,7 @@ public static class RiskLimitsResolver
             MaxOpenOrders = Resolve(opts, endClient, firmId, symbol, l => l.MaxOpenOrders),
             AllowShortSell = Resolve(opts, endClient, firmId, symbol, l => l.AllowShortSell),
             AllowSelfTrade = Resolve(opts, endClient, firmId, symbol, l => l.AllowSelfTrade),
+            EnforceCrossFirmStp = Resolve(opts, endClient, firmId, symbol, l => l.EnforceCrossFirmStp),
             MarketRequiresLiveRef = Resolve(opts, endClient, firmId, symbol, l => l.MarketRequiresLiveRef),
             AllowedOrderTypes = ResolveRef(opts, endClient, firmId, symbol,
                 l => l.AllowedOrderTypes,

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -99,6 +99,7 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<IRiskCheck, MaxOpenOrdersCheck>();
         services.AddSingleton<IRiskCheck, SubAccountLimitsCheck>();
         services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
+        services.TryAddSingleton<IBeneficialOwnerResolver, OptionsBeneficialOwnerResolver>();
         services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
         services.AddSingleton<IRiskCheck, PriceCollarCheck>();
         services.AddSingleton<IRiskCheck, StaleReferencePriceCheck>();

--- a/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SelfTradePreventionCheckTests.cs
@@ -209,4 +209,141 @@ public class SelfTradePreventionCheckTests
         Assert.False(decision.Approved);
         Assert.Contains("clOrdId=7", decision.Reason);
     }
+
+    // ---- #433 cross-firm beneficial-owner scope -------------------------
+
+    private const string FirmA = "FIRM-A";
+    private const string FirmB = "FIRM-B";
+    private const string OwnerA = "alice";
+    private const string OwnerB = "alice_b";
+    private const string BO = "CPF-123";
+
+    private static (SelfTradePreventionCheck check, WorkingOrderBook book) BuildCrossFirm(
+        bool enforceCrossFirm = true, Dictionary<string, string>? boMap = null)
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { EnforceCrossFirmStp = enforceCrossFirm },
+            BeneficialOwners = boMap ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [OwnerA] = BO,
+                [OwnerB] = BO,
+            },
+        };
+        var book = new WorkingOrderBook();
+        var monitor = Wrap(opts);
+        var resolver = new OptionsBeneficialOwnerResolver(monitor);
+        var check = new SelfTradePreventionCheck(monitor, book, resolver);
+        return (check, book);
+    }
+
+    private static Order MakeFor(string firmId, string owner, ulong clOrdId, OrderSide side, decimal price,
+                                 string symbol = Symbol) =>
+        new(clOrdId, new EndClientId(owner), symbol, 4321UL, side, OrderType.Limit, 100, price, firmId);
+
+    private static RiskContext CtxFor(string firmId, string owner, OrderSide side, decimal price,
+                                       string symbol = Symbol) =>
+        new(new EndClientId(owner), firmId, symbol, side, OrderType.Limit, 100, price);
+
+    [Fact]
+    public void CrossFirm_SameBeneficialOwner_OptIn_Rejected()
+    {
+        // CVM 168 práticas equitativas: a single beneficial owner trading
+        // through two firms on this trading-host cannot wash-trade across
+        // the firms. Opt-in via EnforceCrossFirmStp + BeneficialOwners map.
+        var (check, book) = BuildCrossFirm();
+        Assert.True(book.TryAdd(MakeFor(FirmB, OwnerB, clOrdId: 99, OrderSide.Sell, 32.40m)));
+
+        var decision = check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m));
+
+        Assert.False(decision.Approved);
+        Assert.Contains("cross_firm", decision.Reason);
+        Assert.Contains($"beneficial_owner={BO}", decision.Reason);
+        Assert.Contains($"contra_firm={FirmB}", decision.Reason);
+        Assert.Contains("clOrdId=99", decision.Reason);
+    }
+
+    [Fact]
+    public void CrossFirm_SameBeneficialOwner_OptOut_Approved()
+    {
+        // Default-off back-compat: with EnforceCrossFirmStp unset (= null)
+        // the cross-firm wash-trade is allowed through. Tested by
+        // explicitly setting the flag false here for symmetry with the
+        // opt-in case.
+        var (check, book) = BuildCrossFirm(enforceCrossFirm: false);
+        Assert.True(book.TryAdd(MakeFor(FirmB, OwnerB, clOrdId: 99, OrderSide.Sell, 32.40m)));
+
+        var decision = check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m));
+
+        Assert.True(decision.Approved);
+    }
+
+    [Fact]
+    public void CrossFirm_DifferentBeneficialOwners_Approved()
+    {
+        // Different BO = different real-world legal persons; the cross-
+        // firm working order is legitimate counterparty activity even
+        // with EnforceCrossFirmStp on.
+        var (check, book) = BuildCrossFirm(boMap: new Dictionary<string, string>
+        {
+            [OwnerA] = "CPF-AAA",
+            [OwnerB] = "CPF-BBB",
+        });
+        Assert.True(book.TryAdd(MakeFor(FirmB, OwnerB, clOrdId: 99, OrderSide.Sell, 32.40m)));
+
+        var decision = check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m));
+
+        Assert.True(decision.Approved);
+    }
+
+    [Fact]
+    public void CrossFirm_AllowSelfTrade_Wins()
+    {
+        // AllowSelfTrade=true is the global opt-out; cross-firm scope
+        // does not override it.
+        var monitor = Wrap(new RiskOptions
+        {
+            Default = new RiskLimits { AllowSelfTrade = true, EnforceCrossFirmStp = true },
+            BeneficialOwners = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [OwnerA] = BO,
+                [OwnerB] = BO,
+            },
+        });
+        var book = new WorkingOrderBook();
+        var check = new SelfTradePreventionCheck(monitor, book, new OptionsBeneficialOwnerResolver(monitor));
+        Assert.True(book.TryAdd(MakeFor(FirmB, OwnerB, clOrdId: 99, OrderSide.Sell, 32.40m)));
+
+        Assert.True(check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m)).Approved);
+    }
+
+    [Fact]
+    public void CrossFirm_SameFirmContra_ReportedAsSameFirm_NotCrossFirm()
+    {
+        // Phase ordering: same-firm scope must run first so a contra
+        // order in the SAME (firm, owner) tuple is attributed to the
+        // same_firm bucket even with cross-firm enforcement on.
+        var (check, book) = BuildCrossFirm();
+        Assert.True(book.TryAdd(MakeFor(FirmA, OwnerA, clOrdId: 50, OrderSide.Sell, 32.40m)));
+
+        var decision = check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m));
+
+        Assert.False(decision.Approved);
+        Assert.Contains("same_firm", decision.Reason);
+        Assert.DoesNotContain("cross_firm", decision.Reason);
+    }
+
+    [Fact]
+    public void CrossFirm_NoBeneficialOwnerMap_CollapsesToOwnerSelf_NoFalseHit()
+    {
+        // With no BeneficialOwners entries, every owner is its own BO so
+        // OwnersFor(BO) returns just {owner}; a cross-firm contra from a
+        // DIFFERENT owner cannot match — no wash trade.
+        var (check, book) = BuildCrossFirm(boMap: new Dictionary<string, string>());
+        Assert.True(book.TryAdd(MakeFor(FirmB, OwnerB, clOrdId: 99, OrderSide.Sell, 32.40m)));
+
+        var decision = check.Check(CtxFor(FirmA, OwnerA, OrderSide.Buy, 32.50m));
+
+        Assert.True(decision.Approved);
+    }
 }


### PR DESCRIPTION
Closes #433.

CVM 168 — práticas equitativas requires that **a single beneficial owner cannot wash-trade across multiple firms registered on this trading host**. The pre-#433 STP check was scoped to `(firm, owner)` only (#316 narrowed it intentionally for the legitimate "same JWT sub registered in two firms" case), leaving the cross-firm same-beneficial-owner vector open: the B3 matching engine isolates by firm session, so two contra orders from the same CPF routed through `FIRM-A` and `FIRM-B` of this host **would happily match at the venue**.

## What this PR adds

- **`IBeneficialOwnerResolver`** + `OptionsBeneficialOwnerResolver` implementation, bound from `Trading:Risk:BeneficialOwners` (flat `owner_id → BO id` dictionary). Unmapped owners collapse to `BO == owner_id` — full back-compat.
- **`RiskLimits.EnforceCrossFirmStp`** (nullable bool, default off). Resolves through the existing per-end-client → per-firm → per-symbol → default precedence chain — same operator ergonomics as every other risk knob.
- **`SelfTradePreventionCheck`** runs **two phases**:
  - Phase 1 (unchanged): same-firm scope (`ForEndClientAndFirm`) — `same_firm` rejection.
  - Phase 2 (new, opt-in): for every sibling owner of the request's beneficial owner, scan opposite-side restable orders across **all firms** — `cross_firm` rejection. `AllowSelfTrade=true` still wins (global opt-out).
- **Metric `trading.risk.stp.rejected_total`** with tags `scope:{same_firm,cross_firm}` and `mode:block`. The `mode` tag is forward-compat for future `CancelOldest` / `CancelBoth` modes that **require venue-side STP** (see deferred section).

## What this PR intentionally defers

- **Wire-level STP** (`SelfTradePreventionInstruction` / `ExecInst`): verified via metadata inspection that **`B3.EntryPoint.Client` 0.14.4 does NOT expose any STP field on `NewOrderRequest`** — only `ClOrdID`, `SecurityId`, `Side`, `OrderType`, `Price`, `StopPrice`, `OrderQty`, `TimeInForce`, `AccountType`, `Account`, `ExpireDate`, `MinQty`, `MaxFloor`, `MemoText`. The mode enum stays at `block` until the SDK exposes the field. A follow-up issue will track this once a `B3.EntryPoint.Client` release surfaces it.
- **RFC `pre-trade-risk-v2` doc update**: pure documentation, deferred to keep this PR focused on the wire/audit surface.
- **CancelOldest / CancelBoth pre-trade-only emulation**: would require the trading host to issue a Cancel into the gateway before submitting the new order — non-trivial pipeline orchestration. Defer until the SDK exposes the venue-native field and we can compare the two approaches side-by-side.

## Tests

`SelfTradePreventionCheckTests` +6:

| Case | Behavior |
|---|---|
| `CrossFirm_SameBeneficialOwner_OptIn_Rejected` | Opt-in scope catches the wash-trade across firms |
| `CrossFirm_SameBeneficialOwner_OptOut_Approved` | Default off — back-compat |
| `CrossFirm_DifferentBeneficialOwners_Approved` | Distinct legal persons trade freely |
| `CrossFirm_AllowSelfTrade_Wins` | Global opt-out (`AllowSelfTrade=true`) overrides cross-firm enforcement |
| `CrossFirm_SameFirmContra_ReportedAsSameFirm_NotCrossFirm` | Phase ordering: same-firm bucket attributed correctly |
| `CrossFirm_NoBeneficialOwnerMap_CollapsesToOwnerSelf_NoFalseHit` | Implicit BO == owner; cross-firm with no map = no false positive |

22 STP tests total + full Application (1140) / Infrastructure / Domain / Reconciliation / EntryPointListener (134) / SimulatorBot suites green. Unrelated POV algo timing flake on the full slnx run (`PovAlgoEndpointTests.Pov_SlicesAfterMarketTrades`) — passes on rerun.

## Risk

- Additive on options (`BeneficialOwners` defaults to empty), on `RiskLimits` (new nullable bool), and on the wire (no SDK contract change).
- Same-firm scope is byte-identical to the pre-#433 behavior. Cross-firm scope is reachable only when an operator explicitly sets `EnforceCrossFirmStp=true` **and** populates the BO map — both opt-in.
- Legacy 2-arg `SelfTradePreventionCheck` ctor preserved for the existing test fixture; collapses to BO == owner so cross-firm scope is unreachable even if `EnforceCrossFirmStp` is set when wired through a non-DI path.
