### PR TITLE
Infra: mock seam OrderCancelReplaceRequest carries TIF/Stop/GTD (#437)

### DIFF
--- a/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
@@ -66,11 +66,20 @@ public sealed class EntryPointClientGateway : IExchangeGateway
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(original);
-        // Legacy adapter: OrderCancelReplaceRequest predates Q1.1 and
-        // does not carry TIF / StopPrice / GoodTillDate over the wire.
-        // The Q1.1 modify pipeline targets the B3EntryPointClientGateway
-        // (real adapter); this path is retained for the older
-        // IEntryPointClient seam used by tests and the demo driver.
+        // #437. The mock seam now carries TIF / StopPrice / GoodTillDate
+        // so test wire-mapping assertions stay faithful to the real
+        // adapter (B3EntryPointClientGateway.CancelReplaceAsync lines
+        // 232-288). Domain.Order.MergeReplacementOptionals enforces the
+        // invariants (StopPrice required iff Stop*; GTD required iff
+        // TIF==GoodTillDate; auto-clear when TIF moves away from GTD).
+        // Any violation throws ArgumentException which the caller
+        // (OrderModifyService) treats as a gateway-side failure and
+        // rolls back the same way it does any other replace dispatch
+        // failure.
+        var (effTif, effStop, effGtd) = Order.MergeReplacementOptionals(
+            original.Type, original.TimeInForce, original.StopPrice, original.GoodTillDate,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
+
         return _client.SubmitCancelReplaceAsync(
             new OrderCancelReplaceRequest(
                 original.ClOrdId, newClOrdId, original.SecurityId,
@@ -82,7 +91,10 @@ public sealed class EntryPointClientGateway : IExchangeGateway
                 // SDK path in B3EntryPointClientGateway.CancelReplaceAsync.
                 MaxFloor: original.DisplayQty is { } odq
                     ? Math.Min(odq, newQuantity)
-                    : (long?)null),
+                    : (long?)null,
+                TimeInForce: effTif,
+                StopPrice: effStop,
+                GoodTillDate: effGtd),
             cancellationToken);
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
@@ -1,3 +1,5 @@
+using B3.Trading.Domain;
+
 namespace B3.Trading.Infrastructure;
 
 /// <summary>
@@ -83,7 +85,28 @@ public sealed record OrderCancelReplaceRequest(
     /// inherited from the original order, clamped to <c>NewQuantity</c> when the
     /// replace shrinks the order below the original visible portion. Null when
     /// the original was a full-disclosure order.</summary>
-    long? MaxFloor = null);
+    long? MaxFloor = null,
+    /// <summary>
+    /// #437. Effective TimeInForce on the replacement after the
+    /// domain merge in <see cref="EntryPointClientGateway.CancelReplaceAsync"/>
+    /// — mirrors what the real adapter sends on the wire so test
+    /// assertions on the mock seam stay faithful to the venue
+    /// contract. Null only for legacy callers that have not been
+    /// updated to set it.
+    /// </summary>
+    TimeInForce? TimeInForce = null,
+    /// <summary>
+    /// #437. Effective StopPrice on the replacement (required iff
+    /// the order type is Stop / StopLimit). Mirrors the real
+    /// adapter's <c>req.StopPrice</c>.
+    /// </summary>
+    decimal? StopPrice = null,
+    /// <summary>
+    /// #437. Effective GoodTillDate on the replacement (required iff
+    /// <see cref="TimeInForce"/> is <see cref="Domain.TimeInForce.GTD"/>;
+    /// auto-cleared when TIF moves away from GTD by the domain merge).
+    /// </summary>
+    DateTimeOffset? GoodTillDate = null);
 
 /// <summary>
 /// ExecutionReport surfaced by the wire to the platform. <see cref="OrigClOrdId"/>

--- a/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/EntryPointGatewayAndRouterTests.cs
@@ -68,6 +68,44 @@ public class EntryPointGatewayAndRouterTests
         Assert.Equal(200, sent.NewQuantity);
         // Q3.4 (#284). Plain (no-reserve) replace must not surface MaxFloor.
         Assert.Null(sent.MaxFloor);
+        // #437. With no override the replace inherits the original's
+        // TimeInForce (Day default) and carries no Stop/GTD because
+        // OrderType is Limit and TIF != GoodTillDate.
+        Assert.Equal(TimeInForce.Day, sent.TimeInForce);
+        Assert.Null(sent.StopPrice);
+        Assert.Null(sent.GoodTillDate);
+    }
+
+    [Fact]
+    public async Task Gateway_CancelReplace_PropagatesTifStopAndGtd()
+    {
+        // #437. Mock seam parity with B3EntryPointClientGateway: when
+        // the modify pipeline asks to switch TIF to GoodTillDate it
+        // must also supply a GoodTillDate; Stop* order types must
+        // surface their StopPrice. The domain merge enforces these
+        // invariants; the gateway just plumbs the merged values onto
+        // the wire request so test wire-mapping pins both adapter
+        // paths to the same shape.
+        var client = new MockEntryPointClient();
+        var gateway = new EntryPointClientGateway(client, "FIRM-A");
+
+        var stopOrig = new Order(200UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy,
+            OrderType.StopLimit, 100, price: 30m, firmId: "FIRM-A", stopPrice: 29.5m);
+        await gateway.CancelReplaceAsync(stopOrig, 201UL, 100, 31m,
+            requestedTimeInForce: null, requestedStopPrice: 29m, requestedGoodTillDate: null,
+            CancellationToken.None);
+        var withStop = client.SubmittedReplaces.Last();
+        Assert.Equal(29m, withStop.StopPrice);
+
+        var gtdMoment = new DateTimeOffset(2030, 1, 2, 17, 0, 0, TimeSpan.Zero);
+        var dayOrig = new Order(300UL, new EndClientId("alice"), "PETR4", 4321UL, OrderSide.Buy,
+            OrderType.Limit, 100, 30m);
+        await gateway.CancelReplaceAsync(dayOrig, 301UL, 150, 30m,
+            requestedTimeInForce: TimeInForce.GTD, requestedStopPrice: null, requestedGoodTillDate: gtdMoment,
+            CancellationToken.None);
+        var gtd = client.SubmittedReplaces.Last();
+        Assert.Equal(TimeInForce.GTD, gtd.TimeInForce);
+        Assert.Equal(gtdMoment, gtd.GoodTillDate);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #437. The legacy `IEntryPointClient` seam (`MockEntryPointClient`) now carries `TimeInForce` / `StopPrice` / `GoodTillDate` on `OrderCancelReplaceRequest`, plumbed via `Order.MergeReplacementOptionals` exactly like the real `B3EntryPointClientGateway` adapter. Tests that pin wire mapping through the mock seam stay faithful to the venue contract.

3 test updates (2 assertions on the default-defaults case + 1 new test covering Stop-replace and TIF-to-GTD overrides). Full suite green.