### PR TITLE
Compliance: replace 5 TODOs with structured 'Deferred: see #...' notes (#439)

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -202,8 +202,8 @@ public static class AlgoEndpoints
                 case AlgoType.Pegged:
                     // Q3.3 (#283). Pegged shares the POST /algo surface
                     // with the other algos via the type discriminator.
-                    // Tick size has no per-symbol provider yet (open
-                    // TODO across the repo), so the API accepts an
+                    // Tick size has no per-symbol provider yet
+                    // (deferred — see #454), so the API accepts an
                     // explicit override and falls back to 0.01 (BRL
                     // equity default) — documented in the PR notes.
                     if (req.Pegged is null)
@@ -557,8 +557,8 @@ public sealed record CreateAlgoPovParams(
 /// <para>
 /// <b>Defaults.</b> <see cref="RepegIntervalMs"/> defaults to 500ms,
 /// <see cref="TickSize"/> defaults to <c>0.01</c> (BRL equity floor;
-/// per-symbol provider TODO), <see cref="ChildOrderType"/> defaults
-/// to <c>Limit</c> (the only legal value — Market would defeat the
+/// per-symbol provider deferred — see #454), <see cref="ChildOrderType"/>
+/// defaults to <c>Limit</c> (the only legal value — Market would defeat the
 /// peg). <see cref="OffsetTicks"/> is required and may be negative
 /// for passive pegs (Buy below the bid, Sell above the ask).
 /// </para>

--- a/backend/src/B3.Trading.Api/HistoryEndpoints.cs
+++ b/backend/src/B3.Trading.Api/HistoryEndpoints.cs
@@ -39,8 +39,8 @@ namespace B3.Trading.Api;
 /// retention grows. The cursor envelope is intentionally future-proof:
 /// <c>{seq,ts}</c> is enough to anchor a binary search via the segment
 /// index, so an indexed implementation can ship without a wire-shape
-/// change. TODO(history-index): indexed reader keyed by
-/// <c>(endclient, ts)</c>, tracked alongside the EOD materialiser.
+/// change. Deferred — see issue #453 (history-index reader keyed by
+/// <c>(endclient, ts)</c>, to land alongside the EOD materialiser).
 /// </para>
 /// </summary>
 public static class HistoryEndpoints

--- a/backend/src/B3.Trading.Application/Reports/Cvm/CvmReportWriter.cs
+++ b/backend/src/B3.Trading.Application/Reports/Cvm/CvmReportWriter.cs
@@ -157,12 +157,12 @@ public sealed class CvmReportWriter
         w.WriteElementString("ExecutedAtUtc", Namespace, row.ExecutedAtUtc.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
         w.WriteElementString("Counterparty", Namespace, CounterpartyFixed);
 
-        // CVM 505 (fundos) placeholder Fund column. TODO (#308): when
-        // an order-level fund-classification field exists, surface it
-        // here and have CvmReportSource pre-filter the row set to
-        // fund-tagged fills only. For now the element is emitted
-        // empty for 505 reports and omitted entirely for 35 reports
-        // so the same XSD validates both.
+        // CVM 505 (fundos) placeholder Fund column. Deferred to #452
+        // (#308 origin): when an order-level fund-classification
+        // field exists, surface it here and have CvmReportSource
+        // pre-filter the row set to fund-tagged fills only. For now
+        // the element is emitted empty for 505 reports and omitted
+        // entirely for 35 reports so the same XSD validates both.
         if (reportType == CvmReportType.Cvm505)
             w.WriteElementString("Fund", Namespace, string.Empty);
 

--- a/backend/src/B3.Trading.Application/Reports/Cvm/Schemas/CvmReport.xsd
+++ b/backend/src/B3.Trading.Application/Reports/Cvm/Schemas/CvmReport.xsd
@@ -10,7 +10,8 @@
   505 reports — the only difference is the optional <Fund>
   element on each <Transaction>, present in 505 reports as a
   placeholder until an order-level fund-classification field is
-  added (tracked as TODO in CvmReportWriter.WriteTransaction).
+  added (deferred — see issue #452, originally tracked as TODO
+  in CvmReportWriter.WriteTransaction).
 -->
 <xs:schema
     xmlns="urn:b3:cvm:35:v1"


### PR DESCRIPTION
Closes #439.

## What

Comment-only cleanup of the 5 TODOs catalogados na auditoria B3:

| Arquivo | TODO original | Classificação |
| --- | --- | --- |
| `CvmReportWriter.cs:160` | Fund-classification field | Deferred → #452 |
| `CvmReport.xsd:13` | Mesmo TODO (cross-reference) | Deferred → #452 |
| `HistoryEndpoints.cs:42` | Indexed reader O(N) → O(log) | Deferred → #453 |
| `AlgoEndpoints.cs:206` | Per-symbol tick-size provider | Deferred → #454 |
| `AlgoEndpoints.cs:560` | Mesmo TODO (cross-reference) | Deferred → #454 |

Todos são **WONTFIX-by-now**: dependem de SDK / domain extension / nova infra que não cabe nessa PR. Em vez de continuar como marcadores `TODO` órfãos, agora cada nota aponta explicitamente para o issue de rastreamento.

## Why

Auditoria B3 (CVM 168 — práticas equitativas, RFC §4.2) requer que limitações conhecidas tenham rastreabilidade. TODOs sem issue silenciam regressões em revisões futuras. Issues estruturadas têm: contexto, bloqueio, critério de aceite, refs.

## Tests

Comment-only — build verde, nenhum teste tocado. Full suite roda como antes (não rerodada porque o diff é XML doc + C# XML comments).

## Tracking issues abertos

* #452 — Wire CVM 505 fund-classification field
* #453 — Indexed reader para /orders/history
* #454 — Per-symbol tick-size provider
