### PR TITLE
ClOrdID: defense-in-depth on FIX 20-char wire limit (#440)

### DIFF
--- a/backend/src/B3.Trading.Application/ClOrdIdPrefixRegistry.cs
+++ b/backend/src/B3.Trading.Application/ClOrdIdPrefixRegistry.cs
@@ -36,6 +36,32 @@ public sealed class ClOrdIdPrefixRegistry
     public const ulong CounterMask = (1UL << CounterBits) - 1;
     public const long MaxPrefixIndex = 1L << 21;
 
+    /// <summary>
+    /// #440. Hard upper bound on the FIX wire representation of a
+    /// generated ClOrdID. FIX 4.4 §3.1.1 caps tag 11 (ClOrdID) at
+    /// 20 characters; B3 EntryPoint inherits the same limit. Today
+    /// the canonical encoding is the <c>ulong</c> rendered as a
+    /// decimal string via invariant culture (see
+    /// <see cref="EncodeFixClOrdId"/>) and the bit layout caps the
+    /// value at <c>(2^21 - 1) &lt;&lt; 40 | (2^40 - 1) = 2^61 - 1 =
+    /// 2_305_843_009_213_693_951</c> — 19 decimal digits — so we
+    /// have a 1-character margin. The defensive guard in
+    /// <see cref="Generate"/> catches any future encoding change
+    /// (adding a prefix string, switching to hex, widening counter
+    /// bits) that would silently push past the venue limit and
+    /// trigger BusinessReject at the gateway — a known footgun the
+    /// auditoria B3 (#439→#440) explicitly asked us to harden.
+    /// </summary>
+    public const int MaxFixClOrdIdLength = 20;
+
+    /// <summary>
+    /// Canonical wire encoding of a generated ClOrdID for FIX/B3 EntryPoint.
+    /// Centralised so the <see cref="MaxFixClOrdIdLength"/> guard, tests,
+    /// and any future log/audit string representation all agree byte-for-byte.
+    /// </summary>
+    public static string EncodeFixClOrdId(ulong clOrdId) =>
+        clOrdId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
     private readonly ConcurrentDictionary<EndClientId, EndClientCounter> _counters = new();
     private long _nextPrefix;
 
@@ -52,7 +78,22 @@ public sealed class ClOrdIdPrefixRegistry
         var seq = (ulong)Interlocked.Increment(ref entry.Counter);
         if (seq > CounterMask)
             throw new InvalidOperationException($"ClOrdID counter overflow for end-client {endClient.Value} (>2^{CounterBits}).");
-        return (entry.PrefixIdx << CounterBits) | seq;
+        var clOrdId = (entry.PrefixIdx << CounterBits) | seq;
+
+        // #440 defense-in-depth: pin the FIX wire-length cap so a
+        // future encoding change cannot silently push the produced
+        // ClOrdID past 20 characters (FIX 4.4 §3.1.1) and trigger
+        // BusinessReject at the venue. The check is O(log10 N) and
+        // runs once per submit; cheap relative to the WAL append it
+        // precedes.
+        var encoded = EncodeFixClOrdId(clOrdId);
+        if (encoded.Length > MaxFixClOrdIdLength)
+        {
+            throw new InvalidOperationException(
+                $"ClOrdID encoding produced {encoded.Length} characters ('{encoded}'), exceeds FIX limit of {MaxFixClOrdIdLength}. " +
+                "Either the bit layout widened (regression) or the encoding scheme changed without updating MaxFixClOrdIdLength.");
+        }
+        return clOrdId;
     }
 
     private EndClientCounter CreateCounter(EndClientId _)

--- a/backend/tests/B3.Trading.Application.Tests/ClOrdIdPrefixRegistryFixLimitTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ClOrdIdPrefixRegistryFixLimitTests.cs
@@ -1,0 +1,71 @@
+using B3.Trading.Application;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #440. Defense-in-depth coverage for the FIX 4.4 §3.1.1 20-char
+/// ClOrdID limit. The bit layout in <see cref="ClOrdIdPrefixRegistry"/>
+/// (prefix 21 bits, counter 40 bits) currently caps the produced
+/// <c>ulong</c> at <c>2^61 - 1 = 2_305_843_009_213_693_951</c> (19
+/// decimal digits) so the venue limit can never be hit today — but a
+/// future encoding change must NOT regress that silently. These
+/// tests pin both the canonical wire format and the runtime guard.
+/// </summary>
+public class ClOrdIdPrefixRegistryFixLimitTests
+{
+    [Fact]
+    public void MaxFixClOrdIdLength_MatchesFixSpec()
+    {
+        Assert.Equal(20, ClOrdIdPrefixRegistry.MaxFixClOrdIdLength);
+    }
+
+    [Fact]
+    public void EncodeFixClOrdId_AtBitLayoutMax_FitsWithin20Chars()
+    {
+        // Maximum value the current layout can produce:
+        // prefixIdx = MaxPrefixIndex - 1, counter = CounterMask.
+        var prefixIdx = (ulong)(ClOrdIdPrefixRegistry.MaxPrefixIndex - 1);
+        var maxValue = (prefixIdx << ClOrdIdPrefixRegistry.CounterBits) | ClOrdIdPrefixRegistry.CounterMask;
+
+        var encoded = ClOrdIdPrefixRegistry.EncodeFixClOrdId(maxValue);
+
+        // Sanity: the encoding is the invariant-culture decimal string.
+        Assert.Equal(maxValue.ToString(System.Globalization.CultureInfo.InvariantCulture), encoded);
+
+        Assert.True(encoded.Length <= ClOrdIdPrefixRegistry.MaxFixClOrdIdLength,
+            $"Encoded ClOrdID at bit-layout max is {encoded.Length} chars ('{encoded}'), exceeds FIX limit {ClOrdIdPrefixRegistry.MaxFixClOrdIdLength}.");
+
+        // Pin today's headroom so a regression that pushes the layout
+        // toward the limit triggers a code review, not a venue reject.
+        Assert.Equal(19, encoded.Length);
+    }
+
+    [Fact]
+    public void EncodeFixClOrdId_AtUlongMax_StillFitsWithin20Chars()
+    {
+        // The ulong type itself caps at 20 decimal digits
+        // (ulong.MaxValue = 18446744073709551615). Sanity-check this
+        // independently of our bit layout so a future encoding that
+        // emits the raw ulong without our prefix/counter split still
+        // satisfies the FIX cap.
+        var encoded = ClOrdIdPrefixRegistry.EncodeFixClOrdId(ulong.MaxValue);
+        Assert.Equal(20, encoded.Length);
+        Assert.True(encoded.Length <= ClOrdIdPrefixRegistry.MaxFixClOrdIdLength);
+    }
+
+    [Fact]
+    public void Generate_ProducesEncodingWithin20Chars()
+    {
+        var registry = new ClOrdIdPrefixRegistry();
+        var endClient = new EndClientId("END-001");
+
+        for (var i = 0; i < 100; i++)
+        {
+            var id = registry.Generate(endClient);
+            var encoded = ClOrdIdPrefixRegistry.EncodeFixClOrdId(id);
+            Assert.True(encoded.Length <= ClOrdIdPrefixRegistry.MaxFixClOrdIdLength,
+                $"Generated ClOrdID '{encoded}' is {encoded.Length} chars, exceeds FIX limit.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #440.

## What

Defense-in-depth on the **FIX 4.4 §3.1.1 20-char ClOrdID limit**.

Today `ClOrdIdPrefixRegistry.Generate` returns a `ulong` packed as `(prefixIdx << 40) | counter`. The current bit layout (prefix 21 bits, counter 40 bits) caps the value at `2^61 - 1 = 2_305_843_009_213_693_951` — 19 decimal digits in invariant culture, exactly 1 character margin to the venue limit. There was **no guard** pinning that invariant: a future encoding change (adding a string prefix, switching to hex, widening counter bits) could silently push past 20 chars and trigger `BusinessReject` at the gateway.

## How

* New `public const int MaxFixClOrdIdLength = 20` with the FIX spec reference inline in the XML doc.
* New `public static string EncodeFixClOrdId(ulong)` — the **single source of truth** for the wire format. Centralised so the guard, tests, and any future log/audit code agree byte-for-byte.
* Runtime guard at the bottom of `Generate`: encodes the produced ulong and throws `InvalidOperationException` with an actionable message if length exceeds `MaxFixClOrdIdLength`. O(log10 N) — cheap on the submit hot path.

## Why a runtime guard (not just `Debug.Assert`)

Auditoria B3 asked for **defense in depth**. `Debug.Assert` only runs in Debug builds — wouldn't catch a release-mode regression where the encoding shifts (e.g., someone wires a prefix string in front of the ulong without bumping the constant). The runtime cost is negligible.

## Tests

4 boundary tests in `ClOrdIdPrefixRegistryFixLimitTests`:

* `MaxFixClOrdIdLength_MatchesFixSpec` — pins the constant at 20.
* `EncodeFixClOrdId_AtBitLayoutMax_FitsWithin20Chars` — encodes the maximum value the current layout can produce, asserts ≤20 chars **and** pins today's headroom at exactly 19 chars (regression that pushes toward the limit triggers a code review).
* `EncodeFixClOrdId_AtUlongMax_StillFitsWithin20Chars` — `ulong.MaxValue` (`18446744073709551615`) is 20 chars — sanity-check that the ulong type cap matches the FIX limit by accident, not design. Useful if the layout someday emits the raw ulong without the prefix/counter split.
* `Generate_ProducesEncodingWithin20Chars` — smoke-tests 100 real `Generate` calls.

Full suite green: 1138 Application + 493 Api + 134 Listener + 81 Domain + 23 Sim + 12 Recon.
