### PR TITLE
compliance: SDK reflection tripwire para SubAccount/ExecInst/DisplayResetPolicy (#459)

### DIFF
--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using System.Reflection;
+using Up = B3.EntryPoint.Client.Models;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #459 (spin-off de #441 / #436). Tripwire defensivo: a auditoria
+/// de compliance B3 (24/05/2026) identificou 3 campos FIX/B3 que a
+/// plataforma deveria emitir/honrar no wire mas que o
+/// <c>B3.EntryPoint.Client 0.14.4</c> NÃO expõe no shape público
+/// de <see cref="Up.NewOrderRequest"/> e <see cref="Up.ReplaceOrderRequest"/>:
+///
+/// <list type="bullet">
+///   <item><b>SubAccount</b> — tag FIX 1, sub-conta dentro do CBLC
+///   Account, usada para allocation/segregation.</item>
+///   <item><b>ExecInst</b> — tag FIX 18, flags importantes
+///   (STP mode, do-not-aggregate, work-up, AON, …).</item>
+///   <item><b>DisplayResetPolicy</b> / <b>RefreshPolicy</b> —
+///   refresh policy do iceberg nativo (Always / OnPartialFill /
+///   Never). Hoje o REST + risk forçam <c>Always</c> via
+///   <see cref="B3.Trading.Application.OrderSubmissionService"/>
+///   (#297) para que a omissão no wire seja faithful — quando o
+///   SDK expor o campo, esse guard pode cair (fecha #298).</item>
+/// </list>
+///
+/// <para>
+/// <b>Como o tripwire funciona.</b> Cada teste afirma "a propriedade
+/// X NÃO existe no SDK". Quando o mantenedor do SDK adicionar a
+/// propriedade (bump de versão), o teste fica vermelho — o que é
+/// exatamente o sinal para plumbar o campo end-to-end no
+/// <see cref="B3.Trading.Infrastructure.B3EntryPointClientGateway"/>,
+/// no Domain / WAL / REST, e ENTÃO remover este tripwire (junto
+/// com o REST guard correspondente quando aplicável).
+/// </para>
+///
+/// <para>
+/// O lookup é case-insensitive porque o SDK pode escolher
+/// capitalização ligeiramente diferente (e.g. <c>SubAccount</c> vs
+/// <c>SubAcct</c>); usar <see cref="StringComparison.OrdinalIgnoreCase"/>
+/// + a substring evita um falso negativo onde só a capitalização
+/// muda. Caso o SDK exponha um nome inteiramente diferente
+/// (improvável dado o padrão FIX), o tripwire continuará verde e
+/// o gap será pego pela próxima auditoria — risco aceito.
+/// </para>
+/// </summary>
+public class B3EntryPointSdkTripwireTests
+{
+    private static readonly string[] SubAccountAliases = ["SubAccount", "SubAcct", "SubaccountId"];
+    private static readonly string[] ExecInstAliases   = ["ExecInst", "ExecutionInstruction", "ExecutionInstructions"];
+    private static readonly string[] DisplayPolicyAliases = ["DisplayResetPolicy", "RefreshPolicy", "DisplayRefreshPolicy"];
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_SubAccount_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), SubAccountAliases,
+            issueRef: "#441 (CBLC Account mapping) + #458");
+    }
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_ExecInst_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), ExecInstAliases,
+            issueRef: "#441 (ExecInst flags)");
+    }
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_DisplayResetPolicy_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), DisplayPolicyAliases,
+            issueRef: "#298 / #436. When this trips: wire order.DisplayResetPolicy in B3EntryPointClientGateway.BuildNewOrderRequest AND drop the REST/risk guard in OrdersEndpoints + OrderSubmissionService that today restricts policy to Always.");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_SubAccount_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), SubAccountAliases,
+            issueRef: "#441 / #458");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_ExecInst_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), ExecInstAliases,
+            issueRef: "#441");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_DisplayResetPolicy_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), DisplayPolicyAliases,
+            issueRef: "#298 / #436");
+    }
+
+    private static void AssertSdkPropertyMissing(Type sdkType, string[] aliases, string issueRef)
+    {
+        var props = sdkType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var found = aliases.FirstOrDefault(a => props.Contains(a));
+        Assert.True(found is null,
+            $"TRIPWIRE: B3.EntryPoint.Client agora expõe '{found}' em {sdkType.FullName}. " +
+            $"Ação esperada: plumbar o campo end-to-end (Domain → WAL → REST → BuildRequest), " +
+            $"adicionar wire-pinning test em B3EntryPointClientGatewayMapTests / TranslationTests, " +
+            $"e remover este tripwire. Tracking: {issueRef}.");
+    }
+}

--- a/docs/sdk-gaps.md
+++ b/docs/sdk-gaps.md
@@ -1,0 +1,48 @@
+# SDK gaps — `B3.EntryPoint.Client`
+
+Tracks fields/contracts that the **B3.EntryPoint.Client** package does not yet expose on its public surface, with the corresponding gap on this platform and a tripwire test that fires when the SDK starts exposing them.
+
+Verified against: `B3.EntryPoint.Client 0.14.4` (24/05/2026).
+
+## Outbound request shape — missing properties
+
+The auditoria de compliance B3 (#441 umbrella) identified 3 FIX/B3 fields that the platform should emit / honour on the wire but the SDK does not surface on `NewOrderRequest` / `ReplaceOrderRequest`:
+
+| Field | FIX tag | Compliance use | Platform compensation today | Tracking |
+| --- | --- | --- | --- | --- |
+| `SubAccount` | 1 | Sub-account inside the CBLC Account (allocation / segregation) | `Domain.Order.SubAccountId` carried internally; not visible to venue post-trade allocation | [#441](https://github.com/pedrosakuma/B3TradingPlatform/issues/441), [#458](https://github.com/pedrosakuma/B3TradingPlatform/issues/458) |
+| `ExecInst` | 18 | Flags (STP mode, do-not-aggregate, work-up, AON, …) | STP runs 100% host-side (sees every firm, doesn't need venue cooperation). AON / work-up have no host-side compensation | [#441](https://github.com/pedrosakuma/B3TradingPlatform/issues/441) |
+| `DisplayResetPolicy` / `RefreshPolicy` | n/a (B3 iceberg) | Iceberg refresh-on-execution policy (`Always` / `OnPartialFill` / `Never`) | REST + risk gate-bloqueia a escolha do trader a `Always` (#297) para que a omissão no wire seja faithful; loses the other two policies | [#298](https://github.com/pedrosakuma/B3TradingPlatform/issues/298), [#436](https://github.com/pedrosakuma/B3TradingPlatform/issues/436) (closed → covered here) |
+
+## Tripwire test
+
+[`backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs`](../backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs) asserts via reflection that each property is **absent** from `NewOrderRequest` and `ReplaceOrderRequest`. When the SDK adds the property (and we bump the package version) the test goes red — that is the signal to:
+
+1. **Wire the field end-to-end** in `Domain.Order` → WAL `OrderSubmittedEvent` → `OrderSubmissionRequest` → `BuildNewOrderRequest` / `BuildReplaceOrderRequest`.
+2. **Add wire-pinning coverage** in `B3EntryPointClientGatewayMapTests` / `B3EntryPointClientGatewayTranslationTests`.
+3. **Remove the matching REST/risk guard** when applicable (e.g. for `DisplayResetPolicy` drop the `Always`-only restriction in `OrdersEndpoints` + `OrderSubmissionService`, closing #298).
+4. **Delete the tripwire test** for that specific field.
+
+The lookup is case-insensitive and covers known FIX-style aliases (`SubAccount`/`SubAcct`, `ExecInst`/`ExecutionInstruction`, `DisplayResetPolicy`/`RefreshPolicy`); if the SDK ships with an entirely different name the tripwire stays green and the next auditoria catches the gap — risk accepted in favour of not false-positiving on capitalisation changes.
+
+## Outbound request shape — present but not plumbed
+
+These fields **are** exposed by 0.14.4 but the platform does not populate them today. Tracked separately (no tripwire needed — straight implementation):
+
+| Field | Tracking |
+| --- | --- |
+| `NewOrderRequest.MinQty` / `ReplaceOrderRequest.MinQty` | [#457](https://github.com/pedrosakuma/B3TradingPlatform/issues/457) |
+| `NewOrderRequest.Account` (CBLC numeric) | [#458](https://github.com/pedrosakuma/B3TradingPlatform/issues/458) (blocked on modelling decision) |
+
+## How to refresh this doc when the SDK bumps
+
+```bash
+# 1. Bump the package
+$EDITOR backend/Directory.Packages.props          # update B3.EntryPoint.Client version
+
+# 2. Re-run the tripwire
+dotnet test backend/tests/B3.Trading.Application.Tests/B3.Trading.Application.Tests.csproj \
+  --filter "FullyQualifiedName~B3EntryPointSdkTripwire"
+
+# 3. For each tripwire that goes red: plumb the field, update this table, delete the test.
+```


### PR DESCRIPTION
Closes #459. Refs umbrellas #441 e #436.

## Contexto

A auditoria de compliance B3 (24/05) identificou 3 campos FIX/B3 que a plataforma deveria emitir/honrar no wire mas que o `B3.EntryPoint.Client 0.14.4` **não** expõe no shape público de `NewOrderRequest` / `ReplaceOrderRequest`:

| Campo | FIX | Compensação atual |
|---|---|---|
| `SubAccount` | tag 1 | `Domain.Order.SubAccountId` só interno |
| `ExecInst` | tag 18 | STP roda host-side (não precisa cooperação venue); AON/work-up sem compensação |
| `DisplayResetPolicy` / `RefreshPolicy` | iceberg | REST + risk guard restringem a `Always` (#297) p/ omissão wire ser faithful |

Quando o SDK expor cada campo, é hora de plumbar end-to-end **e** dropar o guard correspondente (especialmente o de `DisplayResetPolicy` — fecha #298).

## O que entra

- `backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs` — 6 testes de reflexão case-insensitive (cobrem aliases FIX-style: `SubAcct`, `ExecutionInstruction`, `RefreshPolicy`, …) que assertam "a propriedade NÃO existe". Quando o SDK bumpar e adicionar a propriedade, o teste fica vermelho — sinal explícito para plumbar.
- `docs/sdk-gaps.md` — tabela dos 3 gaps + procedimento de refresh quando o package bumpar + ponteiro p/ a tripwire.

## Verificação

```
dotnet test ...B3.Trading.Application.Tests.csproj --filter "FullyQualifiedName~B3EntryPointSdkTripwire"
Passed!  - Failed: 0, Passed: 6, Total: 6
```

Build limpo, 0 warnings.
