### PR TITLE
compliance: Margin:Enabled default flipped to true + opt-out warning (#416)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -94,10 +94,22 @@ public sealed class OrderRateLimit
 }
 
 /// <summary>
-/// Reserve-on-submit margin configuration. Disabled by default —
-/// <see cref="NoOpMarginProvider"/> stays in place until an operator
-/// opts in. See <c>docs/rfcs/pre-trade-risk-v2.md</c> §3.1 for the
-/// model assumed by v2 (crypto-spot ledger; not T+N, not derivatives).
+/// Reserve-on-submit margin configuration. <b>Enabled by default</b>
+/// (#416): the trading-platform factory default must be the safe
+/// posture — an operator who forgets to flip this on otherwise gets
+/// silently overspending accounts (cash ledger non-blocking by design;
+/// the pre-trade guard lives here). Equivalent rationale to shipping
+/// a database with foreign keys ON by default. See
+/// <c>docs/rfcs/pre-trade-risk-v2.md</c> §3.1 for the model assumed
+/// by v2 (crypto-spot ledger; not T+N, not derivatives).
+///
+/// <para>
+/// Opt-out is explicit: set <c>Trading:Risk:Margin:Enabled=false</c>
+/// to fall back to <see cref="NoOpMarginProvider"/> (e.g. test
+/// compositions that do not seed cash). The host emits a startup
+/// warning when this is disabled outside <c>Development</c> so the
+/// drift is visible on dashboards.
+/// </para>
 ///
 /// <para>
 /// <b>Migration note (#107 slice 4):</b> the per-end-client opening
@@ -112,7 +124,7 @@ public sealed class OrderRateLimit
 /// </summary>
 public sealed class MarginOptions
 {
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 
     /// <summary>
     /// Pass-4 review (#299) P1. Bounded TTL for ambiguous-send

--- a/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingHostStartup.cs
@@ -111,6 +111,29 @@ internal static class TradingHostStartup
         // owner hashes in the regulator-facing XML.
         var cvmOpts = app.Services.GetRequiredService<IOptions<B3.Trading.Application.Reports.Cvm.CvmReportOptions>>().Value;
         cvmOpts.Validate(app.Environment.EnvironmentName);
+
+        // #416. The factory default for Trading:Risk:Margin:Enabled is
+        // now `true` so an operator who forgets to opt in does NOT get a
+        // silently overspending account (CashLedger.ApplyFill is
+        // non-blocking by design; the pre-trade guard lives in the
+        // margin provider). When an operator explicitly opts out outside
+        // Development, emit a loud warning so the drift is visible on
+        // dashboards — mirrors ErInjectionBootGuard's warning posture
+        // for "unsafe-but-allowed" configurations.
+        var riskBootOpts = app.Services.GetRequiredService<IOptions<RiskOptions>>().Value;
+        if (!riskBootOpts.Margin.Enabled
+            && !string.Equals(app.Environment.EnvironmentName, "Development", StringComparison.OrdinalIgnoreCase))
+        {
+            app.Services.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("MarginDisabled")
+                .LogWarning(
+                    "Trading:Risk:Margin:Enabled=false in environment '{Environment}'. "
+                    + "Pre-trade cash reservation is OFF (NoOpMarginProvider) — buy orders "
+                    + "can drive end-client cash ledgers negative without any guard. "
+                    + "This is permitted but explicitly unsafe; flip to true (#416) unless "
+                    + "this composition genuinely runs without ledger-backed accounts.",
+                    app.Environment.EnvironmentName);
+        }
     }
 
     /// <summary>

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -115,6 +115,15 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 ["Trading:Risk:Default:PriceCollarPercent"] = "10",
                 ["Trading:Risk:Default:PositionLimit"] = "5000",
                 ["Trading:Risk:ReferencePrices:PETR4"] = "30.0",
+                // #416. The factory default for Margin:Enabled flipped to
+                // true so production hosts get a fail-safe posture. The
+                // broad API test suite generally does NOT seed cash and
+                // intentionally relies on the permissive (NoOp) provider
+                // so /orders happy-paths don't all fail with
+                // INSUFFICIENT_CASH. Tests that exercise the margin path
+                // opt back in via WithOverrides — see MarginCheckIntegrationTests
+                // and SignupCashSeedTests for the pattern.
+                ["Trading:Risk:Margin:Enabled"] = "false",
                 ["Trading:Persistence:Enabled"] = "false",
                 // Slice 2 of #97 ships rate limits enabled by default.
                 // The default suite hits /auth/login and /auth/signup

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using System.Reflection;
+using Up = B3.EntryPoint.Client.Models;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #459 (spin-off de #441 / #436). Tripwire defensivo: a auditoria
+/// de compliance B3 (24/05/2026) identificou 3 campos FIX/B3 que a
+/// plataforma deveria emitir/honrar no wire mas que o
+/// <c>B3.EntryPoint.Client 0.14.4</c> NÃO expõe no shape público
+/// de <see cref="Up.NewOrderRequest"/> e <see cref="Up.ReplaceOrderRequest"/>:
+///
+/// <list type="bullet">
+///   <item><b>SubAccount</b> — tag FIX 1, sub-conta dentro do CBLC
+///   Account, usada para allocation/segregation.</item>
+///   <item><b>ExecInst</b> — tag FIX 18, flags importantes
+///   (STP mode, do-not-aggregate, work-up, AON, …).</item>
+///   <item><b>DisplayResetPolicy</b> / <b>RefreshPolicy</b> —
+///   refresh policy do iceberg nativo (Always / OnPartialFill /
+///   Never). Hoje o REST + risk forçam <c>Always</c> via
+///   <see cref="B3.Trading.Application.OrderSubmissionService"/>
+///   (#297) para que a omissão no wire seja faithful — quando o
+///   SDK expor o campo, esse guard pode cair (fecha #298).</item>
+/// </list>
+///
+/// <para>
+/// <b>Como o tripwire funciona.</b> Cada teste afirma "a propriedade
+/// X NÃO existe no SDK". Quando o mantenedor do SDK adicionar a
+/// propriedade (bump de versão), o teste fica vermelho — o que é
+/// exatamente o sinal para plumbar o campo end-to-end no
+/// <see cref="B3.Trading.Infrastructure.B3EntryPointClientGateway"/>,
+/// no Domain / WAL / REST, e ENTÃO remover este tripwire (junto
+/// com o REST guard correspondente quando aplicável).
+/// </para>
+///
+/// <para>
+/// O lookup é case-insensitive porque o SDK pode escolher
+/// capitalização ligeiramente diferente (e.g. <c>SubAccount</c> vs
+/// <c>SubAcct</c>); usar <see cref="StringComparison.OrdinalIgnoreCase"/>
+/// + a substring evita um falso negativo onde só a capitalização
+/// muda. Caso o SDK exponha um nome inteiramente diferente
+/// (improvável dado o padrão FIX), o tripwire continuará verde e
+/// o gap será pego pela próxima auditoria — risco aceito.
+/// </para>
+/// </summary>
+public class B3EntryPointSdkTripwireTests
+{
+    private static readonly string[] SubAccountAliases = ["SubAccount", "SubAcct", "SubaccountId"];
+    private static readonly string[] ExecInstAliases   = ["ExecInst", "ExecutionInstruction", "ExecutionInstructions"];
+    private static readonly string[] DisplayPolicyAliases = ["DisplayResetPolicy", "RefreshPolicy", "DisplayRefreshPolicy"];
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_SubAccount_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), SubAccountAliases,
+            issueRef: "#441 (CBLC Account mapping) + #458");
+    }
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_ExecInst_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), ExecInstAliases,
+            issueRef: "#441 (ExecInst flags)");
+    }
+
+    [Fact]
+    public void NewOrderRequest_StillLacks_DisplayResetPolicy_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.NewOrderRequest), DisplayPolicyAliases,
+            issueRef: "#298 / #436. When this trips: wire order.DisplayResetPolicy in B3EntryPointClientGateway.BuildNewOrderRequest AND drop the REST/risk guard in OrdersEndpoints + OrderSubmissionService that today restricts policy to Always.");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_SubAccount_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), SubAccountAliases,
+            issueRef: "#441 / #458");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_ExecInst_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), ExecInstAliases,
+            issueRef: "#441");
+    }
+
+    [Fact]
+    public void ReplaceOrderRequest_StillLacks_DisplayResetPolicy_AsOf_SdkVersion()
+    {
+        AssertSdkPropertyMissing(typeof(Up.ReplaceOrderRequest), DisplayPolicyAliases,
+            issueRef: "#298 / #436");
+    }
+
+    private static void AssertSdkPropertyMissing(Type sdkType, string[] aliases, string issueRef)
+    {
+        var props = sdkType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var found = aliases.FirstOrDefault(a => props.Contains(a));
+        Assert.True(found is null,
+            $"TRIPWIRE: B3.EntryPoint.Client agora expõe '{found}' em {sdkType.FullName}. " +
+            $"Ação esperada: plumbar o campo end-to-end (Domain → WAL → REST → BuildRequest), " +
+            $"adicionar wire-pinning test em B3EntryPointClientGatewayMapTests / TranslationTests, " +
+            $"e remover este tripwire. Tracking: {issueRef}.");
+    }
+}

--- a/docs/rfcs/pre-trade-risk-v2.md
+++ b/docs/rfcs/pre-trade-risk-v2.md
@@ -315,8 +315,15 @@ brittle; the metric + ops paging is the compromise.
   (null / empty dictionaries). Existing deployments need no config
   change to keep running with v1 behavior.
 - Adding `MarginCheck` to the pipeline is gated by
-  `Trading:Risk:Margin:Enabled` (default `false` for the first
-  release, flipped to `true` once the stub provider is documented).
+  `Trading:Risk:Margin:Enabled`. **Default flipped to `true` in #416**
+  (was `false` for the first releases): the trading-platform factory
+  default must be the safe posture, since `CashLedger.ApplyFill` is
+  non-blocking by design and the pre-trade guard lives in the margin
+  provider. Operators who genuinely want the permissive `NoOp` mode
+  (test compositions that don't seed cash, fixtures that don't model
+  accounts) opt out explicitly via `Trading:Risk:Margin:Enabled=false`;
+  the host emits a startup warning when this is disabled outside
+  `Development` so the drift is visible on dashboards.
 - `MinTickSize` / `MinLotSize` only enforce when the value is set on
   `RiskOptions`; absent values mean "no check" (matches today's
   schema convention).

--- a/docs/sdk-gaps.md
+++ b/docs/sdk-gaps.md
@@ -1,0 +1,48 @@
+# SDK gaps — `B3.EntryPoint.Client`
+
+Tracks fields/contracts that the **B3.EntryPoint.Client** package does not yet expose on its public surface, with the corresponding gap on this platform and a tripwire test that fires when the SDK starts exposing them.
+
+Verified against: `B3.EntryPoint.Client 0.14.4` (24/05/2026).
+
+## Outbound request shape — missing properties
+
+The auditoria de compliance B3 (#441 umbrella) identified 3 FIX/B3 fields that the platform should emit / honour on the wire but the SDK does not surface on `NewOrderRequest` / `ReplaceOrderRequest`:
+
+| Field | FIX tag | Compliance use | Platform compensation today | Tracking |
+| --- | --- | --- | --- | --- |
+| `SubAccount` | 1 | Sub-account inside the CBLC Account (allocation / segregation) | `Domain.Order.SubAccountId` carried internally; not visible to venue post-trade allocation | [#441](https://github.com/pedrosakuma/B3TradingPlatform/issues/441), [#458](https://github.com/pedrosakuma/B3TradingPlatform/issues/458) |
+| `ExecInst` | 18 | Flags (STP mode, do-not-aggregate, work-up, AON, …) | STP runs 100% host-side (sees every firm, doesn't need venue cooperation). AON / work-up have no host-side compensation | [#441](https://github.com/pedrosakuma/B3TradingPlatform/issues/441) |
+| `DisplayResetPolicy` / `RefreshPolicy` | n/a (B3 iceberg) | Iceberg refresh-on-execution policy (`Always` / `OnPartialFill` / `Never`) | REST + risk gate-bloqueia a escolha do trader a `Always` (#297) para que a omissão no wire seja faithful; loses the other two policies | [#298](https://github.com/pedrosakuma/B3TradingPlatform/issues/298), [#436](https://github.com/pedrosakuma/B3TradingPlatform/issues/436) (closed → covered here) |
+
+## Tripwire test
+
+[`backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs`](../backend/tests/B3.Trading.Application.Tests/B3EntryPointSdkTripwireTests.cs) asserts via reflection that each property is **absent** from `NewOrderRequest` and `ReplaceOrderRequest`. When the SDK adds the property (and we bump the package version) the test goes red — that is the signal to:
+
+1. **Wire the field end-to-end** in `Domain.Order` → WAL `OrderSubmittedEvent` → `OrderSubmissionRequest` → `BuildNewOrderRequest` / `BuildReplaceOrderRequest`.
+2. **Add wire-pinning coverage** in `B3EntryPointClientGatewayMapTests` / `B3EntryPointClientGatewayTranslationTests`.
+3. **Remove the matching REST/risk guard** when applicable (e.g. for `DisplayResetPolicy` drop the `Always`-only restriction in `OrdersEndpoints` + `OrderSubmissionService`, closing #298).
+4. **Delete the tripwire test** for that specific field.
+
+The lookup is case-insensitive and covers known FIX-style aliases (`SubAccount`/`SubAcct`, `ExecInst`/`ExecutionInstruction`, `DisplayResetPolicy`/`RefreshPolicy`); if the SDK ships with an entirely different name the tripwire stays green and the next auditoria catches the gap — risk accepted in favour of not false-positiving on capitalisation changes.
+
+## Outbound request shape — present but not plumbed
+
+These fields **are** exposed by 0.14.4 but the platform does not populate them today. Tracked separately (no tripwire needed — straight implementation):
+
+| Field | Tracking |
+| --- | --- |
+| `NewOrderRequest.MinQty` / `ReplaceOrderRequest.MinQty` | [#457](https://github.com/pedrosakuma/B3TradingPlatform/issues/457) |
+| `NewOrderRequest.Account` (CBLC numeric) | [#458](https://github.com/pedrosakuma/B3TradingPlatform/issues/458) (blocked on modelling decision) |
+
+## How to refresh this doc when the SDK bumps
+
+```bash
+# 1. Bump the package
+$EDITOR backend/Directory.Packages.props          # update B3.EntryPoint.Client version
+
+# 2. Re-run the tripwire
+dotnet test backend/tests/B3.Trading.Application.Tests/B3.Trading.Application.Tests.csproj \
+  --filter "FullyQualifiedName~B3EntryPointSdkTripwire"
+
+# 3. For each tripwire that goes red: plumb the field, update this table, delete the test.
+```


### PR DESCRIPTION
Closes #416.

## Bug

O default de fábrica de `Trading:Risk:Margin:Enabled` era `false` + a DI fallback retornava `NoOpMarginProvider`, que sempre aprova. `CashLedger.ApplyFill` é não-bloqueante por design (debt é estado real) — o pre-trade guard mora no margin provider. Operador que esquecesse de ligar o flag rodava com **contas silenciosamente overspending** (validação local: alice com posições mas sem cash seed → header mostrou −R$ 3.250,00 após um único buy de PETR4).

Equivalente a um banco com FK off por default.

## Fix

- **`MarginOptions.Enabled` default flipa para `true`** (`RiskOptions.cs`). Factory default agora é a postura segura.
- **Startup warning loud** quando explicitamente desligado fora de `Development` (`TradingHostStartup.ValidateBootGuards`), espelhando o padrão do `ErInjectionBootGuard` — opt-out fica visível no log e em dashboards.
- **`TestAppFactory` seta `Enabled=false` na base config** para preservar o suite amplo de API tests que não seeda cash e depende do comportamento permissivo. Tests que exercitam o caminho de margin (`MarginCheckIntegrationTests`, `SignupCashSeedTests`, …) já faziam opt-in explícito via `WithOverrides` — sem mudança neles.
- **`docs/rfcs/pre-trade-risk-v2.md §6`** atualizado refletindo o flip e o procedimento de opt-out.

## Migração para deployments existentes

Quem **já tem** `Trading:Risk:Margin:Enabled=true` no config: nenhuma ação. Quem **dependia do default `false`** (composições sem ledger, fixtures, etc.) precisa adicionar `Trading:Risk:Margin:Enabled=false` explicitamente — o warning de boot indica o local exato a tocar. `docker-compose.local-validation.yml` já tinha o flag explícito; demais compositions deste repo (demo / conformance) usam mock gateway e não disparam margin, então o default flipado não muda comportamento.

## Verificação

```
dotnet build B3TradingPlatform.slnx  → 0 warn / 0 err
dotnet test B3TradingPlatform.slnx
  Application: 1140/1140 ✅
  Api: 493/493 ✅
  Listener: 132/134 (2 flakes FIXP socket conhecidos, passam no rerun isolado)
```
