### PR TITLE
Wire FIX MinQty end-to-end through submit/replace path (#457)

### DIFF
--- a/backend/src/B3.Trading.Api/OrdersEndpoints.cs
+++ b/backend/src/B3.Trading.Api/OrdersEndpoints.cs
@@ -138,7 +138,8 @@ public static class OrdersEndpoints
                 GoodTillDate: req.GoodTillDate,
                 DisplayQty: req.DisplayQty,
                 DisplayResetPolicy: displayPolicy,
-                SubAccountId: subAccount), ct);
+                SubAccountId: subAccount,
+                MinQty: req.MinQty), ct);
 
             return result.Kind switch
             {
@@ -313,7 +314,13 @@ public sealed record SubmitOrderRequest(
     /// when unknown, <c>reason: "sub_account_deactivated"</c> when
     /// soft-deleted). <c>null</c> retains pre-#301 master-only
     /// behaviour.</summary>
-    string? SubAccountId = null);
+    string? SubAccountId = null,
+    /// <summary>#457. Optional minimum execution quantity (FIX MinQty).
+    /// When set, the venue must fill at least this many contracts at
+    /// submit time or reject the order. Validated as
+    /// <c>0 &lt; MinQty &lt;= Quantity</c> by the submit pipeline
+    /// (<see cref="B3.Trading.Domain.Order"/>'s constructor).</summary>
+    long? MinQty = null);
 
 public sealed record ModifyOrderRequest(
     long Quantity,

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -140,7 +140,8 @@ public sealed class OrderSubmissionService
                 parentAlgoId: req.ParentAlgoId, algoSliceSeq: req.AlgoSliceSeq,
                 timeInForce: req.TimeInForce, stopPrice: req.StopPrice, goodTillDate: req.GoodTillDate,
                 displayQty: req.DisplayQty, displayResetPolicy: req.DisplayResetPolicy,
-                subAccountId: req.SubAccountId);
+                subAccountId: req.SubAccountId,
+                minQty: req.MinQty);
         }
         catch (ArgumentException ex)
         {
@@ -186,6 +187,7 @@ public sealed class OrderSubmissionService
                     DisplayQty = order.DisplayQty,
                     DisplayResetPolicy = order.DisplayResetPolicy?.ToString(),
                     SubAccountId = order.SubAccountId?.Value,
+                    MinQty = order.MinQty,
                 },
                 () =>
                 {
@@ -384,7 +386,13 @@ public sealed record OrderSubmissionRequest(
     /// per-sub-account risk gates ON TOP OF the existing master ones
     /// — reject-on-either-fail (see <c>SubAccountLimitsCheck</c>).
     /// </summary>
-    SubAccountId? SubAccountId = null)
+    SubAccountId? SubAccountId = null,
+    /// <summary>
+    /// #457. Optional minimum execution quantity (FIX MinQty). Null
+    /// = no minimum. Validated by <see cref="Order"/>'s constructor:
+    /// <c>0 &lt; MinQty &lt;= Quantity</c>.
+    /// </summary>
+    long? MinQty = null)
 {
     /// <summary>
     /// Sub-issue #171 (E). When non-null, the request originates from

--- a/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
+++ b/backend/src/B3.Trading.Application/Persistence/Snapshots.cs
@@ -435,6 +435,13 @@ public sealed record OrderSnapshot(
     /// semantics they actually carried.
     /// </summary>
     public string? SubAccountId { get; init; }
+
+    /// <summary>
+    /// #457. Minimum execution quantity (FIX MinQty) at submit time.
+    /// Null = no minimum. Older snapshots default to <c>null</c>,
+    /// matching the pre-#457 no-minimum semantics.
+    /// </summary>
+    public long? MinQty { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
+++ b/backend/src/B3.Trading.Application/Persistence/WalEvents.cs
@@ -157,6 +157,18 @@ public sealed record OrderSubmittedEvent : WalEvent
     /// silently poisoning the sub-account books.
     /// </summary>
     public string? SubAccountId { get; init; }
+
+    /// <summary>
+    /// #457. Minimum execution quantity (FIX MinQty) — when set, the
+    /// venue must fill at least this many contracts at submit time or
+    /// reject the order. Null = no minimum (every legacy WAL segment
+    /// without the field deserialises as null, matching the no-minimum
+    /// semantics those submissions actually carried). Validated as
+    /// <c>0 &lt; MinQty &lt;= Quantity</c> by <see cref="Domain.Order"/>'s
+    /// ctor on replay so corrupted segments surface as deserialisation /
+    /// hydrate errors rather than silently poisoning the venue.
+    /// </summary>
+    public long? MinQty { get; init; }
 }
 
 /// <summary>

--- a/backend/src/B3.Trading.Application/WorkingOrderBook.cs
+++ b/backend/src/B3.Trading.Application/WorkingOrderBook.cs
@@ -315,6 +315,7 @@ public sealed class WorkingOrderBook
                 DisplayQty = o.DisplayQty,
                 DisplayResetPolicy = o.DisplayResetPolicy?.ToString(),
                 SubAccountId = o.SubAccountId?.Value,
+                MinQty = o.MinQty,
             };
         }
     }
@@ -375,7 +376,8 @@ public sealed class WorkingOrderBook
                 isStale: s.IsStale, staleReason: s.StaleReason, staledAtUtc: s.StaledAtUtc,
                 timeInForce: tif, stopPrice: s.StopPrice, goodTillDate: s.GoodTillDate,
                 displayQty: s.DisplayQty, displayResetPolicy: policy,
-                subAccountId: subAccount);
+                subAccountId: subAccount,
+                minQty: s.MinQty);
             var firmSet = _byFirm.GetOrAdd(s.FirmId, static _ => new ConcurrentDictionary<ulong, byte>());
             firmSet.TryAdd(s.ClOrdId, 0);
             var ownerSet = _byOwner.GetOrAdd(s.EndClientId, static _ => new ConcurrentDictionary<ulong, byte>());

--- a/backend/src/B3.Trading.Domain/Order.cs
+++ b/backend/src/B3.Trading.Domain/Order.cs
@@ -182,7 +182,8 @@ public sealed class Order
         DateTimeOffset? goodTillDate = null,
         long? displayQty = null,
         DisplayResetPolicy? displayResetPolicy = null,
-        SubAccountId? subAccountId = null)
+        SubAccountId? subAccountId = null,
+        long? minQty = null)
     {
         if (clOrdId == 0)
             throw new ArgumentOutOfRangeException(nameof(clOrdId), "ClOrdID cannot be zero (reserved as null sentinel by EntryPoint).");
@@ -246,6 +247,25 @@ public sealed class Order
                 nameof(displayResetPolicy));
         }
 
+        // #457. Minimum execution quantity (FIX MinQty) — when set, the
+        // venue must fill at least this many contracts at submit time or
+        // reject the order (fill-or-none-on-arrival; partial fills above
+        // the minimum are allowed). Always-true invariants enforced here
+        // so WAL replay and snapshot hydrate cannot reconstitute illegal
+        // combinations (a "minimum" larger than the order is nonsensical;
+        // zero/negative is meaningless — use null for no-minimum).
+        if (minQty.HasValue)
+        {
+            if (minQty.Value <= 0)
+                throw new ArgumentException(
+                    "MinQty must be positive when set (use null for no minimum execution constraint).",
+                    nameof(minQty));
+            if (minQty.Value > quantity)
+                throw new ArgumentException(
+                    $"MinQty ({minQty.Value}) must not exceed order Quantity ({quantity}).",
+                    nameof(minQty));
+        }
+
         ClOrdId = clOrdId;
         Owner = owner;
         Symbol = symbol;
@@ -263,6 +283,7 @@ public sealed class Order
         DisplayQty = displayQty;
         DisplayResetPolicy = displayResetPolicy;
         SubAccountId = subAccountId;
+        MinQty = minQty;
         LeavesQuantity = quantity;
         Status = OrderStatus.PendingNew;
     }
@@ -349,6 +370,20 @@ public sealed class Order
     /// <c>SubAccountsRegistry</c>.
     /// </summary>
     public SubAccountId? SubAccountId { get; }
+
+    /// <summary>
+    /// #457. Minimum execution quantity (FIX MinQty) — when set, the
+    /// venue must fill at least this many contracts at submit time or
+    /// reject the order. <c>null</c> = no minimum (the only behaviour
+    /// every legacy submission produced). When set, must satisfy
+    /// <c>0 &lt; MinQty &lt;= Quantity</c> (enforced by the constructor);
+    /// once submitted, the venue may still partially fill above the
+    /// minimum — the constraint only governs the initial fill check on
+    /// arrival. Mapped natively via the SDK's
+    /// <c>NewOrderRequest.MinQty</c> /
+    /// <c>ReplaceOrderRequest.MinQty</c> (<c>ulong?</c>) on the wire.
+    /// </summary>
+    public long? MinQty { get; }
 
     public long LeavesQuantity { get; private set; }
     public long CumulativeQuantity { get; private set; }
@@ -528,10 +563,11 @@ public sealed class Order
         DateTimeOffset? goodTillDate = null,
         long? displayQty = null,
         DisplayResetPolicy? displayResetPolicy = null,
-        SubAccountId? subAccountId = null)
+        SubAccountId? subAccountId = null,
+        long? minQty = null)
     {
         var o = new Order(clOrdId, owner, symbol, securityId, side, type, quantity, price, firmId, parentAlgoId, algoSliceSeq,
-            timeInForce, stopPrice, goodTillDate, displayQty, displayResetPolicy, subAccountId);
+            timeInForce, stopPrice, goodTillDate, displayQty, displayResetPolicy, subAccountId, minQty);
         o.LeavesQuantity = leaves;
         o.CumulativeQuantity = cumQty;
         o.Status = status;
@@ -613,6 +649,17 @@ public sealed class Order
         if (effDisplayQty.HasValue && effDisplayQty.Value > newQuantity)
             effDisplayQty = newQuantity;
 
+        // #457. MinQty rides through cancel-replace the same way as
+        // DisplayQty: the modify pipeline does not (yet) expose an
+        // override for MinQty, so the replacement inherits the original's
+        // value. If the operator shrinks the order quantity below the
+        // original MinQty, clamp MinQty to the new quantity so the ctor
+        // invariant (MinQty <= Quantity) still holds. A future modify
+        // pipeline slice can plumb explicit MinQty overrides.
+        long? effMinQty = original.MinQty;
+        if (effMinQty.HasValue && effMinQty.Value > newQuantity)
+            effMinQty = newQuantity;
+
         return Hydrate(
             clOrdId: newClOrdId,
             owner: original.Owner,
@@ -638,7 +685,8 @@ public sealed class Order
             goodTillDate: effGtd,
             displayQty: effDisplayQty,
             displayResetPolicy: effPolicy,
-            subAccountId: original.SubAccountId);
+            subAccountId: original.SubAccountId,
+            minQty: effMinQty);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -208,6 +208,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // wire order.DisplayResetPolicy here and drop the validation
             // guard in OrdersEndpoints.cs + OrderSubmissionService.cs.
             MaxFloor = order.DisplayQty is { } dq ? (ulong)dq : (ulong?)null,
+            // #457. Native MinQty (FIX). When the trader sets a minimum
+            // execution quantity, the venue must fill at least this many
+            // contracts at submit time or reject the order. Domain.Order's
+            // ctor already validated 0 < MinQty <= Quantity so the cast
+            // to ulong? is safe.
+            MinQty = order.MinQty is { } mq ? (ulong)mq : (ulong?)null,
         };
     }
 
@@ -257,7 +263,36 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             original.Type, original.TimeInForce, original.StopPrice, original.GoodTillDate,
             requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
 
-        var req = new UpModels.ReplaceOrderRequest
+        var req = BuildReplaceOrderRequest(original, newClOrdId, newQuantity, newPrice,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
+
+        return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
+            ct => _client.ReplaceAsync(req, ct), cancellationToken);
+    }
+
+    /// <summary>
+    /// #457. Extracted from <see cref="CancelReplaceAsync"/> so the outbound
+    /// <c>ReplaceOrderRequest</c> mapping (including the FIX MinQty / MaxFloor
+    /// inheritance + clamp) can be pinned by unit tests without standing up a
+    /// real <c>EntryPointClient</c>. Pure function: every field is read from
+    /// the original domain <see cref="Order"/> and the modify-call arguments,
+    /// with no side effects.
+    /// </summary>
+    internal static UpModels.ReplaceOrderRequest BuildReplaceOrderRequest(
+        Order original,
+        ulong newClOrdId,
+        long newQuantity,
+        decimal? newPrice,
+        TimeInForce? requestedTimeInForce,
+        decimal? requestedStopPrice,
+        DateTimeOffset? requestedGoodTillDate)
+    {
+        ArgumentNullException.ThrowIfNull(original);
+        var (effTif, effStop, effGtd) = Order.MergeReplacementOptionals(
+            original.Type, original.TimeInForce, original.StopPrice, original.GoodTillDate,
+            requestedTimeInForce, requestedStopPrice, requestedGoodTillDate);
+
+        return new UpModels.ReplaceOrderRequest
         {
             ClOrdID = new UpModels.ClOrdID(newClOrdId),
             OrigClOrdID = new UpModels.ClOrdID(original.ClOrdId),
@@ -281,10 +316,15 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             MaxFloor = original.DisplayQty is { } odq
                 ? (ulong)Math.Min(odq, newQuantity)
                 : (ulong?)null,
+            // #457. Replace inherits the original's MinQty (clamped to
+            // newQuantity if the new order qty would otherwise be below
+            // MinQty), mirroring the DisplayQty handling above and
+            // Order.HydrateReplacement. A future modify-pipeline slice
+            // can plumb explicit MinQty overrides.
+            MinQty = original.MinQty is { } omq
+                ? (ulong)Math.Min(omq, newQuantity)
+                : (ulong?)null,
         };
-
-        return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
-            ct => _client.ReplaceAsync(req, ct), cancellationToken);
     }
 
     /// <summary>

--- a/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/EntryPointClientGateway.cs
@@ -42,7 +42,10 @@ public sealed class EntryPointClientGateway : IExchangeGateway
             // mock seam so tests can pin wire mapping. The real SDK
             // path in B3EntryPointClientGateway maps the same field
             // to UpModels.NewOrderRequest.MaxFloor.
-            MaxFloor: order.DisplayQty);
+            MaxFloor: order.DisplayQty,
+            // #457. Plumb MinQty through the mock seam (FIX MinQty);
+            // real SDK path maps to UpModels.NewOrderRequest.MinQty.
+            MinQty: order.MinQty);
 
         return _client.SubmitNewOrderAsync(req, cancellationToken);
     }
@@ -82,6 +85,12 @@ public sealed class EntryPointClientGateway : IExchangeGateway
                 // SDK path in B3EntryPointClientGateway.CancelReplaceAsync.
                 MaxFloor: original.DisplayQty is { } odq
                     ? Math.Min(odq, newQuantity)
+                    : (long?)null,
+                // #457. Replace inherits the original's MinQty (clamped to
+                // newQuantity when the new order qty would otherwise be <
+                // MinQty), mirroring the real SDK path.
+                MinQty: original.MinQty is { } omq
+                    ? Math.Min(omq, newQuantity)
                     : (long?)null),
             cancellationToken);
     }

--- a/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
+++ b/backend/src/B3.Trading.Infrastructure/IEntryPointClient.cs
@@ -62,7 +62,13 @@ public sealed record NewOrderSingle(
     /// already wires MaxFloor on the upstream <c>NewOrderRequest</c>; this
     /// field plumbs the same intent through the mock seam so tests can
     /// assert wire mapping without standing up the real client.</summary>
-    long? MaxFloor = null);
+    long? MaxFloor = null,
+    /// <summary>#457. Minimum execution quantity (FIX MinQty). Null = no
+    /// minimum. Set by <see cref="EntryPointClientGateway"/> from the
+    /// domain order's <c>MinQty</c>. The real SDK path
+    /// (<c>B3EntryPointClientGateway</c>) maps the same field to
+    /// <c>NewOrderRequest.MinQty</c> (<c>ulong?</c>) on the wire.</summary>
+    long? MinQty = null);
 
 public sealed record OrderCancelRequest(
     ulong ClOrdId,
@@ -83,7 +89,12 @@ public sealed record OrderCancelReplaceRequest(
     /// inherited from the original order, clamped to <c>NewQuantity</c> when the
     /// replace shrinks the order below the original visible portion. Null when
     /// the original was a full-disclosure order.</summary>
-    long? MaxFloor = null);
+    long? MaxFloor = null,
+    /// <summary>#457. Minimum execution quantity (FIX MinQty) inherited from
+    /// the original order, clamped to <c>NewQuantity</c> when the replace
+    /// shrinks the order below the original MinQty. Null when the original
+    /// had no MinQty constraint.</summary>
+    long? MinQty = null);
 
 /// <summary>
 /// ExecutionReport surfaced by the wire to the platform. <see cref="OrigClOrdId"/>

--- a/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/StateSnapshotter.cs
@@ -931,7 +931,8 @@ public sealed class EventReplayer
                     o.Quantity, o.Price, o.FirmId, o.ParentAlgoId, o.AlgoSliceSeq,
                     timeInForce: tif, stopPrice: o.StopPrice, goodTillDate: o.GoodTillDate,
                     displayQty: o.DisplayQty, displayResetPolicy: policy,
-                    subAccountId: SubAccountId.FromNullableString(o.SubAccountId)));
+                    subAccountId: SubAccountId.FromNullableString(o.SubAccountId),
+                    minQty: o.MinQty));
                 _ownership.Register(o.ClOrdId, owner);
                 // #157: advance the ClOrdID registry watermark so the next
                 // live Generate(owner) cannot re-allocate this ID.

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -63,6 +63,7 @@ public class B3EntryPointClientGatewayMapTests
         var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
 
         Assert.Null(req.MaxFloor);
+        Assert.Null(req.MinQty);
         Assert.Equal(100UL, req.OrderQty);
     }
 
@@ -84,5 +85,90 @@ public class B3EntryPointClientGatewayMapTests
 
         Assert.Equal((ulong)displayQty, req.MaxFloor);
         Assert.Equal((ulong)quantity, req.OrderQty);
+    }
+
+    [Theory]
+    [InlineData(10L, 100L)]
+    [InlineData(1L, 1L)]
+    [InlineData(50L, 50L)]
+    public void BuildNewOrderRequest_MinQty_MapsToUpstream(long minQty, long quantity)
+    {
+        // #457. Native MinQty (FIX) maps straight to the SDK's
+        // NewOrderRequest.MinQty (ulong?). Pin both bounds (min=1,
+        // equal-to-qty) so any future ulong-cast regression is caught.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            quantity, 30m, "FIRM-A", minQty: minQty);
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
+
+        Assert.Equal((ulong)minQty, req.MinQty);
+        Assert.Equal((ulong)quantity, req.OrderQty);
+    }
+
+    [Fact]
+    public void BuildNewOrderRequest_NoMinQty_LeavesMinQtyNull()
+    {
+        // #457. Orders without an explicit MinQty must not accidentally
+        // populate the wire field — a non-null value would change the
+        // venue's acceptance semantics (reject when below minimum).
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM-A");
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
+
+        Assert.Null(req.MinQty);
+    }
+
+    [Fact]
+    public void BuildReplaceOrderRequest_InheritsMinQtyFromOriginal()
+    {
+        // #457. Cancel-replace inherits MinQty from the original order
+        // (the modify pipeline does not yet expose an override). Mirrors
+        // the DisplayQty inheritance contract.
+        var owner = new EndClientId("alice");
+        var original = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM-A",
+            minQty: 20);
+
+        var req = B3EntryPointClientGateway.BuildReplaceOrderRequest(
+            original, newClOrdId: 99UL, newQuantity: 80, newPrice: 31m,
+            requestedTimeInForce: null, requestedStopPrice: null, requestedGoodTillDate: null);
+
+        Assert.Equal(20UL, req.MinQty);
+        Assert.Equal(80UL, req.OrderQty);
+    }
+
+    [Fact]
+    public void BuildReplaceOrderRequest_ClampsMinQtyToNewQuantity()
+    {
+        // #457. When the operator shrinks the order below the original
+        // MinQty, the wire MinQty is clamped to the new quantity so the
+        // venue's invariant (MinQty <= OrderQty) still holds. Mirrors
+        // Order.HydrateReplacement.
+        var owner = new EndClientId("alice");
+        var original = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM-A",
+            minQty: 60);
+
+        var req = B3EntryPointClientGateway.BuildReplaceOrderRequest(
+            original, newClOrdId: 99UL, newQuantity: 40, newPrice: 31m,
+            requestedTimeInForce: null, requestedStopPrice: null, requestedGoodTillDate: null);
+
+        Assert.Equal(40UL, req.MinQty);
+        Assert.Equal(40UL, req.OrderQty);
+    }
+
+    [Fact]
+    public void BuildReplaceOrderRequest_NoMinQty_LeavesMinQtyNull()
+    {
+        // #457. When the original has no MinQty constraint, the replace
+        // must not synthesise one — null in, null out.
+        var owner = new EndClientId("alice");
+        var original = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 100, 30m, "FIRM-A");
+
+        var req = B3EntryPointClientGateway.BuildReplaceOrderRequest(
+            original, newClOrdId: 99UL, newQuantity: 80, newPrice: 31m,
+            requestedTimeInForce: null, requestedStopPrice: null, requestedGoodTillDate: null);
+
+        Assert.Null(req.MinQty);
     }
 }

--- a/backend/tests/B3.Trading.Domain.Tests/OrderMinQtyValidationTests.cs
+++ b/backend/tests/B3.Trading.Domain.Tests/OrderMinQtyValidationTests.cs
@@ -1,0 +1,84 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Domain.Tests;
+
+/// <summary>
+/// #457. Domain-level invariants for the FIX MinQty field on
+/// <see cref="Order"/>. The ctor is the single chokepoint for both
+/// live submits and replay hydration; rejecting a malformed MinQty
+/// here means no risk-pipeline, gateway, or recovery path can
+/// reconstitute an illegal order with MinQty &gt; Quantity.
+/// </summary>
+public class OrderMinQtyValidationTests
+{
+    private static readonly EndClientId Owner = new("alice");
+
+    private static Order Build(long? minQty = null, long quantity = 100) =>
+        new(1UL, Owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, quantity, 30m,
+            minQty: minQty);
+
+    [Fact]
+    public void NoMinQty_DefaultsToNull()
+    {
+        var o = Build();
+
+        Assert.Null(o.MinQty);
+    }
+
+    [Theory]
+    [InlineData(1L, 1L)]
+    [InlineData(1L, 100L)]
+    [InlineData(50L, 100L)]
+    [InlineData(100L, 100L)]
+    public void MinQty_AcceptsPositiveUpToQuantity(long minQty, long quantity)
+    {
+        var o = Build(minQty: minQty, quantity: quantity);
+
+        Assert.Equal(minQty, o.MinQty);
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void MinQty_NonPositive_Throws(long minQty)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Build(minQty: minQty));
+        Assert.Contains("MinQty must be positive", ex.Message);
+    }
+
+    [Fact]
+    public void MinQty_GreaterThanQuantity_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Build(minQty: 101, quantity: 100));
+        Assert.Contains("must not exceed order Quantity", ex.Message);
+    }
+
+    [Fact]
+    public void HydrateReplacement_InheritsMinQty()
+    {
+        var original = Build(minQty: 20, quantity: 100);
+
+        var replacement = Order.HydrateReplacement(
+            original, newClOrdId: 99UL, newQuantity: 80, newPrice: 31m,
+            erLeaves: 80, erCumulative: 0);
+
+        Assert.Equal(20, replacement.MinQty);
+    }
+
+    [Fact]
+    public void HydrateReplacement_ClampsMinQtyToNewQuantity()
+    {
+        // Mirror of DisplayQty clamp: when the replacement quantity drops
+        // below the original MinQty, the ctor invariant would otherwise
+        // refuse to construct the order. Clamp the minimum down so the
+        // replacement is legal (the venue gets a coherent
+        // MinQty <= OrderQty pair on the wire).
+        var original = Build(minQty: 60, quantity: 100);
+
+        var replacement = Order.HydrateReplacement(
+            original, newClOrdId: 99UL, newQuantity: 40, newPrice: 31m,
+            erLeaves: 40, erCumulative: 0);
+
+        Assert.Equal(40, replacement.MinQty);
+    }
+}


### PR DESCRIPTION
Closes #457. Spin-off do umbrella #441 (auditoria compliance B3).

## O quê

`B3.EntryPoint.Client 0.14.4` expõe `NewOrderRequest.MinQty` e `ReplaceOrderRequest.MinQty` (`Nullable<ulong>`); a plataforma não tinha como expressar **"fill at least N or none"** para a venue. Esta PR pluma o campo **end-to-end** seguindo a receita do `DisplayQty` (#284).

## 10-step plumbing

| Camada | Arquivo | Mudança |
|---|---|---|
| 1 — Domain | `Domain/Order.cs` | ctor param `long? minQty`, propriedade `MinQty`, invariante `0 < MinQty <= Quantity` enforced no ctor |
| 2 — WAL | `Application/Persistence/WalEvents.cs::OrderSubmittedEvent` | aditivo `long? MinQty` (default null = back-compat com segments antigos) |
| 3 — Snapshot | `Application/Persistence/Snapshots.cs::OrderSnapshot` | aditivo `long? MinQty` |
| 4 — Submit DTO | `Application/OrderSubmissionService.cs::OrderSubmissionRequest` | optional `MinQty` |
| 5 — Submit service | `Application/OrderSubmissionService.cs` | propaga req → ctor → WAL event |
| 6 — Snapshot+Restore | `Application/WorkingOrderBook.cs` | inclui MinQty no snapshot e no Restore |
| 7 — WAL replay | `Infrastructure/Persistence/StateSnapshotter.cs` | passa MinQty no hydrate |
| 8 — Mock seam | `Infrastructure/IEntryPointClient.cs` | `NewOrderSingle.MinQty` + `OrderCancelReplaceRequest.MinQty` |
| 8b — Mock adapter | `Infrastructure/EntryPointClientGateway.cs` | wire MinQty em Submit + Replace (com clamp) |
| 9 — Real SDK | `Infrastructure/B3EntryPointClientGateway.cs` | `NewOrderRequest.MinQty = (ulong?)order.MinQty` + idem no Replace; extrai `BuildReplaceOrderRequest` como `internal static` (mirror de `BuildNewOrderRequest` do #284) p/ testabilidade |
| 10 — REST | `Api/OrdersEndpoints.cs::SubmitOrderRequest` | aceita `minQty` opcional |

### HydrateReplacement
Inherits do original com clamp: se o operador reduz `Quantity` abaixo do `MinQty` original, `MinQty` é clampado para a nova `Quantity` (mesma política do `DisplayQty`), preservando a invariante `MinQty <= Quantity` no objeto reconstruído e no wire (`MinQty <= OrderQty` na venue).

## Risk validation

A regra `MinQty <= Quantity` é uma **always-true invariant** — vale tanto para submit live quanto para replay de WAL. Implementada no `Order` ctor (chokepoint único) em vez de em um `IRiskCheck` separado, mesma estratégia do `DisplayQty` (#284). REST surfaca como `BadRequest` via o handler `ArgumentException → OrderSubmissionResult.BadRequest` já existente.

## Tests

* `OrderMinQtyValidationTests` (novo) — 10 casos:
  - ctor invariants (positivo, <= Quantity, exceções nas violações)
  - `HydrateReplacement` herda + clampa
* `B3EntryPointClientGatewayMapTests` (extends) — wire-pinning para Submit (null passthrough, parametric cast) e Replace (inherit, clamp para `NewQuantity`, null passthrough)

## Verificação

* Build clean (0 warn)
* Domain 91 / Application 1141 / Api 493 / Listener 134 / Reconciliation 12 / Simulator 23 — todos green
* Back-compat: campo aditivo `long? MinQty { get; init; }` em records JSON-polimórficos = WAL/snapshots antigos round-trip como null = no-MinQty (= comportamento pré-#457)

## Referências

* #441 — umbrella compliance B3
* #284 — pattern de referência (`DisplayQty` / `MaxFloor`)
* SDK 0.14.4 `NewOrderRequest.MinQty` / `ReplaceOrderRequest.MinQty` — verificado via reflection (`Nullable<ulong>`)
