### PR TITLE
chore(deps): bump B3.EntryPoint.Client + Sbe to 0.15.0

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.4" />
-    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.14.3" />
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.0" />
+    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.0" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.4.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
## Summary

Bump `B3.EntryPoint.Client` 0.14.4 → **0.15.0** and `B3.EntryPoint.Sbe` 0.14.3 → **0.15.0** (published ~30 min before this PR). Both bumped together because SDK 0.15.0 declares a `[0.15.0,)` floor on Sbe transitively.

This PR is **bump-only** — no callsites changed. New SDK fields will be plumbed in follow-up PRs against the issues they unblock.

## Binary diff (verified via `dotnet-assembly` decompiler)

### `B3.EntryPoint.Sbe` 0.14.3 → 0.15.0 — **wire-safe republish**
- 479 types, 7720 methods on both sides
- Per-type method counts identical (full set-diff: zero rows)
- Conclusion: no API surface change, likely version-parity republish

### `B3.EntryPoint.Client` 0.14.4 → 0.15.0
**Breaking change (no-op for us)**:
- `NewOrderRequest.AccountType` REMOVED. Codebase grep confirms zero references to `AccountType` anywhere → safe.
- Asymmetric: `ReplaceOrderRequest.AccountType` retained.

**Additive — `NewOrderRequest` + `ReplaceOrderRequest`** gain:
- `OrdTagId` (byte?)
- `MmProtectionReset` (bool)
- `SelfTradePreventionInstruction` (enum)
- `RoutingInstruction` (enum?)
- `InvestorId` (struct?)
- `TradingSubAccount` (uint?)

**Additive — `CancelOrderRequest`** gains:
- `OrderId` (ulong?) — cancel by venue OrderID
- `ExecRestatementReason` (`CancelExecRestatementReason?`)
- `ExecutingTrader` (string)
- `DeskId` (string)

**4 new public types** under `B3.EntryPoint.Client.Models`:
| Type | Unblocks |
|---|---|
| `SelfTradePreventionInstruction` | #433 STP venue-side modes (P1) |
| `InvestorId` + `TradingSubAccount` | #441 Account/SubAccount/InvestorID gap (P2) |
| `RoutingInstruction` | #441 ExecInst equivalent (P2) |
| `CancelExecRestatementReason` | #432 BusinessReject taxonomy (P1) |

Also useful for #430 chaos test: `CancelOrderRequest.OrderId` lets us cancel by venue OrderID when ClOrdID is in flight.

## Validation

- `dotnet restore B3TradingPlatform.slnx` — clean
- `dotnet build B3TradingPlatform.slnx --no-restore` — **0 warnings, 0 errors** (17.29s)
- `dotnet test B3TradingPlatform.slnx --no-build` — **1877 passed / 0 failed / 30 skipped** (skipped are conformance specs gated on the docker harness, unaffected by SDK bump)

## Follow-up sequencing

After this lands:
1. **#433** STP venue modes — plumb `SelfTradePreventionInstruction` through `B3EntryPointClientGateway.BuildNewOrderRequest` + risk wiring
2. **#441** split: TradingSubAccount + InvestorId + RoutingInstruction plumbing (mirror of #463 MinQty pattern)
3. **#434** AlgoEngine `LiveChildClOrdId` race — unrelated to SDK, can run in parallel
4. **#432** BusinessReject + `CancelExecRestatementReason` taxonomy refinement
