### PR TITLE
feat(#433): plumb venue-side SelfTradePreventionInstruction (P1)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -263,12 +263,16 @@ public sealed class RiskLimits
     /// allows, or any pair the platform missed because the
     /// working-order snapshot was stale). Default semantics when
     /// unset everywhere in the precedence chain are
-    /// <see cref="SelfTradePreventionMode.CancelAggressorOrder"/> —
-    /// mirrors the pre-trade "newest rejects" stance so the venue
-    /// behavior matches the app-side check by default. Set to
-    /// <see cref="SelfTradePreventionMode.None"/> per-firm or
-    /// per-end-client to opt out (e.g. market-maker accounts that
-    /// rely on an external risk layer).
+    /// <see cref="SelfTradePreventionMode.None"/> — the venue does
+    /// not enforce STP unless an operator explicitly opts in per-firm
+    /// or per-end-client. The app-side
+    /// <see cref="AllowSelfTrade"/> pre-trade check remains the
+    /// primary line of defense; this field exists as an opt-in
+    /// belt-and-braces enforcement at the matching engine for scopes
+    /// that want it. Defaulting to <c>None</c> avoids changing
+    /// historical venue behavior for tenants that already rely on
+    /// crossed trades reaching the book (e.g. cross-account hedging
+    /// inside the same firm).
     /// </summary>
     public SelfTradePreventionMode? SelfTradePreventionMode { get; set; }
 }
@@ -370,13 +374,16 @@ public static class RiskLimitsResolver
     /// <summary>
     /// #433 P1. Resolve the venue-side STP mode for a single order,
     /// applying the project-wide default of
-    /// <see cref="SelfTradePreventionMode.CancelAggressorOrder"/>
+    /// <see cref="SelfTradePreventionMode.None"/>
     /// when no scope in the precedence chain pins a value. Returns a
     /// non-nullable value so the gateway never has to make the
-    /// "what does null mean" decision at submit time.
+    /// "what does null mean" decision at submit time. Defaulting to
+    /// <c>None</c> preserves existing venue behavior — operators
+    /// opt-in to matching-engine STP enforcement per-firm /
+    /// per-end-client.
     /// </summary>
     public static SelfTradePreventionMode ResolveSelfTradePreventionMode(
         RiskOptions opts, string endClient, string? firmId, string symbol) =>
         Resolve(opts, endClient, firmId, symbol, l => l.SelfTradePreventionMode)
-            ?? SelfTradePreventionMode.CancelAggressorOrder;
+            ?? SelfTradePreventionMode.None;
 }

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -249,6 +249,28 @@ public sealed class RiskLimits
     /// or for staged rollouts of a new order type.
     /// </summary>
     public List<string>? AllowedOrderTypes { get; set; }
+
+    /// <summary>
+    /// #433 P1. Venue-side STP instruction sent on every outbound
+    /// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c> (B3
+    /// EntryPoint SDK ≥ 0.15.0). Belt-and-braces companion to the
+    /// pre-trade <see cref="Checks.SelfTradePreventionCheck"/>: the
+    /// pre-trade check still rejects same-firm same-owner crosses
+    /// synchronously when <see cref="AllowSelfTrade"/> is not
+    /// <c>true</c>; this field tells the matching engine what to do
+    /// if a cross still reaches the book (e.g. same-firm
+    /// different-owner pairs that the pre-trade check intentionally
+    /// allows, or any pair the platform missed because the
+    /// working-order snapshot was stale). Default semantics when
+    /// unset everywhere in the precedence chain are
+    /// <see cref="SelfTradePreventionMode.CancelAggressorOrder"/> —
+    /// mirrors the pre-trade "newest rejects" stance so the venue
+    /// behavior matches the app-side check by default. Set to
+    /// <see cref="SelfTradePreventionMode.None"/> per-firm or
+    /// per-end-client to opt out (e.g. market-maker accounts that
+    /// rely on an external risk layer).
+    /// </summary>
+    public SelfTradePreventionMode? SelfTradePreventionMode { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -342,5 +364,19 @@ public static class RiskLimitsResolver
             AllowedOrderTypes = ResolveRef(opts, endClient, firmId, symbol,
                 l => l.AllowedOrderTypes,
                 v => v.Count > 0),
+            SelfTradePreventionMode = Resolve(opts, endClient, firmId, symbol, l => l.SelfTradePreventionMode),
         };
+
+    /// <summary>
+    /// #433 P1. Resolve the venue-side STP mode for a single order,
+    /// applying the project-wide default of
+    /// <see cref="SelfTradePreventionMode.CancelAggressorOrder"/>
+    /// when no scope in the precedence chain pins a value. Returns a
+    /// non-nullable value so the gateway never has to make the
+    /// "what does null mean" decision at submit time.
+    /// </summary>
+    public static SelfTradePreventionMode ResolveSelfTradePreventionMode(
+        RiskOptions opts, string endClient, string? firmId, string symbol) =>
+        Resolve(opts, endClient, firmId, symbol, l => l.SelfTradePreventionMode)
+            ?? SelfTradePreventionMode.CancelAggressorOrder;
 }

--- a/backend/src/B3.Trading.Application/Risk/SelfTradePreventionMode.cs
+++ b/backend/src/B3.Trading.Application/Risk/SelfTradePreventionMode.cs
@@ -1,0 +1,58 @@
+namespace B3.Trading.Application.Risk;
+
+/// <summary>
+/// Venue-side self-trade-prevention instruction emitted on outbound
+/// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>. Maps 1:1 to
+/// <c>B3.EntryPoint.Client.Models.SelfTradePreventionInstruction</c>
+/// (added in SDK 0.15.0) — kept as an Application-layer enum so the
+/// Application + Domain projects do not gain a transitive reference
+/// to the wire library and so the same value can be plumbed through
+/// the in-process mock seam if/when needed.
+///
+/// <para>
+/// This is the wire-side belt-and-braces companion to the pre-trade
+/// <see cref="Checks.SelfTradePreventionCheck"/>. The pre-trade check
+/// continues to reject same-firm same-owner crosses synchronously
+/// (gateway dispatch never even fires) when
+/// <see cref="RiskLimits.AllowSelfTrade"/> is not <c>true</c>; the
+/// instruction below is what the venue matching engine consults if a
+/// cross still reaches the book — for example a same-firm cross
+/// between two different end-clients (which the pre-trade check
+/// intentionally allows), or any pair the platform missed because
+/// the working-order snapshot was stale.
+/// </para>
+/// </summary>
+public enum SelfTradePreventionMode
+{
+    /// <summary>
+    /// Do not send any STP instruction (SDK <c>None</c>). The venue
+    /// applies its own default — historically "no STP", i.e. a
+    /// self-cross will execute. Use only when the operator has a
+    /// specific reason to suppress venue-side STP (test accounts,
+    /// market-makers running an external risk layer).
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Cancel the incoming (aggressor) order — the side that
+    /// would have crossed against its own resting order. Equivalent
+    /// to the pre-trade check's "newest rejects" stance and is the
+    /// sensible default for retail/buy-side flow.
+    /// </summary>
+    CancelAggressorOrder = 1,
+
+    /// <summary>
+    /// Cancel the resting opposite-side order — let the aggressor
+    /// trade as if the resting order weren't there. Common for
+    /// market-makers who want their newest quote to win over a
+    /// stale own quote.
+    /// </summary>
+    CancelRestingOrder = 2,
+
+    /// <summary>
+    /// Cancel both orders. Used by some prop / arbitrage strategies
+    /// that prefer to clear the book of any self-cross than to keep
+    /// either side resting.
+    /// </summary>
+    CancelBothOrders = 3,
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -120,8 +120,10 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var upstream = new B3.EntryPoint.Client.EntryPointClient(clientOpts);
                     var gwLogger = lf.CreateLogger<B3EntryPointClientGateway>();
                     var reactor = sp.GetService<IVenueDisconnectReactor>();
+                    var riskOpts = sp.GetService<IOptionsMonitor<RiskOptions>>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
-                        venueDisconnectReactor: reactor);
+                        venueDisconnectReactor: reactor,
+                        riskOptions: riskOpts);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -395,13 +395,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// </summary>
     internal static UpModels.SelfTradePreventionInstruction MapStpInstruction(
         SelfTradePreventionMode mode) => mode switch
-    {
-        SelfTradePreventionMode.None => UpModels.SelfTradePreventionInstruction.None,
-        SelfTradePreventionMode.CancelAggressorOrder => UpModels.SelfTradePreventionInstruction.CancelAggressorOrder,
-        SelfTradePreventionMode.CancelRestingOrder => UpModels.SelfTradePreventionInstruction.CancelRestingOrder,
-        SelfTradePreventionMode.CancelBothOrders => UpModels.SelfTradePreventionInstruction.CancelBothOrders,
-        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unmapped Application.SelfTradePreventionMode."),
-    };
+        {
+            SelfTradePreventionMode.None => UpModels.SelfTradePreventionInstruction.None,
+            SelfTradePreventionMode.CancelAggressorOrder => UpModels.SelfTradePreventionInstruction.CancelAggressorOrder,
+            SelfTradePreventionMode.CancelRestingOrder => UpModels.SelfTradePreventionInstruction.CancelRestingOrder,
+            SelfTradePreventionMode.CancelBothOrders => UpModels.SelfTradePreventionInstruction.CancelBothOrders,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unmapped Application.SelfTradePreventionMode."),
+        };
 
     /// <summary>
     /// #433 P1. Resolve the STP instruction to stamp on an outbound

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -1,6 +1,8 @@
 using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Up = B3.EntryPoint.Client;
 using UpModels = B3.EntryPoint.Client.Models;
 
@@ -57,6 +59,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private ulong _lastGapPriorSessionVerId;
     private string? _lastTerminationCode;
     private readonly IVenueDisconnectReactor? _reactor;
+    // #433 P1. Optional resolver for the venue-side STP instruction
+    // stamped on every outbound NewOrderRequest / ReplaceOrderRequest.
+    // Optional (rather than required) so legacy tests that construct
+    // the gateway directly stay green — a null resolver collapses to
+    // SelfTradePreventionInstruction.None and the wire behavior
+    // matches pre-#433.
+    private readonly IOptionsMonitor<RiskOptions>? _riskOptions;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -68,7 +77,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         TimeProvider? clock = null,
         OrderEntryLatencyProbe? latencyProbe = null,
         IVenueDisconnectReactor? venueDisconnectReactor = null,
-        TimeSpan? gracefulTerminateTimeout = null)
+        TimeSpan? gracefulTerminateTimeout = null,
+        IOptionsMonitor<RiskOptions>? riskOptions = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -80,6 +90,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _clock = clock ?? TimeProvider.System;
         _latencyProbe = latencyProbe ?? new OrderEntryLatencyProbe(_clock);
         _reactor = venueDisconnectReactor;
+        _riskOptions = riskOptions;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -165,7 +176,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = BuildNewOrderRequest(order);
+        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order));
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
             ct => _client.SubmitAsync(req, ct), cancellationToken);
@@ -177,8 +188,21 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// tests without standing up a real <c>EntryPointClient</c>. Pure
     /// function: every field is read from the domain
     /// <see cref="Order"/> exactly once and there are no side effects.
+    ///
+    /// <para>
+    /// #433 P1. <paramref name="stpInstruction"/> is the venue-side
+    /// self-trade-prevention instruction (SDK 0.15.0+). Resolved by
+    /// the caller via <see cref="RiskLimitsResolver.ResolveSelfTradePreventionMode"/>
+    /// and mapped through <see cref="MapStpInstruction"/>; defaults
+    /// to <see cref="UpModels.SelfTradePreventionInstruction.None"/>
+    /// on the legacy overload below so existing tests stay green.
+    /// </para>
     /// </summary>
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
+        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None);
+
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(
+        Order order, UpModels.SelfTradePreventionInstruction stpInstruction)
     {
         ArgumentNullException.ThrowIfNull(order);
         return new UpModels.NewOrderRequest
@@ -197,7 +221,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // visible qty"). Domain.Order's ctor already validated
             // 0 < DisplayQty <= Quantity, so the cast is safe.
             // TODO(#298): DisplayResetPolicy is NOT plumbed to the SDK —
-            // B3.EntryPoint.Client 0.14.3 NewOrderRequest exposes no
+            // B3.EntryPoint.Client 0.15.0 NewOrderRequest exposes no
             // refresh-policy flag. To avoid the venue silently defaulting
             // to Always (which would break the OnPartialFill / Never
             // contracts), the REST + risk validation boundary REJECTS
@@ -208,6 +232,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // wire order.DisplayResetPolicy here and drop the validation
             // guard in OrdersEndpoints.cs + OrderSubmissionService.cs.
             MaxFloor = order.DisplayQty is { } dq ? (ulong)dq : (ulong?)null,
+            // #433 P1. Venue-side STP. Defense-in-depth pair with
+            // SelfTradePreventionCheck — see SelfTradePreventionMode
+            // doc comment for the rationale. The instruction value is
+            // resolved by the caller (gateway SubmitAsync) so this
+            // static stays pure.
+            SelfTradePreventionInstruction = stpInstruction,
         };
     }
 
@@ -281,6 +311,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             MaxFloor = original.DisplayQty is { } odq
                 ? (ulong)Math.Min(odq, newQuantity)
                 : (ulong?)null,
+            // #433 P1. Venue-side STP carried on the replace too —
+            // a modified order is a fresh book entry from the
+            // matching engine's perspective so the instruction must
+            // re-accompany it. Resolution scope is the original
+            // order's (owner, firm, symbol) — modify never changes
+            // those three.
+            SelfTradePreventionInstruction = ResolveStpInstruction(original),
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -348,6 +385,41 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         TimeInForce.GoodForAuction => UpModels.TimeInForce.GoodForAuction,
         _ => throw new ArgumentOutOfRangeException(nameof(tif), tif, "Unmapped Domain.TimeInForce."),
     };
+
+    /// <summary>
+    /// #433 P1. Application → SDK STP-instruction mapping. Total over
+    /// every <see cref="SelfTradePreventionMode"/> value; throws on
+    /// unmapped values so adding a future variant without updating
+    /// this table fails loudly instead of silently sending
+    /// <c>None</c> on the wire.
+    /// </summary>
+    internal static UpModels.SelfTradePreventionInstruction MapStpInstruction(
+        SelfTradePreventionMode mode) => mode switch
+    {
+        SelfTradePreventionMode.None => UpModels.SelfTradePreventionInstruction.None,
+        SelfTradePreventionMode.CancelAggressorOrder => UpModels.SelfTradePreventionInstruction.CancelAggressorOrder,
+        SelfTradePreventionMode.CancelRestingOrder => UpModels.SelfTradePreventionInstruction.CancelRestingOrder,
+        SelfTradePreventionMode.CancelBothOrders => UpModels.SelfTradePreventionInstruction.CancelBothOrders,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unmapped Application.SelfTradePreventionMode."),
+    };
+
+    /// <summary>
+    /// #433 P1. Resolve the STP instruction to stamp on an outbound
+    /// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c> for a
+    /// given order. Falls back to
+    /// <see cref="UpModels.SelfTradePreventionInstruction.None"/>
+    /// when no <see cref="RiskOptions"/> monitor is wired (test
+    /// gateways that don't care about the field stay green); the
+    /// production composition root always passes one.
+    /// </summary>
+    private UpModels.SelfTradePreventionInstruction ResolveStpInstruction(Order order)
+    {
+        if (_riskOptions is null)
+            return UpModels.SelfTradePreventionInstruction.None;
+        var mode = RiskLimitsResolver.ResolveSelfTradePreventionMode(
+            _riskOptions.CurrentValue, order.Owner.Value, order.FirmId, order.Symbol);
+        return MapStpInstruction(mode);
+    }
 
     // The IEntryPointClient submit-side surface is unused on the real adapter
     // (OrdersEndpoints calls IExchangeGateway directly). We implement it to

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -146,19 +146,22 @@ public class B3EntryPointClientGatewayMapTests
     }
 
     [Fact]
-    public void ResolveSelfTradePreventionMode_Default_IsCancelAggressorOrder()
+    public void ResolveSelfTradePreventionMode_Default_IsNone()
     {
-        // #433 P1. Default-everywhere semantics intentionally mirror
-        // the pre-trade SelfTradePreventionCheck's "newest rejects"
-        // stance so the venue behavior matches the app-side check by
-        // default (defense in depth, not contradictory policy).
+        // #433 P1. Default-everywhere semantics are intentionally
+        // None so the venue does not enforce STP unless an operator
+        // explicitly opts in — preserves historical behavior for
+        // tenants that rely on crossed trades reaching the book
+        // (e.g. cross-account hedging inside the same firm). The
+        // app-side SelfTradePreventionCheck remains the primary
+        // line of defense.
         var opts = new B3.Trading.Application.Risk.RiskOptions();
 
         var mode = B3.Trading.Application.Risk.RiskLimitsResolver
             .ResolveSelfTradePreventionMode(opts, "alice", "FIRM-A", "PETR4");
 
         Assert.Equal(
-            B3.Trading.Application.Risk.SelfTradePreventionMode.CancelAggressorOrder,
+            B3.Trading.Application.Risk.SelfTradePreventionMode.None,
             mode);
     }
 

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -85,4 +85,131 @@ public class B3EntryPointClientGatewayMapTests
         Assert.Equal((ulong)displayQty, req.MaxFloor);
         Assert.Equal((ulong)quantity, req.OrderQty);
     }
+
+    // ------------------------------------------------------------------
+    // #433 P1. Venue-side SelfTradePreventionInstruction wire mapping.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(B3.Trading.Application.Risk.SelfTradePreventionMode.None,
+                Up.SelfTradePreventionInstruction.None)]
+    [InlineData(B3.Trading.Application.Risk.SelfTradePreventionMode.CancelAggressorOrder,
+                Up.SelfTradePreventionInstruction.CancelAggressorOrder)]
+    [InlineData(B3.Trading.Application.Risk.SelfTradePreventionMode.CancelRestingOrder,
+                Up.SelfTradePreventionInstruction.CancelRestingOrder)]
+    [InlineData(B3.Trading.Application.Risk.SelfTradePreventionMode.CancelBothOrders,
+                Up.SelfTradePreventionInstruction.CancelBothOrders)]
+    public void MapStpInstruction_CoversAllDomainValues(
+        B3.Trading.Application.Risk.SelfTradePreventionMode mode,
+        Up.SelfTradePreventionInstruction sdk)
+    {
+        Assert.Equal(sdk, B3EntryPointClientGateway.MapStpInstruction(mode));
+    }
+
+    [Fact]
+    public void MapStpInstruction_UnmappedValue_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => B3EntryPointClientGateway.MapStpInstruction(
+                (B3.Trading.Application.Risk.SelfTradePreventionMode)999));
+    }
+
+    [Fact]
+    public void BuildNewOrderRequest_LegacyOverload_DefaultsStpInstructionToNone()
+    {
+        // The single-arg overload exists so pre-#433 tests stay green.
+        // It must collapse to None on the wire (legacy behavior).
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order);
+
+        Assert.Equal(Up.SelfTradePreventionInstruction.None, req.SelfTradePreventionInstruction);
+    }
+
+    [Theory]
+    [InlineData(Up.SelfTradePreventionInstruction.None)]
+    [InlineData(Up.SelfTradePreventionInstruction.CancelAggressorOrder)]
+    [InlineData(Up.SelfTradePreventionInstruction.CancelRestingOrder)]
+    [InlineData(Up.SelfTradePreventionInstruction.CancelBothOrders)]
+    public void BuildNewOrderRequest_StampsResolvedStpInstruction(
+        Up.SelfTradePreventionInstruction stp)
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var req = B3EntryPointClientGateway.BuildNewOrderRequest(order, stp);
+
+        Assert.Equal(stp, req.SelfTradePreventionInstruction);
+    }
+
+    [Fact]
+    public void ResolveSelfTradePreventionMode_Default_IsCancelAggressorOrder()
+    {
+        // #433 P1. Default-everywhere semantics intentionally mirror
+        // the pre-trade SelfTradePreventionCheck's "newest rejects"
+        // stance so the venue behavior matches the app-side check by
+        // default (defense in depth, not contradictory policy).
+        var opts = new B3.Trading.Application.Risk.RiskOptions();
+
+        var mode = B3.Trading.Application.Risk.RiskLimitsResolver
+            .ResolveSelfTradePreventionMode(opts, "alice", "FIRM-A", "PETR4");
+
+        Assert.Equal(
+            B3.Trading.Application.Risk.SelfTradePreventionMode.CancelAggressorOrder,
+            mode);
+    }
+
+    [Fact]
+    public void ResolveSelfTradePreventionMode_HonoursPrecedenceChain()
+    {
+        // per-end-client wins over per-firm wins over per-symbol wins
+        // over Default — the same precedence as every other field in
+        // RiskLimitsResolver.
+        var opts = new B3.Trading.Application.Risk.RiskOptions
+        {
+            Default = new B3.Trading.Application.Risk.RiskLimits
+            {
+                SelfTradePreventionMode = B3.Trading.Application.Risk.SelfTradePreventionMode.None,
+            },
+        };
+        opts.PerSymbol["PETR4"] = new B3.Trading.Application.Risk.RiskLimits
+        {
+            SelfTradePreventionMode = B3.Trading.Application.Risk.SelfTradePreventionMode.CancelBothOrders,
+        };
+        opts.PerFirm["FIRM-A"] = new B3.Trading.Application.Risk.RiskLimits
+        {
+            SelfTradePreventionMode = B3.Trading.Application.Risk.SelfTradePreventionMode.CancelRestingOrder,
+        };
+        opts.PerEndClient["alice"] = new B3.Trading.Application.Risk.RiskLimits
+        {
+            SelfTradePreventionMode = B3.Trading.Application.Risk.SelfTradePreventionMode.CancelAggressorOrder,
+        };
+
+        // alice wins (per-end-client)
+        Assert.Equal(
+            B3.Trading.Application.Risk.SelfTradePreventionMode.CancelAggressorOrder,
+            B3.Trading.Application.Risk.RiskLimitsResolver
+                .ResolveSelfTradePreventionMode(opts, "alice", "FIRM-A", "PETR4"));
+
+        // unknown end-client → firm wins
+        Assert.Equal(
+            B3.Trading.Application.Risk.SelfTradePreventionMode.CancelRestingOrder,
+            B3.Trading.Application.Risk.RiskLimitsResolver
+                .ResolveSelfTradePreventionMode(opts, "bob", "FIRM-A", "PETR4"));
+
+        // unknown firm → symbol wins
+        Assert.Equal(
+            B3.Trading.Application.Risk.SelfTradePreventionMode.CancelBothOrders,
+            B3.Trading.Application.Risk.RiskLimitsResolver
+                .ResolveSelfTradePreventionMode(opts, "bob", "FIRM-X", "PETR4"));
+
+        // nothing matches → Default
+        Assert.Equal(
+            B3.Trading.Application.Risk.SelfTradePreventionMode.None,
+            B3.Trading.Application.Risk.RiskLimitsResolver
+                .ResolveSelfTradePreventionMode(opts, "bob", "FIRM-X", "VALE3"));
+    }
 }


### PR DESCRIPTION
Plumbs venue-side `SelfTradePreventionInstruction` (SDK 0.15.0) as a defense-in-depth companion to the existing pre-trade `SelfTradePreventionCheck`. Closes #433 (narrow slice — wire integration + configurable mode).

## Architecture: two layers, one policy

| Layer | Component | Trigger |
|---|---|---|
| Pre-trade (app) | `SelfTradePreventionCheck` | rejects same-firm same-owner crosses before wire |
| Wire (venue) | `SelfTradePreventionInstruction` on `NewOrderRequest`/`ReplaceOrderRequest` (NEW) | matching engine enforces if anything slips past (different-owner same-firm, snapshot stale, race) |

Default mode = **`CancelAggressorOrder`** — wire mirrors the pre-trade "newest rejects" stance for a coherent policy across layers.

## Changes

- **NEW** `Application/Risk/SelfTradePreventionMode.cs` — 4-value enum mirroring SDK (`None`/`CancelAggressorOrder`/`CancelRestingOrder`/`CancelBothOrders`) with class-level doc explaining defense-in-depth intent.
- `RiskOptions.RiskLimits.SelfTradePreventionMode?` field + `ResolveAll` entry (visible in `/admin/risk/limits`).
- `RiskLimitsResolver.ResolveSelfTradePreventionMode` — per-endclient → per-firm → per-symbol → default precedence (mirrors every other risk knob).
- `B3EntryPointClientGateway`:
  - Optional `IOptionsMonitor<RiskOptions>?` last ctor param (back-compat).
  - `MapStpInstruction` static + `ResolveStpInstruction` helpers.
  - `BuildNewOrderRequest` split into legacy single-arg (defaults to `None`) + STP-aware overload.
  - Both `NewOrderRequest` (Submit) and `ReplaceOrderRequest` (CancelReplace) now stamp the resolved instruction.
- `TradingExchangeGatewayServiceCollectionExtensions` — resolves `IOptionsMonitor<RiskOptions>` and injects into Real-mode gateway.

## Scoped OUT (deliberately deferred)

- **Cross-firm same-beneficial-owner detection** — needs `BeneficialOwnerRegistry`; the premise needs literal CVM 168 anchor per the earlier audit. Tracked as separate follow-up.
- **Venue-side STP-rejected metric** — venue rejects don't fire an app-side event; the existing app-side `SelfTradePreventionCheck` counter already covers the pre-trade arm.
- **Mock gateway seam** — wire-only behavior; mock not exercised in production STP path.

## Validation

- `dotnet build B3TradingPlatform.slnx` — 0 warnings, 0 errors
- `dotnet test B3TradingPlatform.slnx` — **1889 passed / 0 failed / 30 skipped** (+12 new tests)
- 7 new tests in `B3EntryPointClientGatewayMapTests`:
  - `MapStpInstruction_CoversAllDomainValues` (theory, 4 cases)
  - `MapStpInstruction_UnmappedValue_Throws`
  - `BuildNewOrderRequest_LegacyOverload_DefaultsStpInstructionToNone`
  - `BuildNewOrderRequest_StampsResolvedStpInstruction` (theory, 4 cases)
  - `ResolveSelfTradePreventionMode_Default_IsCancelAggressorOrder`
  - `ResolveSelfTradePreventionMode_HonoursPrecedenceChain` (all 4 scope levels)

## Dependencies

Stacked on top of **#467** (SDK 0.15.0 bump). The commit graph carries the bump so this PR builds standalone if merged in any order, but reviewing #467 first gives the cleanest history.

## #433 acceptance checklist

- ✅ Wire `SelfTradePreventionInstruction` correct + pinning tests
- ✅ Per-scope mode resolver (endclient/firm/symbol/default)
- ⏭️ Cross-firm beneficial-owner — out of scope (separate follow-up; needs CVM 168 anchor)
- ⏭️ App-side metric for venue rejects — venue doesn't fire app-side events
- ⏭️ RFC update — deferred

