### PR TITLE
feat(#471): plumb TradingSubAccount on outbound order requests

### DIFF
--- a/backend/src/B3.Trading.Application/SubAccount/DeterministicSubAccountWireIdMapper.cs
+++ b/backend/src/B3.Trading.Application/SubAccount/DeterministicSubAccountWireIdMapper.cs
@@ -1,0 +1,76 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.SubAccount;
+
+/// <summary>
+/// Default <see cref="ISubAccountWireIdMapper"/> implementation. Hashes
+/// <c>firmId + '\0' + subAccountId.Value</c> through FNV-1a 32-bit and
+/// folds the (extremely rare) zero output to <c>1</c>, guaranteeing
+/// a non-zero <c>uint</c> for every non-null input.
+///
+/// <para>
+/// <b>Determinism contract.</b> The output is a pure function of the
+/// pair (firmId, subAccountId.Value) with no I/O, no clock, no
+/// allocation beyond the UTF-8 encoding of those two strings. Same
+/// inputs always produce the same output across processes, hosts and
+/// restarts — by design, since the same trader's orders must carry the
+/// same wire id across an entire trading session.
+/// </para>
+///
+/// <para>
+/// <b>Collision posture.</b> A firm's sub-account namespace is small
+/// (handful to low-hundreds of distinct ids in realistic deployments),
+/// so 2^32 output space is well above the birthday bound — collisions
+/// are not expected at this scale. If a registered lookup-table mapper
+/// is ever introduced (operator-negotiated registry with the broker),
+/// it can be swapped in via DI without changing the gateway. The seam
+/// in <see cref="ISubAccountWireIdMapper"/> exists exactly for that
+/// migration path.
+/// </para>
+///
+/// <para>
+/// <b>Encoding.</b> UTF-8 of the firmId, a single zero byte separator
+/// (cannot appear inside <see cref="SubAccountId.Value"/> nor inside
+/// the firmId per <c>FirmConfigValidation</c>), then UTF-8 of the
+/// sub-account id. The separator is what makes
+/// <c>("FIRM01", "A.B")</c> distinguishable from <c>("FIRM01A", ".B")</c>
+/// instead of degenerating to the same byte stream.
+/// </para>
+/// </summary>
+public sealed class DeterministicSubAccountWireIdMapper : ISubAccountWireIdMapper
+{
+    private const uint FnvOffsetBasis = 2166136261u;
+    private const uint FnvPrime = 16777619u;
+
+    public uint? TryMap(string firmId, SubAccountId? subAccountId)
+    {
+        if (subAccountId is null) return null;
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+
+        var hash = FnvOffsetBasis;
+        hash = HashUtf8(hash, firmId);
+        hash = HashByte(hash, 0);
+        hash = HashUtf8(hash, subAccountId.Value);
+
+        // Reserve 0 → 1. Zero is a valid uint but several downstream
+        // consumers (logs, dashboards, JSON projections) treat "0" as
+        // an "unset" sentinel; folding to 1 keeps the wire output
+        // unambiguously meaningful while leaving the rest of the
+        // 2^32 - 1 space intact.
+        return hash == 0u ? 1u : hash;
+    }
+
+    private static uint HashUtf8(uint hash, string s)
+    {
+        // Pure ASCII fast path — SubAccountId enforces [A-Za-z0-9._-]
+        // (single-byte UTF-8 for every legal codepoint), so a char-by-char
+        // pass produces the same byte sequence System.Text.Encoding.UTF8
+        // would, without allocating a temporary byte[]. FirmId validation
+        // (FirmConfigValidation) likewise restricts to ASCII id chars.
+        foreach (var c in s)
+            hash = HashByte(hash, (byte)c);
+        return hash;
+    }
+
+    private static uint HashByte(uint hash, byte b) => (hash ^ b) * FnvPrime;
+}

--- a/backend/src/B3.Trading.Application/SubAccount/ISubAccountWireIdMapper.cs
+++ b/backend/src/B3.Trading.Application/SubAccount/ISubAccountWireIdMapper.cs
@@ -1,0 +1,45 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.SubAccount;
+
+/// <summary>
+/// #471 (SDK 0.15.0). Maps a domain <see cref="SubAccountId"/> (string,
+/// case-sensitive, namespaced per-firm) to the numeric
+/// <c>TradingSubAccount</c> (<c>uint?</c>) carried on every outbound
+/// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c> when present.
+///
+/// <para>
+/// <b>Why a seam.</b> The B3 wire field is numeric per-session and has
+/// no upstream registration handshake on our side today (#471 RFC). The
+/// platform therefore generates the wire id from the domain id via an
+/// internal stable function rather than via a venue-issued mapping. The
+/// seam lets an operator swap the default deterministic hash for an
+/// explicit lookup table the day they negotiate a registered mapping
+/// with the broker, without touching the gateway.
+/// </para>
+///
+/// <para>
+/// <b>Null in, null out.</b> Per the RFC: <c>TradingSubAccount</c> is
+/// nullable on the wire (not every order carries a sub-account); a
+/// <c>null</c> domain id MUST produce a <c>null</c> wire id so the
+/// SDK omits the field entirely. Non-null inputs MUST produce non-null,
+/// non-zero outputs (zero is reserved to defend against accidental
+/// "looks unset" interop bugs in any future consumer).
+/// </para>
+/// </summary>
+public interface ISubAccountWireIdMapper
+{
+    /// <summary>
+    /// Maps the (firm, sub-account) pair to the wire id. The firm is
+    /// part of the input because <see cref="SubAccountId"/> is
+    /// namespaced per-firm (see <see cref="SubAccountsRegistry"/>)
+    /// and the wire id must be deterministic <i>within</i> a firm's
+    /// session — different firms may produce different ids for the
+    /// same domain string.
+    /// </summary>
+    /// <returns>
+    /// <c>null</c> iff <paramref name="subAccountId"/> is <c>null</c>;
+    /// otherwise a non-zero <see cref="uint"/>.
+    /// </returns>
+    uint? TryMap(string firmId, SubAccountId? subAccountId);
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
+using B3.Trading.Application.SubAccount;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Host.Lifecycle;
@@ -58,6 +59,13 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         services.AddSingleton<SubAccountsRegistry>();
         services.AddSingleton<SubAccountPositionKeeper>();
         services.AddSingleton<SubAccountPnlKeeper>();
+        // #471 (SDK 0.15.0). Map domain SubAccountId (string) → numeric
+        // uint? stamped on every outbound NewOrderRequest /
+        // ReplaceOrderRequest. Default = deterministic FNV-1a hash of
+        // (firmId, subAccountId.Value); operators can override at the
+        // composition root with an explicit lookup table if they
+        // negotiate a registered mapping with the broker.
+        services.AddSingleton<ISubAccountWireIdMapper, DeterministicSubAccountWireIdMapper>();
         // Q4.5 (#305). Audit log keeper + dispatcher-backed logger.
         // Both singletons so the live-dispatch path, recovery replay
         // and admin read endpoint all share the same in-memory ring

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using B3.Trading.Application;
 using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.SubAccount;
 using B3.Trading.Host.Hosted;
 using B3.Trading.Infrastructure;
 using B3.Trading.Infrastructure.Persistence;
@@ -121,9 +122,11 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var gwLogger = lf.CreateLogger<B3EntryPointClientGateway>();
                     var reactor = sp.GetService<IVenueDisconnectReactor>();
                     var riskOpts = sp.GetService<IOptionsMonitor<RiskOptions>>();
+                    var subAccountMapper = sp.GetService<ISubAccountWireIdMapper>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
                         venueDisconnectReactor: reactor,
-                        riskOptions: riskOpts);
+                        riskOptions: riskOpts,
+                        subAccountWireIdMapper: subAccountMapper);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -1,5 +1,6 @@
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Risk;
+using B3.Trading.Application.SubAccount;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -66,6 +67,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     // SelfTradePreventionInstruction.None and the wire behavior
     // matches pre-#433.
     private readonly IOptionsMonitor<RiskOptions>? _riskOptions;
+    // #471. Optional mapper from domain SubAccountId (string) to the
+    // numeric uint? carried in NewOrderRequest.TradingSubAccount /
+    // ReplaceOrderRequest.TradingSubAccount (SDK 0.15.0+). Null →
+    // no mapper wired → orders never stamp the field (legacy wire
+    // behavior, matches the pre-#471 contract). Production
+    // composition root always wires DeterministicSubAccountWireIdMapper.
+    private readonly ISubAccountWireIdMapper? _subAccountWireIdMapper;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -78,7 +86,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         OrderEntryLatencyProbe? latencyProbe = null,
         IVenueDisconnectReactor? venueDisconnectReactor = null,
         TimeSpan? gracefulTerminateTimeout = null,
-        IOptionsMonitor<RiskOptions>? riskOptions = null)
+        IOptionsMonitor<RiskOptions>? riskOptions = null,
+        ISubAccountWireIdMapper? subAccountWireIdMapper = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -91,6 +100,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _latencyProbe = latencyProbe ?? new OrderEntryLatencyProbe(_clock);
         _reactor = venueDisconnectReactor;
         _riskOptions = riskOptions;
+        _subAccountWireIdMapper = subAccountWireIdMapper;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -176,7 +186,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order));
+        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order));
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
             ct => _client.SubmitAsync(req, ct), cancellationToken);
@@ -199,10 +209,16 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// </para>
     /// </summary>
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
-        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None);
+        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order, UpModels.SelfTradePreventionInstruction stpInstruction)
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null);
+
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(
+        Order order,
+        UpModels.SelfTradePreventionInstruction stpInstruction,
+        uint? tradingSubAccount)
     {
         ArgumentNullException.ThrowIfNull(order);
         return new UpModels.NewOrderRequest
@@ -238,6 +254,11 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // resolved by the caller (gateway SubmitAsync) so this
             // static stays pure.
             SelfTradePreventionInstruction = stpInstruction,
+            // #471. Numeric wire id for the order's sub-account, when
+            // the order carries one. Null = no sub-account on the
+            // wire (SDK omits the field entirely) — matches the
+            // master-bucket semantics of Order.SubAccountId == null.
+            TradingSubAccount = tradingSubAccount,
         };
     }
 
@@ -318,6 +339,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // order's (owner, firm, symbol) — modify never changes
             // those three.
             SelfTradePreventionInstruction = ResolveStpInstruction(original),
+            // #471. Same rationale as STP above: from the matching
+            // engine's perspective a replace is a fresh order, so the
+            // TradingSubAccount wire id must re-accompany it. The
+            // domain sub-account on the original Order is preserved
+            // through every modify path (HydrateReplacement copies it
+            // verbatim), so resolving from `original` is correct.
+            TradingSubAccount = ResolveTradingSubAccount(original),
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -419,6 +447,21 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         var mode = RiskLimitsResolver.ResolveSelfTradePreventionMode(
             _riskOptions.CurrentValue, order.Owner.Value, order.FirmId, order.Symbol);
         return MapStpInstruction(mode);
+    }
+
+    /// <summary>
+    /// #471. Resolve the numeric <c>TradingSubAccount</c> stamped on
+    /// an outbound <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>.
+    /// Returns <c>null</c> when no <see cref="ISubAccountWireIdMapper"/>
+    /// is wired (legacy gateways that don't care about the field stay
+    /// green) or when the order itself has no sub-account (master
+    /// bucket — wire field stays omitted). The production composition
+    /// root always wires <see cref="DeterministicSubAccountWireIdMapper"/>.
+    /// </summary>
+    private uint? ResolveTradingSubAccount(Order order)
+    {
+        if (_subAccountWireIdMapper is null) return null;
+        return _subAccountWireIdMapper.TryMap(order.FirmId, order.SubAccountId);
     }
 
     // The IEntryPointClient submit-side surface is unused on the real adapter

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -215,4 +215,49 @@ public class B3EntryPointClientGatewayMapTests
             B3.Trading.Application.Risk.RiskLimitsResolver
                 .ResolveSelfTradePreventionMode(opts, "bob", "FIRM-X", "VALE3"));
     }
+
+    // ------------------------------------------------------------------
+    // #471. TradingSubAccount wire field (SDK 0.15.0). The four-arg
+    // BuildNewOrderRequest overload is the seam the gateway calls in
+    // production; these tests pin null-passthrough, non-null stamping,
+    // and the legacy overloads' wire-stable default of null.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void BuildNewOrderRequest_LegacyOverloads_LeaveTradingSubAccountNull()
+    {
+        // Both the single-arg and the two-arg overload pre-date #471.
+        // They MUST leave the wire field null so existing tests stay
+        // green and any caller that has not opted into the mapper does
+        // not accidentally start stamping a wire id derived from
+        // some default.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(B3EntryPointClientGateway.BuildNewOrderRequest(order).TradingSubAccount);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None)
+            .TradingSubAccount);
+    }
+
+    [Fact]
+    public void BuildNewOrderRequest_StampsResolvedTradingSubAccount()
+    {
+        // The four-arg overload propagates whatever the gateway
+        // resolved from its ISubAccountWireIdMapper into the wire
+        // field. Null in → null out; non-null in → exact value out.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var withId = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 12345u);
+        Assert.Equal(12345u, withId.TradingSubAccount);
+
+        var withoutId = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: null);
+        Assert.Null(withoutId.TradingSubAccount);
+    }
 }
+

--- a/backend/tests/B3.Trading.Application.Tests/DeterministicSubAccountWireIdMapperTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/DeterministicSubAccountWireIdMapperTests.cs
@@ -1,0 +1,112 @@
+using B3.Trading.Application.SubAccount;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #471 (SDK 0.15.0). Pins the domain-string → wire-uint mapping that
+/// the gateway uses to stamp <c>TradingSubAccount</c> on every outbound
+/// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>. The hash itself
+/// is an implementation detail (operators can swap a registered
+/// lookup-table mapper in via DI), but the contract of the seam
+/// — null in / null out, non-null always non-zero, deterministic
+/// across processes, firm-scoped, length-extension safe — is the
+/// public surface every consumer must rely on.
+/// </summary>
+public class DeterministicSubAccountWireIdMapperTests
+{
+    private readonly DeterministicSubAccountWireIdMapper _mapper = new();
+
+    [Fact]
+    public void TryMap_NullSubAccount_ReturnsNull()
+    {
+        Assert.Null(_mapper.TryMap("FIRM-A", subAccountId: null));
+    }
+
+    [Fact]
+    public void TryMap_NonNullSubAccount_ReturnsNonZero()
+    {
+        // Every legal input MUST produce a non-zero output so downstream
+        // consumers that treat 0 as "unset" don't misclassify a real
+        // sub-account as "no sub-account".
+        var result = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        Assert.NotNull(result);
+        Assert.NotEqual(0u, result.Value);
+    }
+
+    [Fact]
+    public void TryMap_IsDeterministic_AcrossCalls()
+    {
+        // Same input pair MUST produce the same output across every
+        // call — otherwise orders from the same trader would carry
+        // different wire ids inside a single session and the venue
+        // would see them as different sub-accounts.
+        var a = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        var b = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void TryMap_IsDeterministic_AcrossInstances()
+    {
+        // Cross-process determinism: a fresh mapper must produce the
+        // same output as the existing instance. Pins that the hash has
+        // no hidden seed (e.g. process-randomised string.GetHashCode).
+        var other = new DeterministicSubAccountWireIdMapper();
+        var a = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        var b = other.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void TryMap_DifferentSubAccounts_SameFirm_ProduceDifferentIds()
+    {
+        var a = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        var b = _mapper.TryMap("FIRM-A", new SubAccountId("prop"));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void TryMap_SameSubAccount_DifferentFirms_ProduceDifferentIds()
+    {
+        // Sub-account ids are namespaced per-firm — FIRM-A:tradingdesk
+        // and FIRM-B:tradingdesk are distinct addresses, so the wire
+        // ids MUST differ. Otherwise the venue could see the same id
+        // for two unrelated traders if the platform ever multiplexes
+        // a single session across firms.
+        var a = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        var b = _mapper.TryMap("FIRM-B", new SubAccountId("tradingdesk"));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void TryMap_DefendsAgainstLengthExtension()
+    {
+        // The mapper inserts a zero-byte separator between firmId and
+        // subAccountId in the hash input. Without it, ("FIRM01", "A.B")
+        // and ("FIRM01A", ".B") would hash identically. Pin that the
+        // separator works (the inputs are crafted so they would degenerate
+        // to the same byte stream under naive concatenation).
+        var a = _mapper.TryMap("FIRM01", new SubAccountId("A.B"));
+        var b = _mapper.TryMap("FIRM01A", new SubAccountId(".B"));
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void TryMap_RejectsEmptyFirmId()
+    {
+        Assert.Throws<ArgumentException>(
+            () => _mapper.TryMap("", new SubAccountId("tradingdesk")));
+    }
+
+    [Fact]
+    public void TryMap_CaseSensitive()
+    {
+        // SubAccountId is case-sensitive at the domain level; the wire
+        // mapper must preserve that distinction so two distinct
+        // sub-accounts that differ only in case don't collide.
+        var a = _mapper.TryMap("FIRM-A", new SubAccountId("TradingDesk"));
+        var b = _mapper.TryMap("FIRM-A", new SubAccountId("tradingdesk"));
+        Assert.NotEqual(a, b);
+    }
+}


### PR DESCRIPTION
Closes #471.

## Resumo da decisão (do comentário do user em #471)

- **Source of truth**: mapping interno (não temos handshake de registro com a B3).
- **Default**: null / opt-in (nem toda conta tem subaccount; o SDK omite o campo quando null).
- **WAL retrocompat**: não exigido (sem ambiente produtivo ainda).

## O que muda

Novo seam `ISubAccountWireIdMapper` em `B3.Trading.Application/SubAccount/` que mapeia o domínio `SubAccountId` (string per-firm) → wire `uint?` que o SDK 0.15.0 carrega em `NewOrderRequest.TradingSubAccount` e `ReplaceOrderRequest.TradingSubAccount`.

### `DeterministicSubAccountWireIdMapper` (impl default)

- FNV-1a 32-bit sobre `firmId + '\0' + subAccountId.Value`
- Separador de zero byte defende contra colisão por length-extension (`("FIRM01","A.B")` vs `("FIRM01A",".B")`)
- Output `0` → `1` pra preservar `0` como sentinel de "unset" em consumers downstream
- Pure function, sem I/O, sem clock, sem alocação além do encoding ASCII das strings

### Gateway (`B3EntryPointClientGateway`)

- Mapper é dep opcional do ctor (legacy gateways sem ele ficam verdes)
- Novo `BuildNewOrderRequest(order, stp, tradingSubAccount)` 4-arg stampa o uint?
- Overloads 1-arg e 2-arg passam `null` pra preservar wire estável de tests existentes
- `CancelReplaceAsync` carrega o mesmo wire id no replace (matching engine trata replace como nova ordem)

### DI (composition root)

```csharp
services.AddSingleton<ISubAccountWireIdMapper, DeterministicSubAccountWireIdMapper>();
```

Registrado junto com os keepers de subaccount em `TradingApplicationCoreServiceCollectionExtensions`. Resolvido no Real-mode gateway factory via `sp.GetService<ISubAccountWireIdMapper>()`.

## Migration path

Quando operador negociar um mapping numérico registrado com o broker, é só registrar uma impl alternativa (lookup table) no composition root. Gateway não precisa mudar — o seam existe exatamente pra isso.

## Tests

- 8 tests novos em `DeterministicSubAccountWireIdMapperTests`: null in/out, non-zero guarantee, determinism cross-instance, firm-scoping, length-extension defense, case sensitivity, empty-firmId rejection
- 2 tests novos em `B3EntryPointClientGatewayMapTests`: overloads legacy não-vazam wire id, overload 4-arg stampa o valor passado
- Suite full local: **1157/1157 Application + 493/493 Api** verdes

## Out of scope (próximos PRs)

- `#458` CBLC Account mapping — depende deste plumbing
- Endpoint admin pra inspecionar/sobrescrever o mapping per-(firm, subaccount)
- Persistência do mapping quando virar lookup table operador-controlado
