### PR TITLE
feat(#458): plumb CBLC Account via IVenueAccountResolver seam

### DIFF
--- a/backend/src/B3.Trading.Application/SubAccount/IVenueAccountResolver.cs
+++ b/backend/src/B3.Trading.Application/SubAccount/IVenueAccountResolver.cs
@@ -1,0 +1,49 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.SubAccount;
+
+/// <summary>
+/// #458 (SDK 0.14.4+). Resolves the numeric CBLC <c>Account</c> stamped
+/// on every outbound <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>
+/// when known. Unlike <see cref="ISubAccountWireIdMapper"/>, this value
+/// is <b>not</b> internally derivable — CBLC account numbers are issued
+/// by the clearing house and bound to a real investor identity. The
+/// platform therefore models the field as <c>Nullable&lt;ulong&gt;</c>
+/// end-to-end and ships a no-op default that returns <c>null</c> for
+/// every order until an operator wires a real resolver (lookup table,
+/// admin-managed registry, broker handshake, etc.).
+///
+/// <para>
+/// <b>Why a seam.</b> The source of truth for the mapping (per
+/// end-client? per (firmId, subAccountId)? per order via explicit
+/// trader override?) is an operational decision that varies between
+/// participants. The seam lets the production composition root swap
+/// the no-op for a real implementation without touching the gateway,
+/// the order pipeline, or the WAL.
+/// </para>
+///
+/// <para>
+/// <b>Null is the safe default.</b> An order with a null CBLC Account
+/// leaves the wire field omitted; the venue then routes post-trade
+/// allocation via the broker's out-of-band matching (the legacy
+/// behavior pre-#458). Only opt-in operators that have configured a
+/// real resolver start stamping the field.
+/// </para>
+///
+/// <para>
+/// <b>Per-order scope.</b> The resolver receives the full
+/// <see cref="Order"/> so it can branch on owner, firm, sub-account,
+/// symbol, or any combination thereof. Implementations MUST be
+/// thread-safe and side-effect-free — the gateway calls into them on
+/// the hot submit/replace path.
+/// </para>
+/// </summary>
+public interface IVenueAccountResolver
+{
+    /// <summary>
+    /// Returns the CBLC account number for <paramref name="order"/>,
+    /// or <c>null</c> when no mapping is known (the wire field will
+    /// stay omitted).
+    /// </summary>
+    ulong? TryResolve(Order order);
+}

--- a/backend/src/B3.Trading.Application/SubAccount/NullVenueAccountResolver.cs
+++ b/backend/src/B3.Trading.Application/SubAccount/NullVenueAccountResolver.cs
@@ -1,0 +1,23 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.SubAccount;
+
+/// <summary>
+/// Default <see cref="IVenueAccountResolver"/>: always returns
+/// <c>null</c>. Pre-#458 wire behavior — orders carry no CBLC
+/// account number; post-trade allocation continues to rely on the
+/// broker's out-of-band matching. Production operators replace this
+/// with a real resolver (lookup table, admin-managed registry,
+/// broker handshake) at the composition root the day they need the
+/// wire field populated.
+/// </summary>
+public sealed class NullVenueAccountResolver : IVenueAccountResolver
+{
+    public static readonly NullVenueAccountResolver Instance = new();
+
+    public ulong? TryResolve(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        return null;
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -66,6 +66,16 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // composition root with an explicit lookup table if they
         // negotiate a registered mapping with the broker.
         services.AddSingleton<ISubAccountWireIdMapper, DeterministicSubAccountWireIdMapper>();
+        // #458 (SDK 0.14.4+). Resolve CBLC Account number stamped on
+        // every outbound NewOrderRequest / ReplaceOrderRequest. Unlike
+        // the sub-account wire id, the CBLC number is issued by the
+        // clearing house and cannot be derived internally — default is
+        // the null resolver (wire field stays omitted, post-trade
+        // allocation continues via the broker's out-of-band matching).
+        // Operators replace this with a real impl (lookup table,
+        // admin-managed registry, broker handshake) when they have a
+        // negotiated mapping.
+        services.AddSingleton<IVenueAccountResolver>(NullVenueAccountResolver.Instance);
         // Q4.5 (#305). Audit log keeper + dispatcher-backed logger.
         // Both singletons so the live-dispatch path, recovery replay
         // and admin read endpoint all share the same in-memory ring

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -123,10 +123,12 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var reactor = sp.GetService<IVenueDisconnectReactor>();
                     var riskOpts = sp.GetService<IOptionsMonitor<RiskOptions>>();
                     var subAccountMapper = sp.GetService<ISubAccountWireIdMapper>();
+                    var venueAccountResolver = sp.GetService<IVenueAccountResolver>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
                         venueDisconnectReactor: reactor,
                         riskOptions: riskOpts,
-                        subAccountWireIdMapper: subAccountMapper);
+                        subAccountWireIdMapper: subAccountMapper,
+                        venueAccountResolver: venueAccountResolver);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -74,6 +74,14 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     // behavior, matches the pre-#471 contract). Production
     // composition root always wires DeterministicSubAccountWireIdMapper.
     private readonly ISubAccountWireIdMapper? _subAccountWireIdMapper;
+    // #458. Optional resolver for the CBLC Account number (ulong?)
+    // carried in NewOrderRequest.Account / ReplaceOrderRequest.Account.
+    // Default = NullVenueAccountResolver (always null) — wire field
+    // stays omitted and post-trade allocation continues via the
+    // broker's out-of-band matching. Operators that have configured
+    // a real mapping (lookup table, broker handshake) swap in a real
+    // impl at the composition root.
+    private readonly IVenueAccountResolver? _venueAccountResolver;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -87,7 +95,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         IVenueDisconnectReactor? venueDisconnectReactor = null,
         TimeSpan? gracefulTerminateTimeout = null,
         IOptionsMonitor<RiskOptions>? riskOptions = null,
-        ISubAccountWireIdMapper? subAccountWireIdMapper = null)
+        ISubAccountWireIdMapper? subAccountWireIdMapper = null,
+        IVenueAccountResolver? venueAccountResolver = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -101,6 +110,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _reactor = venueDisconnectReactor;
         _riskOptions = riskOptions;
         _subAccountWireIdMapper = subAccountWireIdMapper;
+        _venueAccountResolver = venueAccountResolver;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -186,7 +196,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order));
+        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order), ResolveVenueAccount(order));
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
             ct => _client.SubmitAsync(req, ct), cancellationToken);
@@ -209,16 +219,23 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// </para>
     /// </summary>
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
-        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null);
+        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null, venueAccount: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order, UpModels.SelfTradePreventionInstruction stpInstruction)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null, venueAccount: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
         UpModels.SelfTradePreventionInstruction stpInstruction,
         uint? tradingSubAccount)
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount: null);
+
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(
+        Order order,
+        UpModels.SelfTradePreventionInstruction stpInstruction,
+        uint? tradingSubAccount,
+        ulong? venueAccount)
     {
         ArgumentNullException.ThrowIfNull(order);
         return new UpModels.NewOrderRequest
@@ -259,6 +276,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // wire (SDK omits the field entirely) — matches the
             // master-bucket semantics of Order.SubAccountId == null.
             TradingSubAccount = tradingSubAccount,
+            // #458. CBLC Account number for clearing/allocation, when
+            // an operator has wired a real IVenueAccountResolver. Null
+            // = no mapping known → wire field stays omitted and the
+            // broker's out-of-band post-trade allocation continues to
+            // apply (pre-#458 wire behavior).
+            Account = venueAccount,
         };
     }
 
@@ -346,6 +369,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // through every modify path (HydrateReplacement copies it
             // verbatim), so resolving from `original` is correct.
             TradingSubAccount = ResolveTradingSubAccount(original),
+            // #458. Same rationale: replace is a fresh book entry; the
+            // CBLC Account must re-accompany it. Resolving from
+            // `original` is correct because owner/firm/sub-account
+            // (the typical inputs to the resolver) are immutable
+            // across a modify.
+            Account = ResolveVenueAccount(original),
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -462,6 +491,21 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     {
         if (_subAccountWireIdMapper is null) return null;
         return _subAccountWireIdMapper.TryMap(order.FirmId, order.SubAccountId);
+    }
+
+    /// <summary>
+    /// #458. Resolve the CBLC <c>Account</c> stamped on an outbound
+    /// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>. Returns
+    /// <c>null</c> when no <see cref="IVenueAccountResolver"/> is
+    /// wired (legacy gateways stay green) or when the wired resolver
+    /// has no mapping for the order — in both cases the wire field
+    /// stays omitted and post-trade allocation continues via the
+    /// broker's out-of-band matching.
+    /// </summary>
+    private ulong? ResolveVenueAccount(Order order)
+    {
+        if (_venueAccountResolver is null) return null;
+        return _venueAccountResolver.TryResolve(order);
     }
 
     // The IEntryPointClient submit-side surface is unused on the real adapter

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -259,5 +259,47 @@ public class B3EntryPointClientGatewayMapTests
             order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: null);
         Assert.Null(withoutId.TradingSubAccount);
     }
+
+    // ------------------------------------------------------------------
+    // #458. CBLC Account wire field. The five-arg BuildNewOrderRequest
+    // overload stamps whatever the gateway resolved from its
+    // IVenueAccountResolver. Legacy overloads must leave the field
+    // null so any caller that has not opted into a real resolver
+    // continues to send the field omitted on the wire.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void BuildNewOrderRequest_LegacyOverloads_LeaveAccountNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(B3EntryPointClientGateway.BuildNewOrderRequest(order).Account);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None)
+            .Account);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 42u)
+            .Account);
+    }
+
+    [Fact]
+    public void BuildNewOrderRequest_StampsResolvedVenueAccount()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var withAccount = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: 123456789UL);
+        Assert.Equal(123456789UL, withAccount.Account);
+
+        var withoutAccount = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: null);
+        Assert.Null(withoutAccount.Account);
+    }
 }
 

--- a/backend/tests/B3.Trading.Application.Tests/NullVenueAccountResolverTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NullVenueAccountResolverTests.cs
@@ -1,0 +1,45 @@
+using B3.Trading.Application.SubAccount;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #458. Pins the contract of the no-op CBLC <c>Account</c> resolver
+/// — every order returns <c>null</c> so the wire field stays omitted
+/// and post-trade allocation continues to rely on the broker's
+/// out-of-band matching (pre-#458 wire behavior). Operators that ship
+/// a real resolver swap this default at the composition root.
+/// </summary>
+public class NullVenueAccountResolverTests
+{
+    [Fact]
+    public void TryResolve_AnyOrder_ReturnsNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(NullVenueAccountResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_OrderWithSubAccount_StillReturnsNull()
+    {
+        // SubAccount presence does not influence the null resolver —
+        // CBLC Account is a fundamentally different identifier
+        // (clearing-house issued, real number) and the default impl
+        // refuses to invent one regardless of any domain context.
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A", subAccountId: new SubAccountId("tradingdesk"));
+
+        Assert.Null(NullVenueAccountResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_NullOrder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => NullVenueAccountResolver.Instance.TryResolve(null!));
+    }
+}


### PR DESCRIPTION
Ships the wiring seam for the CBLC `Account` wire field (SDK 0.14.4+). Mirrors the `ISubAccountWireIdMapper` pattern shipped in #474 (#471), with one key difference: CBLC accounts are clearing-house-issued and cannot be derived internally, so the **default impl returns `null`** — pre-#458 wire behavior is preserved (post-trade allocation continues via the broker's out-of-band matching). Operators that negotiate a real mapping plug in a resolver at the composition root.

### Changes

- `IVenueAccountResolver` + `NullVenueAccountResolver` (new seam, `SubAccount/` folder alongside #471).
- `B3EntryPointClientGateway`:
  - Optional `venueAccountResolver` ctor param (legacy ctors stay green).
  - Five-arg `BuildNewOrderRequest` overload; legacy 1/2/3/4-arg chains pass `null`.
  - `ResolveVenueAccount(Order)` helper next to `ResolveTradingSubAccount`.
  - Threaded into **both** `SubmitAsync` and `CancelReplaceAsync` — the matching engine treats a replace as a fresh book entry, so the `Account` must re-accompany it.
- DI: `NullVenueAccountResolver` registered next to `ISubAccountWireIdMapper`; `TradingExchangeGatewayServiceCollectionExtensions` resolves and passes it to the gateway in real mode.
- Tests:
  - `NullVenueAccountResolverTests` (3) — any-order/null contract.
  - `B3EntryPointClientGatewayMapTests` — legacy overloads leave `Account` null; 5-arg overload stamps the passed value.

### Local

- Build: 0 errors / 0 warnings.
- Application: 1162/1162. Api: 493/493.

Closes #458.