### PR TITLE
feat(#472): plumb InvestorId via IInvestorIdResolver seam (LGPD-conscious)

### DIFF
--- a/backend/src/B3.Trading.Application/Investor/IInvestorIdResolver.cs
+++ b/backend/src/B3.Trading.Application/Investor/IInvestorIdResolver.cs
@@ -1,0 +1,50 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Investor;
+
+/// <summary>
+/// #472 (SDK 0.15.0). Resolves the opaque
+/// <see cref="InvestorIdentity"/> stamped on every outbound
+/// <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c> when known.
+///
+/// <para>
+/// <b>Why a seam.</b> The source of truth for the (Prefix, Document)
+/// mapping — broker-issued registry, CBLC association table, KYC
+/// workflow, per-end-client config — is an operator decision that
+/// varies between participants. The seam lets the production
+/// composition root plug in a real impl without touching the gateway,
+/// the order pipeline, or the WAL.
+/// </para>
+///
+/// <para>
+/// <b>Null is the safe default.</b> An order with a null InvestorId
+/// leaves the wire field omitted, which is the pre-#472 behavior
+/// (the venue accepts orders without the field; the broker handles
+/// any out-of-band regulatory attribution). Operators opt in by
+/// wiring a non-null resolver.
+/// </para>
+///
+/// <para>
+/// <b>No PII on the path.</b> Implementations MUST NOT accept or
+/// return CPF/CNPJ in any field — only the opaque (Prefix, Document)
+/// handle issued by the broker. See <see cref="InvestorIdentity"/>
+/// for the LGPD rationale.
+/// </para>
+///
+/// <para>
+/// <b>Per-order scope + thread safety.</b> The resolver receives the
+/// full <see cref="Order"/> so it can branch on owner, firm,
+/// sub-account, symbol, or any combination. Implementations MUST be
+/// thread-safe and side-effect-free — the gateway calls into them on
+/// the hot submit/replace path.
+/// </para>
+/// </summary>
+public interface IInvestorIdResolver
+{
+    /// <summary>
+    /// Returns the opaque investor handle for <paramref name="order"/>,
+    /// or <c>null</c> when no mapping is known (the wire field will
+    /// stay omitted).
+    /// </summary>
+    InvestorIdentity? TryResolve(Order order);
+}

--- a/backend/src/B3.Trading.Application/Investor/InvestorIdentity.cs
+++ b/backend/src/B3.Trading.Application/Investor/InvestorIdentity.cs
@@ -1,0 +1,34 @@
+namespace B3.Trading.Application.Investor;
+
+/// <summary>
+/// #472 (SDK 0.15.0). Opaque investor identifier carried in the
+/// <c>InvestorId</c> wire field of <c>NewOrderRequest</c> /
+/// <c>ReplaceOrderRequest</c>.
+///
+/// <para>
+/// <b>Why this is not CPF/CNPJ.</b> The B3 EntryPoint contract reserves
+/// only <c>(ushort Prefix, uint Document)</c> for the field — 6 bytes.
+/// CPF (11 digits) does not fit in <c>uint</c> at all
+/// (99999999999 &gt; 4294967295), and a raw CNPJ would also overflow.
+/// Per operator guidance, this platform treats <c>InvestorId</c> as an
+/// <b>opaque numeric handle</b> issued out-of-band (broker registry,
+/// CBLC association, KYC workflow, etc.) and associated to the real
+/// CPF/CNPJ at the broker — never on the wire and never in the WAL.
+/// </para>
+///
+/// <para>
+/// <b>LGPD posture.</b> The platform deliberately refuses to know the
+/// CPF/CNPJ at all: orders only ever carry this opaque pair. That keeps
+/// the venue protocol path completely free of PII (Lei 13.709/2018
+/// art. 5º II) while preserving the venue's self-trade-prevention and
+/// regulatory-attribution guarantees.
+/// </para>
+///
+/// <para>
+/// <b>Wire shape.</b> Mirrors the SDK's <c>B3.EntryPoint.Client.Models.InvestorId</c>
+/// struct verbatim (<c>ushort</c> + <c>uint</c>); the gateway boundary
+/// translates one to the other so the Application/Domain layers don't
+/// take a dependency on the SDK type.
+/// </para>
+/// </summary>
+public readonly record struct InvestorIdentity(ushort Prefix, uint Document);

--- a/backend/src/B3.Trading.Application/Investor/NullInvestorIdResolver.cs
+++ b/backend/src/B3.Trading.Application/Investor/NullInvestorIdResolver.cs
@@ -1,0 +1,22 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Investor;
+
+/// <summary>
+/// Default <see cref="IInvestorIdResolver"/>: always returns
+/// <c>null</c>. Pre-#472 wire behavior — orders carry no
+/// <c>InvestorId</c>; the broker handles any out-of-band regulatory
+/// attribution. Production operators replace this with a real
+/// resolver (broker registry lookup, CBLC association table) at the
+/// composition root the day they need the wire field populated.
+/// </summary>
+public sealed class NullInvestorIdResolver : IInvestorIdResolver
+{
+    public static readonly NullInvestorIdResolver Instance = new();
+
+    public InvestorIdentity? TryResolve(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        return null;
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using B3.Trading.Api.Lifecycle;
 using B3.Trading.Application;
+using B3.Trading.Application.Investor;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.SubAccount;
 using B3.Trading.Application.UserBots;
@@ -76,6 +77,14 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // admin-managed registry, broker handshake) when they have a
         // negotiated mapping.
         services.AddSingleton<IVenueAccountResolver>(NullVenueAccountResolver.Instance);
+        // #472 (SDK 0.15.0). Resolve the opaque InvestorId (Prefix,
+        // Document) stamped on every outbound NewOrderRequest /
+        // ReplaceOrderRequest. Default = NullInvestorIdResolver (wire
+        // field omitted, pre-#472 behavior). The platform refuses to
+        // touch CPF/CNPJ on the path; operators wire a real resolver
+        // that hits their broker-issued opaque-id registry. LGPD
+        // posture is documented on IInvestorIdResolver.
+        services.AddSingleton<IInvestorIdResolver>(NullInvestorIdResolver.Instance);
         // Q4.5 (#305). Audit log keeper + dispatcher-backed logger.
         // Both singletons so the live-dispatch path, recovery replay
         // and admin read endpoint all share the same in-memory ring

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application;
+using B3.Trading.Application.Investor;
 using B3.Trading.Application.Lifecycle;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
@@ -124,11 +125,13 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var riskOpts = sp.GetService<IOptionsMonitor<RiskOptions>>();
                     var subAccountMapper = sp.GetService<ISubAccountWireIdMapper>();
                     var venueAccountResolver = sp.GetService<IVenueAccountResolver>();
+                    var investorIdResolver = sp.GetService<IInvestorIdResolver>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
                         venueDisconnectReactor: reactor,
                         riskOptions: riskOpts,
                         subAccountWireIdMapper: subAccountMapper,
-                        venueAccountResolver: venueAccountResolver);
+                        venueAccountResolver: venueAccountResolver,
+                        investorIdResolver: investorIdResolver);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Investor;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.SubAccount;
@@ -82,6 +83,15 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     // a real mapping (lookup table, broker handshake) swap in a real
     // impl at the composition root.
     private readonly IVenueAccountResolver? _venueAccountResolver;
+    // #472. Optional resolver for the opaque InvestorId (Prefix,
+    // Document) carried in NewOrderRequest.InvestorId /
+    // ReplaceOrderRequest.InvestorId. Default = NullInvestorIdResolver
+    // (always null) — wire field stays omitted (pre-#472 behavior).
+    // The platform deliberately treats InvestorId as opaque (NOT
+    // CPF/CNPJ); operators wire a real resolver that hits their
+    // broker-issued registry, keeping PII off the wire and out of the
+    // WAL (LGPD posture — see IInvestorIdResolver doc).
+    private readonly IInvestorIdResolver? _investorIdResolver;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -96,7 +106,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         TimeSpan? gracefulTerminateTimeout = null,
         IOptionsMonitor<RiskOptions>? riskOptions = null,
         ISubAccountWireIdMapper? subAccountWireIdMapper = null,
-        IVenueAccountResolver? venueAccountResolver = null)
+        IVenueAccountResolver? venueAccountResolver = null,
+        IInvestorIdResolver? investorIdResolver = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -111,6 +122,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _riskOptions = riskOptions;
         _subAccountWireIdMapper = subAccountWireIdMapper;
         _venueAccountResolver = venueAccountResolver;
+        _investorIdResolver = investorIdResolver;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -196,7 +208,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order), ResolveVenueAccount(order));
+        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order), ResolveVenueAccount(order), ResolveInvestorId(order));
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
             ct => _client.SubmitAsync(req, ct), cancellationToken);
@@ -219,23 +231,31 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// </para>
     /// </summary>
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
-        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null, venueAccount: null);
+        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null, venueAccount: null, investorId: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order, UpModels.SelfTradePreventionInstruction stpInstruction)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null, venueAccount: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null, venueAccount: null, investorId: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
         UpModels.SelfTradePreventionInstruction stpInstruction,
         uint? tradingSubAccount)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount: null, investorId: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
         UpModels.SelfTradePreventionInstruction stpInstruction,
         uint? tradingSubAccount,
         ulong? venueAccount)
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount, investorId: null);
+
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(
+        Order order,
+        UpModels.SelfTradePreventionInstruction stpInstruction,
+        uint? tradingSubAccount,
+        ulong? venueAccount,
+        InvestorIdentity? investorId)
     {
         ArgumentNullException.ThrowIfNull(order);
         return new UpModels.NewOrderRequest
@@ -282,6 +302,14 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // broker's out-of-band post-trade allocation continues to
             // apply (pre-#458 wire behavior).
             Account = venueAccount,
+            // #472. Opaque InvestorId (Prefix, Document) when an
+            // operator has wired a real IInvestorIdResolver. Null =
+            // wire field omitted (pre-#472 behavior). Translated from
+            // the domain InvestorIdentity record to the SDK struct at
+            // this boundary so Application/Domain stay SDK-free.
+            InvestorId = investorId is { } id
+                ? new UpModels.InvestorId { Prefix = id.Prefix, Document = id.Document }
+                : (UpModels.InvestorId?)null,
         };
     }
 
@@ -375,6 +403,11 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // (the typical inputs to the resolver) are immutable
             // across a modify.
             Account = ResolveVenueAccount(original),
+            // #472. Same rationale: replace is a fresh book entry;
+            // the InvestorId must re-accompany it. Resolving from
+            // `original` is correct because owner/firm (the typical
+            // inputs to the resolver) are immutable across a modify.
+            InvestorId = MapInvestorIdToWire(ResolveInvestorId(original)),
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -507,6 +540,30 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (_venueAccountResolver is null) return null;
         return _venueAccountResolver.TryResolve(order);
     }
+
+    /// <summary>
+    /// #472. Resolve the opaque <see cref="InvestorIdentity"/>
+    /// stamped on an outbound <c>NewOrderRequest</c> /
+    /// <c>ReplaceOrderRequest</c>. Returns <c>null</c> when no
+    /// <see cref="IInvestorIdResolver"/> is wired (legacy gateways
+    /// stay green) or when the wired resolver has no mapping for the
+    /// order — in both cases the wire field stays omitted.
+    /// </summary>
+    private InvestorIdentity? ResolveInvestorId(Order order)
+    {
+        if (_investorIdResolver is null) return null;
+        return _investorIdResolver.TryResolve(order);
+    }
+
+    /// <summary>
+    /// Translate the domain <see cref="InvestorIdentity"/> to the SDK
+    /// wire struct. Kept private so the SDK type never leaks past the
+    /// gateway boundary.
+    /// </summary>
+    private static UpModels.InvestorId? MapInvestorIdToWire(InvestorIdentity? id)
+        => id is { } v
+            ? new UpModels.InvestorId { Prefix = v.Prefix, Document = v.Document }
+            : (UpModels.InvestorId?)null;
 
     // The IEntryPointClient submit-side surface is unused on the real adapter
     // (OrdersEndpoints calls IExchangeGateway directly). We implement it to

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.Investor;
 using B3.Trading.Domain;
 using B3.Trading.Infrastructure;
 using Up = B3.EntryPoint.Client.Models;
@@ -300,6 +301,56 @@ public class B3EntryPointClientGatewayMapTests
             order, Up.SelfTradePreventionInstruction.None,
             tradingSubAccount: null, venueAccount: null);
         Assert.Null(withoutAccount.Account);
+    }
+
+    // ------------------------------------------------------------------
+    // #472. InvestorId wire field. The six-arg BuildNewOrderRequest
+    // overload stamps whatever the gateway resolved from its
+    // IInvestorIdResolver, translating the domain InvestorIdentity
+    // record into the SDK's InvestorId struct. Legacy overloads must
+    // leave the field null so any caller that has not opted into a
+    // real resolver continues to send the field omitted on the wire.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void BuildNewOrderRequest_LegacyOverloads_LeaveInvestorIdNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(B3EntryPointClientGateway.BuildNewOrderRequest(order).InvestorId);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None)
+            .InvestorId);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 42u)
+            .InvestorId);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 42u, venueAccount: 99UL)
+            .InvestorId);
+    }
+
+    [Fact]
+    public void BuildNewOrderRequest_StampsResolvedInvestorId()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var withId = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: null,
+            investorId: new InvestorIdentity(7, 12345));
+        Assert.NotNull(withId.InvestorId);
+        Assert.Equal((ushort)7, withId.InvestorId!.Value.Prefix);
+        Assert.Equal(12345u, withId.InvestorId!.Value.Document);
+
+        var withoutId = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: null,
+            investorId: null);
+        Assert.Null(withoutId.InvestorId);
     }
 }
 

--- a/backend/tests/B3.Trading.Application.Tests/NullInvestorIdResolverTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NullInvestorIdResolverTests.cs
@@ -1,0 +1,56 @@
+using B3.Trading.Application.Investor;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #472. Pins the contract of the no-op InvestorId resolver — every
+/// order returns <c>null</c>, so the wire field stays omitted
+/// (pre-#472 behavior). Operators that ship a real resolver swap
+/// this default at the composition root.
+/// </summary>
+public class NullInvestorIdResolverTests
+{
+    [Fact]
+    public void TryResolve_AnyOrder_ReturnsNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(NullInvestorIdResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_OrderWithSubAccount_StillReturnsNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A", subAccountId: new SubAccountId("tradingdesk"));
+
+        Assert.Null(NullInvestorIdResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_NullOrder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => NullInvestorIdResolver.Instance.TryResolve(null!));
+    }
+
+    [Fact]
+    public void InvestorIdentity_RecordEquality_IsValueBased()
+    {
+        // Defensive: value-equality + non-zero fields survive a copy
+        // round-trip. Confirms the readonly-record-struct semantics
+        // the gateway relies on when comparing/logging.
+        var a = new InvestorIdentity(7, 12345);
+        var b = new InvestorIdentity(7, 12345);
+        var c = new InvestorIdentity(7, 99999);
+
+        Assert.Equal(a, b);
+        Assert.NotEqual(a, c);
+        Assert.Equal((ushort)7, a.Prefix);
+        Assert.Equal(12345u, a.Document);
+    }
+}


### PR DESCRIPTION
Ships the wiring seam for SDK 0.15.0's `NewOrderRequest.InvestorId` / `ReplaceOrderRequest.InvestorId` field.

### LGPD posture (per user guidance on #472)

The platform treats `InvestorId` as an **opaque numeric handle** (`ushort Prefix`, `uint Document`) issued out-of-band by the broker — **not** the raw CPF/CNPJ. The broker holds the opaque-id ↔ CPF/CNPJ binding; the trading platform only ever sees and stamps the opaque pair. Result: zero PII on the venue path, zero PII in the WAL, but full STP + regulatory-attribution preserved at the broker.

(Reinforced by the SDK shape itself: CPF `99999999999 > UInt32.MaxValue = 4294967295`, so the raw doc number doesn't even fit. The field is opaque by construction.)

### Changes

- New `Application/Investor/`:
  - `InvestorIdentity` — domain `readonly record struct (ushort Prefix, uint Document)`. SDK type never leaks past the gateway.
  - `IInvestorIdResolver` — seam (Order → `InvestorIdentity?`).
  - `NullInvestorIdResolver` — default, always null.
- `B3EntryPointClientGateway`:
  - Optional `investorIdResolver` ctor param.
  - Six-arg `BuildNewOrderRequest` overload; legacy 1/2/3/4/5-arg chains pass `null`.
  - `ResolveInvestorId(Order)` + `MapInvestorIdToWire(InvestorIdentity?)` (private boundary translator).
  - Threaded into both `SubmitAsync` and `CancelReplaceAsync`.
- DI: `NullInvestorIdResolver` registered next to the other resolvers.
- Tests: `NullInvestorIdResolverTests` (4) + 6-arg `BuildNewOrderRequest` pins (legacy overloads null, six-arg stamps).

### Local

- Build: 0 warnings / 0 errors.
- Application: 1168/1168. Api: 493/493.

### Pattern lineage

Same seam pattern as #433 (STP), #458 (CBLC Account), #471 (TradingSubAccount). Operators activate any combination by replacing the corresponding null/default impl at the composition root.

Closes #472.