### PR TITLE
feat(#473): plumb RoutingInstruction via resolver seam + whitelist gate

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -26,6 +26,16 @@ public static class MetricsRegistry
     public static readonly Counter<long> OrdersCancelRequested =
         Meter.CreateCounter<long>("trading.orders.cancel_requested");
     /// <summary>
+    /// #473. Counts every approved stamp of a routing instruction on
+    /// an outbound NewOrder / Replace. Tagged with <c>value</c>
+    /// (RetailLiquidityTaker / WaivedPriority / BrokerOnly /
+    /// BrokerOnlyRemoval) and <c>firmId</c>. Conflict-of-interest
+    /// sensitive (BrokerOnly especially) — downstream alerts can
+    /// pin a threshold on the BrokerOnly slice per firm.
+    /// </summary>
+    public static readonly Counter<long> RoutingInstructionStamped =
+        Meter.CreateCounter<long>("trading.orders.routing_instruction_stamped");
+    /// <summary>
     /// Q1.3 (#255). Counts every GTD expiry the scheduler dispatched.
     /// Tagged with <c>cancel_result</c> = the
     /// <see cref="OrderCancelResultKind"/> the cancel pipeline

--- a/backend/src/B3.Trading.Application/OrderModifyService.cs
+++ b/backend/src/B3.Trading.Application/OrderModifyService.cs
@@ -35,6 +35,7 @@ public sealed class OrderModifyService
     private readonly PendingReplacementRegistry _replacements;
     private readonly EventDispatcher _dispatcher;
     private readonly Lifecycle.IDrainGate _drain;
+    private readonly Routing.IRoutingInstructionResolver? _routingResolver;
     private readonly ILogger<OrderModifyService> _logger;
 
     public OrderModifyService(
@@ -48,7 +49,8 @@ public sealed class OrderModifyService
         PendingReplacementRegistry replacements,
         EventDispatcher dispatcher,
         Lifecycle.IDrainGate drain,
-        ILogger<OrderModifyService> logger)
+        ILogger<OrderModifyService> logger,
+        Routing.IRoutingInstructionResolver? routingInstructionResolver = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -60,6 +62,7 @@ public sealed class OrderModifyService
         _replacements = replacements;
         _dispatcher = dispatcher;
         _drain = drain;
+        _routingResolver = routingInstructionResolver;
         _logger = logger;
     }
 
@@ -228,7 +231,13 @@ public sealed class OrderModifyService
             TimeInForce: effTif,
             StopPrice: effStop,
             GoodTillDate: effGtd,
-            SubAccountId: orig.SubAccountId);
+            SubAccountId: orig.SubAccountId,
+            // #473. Resolve the routing instruction for the modify so
+            // the per-scope whitelist gates the replace identically to
+            // a fresh submit. Resolved off the original Order since
+            // replace inherits routing intent (owner/firm/sub-account
+            // are immutable across modify).
+            RoutingInstruction: _routingResolver?.TryResolve(orig));
 
         // Ordering note (RFC docs/rfcs/risk-pipeline-ordering-v0.md, #262):
         // risk evaluation runs *pre-WAL* on the modify path. #337 closed

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -39,6 +39,7 @@ public sealed class OrderSubmissionService
     private readonly IUserBotOrderMappingRegistry? _botMappings;
     private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
     private readonly Scheduling.IocFokWatchdog? _iocWatchdog;
+    private readonly Routing.IRoutingInstructionResolver? _routingResolver;
     private readonly ILogger<OrderSubmissionService> _logger;
 
     public OrderSubmissionService(
@@ -55,7 +56,8 @@ public sealed class OrderSubmissionService
         ILogger<OrderSubmissionService> logger,
         IUserBotOrderMappingRegistry? botMappings = null,
         Scheduling.GtdExpirationScheduler? gtdScheduler = null,
-        Scheduling.IocFokWatchdog? iocWatchdog = null)
+        Scheduling.IocFokWatchdog? iocWatchdog = null,
+        Routing.IRoutingInstructionResolver? routingInstructionResolver = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -70,6 +72,7 @@ public sealed class OrderSubmissionService
         _botMappings = botMappings;
         _gtdScheduler = gtdScheduler;
         _iocWatchdog = iocWatchdog;
+        _routingResolver = routingInstructionResolver;
         _logger = logger;
     }
 
@@ -243,7 +246,14 @@ public sealed class OrderSubmissionService
             TimeInForce: req.TimeInForce,
             StopPrice: req.StopPrice,
             GoodTillDate: req.GoodTillDate,
-            SubAccountId: req.SubAccountId);
+            SubAccountId: req.SubAccountId,
+            // #473. Resolve the routing instruction once here so the
+            // pre-trade RoutingInstructionAllowedCheck can gate it
+            // against the per-scope whitelist before the gateway
+            // ever sees the order. The gateway will resolve again at
+            // stamp time — resolvers MUST be deterministic per-Order
+            // (see IRoutingInstructionResolver doc).
+            RoutingInstruction: _routingResolver?.TryResolve(order));
         var decision = _risk.Evaluate(riskCtx);
         var marginReserved = false;
         if (decision.Approved)

--- a/backend/src/B3.Trading.Application/Risk/Checks/RoutingInstructionAllowedCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/RoutingInstructionAllowedCheck.cs
@@ -1,0 +1,89 @@
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Routing;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// #473. Pre-trade gate that enforces the per-scope whitelist of
+/// <see cref="RoutingInstruction"/> values
+/// (<see cref="RiskLimits.AllowedRoutingInstructions"/>) against
+/// whatever the submit/modify caller resolved via
+/// <see cref="IRoutingInstructionResolver"/>.
+///
+/// <para>
+/// <b>Default-deny.</b> When the resolver returned a non-null value
+/// and the resolved scope has no whitelist configured (or an empty
+/// one), the check rejects. This is the inverse of
+/// <see cref="OrderTypeAllowedCheck"/> (which defaults to allow when
+/// unconfigured) because routing instructions carry fairness /
+/// conflict-of-interest implications — an operator that wires a
+/// resolver MUST also explicitly opt in to the values they want
+/// permitted per scope.
+/// </para>
+///
+/// <para>
+/// <b>Audit.</b> Every approved stamp increments
+/// <see cref="MetricsRegistry.RoutingInstructionStamped"/> tagged
+/// with the value and firm id; <c>BrokerOnly</c> in particular is
+/// surfaced for downstream alerting (conflict-of-interest sensitive).
+/// </para>
+///
+/// <para>
+/// Pipeline order=16 — runs right after <see cref="OrderTypeAllowedCheck"/>
+/// (15) so misconfigured routing intents short-circuit before any
+/// per-instrument / margin / position work runs.
+/// </para>
+/// </summary>
+public sealed class RoutingInstructionAllowedCheck : IRiskCheck
+{
+    private readonly IOptionsMonitor<RiskOptions> _options;
+
+    public RoutingInstructionAllowedCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
+
+    public int Order => 16;
+    public string Name => "routing_instruction_blocked";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (ctx.RoutingInstruction is not { } ri)
+        {
+            // Resolver yielded nothing → wire field stays omitted →
+            // nothing to gate. Legacy / unmigrated callers always hit
+            // this branch (they pass RoutingInstruction = null).
+            return RiskDecision.Approve;
+        }
+
+        var opts = _options.CurrentValue;
+        var allowed = RiskLimitsResolver.ResolveRef(
+            opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol,
+            l => l.AllowedRoutingInstructions,
+            v => v.Count > 0);
+
+        if (allowed is null)
+        {
+            // Default-deny: a resolver shipping a routing instruction
+            // into a scope that has not explicitly opted in is a
+            // configuration smell. Reject loudly rather than silently
+            // dropping the instruction.
+            return RiskDecision.Reject(
+                Name,
+                $"routing instruction '{ri}' resolved but no AllowedRoutingInstructions whitelist configured for this scope");
+        }
+
+        foreach (var name in allowed)
+        {
+            if (Enum.TryParse<RoutingInstruction>(name, ignoreCase: true, out var v) && v == ri)
+            {
+                MetricsRegistry.RoutingInstructionStamped.Add(1,
+                    new KeyValuePair<string, object?>("value", ri.ToString()),
+                    new KeyValuePair<string, object?>("firmId", ctx.FirmId));
+                return RiskDecision.Approve;
+            }
+        }
+
+        return RiskDecision.Reject(
+            Name,
+            $"routing instruction '{ri}' not in allowed list for this scope ({string.Join(",", allowed)})");
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/IRiskCheck.cs
@@ -44,7 +44,20 @@ public sealed record RiskContext(
     /// per-(firm, subAccount) caps are applied alongside the master
     /// caps. <c>null</c> means master-only (legacy semantics).
     /// </summary>
-    SubAccountId? SubAccountId = null);
+    SubAccountId? SubAccountId = null,
+    /// <summary>
+    /// #473. Routing instruction the gateway intends to stamp on the
+    /// outbound order (resolved via
+    /// <see cref="Routing.IRoutingInstructionResolver"/> by the
+    /// submit/modify caller before the pipeline runs). When non-null,
+    /// <see cref="Checks.RoutingInstructionAllowedCheck"/> enforces
+    /// the per-scope whitelist
+    /// (<see cref="RiskLimits.AllowedRoutingInstructions"/>) and
+    /// rejects pre-trade if the value is not permitted. Default null
+    /// = the resolver yielded nothing → wire field will stay omitted
+    /// → check is a no-op (legacy / unmigrated callers stay green).
+    /// </summary>
+    Routing.RoutingInstruction? RoutingInstruction = null);
 
 public sealed record RiskDecision(bool Approved, string? Reason, string? Code = null)
 {

--- a/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskOptions.cs
@@ -275,6 +275,27 @@ public sealed class RiskLimits
     /// inside the same firm).
     /// </summary>
     public SelfTradePreventionMode? SelfTradePreventionMode { get; set; }
+
+    /// <summary>
+    /// #473 (SDK 0.15.0). Optional whitelist of
+    /// <see cref="Routing.RoutingInstruction"/> values the resolved
+    /// scope may stamp on outbound orders. Case-insensitive enum
+    /// names (e.g. <c>"RetailLiquidityTaker"</c>, <c>"BrokerOnly"</c>).
+    /// <c>null</c> or empty = <b>no instruction permitted</b> (the
+    /// resolved value, if any, is rejected pre-trade). Non-empty =
+    /// only the listed values are permitted; anything else is
+    /// rejected with <c>routing_instruction_blocked</c>.
+    ///
+    /// <para>
+    /// Default is intentionally restrictive (null → block) so a
+    /// misconfigured <see cref="Routing.IRoutingInstructionResolver"/>
+    /// cannot ship a routing instruction past the risk pipeline by
+    /// accident. Operators that want to use any value must explicitly
+    /// opt in per scope. Stamps of <c>BrokerOnly</c> are additionally
+    /// metric-tagged for audit (conflict-of-interest sensitive).
+    /// </para>
+    /// </summary>
+    public List<string>? AllowedRoutingInstructions { get; set; }
 }
 
 public static class RiskLimitsResolver
@@ -369,6 +390,9 @@ public static class RiskLimitsResolver
                 l => l.AllowedOrderTypes,
                 v => v.Count > 0),
             SelfTradePreventionMode = Resolve(opts, endClient, firmId, symbol, l => l.SelfTradePreventionMode),
+            AllowedRoutingInstructions = ResolveRef(opts, endClient, firmId, symbol,
+                l => l.AllowedRoutingInstructions,
+                v => v.Count > 0),
         };
 
     /// <summary>

--- a/backend/src/B3.Trading.Application/Routing/IRoutingInstructionResolver.cs
+++ b/backend/src/B3.Trading.Application/Routing/IRoutingInstructionResolver.cs
@@ -1,0 +1,47 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Routing;
+
+/// <summary>
+/// #473 (SDK 0.15.0). Resolves the <see cref="RoutingInstruction"/>
+/// stamped on every outbound <c>NewOrderRequest</c> /
+/// <c>ReplaceOrderRequest</c> when known.
+///
+/// <para>
+/// <b>Why a seam.</b> The platform deliberately refuses to invent a
+/// trader's routing intent — operators decide their own policy
+/// (per-end-client tag, broker-only liquidity desk, retail-flow
+/// program participation, etc.) and plug it in here. Default
+/// behavior is <see cref="NullRoutingInstructionResolver"/> (always
+/// null → wire field omitted, pre-#473 behavior).
+/// </para>
+///
+/// <para>
+/// <b>Defense in depth.</b> Whatever this resolver returns is gated
+/// by <see cref="Risk.RiskLimits.AllowedRoutingInstructions"/>
+/// at pre-trade time
+/// (<see cref="Risk.Checks.RoutingInstructionAllowedCheck"/>). Even
+/// a misconfigured resolver cannot ship a forbidden instruction past
+/// the risk pipeline.
+/// </para>
+///
+/// <para>
+/// <b>Determinism contract.</b> The same <see cref="Order"/> may be
+/// resolved twice in a submit lifecycle: once at risk-pipeline time
+/// (to gate against the whitelist) and once at gateway stamp time.
+/// Implementations MUST therefore be deterministic per-<c>Order</c>
+/// — reading mutable global state mid-submit risks an approve/stamp
+/// mismatch. Thread-safe and side-effect-free are also required
+/// because the gateway calls into them on the hot submit/replace
+/// path.
+/// </para>
+/// </summary>
+public interface IRoutingInstructionResolver
+{
+    /// <summary>
+    /// Returns the routing instruction to stamp for
+    /// <paramref name="order"/>, or <c>null</c> when no instruction
+    /// applies (the wire field stays omitted).
+    /// </summary>
+    RoutingInstruction? TryResolve(Order order);
+}

--- a/backend/src/B3.Trading.Application/Routing/NullRoutingInstructionResolver.cs
+++ b/backend/src/B3.Trading.Application/Routing/NullRoutingInstructionResolver.cs
@@ -1,0 +1,22 @@
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Routing;
+
+/// <summary>
+/// Default <see cref="IRoutingInstructionResolver"/>: always returns
+/// <c>null</c>. Pre-#473 wire behavior — orders carry no routing
+/// instruction. Production operators that need any of the four
+/// values (RetailLiquidityTaker / WaivedPriority / BrokerOnly /
+/// BrokerOnlyRemoval) replace this with a real resolver at the
+/// composition root.
+/// </summary>
+public sealed class NullRoutingInstructionResolver : IRoutingInstructionResolver
+{
+    public static readonly NullRoutingInstructionResolver Instance = new();
+
+    public RoutingInstruction? TryResolve(Order order)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+        return null;
+    }
+}

--- a/backend/src/B3.Trading.Application/Routing/RoutingInstruction.cs
+++ b/backend/src/B3.Trading.Application/Routing/RoutingInstruction.cs
@@ -1,0 +1,40 @@
+namespace B3.Trading.Application.Routing;
+
+/// <summary>
+/// #473 (SDK 0.15.0). Routing instruction stamped on
+/// <c>NewOrderRequest.RoutingInstruction</c> /
+/// <c>ReplaceOrderRequest.RoutingInstruction</c>.
+///
+/// <para>
+/// Domain mirror of <c>B3.EntryPoint.Client.Models.RoutingInstruction</c>;
+/// kept in the Application layer (parallel to
+/// <see cref="Risk.SelfTradePreventionMode"/>) so the
+/// <c>B3.Trading.Domain</c> project stays SDK-free. The gateway
+/// translates this enum to the SDK type at the boundary.
+/// </para>
+///
+/// <para>
+/// <b>Fairness gates.</b> Each value carries different matching
+/// semantics; the platform gates them with an opt-in per-scope
+/// whitelist (<see cref="Risk.RiskLimits.AllowedRoutingInstructions"/>).
+/// </para>
+/// <list type="bullet">
+///   <item><b>RetailLiquidityTaker</b> — signals retail order taking
+///   liquidity (relevant to retail-flow programs).</item>
+///   <item><b>WaivedPriority</b> — order waives time/price priority
+///   (used by specific work-up / cross strategies). MUST be audited
+///   per scope.</item>
+///   <item><b>BrokerOnly</b> — order may only match internal flow of
+///   the same broker. Conflict-of-interest sensitive: every stamp is
+///   metric-tagged for audit.</item>
+///   <item><b>BrokerOnlyRemoval</b> — removes a prior BrokerOnly
+///   restriction.</item>
+/// </list>
+/// </summary>
+public enum RoutingInstruction
+{
+    RetailLiquidityTaker = 1,
+    WaivedPriority = 2,
+    BrokerOnly = 3,
+    BrokerOnlyRemoval = 4,
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using B3.Trading.Api.Lifecycle;
 using B3.Trading.Application;
 using B3.Trading.Application.Investor;
 using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Routing;
 using B3.Trading.Application.SubAccount;
 using B3.Trading.Application.UserBots;
 using B3.Trading.Api.WebSockets;
@@ -85,6 +86,14 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // that hits their broker-issued opaque-id registry. LGPD
         // posture is documented on IInvestorIdResolver.
         services.AddSingleton<IInvestorIdResolver>(NullInvestorIdResolver.Instance);
+        // #473 (SDK 0.15.0). Resolve the RoutingInstruction stamped
+        // on outbound NewOrderRequest / ReplaceOrderRequest. Default
+        // = NullRoutingInstructionResolver (wire field omitted,
+        // pre-#473 behavior). Pre-trade gating happens via
+        // RiskLimits.AllowedRoutingInstructions +
+        // RoutingInstructionAllowedCheck (default-deny: a resolver
+        // value with no whitelist configured is rejected).
+        services.AddSingleton<IRoutingInstructionResolver>(NullRoutingInstructionResolver.Instance);
         // Q4.5 (#305). Audit log keeper + dispatcher-backed logger.
         // Both singletons so the live-dispatch path, recovery replay
         // and admin read endpoint all share the same in-memory ring

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using B3.Trading.Application;
 using B3.Trading.Application.Investor;
 using B3.Trading.Application.Lifecycle;
+using B3.Trading.Application.Routing;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.SubAccount;
@@ -126,12 +127,14 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var subAccountMapper = sp.GetService<ISubAccountWireIdMapper>();
                     var venueAccountResolver = sp.GetService<IVenueAccountResolver>();
                     var investorIdResolver = sp.GetService<IInvestorIdResolver>();
+                    var routingInstructionResolver = sp.GetService<IRoutingInstructionResolver>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
                         venueDisconnectReactor: reactor,
                         riskOptions: riskOpts,
                         subAccountWireIdMapper: subAccountMapper,
                         venueAccountResolver: venueAccountResolver,
-                        investorIdResolver: investorIdResolver);
+                        investorIdResolver: investorIdResolver,
+                        routingInstructionResolver: routingInstructionResolver);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -88,6 +88,16 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<IRiskCheck, SymbolHaltedCheck>();
         services.AddSingleton<IRiskCheck, SessionPhaseCheck>();
         services.AddSingleton<IRiskCheck, OrderTypeAllowedCheck>();
+        // #473 (SDK 0.15.0). Pre-trade whitelist gate for the
+        // routing instruction stamped on outbound orders. Default-
+        // DENY: if a resolver returns a value but the resolved
+        // scope has no AllowedRoutingInstructions whitelist, the
+        // order is rejected. This is intentionally inverse to
+        // OrderTypeAllowedCheck (default-allow) because routing
+        // instructions carry fairness / conflict-of-interest
+        // implications (e.g. BrokerOnly) — a value flowing into
+        // an unconfigured scope is a config smell.
+        services.AddSingleton<IRiskCheck, RoutingInstructionAllowedCheck>();
         services.AddSingleton<IRiskCheck, MinTickSizeCheck>();
         services.AddSingleton<IRiskCheck, MinLotSizeCheck>();
         services.AddSingleton<IRiskCheck, MaxQuantityCheck>();

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -1,5 +1,6 @@
 using B3.Trading.Application.Investor;
 using B3.Trading.Application.Observability;
+using B3.Trading.Application.Routing;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.SubAccount;
 using B3.Trading.Domain;
@@ -92,6 +93,16 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     // broker-issued registry, keeping PII off the wire and out of the
     // WAL (LGPD posture — see IInvestorIdResolver doc).
     private readonly IInvestorIdResolver? _investorIdResolver;
+    // #473. Optional resolver for the RoutingInstruction stamped on
+    // outbound NewOrderRequest / ReplaceOrderRequest. Default = null
+    // → resolver helper short-circuits to null → wire field stays
+    // omitted (pre-#473 behavior). Pre-trade gating happens at the
+    // caller (OrderSubmissionService / OrderModifyService) via
+    // RoutingInstructionAllowedCheck; the gateway re-resolves here
+    // to keep the BuildNewOrderRequest path SDK-self-contained, and
+    // resolvers MUST be deterministic per-Order so the two
+    // resolutions agree (see IRoutingInstructionResolver doc).
+    private readonly IRoutingInstructionResolver? _routingInstructionResolver;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -107,7 +118,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         IOptionsMonitor<RiskOptions>? riskOptions = null,
         ISubAccountWireIdMapper? subAccountWireIdMapper = null,
         IVenueAccountResolver? venueAccountResolver = null,
-        IInvestorIdResolver? investorIdResolver = null)
+        IInvestorIdResolver? investorIdResolver = null,
+        IRoutingInstructionResolver? routingInstructionResolver = null)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
@@ -123,6 +135,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _subAccountWireIdMapper = subAccountWireIdMapper;
         _venueAccountResolver = venueAccountResolver;
         _investorIdResolver = investorIdResolver;
+        _routingInstructionResolver = routingInstructionResolver;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -208,7 +221,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         if (order.Quantity < 0)
             throw new ArgumentOutOfRangeException(nameof(order), "Quantity cannot be negative when submitted upstream.");
 
-        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order), ResolveVenueAccount(order), ResolveInvestorId(order));
+        var req = BuildNewOrderRequest(order, ResolveStpInstruction(order), ResolveTradingSubAccount(order), ResolveVenueAccount(order), ResolveInvestorId(order), ResolveRoutingInstruction(order));
 
         return SendAsync(req.ClOrdID.Value, OrderEntryLatencyProbe.OpSubmit,
             ct => _client.SubmitAsync(req, ct), cancellationToken);
@@ -231,24 +244,24 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     /// </para>
     /// </summary>
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(Order order)
-        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null, venueAccount: null, investorId: null);
+        => BuildNewOrderRequest(order, UpModels.SelfTradePreventionInstruction.None, tradingSubAccount: null, venueAccount: null, investorId: null, routingInstruction: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order, UpModels.SelfTradePreventionInstruction stpInstruction)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null, venueAccount: null, investorId: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount: null, venueAccount: null, investorId: null, routingInstruction: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
         UpModels.SelfTradePreventionInstruction stpInstruction,
         uint? tradingSubAccount)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount: null, investorId: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount: null, investorId: null, routingInstruction: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
         UpModels.SelfTradePreventionInstruction stpInstruction,
         uint? tradingSubAccount,
         ulong? venueAccount)
-        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount, investorId: null);
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount, investorId: null, routingInstruction: null);
 
     internal static UpModels.NewOrderRequest BuildNewOrderRequest(
         Order order,
@@ -256,6 +269,15 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         uint? tradingSubAccount,
         ulong? venueAccount,
         InvestorIdentity? investorId)
+        => BuildNewOrderRequest(order, stpInstruction, tradingSubAccount, venueAccount, investorId, routingInstruction: null);
+
+    internal static UpModels.NewOrderRequest BuildNewOrderRequest(
+        Order order,
+        UpModels.SelfTradePreventionInstruction stpInstruction,
+        uint? tradingSubAccount,
+        ulong? venueAccount,
+        InvestorIdentity? investorId,
+        RoutingInstruction? routingInstruction)
     {
         ArgumentNullException.ThrowIfNull(order);
         return new UpModels.NewOrderRequest
@@ -310,6 +332,13 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             InvestorId = investorId is { } id
                 ? new UpModels.InvestorId { Prefix = id.Prefix, Document = id.Document }
                 : (UpModels.InvestorId?)null,
+            // #473. Routing instruction stamped when an operator has
+            // wired a real IRoutingInstructionResolver AND the
+            // resolved scope's RiskLimits.AllowedRoutingInstructions
+            // permits the value (gating happens upstream in
+            // RoutingInstructionAllowedCheck). Null = wire field
+            // omitted (pre-#473 behavior).
+            RoutingInstruction = MapRoutingInstructionToWire(routingInstruction),
         };
     }
 
@@ -408,6 +437,12 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
             // `original` is correct because owner/firm (the typical
             // inputs to the resolver) are immutable across a modify.
             InvestorId = MapInvestorIdToWire(ResolveInvestorId(original)),
+            // #473. Same rationale: replace is a fresh book entry,
+            // routing intent must re-accompany it. Resolved off the
+            // original since owner/firm (the typical inputs) are
+            // immutable across modify; pre-trade whitelist gating
+            // was already applied by OrderModifyService.
+            RoutingInstruction = MapRoutingInstructionToWire(ResolveRoutingInstruction(original)),
         };
 
         return SendAsync(newClOrdId, OrderEntryLatencyProbe.OpReplace,
@@ -564,6 +599,38 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         => id is { } v
             ? new UpModels.InvestorId { Prefix = v.Prefix, Document = v.Document }
             : (UpModels.InvestorId?)null;
+
+    /// <summary>
+    /// #473. Resolve the <see cref="RoutingInstruction"/> stamped on
+    /// an outbound <c>NewOrderRequest</c> / <c>ReplaceOrderRequest</c>.
+    /// Returns <c>null</c> when no
+    /// <see cref="IRoutingInstructionResolver"/> is wired (legacy
+    /// gateways stay green) or when the wired resolver has no
+    /// instruction for the order. Pre-trade whitelist gating is the
+    /// caller's responsibility — the gateway trusts what the resolver
+    /// returns here.
+    /// </summary>
+    private RoutingInstruction? ResolveRoutingInstruction(Order order)
+    {
+        if (_routingInstructionResolver is null) return null;
+        return _routingInstructionResolver.TryResolve(order);
+    }
+
+    /// <summary>
+    /// Translate domain <see cref="RoutingInstruction"/> → SDK wire
+    /// enum. Kept private so the SDK type never leaks past the
+    /// gateway boundary.
+    /// </summary>
+    private static UpModels.RoutingInstruction? MapRoutingInstructionToWire(RoutingInstruction? value)
+        => value switch
+        {
+            RoutingInstruction.RetailLiquidityTaker => UpModels.RoutingInstruction.RetailLiquidityTaker,
+            RoutingInstruction.WaivedPriority => UpModels.RoutingInstruction.WaivedPriority,
+            RoutingInstruction.BrokerOnly => UpModels.RoutingInstruction.BrokerOnly,
+            RoutingInstruction.BrokerOnlyRemoval => UpModels.RoutingInstruction.BrokerOnlyRemoval,
+            null => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown RoutingInstruction"),
+        };
 
     // The IEntryPointClient submit-side surface is unused on the real adapter
     // (OrdersEndpoints calls IExchangeGateway directly). We implement it to

--- a/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/B3EntryPointClientGatewayMapTests.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application.Investor;
+using B3.Trading.Application.Routing;
 using B3.Trading.Domain;
 using B3.Trading.Infrastructure;
 using Up = B3.EntryPoint.Client.Models;
@@ -351,6 +352,63 @@ public class B3EntryPointClientGatewayMapTests
             tradingSubAccount: null, venueAccount: null,
             investorId: null);
         Assert.Null(withoutId.InvestorId);
+    }
+
+    // ------------------------------------------------------------------
+    // #473. RoutingInstruction wire field. The seven-arg
+    // BuildNewOrderRequest overload stamps whatever the gateway
+    // resolved via IRoutingInstructionResolver, translating the
+    // Application-layer enum into the SDK wire enum. Legacy overloads
+    // must leave the field null so callers that have not opted in
+    // continue to omit the field on the wire.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void BuildNewOrderRequest_LegacyOverloads_LeaveRoutingInstructionNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(B3EntryPointClientGateway.BuildNewOrderRequest(order).RoutingInstruction);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None)
+            .RoutingInstruction);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 42u)
+            .RoutingInstruction);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None, tradingSubAccount: 42u, venueAccount: 99UL)
+            .RoutingInstruction);
+        Assert.Null(B3EntryPointClientGateway
+            .BuildNewOrderRequest(order, Up.SelfTradePreventionInstruction.None,
+                tradingSubAccount: 42u, venueAccount: 99UL, investorId: new InvestorIdentity(1, 2))
+            .RoutingInstruction);
+    }
+
+    [Theory]
+    [InlineData(RoutingInstruction.RetailLiquidityTaker, Up.RoutingInstruction.RetailLiquidityTaker)]
+    [InlineData(RoutingInstruction.WaivedPriority, Up.RoutingInstruction.WaivedPriority)]
+    [InlineData(RoutingInstruction.BrokerOnly, Up.RoutingInstruction.BrokerOnly)]
+    [InlineData(RoutingInstruction.BrokerOnlyRemoval, Up.RoutingInstruction.BrokerOnlyRemoval)]
+    public void BuildNewOrderRequest_StampsResolvedRoutingInstruction(
+        RoutingInstruction domain, Up.RoutingInstruction wire)
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        var withRi = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: null,
+            investorId: null, routingInstruction: domain);
+        Assert.Equal(wire, withRi.RoutingInstruction);
+
+        var withoutRi = B3EntryPointClientGateway.BuildNewOrderRequest(
+            order, Up.SelfTradePreventionInstruction.None,
+            tradingSubAccount: null, venueAccount: null,
+            investorId: null, routingInstruction: null);
+        Assert.Null(withoutRi.RoutingInstruction);
     }
 }
 

--- a/backend/tests/B3.Trading.Application.Tests/NullRoutingInstructionResolverTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/NullRoutingInstructionResolverTests.cs
@@ -1,0 +1,42 @@
+using B3.Trading.Application.Routing;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #473. Pins the contract of the no-op RoutingInstruction resolver —
+/// every order returns <c>null</c>, so the wire field stays omitted
+/// (pre-#473 behavior) and the pre-trade whitelist check is a no-op
+/// for that order. Operators that ship a real resolver swap this
+/// default at the composition root and must also opt in via
+/// <c>RiskLimits.AllowedRoutingInstructions</c>.
+/// </summary>
+public class NullRoutingInstructionResolverTests
+{
+    [Fact]
+    public void TryResolve_AnyOrder_ReturnsNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A");
+
+        Assert.Null(NullRoutingInstructionResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_OrderWithSubAccount_StillReturnsNull()
+    {
+        var owner = new EndClientId("alice");
+        var order = new Order(42UL, owner, "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            100, 30m, "FIRM-A", subAccountId: new SubAccountId("tradingdesk"));
+
+        Assert.Null(NullRoutingInstructionResolver.Instance.TryResolve(order));
+    }
+
+    [Fact]
+    public void TryResolve_NullOrder_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => NullRoutingInstructionResolver.Instance.TryResolve(null!));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/RoutingInstructionAllowedCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RoutingInstructionAllowedCheckTests.cs
@@ -1,0 +1,89 @@
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Application.Routing;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #473. Pins the default-deny semantics of the routing-instruction
+/// whitelist gate. The gate must:
+///   - approve when the resolver yielded nothing (pre-#473 callers)
+///   - reject when the resolver yielded a value but no whitelist
+///     exists at any scope (configuration smell — fail loud)
+///   - reject when the value is not in the configured whitelist
+///   - approve when the value matches the whitelist, and emit the
+///     <c>trading.orders.routing_instruction_stamped</c> metric so
+///     downstream alerting can pin BrokerOnly slices.
+/// </summary>
+public class RoutingInstructionAllowedCheckTests
+{
+    private static IOptionsMonitor<RiskOptions> Wrap(RiskOptions o) => new StaticOptionsMonitor<RiskOptions>(o);
+
+    private static RiskContext Ctx(RoutingInstruction? ri) =>
+        new(new EndClientId("alice"), "FIRM-A", "PETR4", OrderSide.Buy, OrderType.Limit, 100, 30m,
+            RoutingInstruction: ri);
+
+    [Fact]
+    public void NullRouting_Approves_LegacyCallersStayGreen()
+    {
+        var check = new RoutingInstructionAllowedCheck(Wrap(new RiskOptions()));
+        Assert.True(check.Check(Ctx(null)).Approved);
+    }
+
+    [Fact]
+    public void Value_NoWhitelist_RejectsByDefault()
+    {
+        // Default-deny: a resolver shipping a value into an
+        // unconfigured scope is a config smell. This is the inverse
+        // of OrderTypeAllowedCheck (which defaults to allow).
+        var check = new RoutingInstructionAllowedCheck(Wrap(new RiskOptions()));
+        var d = check.Check(Ctx(RoutingInstruction.BrokerOnly));
+        Assert.False(d.Approved);
+        Assert.Contains("AllowedRoutingInstructions", d.Reason);
+    }
+
+    [Fact]
+    public void Value_NotInWhitelist_Rejects()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedRoutingInstructions = new List<string> { "WaivedPriority" } },
+        };
+        var check = new RoutingInstructionAllowedCheck(Wrap(opts));
+        var d = check.Check(Ctx(RoutingInstruction.BrokerOnly));
+        Assert.False(d.Approved);
+        Assert.Contains("not in allowed list", d.Reason);
+    }
+
+    [Fact]
+    public void Value_InWhitelist_Approves()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedRoutingInstructions = new List<string> { "BrokerOnly", "WaivedPriority" } },
+        };
+        var check = new RoutingInstructionAllowedCheck(Wrap(opts));
+        Assert.True(check.Check(Ctx(RoutingInstruction.BrokerOnly)).Approved);
+        Assert.True(check.Check(Ctx(RoutingInstruction.WaivedPriority)).Approved);
+    }
+
+    [Fact]
+    public void Whitelist_CaseInsensitive()
+    {
+        var opts = new RiskOptions
+        {
+            Default = new RiskLimits { AllowedRoutingInstructions = new List<string> { "brokeronly" } },
+        };
+        var check = new RoutingInstructionAllowedCheck(Wrap(opts));
+        Assert.True(check.Check(Ctx(RoutingInstruction.BrokerOnly)).Approved);
+    }
+
+    [Fact]
+    public void PipelineOrder_Is16_RightAfterOrderTypeAllowedCheck()
+    {
+        var check = new RoutingInstructionAllowedCheck(Wrap(new RiskOptions()));
+        Assert.Equal(16, check.Order);
+    }
+}


### PR DESCRIPTION
## Changes

**Fase A — opt-in seam** (mirrors #471 / #458 / #472):
- `Application/Routing/{RoutingInstruction,IRoutingInstructionResolver,NullRoutingInstructionResolver}.cs` — domain enum (4 SDK values) + seam + null default
- `B3EntryPointClientGateway` — 7-arg `BuildNewOrderRequest` overload, `ResolveRoutingInstruction(Order)` + `MapRoutingInstructionToWire` boundary translator, threaded into `SubmitAsync` + `CancelReplaceAsync`
- DI: `NullRoutingInstructionResolver` registered in `TradingApplicationCoreServiceCollectionExtensions`; factory wires resolver into gateway in `TradingExchangeGatewayServiceCollectionExtensions`

**Fase B — default-DENY whitelist gate**:
- `RiskLimits.AllowedRoutingInstructions: List<string>?` (+ `ResolveAll` precedence)
- `RiskContext.RoutingInstruction` optional positional record param (existing callers stay green via named args)
- `RoutingInstructionAllowedCheck : IRiskCheck` — pipeline order=16, default-DENY (inverse of `OrderTypeAllowedCheck`). A resolver value with no whitelist configured is rejected loudly — fairness/conflict-of-interest implications (e.g. BrokerOnly) mean an unconfigured scope is a config smell.
- Pre-trade resolution in `OrderSubmissionService` and `OrderModifyService` before `new RiskContext(...)`; gateway re-resolves at stamp time — resolvers MUST be deterministic per-Order (documented).
- `trading.orders.routing_instruction_stamped` counter tagged `(value, firmId)` so downstream alerting can pin the BrokerOnly slice.

## Local

```
dotnet build B3TradingPlatform.slnx -c Release  →  0/0
dotnet test  Application.Tests  →  1182/1182
dotnet test  Api.Tests           →   493/493
```

New tests:
- `NullRoutingInstructionResolverTests` (3 — null contract pin)
- `RoutingInstructionAllowedCheckTests` (6 — default-allow on null, default-deny on unconfigured, whitelist match/miss, case-insensitive parse, pipeline order)
- Extended `B3EntryPointClientGatewayMapTests` with 5 pins (legacy overloads → null + 4 enum values → wire round-trip)

## Pattern lineage

- #433 (STP) — via `RiskLimitsResolver`
- #471 (TradingSubAccount) — `ISubAccountWireIdMapper` seam
- #458 (CBLC Account) — `IVenueAccountResolver` seam
- #472 (InvestorId) — `IInvestorIdResolver` seam
- **#473 (RoutingInstruction)** — `IRoutingInstructionResolver` seam **+** risk-pipeline whitelist gate (only one of the five with gating, due to fairness implications)

Closes #473