### PR TITLE
feat(#435): mask ClOrdId on drop-copy projection (Part B)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyExecutionEventSink.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using Microsoft.Extensions.Hosting;
@@ -47,6 +48,7 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
 
     private readonly DropCopyManager _manager;
     private readonly WorkingOrderBook _orders;
+    private readonly IClOrdIdMasker _masker;
     private readonly ILogger<DropCopyExecutionEventSink>? _logger;
     private readonly Channel<ExecutionEvent> _channel;
     private readonly CancellationTokenSource _cts = new();
@@ -56,10 +58,12 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
     public DropCopyExecutionEventSink(
         DropCopyManager manager,
         WorkingOrderBook orders,
+        IClOrdIdMasker masker,
         ILogger<DropCopyExecutionEventSink>? logger = null)
     {
         _manager = manager;
         _orders = orders;
+        _masker = masker;
         _logger = logger;
         _channel = Channel.CreateBounded<ExecutionEvent>(
             new BoundedChannelOptions(ChannelCapacity)
@@ -127,9 +131,15 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
                     try { PublishCore(ev); }
                     catch (Exception ex)
                     {
+                        // #435 Part B: mask the ClOrdId on the failure-log
+                        // path too — this line tails to centralized logging
+                        // which is itself an externally-observable surface.
+                        var maskedClOrdId = !string.IsNullOrEmpty(ev.FirmId)
+                            ? _masker.MaskClOrdId(ev.FirmId, ev.ClOrdId)
+                            : "<no-firm>";
                         _logger?.LogWarning(ex,
-                            "drop-copy fan-out publish failed for firmId={Firm} clOrdId={ClOrdId}",
-                            ev.FirmId, ev.ClOrdId);
+                            "drop-copy fan-out publish failed for firmId={Firm} clOrdId={MaskedClOrdId}",
+                            ev.FirmId, maskedClOrdId);
                     }
                 }
             }
@@ -153,16 +163,17 @@ public sealed class DropCopyExecutionEventSink : IExecutionFanOutSink, IExecutio
 
         // orders.* — current order state after mutation (skip if the
         // order is no longer in the book, same fall-through as orders.me).
+        // #435 Part B: drop-copy projection masks ClOrdId + ParentAlgoId.
         if (_orders.TryGet(ev.ClOrdId, out var order) && order is not null)
-            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Orders, order.ToDto());
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Orders, order.ToDropCopyDto(_masker, firmId));
 
         // fills.* — only economic fills.
         if (ev.Kind is ExecKind.Fill or ExecKind.PartialFill && ev.LastQuantity > 0)
-            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Fills, ev.ToDto());
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Fills, ev.ToDropCopyDto(_masker, firmId));
 
         // cancels.* — venue cancels (incl. GTD-expired). Replaces/rejects
         // are visible via the orders channel as state transitions.
         if (ev.Kind == ExecKind.Canceled)
-            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Cancels, ev.ToDto());
+            _manager.Publish(firmId, DropCopyManager.DropCopyChannels.Cancels, ev.ToDropCopyDto(_masker, firmId));
     }
 }

--- a/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/DropCopy/DropCopyManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 
 namespace B3.Trading.Api.WebSockets.DropCopy;
 
@@ -82,10 +83,12 @@ public sealed class DropCopyManager
         new(StringComparer.Ordinal);
 
     private readonly WorkingOrderBook _orders;
+    private readonly IClOrdIdMasker _masker;
 
-    public DropCopyManager(WorkingOrderBook orders)
+    public DropCopyManager(WorkingOrderBook orders, IClOrdIdMasker masker)
     {
         _orders = orders;
+        _masker = masker;
     }
 
     private object LockFor(string firmId) =>
@@ -111,7 +114,8 @@ public sealed class DropCopyManager
                 (_, set) => set.Add(client));
 
             // Orders snapshot: every non-terminal working order in the firm.
-            var orderDtos = _orders.EnumerateForFirm(firmId).Select(o => o.ToDto()).ToArray();
+            // #435 Part B: drop-copy projection masks ClOrdId + ParentAlgoId.
+            var orderDtos = _orders.EnumerateForFirm(firmId).Select(o => o.ToDropCopyDto(_masker, firmId)).ToArray();
 
             if (client.Subscribe(DropCopyChannels.Orders))
                 client.Enqueue(new OutboundMessage("snapshot", DropCopyChannels.Orders, 0, orderDtos));

--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application;
+using B3.Trading.Application.Audit;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Domain;
 
@@ -286,6 +287,39 @@ public static class DtoMappings
 
     public static ExecutionDto ToDto(this ExecutionEvent ev) => new(
         ev.ClOrdId.ToString(), ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),
+        ev.LeavesQuantity, ev.CumulativeQuantity, ev.LastQuantity, ev.LastPrice, ev.RejectReason, ev.TimestampUtc,
+        ev.IsNativeStp,
+        ev.BookTouch is null ? null : ev.BookTouch.ToDto());
+
+    /// <summary>
+    /// #435 Part B. Drop-copy projection of <see cref="Order"/> with
+    /// the externally-observable <c>ClOrdId</c> and <c>ParentAlgoId</c>
+    /// replaced by an opaque, per-(firm, UTC-day) handle. Wire shape
+    /// (<see cref="OrderDto"/>) is unchanged — only the values mutate.
+    /// AlgoSliceSeq is also stripped because a monotonic seq trivially
+    /// re-links children to a parent even if both ids are masked.
+    /// </summary>
+    public static OrderDto ToDropCopyDto(this Order o, IClOrdIdMasker masker, string firmId) => new(
+        masker.MaskClOrdId(firmId, o.ClOrdId),
+        o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
+        o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
+        o.ParentAlgoId is { } parentId ? masker.MaskAlgoId(firmId, parentId) : null,
+        AlgoSliceSeq: null,
+        o.IsStale, o.StaleReason, o.StaledAtUtc,
+        o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate,
+        o.DisplayQty, o.DisplayResetPolicy?.ToString(),
+        o.SubAccountId?.Value);
+
+    /// <summary>
+    /// #435 Part B. Drop-copy projection of <see cref="ExecutionEvent"/>
+    /// with the externally-observable <c>ClOrdId</c> replaced by an
+    /// opaque, per-(firm, UTC-day) handle. <see cref="ExecutionEvent"/>
+    /// carries no <c>ParentAlgoId</c>, so this overload only rewrites
+    /// the one field.
+    /// </summary>
+    public static ExecutionDto ToDropCopyDto(this ExecutionEvent ev, IClOrdIdMasker masker, string firmId) => new(
+        masker.MaskClOrdId(firmId, ev.ClOrdId),
+        ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),
         ev.LeavesQuantity, ev.CumulativeQuantity, ev.LastQuantity, ev.LastPrice, ev.RejectReason, ev.TimestampUtc,
         ev.IsNativeStp,
         ev.BookTouch is null ? null : ev.BookTouch.ToDto());

--- a/backend/src/B3.Trading.Application/Audit/ClOrdIdMasker.cs
+++ b/backend/src/B3.Trading.Application/Audit/ClOrdIdMasker.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// #435 Part B. Default <see cref="IClOrdIdMasker"/> implementation.
+/// Pattern lifted from <c>CvmReportWriter.OpaqueOwner</c>: SHA-256 over
+/// <c>{salt}|{firmId}|{utcDate:yyyy-MM-dd}|{domain}|{id}</c>, truncated
+/// to 16 hex chars (64 bits — more than enough to keep within-stream
+/// uniqueness while staying compact for human review of drop-copy logs).
+/// </summary>
+public sealed class ClOrdIdMasker : IClOrdIdMasker
+{
+    private const string ClOrdIdDomain = "clordid";
+    private const string AlgoIdDomain = "algoid";
+
+    private readonly ClOrdIdMaskerOptions _options;
+    private readonly Func<DateTime> _utcNow;
+
+    public ClOrdIdMasker(IOptions<ClOrdIdMaskerOptions> options)
+        : this(options?.Value ?? throw new ArgumentNullException(nameof(options)), () => DateTime.UtcNow)
+    { }
+
+    internal ClOrdIdMasker(ClOrdIdMaskerOptions options, Func<DateTime> utcNow)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
+        if (string.IsNullOrEmpty(_options.ClOrdIdMaskSalt))
+        {
+            throw new InvalidOperationException(
+                "ClOrdIdMaskerOptions.ClOrdIdMaskSalt must be set " +
+                "(use ClOrdIdMaskerOptions.TestOnlySalt in tests). " +
+                "Required for drop-copy compliance gating (#435 Part B).");
+        }
+    }
+
+    public string MaskClOrdId(string firmId, ulong clOrdId) =>
+        Compute(firmId, ClOrdIdDomain, clOrdId);
+
+    public string MaskAlgoId(string firmId, ulong algoId) =>
+        Compute(firmId, AlgoIdDomain, algoId);
+
+    private string Compute(string firmId, string domain, ulong id)
+    {
+        var today = DateOnly.FromDateTime(_utcNow());
+        var seed = $"{_options.ClOrdIdMaskSalt}|{firmId}|{today:yyyy-MM-dd}|{domain}|{id}";
+        var bytes = Encoding.UTF8.GetBytes(seed);
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(bytes, hash);
+        return Convert.ToHexString(hash[..8]);
+    }
+}

--- a/backend/src/B3.Trading.Application/Audit/ClOrdIdMaskerOptions.cs
+++ b/backend/src/B3.Trading.Application/Audit/ClOrdIdMaskerOptions.cs
@@ -1,0 +1,26 @@
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// #435 Part B. Configuration for <see cref="ClOrdIdMasker"/>. Salt
+/// MUST be set in non-Development environments — the masker ctor
+/// throws on construction otherwise, matching the boot-guard
+/// convention used by <c>CvmReportWriter</c> for <c>OwnerHashSalt</c>.
+/// Bound from <c>Trading:DropCopy</c>.
+/// </summary>
+public sealed class ClOrdIdMaskerOptions
+{
+    /// <summary>
+    /// Secret-grade entropy mixed into every mask. Rotate operationally
+    /// to retire correlations on a known cadence (the per-UTC-day
+    /// rotation done by the masker is independent of this and provides
+    /// the daily unlinkability — the salt is the global key).
+    /// </summary>
+    public string? ClOrdIdMaskSalt { get; set; }
+
+    /// <summary>
+    /// Test-only fixed salt — used by the API <c>TestAppFactory</c>
+    /// and unit tests so deterministic mask outputs can be asserted.
+    /// MUST NOT be used in real environments.
+    /// </summary>
+    public const string TestOnlySalt = "TEST-ONLY-CLORDID-MASK-SALT-DO-NOT-USE-IN-PROD";
+}

--- a/backend/src/B3.Trading.Application/Audit/IClOrdIdMasker.cs
+++ b/backend/src/B3.Trading.Application/Audit/IClOrdIdMasker.cs
@@ -1,0 +1,39 @@
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// #435 Part B. Opaque, time-rotated handle used in place of the
+/// raw <c>ClOrdId</c> / <c>ParentAlgoId</c> on externally-observable
+/// surfaces (today: the drop-copy stream). The contract is:
+///
+/// <list type="bullet">
+///   <item><b>Deterministic within a (firmId, UTC day)</b> so the
+///   legitimate drop-copy consumer can still group consecutive child
+///   events of the same order / algo within the same trading day.</item>
+///   <item><b>Unlinkable across days</b> so a counterparty consuming
+///   a downstream tap of the drop-copy channel cannot reconstruct an
+///   algo's footprint across multiple sessions.</item>
+///   <item><b>Unlinkable across firms</b> so cross-firm correlation
+///   is impossible even if a single tap receives multi-firm traffic.</item>
+///   <item><b>One-way</b>: the host's internal index (<c>WorkingOrderBook</c>,
+///   <c>OrderOwnershipMap</c>, <c>ClOrdIdPrefixRegistry</c>) continues
+///   to use raw IDs — masking happens only at the DTO projection
+///   that crosses the drop-copy WebSocket boundary.</item>
+/// </list>
+///
+/// <para>
+/// <b>Why two methods, not one.</b> <see cref="MaskClOrdId"/> and
+/// <see cref="MaskAlgoId"/> hash the same <c>ulong</c> domain but
+/// must produce different outputs for the same numeric id, otherwise
+/// an algo whose <c>ParentAlgoId</c> happens to equal the
+/// <c>ClOrdId</c> of an unrelated order would leak that coincidence
+/// to the drop-copy consumer.
+/// </para>
+/// </summary>
+public interface IClOrdIdMasker
+{
+    /// <summary>Mask a child / standalone order's wire ClOrdId.</summary>
+    string MaskClOrdId(string firmId, ulong clOrdId);
+
+    /// <summary>Mask an algo parent identifier.</summary>
+    string MaskAlgoId(string firmId, ulong algoId);
+}

--- a/backend/src/B3.Trading.Application/Audit/NullClOrdIdMasker.cs
+++ b/backend/src/B3.Trading.Application/Audit/NullClOrdIdMasker.cs
@@ -1,0 +1,23 @@
+namespace B3.Trading.Application.Audit;
+
+/// <summary>
+/// #435 Part B. Pass-through masker that returns the raw id verbatim
+/// (no masking, no rotation, no entropy). Used by unit tests that need
+/// to assert against deterministic numeric ids and by composition
+/// roots that have explicitly opted out of #435 Part B gating (e.g. an
+/// isolated single-firm self-clearing setup with no external drop-copy
+/// consumers). NEVER bind this in a production composition root that
+/// fans drop-copy out across a public WebSocket boundary.
+/// </summary>
+public sealed class NullClOrdIdMasker : IClOrdIdMasker
+{
+    public static readonly NullClOrdIdMasker Instance = new();
+
+    private NullClOrdIdMasker() { }
+
+    public string MaskClOrdId(string firmId, ulong clOrdId) =>
+        clOrdId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    public string MaskAlgoId(string firmId, ulong algoId) =>
+        algoId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingApplicationCoreServiceCollectionExtensions.cs
@@ -155,6 +155,17 @@ public static class TradingApplicationCoreServiceCollectionExtensions
         // target=DropCopy); synthetic publishes from
         // OrderStalenessService / WAL-backpressure fallback also reach
         // it via the composite IExecutionEventSink wired below.
+        //
+        // #435 Part B. IClOrdIdMasker rewrites ClOrdId/ParentAlgoId on
+        // every DTO that crosses the drop-copy WebSocket boundary, so
+        // a counterparty consuming a downstream tap cannot reconstruct
+        // an algo's footprint across days or correlate flow across firms.
+        // Bind options from "Trading:DropCopy"; the default impl throws
+        // at construction if ClOrdIdMaskSalt is unset (matches
+        // CvmReportWriter.OwnerHashSalt boot-guard convention).
+        services.AddOptions<B3.Trading.Application.Audit.ClOrdIdMaskerOptions>()
+            .Bind(configuration.GetSection("Trading:DropCopy"));
+        services.AddSingleton<B3.Trading.Application.Audit.IClOrdIdMasker, B3.Trading.Application.Audit.ClOrdIdMasker>();
         services.AddSingleton<B3.Trading.Api.WebSockets.DropCopy.DropCopyManager>();
         services.AddSingleton<B3.Trading.Api.WebSockets.DropCopy.DropCopyExecutionEventSink>();
         services.AddSingleton<IExecutionFanOutSink>(sp =>

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyDtoMaskingTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyDtoMaskingTests.cs
@@ -1,0 +1,108 @@
+using B3.Trading.Api.WebSockets;
+using B3.Trading.Application;
+using B3.Trading.Application.Audit;
+using B3.Trading.Domain;
+using Xunit;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// #435 Part B. Verifies that the new <c>ToDropCopyDto</c> projection
+/// masks ClOrdId + ParentAlgoId and strips AlgoSliceSeq, while the
+/// legacy <c>ToDto</c> projection (still used by per-user
+/// <c>orders.me</c> / <c>executions.me</c>) is left untouched.
+/// </summary>
+public sealed class DropCopyDtoMaskingTests
+{
+    private static readonly EndClientId Alice = new("alice");
+    private const string Firm = "FIRM01";
+
+    private static ClOrdIdMasker MakeMasker(DateTime? at = null) =>
+        new(
+            new ClOrdIdMaskerOptions { ClOrdIdMaskSalt = ClOrdIdMaskerOptions.TestOnlySalt },
+            () => at ?? new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc));
+
+    [Fact]
+    public void OrderToDropCopyDto_MasksClOrdIdAndParentAlgoId_AndStripsSliceSeq()
+    {
+        var masker = MakeMasker();
+        var order = new Order(
+            clOrdId: 12345UL, owner: Alice, symbol: "PETR4", securityId: 9001UL,
+            side: OrderSide.Buy, type: OrderType.Limit, quantity: 100, price: 30m,
+            firmId: Firm, parentAlgoId: 999UL, algoSliceSeq: 7);
+
+        var raw = order.ToDto();
+        var masked = order.ToDropCopyDto(masker, Firm);
+
+        // Raw projection (orders.me) is unchanged.
+        Assert.Equal("12345", raw.ClOrdId);
+        Assert.Equal("999", raw.ParentAlgoId);
+        Assert.Equal(7, raw.AlgoSliceSeq);
+
+        // Drop-copy projection masks both ids + strips slice seq.
+        Assert.NotEqual("12345", masked.ClOrdId);
+        Assert.NotEqual("999", masked.ParentAlgoId);
+        Assert.Equal(16, masked.ClOrdId.Length);
+        Assert.Equal(16, masked.ParentAlgoId!.Length);
+        Assert.Null(masked.AlgoSliceSeq);
+
+        // Non-identity fields are passed through verbatim.
+        Assert.Equal(order.Symbol, masked.Symbol);
+        Assert.Equal(order.Quantity, masked.Quantity);
+        Assert.Equal(order.Price, masked.Price);
+    }
+
+    [Fact]
+    public void OrderToDropCopyDto_NullParentAlgoId_StaysNull()
+    {
+        var masker = MakeMasker();
+        var order = new Order(
+            clOrdId: 42UL, owner: Alice, symbol: "PETR4", securityId: 9001UL,
+            side: OrderSide.Buy, type: OrderType.Limit, quantity: 100, price: 30m,
+            firmId: Firm);
+
+        var masked = order.ToDropCopyDto(masker, Firm);
+        Assert.Null(masked.ParentAlgoId);
+        Assert.Null(masked.AlgoSliceSeq);
+        Assert.NotEqual("42", masked.ClOrdId);
+    }
+
+    [Fact]
+    public void ExecutionEventToDropCopyDto_MasksClOrdId()
+    {
+        var masker = MakeMasker();
+        var ev = new ExecutionEvent(
+            Owner: Alice, ClOrdId: 99UL, Symbol: "PETR4",
+            Side: OrderSide.Buy, Status: OrderStatus.PartiallyFilled, Kind: ExecKind.PartialFill,
+            LeavesQuantity: 50, CumulativeQuantity: 50, LastQuantity: 50, LastPrice: 30m,
+            RejectReason: null, TimestampUtc: DateTimeOffset.UtcNow,
+            FirmId: Firm);
+
+        var raw = ev.ToDto();
+        var masked = ev.ToDropCopyDto(masker, Firm);
+
+        Assert.Equal("99", raw.ClOrdId);
+        Assert.NotEqual("99", masked.ClOrdId);
+        Assert.Equal(16, masked.ClOrdId.Length);
+        Assert.Equal(ev.LastQuantity, masked.LastQuantity);
+        Assert.Equal(ev.LastPrice, masked.LastPrice);
+    }
+
+    [Fact]
+    public void Entropy_100SequentialChildren_AllDistinctMasks()
+    {
+        // Drop-copy threat model — see ClOrdIdMaskerTests; reasserted
+        // at the DTO projection layer to catch any future short-circuit
+        // that might leak the raw id past the masker.
+        var masker = MakeMasker();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (ulong i = 1; i <= 100; i++)
+        {
+            var o = new Order(
+                clOrdId: i, owner: Alice, symbol: "PETR4", securityId: 9001UL,
+                side: OrderSide.Buy, type: OrderType.Limit, quantity: 100, price: 30m,
+                firmId: Firm);
+            Assert.True(seen.Add(o.ToDropCopyDto(masker, Firm).ClOrdId));
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/DropCopyWebSocketTests.cs
@@ -27,6 +27,15 @@ public class DropCopyWebSocketTests
     private const string Firm01 = "FIRM01";
     private const string Firm02 = "FIRM02";
 
+    /// <summary>
+    /// #435 Part B. Resolve the masked drop-copy form of a raw ClOrdId.
+    /// The integration tests publish ExecutionEvents with raw ulong
+    /// ClOrdIds; the drop-copy DTO emitted on the wire carries the
+    /// opaque mask, so assertions need the masked equivalent.
+    /// </summary>
+    private static string Mask(TestAppFactory factory, string firmId, ulong clOrdId) =>
+        factory.Services.GetRequiredService<IClOrdIdMasker>().MaskClOrdId(firmId, clOrdId);
+
     // 1. Compliance sees orders/fills/cancels submitted by OTHER users in the same firm.
     [Fact]
     public async Task ComplianceUser_SeesEventsFromOtherUsersInSameFirm()
@@ -61,14 +70,14 @@ public class DropCopyWebSocketTests
             OrderStatus.Cancelled, ExecKind.Canceled, 0, 0, 0, 0m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
 
         var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
-            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "101")) &&
-                              bag.Contains((DropCopyManager.DropCopyChannels.Cancels, "102")) &&
-                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, "101")) &&
-                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, "102")));
-        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "101"), observed);
-        Assert.Contains((DropCopyManager.DropCopyChannels.Cancels, "102"), observed);
-        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, "101"), observed);
-        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, "102"), observed);
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 101UL))) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Cancels, Mask(factory, Firm01, 102UL))) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, Mask(factory, Firm01, 101UL))) &&
+                              bag.Contains((DropCopyManager.DropCopyChannels.Orders, Mask(factory, Firm01, 102UL))));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 101UL)), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Cancels, Mask(factory, Firm01, 102UL)), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, Mask(factory, Firm01, 101UL)), observed);
+        Assert.Contains((DropCopyManager.DropCopyChannels.Orders, Mask(factory, Firm01, 102UL)), observed);
     }
 
     // 2. Compliance does NOT see orders from a different firm.
@@ -97,10 +106,10 @@ public class DropCopyWebSocketTests
             OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
 
         var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
-            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "888")));
-        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "888"), observed);
-        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, "999"), observed);
-        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Orders, "999"), observed);
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 888UL))));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 888UL)), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm02, 999UL)), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Orders, Mask(factory, Firm02, 999UL)), observed);
     }
 
     // 3. Snapshot+stream consistency: N pre-connect orders → snapshot N entries; M after → stream M; no dupes/no gaps.
@@ -189,8 +198,8 @@ public class DropCopyWebSocketTests
             OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 60m, null, DateTimeOffset.UtcNow, FirmId: Firm02));
 
         var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
-            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "777")));
-        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "777"), observed);
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm02, 777UL))));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm02, 777UL)), observed);
     }
 
     // 5. Admin without ?firmId defaults to its own firm.
@@ -215,8 +224,8 @@ public class DropCopyWebSocketTests
             OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: "default"));
 
         var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
-            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "555")));
-        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "555"), observed);
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, "default", 555UL))));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, "default", 555UL)), observed);
     }
 
     // 6. Compliance passing ?firmId is IGNORED (returns its own firm's drop-copy).
@@ -250,9 +259,9 @@ public class DropCopyWebSocketTests
             OrderStatus.Filled, ExecKind.Fill, 0, 100, 100, 30m, null, DateTimeOffset.UtcNow, FirmId: Firm01));
 
         var observed = await DrainDeltasUntilAsync(ws, cts.Token, deadline: TimeSpan.FromSeconds(5),
-            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, "667")));
-        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, "667"), observed);
-        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, "666"), observed);
+            condition: bag => bag.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 667UL))));
+        Assert.Contains((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm01, 667UL)), observed);
+        Assert.DoesNotContain((DropCopyManager.DropCopyChannels.Fills, Mask(factory, Firm02, 666UL)), observed);
     }
 
     // 7. Non-compliance/non-admin user is rejected (WS close 1008).
@@ -359,7 +368,7 @@ public class DropCopyWebSocketTests
     public void DisconnectAllForResync_MarksEverySubscriberForReconnect()
     {
         var book = new WorkingOrderBook();
-        var manager = new DropCopyManager(book);
+        var manager = new DropCopyManager(book, NullClOrdIdMasker.Instance);
 
         var a = new DropCopyClient(Firm01, "dave", "compliance");
         var b = new DropCopyClient(Firm01, "eve", "admin");
@@ -390,7 +399,7 @@ public class DropCopyWebSocketTests
     public void DisconnectAllForResync_CoalescesWithinBurst_ReArmsOnAdd()
     {
         var book = new WorkingOrderBook();
-        var manager = new DropCopyManager(book);
+        var manager = new DropCopyManager(book, NullClOrdIdMasker.Instance);
 
         var a = new DropCopyClient(Firm01, "dave", "compliance");
         manager.Add(a);
@@ -428,7 +437,7 @@ public class DropCopyWebSocketTests
     public async Task ConcurrentAddAndDisconnectAllForResync_NeverLeavesClientUnmarked()
     {
         var book = new WorkingOrderBook();
-        var manager = new DropCopyManager(book);
+        var manager = new DropCopyManager(book, NullClOrdIdMasker.Instance);
         var clients = new List<DropCopyClient>(capacity: 500);
         var cts = new CancellationTokenSource();
 
@@ -557,7 +566,7 @@ public class DropCopyWebSocketTests
         for (var iter = 0; iter < Iterations; iter++)
         {
             var book = new WorkingOrderBook();
-            var manager = new DropCopyManager(book);
+            var manager = new DropCopyManager(book, NullClOrdIdMasker.Instance);
             var client = new DropCopyClient(Firm, "compliance-" + iter, "compliance");
 
             long published = 0;

--- a/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
+++ b/backend/tests/B3.Trading.Api.Tests/TestAppFactory.cs
@@ -143,6 +143,9 @@ public class TestAppFactory : WebApplicationFactory<Program>
                 // TestOnly sentinel; production hosts MUST configure a
                 // real secret — see CvmReportOptions.Validate.
                 ["Trading:Reports:Cvm:OwnerHashSalt"] = B3.Trading.Application.Reports.Cvm.CvmReportOptions.TestOnlySalt,
+                // #435 Part B. Drop-copy ClOrdId masker salt — boot-guard
+                // throws if unset in non-Development, mirrors CVM pattern.
+                ["Trading:DropCopy:ClOrdIdMaskSalt"] = B3.Trading.Application.Audit.ClOrdIdMaskerOptions.TestOnlySalt,
             });
 
             if (_configOverrides is not null)

--- a/backend/tests/B3.Trading.Application.Tests/Audit/ClOrdIdMaskerTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Audit/ClOrdIdMaskerTests.cs
@@ -1,0 +1,94 @@
+using B3.Trading.Application.Audit;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace B3.Trading.Application.Tests.Audit;
+
+/// <summary>
+/// #435 Part B. Contract tests for <see cref="ClOrdIdMasker"/>:
+/// determinism within (firm, UTC-day), cross-day unlinkability,
+/// cross-firm isolation, ClOrdId/AlgoId domain separation, and the
+/// boot-guard on unset salt.
+/// </summary>
+public sealed class ClOrdIdMaskerTests
+{
+    private static ClOrdIdMasker MakerAt(DateTime utcNow, string salt = ClOrdIdMaskerOptions.TestOnlySalt) =>
+        new(new ClOrdIdMaskerOptions { ClOrdIdMaskSalt = salt }, () => utcNow);
+
+    [Fact]
+    public void Ctor_Throws_WhenSaltUnset()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new ClOrdIdMasker(Options.Create(new ClOrdIdMaskerOptions())));
+        Assert.Contains("ClOrdIdMaskSalt", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_Accepts_TestOnlySalt()
+    {
+        _ = new ClOrdIdMasker(Options.Create(new ClOrdIdMaskerOptions
+        {
+            ClOrdIdMaskSalt = ClOrdIdMaskerOptions.TestOnlySalt,
+        }));
+    }
+
+    [Fact]
+    public void Mask_IsDeterministic_WithinSameDay()
+    {
+        var m = MakerAt(new DateTime(2026, 5, 25, 12, 30, 0, DateTimeKind.Utc));
+        var a = m.MaskClOrdId("firmA", 12345UL);
+        var b = m.MaskClOrdId("firmA", 12345UL);
+        Assert.Equal(a, b);
+        Assert.Equal(16, a.Length);
+    }
+
+    [Fact]
+    public void Mask_Rotates_AcrossUtcDays()
+    {
+        var day1 = MakerAt(new DateTime(2026, 5, 25, 23, 59, 0, DateTimeKind.Utc));
+        var day2 = MakerAt(new DateTime(2026, 5, 26, 00, 01, 0, DateTimeKind.Utc));
+        Assert.NotEqual(day1.MaskClOrdId("firmA", 12345UL), day2.MaskClOrdId("firmA", 12345UL));
+    }
+
+    [Fact]
+    public void Mask_IsolatesAcrossFirms()
+    {
+        var m = MakerAt(new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc));
+        Assert.NotEqual(m.MaskClOrdId("firmA", 42UL), m.MaskClOrdId("firmB", 42UL));
+    }
+
+    [Fact]
+    public void Mask_SeparatesClOrdIdVsAlgoIdDomain()
+    {
+        // Same firm, same day, same numeric id — but different domain
+        // (ClOrdId vs ParentAlgoId) must produce different opaque tokens
+        // so a coincidental id collision does not leak across the two
+        // identifier namespaces on the drop-copy stream.
+        var m = MakerAt(new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc));
+        Assert.NotEqual(m.MaskClOrdId("firmA", 99UL), m.MaskAlgoId("firmA", 99UL));
+    }
+
+    [Fact]
+    public void Mask_DiffersAcrossSequentialIds()
+    {
+        // Drop-copy threat model: 100 sequential child ClOrdIds must
+        // hash to 100 distinct opaque tokens — otherwise a counterparty
+        // could group consecutive children of the same algo by mask
+        // collisions even with daily rotation in place.
+        var m = MakerAt(new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc));
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (ulong i = 1; i <= 100; i++)
+        {
+            Assert.True(seen.Add(m.MaskClOrdId("firmA", i)), $"collision at id={i}");
+        }
+    }
+
+    [Fact]
+    public void Mask_DifferentSalts_DifferentOutputs()
+    {
+        var t = new DateTime(2026, 5, 25, 12, 0, 0, DateTimeKind.Utc);
+        var a = MakerAt(t, "salt-A").MaskClOrdId("firmA", 1UL);
+        var b = MakerAt(t, "salt-B").MaskClOrdId("firmA", 1UL);
+        Assert.NotEqual(a, b);
+    }
+}

--- a/docker/docker-compose.conformance.yml
+++ b/docker/docker-compose.conformance.yml
@@ -43,6 +43,9 @@ services:
       # startup; bind a fixed placeholder so the host can come up.
       # Production hosts MUST configure a real secret.
       Trading__Reports__Cvm__OwnerHashSalt: "conformance-only-cvm-salt-placeholder-DO-NOT-USE-IN-PROD"
+      # #435 Part B. Drop-copy ClOrdId masker salt — boot-guard throws
+      # if unset in non-Development. Placeholder for conformance only.
+      Trading__DropCopy__ClOrdIdMaskSalt: "conformance-only-clordid-mask-salt-placeholder-DO-NOT-USE-IN-PROD"
 
   conformance:
     build:

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -73,6 +73,9 @@ services:
       # demo overlay runs the host in Docker env, so set a fixed
       # placeholder so the host boots. Production must override.
       Trading__Reports__Cvm__OwnerHashSalt: "demo-only-cvm-salt-placeholder-DO-NOT-USE-IN-PROD"
+      # #435 Part B. Drop-copy ClOrdId masker salt — boot-guard throws
+      # if unset in non-Development. Placeholder for demo only.
+      Trading__DropCopy__ClOrdIdMaskSalt: "demo-only-clordid-mask-salt-placeholder-DO-NOT-USE-IN-PROD"
 
       # The demo bots produce Buys and Sells uniformly to populate
       # both sides of the book. With the naked-short gate enabled


### PR DESCRIPTION
## Threat model

#435 Part B — counterparty consuming a downstream tap of the compliance drop-copy stream must not be able to:
1. Reconstruct an algo's footprint across trading days
2. Correlate flow across firms (in a multi-firm tap)
3. Follow a sequential child-id pattern within an algo

## Leak audit

| Surface | Status |
|---|---|
| Metrics tags | clean — 0 occurrences of `clOrdId` |
| Tracing (Activity SetTag/AddTag) | clean — 0 occurrences |
| Per-user `orders.me` / `executions.me` | **out of scope** — owner is legitimately authorized |
| Drop-copy `dropcopy.orders/fills/cancels` | **leak** — raw ClOrdId + ParentAlgoId + AlgoSliceSeq |
| Drop-copy publish-failure log line | **leak** — raw ClOrdId |

## Changes

- **`IClOrdIdMasker`** seam (`Application/Audit/`) — `MaskClOrdId` + `MaskAlgoId`. Same numeric id in different domains must mask differently.
- **Default impl** mirrors `CvmReportWriter.OpaqueOwner`: SHA-256(`{salt}|{firmId}|{utcDate}|{domain}|{id}`) → 16-hex token. Deterministic within (firm, UTC day), rotates across days, isolated across firms. Boot-guard throws if salt unset.
- **`ToDropCopyDto` extensions** on `Order` + `ExecutionEvent` — legacy `ToDto` stays untouched. AlgoSliceSeq is stripped (monotonic seq trivially re-links children).
- **`DropCopyExecutionEventSink` + `DropCopyManager`** use the masker on every DTO crossing the WS boundary + the failure-log path.
- **DI + config**: `TestAppFactory` binds `TestOnlySalt`; compose demo + conformance overlays add the env var.

## Pattern lineage

All opt-in seam: #433 STP / #471 TradingSubAccount / #458 CBLC / #472 InvestorId / #473 RoutingInstruction / #435 Part A (throttle, `8af57f9`) / Part B (this PR).

## Local

- `backend/tests/B3.Trading.Application.Tests`: **1190 passed** (8 new in `Audit/ClOrdIdMaskerTests.cs`)
- `backend/tests/B3.Trading.Api.Tests`: **497 passed** (4 new in `DropCopyDtoMaskingTests.cs`; 5 existing drop-copy E2E tests updated to assert against the masked ClOrdId via a `Mask(factory, ...)` helper)

Closes #435 (Part B)