### PR TITLE
feat(#454): per-symbol tick-size provider seam (Fase 1)

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -4,6 +4,7 @@ using B3.Trading.Api.Lifecycle;
 using B3.Trading.Api.WebSockets;
 using B3.Trading.Application;
 
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -57,7 +58,8 @@ public static class AlgoEndpoints
             EventDispatcher dispatcher,
             DrainState drain,
             SymbolDirectory symbols,
-            IAlgoSignalQueue signals) =>
+            IAlgoSignalQueue signals,
+            ITickSizeProvider tickSizes) =>
         {
             if (drain.IsDraining)
             {
@@ -202,10 +204,15 @@ public static class AlgoEndpoints
                 case AlgoType.Pegged:
                     // Q3.3 (#283). Pegged shares the POST /algo surface
                     // with the other algos via the type discriminator.
-                    // Tick size has no per-symbol provider yet (open
-                    // TODO across the repo), so the API accepts an
-                    // explicit override and falls back to 0.01 (BRL
-                    // equity default) — documented in the PR notes.
+                    // #454 Fase 1: tick now resolves through
+                    // ITickSizeProvider (config-backed SymbolDirectory
+                    // today; SDK-backed in Fase 2 once upstream
+                    // pedrosakuma/B3MarketDataPlatform#55 ships
+                    // SecurityDefinitionEvent). The request body keeps
+                    // its explicit override (operator wins), but the
+                    // legacy 0.01m BRL-equity floor is gone — a missing
+                    // tick now surfaces as an explicit reject instead
+                    // of a silent fallback that could mismatch the venue.
                     if (req.Pegged is null)
                         return Results.BadRequest(new { error = "pegged parameters are required for type=Pegged" });
                     if (!Enum.TryParse<PegRef>(req.Pegged.Ref, ignoreCase: true, out var peggedRef))
@@ -213,9 +220,21 @@ public static class AlgoEndpoints
                     var peggedRepegMs = req.Pegged.RepegIntervalMs ?? 500;
                     if (peggedRepegMs <= 0)
                         return Results.BadRequest(new { error = "pegged.repegIntervalMs must be positive" });
-                    var peggedTickSize = req.Pegged.TickSize ?? 0.01m;
-                    if (peggedTickSize <= 0m)
-                        return Results.BadRequest(new { error = "pegged.tickSize must be positive" });
+                    decimal peggedTickSize;
+                    if (req.Pegged.TickSize is { } overrideTick)
+                    {
+                        if (overrideTick <= 0m)
+                            return Results.BadRequest(new { error = "pegged.tickSize must be positive" });
+                        peggedTickSize = overrideTick;
+                    }
+                    else if (tickSizes.TryGetTickSize(req.Symbol, req.Pegged.PriceLimit, out var resolvedTick))
+                    {
+                        peggedTickSize = resolvedTick;
+                    }
+                    else
+                    {
+                        return Results.BadRequest(new { error = $"pegged.tickSize is required for symbol '{req.Symbol}' (no per-symbol tick configured)" });
+                    }
                     var peggedChildType = OrderType.Limit;
                     if (!string.IsNullOrWhiteSpace(req.Pegged.ChildOrderType))
                     {
@@ -556,11 +575,13 @@ public sealed record CreateAlgoPovParams(
 /// HTTP request shape for the Pegged parameter block (Q3.3 / #283).
 /// <para>
 /// <b>Defaults.</b> <see cref="RepegIntervalMs"/> defaults to 500ms,
-/// <see cref="TickSize"/> defaults to <c>0.01</c> (BRL equity floor;
-/// per-symbol provider TODO), <see cref="ChildOrderType"/> defaults
-/// to <c>Limit</c> (the only legal value — Market would defeat the
-/// peg). <see cref="OffsetTicks"/> is required and may be negative
-/// for passive pegs (Buy below the bid, Sell above the ask).
+/// <see cref="TickSize"/> is now resolved from
+/// <c>ITickSizeProvider</c> when the request omits it (#454 Fase 1 —
+/// the legacy 0.01 BRL-equity fallback was removed; explicit override
+/// still wins). <see cref="ChildOrderType"/> defaults to <c>Limit</c>
+/// (the only legal value — Market would defeat the peg).
+/// <see cref="OffsetTicks"/> is required and may be negative for
+/// passive pegs (Buy below the bid, Sell above the ask).
 /// </para>
 /// </summary>
 public sealed record CreateAlgoPeggedParams(

--- a/backend/src/B3.Trading.Application/MarketData/ITickSizeProvider.cs
+++ b/backend/src/B3.Trading.Application/MarketData/ITickSizeProvider.cs
@@ -1,0 +1,36 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// #454 Fase 1. Per-symbol tick-size lookup. Today the only canonical
+/// source is operator config (<see cref="SymbolDirectory"/> →
+/// <see cref="InstrumentSpec.ResolveTick(decimal)"/>); Fase 2 will add
+/// an SDK-backed impl in <c>B3.Trading.Host</c> that subscribes to the
+/// upstream <c>SecurityDefinition</c> event proposed in
+/// <c>pedrosakuma/B3MarketDataPlatform#55</c> and falls back to the
+/// config-backed impl for bootstrap / operational overrides.
+///
+/// <para>
+/// Consumers MUST treat a <c>false</c> return as
+/// "fail-open / approve" — the same posture that
+/// <see cref="Risk.Checks.MinTickSizeCheck"/> uses when a symbol is
+/// missing from the directory. The default <c>0.01m</c> BRL-equity
+/// floor that used to live in <c>AlgoEndpoints</c> is intentionally
+/// gone: a missing tick now surfaces as an explicit reject with a
+/// precise reason instead of a silent fallback that might mismatch
+/// the venue tick and trigger downstream rejects.
+/// </para>
+///
+/// <para>
+/// <paramref name="referencePrice"/> is required for CVM-style tiered
+/// tick ladders (different ticks per price band — see #360). When the
+/// caller has no reference price (e.g. a market order, or a pegged
+/// algo with no limit), pass <c>null</c> and the provider falls back
+/// to the flat <c>TickSize</c>; symbols configured ONLY with a ladder
+/// will return <c>false</c>, forcing the caller to either supply a
+/// reference price or reject.
+/// </para>
+/// </summary>
+public interface ITickSizeProvider
+{
+    bool TryGetTickSize(string symbol, decimal? referencePrice, out decimal tickSize);
+}

--- a/backend/src/B3.Trading.Application/MarketData/SymbolDirectoryTickSizeProvider.cs
+++ b/backend/src/B3.Trading.Application/MarketData/SymbolDirectoryTickSizeProvider.cs
@@ -1,0 +1,46 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// #454 Fase 1. Default <see cref="ITickSizeProvider"/>: resolves
+/// tick from the operator-configured <see cref="SymbolDirectory"/>
+/// (<see cref="InstrumentSpec.TickSize"/> for flat symbols,
+/// <see cref="InstrumentSpec.ResolveTick(decimal)"/> for CVM-style
+/// tiered ladders). Will be wrapped (NOT replaced) by an SDK-backed
+/// impl in <c>B3.Trading.Host</c> in Fase 2, with this impl acting
+/// as the bootstrap + operational-override fallback.
+/// </summary>
+public sealed class SymbolDirectoryTickSizeProvider : ITickSizeProvider
+{
+    private readonly SymbolDirectory _directory;
+
+    public SymbolDirectoryTickSizeProvider(SymbolDirectory directory)
+    {
+        _directory = directory ?? throw new ArgumentNullException(nameof(directory));
+    }
+
+    public bool TryGetTickSize(string symbol, decimal? referencePrice, out decimal tickSize)
+    {
+        tickSize = 0m;
+        if (string.IsNullOrWhiteSpace(symbol)) return false;
+        if (!_directory.TryGetSpec(symbol, out var spec)) return false;
+
+        // Prefer the ladder when a reference price is available — that's
+        // the only way to honor CVM tiered ticks accurately. Without a
+        // price, fall back to the flat TickSize; ladder-only symbols
+        // legitimately return false here (caller must supply a price
+        // or reject — see ITickSizeProvider doc).
+        if (referencePrice is { } px && spec.ResolveTick(px) is { } tFromLadder && tFromLadder > 0m)
+        {
+            tickSize = tFromLadder;
+            return true;
+        }
+
+        if (spec.TickSize is { } flat && flat > 0m)
+        {
+            tickSize = flat;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/InstrumentRulesChecks.cs
@@ -1,5 +1,7 @@
 namespace B3.Trading.Application.Risk.Checks;
 
+using B3.Trading.Application.MarketData;
+
 /// <summary>
 /// Server-side fat-finger guard (slice 6 of pre-trade risk v2).
 ///
@@ -23,6 +25,15 @@ namespace B3.Trading.Application.Risk.Checks;
 /// </para>
 ///
 /// <para>
+/// #454 Fase 1. The active tick is now resolved through
+/// <see cref="ITickSizeProvider"/> so an SDK-backed impl (Fase 2,
+/// gated on upstream <c>pedrosakuma/B3MarketDataPlatform#55</c>) can
+/// be swapped in without touching this check. The directory-backed
+/// default still wraps <see cref="SymbolDirectory"/>, so band-aware
+/// reject reasons remain unchanged.
+/// </para>
+///
+/// <para>
 /// <b>Fail-open:</b> symbols missing from
 /// <see cref="SymbolDirectory.TryGetSpec"/> approve. The fat-finger
 /// checks are additive — never blocking on a symbol whose spec wasn't
@@ -37,7 +48,13 @@ namespace B3.Trading.Application.Risk.Checks;
 public sealed class MinTickSizeCheck : IRiskCheck
 {
     private readonly SymbolDirectory _directory;
-    public MinTickSizeCheck(SymbolDirectory directory) => _directory = directory;
+    private readonly ITickSizeProvider _ticks;
+
+    public MinTickSizeCheck(SymbolDirectory directory, ITickSizeProvider ticks)
+    {
+        _directory = directory;
+        _ticks = ticks;
+    }
 
     public int Order => 50; // run before max-quantity / collar so a malformed price fails fast
     public string Name => "min_tick_size";
@@ -45,25 +62,30 @@ public sealed class MinTickSizeCheck : IRiskCheck
     public RiskDecision Check(RiskContext ctx)
     {
         if (!ctx.Price.HasValue) return RiskDecision.Approve;
-        if (!_directory.TryGetSpec(ctx.Symbol, out var spec)) return RiskDecision.Approve;
-
         var price = ctx.Price.Value;
-        var tick = spec.ResolveTick(price);
-        if (tick is not { } t || t <= 0m) return RiskDecision.Approve;
+
+        // #454 Fase 1. Provider is the canonical source; the directory
+        // is only consulted to surface the band range in the reject
+        // reason (band metadata is not part of the seam — Fase 2 may
+        // add a richer overload if needed).
+        if (!_ticks.TryGetTickSize(ctx.Symbol, price, out var tick) || tick <= 0m)
+            return RiskDecision.Approve;
 
         // decimal arithmetic is exact for the values we care about
         // (tick sizes are 0.01 / 0.001 etc., prices have at most 4-6
         // decimals). decimal.Remainder avoids the FP precision trap
         // that would bite a double-based modulus.
-        if (decimal.Remainder(price, t) != 0m)
+        if (decimal.Remainder(price, tick) != 0m)
         {
             // #360. When a ladder is in play surface the band in the
             // reject reason so the trader sees *why* the tick changed
             // ("...in band [10,100)" vs the global flat "...0.05").
-            var band = spec.ResolveBand(price);
+            var band = _directory.TryGetSpec(ctx.Symbol, out var spec)
+                ? spec.ResolveBand(price)
+                : null;
             var reason = band is { } b
-                ? $"price {price} is not a multiple of tick size {t} (band [{b.LowerInclusive},{(b.UpperExclusive?.ToString() ?? "+inf")})) for {ctx.Symbol}"
-                : $"price {price} is not a multiple of tick size {t} for {ctx.Symbol}";
+                ? $"price {price} is not a multiple of tick size {tick} (band [{b.LowerInclusive},{(b.UpperExclusive?.ToString() ?? "+inf")})) for {ctx.Symbol}"
+                : $"price {price} is not a multiple of tick size {tick} for {ctx.Symbol}";
             return RiskDecision.Reject(RiskRejectCodes.MinTickSize, reason);
         }
         return RiskDecision.Approve;

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -39,6 +39,13 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton(sp =>
             new SymbolDirectory(sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value));
 
+        // #454 Fase 1. Per-symbol tick-size provider seam. Default impl
+        // wraps the config-backed SymbolDirectory; Fase 2 will swap (or
+        // chain in front of) an SDK-backed impl once upstream
+        // pedrosakuma/B3MarketDataPlatform#55 ships SecurityDefinitionEvent.
+        services.AddSingleton<B3.Trading.Application.MarketData.ITickSizeProvider,
+            B3.Trading.Application.MarketData.SymbolDirectoryTickSizeProvider>();
+
         // Pre-trade risk: pipeline + checks + kill-switch + reference price +
         // margin provider. Each IRiskCheck registration is auto-discovered by
         // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.

--- a/backend/tests/B3.Trading.Api.Tests/AlgoPeggedTickProviderTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoPeggedTickProviderTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace B3.Trading.Api.Tests;
+
+/// <summary>
+/// #454 Fase 1. Exercises the POST /algo Pegged path through the new
+/// <c>ITickSizeProvider</c> seam: explicit override wins, provider
+/// resolves from <c>SymbolDirectory</c> when override is omitted, and
+/// the request rejects (400) when neither is available — closing the
+/// silent <c>0.01m</c> BRL-equity fallback that used to mask
+/// venue-tick mismatches.
+/// </summary>
+public class AlgoPeggedTickProviderTests
+{
+    private static IDictionary<string, string?> BaseConfig() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+            ["Trading:SymbolDirectory:SecurityIds:VALE3"] = "4322",
+            ["Trading:SymbolDirectory:Specs:PETR4:TickSize"] = "0.01",
+        };
+
+    private static object PeggedBody(string symbol, decimal? tickSize) => new
+    {
+        Symbol = symbol,
+        Side = "Buy",
+        Type = "Pegged",
+        TotalQuantity = 100L,
+        Pegged = new
+        {
+            Ref = "Mid",
+            OffsetTicks = 0,
+            RepegIntervalMs = 100,
+            TickSize = tickSize,
+            ChildOrderType = (string?)null,
+            PriceLimit = (decimal?)null,
+        },
+    };
+
+    [Fact]
+    public async Task Pegged_ExplicitOverride_Wins()
+    {
+        using var f = TestAppFactory.WithOverrides(BaseConfig());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var algoId = await PostAlgo(http, token, PeggedBody("PETR4", tickSize: 0.02m));
+        var algo = await GetAlgo(http, token, algoId);
+        var pgd = algo.GetProperty("pegged");
+        Assert.Equal(0.02m, pgd.GetProperty("tickSize").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Pegged_NoOverride_ResolvesFromProvider()
+    {
+        using var f = TestAppFactory.WithOverrides(BaseConfig());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var algoId = await PostAlgo(http, token, PeggedBody("PETR4", tickSize: null));
+        var algo = await GetAlgo(http, token, algoId);
+        var pgd = algo.GetProperty("pegged");
+        // PETR4 spec configured at 0.01.
+        Assert.Equal(0.01m, pgd.GetProperty("tickSize").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Pegged_NoOverride_NoSpec_Returns400_NoSilentDefault()
+    {
+        // VALE3 has a SecurityId but no Specs entry → provider returns false
+        // → endpoint must reject (the legacy 0.01m fallback is gone).
+        using var f = TestAppFactory.WithOverrides(BaseConfig());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(PeggedBody("VALE3", tickSize: null)),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("pegged.tickSize is required for symbol 'VALE3'", body);
+        Assert.Contains("no per-symbol tick configured", body);
+    }
+
+    private static async Task<string> PostAlgo(HttpClient http, string token, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+        var posted = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return posted.GetProperty("algoId").GetString()!;
+    }
+
+    private static async Task<JsonElement> GetAlgo(HttpClient http, string token, string algoId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/algo/{algoId}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonElement>();
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryTickSizeProviderTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryTickSizeProviderTests.cs
@@ -1,0 +1,125 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+public class SymbolDirectoryTickSizeProviderTests
+{
+    private static SymbolDirectory Dir(Action<SymbolDirectoryOptions> configure)
+    {
+        var opts = new SymbolDirectoryOptions();
+        configure(opts);
+        return new SymbolDirectory(opts);
+    }
+
+    [Fact]
+    public void FlatTick_Resolves_RegardlessOfReferencePrice()
+    {
+        var dir = Dir(o => o.Specs["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.True(sut.TryGetTickSize("PETR4", referencePrice: 30m, out var t1));
+        Assert.Equal(0.01m, t1);
+
+        Assert.True(sut.TryGetTickSize("PETR4", referencePrice: null, out var t2));
+        Assert.Equal(0.01m, t2);
+    }
+
+    [Fact]
+    public void Ladder_Resolves_BandSpecificTick_WhenReferencePriceProvided()
+    {
+        var dir = Dir(o => o.Specs["XPTO"] = new InstrumentSpecOptions
+        {
+            TickSize = 0.01m, // flat fallback
+            TickLadder = new()
+            {
+                new TickBandOptions { MinPriceInclusive = 0m,   Tick = 0.01m },
+                new TickBandOptions { MinPriceInclusive = 10m,  Tick = 0.05m },
+                new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.10m },
+            }
+        });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.True(sut.TryGetTickSize("XPTO", 5m, out var t1));
+        Assert.Equal(0.01m, t1);
+
+        Assert.True(sut.TryGetTickSize("XPTO", 50m, out var t2));
+        Assert.Equal(0.05m, t2);
+
+        Assert.True(sut.TryGetTickSize("XPTO", 500m, out var t3));
+        Assert.Equal(0.10m, t3);
+    }
+
+    [Fact]
+    public void Ladder_WithoutReferencePrice_FallsBackToFlatTick()
+    {
+        var dir = Dir(o => o.Specs["XPTO"] = new InstrumentSpecOptions
+        {
+            TickSize = 0.07m,
+            TickLadder = new()
+            {
+                new TickBandOptions { MinPriceInclusive = 0m, Tick = 0.05m },
+            }
+        });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.True(sut.TryGetTickSize("XPTO", referencePrice: null, out var tick));
+        Assert.Equal(0.07m, tick);
+    }
+
+    [Fact]
+    public void LadderOnly_WithoutReferencePrice_ReturnsFalse()
+    {
+        var dir = Dir(o => o.Specs["XPTO"] = new InstrumentSpecOptions
+        {
+            TickSize = null,
+            TickLadder = new()
+            {
+                new TickBandOptions { MinPriceInclusive = 0m, Tick = 0.05m },
+            }
+        });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.False(sut.TryGetTickSize("XPTO", referencePrice: null, out var tick));
+        Assert.Equal(0m, tick);
+    }
+
+    [Fact]
+    public void UnknownSymbol_ReturnsFalse()
+    {
+        var dir = Dir(o => o.Specs["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.False(sut.TryGetTickSize("DOESNOTEXIST", 10m, out var tick));
+        Assert.Equal(0m, tick);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NullOrWhitespaceSymbol_ReturnsFalse(string? symbol)
+    {
+        var dir = Dir(_ => { });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.False(sut.TryGetTickSize(symbol!, 10m, out var tick));
+        Assert.Equal(0m, tick);
+    }
+
+    [Fact]
+    public void ZeroOrNegativeFlatTick_ReturnsFalse()
+    {
+        var dir = Dir(o => o.Specs["PETR4"] = new InstrumentSpecOptions { TickSize = 0m });
+        var sut = new SymbolDirectoryTickSizeProvider(dir);
+
+        Assert.False(sut.TryGetTickSize("PETR4", referencePrice: null, out var tick));
+        Assert.Equal(0m, tick);
+    }
+
+    [Fact]
+    public void Ctor_NullDirectory_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SymbolDirectoryTickSizeProvider(null!));
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -1,4 +1,5 @@
 using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Risk;
 using B3.Trading.Application.Risk.Checks;
 using B3.Trading.Domain;
@@ -442,7 +443,7 @@ public class RiskPipelineTests
     public void MinTickSize_RejectsNonMultiple()
     {
         var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
-        var check = new MinTickSizeCheck(dir);
+        var check = new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir));
         Assert.True(check.Check(Ctx(price: 30.01m)).Approved);
         Assert.True(check.Check(Ctx(price: 30.00m)).Approved);
         var rejected = check.Check(Ctx(price: 30.001m));
@@ -456,14 +457,14 @@ public class RiskPipelineTests
     public void MinTickSize_NoSpec_Approves()
     {
         var dir = BuildDirectory();
-        Assert.True(new MinTickSizeCheck(dir).Check(Ctx(price: 30.001m)).Approved);
+        Assert.True(new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir)).Check(Ctx(price: 30.001m)).Approved);
     }
 
     [Fact]
     public void MinTickSize_MarketOrder_Approves()
     {
         var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
-        Assert.True(new MinTickSizeCheck(dir).Check(Ctx(price: null, type: OrderType.Market)).Approved);
+        Assert.True(new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir)).Check(Ctx(price: null, type: OrderType.Market)).Approved);
     }
 
     // ── #360 tiered tick-ladder coverage ──────────────────────────────
@@ -484,7 +485,7 @@ public class RiskPipelineTests
                 },
             },
         });
-        var check = new MinTickSizeCheck(dir);
+        var check = new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir));
 
         // 0.01 band [0,1): 0.50 valid, 0.501 rejects.
         Assert.True(check.Check(Ctx(price: 0.50m)).Approved);
@@ -518,7 +519,7 @@ public class RiskPipelineTests
                 },
             },
         });
-        var check = new MinTickSizeCheck(dir);
+        var check = new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir));
 
         var midBand = check.Check(Ctx(price: 50.05m));
         Assert.False(midBand.Approved);
@@ -551,7 +552,7 @@ public class RiskPipelineTests
                 },
             },
         });
-        var check = new MinTickSizeCheck(dir);
+        var check = new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir));
 
         // Sub-real: flat 0.01 fallback approves valid + reject reason omits band.
         Assert.True(check.Check(Ctx(symbol: "MGLU3", price: 0.50m)).Approved);
@@ -572,7 +573,7 @@ public class RiskPipelineTests
         // the ladder schema — surface the exact same reject text the
         // earlier tests asserted.
         var dir = BuildDirectory(specs: new() { ["PETR4"] = new() { TickSize = 0.01m } });
-        var rej = new MinTickSizeCheck(dir).Check(Ctx(price: 30.001m));
+        var rej = new MinTickSizeCheck(dir, new SymbolDirectoryTickSizeProvider(dir)).Check(Ctx(price: 30.001m));
         Assert.False(rej.Approved);
         Assert.Equal(
             "price 30.001 is not a multiple of tick size 0.01 for PETR4",


### PR DESCRIPTION
## Changes

- New `ITickSizeProvider` seam in `B3.Trading.Application.MarketData` — `bool TryGetTickSize(symbol, decimal? referencePrice, out decimal tickSize)`.
- Default impl `SymbolDirectoryTickSizeProvider` wraps the existing `SymbolDirectory`: prefers the #360 ladder when a reference price is available, falls back to flat `TickSize`. DI-registered next to `SymbolDirectory` in `TradingRiskServiceCollectionExtensions`.
- `AlgoEndpoints` POST /algo (Pegged): explicit `pegged.tickSize` override wins → provider lookup → 400 `pegged.tickSize is required for symbol 'X' (no per-symbol tick configured)`. **Removes the silent `0.01m` BRL-equity fallback** — a missing tick now fails fast with a precise reason instead of mismatching the venue tick.
- `MinTickSizeCheck` consults the provider for the active tick; `SymbolDirectory` is kept only to surface the band range in the reject reason.

## Fase 2 — deferred

The issue's Fase 2 (SDK-backed impl) is blocked on upstream `pedrosakuma/B3MarketDataPlatform#55` which proposes `SecurityDefinitionEvent` + `SubscribeFlags.SecurityDefinition` in `B3.MarketData.WebSocketClient`. The wire already carries tick/lot via SBE `SecurityDefinition_12`; only the SDK projection is missing.

## Note on "RiskOptions-backed"

The issue text mentions a `RiskOptions`-backed impl; in this codebase the canonical config source for ticks is `Trading:SymbolDirectory:Specs:<SYMBOL>:TickSize` (with optional #360 `TickLadder`), not `RiskOptions.PerSymbol.TickSize` (which does not exist). The seam wraps that source verbatim.

## Pattern lineage

#433 STP / #449 MinQty / #459 BusinessReject / #458 CBLC / #471 TradingSubAccount / #472 InvestorId / #473 RoutingInstruction / #435 ClOrdId masking / **#454 Fase 1**.

## Local

- `B3.Trading.Application.Tests`: 1190 → **1200** green (+10 `SymbolDirectoryTickSizeProviderTests`).
- `B3.Trading.Api.Tests`: 497 → **500** green (+3 `AlgoPeggedTickProviderTests` — override wins / provider resolves / 400 no-silent-default).

Closes #454 (Fase 1; issue stays open for Fase 2 SDK swap).