### PR TITLE
chore(#332): wrap MeterListener flake in [RetryFact]

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -37,5 +37,6 @@
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xRetry" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/B3.Trading.EntryPointListener.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xRetry" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
+++ b/backend/tests/B3.Trading.EntryPointListener.Tests/Hosting/FixpOutboundChannelWriterTests.cs
@@ -4,6 +4,7 @@ using B3.Trading.Application.Observability;
 using B3.Trading.Application.UserBots;
 using B3.Trading.EntryPointListener.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using xRetry;
 
 namespace B3.Trading.EntryPointListener.Tests.Hosting;
 
@@ -229,7 +230,11 @@ public sealed class FixpOutboundChannelWriterTests
     /// double subclasses <see cref="System.Buffers.ArrayPool{T}"/> to
     /// observe the return.
     /// </summary>
-    [Fact(Timeout = 10_000)]
+    // #332. Wrapped in <c>[RetryFact]</c> because the MeterListener
+    // start-vs-publish race occasionally drops the increment under CI
+    // parallelism (see in-line comment on the bounded poll). Retry up
+    // to 3 times before failing CI — a genuine regression still loses.
+    [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 250)]
     public async Task CompleteAsync_AbandonedPath_IncrementsOtelCounter()
     {
         // Issue #233. The abandoned path must increment the


### PR DESCRIPTION
## Why

`FixpOutboundChannelWriterTests.CompleteAsync_AbandonedPath_IncrementsOtelCounter` has been a known CI flake since #332 — the `MeterListener.Start()` vs concurrent instrument-publication race under xunit parallelism occasionally drops the expected counter increment. The in-test bounded poll mitigates but does not eliminate the window, and the noise has been blocking unrelated PRs (most recently #479).

## What

- Add **xRetry 1.9.0** to `backend/Directory.Packages.props` (centrally managed).
- Add `PackageReference Include="xRetry"` to `B3.Trading.EntryPointListener.Tests.csproj`.
- Swap the single offending `[Fact(Timeout = 10_000)]` for `[RetryFact(maxRetries: 3, delayBetweenRetriesMs: 250)]` with an in-line comment pointing at #332.

A genuine regression (counter actually not wired) still fails after 3 attempts — coverage of the #233 abandoned-path counter wiring is preserved.

## Scope

Narrow: one attribute swap + one package add. No production code, no other test changed.

## Local

- EPL tests: **134/134 green**; the wrapped test still passes deterministically in isolation.

Refs #332.