### PR TITLE
feat(#483): SecurityType enum + OptionMetadata on InstrumentSpec (OPT-A)

### DIFF
--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -67,11 +67,25 @@ public sealed class SymbolDirectory
             var ladder = NormalizeLadder(kv.Value.TickLadder);
             // Drop entries that wouldn't constrain anything — keeps
             // TryGetSpec callers from having to special-case zero/negative.
-            if ((t is null or <= 0m) && (l is null or <= 0) && ladder is null) continue;
+            // OPT-A (#483). Bind optional OptionMetadata. We require
+            // at minimum ContractMultiplier and ExpirationDate to be
+            // present — without those two we can't honour OPT-B
+            // (notional = price * qty * multiplier) or OPT-C
+            // (expiry-aware lifecycle). A malformed option block is
+            // dropped silently, same defensive contract as a
+            // non-positive TickSize. SecurityType is derived: if
+            // OptionMetadata survives, the spec is Option; otherwise
+            // Equity (the historical default for every existing
+            // symbol).
+            var option = NormalizeOption(kv.Value.Option);
+            var securityType = option is null ? SecurityType.Equity : SecurityType.Option;
+            if ((t is null or <= 0m) && (l is null or <= 0) && ladder is null && option is null) continue;
             specs[kv.Key] = new InstrumentSpec(
                 t is > 0m ? t : null,
                 l is > 0 ? l : null,
-                ladder);
+                ladder,
+                securityType,
+                option);
         }
         _specs = specs;
     }
@@ -98,6 +112,43 @@ public sealed class SymbolDirectory
         var i = 0;
         foreach (var kv in sorted) list[i++] = new TickBand(kv.Key, kv.Value);
         return list;
+    }
+
+    // OPT-A (#483). Validate and freeze the optional OptionMetadata
+    // block bound from configuration. Drops the block when the
+    // minimum-viable fields are missing or invalid (no
+    // ContractMultiplier, non-positive multiplier, no ExpirationDate,
+    // or an unknown PutOrCall/ExerciseStyle string). Defensive on
+    // purpose: an "option" entry that doesn't carry the data we need
+    // to honour OPT-B (multiplier-aware notional) or OPT-C
+    // (expiry-aware checks) is worse than no entry at all.
+    private static OptionMetadata? NormalizeOption(OptionMetadataOptions? src)
+    {
+        if (src is null) return null;
+        if (src.ContractMultiplier is not { } mult || mult <= 0m) return null;
+        if (src.ExpirationDate is not { } expiry) return null;
+        if (!TryParseEnum<PutOrCall>(src.PutOrCall, out var pc)) return null;
+        if (!TryParseEnum<ExerciseStyle>(src.ExerciseStyle, out var ex)) return null;
+        var payout = OptPayoutType.Vanilla;
+        if (!string.IsNullOrWhiteSpace(src.OptPayoutType)
+            && !Enum.TryParse(src.OptPayoutType, ignoreCase: true, out payout))
+        {
+            return null;
+        }
+        return new OptionMetadata(
+            src.StrikePrice ?? 0m,
+            expiry,
+            pc,
+            ex,
+            src.UnderlyingSymbol ?? string.Empty,
+            mult,
+            payout);
+    }
+
+    private static bool TryParseEnum<TEnum>(string? raw, out TEnum value) where TEnum : struct, Enum
+    {
+        if (string.IsNullOrWhiteSpace(raw)) { value = default; return false; }
+        return Enum.TryParse(raw, ignoreCase: true, out value) && Enum.IsDefined(value);
     }
 
     public int Count => _byName.Count;
@@ -178,7 +229,9 @@ public sealed class SymbolDirectory
 public readonly record struct InstrumentSpec(
     decimal? TickSize,
     long? LotSize,
-    IReadOnlyList<TickBand>? TickLadder = null)
+    IReadOnlyList<TickBand>? TickLadder = null,
+    SecurityType SecurityType = SecurityType.Equity,
+    OptionMetadata? Option = null)
 {
     /// <summary>
     /// #360. Returns the tick that applies at <paramref name="price"/>:
@@ -247,6 +300,72 @@ public readonly record struct TickBandMatch(
     decimal Tick);
 
 /// <summary>
+/// OPT-A (#483). Discriminates the instrument family. The pipeline
+/// historically assumed Equity end-to-end; OPT-B / OPT-C / OPT-F use
+/// this enum to gate option-only behaviour (contract-multiplier
+/// notional, zero-price relax, option-specific metrics) without
+/// touching the equity hot path. Equity is the default so existing
+/// configuration and tests stay byte-identical.
+/// </summary>
+public enum SecurityType
+{
+    Equity = 0,
+    Option = 1,
+}
+
+/// <summary>
+/// OPT-A (#483). Option side — Put (right to sell) or Call (right to
+/// buy). Matches the upstream <c>SecurityDefinition_12</c> field
+/// landed in pedrosakuma/B3MatchingPlatform#473.
+/// </summary>
+public enum PutOrCall
+{
+    Put = 0,
+    Call = 1,
+}
+
+/// <summary>
+/// OPT-A (#483). Exercise style of the listed option. B3 lists both
+/// American (early exercise allowed at any time before expiry) and
+/// European (exercise only at expiry) series.
+/// </summary>
+public enum ExerciseStyle
+{
+    American = 0,
+    European = 1,
+}
+
+/// <summary>
+/// OPT-A (#483). Payout family — vanilla is the only kind currently
+/// emitted by upstream. The enum exists so binary / exotic payouts
+/// can be added later without re-shaping <see cref="OptionMetadata"/>.
+/// </summary>
+public enum OptPayoutType
+{
+    Vanilla = 0,
+}
+
+/// <summary>
+/// OPT-A (#483). Option-specific metadata bound from
+/// <c>Trading:SymbolDirectory:Specs:&lt;SYMBOL&gt;:Option</c>.
+/// Present only when the spec describes an option (see
+/// <see cref="InstrumentSpec.SecurityType"/>); equity specs leave
+/// this null. <see cref="ContractMultiplier"/> drives OPT-B notional
+/// math (qty is in contracts, each contract is worth
+/// <c>price * multiplier</c> shares — typically 100 for B3 equity
+/// options). <see cref="ExpirationDate"/> drives OPT-C zero-price
+/// relax (and future expiry-aware lifecycle checks).
+/// </summary>
+public readonly record struct OptionMetadata(
+    decimal StrikePrice,
+    DateOnly ExpirationDate,
+    PutOrCall PutOrCall,
+    ExerciseStyle ExerciseStyle,
+    string UnderlyingSymbol,
+    decimal ContractMultiplier,
+    OptPayoutType OptPayoutType);
+
+/// <summary>
 /// Bound from <c>Trading:SymbolDirectory</c>.
 /// </summary>
 public sealed class SymbolDirectoryOptions
@@ -287,6 +406,36 @@ public sealed class InstrumentSpecOptions
     /// canonicalizes (sort + dedup + drop malformed) at startup.
     /// </summary>
     public List<TickBandOptions>? TickLadder { get; set; }
+
+    /// <summary>
+    /// OPT-A (#483). Optional option-specific metadata. When set
+    /// (and well-formed — see <see cref="OptionMetadataOptions"/>)
+    /// the resulting <see cref="InstrumentSpec"/> reports
+    /// <see cref="SecurityType.Option"/>; otherwise the spec stays
+    /// Equity. Malformed blocks are dropped silently in the
+    /// directory ctor.
+    /// </summary>
+    public OptionMetadataOptions? Option { get; set; }
+}
+
+/// <summary>
+/// OPT-A (#483). Mutable counterpart of <see cref="OptionMetadata"/>
+/// used by <c>Microsoft.Extensions.Configuration</c> binding.
+/// <see cref="PutOrCall"/> and <see cref="ExerciseStyle"/> are
+/// stringly-typed for JSON ergonomics (e.g. "Call" / "American");
+/// <see cref="SymbolDirectory"/> parses them case-insensitively.
+/// <see cref="OptPayoutType"/> defaults to <c>Vanilla</c> when
+/// omitted.
+/// </summary>
+public sealed class OptionMetadataOptions
+{
+    public decimal? StrikePrice { get; set; }
+    public DateOnly? ExpirationDate { get; set; }
+    public string? PutOrCall { get; set; }
+    public string? ExerciseStyle { get; set; }
+    public string? UnderlyingSymbol { get; set; }
+    public decimal? ContractMultiplier { get; set; }
+    public string? OptPayoutType { get; set; }
 }
 
 /// <summary>

--- a/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SymbolDirectoryTests.cs
@@ -400,4 +400,206 @@ public class SymbolDirectoryTests
         Assert.True(flat.TryGetSpec("X", out var flatSpec));
         Assert.Null(flatSpec.ResolveBand(1m));
     }
+
+    // ── OPT-A (#483) option-metadata coverage ──────────────────────────
+
+    [Fact]
+    public void Option_wellFormedBlock_producesOptionSpec()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETRL200"] = new InstrumentSpecOptions
+                {
+                    TickSize = 0.01m,
+                    LotSize = 100,
+                    Option = new OptionMetadataOptions
+                    {
+                        StrikePrice = 20m,
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "Call",
+                        ExerciseStyle = "American",
+                        UnderlyingSymbol = "PETR4",
+                        ContractMultiplier = 100m,
+                        OptPayoutType = "Vanilla",
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("PETRL200", out var spec));
+        Assert.Equal(SecurityType.Option, spec.SecurityType);
+        Assert.NotNull(spec.Option);
+        var opt = spec.Option!.Value;
+        Assert.Equal(20m, opt.StrikePrice);
+        Assert.Equal(new DateOnly(2026, 12, 18), opt.ExpirationDate);
+        Assert.Equal(PutOrCall.Call, opt.PutOrCall);
+        Assert.Equal(ExerciseStyle.American, opt.ExerciseStyle);
+        Assert.Equal("PETR4", opt.UnderlyingSymbol);
+        Assert.Equal(100m, opt.ContractMultiplier);
+        Assert.Equal(OptPayoutType.Vanilla, opt.OptPayoutType);
+    }
+
+    [Fact]
+    public void Option_omitted_defaultsToEquity_andNoOptionBlock()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs = { ["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100 } },
+        });
+
+        Assert.True(sut.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(SecurityType.Equity, spec.SecurityType);
+        Assert.Null(spec.Option);
+    }
+
+    [Fact]
+    public void Option_payoutTypeOmitted_defaultsToVanilla()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETRX250"] = new InstrumentSpecOptions
+                {
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "put",
+                        ExerciseStyle = "european",
+                        ContractMultiplier = 100m,
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("PETRX250", out var spec));
+        Assert.Equal(SecurityType.Option, spec.SecurityType);
+        Assert.Equal(OptPayoutType.Vanilla, spec.Option!.Value.OptPayoutType);
+        // Defensive: missing strike binds to 0 (deep-OTM is legitimate
+        // upstream — the option block survives so downstream multiplier
+        // math still works).
+        Assert.Equal(0m, spec.Option!.Value.StrikePrice);
+    }
+
+    [Theory]
+    [InlineData(null, 100, "Call", "American")]    // missing expiry
+    [InlineData("2026-12-18", null, "Call", "American")]    // missing multiplier
+    [InlineData("2026-12-18", 0, "Call", "American")]   // non-positive multiplier
+    [InlineData("2026-12-18", -100, "Call", "American")]    // negative multiplier
+    [InlineData("2026-12-18", 100, "Bogus", "American")]    // unknown put/call
+    [InlineData("2026-12-18", 100, "Call", "Bermudan")] // unknown exercise style
+    [InlineData("2026-12-18", 100, null, "American")]   // missing put/call
+    [InlineData("2026-12-18", 100, "Call", null)]   // missing exercise style
+    public void Option_malformedBlock_isDropped(string? expiryIso, int? multiplier, string? putOrCall, string? style)
+    {
+        // Spec keeps a tick so it survives the "no constraint" drop;
+        // the OptionMetadata itself is the only thing we're testing.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["BAD"] = new InstrumentSpecOptions
+                {
+                    TickSize = 0.01m,
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = expiryIso is null ? null : DateOnly.Parse(expiryIso),
+                        ContractMultiplier = multiplier,
+                        PutOrCall = putOrCall,
+                        ExerciseStyle = style,
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("BAD", out var spec));
+        Assert.Equal(SecurityType.Equity, spec.SecurityType);
+        Assert.Null(spec.Option);
+    }
+
+    [Fact]
+    public void Option_unknownPayoutType_dropsEntireBlock()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["EXOTIC"] = new InstrumentSpecOptions
+                {
+                    TickSize = 0.01m,
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "Call",
+                        ExerciseStyle = "American",
+                        ContractMultiplier = 100m,
+                        OptPayoutType = "Binary",
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("EXOTIC", out var spec));
+        Assert.Equal(SecurityType.Equity, spec.SecurityType);
+        Assert.Null(spec.Option);
+    }
+
+    [Fact]
+    public void Option_caseInsensitiveEnumParsing()
+    {
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["MIX"] = new InstrumentSpecOptions
+                {
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "CALL",
+                        ExerciseStyle = "european",
+                        ContractMultiplier = 100m,
+                        OptPayoutType = "vanilla",
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("MIX", out var spec));
+        Assert.Equal(PutOrCall.Call, spec.Option!.Value.PutOrCall);
+        Assert.Equal(ExerciseStyle.European, spec.Option!.Value.ExerciseStyle);
+        Assert.Equal(OptPayoutType.Vanilla, spec.Option!.Value.OptPayoutType);
+    }
+
+    [Fact]
+    public void Option_onlyOptionBlock_survivesEvenWithoutTickOrLot()
+    {
+        // The directory previously dropped any spec without
+        // TickSize/LotSize/TickLadder; an option-only entry must now
+        // survive so OPT-B can read ContractMultiplier without
+        // requiring operators to repeat tick/lot.
+        var sut = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["OPTONLY"] = new InstrumentSpecOptions
+                {
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "Call",
+                        ExerciseStyle = "American",
+                        ContractMultiplier = 100m,
+                    },
+                },
+            },
+        });
+
+        Assert.True(sut.TryGetSpec("OPTONLY", out var spec));
+        Assert.Equal(SecurityType.Option, spec.SecurityType);
+        Assert.Null(spec.TickSize);
+        Assert.Null(spec.LotSize);
+    }
 }


### PR DESCRIPTION
## Why

Upstream pedrosakuma/B3MatchingPlatform#473 (merged) populates option-specific fields on `SecurityDefinition_12`: `strikePrice`, `expirationDate`, `putOrCall`, `exerciseStyle`, `underlyingSymbol`, `contractMultiplier`, `optPayoutType`. Our `InstrumentSpec` only carries `TickSize` / `LotSize` / `TickLadder` — no place to land option metadata and no discriminator to gate option-only behavior. OPT-B (#484, multiplier-aware notional — silent `MaxNotional` bypass for options), OPT-C (#485, zero-price relax) and OPT-F (#488, option metrics) all need this seam first.

## What

- `SecurityType { Equity, Option }` enum (Equity default — fully retro-compatible).
- `OptionMetadata` record + `PutOrCall` / `ExerciseStyle` / `OptPayoutType` enums.
- `InstrumentSpec` ctor extended with optional `SecurityType` + `Option`; every existing call site and config bind path remains identical for equity.
- `SymbolDirectory.NormalizeOption` defensively drops malformed option blocks: missing `ContractMultiplier` / `ExpirationDate`, non-positive multiplier, unknown `PutOrCall` / `ExerciseStyle` / `OptPayoutType`. Same posture as the pre-existing "non-positive TickSize" drop.
- Option-only specs (no tick/lot) survive the "no constraint" drop so OPT-B multiplier math works without forcing operators to repeat tick/lot per series.

## Local

- `backend/tests/B3.Trading.Application.Tests` — **1214/1214** (+14 OPT-A tests: well-formed, equity default, payout default, malformed parametrized × 8, unknown payout, case-insensitive enums, option-only survival)
- `backend/tests/B3.Trading.Api.Tests` — **500/500**

## Out of scope

Behavior gated on the new fields — covered by OPT-B (#484), OPT-C (#485), OPT-F (#488).

Closes #483
Refs #482
