### PR TITLE
feat(#484): IMarketValueCalculator seam — apply contractMultiplier in notional checks (OPT-B)

### DIFF
--- a/backend/src/B3.Trading.Application/MarketData/IMarketValueCalculator.cs
+++ b/backend/src/B3.Trading.Application/MarketData/IMarketValueCalculator.cs
@@ -1,0 +1,59 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// OPT-B (#484). Per-symbol gross notional calculation. For equity
+/// this is the historical <c>price * quantity</c>; for options
+/// (<see cref="SecurityType.Option"/>) it multiplies by the contract
+/// multiplier landed in OPT-A (#483) — option quantities are in
+/// CONTRACTS and each contract is worth <c>multiplier</c> shares of
+/// the underlying (typically 100 for B3 equity options).
+///
+/// <para>
+/// Without this seam, every pre-trade notional gate
+/// (<c>MaxNotionalCheck</c>, <c>MinNotionalCheck</c>,
+/// <c>SubAccountLimitsCheck.MaxNotional</c>, the rolling-notional
+/// ledger, and the margin reservation) under-counts option notional
+/// by a factor of <c>contractMultiplier</c> — a 100x silent bypass of
+/// every <c>MaxNotional</c> cap on PETR-class option series with the
+/// upstream sample multiplier of 100.
+/// </para>
+///
+/// <para>
+/// Fail-open contract: unknown symbols fall back to the equity
+/// formula (<c>price * quantity</c>, multiplier = 1). Same posture as
+/// <see cref="ITickSizeProvider"/> — a symbol missing from the
+/// directory must never make a notional gate fire spurious rejects.
+/// The cost of fail-open is bounded because (a) all production
+/// option symbols come from the same SymbolDirectory that carries the
+/// multiplier and (b) Fase 2 (#454/#486) replaces the static
+/// directory with the SDK-driven <c>SecurityDefinitionEvent</c>
+/// projection, eliminating the configuration gap entirely.
+/// </para>
+/// </summary>
+public interface IMarketValueCalculator
+{
+    /// <summary>
+    /// Returns the gross notional for the given (symbol, price, qty).
+    /// Callers pass the LIMIT price (or a reference price for market
+    /// orders); the calculator does not know about order type, side,
+    /// or fees — those concerns stay with the risk checks that
+    /// consume the value.
+    /// </summary>
+    decimal GetNotional(string symbol, decimal price, long quantity);
+}
+
+/// <summary>
+/// OPT-B (#484). Equity-only fallback that returns the historical
+/// <c>price * quantity</c> with no multiplier lookup. Exposed as a
+/// shared singleton so test fixtures that construct risk checks
+/// directly (no DI) can pass it without recreating a directory; the
+/// equity-only default is also wired into the consumer ctors as a
+/// fallback for missing DI registrations.
+/// </summary>
+public sealed class EquityMarketValueCalculator : IMarketValueCalculator
+{
+    public static readonly EquityMarketValueCalculator Instance = new();
+
+    public decimal GetNotional(string symbol, decimal price, long quantity)
+        => price * quantity;
+}

--- a/backend/src/B3.Trading.Application/MarketData/SymbolDirectoryMarketValueCalculator.cs
+++ b/backend/src/B3.Trading.Application/MarketData/SymbolDirectoryMarketValueCalculator.cs
@@ -1,0 +1,35 @@
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// OPT-B (#484). Default <see cref="IMarketValueCalculator"/> impl
+/// that reads <see cref="InstrumentSpec.Option"/> from the
+/// configured <see cref="SymbolDirectory"/>. Symbols without an
+/// option block (i.e. equity, or unknown) get the equity formula
+/// (<c>multiplier = 1</c>); option symbols multiply by
+/// <see cref="OptionMetadata.ContractMultiplier"/>.
+///
+/// <para>
+/// Pairs with <see cref="SymbolDirectoryTickSizeProvider"/> — same
+/// source of truth, same fail-open posture, registered side-by-side
+/// in DI. Replaced wholesale by the SDK-driven directory projection
+/// once #454 Fase 2 / pedrosakuma/B3MarketDataPlatform#55 ships.
+/// </para>
+/// </summary>
+public sealed class SymbolDirectoryMarketValueCalculator : IMarketValueCalculator
+{
+    private readonly SymbolDirectory _directory;
+
+    public SymbolDirectoryMarketValueCalculator(SymbolDirectory directory)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+        _directory = directory;
+    }
+
+    public decimal GetNotional(string symbol, decimal price, long quantity)
+    {
+        var multiplier = 1m;
+        if (_directory.TryGetSpec(symbol, out var spec) && spec.Option is { } opt)
+            multiplier = opt.ContractMultiplier;
+        return price * quantity * multiplier;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/Accounting/RollingNotionalAccountant.cs
+++ b/backend/src/B3.Trading.Application/Risk/Accounting/RollingNotionalAccountant.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using Microsoft.Extensions.Options;
 
@@ -15,14 +16,17 @@ public sealed class RollingNotionalAccountant : IRiskAccountant
     private readonly SlidingWindowLedger _perFirm;
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly IReferencePrice _refPrice;
+    private readonly IMarketValueCalculator _values;
 
     public RollingNotionalAccountant(
         IOptionsMonitor<RiskOptions> options,
         IReferencePrice refPrice,
-        TimeProvider clock)
+        TimeProvider clock,
+        IMarketValueCalculator? values = null)
     {
         _options = options;
         _refPrice = refPrice;
+        _values = values ?? EquityMarketValueCalculator.Instance;
         _perEndClient = new SlidingWindowLedger(clock);
         _perFirm = new SlidingWindowLedger(clock);
     }
@@ -37,14 +41,21 @@ public sealed class RollingNotionalAccountant : IRiskAccountant
     /// no reference is available the notional is 0 and a bypass
     /// metric is incremented — fail-open posture matching the
     /// price-collar check.
+    ///
+    /// <para>
+    /// OPT-B (#484): both branches go through
+    /// <see cref="IMarketValueCalculator"/> so option flow charges
+    /// the ledger the correct multiplier-adjusted notional (the
+    /// rolling cap is in BRL, not contracts).
+    /// </para>
     /// </summary>
     public decimal NotionalFor(RiskContext ctx)
     {
-        if (ctx.Price is { } px) return px * ctx.Quantity;
+        if (ctx.Price is { } px) return _values.GetNotional(ctx.Symbol, px, ctx.Quantity);
 
         var lookup = _refPrice.Lookup(ctx.Symbol);
         if (lookup.Found && lookup.Price > 0m)
-            return lookup.Price * ctx.Quantity;
+            return _values.GetNotional(ctx.Symbol, lookup.Price, ctx.Quantity);
 
         MetricsRegistry.RollingNotionalBypassedNoReference.Add(1,
             new KeyValuePair<string, object?>("symbol", ctx.Symbol));

--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.MarketData;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Application.Risk.Checks;
@@ -23,7 +24,15 @@ public sealed class MaxQuantityCheck : IRiskCheck
 public sealed class MaxNotionalCheck : IRiskCheck
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
-    public MaxNotionalCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
+    private readonly IMarketValueCalculator _values;
+
+    public MaxNotionalCheck(
+        IOptionsMonitor<RiskOptions> options,
+        IMarketValueCalculator? values = null)
+    {
+        _options = options;
+        _values = values ?? EquityMarketValueCalculator.Instance;
+    }
 
     public int Order => 100;
     public string Name => "max_notional";
@@ -34,7 +43,9 @@ public sealed class MaxNotionalCheck : IRiskCheck
         var max = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MaxNotional);
         if (!max.HasValue || !ctx.Price.HasValue)
             return RiskDecision.Approve; // no cap, or market order — let venue handle
-        var notional = ctx.Price.Value * ctx.Quantity;
+        // OPT-B (#484): _values applies contractMultiplier for option
+        // symbols; equity stays price * qty (Equity fallback).
+        var notional = _values.GetNotional(ctx.Symbol, ctx.Price.Value, ctx.Quantity);
         if (notional > max.Value)
             return RiskDecision.Reject($"notional {notional} exceeds max {max.Value}");
         return RiskDecision.Approve;
@@ -64,7 +75,15 @@ public sealed class MaxNotionalCheck : IRiskCheck
 public sealed class MinNotionalCheck : IRiskCheck
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
-    public MinNotionalCheck(IOptionsMonitor<RiskOptions> options) => _options = options;
+    private readonly IMarketValueCalculator _values;
+
+    public MinNotionalCheck(
+        IOptionsMonitor<RiskOptions> options,
+        IMarketValueCalculator? values = null)
+    {
+        _options = options;
+        _values = values ?? EquityMarketValueCalculator.Instance;
+    }
 
     public int Order => 110; // after max-quantity / max-notional, before throttles
     public string Name => "min_notional";
@@ -75,7 +94,9 @@ public sealed class MinNotionalCheck : IRiskCheck
         var min = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MinNotional);
         if (!min.HasValue || !ctx.Price.HasValue)
             return RiskDecision.Approve; // no floor configured, or market order
-        var notional = ctx.Price.Value * ctx.Quantity;
+        // OPT-B (#484): notional is in BRL (price * qty * multiplier
+        // for options); fee/dust math compares apples-to-apples.
+        var notional = _values.GetNotional(ctx.Symbol, ctx.Price.Value, ctx.Quantity);
         if (notional < min.Value)
             return RiskDecision.Reject($"notional {notional} below min {min.Value}");
         return RiskDecision.Approve;

--- a/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/SubAccountLimitsCheck.cs
@@ -1,3 +1,4 @@
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Options;
@@ -33,17 +34,20 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
     private readonly WorkingOrderBook _book;
     private readonly SubAccountPositionKeeper _positions;
     private readonly SubAccountsRegistry _registry;
+    private readonly IMarketValueCalculator _values;
 
     public SubAccountLimitsCheck(
         IOptionsMonitor<SubAccountRiskOptions> options,
         WorkingOrderBook book,
         SubAccountPositionKeeper positions,
-        SubAccountsRegistry registry)
+        SubAccountsRegistry registry,
+        IMarketValueCalculator? values = null)
     {
         _options = options;
         _book = book;
         _positions = positions;
         _registry = registry;
+        _values = values ?? EquityMarketValueCalculator.Instance;
     }
 
     public int Order => 175;
@@ -99,7 +103,10 @@ public sealed class SubAccountLimitsCheck : IRiskCheck
 
         if (limits.MaxNotional is { } notCap && ctx.Type == OrderType.Limit && ctx.Price is { } price)
         {
-            var notional = price * ctx.Quantity;
+            // OPT-B (#484): option qty is in contracts; apply
+            // contractMultiplier so MaxNotional caps options at the
+            // right BRL-equivalent (silent 100x bypass without this).
+            var notional = _values.GetNotional(ctx.Symbol, price, ctx.Quantity);
             if (notional > notCap)
                 return RiskDecision.Reject(
                     $"{LimitExceededPrefix}: notional {notional} would exceed sub-account cap {notCap} for {ctx.FirmId}:{sub.Value}");

--- a/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
+++ b/backend/src/B3.Trading.Application/Risk/ReserveOnSubmitMarginProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using B3.Trading.Application.MarketData;
 using B3.Trading.Application.Observability;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
@@ -55,6 +56,7 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly ILogger<ReserveOnSubmitMarginProvider> _logger;
     private readonly CashLedger? _cash;
+    private readonly IMarketValueCalculator _values;
 
     private readonly ConcurrentDictionary<ulong, ReservationEntry> _reservations = new();
     private readonly ConcurrentDictionary<string, decimal> _reserved =
@@ -64,11 +66,13 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
     public ReserveOnSubmitMarginProvider(
         IOptionsMonitor<RiskOptions> options,
         ILogger<ReserveOnSubmitMarginProvider> logger,
-        CashLedger? cash = null)
+        CashLedger? cash = null,
+        IMarketValueCalculator? values = null)
     {
         _options = options;
         _logger = logger;
         _cash = cash;
+        _values = values ?? EquityMarketValueCalculator.Instance;
     }
 
     public Task<RiskDecision> TryReserveAsync(ulong clOrdId, RiskContext ctx, CancellationToken ct)
@@ -94,7 +98,7 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         if (!ctx.Type.IsMarginBearing())
             return Task.FromResult(RiskDecision.Approve);
 
-        var notional = ctx.Price.Value * ctx.Quantity;
+        var notional = _values.GetNotional(ctx.Symbol, ctx.Price.Value, ctx.Quantity);
         if (notional <= 0m)
             return Task.FromResult(RiskDecision.Approve);
 
@@ -210,7 +214,16 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
 
     private void ReleasePartial_Locked(ulong clOrdId, ReservationEntry entry, long lastQty)
     {
-        var amount = entry.Price * lastQty;
+        // OPT-B (#484). Release per-contract using the originally
+        // reserved per-unit notional (Price * multiplier for options,
+        // Price for equity). Recomputing from entry.Price * lastQty
+        // would under-release options by exactly the contract
+        // multiplier and leak reserved cash for the lifetime of the
+        // order.
+        var perUnit = entry.OriginalQty > 0
+            ? entry.OriginalNotional / entry.OriginalQty
+            : entry.Price;
+        var amount = perUnit * lastQty;
         if (amount <= 0m) return;
         var newRemaining = entry.RemainingNotional - amount;
         if (newRemaining < 0m)
@@ -493,5 +506,12 @@ public sealed class ReserveOnSubmitMarginProvider : IMarginProvider, IReplaceMar
         }
     }
 
-    private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional, bool IsSuspended = false);
+    private sealed record ReservationEntry(string Owner, decimal Price, long OriginalQty, decimal RemainingNotional, bool IsSuspended = false)
+    {
+        // OPT-B (#484). Snapshot of the notional reserved at submit
+        // (price * qty * multiplier). RemainingNotional shrinks with
+        // partial releases; OriginalNotional stays put so the
+        // per-contract release amount is derivable for partial fills.
+        public decimal OriginalNotional { get; init; } = RemainingNotional;
+    }
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -46,6 +46,15 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<B3.Trading.Application.MarketData.ITickSizeProvider,
             B3.Trading.Application.MarketData.SymbolDirectoryTickSizeProvider>();
 
+        // OPT-B (#484). Per-symbol notional calculator seam — applies
+        // OptionMetadata.ContractMultiplier so MaxNotional / margin
+        // reserve / rolling-notional ledger don't silently
+        // under-count option flow by ~100x. Same source of truth as
+        // ITickSizeProvider above; Fase 2 swaps both when
+        // SecurityDefinitionEvent lands.
+        services.AddSingleton<B3.Trading.Application.MarketData.IMarketValueCalculator,
+            B3.Trading.Application.MarketData.SymbolDirectoryMarketValueCalculator>();
+
         // Pre-trade risk: pipeline + checks + kill-switch + reference price +
         // margin provider. Each IRiskCheck registration is auto-discovered by
         // the RiskPipeline through the IEnumerable<IRiskCheck> ctor injection.

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryMarketValueCalculatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryMarketValueCalculatorTests.cs
@@ -1,0 +1,116 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+public class SymbolDirectoryMarketValueCalculatorTests
+{
+    private static SymbolDirectory Dir(Action<SymbolDirectoryOptions> configure)
+    {
+        var opts = new SymbolDirectoryOptions();
+        configure(opts);
+        return new SymbolDirectory(opts);
+    }
+
+    [Fact]
+    public void Equity_returnsPriceTimesQty()
+    {
+        var dir = Dir(o => o.Specs["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100 });
+        var sut = new SymbolDirectoryMarketValueCalculator(dir);
+
+        Assert.Equal(30_000m, sut.GetNotional("PETR4", price: 30m, quantity: 1_000));
+    }
+
+    [Fact]
+    public void Option_appliesContractMultiplier()
+    {
+        // PETRL200 Call, multiplier 100, quoted at 0.50 per contract.
+        // 10 contracts = 500 BRL of premium (10 * 0.50 * 100), NOT 5 BRL.
+        // This is the compliance bug OPT-B closes: without the
+        // multiplier, MaxNotional caps options at 0.5% of intended.
+        var dir = Dir(o => o.Specs["PETRL200"] = new InstrumentSpecOptions
+        {
+            Option = new OptionMetadataOptions
+            {
+                ExpirationDate = new DateOnly(2026, 12, 18),
+                PutOrCall = "Call",
+                ExerciseStyle = "American",
+                ContractMultiplier = 100m,
+            },
+        });
+        var sut = new SymbolDirectoryMarketValueCalculator(dir);
+
+        Assert.Equal(500m, sut.GetNotional("PETRL200", price: 0.50m, quantity: 10));
+    }
+
+    [Fact]
+    public void Option_nonStandardMultiplier_isHonored()
+    {
+        // Index options on B3 often use multiplier = 1 (quoted in
+        // index points); some mini-contracts use 5. The provider
+        // must respect whatever the spec carries, not hardcode 100.
+        var dir = Dir(o => o.Specs["MINI"] = new InstrumentSpecOptions
+        {
+            Option = new OptionMetadataOptions
+            {
+                ExpirationDate = new DateOnly(2026, 12, 18),
+                PutOrCall = "Call",
+                ExerciseStyle = "European",
+                ContractMultiplier = 5m,
+            },
+        });
+        var sut = new SymbolDirectoryMarketValueCalculator(dir);
+
+        Assert.Equal(50m, sut.GetNotional("MINI", price: 2m, quantity: 5));
+    }
+
+    [Fact]
+    public void UnknownSymbol_failsOpenAsEquity()
+    {
+        // Fail-open contract — symbols not configured fall back to
+        // the equity formula so a missing directory entry never
+        // makes a notional gate fire spurious rejects. Same posture
+        // as ITickSizeProvider.
+        var dir = Dir(_ => { });
+        var sut = new SymbolDirectoryMarketValueCalculator(dir);
+
+        Assert.Equal(3_000m, sut.GetNotional("UNKNOWN", price: 30m, quantity: 100));
+    }
+
+    [Fact]
+    public void EquitySpecWithNoOptionBlock_returnsPriceTimesQty()
+    {
+        // Sanity: a richly-configured equity spec (tick + lot +
+        // ladder) still yields the historical multiplier=1.
+        var dir = Dir(o => o.Specs["VALE3"] = new InstrumentSpecOptions
+        {
+            TickSize = 0.01m,
+            LotSize = 100,
+            TickLadder = new()
+            {
+                new TickBandOptions { MinPriceInclusive = 0m, Tick = 0.01m },
+                new TickBandOptions { MinPriceInclusive = 100m, Tick = 0.05m },
+            },
+        });
+        var sut = new SymbolDirectoryMarketValueCalculator(dir);
+
+        Assert.Equal(70_000m, sut.GetNotional("VALE3", price: 70m, quantity: 1_000));
+    }
+
+    [Fact]
+    public void Constructor_nullDirectory_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SymbolDirectoryMarketValueCalculator(null!));
+    }
+
+    [Fact]
+    public void EquityFallbackInstance_returnsPriceTimesQty_withoutDirectory()
+    {
+        // Surfaced singleton used by risk-check ctors when DI hasn't
+        // registered an IMarketValueCalculator — preserves the
+        // pre-OPT-B equity behavior for test fixtures and legacy
+        // wiring.
+        Assert.Equal(900m, EquityMarketValueCalculator.Instance.GetNotional("X", 9m, 100));
+        Assert.Same(EquityMarketValueCalculator.Instance, EquityMarketValueCalculator.Instance);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/SubAccountLimitsCheckTests.cs
@@ -172,4 +172,90 @@ public class SubAccountLimitsCheckTests
         Assert.False(f2.Approved);
         Assert.Contains("position", f2.Reason);
     }
+
+    // ── OPT-B (#484) compliance regression ────────────────────────────
+
+    [Fact]
+    public void Option_MaxNotional_HonoursContractMultiplier_NotJustPriceTimesQty()
+    {
+        // Before OPT-B (#484): the check computed notional = price * qty
+        // and silently let options breeze past MaxNotional caps by a
+        // factor of contractMultiplier (typically 100). After the fix,
+        // an option order with 10 contracts at 0.50 premium and a 100x
+        // multiplier reports notional = 500 BRL, which CORRECTLY trips
+        // a 200-BRL sub-account cap. The same notional in equity (50
+        // BRL on AnotherSym) stays well under the cap.
+        var book = new WorkingOrderBook();
+        var pos = new SubAccountPositionKeeper();
+        var reg = new SubAccountsRegistry();
+        reg.ApplyCreated(Firm, Sub, null);
+
+        var dir = new SymbolDirectory(new SymbolDirectoryOptions
+        {
+            Specs =
+            {
+                ["PETRL200"] = new InstrumentSpecOptions
+                {
+                    Option = new OptionMetadataOptions
+                    {
+                        ExpirationDate = new DateOnly(2026, 12, 18),
+                        PutOrCall = "Call",
+                        ExerciseStyle = "American",
+                        ContractMultiplier = 100m,
+                    },
+                },
+            },
+        });
+        var values = new B3.Trading.Application.MarketData.SymbolDirectoryMarketValueCalculator(dir);
+
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [Firm] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { MaxNotional = 200m } },
+                },
+            },
+        };
+        var check = new SubAccountLimitsCheck(
+            new StaticOptionsMonitor<SubAccountRiskOptions>(opts),
+            book, pos, reg, values);
+
+        // 10 contracts × 0.50 × 100 multiplier = 500 BRL → exceeds 200 cap.
+        var ctxOpt = new RiskContext(
+            new EndClientId(Owner), Firm, "PETRL200",
+            OrderSide.Buy, OrderType.Limit, Quantity: 10, Price: 0.50m,
+            SubAccountId: new SubAccountId(Sub));
+        var d = check.Check(ctxOpt);
+        Assert.False(d.Approved);
+        Assert.Contains("sub_account_limit_exceeded", d.Reason);
+        Assert.Contains("500", d.Reason);
+    }
+
+    [Fact]
+    public void Equity_MaxNotional_BehaviorByteIdentical_WithOrWithoutCalculator()
+    {
+        // Sanity: introducing IMarketValueCalculator must not change
+        // any equity reject reason — the equity-only fallback returns
+        // the historical price * qty.
+        var opts = new SubAccountRiskOptions
+        {
+            PerFirm = new()
+            {
+                [Firm] = new FirmSubAccountRiskOptions
+                {
+                    PerSubAccount = new() { [Sub] = new SubAccountRiskLimits { MaxNotional = 500m } },
+                },
+            },
+        };
+        var (defaultCheck, _, _, _) = Build(opts);
+
+        // No injected calculator → EquityMarketValueCalculator.Instance fallback.
+        var ctx = Ctx(new SubAccountId(Sub), qty: 100, px: 10m); // 1000 > 500
+        var d = defaultCheck.Check(ctx);
+        Assert.False(d.Approved);
+        Assert.Contains("1000", d.Reason);
+        Assert.Contains("500", d.Reason);
+    }
 }


### PR DESCRIPTION
## Why

Compliance bug: every pre-trade notional gate computed `price * qty` and silently **bypassed `MaxNotional` / margin reserve / rolling-notional ledger by 100×** for option symbols (PETR options have contractMultiplier = 100). Goes live once `pedrosakuma/B3MatchingPlatform` ships the OPT channel (#478 upstream).

## What

**Seam**: `IMarketValueCalculator` + `EquityMarketValueCalculator.Instance` fail-open singleton. Default impl `SymbolDirectoryMarketValueCalculator` reads `InstrumentSpec.Option?.ContractMultiplier ?? 1m` (lands #483 OPT-A's metadata into pre-trade math).

**5 production sites wired**:
- `MaxNotionalCheck`, `MinNotionalCheck` (`MaxQuantityCheck.cs`)
- `SubAccountLimitsCheck` MaxNotional branch
- `ReserveOnSubmitMarginProvider.TryReserveAsync`
- `RollingNotionalAccountant.NotionalFor` (both limit + ref-price branches)

All consumers gained an optional ctor param with `EquityMarketValueCalculator.Instance` fallback — keeps ~10 test fixtures byte-identical (RiskPipelineTests, ReserveOnSubmitMarginProviderTests, OrderModifyMarginAndProcessorTests, ThrottleChecksTests, Algo/AlgoSchedulerTests, etc.).

**Sub-bug fixed**: `ReserveOnSubmitMarginProvider.ReleasePartial_Locked` did `entry.Price * lastQty` — reserved `price*qty*mult` at submit but released only `price*lastQty` per fill, leaving the multiplier slice stuck in `_reserved` for the order's lifetime (option-only cash leak). Now derives per-unit as `OriginalNotional / OriginalQty` via new `OriginalNotional` init-prop on `ReservationEntry`. Equity arithmetic is identical.

## Out of scope (post-trade — own follow-ups)

- `Domain/Account/CashBalance.cs:38` (settlement)
- `ExecutionReportProcessor.cs:444` (audit/WAL Notional)
- `IFeeCalculator` `fillQuantity * fillPrice` (broker fee calc)

## Local

- Application: 1223/1223 (one CashWithdrawalAtomicity flake passed on rerun, unrelated)
- Api: 500/500
- 9 new tests (7 calculator + 2 SubAccountLimits regressions)

Closes #484
Refs #482