### PR TITLE
feat(#485): MinNotional zero-price relax for options (OPT-C)

### DIFF
--- a/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/MaxQuantityCheck.cs
@@ -76,13 +76,16 @@ public sealed class MinNotionalCheck : IRiskCheck
 {
     private readonly IOptionsMonitor<RiskOptions> _options;
     private readonly IMarketValueCalculator _values;
+    private readonly SymbolDirectory? _directory;
 
     public MinNotionalCheck(
         IOptionsMonitor<RiskOptions> options,
-        IMarketValueCalculator? values = null)
+        IMarketValueCalculator? values = null,
+        SymbolDirectory? directory = null)
     {
         _options = options;
         _values = values ?? EquityMarketValueCalculator.Instance;
+        _directory = directory;
     }
 
     public int Order => 110; // after max-quantity / max-notional, before throttles
@@ -94,6 +97,24 @@ public sealed class MinNotionalCheck : IRiskCheck
         var min = RiskLimitsResolver.Resolve(opts, ctx.Owner.Value, ctx.FirmId, ctx.Symbol, l => l.MinNotional);
         if (!min.HasValue || !ctx.Price.HasValue)
             return RiskDecision.Approve; // no floor configured, or market order
+
+        // OPT-C (#485). B3 OPT channel relaxes minPx to 0 for equity
+        // options (upstream B3MatchingPlatform#473): cabinet trades and
+        // worthless out-of-the-money closeouts legitimately price at 0.
+        // The MinNotional dust floor is a fat-finger guard for equities;
+        // applying it to a zero-priced option closeout would reject a
+        // venue-legal order with a spurious dust reason. Skip when the
+        // symbol resolves as Option AND price is exactly 0 — any
+        // positive option price still trips the floor (so a 0.005×100=0.5
+        // BRL real option still gets caught if the floor is set higher).
+        if (ctx.Price.Value == 0m
+            && _directory is { } dir
+            && dir.TryGetSpec(ctx.Symbol, out var spec)
+            && spec.SecurityType == SecurityType.Option)
+        {
+            return RiskDecision.Approve;
+        }
+
         // OPT-B (#484): notional is in BRL (price * qty * multiplier
         // for options); fee/dust math compares apples-to-apples.
         var notional = _values.GetNotional(ctx.Symbol, ctx.Price.Value, ctx.Quantity);

--- a/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/RiskPipelineTests.cs
@@ -392,6 +392,84 @@ public class RiskPipelineTests
     }
 
     [Fact]
+    public void MinNotional_OptionAtZeroPrice_SkipsFloor()
+    {
+        // OPT-C (#485). B3 OPT channel allows minPx=0 for options
+        // (cabinet trades / worthless closeouts). MinNotional dust
+        // floor must not reject a venue-legal zero-priced option.
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MinNotional = 100m } });
+        var dir = BuildDirectory(specs: new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PETRL200"] = new InstrumentSpecOptions
+            {
+                Option = new OptionMetadataOptions
+                {
+                    ExpirationDate = new DateOnly(2026, 12, 18),
+                    PutOrCall = "Call",
+                    ExerciseStyle = "American",
+                    ContractMultiplier = 100m,
+                },
+            },
+        });
+        var check = new MinNotionalCheck(
+            opts,
+            values: new SymbolDirectoryMarketValueCalculator(dir),
+            directory: dir);
+
+        Assert.True(check.Check(Ctx(symbol: "PETRL200", qty: 100, price: 0m)).Approved);
+    }
+
+    [Fact]
+    public void MinNotional_OptionAtNonZeroPrice_StillEnforcesFloor()
+    {
+        // Real option price (0.01 × 100 × 10 = 10 BRL) is still
+        // subject to the floor — the OPT-C relax is strictly
+        // scoped to price == 0 (cabinet/worthless), not to any
+        // small-but-positive option price.
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MinNotional = 100m } });
+        var dir = BuildDirectory(specs: new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PETRL200"] = new InstrumentSpecOptions
+            {
+                Option = new OptionMetadataOptions
+                {
+                    ExpirationDate = new DateOnly(2026, 12, 18),
+                    PutOrCall = "Call",
+                    ExerciseStyle = "American",
+                    ContractMultiplier = 100m,
+                },
+            },
+        });
+        var check = new MinNotionalCheck(
+            opts,
+            values: new SymbolDirectoryMarketValueCalculator(dir),
+            directory: dir);
+
+        var d = check.Check(Ctx(symbol: "PETRL200", qty: 10, price: 0.01m));
+        Assert.False(d.Approved);
+        Assert.Contains("min", d.Reason);
+    }
+
+    [Fact]
+    public void MinNotional_EquityAtZeroPrice_StillRejects()
+    {
+        // Equity zero-price isn't a venue-legal scenario; the OPT-C
+        // relax is options-only. Equities at price=0 keep the legacy
+        // reject (defense-in-depth fat-finger guard).
+        var opts = Wrap(new RiskOptions { Default = new RiskLimits { MinNotional = 100m } });
+        var dir = BuildDirectory(specs: new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100 },
+        });
+        var check = new MinNotionalCheck(
+            opts,
+            values: new SymbolDirectoryMarketValueCalculator(dir),
+            directory: dir);
+
+        Assert.False(check.Check(Ctx(symbol: "PETR4", qty: 100, price: 0m)).Approved);
+    }
+
+    [Fact]
     public void PriceCollar_RejectsOutsideBand()
     {
         var refPx = new StubRef(("PETR4", 30m));


### PR DESCRIPTION
## Why

B3 OPT channel (upstream `B3MatchingPlatform#473`) relaxes `minPx=0` for equity options to allow **cabinet trades** and **worthless out-of-the-money closeouts**. Our `MinNotionalCheck` dust floor was sized for equities — at price=0 the computed notional is 0, which trips any positive floor and rejects a venue-legal option order with a spurious dust reason.

## What

`MinNotionalCheck` gains an optional `SymbolDirectory? directory` ctor param. When the symbol resolves as `SecurityType.Option` AND price is exactly `0m`, the floor is skipped. Any positive option price still goes through the floor (so a real 0.01 × 100mult × 10 = 10 BRL option still trips a 100 BRL floor).

- **DI**: no wire change. `SymbolDirectory` is already registered for `MinTickSizeCheck`; the container resolves it automatically.
- **Test fixtures**: byte-identical — optional param, fail-open when null.
- **Other checks**: `MinTickSizeCheck` and `MaxNotionalCheck` already approve at price=0 by construction (`decimal.Remainder(0, tick) == 0`; `0 > max` is false). No changes needed there.

## Scope guardrails

- Strictly options at exactly `price == 0m`.
- Positive option prices: enforced.
- All equity prices including zero (defense-in-depth): unchanged.
- Unset floors: unchanged.

## Local

- Application: 1226/1226 (+3 new tests)
- Api: 500/500

Closes #485
Refs #482