### PR TITLE
feat(#488): option-specific surveillance metrics + METRICS.md (OPT-F)

### DIFF
--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -60,6 +60,19 @@ public static class MetricsRegistry
     public static readonly Counter<long> OrdersIocNoResponse =
         Meter.CreateCounter<long>("trading.orders.ioc_no_response");
 
+    /// <summary>
+    /// OPT-F (#488). Surveillance counter for cabinet trades and
+    /// worthless out-of-the-money option closeouts that travel as
+    /// Limit Price=0 on the OPT channel (relaxed by OPT-C / #485 +
+    /// upstream B3MatchingPlatform#473). A small steady stream is
+    /// normal end-of-cycle hygiene; a sudden spike on a single
+    /// (symbol, firmId, put_call) tuple is a compliance signal
+    /// (off-market levelling, wash-out, mis-keyed price).
+    /// Tags: <c>symbol</c>, <c>side</c>, <c>firmId</c>, <c>put_call</c>.
+    /// </summary>
+    public static readonly Counter<long> OptionZeroPriceOrdersSubmitted =
+        Meter.CreateCounter<long>("trading.options.zero_price_orders_submitted");
+
     // Execution reports inbound
     public static readonly Counter<long> ExecutionReportsReceived =
         Meter.CreateCounter<long>("trading.er.received");

--- a/backend/src/B3.Trading.Application/OrderSubmissionService.cs
+++ b/backend/src/B3.Trading.Application/OrderSubmissionService.cs
@@ -40,6 +40,7 @@ public sealed class OrderSubmissionService
     private readonly Scheduling.GtdExpirationScheduler? _gtdScheduler;
     private readonly Scheduling.IocFokWatchdog? _iocWatchdog;
     private readonly Routing.IRoutingInstructionResolver? _routingResolver;
+    private readonly SymbolDirectory? _symbolDirectory;
     private readonly ILogger<OrderSubmissionService> _logger;
 
     public OrderSubmissionService(
@@ -57,7 +58,8 @@ public sealed class OrderSubmissionService
         IUserBotOrderMappingRegistry? botMappings = null,
         Scheduling.GtdExpirationScheduler? gtdScheduler = null,
         Scheduling.IocFokWatchdog? iocWatchdog = null,
-        Routing.IRoutingInstructionResolver? routingInstructionResolver = null)
+        Routing.IRoutingInstructionResolver? routingInstructionResolver = null,
+        SymbolDirectory? symbolDirectory = null)
     {
         _clOrdIds = clOrdIds;
         _ownership = ownership;
@@ -73,6 +75,7 @@ public sealed class OrderSubmissionService
         _gtdScheduler = gtdScheduler;
         _iocWatchdog = iocWatchdog;
         _routingResolver = routingInstructionResolver;
+        _symbolDirectory = symbolDirectory;
         _logger = logger;
     }
 
@@ -227,12 +230,46 @@ public sealed class OrderSubmissionService
             return OrderSubmissionResult.WalBackpressure(ex.Message);
         }
 
+        // OPT-F (#488). Classify the symbol so equity vs option flow
+        // can be split on dashboards. SymbolDirectory is optional —
+        // when not injected (most tests), the tag value is "unknown"
+        // and the option-specific counter is silenced. Unknown symbols
+        // (not in the directory) also tag as "unknown" so onboarding
+        // a new ticker is observable in surveillance.
+        var securityTypeTag = "unknown";
+        var isOption = false;
+        OptionMetadata? optionMeta = null;
+        if (_symbolDirectory is { } dir && dir.TryGetSpec(req.Symbol, out var spec))
+        {
+            isOption = spec.SecurityType == SecurityType.Option;
+            securityTypeTag = isOption ? "option" : "equity";
+            optionMeta = spec.Option;
+        }
+
         MetricsRegistry.OrdersSubmitted.Add(1,
             new KeyValuePair<string, object?>("symbol", req.Symbol),
             new KeyValuePair<string, object?>("side", req.Side.ToString()),
             new KeyValuePair<string, object?>("source",
                 req.Source == OrderSubmissionSource.Algo ? "algo" : "manual"),
-            new KeyValuePair<string, object?>("firmId", req.FirmId));
+            new KeyValuePair<string, object?>("firmId", req.FirmId),
+            new KeyValuePair<string, object?>("security_type", securityTypeTag));
+
+        // OPT-F (#488). Cabinet / worthless-OTM closeout surveillance
+        // counter. OPT-C (#485) relaxed MinNotional for option orders
+        // at price=0; this metric makes the (small) population of such
+        // orders observable per (symbol, side, firm, put_call) so a
+        // sudden spike — which would be unusual for a healthy desk —
+        // can trip a compliance alert. Only fires for orders we can
+        // classify as Option AND that carry an explicit price of 0.
+        if (isOption && req.Price is 0m)
+        {
+            MetricsRegistry.OptionZeroPriceOrdersSubmitted.Add(1,
+                new KeyValuePair<string, object?>("symbol", req.Symbol),
+                new KeyValuePair<string, object?>("side", req.Side.ToString()),
+                new KeyValuePair<string, object?>("firmId", req.FirmId),
+                new KeyValuePair<string, object?>("put_call",
+                    optionMeta?.PutOrCall.ToString().ToLowerInvariant() ?? "unknown"));
+        }
 
         // Ordering note (RFC docs/rfcs/risk-pipeline-ordering-v0.md, #262):
         // risk evaluation runs *post-WAL* on the submit path. On reject we

--- a/backend/tests/B3.Trading.Application.Tests/Observability/OptionMetricsTagsTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Observability/OptionMetricsTagsTests.cs
@@ -1,0 +1,293 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application;
+using B3.Trading.Application.Lifecycle;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Accounting;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests.Observability;
+
+/// <summary>
+/// OPT-F (#488). The order-flow counters must distinguish equity
+/// from option submissions so dashboards can split the two flows
+/// and a dedicated cabinet/worthless-OTM surveillance counter must
+/// fire on the OPT-C (#485) zero-price-option path.
+///
+/// <para>
+/// Process-global Meter caveat (see CodebaseFact "testing" /
+/// MetricsFirmTagTests): the listener captures increments from
+/// every parallel TestAppFactory; assertions filter by symbol +
+/// value, never on "last seen".
+/// </para>
+/// </summary>
+public class OptionMetricsTagsTests
+{
+    private static readonly EndClientId Alice = new("alice");
+
+    [Fact]
+    public async Task OrdersSubmitted_CarriesSecurityTypeTag_ForOptionSymbol()
+    {
+        var tags = new System.Collections.Concurrent.ConcurrentBag<(string symbol, string securityType, long value)>();
+        using var listener = StartListener("trading.orders.submitted", (value, kv) =>
+        {
+            string? symbol = null, secType = null;
+            foreach (var t in kv)
+            {
+                if (t.Key == "symbol" && t.Value is string s) symbol = s;
+                if (t.Key == "security_type" && t.Value is string st) secType = st;
+            }
+            if (symbol is not null && secType is not null)
+                tags.Add((symbol, secType, value));
+        });
+
+        var h = new Harness(WithPetrl200());
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETRL200", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 10, Price: 0.50m);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        Poll(() => tags.Any(t => t.symbol == "PETRL200" && t.securityType == "option" && t.value >= 1),
+            $"expected at least one PETRL200/option increment; saw: [{string.Join(",", tags)}]");
+    }
+
+    [Fact]
+    public async Task OrdersSubmitted_CarriesSecurityTypeTag_ForEquitySymbol()
+    {
+        var tags = new System.Collections.Concurrent.ConcurrentBag<(string symbol, string securityType)>();
+        using var listener = StartListener("trading.orders.submitted", (_, kv) =>
+        {
+            string? symbol = null, secType = null;
+            foreach (var t in kv)
+            {
+                if (t.Key == "symbol" && t.Value is string s) symbol = s;
+                if (t.Key == "security_type" && t.Value is string st) secType = st;
+            }
+            if (symbol is not null && secType is not null)
+                tags.Add((symbol, secType));
+        });
+
+        var h = new Harness(WithPetr4Equity());
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 30m);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        Poll(() => tags.Any(t => t.symbol == "PETR4" && t.securityType == "equity"),
+            $"expected PETR4/equity tag; saw: [{string.Join(",", tags)}]");
+    }
+
+    [Fact]
+    public async Task OrdersSubmitted_TagIsUnknown_WhenSymbolDirectoryNotInjected()
+    {
+        var tags = new System.Collections.Concurrent.ConcurrentBag<(string symbol, string securityType)>();
+        using var listener = StartListener("trading.orders.submitted", (_, kv) =>
+        {
+            string? symbol = null, secType = null;
+            foreach (var t in kv)
+            {
+                if (t.Key == "symbol" && t.Value is string s) symbol = s;
+                if (t.Key == "security_type" && t.Value is string st) secType = st;
+            }
+            if (symbol is not null && secType is not null)
+                tags.Add((symbol, secType));
+        });
+
+        var h = new Harness(symbolDirectory: null);
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "UNKNOWN1", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 30m);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        Poll(() => tags.Any(t => t.symbol == "UNKNOWN1" && t.securityType == "unknown"),
+            $"expected UNKNOWN1/unknown tag; saw: [{string.Join(",", tags)}]");
+    }
+
+    [Fact]
+    public async Task OptionZeroPriceCounter_Fires_OnCabinetTrade()
+    {
+        var hits = new System.Collections.Concurrent.ConcurrentBag<(string symbol, string putCall, long value)>();
+        using var listener = StartListener("trading.options.zero_price_orders_submitted", (value, kv) =>
+        {
+            string? symbol = null, pc = null;
+            foreach (var t in kv)
+            {
+                if (t.Key == "symbol" && t.Value is string s) symbol = s;
+                if (t.Key == "put_call" && t.Value is string p) pc = p;
+            }
+            if (symbol is not null && pc is not null)
+                hits.Add((symbol, pc, value));
+        });
+
+        var h = new Harness(WithPetrl200());
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETRL200", 4321UL, OrderSide.Sell, OrderType.Limit,
+            Quantity: 5, Price: 0m);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        Poll(() => hits.Any(t => t.symbol == "PETRL200" && t.putCall == "call" && t.value >= 1),
+            $"expected one PETRL200/call cabinet increment; saw: [{string.Join(",", hits)}]");
+    }
+
+    [Fact]
+    public async Task OptionZeroPriceCounter_DoesNotFire_OnRealOptionPrice()
+    {
+        var hits = new System.Collections.Concurrent.ConcurrentBag<string>();
+        using var listener = StartListener("trading.options.zero_price_orders_submitted", (_, kv) =>
+        {
+            foreach (var t in kv)
+                if (t.Key == "symbol" && t.Value is string s)
+                    hits.Add(s);
+        });
+
+        var h = new Harness(WithPetrl200_NonZeroAlias());
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETRL200_NONZERO", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 1, Price: 0.05m);
+
+        var result = await h.Submitter.SubmitAsync(req, CancellationToken.None);
+        Assert.Equal(OrderSubmissionResultKind.Accepted, result.Kind);
+
+        await Task.Delay(150);
+        Assert.DoesNotContain("PETRL200_NONZERO", hits);
+    }
+
+    [Fact]
+    public async Task OptionZeroPriceCounter_DoesNotFire_OnEquityZero()
+    {
+        // OPT-C scope guardrail: counter must be strictly options-only.
+        // Equity at price=0 isn't venue-legal anyway, but if some path
+        // ever sends one, the cabinet surveillance counter must not
+        // mis-attribute it.
+        var hits = new System.Collections.Concurrent.ConcurrentBag<string>();
+        using var listener = StartListener("trading.options.zero_price_orders_submitted", (_, kv) =>
+        {
+            foreach (var t in kv)
+                if (t.Key == "symbol" && t.Value is string s)
+                    hits.Add(s);
+        });
+
+        var h = new Harness(WithPetr4Equity());
+        var req = new OrderSubmissionRequest(
+            Alice, "FIRM-A", "PETR4_EQUITY_ZERO", 4321UL, OrderSide.Buy, OrderType.Limit,
+            Quantity: 100, Price: 0m);
+        await h.Submitter.SubmitAsync(req, CancellationToken.None);
+
+        await Task.Delay(150);
+        Assert.DoesNotContain("PETR4_EQUITY_ZERO", hits);
+    }
+
+    private static MeterListener StartListener(string instrumentName, Action<long, ReadOnlySpan<KeyValuePair<string, object?>>> onMeasurement)
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instr, l) =>
+        {
+            if (instr.Meter.Name == "B3.Trading" && instr.Name == instrumentName)
+                l.EnableMeasurementEvents(instr);
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) => onMeasurement(value, tags));
+        listener.Start();
+        return listener;
+    }
+
+    private static void Poll(Func<bool> predicate, string message)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (!predicate() && DateTime.UtcNow < deadline)
+            Thread.Sleep(20);
+        Assert.True(predicate(), message);
+    }
+
+    private static SymbolDirectory WithPetrl200()
+    {
+        var opts = new SymbolDirectoryOptions();
+        opts.Specs["PETRL200"] = new InstrumentSpecOptions
+        {
+            Option = new OptionMetadataOptions
+            {
+                ExpirationDate = new DateOnly(2026, 12, 18),
+                PutOrCall = "Call",
+                ExerciseStyle = "American",
+                ContractMultiplier = 100m,
+            },
+        };
+        return new SymbolDirectory(opts);
+    }
+
+    private static SymbolDirectory WithPetrl200_NonZeroAlias()
+    {
+        var opts = new SymbolDirectoryOptions();
+        opts.Specs["PETRL200_NONZERO"] = new InstrumentSpecOptions
+        {
+            Option = new OptionMetadataOptions
+            {
+                ExpirationDate = new DateOnly(2026, 12, 18),
+                PutOrCall = "Call",
+                ExerciseStyle = "American",
+                ContractMultiplier = 100m,
+            },
+        };
+        return new SymbolDirectory(opts);
+    }
+
+    private static SymbolDirectory WithPetr4Equity()
+    {
+        var opts = new SymbolDirectoryOptions();
+        opts.Specs["PETR4"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100 };
+        opts.Specs["PETR4_EQUITY_ZERO"] = new InstrumentSpecOptions { TickSize = 0.01m, LotSize = 100 };
+        return new SymbolDirectory(opts);
+    }
+
+    private sealed class Harness
+    {
+        public WorkingOrderBook Book { get; } = new();
+        public OrderOwnershipMap Ownership { get; } = new();
+        public ClOrdIdPrefixRegistry ClOrdIds { get; } = new();
+        public NullEventStore Store { get; } = new();
+        public EventDispatcher Dispatcher { get; }
+        public RecordingGateway Gateway { get; } = new();
+        public NoOpExecutionEventSink Sink { get; } = new();
+        public RiskPipeline Risk { get; } = new(Array.Empty<IRiskCheck>());
+        public NoOpMarginProvider Margin { get; } = new();
+        public CompositeRiskAccountant Accountant { get; } = new(Array.Empty<IRiskAccountant>());
+        public NeverDrainingGate Drain { get; } = new();
+        public OrderSubmissionService Submitter { get; }
+
+        public Harness(SymbolDirectory? symbolDirectory = null)
+        {
+            Dispatcher = new EventDispatcher(Store);
+            Submitter = new OrderSubmissionService(
+                ClOrdIds, Ownership, Book, Gateway, Sink, Risk, Margin, Accountant,
+                Dispatcher, Drain, NullLogger<OrderSubmissionService>.Instance,
+                symbolDirectory: symbolDirectory);
+        }
+    }
+
+    private sealed class RecordingGateway : IExchangeGateway
+    {
+        public Task SubmitAsync(Order order, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelAsync(Order order, ulong newClOrdId, CancellationToken ct) => Task.CompletedTask;
+        public Task CancelReplaceAsync(
+            Order original, ulong newClOrdId, long newQuantity, decimal? newPrice,
+            TimeInForce? requestedTimeInForce, decimal? requestedStopPrice,
+            DateTimeOffset? requestedGoodTillDate, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class NeverDrainingGate : IDrainGate
+    {
+        public bool IsDraining => false;
+        public Task BeginDrainAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task CompleteDrainAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -41,7 +41,7 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 
 | OTel name | Type | Tags |
 |---|---|---|
-| `trading.orders.submitted` | Counter | `symbol`, `side`, `source` (manual/algo) |
+| `trading.orders.submitted` | Counter | `symbol`, `side`, `source` (manual/algo), `firmId`, `security_type` (equity/option/unknown) |
 | `trading.orders.rejected_by_risk` | Counter | `check` |
 | `trading.orders.gateway_failed` | Counter | (none) |
 | `trading.orders.cancel_requested` | Counter | (none) |
@@ -76,6 +76,7 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 | `trading.algo.twap.slice_fire_jitter` | Histogram (ms) | (none) |
 | `trading.algo.scheduler.tick_duration` | Histogram (ms) | (none) |
 | `trading.algo.signal_queue_depth` | UpDownCounter | (none) |
+| `trading.options.zero_price_orders_submitted` | Counter | `symbol`, `side`, `firmId`, `put_call` |
 
 The `trading.risk.*` series back the **B3 Trading — Risk** Grafana
 dashboard (`docker/observability/grafana/dashboards/risk.json`); the
@@ -90,6 +91,21 @@ v0 algo pipeline is documented in
 C1, `parentAlgoId` is intentionally **not** a metric tag (cardinality
 would explode); per-algo drill-down lives in structured logs and
 traces.
+
+## Option-specific surveillance (OPT-F / #488)
+
+`trading.orders.submitted.security_type` lets dashboards split equity
+vs option flow (and surface "unknown" buckets that signal a symbol
+missing from the directory). The `security_type` value is derived from
+`SymbolDirectory.TryGetSpec(...).SecurityType` at submit time; when
+the directory is not injected (most unit tests) the tag is `unknown`.
+
+`trading.options.zero_price_orders_submitted` is the dedicated
+surveillance signal for the OPT-C (#485) cabinet / worthless-OTM
+closeout flow — orders that travel as `Limit Price=0` on the OPT
+channel. A small steady stream is normal end-of-cycle hygiene; a
+sudden spike on one `(symbol, firmId, put_call)` tuple is the
+compliance alert (off-market levelling, wash-out, mis-keyed price).
 
 ## Auto-instrumentation also exported
 


### PR DESCRIPTION
## Why
After OPT-A/B/C (#489/#490/#491) equity options are routable end-to-end. Surveillance needs to (a) distinguish option vs equity flow on the hot submit counter, and (b) flag cabinet/worthless option trades (Price=0) — those are the price points OPT-C MinNotional relaxed and they want ops eyes.

## What
- **MetricsRegistry**: new counter `trading.options.zero_price_orders_submitted` tagged `symbol/side/firmId/put_call`. Bounded cardinality (`put_call` ∈ {put,call,unknown}; symbol already accepted).
- **OrderSubmissionService**: optional `SymbolDirectory` ctor param (DI auto-resolves; nullable preserves the 2 direct-construction test sites byte-identical). Classifies symbol via `TryGetSpec` → `security_type` (equity/option/unknown) tag added to `trading.orders.submitted`. Zero-price counter fires only when `isOption && Price is 0m` (symmetric with OPT-C MinNotional skip).
- **METRICS.md**: updated `trading.orders.submitted` row + new counter row + prose section *Option-specific surveillance (OPT-F / #488)*.

## Local
- 6 new tests in `Observability/OptionMetricsTagsTests.cs` — 3 `security_type` paths (option/equity/null-directory→unknown), 3 zero-price counter paths (cabinet fires / non-zero option / equity-zero).
- MeterListener pattern per repo convention: process-global meter, ConcurrentBag + bounded Poll, filter by symbol tag (never assert 'last seen').
- Application 1232/1232 + Api 500/500 green.

Closes #488
Refs #482