### PR TITLE
feat(#486): SDK 0.5.0 SecurityDefinition projection into SymbolDirectory (OPT-D / #454 Fase 2)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.0" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.0" />
-    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.4.0" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.5.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
@@ -61,4 +61,33 @@ public sealed class MarketDataOptions
     /// </para>
     /// </summary>
     public bool EnableBook { get; set; } = false;
+
+    /// <summary>
+    /// OPT-D (#486, refs #454 Fase 2). Opt-in flag to subscribe to the
+    /// SDK <c>SecurityDefinition</c> channel
+    /// (<c>SubscribeFlags.SecurityDefinition</c>, 0x20) introduced in
+    /// upstream <c>pedrosakuma/B3MarketDataPlatform#55</c> / SDK 0.5.0.
+    /// When <c>true</c>, every symbol passed to
+    /// <see cref="IMarketDataSubscriber.SubscribeAsync"/> receives a
+    /// bootstrap + delta stream of <c>SecurityDefinitionEvent</c> frames
+    /// carrying tick (<c>MinPriceIncrement</c>), lot
+    /// (<c>MinTradeVolume</c>), <c>ContractMultiplier</c>, option
+    /// metadata (<c>StrikePrice</c>, <c>MaturityDate</c>,
+    /// <c>PutOrCall</c>, <c>ExerciseStyle</c>), <c>SecurityType</c> and
+    /// the rest of the static instrument metadata. The host adapter
+    /// projects those frames into <see cref="SecurityDefinitionRegistry"/>,
+    /// which the tick / lot / market-value providers consult before
+    /// falling back to the operator-configured
+    /// <see cref="SymbolDirectory"/>.
+    /// <para>
+    /// Default <c>true</c>: once the SDK is bumped past 0.5.0 we always
+    /// want venue-pushed metadata to win over hand-typed config because
+    /// the OPT umbrella ships hundreds of option series per underlying
+    /// and config-only entry is infeasible. Set to <c>false</c> as an
+    /// emergency kill-switch only — providers will then keep returning
+    /// the static <see cref="SymbolDirectory"/> values exclusively
+    /// (legacy behaviour).
+    /// </para>
+    /// </summary>
+    public bool EnableSecurityDefinition { get; set; } = true;
 }

--- a/backend/src/B3.Trading.Application/MarketData/SecurityDefinitionRegistry.cs
+++ b/backend/src/B3.Trading.Application/MarketData/SecurityDefinitionRegistry.cs
@@ -1,0 +1,225 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// OPT-D (#486, refs #454 Fase 2). Thread-safe, in-process registry
+/// of <see cref="InstrumentSpec"/>s sourced from the upstream
+/// <c>SecurityDefinition</c> WebSocket channel
+/// (<c>pedrosakuma/B3MarketDataPlatform#55</c> / SDK 0.5.0). The host
+/// adapter (<c>SdkMarketDataSubscriber</c>) translates each
+/// <c>SecurityDefinitionEvent</c> the SDK raises into an
+/// <see cref="InstrumentSpec"/> + <c>SecurityId</c> and calls
+/// <see cref="Upsert(string, InstrumentSpec, ulong)"/>. Consumers
+/// (currently <see cref="SymbolDirectory.TryGetSpec(string?, out InstrumentSpec)"/>
+/// via the overlay ctor parameter) check the registry FIRST and only
+/// fall back to the operator-configured static directory when the
+/// registry has no entry — which happens before the first
+/// <c>SecurityDefinition</c> frame for that symbol arrives and any
+/// time the kill-switch <c>Trading:MarketData:EnableSecurityDefinition</c>
+/// is set to <c>false</c>.
+///
+/// <para>
+/// Concurrency contract: a single SDK callback thread writes (the SDK
+/// guarantees ordered, single-threaded event dispatch); arbitrary
+/// hot-path threads read on every order submit and risk check. A
+/// <see cref="ConcurrentDictionary{TKey, TValue}"/> with
+/// <see cref="StringComparer.OrdinalIgnoreCase"/> gives us lock-free
+/// reads and the same case-insensitive lookup semantics the static
+/// directory uses.
+/// </para>
+///
+/// <para>
+/// "Registry wins" semantics: when a symbol is present in both the
+/// registry and the static directory, the registry entry replaces the
+/// static one wholesale (no field-level merge). The rationale is that
+/// venue-pushed data is more authoritative than hand-typed YAML; if
+/// an operator needs to override (e.g. roll out an emergency tick
+/// hot-fix), they set <c>EnableSecurityDefinition=false</c> and lean
+/// on the static directory exclusively. This is symmetric with how
+/// <c>MarketDataReferencePrice</c> overlays the static
+/// <c>ConfigReferencePrice</c>.
+/// </para>
+/// </summary>
+public sealed class SecurityDefinitionRegistry
+{
+    private readonly ConcurrentDictionary<string, Entry> _bySymbol =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Replaces (or installs) the spec for <paramref name="symbol"/>.
+    /// The SDK's <c>SecurityDefinitionEvent</c> ships both a bootstrap
+    /// snapshot at subscribe time and deltas on every real change;
+    /// <see cref="Upsert(string, InstrumentSpec, ulong)"/> is the
+    /// single mutation path for both — duplicates are inherently safe
+    /// because the registry stores the full spec, not deltas.
+    /// </summary>
+    public void Upsert(string symbol, InstrumentSpec spec, ulong securityId)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        _bySymbol[symbol] = new Entry(spec, securityId);
+    }
+
+    /// <summary>
+    /// Registry-first spec lookup. Returns <c>false</c> when no
+    /// upstream <c>SecurityDefinition</c> frame has been observed for
+    /// the symbol; callers (currently <see cref="SymbolDirectory"/>)
+    /// then fall back to the static, operator-configured directory.
+    /// </summary>
+    public bool TryGetSpec(string? symbol, out InstrumentSpec spec)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            spec = default;
+            return false;
+        }
+        if (_bySymbol.TryGetValue(symbol, out var entry))
+        {
+            spec = entry.Spec;
+            return true;
+        }
+        spec = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the <c>SecurityId</c> the venue declared for the
+    /// symbol in its <c>SecurityDefinition_12</c> frame. Used as a
+    /// future hook for the FIXP adapter's inverse lookup (#171 E) so
+    /// dynamically-onboarded option series don't have to be
+    /// pre-listed in <c>Trading:SymbolDirectory:SecurityIds</c>;
+    /// today only the spec side of the projection is wired through
+    /// the host.
+    /// </summary>
+    public bool TryGetSecurityId(string? symbol, out ulong securityId)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            securityId = 0;
+            return false;
+        }
+        if (_bySymbol.TryGetValue(symbol, out var entry))
+        {
+            securityId = entry.SecurityId;
+            return true;
+        }
+        securityId = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Number of symbols currently held by the registry. Exposed for
+    /// startup logging and for tests that assert "the SDK frame was
+    /// projected" without binding to a specific symbol.
+    /// </summary>
+    public int Count => _bySymbol.Count;
+
+    private readonly record struct Entry(InstrumentSpec Spec, ulong SecurityId);
+
+    /// <summary>
+    /// OPT-D (#486). Side-table for projecting raw SBE numerics
+    /// (PutOrCall / ExerciseStyle / MaturityDate / StrikePrice +
+    /// PriceDivisor) coming over the wire on
+    /// <c>SecurityDefinition_12</c> into a typed
+    /// <see cref="OptionMetadata"/>. SDK-agnostic on purpose — the
+    /// host adapter passes primitives so Application can unit-test
+    /// the translation without a SDK package dependency. Returns
+    /// <c>null</c> when any minimum-viable field is missing or
+    /// invalid (the spec degrades gracefully to equity-like;
+    /// callers may still upsert tick + lot).
+    /// </summary>
+    public static OptionMetadata? TryProject(
+        long? contractMultiplier,
+        long? maturityDate,
+        long? putOrCall,
+        long? exerciseStyle,
+        long? strikePrice,
+        long? priceDivisor,
+        string? underlyingAsset)
+    {
+        if (contractMultiplier is not { } rawMult || rawMult <= 0) return null;
+        if (maturityDate is not { } rawMaturity) return null;
+        if (putOrCall is not { } rawPc) return null;
+        if (!TryMapPutOrCall(rawPc, out var pc)) return null;
+        if (!TryMapExerciseStyle(exerciseStyle, out var exStyle)) return null;
+        if (!TryParseMaturity(rawMaturity, out var expiration)) return null;
+
+        var divisor = priceDivisor is { } d && d > 0 ? (decimal)d : 10000m;
+        var strike = strikePrice is { } rawStrike && rawStrike > 0
+            ? rawStrike / divisor
+            : 0m;
+
+        return new OptionMetadata(
+            StrikePrice: strike,
+            ExpirationDate: expiration,
+            PutOrCall: pc,
+            ExerciseStyle: exStyle,
+            UnderlyingSymbol: underlyingAsset ?? string.Empty,
+            ContractMultiplier: rawMult,
+            OptPayoutType: OptPayoutType.Vanilla);
+    }
+
+    private static bool TryMapPutOrCall(long raw, out PutOrCall value)
+    {
+        // SBE PutOrCall convention shared with upstream
+        // pedrosakuma/B3MatchingPlatform#473: 0 = Put, 1 = Call.
+        switch (raw)
+        {
+            case 0: value = PutOrCall.Put; return true;
+            case 1: value = PutOrCall.Call; return true;
+            default: value = default; return false;
+        }
+    }
+
+    private static bool TryMapExerciseStyle(long? raw, out ExerciseStyle value)
+    {
+        // SBE ExerciseStyle: 1 = European, 2 = American. Missing is
+        // tolerated (defaults to American — B3's most-listed style)
+        // so a venue partial frame doesn't drop the entire option
+        // projection.
+        switch (raw)
+        {
+            case null: value = ExerciseStyle.American; return true;
+            case 1: value = ExerciseStyle.European; return true;
+            case 2: value = ExerciseStyle.American; return true;
+            default: value = default; return false;
+        }
+    }
+
+    private static bool TryParseMaturity(long raw, out DateOnly value)
+    {
+        // YYYYMMDD encoding per SecurityDefinition_12 wire layout.
+        var y = (int)(raw / 10000);
+        var m = (int)((raw / 100) % 100);
+        var d = (int)(raw % 100);
+        if (y < 1970 || y > 2100 || m < 1 || m > 12 || d < 1 || d > 31)
+        {
+            value = default;
+            return false;
+        }
+        try { value = new DateOnly(y, m, d); return true; }
+        catch (ArgumentOutOfRangeException) { value = default; return false; }
+    }
+}
+
+/// <summary>
+/// OPT-D (#486). Static helper for projecting raw SBE numerics into
+/// <see cref="OptionMetadata"/>. Lives outside
+/// <see cref="SecurityDefinitionRegistry"/> for testability — wraps
+/// the registry's nested translator without changing the public
+/// surface.
+/// </summary>
+internal static class SecurityDefinitionTranslator
+{
+    public static OptionMetadata? TryProjectOption(
+        long? contractMultiplier,
+        long? maturityDate,
+        long? putOrCall,
+        long? exerciseStyle,
+        long? strikePrice,
+        long? priceDivisor,
+        string? underlyingAsset)
+        => SecurityDefinitionRegistry.TryProject(
+            contractMultiplier, maturityDate, putOrCall, exerciseStyle,
+            strikePrice, priceDivisor, underlyingAsset);
+}

--- a/backend/src/B3.Trading.Application/SymbolDirectory.cs
+++ b/backend/src/B3.Trading.Application/SymbolDirectory.cs
@@ -32,10 +32,27 @@ public sealed class SymbolDirectory
     private readonly IReadOnlyDictionary<string, ulong> _byName;
     private readonly IReadOnlyDictionary<ulong, string> _bySecurityId;
     private readonly IReadOnlyDictionary<string, InstrumentSpec> _specs;
+    private readonly MarketData.SecurityDefinitionRegistry? _registry;
 
     public SymbolDirectory(SymbolDirectoryOptions options)
+        : this(options, registry: null)
+    {
+    }
+
+    /// <summary>
+    /// OPT-D (#486, refs #454 Fase 2). Construct with an optional
+    /// <see cref="MarketData.SecurityDefinitionRegistry"/> overlay.
+    /// When supplied, <see cref="TryGetSpec(string?, out InstrumentSpec)"/>
+    /// consults the registry FIRST and only falls back to the static
+    /// <paramref name="options"/>-bound dictionary when the registry
+    /// has no entry for the symbol. The single-arg ctor preserves
+    /// the v1 behaviour for tests that construct the directory
+    /// directly without DI.
+    /// </summary>
+    public SymbolDirectory(SymbolDirectoryOptions options, MarketData.SecurityDefinitionRegistry? registry)
     {
         ArgumentNullException.ThrowIfNull(options);
+        _registry = registry;
         // Always copy to enforce case-insensitive comparison even if
         // the binder produced a culture-sensitive dictionary.
         var copy = new Dictionary<string, ulong>(StringComparer.OrdinalIgnoreCase);
@@ -201,6 +218,15 @@ public sealed class SymbolDirectory
         {
             spec = default;
             return false;
+        }
+        // OPT-D (#486): the SDK-driven SecurityDefinition projection
+        // wins over the static config. Bootstrap + delta semantics
+        // mean once a frame has been seen for the symbol the registry
+        // entry is authoritative; before the first frame (and when
+        // the kill-switch is set) we fall through to the config.
+        if (_registry is not null && _registry.TryGetSpec(symbol, out spec))
+        {
+            return true;
         }
         return _specs.TryGetValue(symbol, out spec!);
     }

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -36,8 +36,18 @@ public static class TradingRiskServiceCollectionExtensions
             configuration.GetSection(SubAccountRiskOptions.SectionName));
         services.Configure<SymbolDirectoryOptions>(
             configuration.GetSection(SymbolDirectoryOptions.SectionName));
+        // OPT-D (#486, refs #454 Fase 2). SecurityDefinitionRegistry
+        // is the projection target for SDK 0.5.0's SecurityDefinition
+        // channel. Registered as a singleton so the host adapter
+        // (writer) and SymbolDirectory (reader) share the same
+        // instance; tests that build SymbolDirectory directly without
+        // DI still get the v1 (config-only) behaviour because the
+        // ctor with no registry argument remains.
+        services.AddSingleton<B3.Trading.Application.MarketData.SecurityDefinitionRegistry>();
         services.AddSingleton(sp =>
-            new SymbolDirectory(sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value));
+            new SymbolDirectory(
+                sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value,
+                sp.GetService<B3.Trading.Application.MarketData.SecurityDefinitionRegistry>()));
 
         // #454 Fase 1. Per-symbol tick-size provider seam. Default impl
         // wraps the config-backed SymbolDirectory; Fase 2 will swap (or

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -1,4 +1,5 @@
 using B3.MarketData.WebSocketClient;
+using B3.Trading.Application;
 using B3.Trading.Application.MarketData;
 using B3.Trading.Domain;
 using Microsoft.Extensions.Logging;
@@ -44,6 +45,8 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
     private readonly ILogger<SdkMarketDataSubscriber> _logger;
     private readonly SubscribeFlags _subscribeFlags;
     private readonly bool _bookEnabled;
+    private readonly bool _securityDefinitionEnabled;
+    private readonly SecurityDefinitionRegistry? _securityDefinitionRegistry;
     private readonly AuctionProjector _auctionProjector;
 
     public event Action<AppTrade>? Trade;
@@ -74,14 +77,27 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
     public SdkMarketDataSubscriber(
         MarketDataClient client,
         ILogger<SdkMarketDataSubscriber> logger,
-        IOptions<MarketDataOptions> options)
+        IOptions<MarketDataOptions> options,
+        SecurityDefinitionRegistry? securityDefinitionRegistry = null)
     {
         _client = client;
         _logger = logger;
         _bookEnabled = options.Value.EnableBook;
-        _subscribeFlags = _bookEnabled
-            ? SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Book
-            : SubscribeFlags.Trades | SubscribeFlags.Info;
+        _securityDefinitionEnabled = options.Value.EnableSecurityDefinition
+            && securityDefinitionRegistry is not null;
+        _securityDefinitionRegistry = _securityDefinitionEnabled
+            ? securityDefinitionRegistry
+            : null;
+
+        // OPT-D (#486). SubscribeFlags.SecurityDefinition (0x20) ships
+        // in SDK 0.5.0 / pedrosakuma/B3MarketDataPlatform#55 — bootstrap
+        // + delta of tick / lot / contractMultiplier / option metadata
+        // per symbol, projected by OnSdkSecurityDefinition into the
+        // registry SymbolDirectory.TryGetSpec consults first.
+        var flags = SubscribeFlags.Trades | SubscribeFlags.Info;
+        if (_bookEnabled) flags |= SubscribeFlags.Book;
+        if (_securityDefinitionEnabled) flags |= SubscribeFlags.SecurityDefinition;
+        _subscribeFlags = flags;
 
         _auctionProjector = new AuctionProjector();
         _auctionProjector.TheoreticalOpening += ev => TheoreticalOpening?.Invoke(ev);
@@ -92,6 +108,10 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         _client.InfoSnapshot += OnSdkInfo;
         _client.ConnectionStateChanged += OnSdkConn;
         _client.SubscribeError += OnSdkSubErr;
+        if (_securityDefinitionEnabled)
+        {
+            _client.SecurityDefinition += OnSdkSecurityDefinition;
+        }
 
         // Note: when _bookEnabled is true the host registers SDK 0.4.0's
         // IBookFeed which subscribes to MarketDataClient.Book* events
@@ -128,6 +148,10 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         _client.InfoSnapshot -= OnSdkInfo;
         _client.ConnectionStateChanged -= OnSdkConn;
         _client.SubscribeError -= OnSdkSubErr;
+        if (_securityDefinitionEnabled)
+        {
+            _client.SecurityDefinition -= OnSdkSecurityDefinition;
+        }
         return _client.DisposeAsync();
     }
 
@@ -201,6 +225,42 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         // Balanced / Unknown / null → no pending side → no imbalance delta.
         _ => null,
     };
+
+    private void OnSdkSecurityDefinition(SecurityDefinitionEvent ev)
+    {
+        if (_securityDefinitionRegistry is null) return;
+        if (string.IsNullOrWhiteSpace(ev.Symbol)) return;
+
+        // tick: already a scaled decimal per SDK 0.5.0 contract
+        // (Fixed8 / 1e8 unwrapped by the client).
+        var tick = ev.MinPriceIncrement is { } t && t > 0m ? t : (decimal?)null;
+        // lot: shares (equity) or contracts (option), 1-based long.
+        var lot = ev.MinTradeVolume is { } l && l > 0 ? l : (long?)null;
+
+        // OPT-D translator lives in Application
+        // (SecurityDefinitionRegistry.TryProject) so it can be unit-
+        // tested without taking the SDK as a test-project dep. The
+        // host adapter passes primitives only.
+        var option = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: ev.ContractMultiplier,
+            maturityDate: ev.MaturityDate,
+            putOrCall: ev.PutOrCall,
+            exerciseStyle: ev.ExerciseStyle,
+            strikePrice: ev.StrikePrice,
+            priceDivisor: ev.PriceDivisor,
+            underlyingAsset: ev.Asset);
+        var securityType = option is null ? SecurityType.Equity : SecurityType.Option;
+
+        if (tick is null && lot is null && option is null) return;
+
+        var spec = new InstrumentSpec(tick, lot, TickLadder: null, securityType, option);
+        _securityDefinitionRegistry.Upsert(ev.Symbol, spec, ev.SecurityId);
+
+        _logger.LogDebug(
+            "SecurityDefinition upsert: Symbol={Symbol} SecurityId={SecurityId} Tick={Tick} Lot={Lot} SecurityType={SecurityType} ContractMultiplier={Multiplier}",
+            ev.Symbol, ev.SecurityId, tick, lot, securityType,
+            option is { } o ? o.ContractMultiplier : 1m);
+    }
 
     private void OnSdkConn(ConnectionStateChangedEvent ev) =>
         ConnectionStateChanged?.Invoke(Translate(ev.State));

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/SecurityDefinitionRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/SecurityDefinitionRegistryTests.cs
@@ -1,0 +1,109 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// OPT-D (#486, refs #454 Fase 2). The registry is the projection
+/// target for SDK 0.5.0's <c>SecurityDefinition</c> WebSocket
+/// channel. These tests pin the upsert + lookup contract; the
+/// SDK→registry translation lives in
+/// <c>B3.Trading.Host.MarketData.SdkMarketDataSubscriber</c> and is
+/// covered separately.
+/// </summary>
+public class SecurityDefinitionRegistryTests
+{
+    [Fact]
+    public void TryGetSpec_ReturnsFalse_WhenSymbolMissing()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        Assert.False(sut.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(default, spec);
+    }
+
+    [Fact]
+    public void TryGetSpec_ReturnsFalse_OnNullOrWhitespace()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        sut.Upsert("PETR4", new InstrumentSpec(TickSize: 0.01m, LotSize: 100), 4);
+        Assert.False(sut.TryGetSpec("", out _));
+        Assert.False(sut.TryGetSpec("   ", out _));
+        Assert.False(sut.TryGetSpec(null, out _));
+    }
+
+    [Fact]
+    public void Upsert_StoresSpec_AndIsCaseInsensitive()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        var spec = new InstrumentSpec(TickSize: 0.05m, LotSize: 10);
+        sut.Upsert("PETR4", spec, 4);
+
+        // Round-trip exact match
+        Assert.True(sut.TryGetSpec("PETR4", out var got));
+        Assert.Equal(0.05m, got.TickSize);
+        Assert.Equal(10, got.LotSize);
+
+        // Case-insensitive lookup — matches SymbolDirectory contract
+        Assert.True(sut.TryGetSpec("petr4", out var lower));
+        Assert.Equal(spec, lower);
+        Assert.True(sut.TryGetSpec("Petr4", out var mixed));
+        Assert.Equal(spec, mixed);
+    }
+
+    [Fact]
+    public void Upsert_ReplacesPreviousSpec_LastWriteWins()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        sut.Upsert("PETR4", new InstrumentSpec(TickSize: 0.01m, LotSize: 100), 4);
+        sut.Upsert("PETR4", new InstrumentSpec(TickSize: 0.02m, LotSize: 50), 4);
+
+        Assert.True(sut.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.02m, spec.TickSize);
+        Assert.Equal(50, spec.LotSize);
+        Assert.Equal(1, sut.Count);
+    }
+
+    [Fact]
+    public void Upsert_IsNoOp_WhenSymbolIsBlank()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        sut.Upsert("", new InstrumentSpec(0.01m, 100), 0);
+        sut.Upsert("   ", new InstrumentSpec(0.01m, 100), 0);
+        Assert.Equal(0, sut.Count);
+    }
+
+    [Fact]
+    public void TryGetSecurityId_RoundTrips_AndIsCaseInsensitive()
+    {
+        var sut = new SecurityDefinitionRegistry();
+        sut.Upsert("PETR4", new InstrumentSpec(0.01m, 100), 4);
+        Assert.True(sut.TryGetSecurityId("petr4", out var id));
+        Assert.Equal(4UL, id);
+
+        Assert.False(sut.TryGetSecurityId("UNKNOWN", out var unknown));
+        Assert.Equal(0UL, unknown);
+        Assert.False(sut.TryGetSecurityId("", out _));
+    }
+
+    [Fact]
+    public void Upsert_IsThreadSafe_UnderConcurrentWriters()
+    {
+        // SDK callback path is single-threaded but registry's
+        // contract allows concurrent writers per the doc; this test
+        // pins that invariant so a future SDK change (or a parallel
+        // bootstrap path) doesn't silently corrupt the dictionary.
+        var sut = new SecurityDefinitionRegistry();
+        Parallel.For(0, 200, i =>
+        {
+            var sym = "SYM" + (i % 20);
+            sut.Upsert(sym, new InstrumentSpec(0.01m * (i % 20 + 1), i + 1), (ulong)i);
+        });
+
+        Assert.Equal(20, sut.Count);
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.True(sut.TryGetSpec("SYM" + i, out var spec));
+            Assert.True(spec.TickSize > 0);
+        }
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/SecurityDefinitionTranslatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/SecurityDefinitionTranslatorTests.cs
@@ -1,0 +1,176 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// OPT-D (#486). Covers the SDK→OptionMetadata translation that
+/// projects raw SBE numerics from <c>SecurityDefinition_12</c> into
+/// the typed <see cref="OptionMetadata"/> the application risk
+/// pipeline consumes. Translator lives in Application (not Host) so
+/// these tests don't carry the SDK package dependency.
+/// </summary>
+public class SecurityDefinitionTranslatorTests
+{
+    [Fact]
+    public void TryProject_ReturnsNull_WhenMultiplierMissing()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: null, maturityDate: 20271231, putOrCall: 1,
+            exerciseStyle: 2, strikePrice: 200000, priceDivisor: 10000, underlyingAsset: "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_ReturnsNull_WhenMaturityMissing()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: 100, maturityDate: null, putOrCall: 1,
+            exerciseStyle: 2, strikePrice: 200000, priceDivisor: 10000, underlyingAsset: "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_ReturnsNull_WhenPutOrCallMissing()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: 100, maturityDate: 20271231, putOrCall: null,
+            exerciseStyle: 2, strikePrice: 200000, priceDivisor: 10000, underlyingAsset: "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_ReturnsNull_OnUnknownPutOrCall()
+    {
+        // Defensive: any value outside {0, 1} drops the option block
+        // (better no metadata than wrong P/C — a Put mis-projected as
+        // Call would mis-classify hedges).
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: 100, maturityDate: 20271231, putOrCall: 9,
+            exerciseStyle: 2, strikePrice: 200000, priceDivisor: 10000, underlyingAsset: "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_DefaultsExerciseToAmerican_WhenMissing()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: 100, maturityDate: 20271231, putOrCall: 1,
+            exerciseStyle: null, strikePrice: 200000, priceDivisor: 10000, underlyingAsset: "PETR");
+        Assert.NotNull(opt);
+        Assert.Equal(ExerciseStyle.American, opt!.Value.ExerciseStyle);
+    }
+
+    [Fact]
+    public void TryProject_MapsExerciseStyleCodes()
+    {
+        var american = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, exerciseStyle: 2, 200000, 10000, "PETR");
+        var european = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, exerciseStyle: 1, 200000, 10000, "PETR");
+        Assert.Equal(ExerciseStyle.American, american!.Value.ExerciseStyle);
+        Assert.Equal(ExerciseStyle.European, european!.Value.ExerciseStyle);
+    }
+
+    [Fact]
+    public void TryProject_ReturnsNull_OnUnknownExerciseStyle()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, exerciseStyle: 9, 200000, 10000, "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_ScalesStrikeByPriceDivisor()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, 2, strikePrice: 200000, priceDivisor: 10000, "PETR");
+        Assert.NotNull(opt);
+        Assert.Equal(20m, opt!.Value.StrikePrice);
+    }
+
+    [Fact]
+    public void TryProject_DefaultsPriceDivisor_To10000_WhenMissing()
+    {
+        // B3 default 4-decimal-place grid — venue routinely omits the
+        // PriceDivisor field on stable instruments.
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, 2, strikePrice: 350000, priceDivisor: null, "PETR");
+        Assert.NotNull(opt);
+        Assert.Equal(35m, opt!.Value.StrikePrice);
+    }
+
+    [Fact]
+    public void TryProject_StrikeIsZero_WhenStrikeMissing()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 0, 2, strikePrice: null, priceDivisor: 10000, "PETR");
+        Assert.NotNull(opt);
+        Assert.Equal(0m, opt!.Value.StrikePrice);
+    }
+
+    [Fact]
+    public void TryProject_ParsesMaturityYyyyMmDd_To_DateOnly()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, maturityDate: 20271231, 1, 2, 200000, 10000, "PETR");
+        Assert.NotNull(opt);
+        Assert.Equal(new DateOnly(2027, 12, 31), opt!.Value.ExpirationDate);
+    }
+
+    [Theory]
+    [InlineData(20270000L)] // month 0
+    [InlineData(20271300L)] // month 13
+    [InlineData(20270132L)] // day 32
+    [InlineData(19691231L)] // year < 1970
+    [InlineData(21010101L)] // year > 2100
+    [InlineData(20270230L)] // Feb 30 (calendar invalid)
+    public void TryProject_ReturnsNull_OnMalformedMaturity(long bad)
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, maturityDate: bad, 1, 2, 200000, 10000, "PETR");
+        Assert.Null(opt);
+    }
+
+    [Fact]
+    public void TryProject_HappyPath_PETRL200_Call_European()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            contractMultiplier: 100,
+            maturityDate: 20271015,
+            putOrCall: 1,
+            exerciseStyle: 1,
+            strikePrice: 200000,
+            priceDivisor: 10000,
+            underlyingAsset: "PETR");
+
+        Assert.NotNull(opt);
+        var o = opt!.Value;
+        Assert.Equal(100m, o.ContractMultiplier);
+        Assert.Equal(20m, o.StrikePrice);
+        Assert.Equal(PutOrCall.Call, o.PutOrCall);
+        Assert.Equal(ExerciseStyle.European, o.ExerciseStyle);
+        Assert.Equal(new DateOnly(2027, 10, 15), o.ExpirationDate);
+        Assert.Equal("PETR", o.UnderlyingSymbol);
+        Assert.Equal(OptPayoutType.Vanilla, o.OptPayoutType);
+    }
+
+    [Fact]
+    public void TryProject_HappyPath_PutLeg()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20281001, putOrCall: 0, exerciseStyle: 2, 250000, 10000, "VALE");
+        Assert.NotNull(opt);
+        Assert.Equal(PutOrCall.Put, opt!.Value.PutOrCall);
+        Assert.Equal("VALE", opt.Value.UnderlyingSymbol);
+    }
+
+    [Fact]
+    public void TryProject_NullUnderlying_DegradesToEmptyString()
+    {
+        var opt = SecurityDefinitionRegistry.TryProject(
+            100, 20271231, 1, 2, 200000, 10000, underlyingAsset: null);
+        Assert.NotNull(opt);
+        Assert.Equal(string.Empty, opt!.Value.UnderlyingSymbol);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryRegistryOverlayTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/SymbolDirectoryRegistryOverlayTests.cs
@@ -1,0 +1,106 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// OPT-D (#486, refs #454 Fase 2). When the directory is constructed
+/// with a <see cref="SecurityDefinitionRegistry"/> overlay,
+/// <see cref="SymbolDirectory.TryGetSpec(string?, out InstrumentSpec)"/>
+/// must consult the registry FIRST and only fall back to the
+/// operator-configured static dictionary on miss. The static-only
+/// ctor preserves the v1 behaviour (registry-less; tests that build
+/// the directory directly remain byte-identical).
+/// </summary>
+public class SymbolDirectoryRegistryOverlayTests
+{
+    private static SymbolDirectoryOptions OneSpec(string symbol, decimal tick, long lot) =>
+        new()
+        {
+            SecurityIds = { [symbol] = 4 },
+            Specs =
+            {
+                [symbol] = new InstrumentSpecOptions { TickSize = tick, LotSize = lot },
+            },
+        };
+
+    [Fact]
+    public void TryGetSpec_FallsBackToConfig_WhenRegistryEmpty()
+    {
+        var registry = new SecurityDefinitionRegistry();
+        var dir = new SymbolDirectory(OneSpec("PETR4", 0.01m, 100), registry);
+
+        Assert.True(dir.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.01m, spec.TickSize);
+        Assert.Equal(100, spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_RegistryWins_OverConfig()
+    {
+        var registry = new SecurityDefinitionRegistry();
+        // Config says tick=0.01 / lot=100; SDK frame says tick=0.05 /
+        // lot=10. Registry-wins semantics: venue truth replaces the
+        // hand-typed YAML wholesale (no field-level merge).
+        registry.Upsert("PETR4", new InstrumentSpec(TickSize: 0.05m, LotSize: 10), 4);
+        var dir = new SymbolDirectory(OneSpec("PETR4", 0.01m, 100), registry);
+
+        Assert.True(dir.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.05m, spec.TickSize);
+        Assert.Equal(10, spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_RegistryWins_EvenWhenRegistryHasOnlySomeFields()
+    {
+        // Even if the registry frame only carries tick (no lot, no
+        // option), it still wins as a whole. This is intentional —
+        // a partial SDK frame implies the venue's authoritative
+        // statement is "tick T, no other constraint". Merging field-
+        // by-field would silently keep stale operator overrides.
+        var registry = new SecurityDefinitionRegistry();
+        registry.Upsert("PETR4", new InstrumentSpec(TickSize: 0.05m, LotSize: null), 4);
+        var dir = new SymbolDirectory(OneSpec("PETR4", 0.01m, 100), registry);
+
+        Assert.True(dir.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.05m, spec.TickSize);
+        Assert.Null(spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_NoRegistry_BehavesAsV1()
+    {
+        // Backward-compat: the single-arg ctor (no registry) must
+        // continue to return the config-bound spec unchanged.
+        var dir = new SymbolDirectory(OneSpec("PETR4", 0.01m, 100));
+        Assert.True(dir.TryGetSpec("PETR4", out var spec));
+        Assert.Equal(0.01m, spec.TickSize);
+        Assert.Equal(100, spec.LotSize);
+    }
+
+    [Fact]
+    public void TryGetSpec_RegistryMiss_ConfigMiss_ReturnsFalse()
+    {
+        var registry = new SecurityDefinitionRegistry();
+        var dir = new SymbolDirectory(new SymbolDirectoryOptions(), registry);
+        Assert.False(dir.TryGetSpec("UNKNOWN", out _));
+    }
+
+    [Fact]
+    public void TryResolve_IsNotAffectedByRegistry()
+    {
+        // SecurityId resolution is still config-only on this PR — the
+        // registry exposes TryGetSecurityId for future wiring but the
+        // SymbolDirectory.TryResolve path stays bound to the static
+        // dictionary. Lock that in so a future overlay doesn't break
+        // the FIXP adapter's lookup.
+        var registry = new SecurityDefinitionRegistry();
+        registry.Upsert("DYNAMIC", new InstrumentSpec(0.01m, 100), 999);
+        var dir = new SymbolDirectory(OneSpec("PETR4", 0.01m, 100), registry);
+
+        Assert.True(dir.TryResolve("PETR4", out var id));
+        Assert.Equal(4UL, id);
+        Assert.False(dir.TryResolve("DYNAMIC", out var dyn));
+        Assert.Equal(0UL, dyn);
+    }
+}

--- a/docs/MARKET-DATA.md
+++ b/docs/MARKET-DATA.md
@@ -14,11 +14,26 @@ L3) events flow through the application after PR #286 (Stages A–C).
 - `SubscribeFlags.Book` — MBO order-by-order events
   (`OrderAdded` / `OrderUpdated` / `OrderDeleted` /
   `BookSnapshot` / `BookCleared`)
+- `SubscribeFlags.SecurityDefinition` — bootstrap + delta of
+  `SecurityDefinition_12` (tick, lot, contract multiplier, option
+  metadata). Projected by `SdkMarketDataSubscriber` into
+  `SecurityDefinitionRegistry`, which `SymbolDirectory.TryGetSpec`
+  consults before falling back to the operator-configured static
+  dictionary. Added in SDK 0.5.0 (#486 / upstream
+  `pedrosakuma/B3MarketDataPlatform#55`).
 
 The book flag is opt-in; the trading-host subscribes to it only
 when `Trading:MarketData:EnableBook` is `true`. With the flag off
 the host runs in legacy mode: no MBO events, Pegged algos fall
 back to last-trade for `PegRef.Mid`/`Best`.
+
+The `SecurityDefinition` flag is **opt-out**: enabled by default
+once the SDK is bumped past 0.5.0 because the OPT umbrella ships
+hundreds of option series per underlying and config-only entry is
+infeasible. Set `Trading:MarketData:EnableSecurityDefinition=false`
+as an emergency kill-switch — `SymbolDirectory` will then keep
+returning the static config values exclusively (legacy v1
+behaviour).
 
 ## Configuration
 
@@ -37,7 +52,15 @@ back to last-trade for `PegRef.Mid`/`Best`.
       // When true, includes SubscribeFlags.Book in the SDK
       // subscribe call so MBO events flow into MboBookStore.
       // Default: false.
-      "EnableBook": true
+      "EnableBook": true,
+
+      // OPT-D (#486). When true, includes
+      // SubscribeFlags.SecurityDefinition so the SDK pushes tick /
+      // lot / multiplier / option metadata per symbol; the host
+      // projects each frame into SecurityDefinitionRegistry which
+      // SymbolDirectory.TryGetSpec consults before falling back to
+      // static config. Default: true (kill-switch only).
+      "EnableSecurityDefinition": true
     }
   }
 }


### PR DESCRIPTION
## Why
Upstream `pedrosakuma/B3MarketDataPlatform#55` closed today with SDK **0.5.0** shipping `SubscribeFlags.SecurityDefinition` (0x20): venue now PUSHES tick, lot, contract multiplier and full option metadata per symbol over the market-data WebSocket. This is the gate identified in #486 / #454 Fase 2 for OPT support — each underlying lists hundreds of option series and hand-typing each spec in YAML is infeasible.

## What
- **SDK bump** `B3.MarketData.WebSocketClient` 0.4.0 → 0.5.0.
- **`SecurityDefinitionRegistry`** (new, Application): thread-safe `ConcurrentDictionary` projection target. Static helper `TryProject(...)` translates raw SBE numerics (PutOrCall 0/1, ExerciseStyle 1/2 with American default, StrikePrice scaled by PriceDivisor with 10000 fallback, MaturityDate YYYYMMDD) into typed `OptionMetadata` — kept in Application so it's unit-testable without an SDK package dep on the test project. Defensive: partial / malformed option blocks return `null` so the spec degrades to equity-like (tick + lot still propagate).
- **`SymbolDirectory`** gains optional registry overlay; `TryGetSpec` consults registry FIRST, falls back to config on miss. Single-arg ctor preserved → direct-construction test sites unchanged. **Registry-wins** semantics (no field-level merge): venue truth replaces config wholesale; emergency override = kill-switch.
- **`MarketDataOptions.EnableSecurityDefinition`** (default **true**, opt-out kill-switch).
- **`SdkMarketDataSubscriber`** subscribes when registry + flag are on; pushes every `SecurityDefinitionEvent` through `TryProject` + `Upsert`. Debug log per upsert.
- **DI** wiring + **docs/MARKET-DATA.md** updated.

## Local
- **33 new tests** (Application 1265/1265 +33, Api 500/500):
  - 7 `SecurityDefinitionRegistryTests` — upsert / case-insensitivity / last-write-wins / blank-symbol no-op / concurrent writers / SecurityId round-trip.
  - 6 `SymbolDirectoryRegistryOverlayTests` — registry-wins / fallback on miss / partial-spec replace / single-arg ctor unchanged / `TryResolve` unaffected.
  - 20 `SecurityDefinitionTranslatorTests` — min-viable validation, PutOrCall guard, ExerciseStyle codes + American default + unknown reject, StrikePrice/PriceDivisor scaling, YYYYMMDD parsing + malformed-date guards (Theory: month 0/13, day 32, pre-1970, post-2100, Feb 30), Put / Call happy paths.

Closes #486
Refs #454, refs #482