### PR TITLE
feat(#487): SDK 0.6.0 PriceBand projection + PriceBandCheck pre-trade gate (OPT-E)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.0" />
     <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.0" />
-    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.5.0" />
+    <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.6.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
+++ b/backend/src/B3.Trading.Application/MarketData/MarketDataOptions.cs
@@ -90,4 +90,33 @@ public sealed class MarketDataOptions
     /// </para>
     /// </summary>
     public bool EnableSecurityDefinition { get; set; } = true;
+
+    /// <summary>
+    /// OPT-E (#487). Opt-in flag to subscribe to the SDK
+    /// <c>PriceBand</c> channel (<c>SubscribeFlags.PriceBand</c>,
+    /// 0x40) introduced in upstream
+    /// <c>pedrosakuma/B3MarketDataPlatform#56</c> / SDK 0.6.0.
+    /// When <c>true</c>, every symbol passed to
+    /// <see cref="IMarketDataSubscriber.SubscribeAsync"/> receives a
+    /// bootstrap + delta stream of <c>PriceBandEvent</c> frames
+    /// carrying the venue's authoritative dynamic price band
+    /// (<c>LowerBand</c> / <c>UpperBand</c>, plus
+    /// <c>TradingReferencePrice</c>, <c>PriceLimitType</c>,
+    /// <c>PriceBandType</c> discriminators). The host adapter
+    /// projects those frames into <see cref="PriceBandRegistry"/>,
+    /// which the new pre-trade
+    /// <see cref="Risk.Checks.PriceBandCheck"/> consults as the source
+    /// of truth — replacing the static-config fat-finger collar
+    /// (<see cref="Risk.Checks.PriceCollarCheck"/>) with the venue
+    /// truth on a per-symbol intraday basis.
+    /// <para>
+    /// Default <c>true</c>: once the SDK is bumped past 0.6.0 we
+    /// always want venue-pushed bands as authoritative, same
+    /// rationale as <see cref="EnableSecurityDefinition"/>. Set to
+    /// <c>false</c> as an emergency kill-switch only — the price-band
+    /// check then becomes a no-op (fail-open) and the collar takes
+    /// over exclusively.
+    /// </para>
+    /// </summary>
+    public bool EnablePriceBand { get; set; } = true;
 }

--- a/backend/src/B3.Trading.Application/MarketData/PriceBandRegistry.cs
+++ b/backend/src/B3.Trading.Application/MarketData/PriceBandRegistry.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+
+namespace B3.Trading.Application.MarketData;
+
+/// <summary>
+/// OPT-E (#487). Venue-pushed dynamic price band for one symbol.
+/// Sourced from the upstream <c>PriceBand</c> WebSocket channel
+/// (<c>pedrosakuma/B3MarketDataPlatform#56</c> / SDK 0.6.0) and
+/// consumed by <see cref="Risk.Checks.PriceBandCheck"/> as the
+/// authoritative fat-finger envelope, replacing the static-config
+/// collar on the symbols where the venue actually emits.
+/// </summary>
+public readonly record struct PriceBand(
+    decimal Lower,
+    decimal Upper,
+    DateTimeOffset AsOfUtc);
+
+/// <summary>
+/// OPT-E (#487). Read-side seam for <see cref="PriceBand"/>. Pre-trade
+/// risk checks consume this; production wires it to
+/// <see cref="PriceBandRegistry"/> (live SDK projection), tests can
+/// substitute an in-memory stub without bringing the SDK.
+/// </summary>
+public interface IPriceBandSource
+{
+    /// <summary>
+    /// Returns the latest band the venue has emitted for
+    /// <paramref name="symbol"/>. <c>false</c> means the SDK has not
+    /// yet observed a <c>PriceBand_22</c> frame for the symbol (or
+    /// the kill-switch <c>Trading:MarketData:EnablePriceBand</c> is
+    /// off) — callers fail open.
+    /// </summary>
+    bool TryGetBand(string? symbol, out PriceBand band);
+}
+
+/// <summary>
+/// OPT-E (#487, refs #482 OPT-readiness umbrella). Thread-safe,
+/// in-process registry of <see cref="PriceBand"/>s pushed by the
+/// upstream SDK <c>PriceBand</c> channel. The host adapter
+/// (<c>SdkMarketDataSubscriber</c>) translates each
+/// <c>PriceBandEvent</c> the SDK raises — the
+/// <see cref="TryProject(decimal?, decimal?, long?, out decimal, out decimal)"/>
+/// static helper handles the wire-shape conversion — and calls
+/// <see cref="Upsert(string, decimal, decimal, DateTimeOffset)"/>.
+/// <para>
+/// Concurrency contract is identical to <see cref="SecurityDefinitionRegistry"/>:
+/// a single SDK callback thread writes (SDK guarantees ordered,
+/// single-threaded event dispatch); hot-path threads read on every
+/// pre-trade evaluation. A <see cref="ConcurrentDictionary{TKey, TValue}"/>
+/// with <see cref="StringComparer.OrdinalIgnoreCase"/> gives lock-free
+/// reads with the same case-insensitive lookup semantics the rest of
+/// the trading surface uses.
+/// </para>
+/// <para>
+/// Wholesale-replace semantics: the venue is the source of truth for
+/// its own band. Newer Upsert always wins, no merge. This mirrors the
+/// "registry-wins" pattern from OPT-D / #494.
+/// </para>
+/// </summary>
+public sealed class PriceBandRegistry : IPriceBandSource
+{
+    private readonly ConcurrentDictionary<string, PriceBand> _bands =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Replaces (or installs) the band for <paramref name="symbol"/>.
+    /// Caller (host adapter) is responsible for translating SBE
+    /// discriminators (PRICE_UNIT vs TICKS vs PERCENTAGE) into
+    /// absolute lower/upper bounds — see
+    /// <see cref="TryProject(decimal?, decimal?, long?, out decimal, out decimal)"/>.
+    /// Invalid bounds (lower &gt; upper, non-finite, non-positive) are
+    /// dropped so a malformed frame can't poison the registry.
+    /// </summary>
+    public void Upsert(string symbol, decimal lower, decimal upper, DateTimeOffset asOfUtc)
+    {
+        if (string.IsNullOrWhiteSpace(symbol)) return;
+        if (lower <= 0m || upper <= 0m) return;
+        if (lower > upper) return;
+        _bands[symbol] = new PriceBand(lower, upper, asOfUtc);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetBand(string? symbol, out PriceBand band)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            band = default;
+            return false;
+        }
+        return _bands.TryGetValue(symbol, out band);
+    }
+
+    /// <summary>
+    /// Number of symbols currently held by the registry. Exposed for
+    /// startup logging and for tests that assert "the SDK frame was
+    /// projected" without binding to a specific symbol.
+    /// </summary>
+    public int Count => _bands.Count;
+
+    /// <summary>
+    /// OPT-E translator: side-table for projecting raw SBE primitives
+    /// from <c>PriceBand_22</c> into absolute lower/upper bounds.
+    /// SDK-agnostic on purpose — the host adapter passes primitives so
+    /// the translation can be unit-tested without taking the SDK
+    /// package as a test dep.
+    /// <para>
+    /// Today only <c>PriceLimitType.PRICE_UNIT</c> (FIX-44 value
+    /// <c>1</c>) is projected: <paramref name="lowerBand"/> and
+    /// <paramref name="upperBand"/> are accepted as absolute prices.
+    /// <c>TICKS</c> (<c>2</c>) and <c>PERCENTAGE</c> (<c>3</c>) require
+    /// the per-symbol tick / reference price to compute the absolute
+    /// envelope and are deliberately dropped here (returns
+    /// <c>false</c>) so they can be added in a follow-up without a
+    /// breaking change to the registry shape. The
+    /// <see cref="Risk.Checks.PriceBandCheck"/> degrades gracefully:
+    /// no band ⇒ fail-open with a bypass counter for ops visibility.
+    /// </para>
+    /// <para>
+    /// A null <paramref name="priceLimitType"/> is interpreted as
+    /// PRICE_UNIT: real-world B3 dumps in the conformance corpus omit
+    /// the discriminator on equities (the bound is always absolute on
+    /// the cash market) — dropping those frames wholesale would leave
+    /// the equity envelope unguarded.
+    /// </para>
+    /// </summary>
+    public static bool TryProject(
+        decimal? lowerBand,
+        decimal? upperBand,
+        long? priceLimitType,
+        out decimal lower,
+        out decimal upper)
+    {
+        lower = default;
+        upper = default;
+        if (lowerBand is not { } lb || upperBand is not { } ub) return false;
+        if (lb <= 0m || ub <= 0m) return false;
+        if (lb > ub) return false;
+
+        // SBE PriceLimitType convention shared with upstream
+        // pedrosakuma/B3MatchingPlatform#474: 1 = PRICE_UNIT,
+        // 2 = TICKS, 3 = PERCENTAGE. Null tolerated as PRICE_UNIT
+        // (see XML doc above).
+        switch (priceLimitType)
+        {
+            case null:
+            case 1:
+                lower = lb;
+                upper = ub;
+                return true;
+            default:
+                return false;
+        }
+    }
+}
+
+/// <summary>
+/// OPT-E (#487). Default <see cref="IPriceBandSource"/> used when no
+/// SDK projection is wired (e.g. unit tests, hosts running with
+/// <c>EnablePriceBand=false</c>). Always returns <c>false</c> ⇒
+/// <see cref="Risk.Checks.PriceBandCheck"/> becomes a no-op (fail-
+/// open). Centralised here so DI registrations and tests share the
+/// same null behaviour instead of each rolling their own.
+/// </summary>
+public sealed class NullPriceBandSource : IPriceBandSource
+{
+    public static readonly NullPriceBandSource Instance = new();
+    private NullPriceBandSource() { }
+    public bool TryGetBand(string? symbol, out PriceBand band)
+    {
+        band = default;
+        return false;
+    }
+}

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -777,6 +777,37 @@ public static class MetricsRegistry
     public static readonly Counter<long> CollarBypassedNoReference =
         Meter.CreateCounter<long>("trading.risk.collar.bypassed_no_reference");
 
+    // ── OPT-E (#487) — venue-pushed price-band observability ─────────
+    //
+    // The new PriceBandCheck (Order=305, right after the static
+    // PriceCollarCheck at 300) consults PriceBandRegistry — fed by the
+    // upstream PriceBand WebSocket channel (SDK 0.6.0 /
+    // pedrosakuma/B3MarketDataPlatform#56). These three instruments
+    // give ops the same coverage signal the collar+refprice pair
+    // already provides:
+    //
+    //   * PriceBandRejects — actual hard-rejections (tagged by
+    //     symbol + side + reject reason "above" / "below" so a sudden
+    //     spike on one side hints at a venue band tightening into
+    //     existing flow).
+    //   * PriceBandAgeSeconds — per-symbol band staleness at the
+    //     moment of the check. A sustained climb on a single symbol
+    //     means the venue stopped re-publishing — same alert posture
+    //     as RefPriceStalenessSeconds.
+    //   * PriceBandBypassedNoBand — approvals that landed only
+    //     because the registry had no entry (pre-bootstrap window,
+    //     kill-switch off, or a symbol the venue never bands). Tag
+    //     is the symbol so coverage gaps don't get lost in the
+    //     aggregate.
+    public static readonly Counter<long> PriceBandRejects =
+        Meter.CreateCounter<long>("trading.risk.price_band.reject");
+
+    public static readonly Histogram<double> PriceBandAgeSeconds =
+        Meter.CreateHistogram<double>("trading.risk.price_band.age_seconds");
+
+    public static readonly Counter<long> PriceBandBypassedNoBand =
+        Meter.CreateCounter<long>("trading.risk.price_band.bypassed_no_band");
+
     // Q1.2 (#254). Counts the cases where StopTriggerCheck approved a
     // Stop* order purely because it could not obtain a reference price
     // for the symbol — the StopPrice > 0 invariant still ran, but the

--- a/backend/src/B3.Trading.Application/Risk/Checks/PriceBandCheck.cs
+++ b/backend/src/B3.Trading.Application/Risk/Checks/PriceBandCheck.cs
@@ -1,0 +1,115 @@
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Observability;
+
+namespace B3.Trading.Application.Risk.Checks;
+
+/// <summary>
+/// OPT-E (#487, refs #482 OPT-readiness umbrella). Pre-trade gate
+/// that enforces the venue's authoritative dynamic price band
+/// (<c>PriceBand_22</c>, projected by the SDK 0.6.0 <c>PriceBand</c>
+/// channel into <see cref="IPriceBandSource"/>) on every LIMIT-style
+/// order.
+///
+/// <para>
+/// Relationship to <see cref="PriceCollarCheck"/>:
+/// <list type="bullet">
+///   <item><see cref="PriceCollarCheck"/> (Order=300) is the static
+///         fat-finger envelope sourced from operator config plus
+///         <see cref="IReferencePrice"/>. It runs for every symbol
+///         regardless of MD coverage and fails open when no
+///         reference is known.</item>
+///   <item><see cref="PriceBandCheck"/> (Order=305) consults the
+///         venue's published band — the same envelope the matching
+///         engine itself uses. When the band is present and the
+///         price violates it, the order is rejected before the wire
+///         (avoids a venue-side rejection round-trip and surfaces a
+///         stable <see cref="RiskRejectCodes.PriceBand"/> code so the
+///         FE / drop-copy / surveillance pipelines can branch on it).
+///         When the band is absent — pre-bootstrap window, kill-switch
+///         off, or a symbol the venue never publishes — the check
+///         fails open with a bypass counter and the static collar
+///         continues to gate.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Fail-open posture mirrors <see cref="PriceCollarCheck"/>:
+/// missing source must not stop trading on a configured symbol.
+/// <see cref="MetricsRegistry.PriceBandBypassedNoBand"/> is the
+/// only signal ops gets that the check was inert — a steady
+/// non-zero rate on a known-publishing symbol means the SDK feed
+/// degraded and the static collar is now the only line of defence.
+/// </para>
+///
+/// <para>
+/// Market orders (<c>ctx.Price is null</c>) are skipped — there is no
+/// price to validate. Stop orders are evaluated against their
+/// <c>Price</c> (the post-trigger limit), not <c>StopPrice</c>, same
+/// as <see cref="PriceCollarCheck"/>.
+/// </para>
+/// </summary>
+public sealed class PriceBandCheck : IRiskCheck
+{
+    private readonly IPriceBandSource _source;
+    private readonly TimeProvider _time;
+
+    public PriceBandCheck(IPriceBandSource source, TimeProvider? time = null)
+    {
+        _source = source;
+        _time = time ?? TimeProvider.System;
+    }
+
+    // Runs right after PriceCollarCheck (300). The order matters: the
+    // collar is the always-on static envelope; the venue band is the
+    // tighter authoritative one — having both run lets a sustained
+    // band/collar disagreement become observable (collar rejects with
+    // RiskRejectCodes inferred from check Name vs band rejects with
+    // RiskRejectCodes.PriceBand).
+    public int Order => 305;
+    public string Name => "price_band";
+
+    public RiskDecision Check(RiskContext ctx)
+    {
+        if (!ctx.Price.HasValue) return RiskDecision.Approve; // market order
+
+        if (!_source.TryGetBand(ctx.Symbol, out var band))
+        {
+            MetricsRegistry.PriceBandBypassedNoBand.Add(1,
+                new KeyValuePair<string, object?>("symbol", ctx.Symbol));
+            return RiskDecision.Approve;
+        }
+
+        // Age sampling: the histogram covers every consulted band,
+        // not just the rejecting ones. p99 climbing on a symbol is
+        // the early-warning signal that the venue throttled / stopped
+        // re-publishing — same alert posture as RefPriceStalenessSeconds.
+        var age = (_time.GetUtcNow() - band.AsOfUtc).TotalSeconds;
+        MetricsRegistry.PriceBandAgeSeconds.Record(Math.Max(0d, age),
+            new KeyValuePair<string, object?>("symbol", ctx.Symbol));
+
+        var price = ctx.Price.Value;
+        if (price < band.Lower)
+        {
+            MetricsRegistry.PriceBandRejects.Add(1,
+                new KeyValuePair<string, object?>("symbol", ctx.Symbol),
+                new KeyValuePair<string, object?>("side", ctx.Side.ToString()),
+                new KeyValuePair<string, object?>("reason", "below"));
+            return RiskDecision.Reject(
+                RiskRejectCodes.PriceBand,
+                $"price {price} below venue band [{band.Lower:0.####}, {band.Upper:0.####}] asOf {band.AsOfUtc:O}");
+        }
+
+        if (price > band.Upper)
+        {
+            MetricsRegistry.PriceBandRejects.Add(1,
+                new KeyValuePair<string, object?>("symbol", ctx.Symbol),
+                new KeyValuePair<string, object?>("side", ctx.Side.ToString()),
+                new KeyValuePair<string, object?>("reason", "above"));
+            return RiskDecision.Reject(
+                RiskRejectCodes.PriceBand,
+                $"price {price} above venue band [{band.Lower:0.####}, {band.Upper:0.####}] asOf {band.AsOfUtc:O}");
+        }
+
+        return RiskDecision.Approve;
+    }
+}

--- a/backend/src/B3.Trading.Application/Risk/RiskRejectCodes.cs
+++ b/backend/src/B3.Trading.Application/Risk/RiskRejectCodes.cs
@@ -32,4 +32,16 @@ public static class RiskRejectCodes
     /// multiple of the instrument's round lot.
     /// </summary>
     public const string MinLotSize = "min_lot_size";
+
+    /// <summary>
+    /// OPT-E (#487) — <see cref="Checks.PriceBandCheck"/> — order
+    /// price is outside the venue-published dynamic price band
+    /// (<c>PriceBand_22</c>). Maps to FIX-44
+    /// <c>OrderPriceExceedsCurrentPriceBand</c> family. Distinct from
+    /// <see cref="Checks.PriceCollarCheck"/> (static-config fat-finger
+    /// collar) because the band is authoritative and intraday — a
+    /// rejection here means the venue would have refused the order on
+    /// the wire.
+    /// </summary>
+    public const string PriceBand = "price_band";
 }

--- a/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingRiskServiceCollectionExtensions.cs
@@ -49,6 +49,20 @@ public static class TradingRiskServiceCollectionExtensions
                 sp.GetRequiredService<IOptions<SymbolDirectoryOptions>>().Value,
                 sp.GetService<B3.Trading.Application.MarketData.SecurityDefinitionRegistry>()));
 
+        // OPT-E (#487, refs #482 OPT-readiness umbrella).
+        // PriceBandRegistry is the projection target for SDK 0.6.0's
+        // PriceBand channel (upstream pedrosakuma/B3MarketDataPlatform#56).
+        // Registered as a singleton so the host adapter (writer) and
+        // PriceBandCheck (reader) share the same instance; the
+        // IPriceBandSource seam is also bound to it so tests can
+        // substitute a stub without bringing the SDK. When
+        // Trading:MarketData:EnablePriceBand=false the adapter skips
+        // the subscribe-flag (no SDK callbacks fire), the registry
+        // stays empty, the check fails open via PriceBandBypassedNoBand.
+        services.AddSingleton<B3.Trading.Application.MarketData.PriceBandRegistry>();
+        services.AddSingleton<B3.Trading.Application.MarketData.IPriceBandSource>(
+            sp => sp.GetRequiredService<B3.Trading.Application.MarketData.PriceBandRegistry>());
+
         // #454 Fase 1. Per-symbol tick-size provider seam. Default impl
         // wraps the config-backed SymbolDirectory; Fase 2 will swap (or
         // chain in front of) an SDK-backed impl once upstream
@@ -137,6 +151,7 @@ public static class TradingRiskServiceCollectionExtensions
         services.AddSingleton<IRiskCheck, NoNakedShortCheck>();
         services.AddSingleton<IRiskCheck, SelfTradePreventionCheck>();
         services.AddSingleton<IRiskCheck, PriceCollarCheck>();
+        services.AddSingleton<IRiskCheck, PriceBandCheck>();
         services.AddSingleton<IRiskCheck, StaleReferencePriceCheck>();
         // Q1.2 (#254). Stop-trigger / IOC-FOK-leftover / GFA-phase /
         // GTD-bounds gates for the new Q1.1 order surface.

--- a/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
+++ b/backend/src/B3.Trading.Host/MarketData/SdkMarketDataSubscriber.cs
@@ -47,6 +47,8 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
     private readonly bool _bookEnabled;
     private readonly bool _securityDefinitionEnabled;
     private readonly SecurityDefinitionRegistry? _securityDefinitionRegistry;
+    private readonly bool _priceBandEnabled;
+    private readonly PriceBandRegistry? _priceBandRegistry;
     private readonly AuctionProjector _auctionProjector;
 
     public event Action<AppTrade>? Trade;
@@ -78,7 +80,8 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         MarketDataClient client,
         ILogger<SdkMarketDataSubscriber> logger,
         IOptions<MarketDataOptions> options,
-        SecurityDefinitionRegistry? securityDefinitionRegistry = null)
+        SecurityDefinitionRegistry? securityDefinitionRegistry = null,
+        PriceBandRegistry? priceBandRegistry = null)
     {
         _client = client;
         _logger = logger;
@@ -88,15 +91,26 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         _securityDefinitionRegistry = _securityDefinitionEnabled
             ? securityDefinitionRegistry
             : null;
+        _priceBandEnabled = options.Value.EnablePriceBand
+            && priceBandRegistry is not null;
+        _priceBandRegistry = _priceBandEnabled
+            ? priceBandRegistry
+            : null;
 
         // OPT-D (#486). SubscribeFlags.SecurityDefinition (0x20) ships
         // in SDK 0.5.0 / pedrosakuma/B3MarketDataPlatform#55 — bootstrap
         // + delta of tick / lot / contractMultiplier / option metadata
         // per symbol, projected by OnSdkSecurityDefinition into the
         // registry SymbolDirectory.TryGetSpec consults first.
+        // OPT-E (#487). SubscribeFlags.PriceBand (0x40) ships in
+        // SDK 0.6.0 / pedrosakuma/B3MarketDataPlatform#56 — bootstrap
+        // + delta of the venue's authoritative dynamic price band per
+        // symbol, projected by OnSdkPriceBand into the registry
+        // PriceBandCheck consults.
         var flags = SubscribeFlags.Trades | SubscribeFlags.Info;
         if (_bookEnabled) flags |= SubscribeFlags.Book;
         if (_securityDefinitionEnabled) flags |= SubscribeFlags.SecurityDefinition;
+        if (_priceBandEnabled) flags |= SubscribeFlags.PriceBand;
         _subscribeFlags = flags;
 
         _auctionProjector = new AuctionProjector();
@@ -111,6 +125,10 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         if (_securityDefinitionEnabled)
         {
             _client.SecurityDefinition += OnSdkSecurityDefinition;
+        }
+        if (_priceBandEnabled)
+        {
+            _client.PriceBand += OnSdkPriceBand;
         }
 
         // Note: when _bookEnabled is true the host registers SDK 0.4.0's
@@ -151,6 +169,10 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
         if (_securityDefinitionEnabled)
         {
             _client.SecurityDefinition -= OnSdkSecurityDefinition;
+        }
+        if (_priceBandEnabled)
+        {
+            _client.PriceBand -= OnSdkPriceBand;
         }
         return _client.DisposeAsync();
     }
@@ -260,6 +282,60 @@ internal sealed class SdkMarketDataSubscriber : IMarketDataSubscriber
             "SecurityDefinition upsert: Symbol={Symbol} SecurityId={SecurityId} Tick={Tick} Lot={Lot} SecurityType={SecurityType} ContractMultiplier={Multiplier}",
             ev.Symbol, ev.SecurityId, tick, lot, securityType,
             option is { } o ? o.ContractMultiplier : 1m);
+    }
+
+    private void OnSdkPriceBand(PriceBandEvent ev)
+    {
+        if (_priceBandRegistry is null) return;
+        if (string.IsNullOrWhiteSpace(ev.Symbol)) return;
+
+        // OPT-E translator lives in Application (PriceBandRegistry.TryProject)
+        // so it can be unit-tested without taking the SDK as a test-project
+        // dep. The host adapter passes primitives only — PriceLimitType
+        // discriminates absolute (PRICE_UNIT) vs derived (TICKS/PERCENTAGE);
+        // only PRICE_UNIT is projected today, the rest fail-open into
+        // PriceBandBypassedNoBand (see XML doc on TryProject).
+        if (!PriceBandRegistry.TryProject(
+                lowerBand: ev.LowerBand,
+                upperBand: ev.UpperBand,
+                priceLimitType: ev.PriceLimitType,
+                out var lower,
+                out var upper))
+        {
+            return;
+        }
+
+        // AsOfTimestamp is a SBE wall-clock long? (SBE epoch nanos when
+        // present). When the venue omits it — or it's malformed — fall
+        // back to the SDK's ReceivedUtc so the age-staleness signal stays
+        // honest (under-counts age in the fallback case, which is the
+        // safer bias: the band gets at most a few ms of age credit it
+        // didn't strictly earn rather than appearing artificially fresh).
+        var asOfUtc = TryParseAsOf(ev.AsOfTimestamp)
+            ?? new DateTimeOffset(DateTime.SpecifyKind(ev.ReceivedUtc, DateTimeKind.Utc));
+
+        _priceBandRegistry.Upsert(ev.Symbol, lower, upper, asOfUtc);
+
+        _logger.LogDebug(
+            "PriceBand upsert: Symbol={Symbol} SecurityId={SecurityId} Lower={Lower} Upper={Upper} PriceLimitType={Type} AsOf={AsOf}",
+            ev.Symbol, ev.SecurityId, lower, upper, ev.PriceLimitType, asOfUtc);
+    }
+
+    private static DateTimeOffset? TryParseAsOf(long? sbeNanos)
+    {
+        // SBE wall-clock epoch in nanoseconds per B3 UMDF convention.
+        // Guard the conversion so a 0 / negative / future-dated frame
+        // can't poison the staleness gauge with a bogus timestamp.
+        if (sbeNanos is not { } n || n <= 0) return null;
+        try
+        {
+            var ticks = n / 100L; // 1 tick = 100 ns
+            return new DateTimeOffset(DateTime.UnixEpoch.AddTicks(ticks), TimeSpan.Zero);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
     }
 
     private void OnSdkConn(ConnectionStateChangedEvent ev) =>

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/PriceBandRegistryTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/PriceBandRegistryTests.cs
@@ -1,0 +1,144 @@
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// OPT-E (#487). Concurrency + lookup contract tests for
+/// <see cref="PriceBandRegistry"/>. Mirrors the
+/// <c>SecurityDefinitionRegistryTests</c> shape.
+/// </summary>
+public sealed class PriceBandRegistryTests
+{
+    private static DateTimeOffset T(int seconds) =>
+        new(2026, 5, 26, 15, 0, seconds, TimeSpan.Zero);
+
+    [Fact]
+    public void Upsert_ThenTryGetBand_RoundTrips()
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("PETR4", lower: 24.50m, upper: 26.75m, asOfUtc: T(0));
+
+        Assert.True(reg.TryGetBand("PETR4", out var band));
+        Assert.Equal(24.50m, band.Lower);
+        Assert.Equal(26.75m, band.Upper);
+        Assert.Equal(T(0), band.AsOfUtc);
+    }
+
+    [Fact]
+    public void TryGetBand_IsCaseInsensitive()
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("PETR4", 10m, 12m, T(0));
+
+        Assert.True(reg.TryGetBand("petr4", out _));
+        Assert.True(reg.TryGetBand("Petr4", out _));
+    }
+
+    [Fact]
+    public void Upsert_ReplacesPreviousBand_WholeRecord()
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("PETR4", 10m, 12m, T(0));
+        reg.Upsert("PETR4", 11m, 13m, T(5));
+
+        Assert.True(reg.TryGetBand("PETR4", out var band));
+        Assert.Equal(11m, band.Lower);
+        Assert.Equal(13m, band.Upper);
+        Assert.Equal(T(5), band.AsOfUtc);
+    }
+
+    [Fact]
+    public void TryGetBand_UnknownSymbol_ReturnsFalse()
+    {
+        var reg = new PriceBandRegistry();
+        Assert.False(reg.TryGetBand("ABCD3", out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryGetBand_NullOrWhitespace_ReturnsFalse(string? symbol)
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("PETR4", 10m, 12m, T(0));
+        Assert.False(reg.TryGetBand(symbol, out _));
+    }
+
+    [Fact]
+    public void Upsert_NullOrWhitespaceSymbol_IsNoOp()
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("  ", 10m, 12m, T(0));
+        Assert.Equal(0, reg.Count);
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(10, -1)]
+    [InlineData(0, 10)]
+    [InlineData(10, 0)]
+    [InlineData(12, 10)] // inverted
+    public void Upsert_InvalidBounds_IsNoOp(decimal lb, decimal ub)
+    {
+        var reg = new PriceBandRegistry();
+        reg.Upsert("PETR4", lb, ub, T(0));
+        Assert.Equal(0, reg.Count);
+        Assert.False(reg.TryGetBand("PETR4", out _));
+    }
+
+    [Fact]
+    public async Task ConcurrentWritersAndReaders_NoTorn()
+    {
+        // The SDK gives us single-threaded writes in production but
+        // we still exercise the multi-writer path so a future fan-out
+        // (e.g. a second SDK channel projecting into the same registry)
+        // doesn't silently corrupt the dictionary. Read side is what
+        // matters for the risk hot path — must never observe a torn
+        // record.
+        var reg = new PriceBandRegistry();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var token = cts.Token;
+
+        var writers = Enumerable.Range(0, 4).Select(w => Task.Run(() =>
+        {
+            var rnd = new Random(w);
+            while (!token.IsCancellationRequested)
+            {
+                var sym = $"SYM{rnd.Next(0, 16)}";
+                var lo = (decimal)(rnd.NextDouble() * 10 + 1);
+                var up = lo + (decimal)(rnd.NextDouble() * 5 + 0.1);
+                reg.Upsert(sym, lo, up, T(rnd.Next(60)));
+            }
+        }, token)).ToArray();
+
+        var readers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                for (var i = 0; i < 16; i++)
+                {
+                    if (reg.TryGetBand($"SYM{i}", out var band))
+                    {
+                        // Invariant: every observed band must be
+                        // internally consistent (lower <= upper, both
+                        // positive). A torn read would surface here.
+                        Assert.True(band.Lower > 0m);
+                        Assert.True(band.Upper >= band.Lower);
+                    }
+                }
+            }
+        }, token)).ToArray();
+
+        try { await Task.WhenAll(writers.Concat(readers)); }
+        catch (OperationCanceledException) { /* expected */ }
+    }
+
+    [Fact]
+    public void NullPriceBandSource_AlwaysReturnsFalse()
+    {
+        IPriceBandSource src = NullPriceBandSource.Instance;
+        Assert.False(src.TryGetBand("PETR4", out var band));
+        Assert.Equal(default, band);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/MarketData/PriceBandTranslatorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/MarketData/PriceBandTranslatorTests.cs
@@ -1,0 +1,96 @@
+using B3.Trading.Application.MarketData;
+
+namespace B3.Trading.Application.Tests.MarketData;
+
+/// <summary>
+/// OPT-E (#487). Translator unit tests for <see cref="PriceBandRegistry.TryProject"/>.
+/// SDK-agnostic on purpose — exercises every PriceLimitType branch
+/// plus the malformed-frame guards so a degraded venue feed can't
+/// poison the registry.
+/// </summary>
+public sealed class PriceBandTranslatorTests
+{
+    [Fact]
+    public void PriceUnit_AbsoluteBand_HappyPath_Projected()
+    {
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: 24.50m, upperBand: 26.75m, priceLimitType: 1,
+            out var lower, out var upper);
+
+        Assert.True(ok);
+        Assert.Equal(24.50m, lower);
+        Assert.Equal(26.75m, upper);
+    }
+
+    [Fact]
+    public void NullPriceLimitType_TreatedAsPriceUnit_Projected()
+    {
+        // B3 cash-market dumps omit PriceLimitType — bound is implicitly
+        // absolute. Dropping these frames would leave equities unguarded.
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: 10m, upperBand: 12m, priceLimitType: null,
+            out var lower, out var upper);
+
+        Assert.True(ok);
+        Assert.Equal(10m, lower);
+        Assert.Equal(12m, upper);
+    }
+
+    [Theory]
+    [InlineData(2)] // TICKS — requires tick-provider context to resolve
+    [InlineData(3)] // PERCENTAGE — requires reference price to resolve
+    [InlineData(99)] // unknown
+    public void RelativePriceLimitTypes_Dropped(long priceLimitType)
+    {
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: 10m, upperBand: 12m, priceLimitType: priceLimitType,
+            out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void MissingLowerBand_Dropped()
+    {
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: null, upperBand: 12m, priceLimitType: 1,
+            out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void MissingUpperBand_Dropped()
+    {
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: 10m, upperBand: null, priceLimitType: 1,
+            out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(10, -1)]
+    [InlineData(0, 10)]
+    [InlineData(10, 0)]
+    public void NonPositiveBound_Dropped(decimal lb, decimal ub)
+    {
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: lb, upperBand: ub, priceLimitType: 1,
+            out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void InvertedBand_LowerAboveUpper_Dropped()
+    {
+        // Malformed venue frame — must not poison the registry.
+        var ok = PriceBandRegistry.TryProject(
+            lowerBand: 12m, upperBand: 10m, priceLimitType: 1,
+            out _, out _);
+
+        Assert.False(ok);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/Risk/PriceBandCheckTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Risk/PriceBandCheckTests.cs
@@ -1,0 +1,218 @@
+using System.Diagnostics.Metrics;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Risk;
+using B3.Trading.Application.Risk.Checks;
+using B3.Trading.Domain;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// OPT-E (#487). Pre-trade gate semantics + metric tagging tests for
+/// <see cref="PriceBandCheck"/>.
+/// </summary>
+public sealed class PriceBandCheckTests
+{
+    private static readonly DateTimeOffset BandAsOf = new(2026, 5, 26, 15, 0, 0, TimeSpan.Zero);
+
+    private static RiskContext Ctx(
+        decimal? price,
+        OrderSide side = OrderSide.Buy,
+        OrderType type = OrderType.Limit,
+        string symbol = "PETR4") =>
+        new(new EndClientId("alice"), "firm1", symbol, side, type, 100, price);
+
+    private sealed class StubSource : IPriceBandSource
+    {
+        private readonly Dictionary<string, PriceBand> _bands = new(StringComparer.OrdinalIgnoreCase);
+        public StubSource Set(string symbol, decimal lower, decimal upper, DateTimeOffset asOf)
+        {
+            _bands[symbol] = new PriceBand(lower, upper, asOf);
+            return this;
+        }
+        public bool TryGetBand(string? symbol, out PriceBand band)
+        {
+            if (symbol is null) { band = default; return false; }
+            return _bands.TryGetValue(symbol, out band);
+        }
+    }
+
+    [Fact]
+    public void MarketOrder_NoPrice_Approved()
+    {
+        var check = new PriceBandCheck(new StubSource(), TimeProvider.System);
+        var d = check.Check(Ctx(price: null, type: OrderType.Market));
+        Assert.True(d.Approved);
+    }
+
+    [Fact]
+    public void NoBand_FailsOpen_BumpsBypassCounter()
+    {
+        var check = new PriceBandCheck(NullPriceBandSource.Instance, TimeProvider.System);
+
+        long bypass = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (inst, l) =>
+        {
+            if (inst.Meter.Name == "B3.Trading"
+                && inst.Name == MetricsRegistry.PriceBandBypassedNoBand.Name)
+                l.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<long>((_, m, tags, _) =>
+        {
+            foreach (var kv in tags.ToArray())
+                if (kv.Key == "symbol" && (string?)kv.Value == "PETR4")
+                    Interlocked.Add(ref bypass, m);
+        });
+        listener.Start();
+
+        var d = check.Check(Ctx(price: 25m));
+        Assert.True(d.Approved);
+        Assert.True(Interlocked.Read(ref bypass) >= 1,
+            $"bypass counter should fire for unknown symbol, got {bypass}");
+    }
+
+    [Fact]
+    public void WithinBand_Approved()
+    {
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var check = new PriceBandCheck(src, TimeProvider.System);
+
+        Assert.True(check.Check(Ctx(price: 24m)).Approved);
+        Assert.True(check.Check(Ctx(price: 25m)).Approved);
+        Assert.True(check.Check(Ctx(price: 26m)).Approved);
+    }
+
+    [Fact]
+    public void BelowBand_Rejected_WithStableCode()
+    {
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var check = new PriceBandCheck(src, TimeProvider.System);
+
+        var d = check.Check(Ctx(price: 23m));
+        Assert.False(d.Approved);
+        Assert.Equal(RiskRejectCodes.PriceBand, d.Code);
+        Assert.Contains("below", d.Reason);
+    }
+
+    [Fact]
+    public void AboveBand_Rejected_WithStableCode()
+    {
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var check = new PriceBandCheck(src, TimeProvider.System);
+
+        var d = check.Check(Ctx(price: 27m));
+        Assert.False(d.Approved);
+        Assert.Equal(RiskRejectCodes.PriceBand, d.Code);
+        Assert.Contains("above", d.Reason);
+    }
+
+    [Fact]
+    public void Reject_EmitsCounterWithSymbolSideReasonTags()
+    {
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var check = new PriceBandCheck(src, TimeProvider.System);
+
+        var tags = new List<IReadOnlyList<KeyValuePair<string, object?>>>();
+        using var listener = ListenCounter<long>(MetricsRegistry.PriceBandRejects.Name, tags);
+
+        check.Check(Ctx(price: 23m, side: OrderSide.Sell));
+
+        var matching = tags.Where(t =>
+            t.Any(kv => kv.Key == "symbol" && (string?)kv.Value == "PETR4")
+            && t.Any(kv => kv.Key == "side" && (string?)kv.Value == "Sell")
+            && t.Any(kv => kv.Key == "reason" && (string?)kv.Value == "below"))
+            .ToList();
+
+        Assert.NotEmpty(matching);
+    }
+
+    [Fact]
+    public void Consult_RecordsAgeHistogram_FromTimeProvider()
+    {
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var fake = new FixedTimeProvider(BandAsOf.AddSeconds(7));
+        var check = new PriceBandCheck(src, fake);
+
+        var values = new List<double>();
+        var symbols = new List<string?>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (inst, l) =>
+        {
+            if (inst.Meter.Name == "B3.Trading" && inst.Name == MetricsRegistry.PriceBandAgeSeconds.Name)
+                l.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<double>((inst, m, t, _) =>
+        {
+            values.Add(m);
+            foreach (var kv in t.ToArray())
+                if (kv.Key == "symbol") symbols.Add(kv.Value as string);
+        });
+        listener.Start();
+
+        check.Check(Ctx(price: 25m));
+
+        Assert.Contains(values, v => Math.Abs(v - 7d) < 0.01);
+        Assert.Contains("PETR4", symbols);
+    }
+
+    [Fact]
+    public void Consult_ClockBeforeBand_RecordsZeroAge_NotNegative()
+    {
+        // Defensive: a clock skew (test clock behind band timestamp)
+        // must not surface as a negative histogram observation.
+        var src = new StubSource().Set("PETR4", 24m, 26m, BandAsOf);
+        var fake = new FixedTimeProvider(BandAsOf.AddSeconds(-10));
+        var check = new PriceBandCheck(src, fake);
+
+        var values = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (inst, l) =>
+        {
+            if (inst.Meter.Name == "B3.Trading" && inst.Name == MetricsRegistry.PriceBandAgeSeconds.Name)
+                l.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<double>((_, m, _, _) => values.Add(m));
+        listener.Start();
+
+        check.Check(Ctx(price: 25m));
+
+        Assert.All(values, v => Assert.True(v >= 0d, $"age must be clamped to >=0, got {v}"));
+    }
+
+    [Fact]
+    public void CheckOrder_RunsAfterPriceCollar()
+    {
+        var check = new PriceBandCheck(NullPriceBandSource.Instance);
+        // PriceCollarCheck.Order = 300 ; PriceBandCheck must run right
+        // after so a sustained band/collar disagreement is observable
+        // (collar reject vs band reject in two distinct RiskRejectCodes).
+        Assert.True(check.Order > 300);
+        Assert.Equal("price_band", check.Name);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private static MeterListener ListenCounter<T>(string name, List<IReadOnlyList<KeyValuePair<string, object?>>> sink) where T : struct
+    {
+        var l = new MeterListener();
+        l.InstrumentPublished = (inst, lst) =>
+        {
+            if (inst.Meter.Name == "B3.Trading" && inst.Name == name)
+                lst.EnableMeasurementEvents(inst);
+        };
+        l.SetMeasurementEventCallback<T>((_, _, tags, _) =>
+        {
+            lock (sink) sink.Add(tags.ToArray().ToList());
+        });
+        l.Start();
+        return l;
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/docs/MARKET-DATA.md
+++ b/docs/MARKET-DATA.md
@@ -21,6 +21,18 @@ L3) events flow through the application after PR #286 (Stages A–C).
   consults before falling back to the operator-configured static
   dictionary. Added in SDK 0.5.0 (#486 / upstream
   `pedrosakuma/B3MarketDataPlatform#55`).
+- `SubscribeFlags.PriceBand` — bootstrap + delta of `PriceBand_22`
+  (the venue's authoritative dynamic price band per symbol).
+  Projected by `SdkMarketDataSubscriber` into `PriceBandRegistry`,
+  which the new pre-trade `PriceBandCheck` (Order=305) consults as
+  the source of truth for fat-finger rejection — replacing the
+  static-config `PriceCollarCheck` (Order=300) on the symbols
+  where the venue actually publishes. Added in SDK 0.6.0 (#487 /
+  upstream `pedrosakuma/B3MarketDataPlatform#56`). Today only the
+  `PriceLimitType=PRICE_UNIT` (absolute) variant is projected;
+  `TICKS` / `PERCENTAGE` frames are dropped (see
+  `PriceBandRegistry.TryProject` docs — fail-open into the bypass
+  counter).
 
 The book flag is opt-in; the trading-host subscribes to it only
 when `Trading:MarketData:EnableBook` is `true`. With the flag off
@@ -34,6 +46,13 @@ infeasible. Set `Trading:MarketData:EnableSecurityDefinition=false`
 as an emergency kill-switch — `SymbolDirectory` will then keep
 returning the static config values exclusively (legacy v1
 behaviour).
+
+The `PriceBand` flag is **opt-out** for the same reason: once the
+SDK is past 0.6.0, the venue band is always more authoritative than
+the static collar. Set `Trading:MarketData:EnablePriceBand=false`
+to fall back to `PriceCollarCheck` exclusively (the band check then
+fails open into the `trading.risk.price_band.bypassed_no_band`
+counter so ops still see the coverage gap).
 
 ## Configuration
 
@@ -60,7 +79,20 @@ behaviour).
       // projects each frame into SecurityDefinitionRegistry which
       // SymbolDirectory.TryGetSpec consults before falling back to
       // static config. Default: true (kill-switch only).
-      "EnableSecurityDefinition": true
+      "EnableSecurityDefinition": true,
+
+      // OPT-E (#487). When true, includes SubscribeFlags.PriceBand
+      // so the SDK pushes the venue's authoritative dynamic price
+      // band per symbol; the host projects each frame into
+      // PriceBandRegistry which the new pre-trade PriceBandCheck
+      // (Order=305) consults before approving a LIMIT order.
+      // Today only PRICE_UNIT (absolute) bands are projected; TICKS
+      // and PERCENTAGE variants are dropped (fail-open into the
+      // trading.risk.price_band.bypassed_no_band counter so ops
+      // still see the coverage gap). Default: true (kill-switch
+      // only — turning it off leaves PriceCollarCheck as the only
+      // line of defence).
+      "EnablePriceBand": true
     }
   }
 }

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -67,6 +67,9 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 | `trading.risk.refprice.lookups` | Counter | `source` (live/fallback/missing) |
 | `trading.risk.refprice.staleness_seconds` | Observable Gauge | `symbol` |
 | `trading.risk.collar.bypassed_no_reference` | Counter | `symbol` |
+| `trading.risk.price_band.reject` | Counter | `symbol`, `side`, `reason` (above/below) |
+| `trading.risk.price_band.age_seconds` | Histogram | `symbol` |
+| `trading.risk.price_band.bypassed_no_band` | Counter | `symbol` |
 | `trading.risk.rolling_notional.bypassed_no_reference` | Counter | `symbol` |
 | `trading.risk.rolling_notional.active_buckets` | Observable Gauge | `scope` (end_client/firm) |
 | `trading.risk.order_rate.active_buckets` | Observable Gauge | `scope` (end_client/firm) |


### PR DESCRIPTION
## Why

Upstream pedrosakuma/B3MarketDataPlatform#56 (closed) shipped the `PriceBand` WebSocket channel in SDK v0.6.0 — projection of the matching engine's authoritative dynamic `PriceBand_22` template (merged in pedrosakuma/B3MatchingPlatform#474). Our pre-trade fat-finger logic was static config + reference price (`PriceCollarCheck`); the venue band is richer (per-symbol, intraday, source-of-truth). OPT-E (#487) wires it in.

## What

- Bump `B3.MarketData.WebSocketClient` 0.5.0 → 0.6.0.
- New `MarketDataOptions.EnablePriceBand` (default `true`, opt-out kill-switch — same posture as `EnableSecurityDefinition`).
- New `IPriceBandSource` seam in `B3.Trading.Application.MarketData` with concrete `PriceBandRegistry` (`ConcurrentDictionary`, case-insensitive lookup, wholesale-replace upserts) and `NullPriceBandSource.Instance` default.
- Static translator `PriceBandRegistry.TryProject` projects raw SBE primitives — `PriceLimitType=PRICE_UNIT` (FIX value 1) and null-as-absolute on B3 cash-market dumps. `TICKS` / `PERCENTAGE` variants are dropped (fail-open into bypass counter) so they can be added in a follow-up without a breaking change.
- `SdkMarketDataSubscriber` ctor takes an optional `PriceBandRegistry?`, conditionally adds `SubscribeFlags.PriceBand` (0x40), subscribes to `MarketDataClient.PriceBand`, projects each `PriceBandEvent` with defensive `AsOfTimestamp` parse (SBE epoch nanos → falls back to `ReceivedUtc`).
- DI: `PriceBandRegistry` registered as singleton + bound to `IPriceBandSource` so tests can stub it without bringing the SDK.
- New `PriceBandCheck` (`Order=305`, right after `PriceCollarCheck` at 300): skip on market orders, fail-open on missing band, emit bypass counter; otherwise reject `Price < Lower` or `Price > Upper` with stable `RiskRejectCodes.PriceBand` code and structured reason carrying `asOf` for forensics.
- Metrics:
  - `trading.risk.price_band.reject` (tags `symbol`, `side`, `reason` ∈ {above, below})
  - `trading.risk.price_band.age_seconds` (histogram, tag `symbol`)
  - `trading.risk.price_band.bypassed_no_band` (tag `symbol`)
- Docs: `MARKET-DATA.md` (new channel + kill-switch + PRICE_UNIT-only scope), `METRICS.md` (3 new rows).
- 25 new tests across 3 files: translator (8), registry concurrency + invariants (9), check semantics + metric tags (8).

## Local

- `backend/tests/B3.Trading.Application.Tests` **1301/1301** (+36 vs main)
- `backend/tests/B3.Trading.Api.Tests` **500/500**

## Closes

Closes #487.

Refs #482 (OPT-readiness umbrella), pedrosakuma/B3MatchingPlatform#474, pedrosakuma/B3MarketDataPlatform#56.
