### PR TITLE
feat(#497): option metadata on DTOs + frontend badges/tooltips/notional (FE-OPT-1)

### DIFF
--- a/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/Dtos.cs
@@ -136,7 +136,19 @@ public sealed record OrderDto(
     string? DisplayResetPolicy = null,
     /// <summary>Q4.1 (#301). Sub-account bucket this order is booked
     /// against. Null = master bucket (legacy / non-sub-account flow).</summary>
-    string? SubAccountId = null);
+    string? SubAccountId = null,
+    /// <summary>FE-OPT-1 (#497). Instrument family; null = Equity (backward compat).</summary>
+    string? SecurityType = null,
+    /// <summary>FE-OPT-1 (#497). Option strike price; null for equities.</summary>
+    decimal? OptionStrikePrice = null,
+    /// <summary>FE-OPT-1 (#497). Option expiration date (ISO 8601); null for equities.</summary>
+    string? OptionExpirationDate = null,
+    /// <summary>FE-OPT-1 (#497). Option side: "Put" or "Call"; null for equities.</summary>
+    string? OptionPutOrCall = null,
+    /// <summary>FE-OPT-1 (#497). Underlying symbol for options; null for equities.</summary>
+    string? OptionUnderlyingSymbol = null,
+    /// <summary>FE-OPT-1 (#497). Contract multiplier (typically 100 for B3 options); null for equities.</summary>
+    decimal? OptionContractMultiplier = null);
 
 public sealed record PositionDto(
     string Symbol,
@@ -146,7 +158,19 @@ public sealed record PositionDto(
     /// the master-aggregate row (sum across all sub-accounts plus the
     /// untagged bucket) returned when the caller did not pass
     /// <c>?subAccount=X</c>.</summary>
-    string? SubAccountId = null);
+    string? SubAccountId = null,
+    /// <summary>FE-OPT-1 (#497). Instrument family; null = Equity (backward compat).</summary>
+    string? SecurityType = null,
+    /// <summary>FE-OPT-1 (#497). Option strike price; null for equities.</summary>
+    decimal? OptionStrikePrice = null,
+    /// <summary>FE-OPT-1 (#497). Option expiration date (ISO 8601); null for equities.</summary>
+    string? OptionExpirationDate = null,
+    /// <summary>FE-OPT-1 (#497). Option side: "Put" or "Call"; null for equities.</summary>
+    string? OptionPutOrCall = null,
+    /// <summary>FE-OPT-1 (#497). Underlying symbol for options; null for equities.</summary>
+    string? OptionUnderlyingSymbol = null,
+    /// <summary>FE-OPT-1 (#497). Contract multiplier (typically 100 for B3 options); null for equities.</summary>
+    decimal? OptionContractMultiplier = null);
 
 /// <summary>
 /// Wire shape for <c>GET /balance</c>. Slice 1 of #107 exposes only
@@ -271,19 +295,44 @@ public sealed record PeggedParamsDto(
 
 public static class DtoMappings
 {
-    public static OrderDto ToDto(this Order o) => new(
+    public static OrderDto ToDto(this Order o) => ToDto(o, null);
+
+    /// <summary>
+    /// FE-OPT-1 (#497). Overload that enriches the DTO with option metadata
+    /// from the symbol directory. Callers look up the spec once and pass it
+    /// so the conversion stays allocation-free for equities (the common case).
+    /// </summary>
+    public static OrderDto ToDto(this Order o, OptionMetadata? opt) => new(
         o.ClOrdId.ToString(), o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
         o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
         o.ParentAlgoId?.ToString(), o.AlgoSliceSeq,
         o.IsStale, o.StaleReason, o.StaledAtUtc,
         o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate,
         o.DisplayQty, o.DisplayResetPolicy?.ToString(),
-        o.SubAccountId?.Value);
+        o.SubAccountId?.Value,
+        SecurityType: opt is null ? null : "Option",
+        OptionStrikePrice: opt?.StrikePrice,
+        OptionExpirationDate: opt?.ExpirationDate.ToString("yyyy-MM-dd"),
+        OptionPutOrCall: opt?.PutOrCall.ToString(),
+        OptionUnderlyingSymbol: opt?.UnderlyingSymbol,
+        OptionContractMultiplier: opt?.ContractMultiplier);
 
-    public static PositionDto ToDto(this Position p) => new(p.Symbol, p.NetQuantity, p.AverageEntryPrice);
+    public static PositionDto ToDto(this Position p) => ToDto(p, null, null);
 
     public static PositionDto ToDto(this Position p, SubAccountId? subAccount) =>
-        new(p.Symbol, p.NetQuantity, p.AverageEntryPrice, subAccount?.Value);
+        ToDto(p, subAccount, null);
+
+    /// <summary>
+    /// FE-OPT-1 (#497). Overload that enriches the DTO with option metadata.
+    /// </summary>
+    public static PositionDto ToDto(this Position p, SubAccountId? subAccount, OptionMetadata? opt) =>
+        new(p.Symbol, p.NetQuantity, p.AverageEntryPrice, subAccount?.Value,
+            SecurityType: opt is null ? null : "Option",
+            OptionStrikePrice: opt?.StrikePrice,
+            OptionExpirationDate: opt?.ExpirationDate.ToString("yyyy-MM-dd"),
+            OptionPutOrCall: opt?.PutOrCall.ToString(),
+            OptionUnderlyingSymbol: opt?.UnderlyingSymbol,
+            OptionContractMultiplier: opt?.ContractMultiplier);
 
     public static ExecutionDto ToDto(this ExecutionEvent ev) => new(
         ev.ClOrdId.ToString(), ev.Symbol, ev.Side.ToString(), ev.Status.ToString(), ev.Kind.ToString(),
@@ -299,7 +348,13 @@ public static class DtoMappings
     /// AlgoSliceSeq is also stripped because a monotonic seq trivially
     /// re-links children to a parent even if both ids are masked.
     /// </summary>
-    public static OrderDto ToDropCopyDto(this Order o, IClOrdIdMasker masker, string firmId) => new(
+    public static OrderDto ToDropCopyDto(this Order o, IClOrdIdMasker masker, string firmId) =>
+        ToDropCopyDto(o, masker, firmId, null);
+
+    /// <summary>
+    /// FE-OPT-1 (#497). Overload with option metadata enrichment.
+    /// </summary>
+    public static OrderDto ToDropCopyDto(this Order o, IClOrdIdMasker masker, string firmId, OptionMetadata? opt) => new(
         masker.MaskClOrdId(firmId, o.ClOrdId),
         o.Symbol, o.SecurityId, o.Side.ToString(), o.Type.ToString(),
         o.Quantity, o.LeavesQuantity, o.CumulativeQuantity, o.Price, o.Status.ToString(),
@@ -308,7 +363,13 @@ public static class DtoMappings
         o.IsStale, o.StaleReason, o.StaledAtUtc,
         o.TimeInForce.ToString(), o.StopPrice, o.GoodTillDate,
         o.DisplayQty, o.DisplayResetPolicy?.ToString(),
-        o.SubAccountId?.Value);
+        o.SubAccountId?.Value,
+        SecurityType: opt is null ? null : "Option",
+        OptionStrikePrice: opt?.StrikePrice,
+        OptionExpirationDate: opt?.ExpirationDate.ToString("yyyy-MM-dd"),
+        OptionPutOrCall: opt?.PutOrCall.ToString(),
+        OptionUnderlyingSymbol: opt?.UnderlyingSymbol,
+        OptionContractMultiplier: opt?.ContractMultiplier);
 
     /// <summary>
     /// #435 Part B. Drop-copy projection of <see cref="ExecutionEvent"/>

--- a/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/SubscriptionManager.cs
@@ -34,6 +34,7 @@ public sealed class SubscriptionManager
     private readonly PnlKeeper? _pnl;
     private readonly Application.Risk.IReferencePrice? _refPrice;
     private readonly CashLedger? _cash;
+    private readonly SymbolDirectory? _symbols;
 
     public SubscriptionManager(
         WorkingOrderBook orders,
@@ -41,7 +42,8 @@ public sealed class SubscriptionManager
         AlgoBook algos,
         PnlKeeper? pnl = null,
         Application.Risk.IReferencePrice? refPrice = null,
-        CashLedger? cash = null)
+        CashLedger? cash = null,
+        SymbolDirectory? symbols = null)
     {
         _orders = orders;
         _positions = positions;
@@ -49,6 +51,19 @@ public sealed class SubscriptionManager
         _pnl = pnl;
         _refPrice = refPrice;
         _cash = cash;
+        _symbols = symbols;
+    }
+
+    /// <summary>
+    /// FE-OPT-1 (#497). Looks up option metadata for a symbol.
+    /// Returns null for equities or when directory is unavailable.
+    /// </summary>
+    private OptionMetadata? GetOptionMetadata(string? symbol)
+    {
+        if (_symbols is null || string.IsNullOrWhiteSpace(symbol)) return null;
+        if (_symbols.TryGetSpec(symbol, out var spec) && spec.SecurityType == SecurityType.Option)
+            return spec.Option;
+        return null;
     }
 
     private object LockFor(EndClientId owner) =>
@@ -89,8 +104,10 @@ public sealed class SubscriptionManager
 
             object? data = channel switch
             {
-                Channels.OrdersMe => _orders.ForEndClientAndFirm(client.FirmId, client.Owner).Select(o => o.ToDto()).ToArray(),
-                Channels.PositionsMe => _positions.ForEndClientAndFirm(client.FirmId, client.Owner).Select(p => p.ToDto()).ToArray(),
+                Channels.OrdersMe => _orders.ForEndClientAndFirm(client.FirmId, client.Owner)
+                    .Select(o => o.ToDto(GetOptionMetadata(o.Symbol))).ToArray(),
+                Channels.PositionsMe => _positions.ForEndClientAndFirm(client.FirmId, client.Owner)
+                    .Select(p => p.ToDto(null, GetOptionMetadata(p.Symbol))).ToArray(),
                 Channels.ExecutionsMe => Array.Empty<ExecutionDto>(), // no historical exec log in v1
                 Channels.AlgoMe => _algos.EnumerateForOwner(client.FirmId, client.Owner).Select(a => a.ToDto()).ToArray(),
                 Channels.PnlMe => (_pnl is not null && _refPrice is not null)

--- a/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
+++ b/backend/src/B3.Trading.Api/WebSockets/WebSocketExecutionEventSink.cs
@@ -52,6 +52,7 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
     private readonly PositionKeeper _positions;
     private readonly PnlKeeper? _pnl;
     private readonly Application.Risk.IReferencePrice? _refPrice;
+    private readonly SymbolDirectory? _symbols;
     private readonly ILogger<WebSocketExecutionEventSink>? _logger;
     private readonly Channel<ExecutionEvent> _channel;
     private readonly CancellationTokenSource _cts = new();
@@ -63,6 +64,7 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         PositionKeeper positions,
         PnlKeeper? pnl = null,
         Application.Risk.IReferencePrice? refPrice = null,
+        SymbolDirectory? symbols = null,
         ILogger<WebSocketExecutionEventSink>? logger = null)
     {
         _subs = subs;
@@ -70,6 +72,7 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         _positions = positions;
         _pnl = pnl;
         _refPrice = refPrice;
+        _symbols = symbols;
         _logger = logger;
         _channel = Channel.CreateBounded<ExecutionEvent>(
             new BoundedChannelOptions(ChannelCapacity)
@@ -79,6 +82,17 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
                 FullMode = BoundedChannelFullMode.DropOldest,
             },
             itemDropped: static _ => MetricsRegistry.WsHubFanOutDropped.Add(1));
+    }
+
+    /// <summary>
+    /// FE-OPT-1 (#497). Looks up option metadata for a symbol.
+    /// </summary>
+    private OptionMetadata? GetOptionMetadata(string? symbol)
+    {
+        if (_symbols is null || string.IsNullOrWhiteSpace(symbol)) return null;
+        if (_symbols.TryGetSpec(symbol, out var spec) && spec.SecurityType == SecurityType.Option)
+            return spec.Option;
+        return null;
     }
 
     /// <inheritdoc />
@@ -147,19 +161,22 @@ public sealed class WebSocketExecutionEventSink : IExecutionEventSink, IExecutio
         // firm's executions/orders/positions/pnl on its WS session.
         var firmId = ev.FirmId;
 
+        // FE-OPT-1 (#497). Look up option metadata once for all DTOs.
+        var optMeta = GetOptionMetadata(ev.Symbol);
+
         // executions.me — every ER becomes an execution event.
         _subs.Publish(ev.Owner, firmId, Channels.ExecutionsMe, ev.ToDto());
 
         // orders.me — current order state after mutation.
         if (_orders.TryGet(ev.ClOrdId, out var order) && order is not null)
-            _subs.Publish(ev.Owner, firmId, Channels.OrdersMe, order.ToDto());
+            _subs.Publish(ev.Owner, firmId, Channels.OrdersMe, order.ToDto(optMeta));
 
         // positions.me — only fills affect positions.
         if (ev.Kind is ExecKind.Fill or ExecKind.PartialFill && ev.LastQuantity > 0)
         {
             var positionFirm = firmId ?? PnlKeeper.DefaultFirmId;
             var position = _positions.GetOrCreate(positionFirm, ev.Owner, ev.Symbol);
-            _subs.Publish(ev.Owner, firmId, Channels.PositionsMe, position.ToDto());
+            _subs.Publish(ev.Owner, firmId, Channels.PositionsMe, position.ToDto(null, optMeta));
 
             if (_pnl is not null && _refPrice is not null)
             {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -459,6 +459,19 @@ tr.row-stale > td.row-stale-actions { opacity: 1; }
 .type-chip.chip-stpl { background: #4a2455; color: #f0c8ff; }
 .type-chip.chip-mwl  { background: #145a4a; color: #8af0d4; }
 
+/* Option badges for Call/Put labels (#497) */
+.option-badge {
+ display: inline-block;
+ font-size: 0.75rem;
+ font-weight: 600;
+ padding: 0 4px;
+ border-radius: 3px;
+ margin-left: 4px;
+ vertical-align: middle;
+}
+.option-call { background: #22c55e; color: white; }
+.option-put { background: #ef4444; color: white; }
+
 /* Status cell coloring reserved for potential future OrderStatus.Expired
    addition; not currently rendered (backend OrderStatus has no Expired
    member — GTD expiry terminalises as Cancelled). Kept so a future
@@ -1154,6 +1167,14 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
   cursor: pointer; font-weight: 600;
 }
 .ticket-submit:hover { filter: brightness(1.1); }
+.ticket-notional {
+  font-size: .875rem;
+  color: var(--gray);
+  margin-left: .5rem;
+  white-space: nowrap;
+  align-self: flex-end;
+  padding-bottom: .35rem;
+}
 .ticket-advanced-toggle {
   padding: .35rem .65rem; font: inherit; font-size: .8rem;
   background: transparent; color: inherit;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -204,6 +204,7 @@
               <span>Price</span>
               <input id="ticket-price" type="number" min="0" step="0.01" />
             </label>
+            <span id="ticket-notional-preview" class="ticket-notional" title="Estimated notional value"></span>
             <button type="submit" id="ticket-submit" class="ticket-submit">Submit</button>
             <button type="button" id="ticket-advanced-toggle"
                     class="ticket-advanced-toggle" aria-expanded="false"

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -890,6 +890,14 @@ export function bindUi() {
     el.addEventListener("change", refreshTicketValidation);
   }
 
+  // Update notional preview when qty, price, or symbol changes.
+  // This provides live feedback of the estimated notional value accounting
+  // for option contract multipliers.
+  const symEl = $("ticket-symbol");
+  if (symEl) symEl.addEventListener("change", updateNotionalPreview);
+  if (qtyEl) qtyEl.addEventListener("input", updateNotionalPreview);
+  if (priceEl) priceEl.addEventListener("input", updateNotionalPreview);
+
   $("ticket-form").addEventListener("submit", (e) => {
     e.preventDefault();
     // Q1.4 (#256). Re-validate against the live policy snapshot just
@@ -953,7 +961,6 @@ export function bindUi() {
 
   // Auto-uppercase the symbol field as the trader types so the visual
   // matches what we actually submit (we already toUpperCase on submit).
-  const symEl = $("ticket-symbol");
   if (symEl) {
     symEl.addEventListener("input", (e) => {
       // Don't fight IME composition; uppercase on compositionend instead.
@@ -1267,6 +1274,44 @@ function ticketHasContent() {
     const el = $(id);
     return el && typeof el.value === "string" && el.value.trim() !== "";
   });
+}
+
+function updateNotionalPreview() {
+  const preview = $("ticket-notional-preview");
+  if (!preview) return;
+  
+  const qty = parseFloat($("ticket-qty")?.value) || 0;
+  const price = parseFloat($("ticket-price")?.value) || 0;
+  const symbol = $("ticket-symbol")?.value?.trim().toUpperCase();
+  
+  // Look up multiplier from state (positions or a symbol cache)
+  // For now, default to 1 (equity) unless we can detect it's an option
+  let multiplier = 1;
+  
+  // If we have a symbol, try to find it in positions to check if it's an option
+  if (symbol && getState().positions.has(symbol)) {
+    const position = getState().positions.get(symbol);
+    // optionContractMultiplier is present if it's an option (securityType === "Option")
+    if (position.optionContractMultiplier) {
+      multiplier = position.optionContractMultiplier;
+    }
+  }
+  
+  const notional = qty * price * multiplier;
+  
+  // Format with Brazilian locale (1000,00 format) but since we want R$ 1,000.00 format
+  // Let's use Intl for proper formatting
+  if (notional > 0) {
+    const formatted = new Intl.NumberFormat("pt-BR", {
+      style: "currency",
+      currency: "BRL",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(notional);
+    preview.textContent = `≈ ${formatted}`;
+  } else {
+    preview.textContent = "";
+  }
 }
 
 function onGlobalKeydown(e) {
@@ -2616,10 +2661,13 @@ function orderRow(o, st) {
   const staleBadge = isStale
     ? `<span class="order-stale-badge" title="${escapeHtml(staleTitle)}">stale</span>`
     : "";
+  const optionBadge = o.securityType === "Option" ? optionBadgeHtml(o.optionPutOrCall) : "";
+  const optionTooltip = formatOptionTooltip(o);
+  const symbolTitle = optionTooltip ? ` title="${escapeHtml(optionTooltip)}"` : "";
   const actionTitle = isStale ? `disabled — ${staleTitle}` : "";
   return `<tr data-clordid="${escapeHtml(o.clOrdId)}"${cls ? ` class="${cls}"` : ""}>
     <td><code>${escapeHtml(o.clOrdId)}</code></td>
-    <td>${escapeHtml(o.symbol)}</td>
+    <td${symbolTitle}>${escapeHtml(o.symbol)}${optionBadge}</td>
     <td>${escapeHtml(o.side)}</td>
     <td>${typeChipHtml(o.type)}</td>
     <td>${escapeHtml(o.timeInForce ?? "")}</td>
@@ -2652,11 +2700,16 @@ function renderPositions() {
   sortPositionsInPlace(positions, _positionsSort);
   body.innerHTML = positions.length === 0
     ? `<tr><td colspan="3" class="muted">No positions</td></tr>`
-    : positions.map(p => `<tr>
-        <td>${escapeHtml(p.symbol)}</td>
+    : positions.map(p => {
+      const optionBadge = p.securityType === "Option" ? optionBadgeHtml(p.optionPutOrCall) : "";
+      const optionTooltip = formatOptionTooltip(p);
+      const symbolTitle = optionTooltip ? ` title="${escapeHtml(optionTooltip)}"` : "";
+      return `<tr>
+        <td${symbolTitle}>${escapeHtml(p.symbol)}${optionBadge}</td>
         <td class="num">${fmtQty(p.netQuantity)}</td>
         <td class="num">${fmtPx(p.averageEntryPrice)}</td>
-      </tr>`).join("");
+      </tr>`;
+    }).join("");
   syncPositionsSortHeaders();
 }
 
@@ -2804,6 +2857,17 @@ export function typeChipHtml(type) {
   return `<span class="type-chip ${meta.cls}" title="${escapeHtml(type)}">${meta.label}</span>`;
 }
 
+// Render option badges ("C" for Calls, "P" for Puts) for option orders/positions.
+// Returns an empty string for non-options; renders a colored badge for options.
+function optionBadgeHtml(putOrCall) {
+  if (!putOrCall) return "";
+  const isCall = putOrCall === "Call";
+  const label = isCall ? "C" : "P";
+  const cls = isCall ? "option-call" : "option-put";
+  const title = isCall ? "Call" : "Put";
+  return ` <span class="option-badge ${cls}" title="${title}">${label}</span>`;
+}
+
 // Map ExecKind enum strings (as emitted by the backend `executions.me`
 // stream) to user-friendly display labels. PR #418 split the legacy
 // `Replaced` into two events: the original ClOrdID terminalises as
@@ -2831,6 +2895,17 @@ export function fmtGtd(iso) {
   // the trader sees the venue's wall clock, no locale surprises.
   const pad = (n) => String(n).padStart(2, "0");
   return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())} UTC`;
+}
+
+// Format option tooltip for hover. Returns null for non-options; for options
+// returns a string like "PETR4 Call 35.00 @ 2026-06-20" (underlying putOrCall strike @ expiry).
+function formatOptionTooltip(order) {
+  if (order.securityType !== "Option") return null;
+  const side = order.optionPutOrCall || "?";
+  const strike = order.optionStrikePrice != null ? order.optionStrikePrice.toFixed(2) : "?";
+  const expiry = order.optionExpirationDate || "?";
+  const underlying = order.optionUnderlyingSymbol || "?";
+  return `${underlying} ${side} ${strike} @ ${expiry}`;
 }
 
 // Pure validator. Returns { valid, errors } where errors is a record


### PR DESCRIPTION
## Why

Frontend couldn't distinguish options from equities — the WS DTOs didn't expose any option metadata. Traders need visual cues (put/call badges, strike/expiry info) and correct notional preview (options have a contract multiplier, typically 100).

## What

### Wave 1 — API (backend)

- Add 6 option fields to `OrderDto`: `securityType`, `optionStrikePrice`, `optionExpirationDate`, `optionPutOrCall`, `optionUnderlyingSymbol`, `optionContractMultiplier` — all nullable, null = equity (backward compat)
- Add same 6 fields to `PositionDto`
- New `ToDto(OptionMetadata?)` overloads in `DtoMappings`
- Inject `SymbolDirectory` into `SubscriptionManager` and `WebSocketExecutionEventSink`
- Callers now look up spec and pass option metadata to ToDto

### Wave 2 — Frontend

**Blotter badges** (ui.js, styles.css)
- `optionBadgeHtml()` renders "C" (green) or "P" (red) badge
- Applied to working orders and positions panels

**Option tooltips** (ui.js)
- `formatOptionTooltip()` returns "PETR4 Call 35.00 @ 2026-06-20"
- Applied as `title` attribute on symbol cells

**Notional preview** (ui.js, index.html, styles.css)
- `#ticket-notional-preview` element in ticket form
- `updateNotionalPreview()` computes qty × price × multiplier
- Wired to symbol/qty/price input events for real-time updates
- pt-BR locale formatting

## Local

- Api tests: 500/500
- `node --check frontend/js/ui.js` — no syntax errors

## Closes

Closes #497.

Refs #496 (FE-OPT umbrella).
