### PR TITLE
feat(frontend): option chain picker

### DIFF
--- a/backend/src/B3.Trading.Api/InstrumentsEndpoints.cs
+++ b/backend/src/B3.Trading.Api/InstrumentsEndpoints.cs
@@ -1,0 +1,76 @@
+using B3.Trading.Application;
+using B3.Trading.Application.MarketData;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace B3.Trading.Api;
+
+/// <summary>
+/// FE-OPT-2 (#498). Exposes the <see cref="SecurityDefinitionRegistry"/>
+/// for option chain lookup. The registry is populated by SDK events
+/// (see <c>SdkMarketDataSubscriber</c>); if the SDK hasn't projected any
+/// instruments yet, responses will be empty arrays.
+/// </summary>
+public static class InstrumentsEndpoints
+{
+    public static IEndpointRouteBuilder MapInstruments(this IEndpointRouteBuilder app)
+    {
+        // GET /instruments?underlying=PETR4 — returns options for that underlying
+        // GET /instruments?type=option — returns all options
+        // GET /instruments — returns all known instruments (options + equities)
+        app.MapGet("/instruments", [Authorize] (
+            SecurityDefinitionRegistry registry,
+            SymbolDirectory directory,
+            string? underlying,
+            string? type) =>
+        {
+            var optionsOnly = string.Equals(type, "option", StringComparison.OrdinalIgnoreCase);
+
+            // When underlying is specified, always filter to options
+            if (!string.IsNullOrWhiteSpace(underlying))
+                optionsOnly = true;
+
+            var results = registry.Enumerate(underlying, optionsOnly)
+                .Select(x => new InstrumentDto(
+                    x.Symbol,
+                    x.SecurityId,
+                    x.Spec.SecurityType.ToString(),
+                    x.Spec.TickSize,
+                    x.Spec.LotSize,
+                    x.Spec.Option?.StrikePrice,
+                    x.Spec.Option?.ExpirationDate.ToString("yyyy-MM-dd"),
+                    x.Spec.Option?.PutOrCall.ToString(),
+                    x.Spec.Option?.UnderlyingSymbol,
+                    x.Spec.Option?.ContractMultiplier))
+                .OrderBy(x => x.UnderlyingSymbol)
+                .ThenBy(x => x.ExpirationDate)
+                .ThenBy(x => x.StrikePrice)
+                .ThenBy(x => x.PutOrCall)
+                .ToArray();
+
+            return Results.Ok(results);
+        })
+        .WithName("GetInstruments")
+        .WithTags("Instruments");
+
+        return app;
+    }
+}
+
+/// <summary>
+/// FE-OPT-2 (#498). Wire shape for instrument metadata. Option-specific
+/// fields are null for equities.
+/// </summary>
+public sealed record InstrumentDto(
+    string Symbol,
+    ulong SecurityId,
+    string SecurityType,
+    decimal? TickSize,
+    long? LotSize,
+    decimal? StrikePrice,
+    string? ExpirationDate,
+    string? PutOrCall,
+    string? UnderlyingSymbol,
+    decimal? ContractMultiplier);

--- a/backend/src/B3.Trading.Application/MarketData/SecurityDefinitionRegistry.cs
+++ b/backend/src/B3.Trading.Application/MarketData/SecurityDefinitionRegistry.cs
@@ -114,6 +114,30 @@ public sealed class SecurityDefinitionRegistry
     /// </summary>
     public int Count => _bySymbol.Count;
 
+    /// <summary>
+    /// FE-OPT-2 (#498). Enumerates all symbols matching the given filter.
+    /// When <paramref name="underlying"/> is non-null, returns only option
+    /// symbols whose <see cref="OptionMetadata.UnderlyingSymbol"/> matches
+    /// (case-insensitive). When <paramref name="optionsOnly"/> is true,
+    /// returns only symbols with <see cref="SecurityType.Option"/>.
+    /// Returns a snapshot — concurrent upserts may not be visible.
+    /// </summary>
+    public IEnumerable<(string Symbol, ulong SecurityId, InstrumentSpec Spec)> Enumerate(
+        string? underlying = null,
+        bool optionsOnly = false)
+    {
+        foreach (var kvp in _bySymbol)
+        {
+            var spec = kvp.Value.Spec;
+            if (optionsOnly && spec.SecurityType != SecurityType.Option)
+                continue;
+            if (underlying is not null &&
+                !string.Equals(spec.Option?.UnderlyingSymbol, underlying, StringComparison.OrdinalIgnoreCase))
+                continue;
+            yield return (kvp.Key, kvp.Value.SecurityId, spec);
+        }
+    }
+
     private readonly record struct Entry(InstrumentSpec Spec, ulong SecurityId);
 
     /// <summary>

--- a/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingEndpointsExtensions.cs
@@ -33,6 +33,7 @@ public static class TradingEndpointsExtensions
         app.MapFills();
         app.MapAlgo();
         app.MapPositions();
+        app.MapInstruments();
         app.MapBalance();
         app.MapPnl();
         app.MapSubAccounts();

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -834,6 +834,149 @@ tr[data-clordid]:hover > td { background: rgba(255,255,255,.025); }
 #blotter-body tr[data-clordid] { cursor: pointer; }
 #blotter-body tr[data-clordid] td.row-stale-actions { cursor: default; }
 
+/* ---------- FE-OPT-2 (#498) Option chain picker ---------- */
+.chain-picker-modal {
+  max-width: 90vw;
+  max-height: 90vh;
+}
+.chain-picker-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+.modal-header h2 { margin: 0; }
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text);
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-close:hover { color: var(--accent); }
+.chain-picker-controls {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+.chain-picker-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: .8rem;
+  color: var(--muted);
+}
+.chain-picker-controls input {
+  width: 120px;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 4px;
+  font-size: .8rem;
+}
+.chain-picker-grid {
+  flex: 1;
+  overflow: auto;
+  padding: 1rem;
+}
+.chain-placeholder {
+  color: #6b7280;
+  text-align: center;
+  padding: 2rem;
+  margin: 0;
+}
+.chain-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.875rem;
+}
+.chain-table th,
+.chain-table td {
+  border: 1px solid var(--border-color, #e5e7eb);
+  padding: 0.5rem;
+  text-align: center;
+}
+.chain-table th {
+  background: var(--header-bg, #f3f4f6);
+  position: sticky;
+  top: 0;
+}
+.chain-table .strike-col {
+  font-weight: 600;
+  background: var(--header-bg, #f3f4f6);
+  position: sticky;
+  left: 0;
+}
+.chain-cell {
+  cursor: pointer;
+}
+.chain-cell:hover {
+  background: var(--hover-bg, #e0f2fe);
+}
+.chain-cell-call { color: #16a34a; }
+.chain-cell-put { color: #dc2626; }
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+}
+.btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: .8rem;
+  background: var(--panel);
+  color: var(--text);
+}
+.btn:hover {
+  filter: brightness(1.1);
+}
+.btn-primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.btn-secondary {
+  background: var(--panel-2);
+  border-color: var(--border-color, #e5e7eb);
+}
+.btn-icon {
+  padding: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Mobile: full screen */
+@media (max-width: 768px) {
+  .chain-picker-modal {
+    max-width: 100vw;
+    max-height: 100vh;
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
+    border-radius: 0;
+  }
+}
+
 /* ---------- Phase badges + auction panel (Q1.6 / #258) ---------- */
 
 /* Compact pill rendered next to the symbol cell in the market-data

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -206,6 +206,9 @@
             </label>
             <span id="ticket-notional-preview" class="ticket-notional" title="Estimated notional value"></span>
             <button type="submit" id="ticket-submit" class="ticket-submit">Submit</button>
+            <button type="button" id="open-chain-picker" class="btn btn-icon" title="Open option chain (Ctrl+O)" aria-label="Open option chain">
+              ⛓
+            </button>
             <button type="button" id="ticket-advanced-toggle"
                     class="ticket-advanced-toggle" aria-expanded="false"
                     aria-controls="ticket-advanced"
@@ -699,6 +702,31 @@
       </div>
     </form>
   </div>
+
+  <!-- FE-OPT-2 (#498). Option chain picker modal -->
+  <dialog id="chain-picker-modal" class="modal chain-picker-modal" aria-labelledby="chain-picker-title">
+    <div class="modal-content chain-picker-content">
+      <header class="modal-header">
+        <h2 id="chain-picker-title">Option Chain</h2>
+        <button type="button" class="modal-close" aria-label="Close">&times;</button>
+      </header>
+      <div class="chain-picker-controls">
+        <label>
+          Underlying
+          <input type="text" id="chain-underlying" placeholder="e.g. PETR4" list="chain-underlying-list" />
+          <datalist id="chain-underlying-list"></datalist>
+        </label>
+        <button type="button" id="chain-load-btn" class="btn btn-primary">Load Chain</button>
+      </div>
+      <div id="chain-picker-grid" class="chain-picker-grid">
+        <!-- Grid populated by JS: rows=strikes, cols=expiries -->
+        <p class="chain-placeholder">Enter an underlying symbol and click Load</p>
+      </div>
+      <footer class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+      </footer>
+    </div>
+  </dialog>
 
   <!-- HISTORY / P&L / STATEMENT VIEW (Q2.6 #273) ---------------------
        Consumes the read-side endpoints shipped by Q2.1 (#268),

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -10,7 +10,8 @@ import { defaultBackend, defaultMarketDataUrl, login, signup, submitOrder, cance
          getStatement, downloadStatementCsv,
          searchAuditLog, getFillTouch, downloadCvmReport, buildDropCopyWebSocketUrl,
          verifyTotp, enrollTotp, disableTotp,
-         listAlgos, createAlgo, cancelAlgo, modifyAlgo } from "./protocol.js";
+         listAlgos, createAlgo, cancelAlgo, modifyAlgo,
+         getInstruments } from "./protocol.js";
 import { validateCreateAlgo } from "./validation.js";
 import * as algosUi from "./algosUi.js";
 import * as settingsUi from "./settingsUi.js";
@@ -171,6 +172,9 @@ function init() {
     onFillTouchLookup: handleFillTouchLookup,
     onCvmDownload:     handleCvmDownload,
   });
+
+  // FE-OPT-2 (#498). Chain picker load button — needs session for API call.
+  document.getElementById("chain-load-btn")?.addEventListener("click", handleLoadChain);
 
   // Fase 5 (#401). Global keyboard shortcuts. Handlers gate on
   // `session` so they no-op while the user is on the login screen.
@@ -954,6 +958,29 @@ function formatPretradeWarning(w) {
     }
     default:
       return "advisory warning";
+  }
+}
+
+// FE-OPT-2 (#498). Load option chain from API and build grid in modal.
+async function handleLoadChain() {
+  if (!session) return;
+  const underlying = document.getElementById("chain-underlying")?.value?.trim().toUpperCase();
+  if (!underlying) {
+    document.getElementById("chain-picker-grid").innerHTML =
+      '<p class="chain-placeholder">Enter an underlying symbol (e.g., PETR4)</p>';
+    return;
+  }
+  const grid = document.getElementById("chain-picker-grid");
+  if (grid) grid.innerHTML = '<p class="chain-placeholder">Loading…</p>';
+  try {
+    const instruments = await getInstruments(session.backend, session.token, { underlying });
+    if (!instruments || instruments.length === 0) {
+      if (grid) grid.innerHTML = '<p class="chain-placeholder">No options found for this underlying</p>';
+      return;
+    }
+    if (grid) grid.innerHTML = ui.buildChainGrid(instruments);
+  } catch (err) {
+    if (grid) grid.innerHTML = `<p class="chain-placeholder" style="color:#dc2626">Error: ${err.message}</p>`;
   }
 }
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -496,6 +496,21 @@ export async function downloadCvmReport(backend, token, model, dayKey) {
   return { blob, filename };
 }
 
+// FE-OPT-2 (#498). Fetch option chain for an underlying symbol.
+// Returns array of { symbol, securityId, securityType, strikePrice,
+// expirationDate, putOrCall, underlyingSymbol, contractMultiplier }.
+export async function getInstruments(backend, token, { underlying, type } = {}) {
+  const params = new URLSearchParams();
+  if (underlying) params.set("underlying", underlying);
+  if (type) params.set("type", type);
+  const qs = params.toString();
+  const url = `${backend}/instruments${qs ? "?" + qs : ""}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return jsonOrThrow(resp);
+}
+
 // Build the WebSocket URL for the drop-copy feed. Browsers cannot
 // set Authorization on a WS handshake; the JWT travels as
 // ?access_token= (per the host's JwtBearerEvents convention for

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -851,6 +851,80 @@ function renderCancelAllButton() {
   btn.textContent = `Cancel all (${n})`;
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// FE-OPT-2 (#498). Option chain picker
+// ═══════════════════════════════════════════════════════════════════
+
+let chainPickerOnSelect = null; // callback when user clicks a cell
+
+function openChainPicker(onSelect) {
+  chainPickerOnSelect = onSelect;
+  const modal = $("chain-picker-modal");
+  if (modal && typeof modal.showModal === "function") {
+   modal.showModal();
+  }
+}
+
+function closeChainPicker() {
+  const modal = $("chain-picker-modal");
+  if (modal && typeof modal.close === "function") {
+   modal.close();
+  }
+  chainPickerOnSelect = null;
+}
+
+function buildChainGrid(instruments) {
+  // Group by expiry (columns) and strike (rows)
+  const expiries = [...new Set(instruments.map(i => i.expirationDate))].sort();
+  const strikes = [...new Set(instruments.map(i => i.strikePrice))].sort((a, b) => a - b);
+  
+  // Build lookup: { "strike|expiry|putOrCall" => instrument }
+  const lookup = new Map();
+  for (const inst of instruments) {
+   lookup.set(`${inst.strikePrice}|${inst.expirationDate}|${inst.putOrCall}`, inst);
+  }
+  
+  // Build table HTML
+  let html = '<table class="chain-table"><thead><tr><th class="strike-col">Strike</th>';
+  for (const exp of expiries) {
+   // Show both C and P columns per expiry
+   html += `<th colspan="2">${exp}</th>`;
+  }
+  html += '</tr><tr><th></th>';
+  for (const exp of expiries) {
+   html += '<th>Call</th><th>Put</th>';
+  }
+  html += '</tr></thead><tbody>';
+  
+  for (const strike of strikes) {
+   html += `<tr><td class="strike-col">${strike.toFixed(2)}</td>`;
+   for (const exp of expiries) {
+     const call = lookup.get(`${strike}|${exp}|Call`);
+     const put = lookup.get(`${strike}|${exp}|Put`);
+     html += call 
+       ? `<td class="chain-cell chain-cell-call" data-symbol="${call.symbol}" data-security-id="${call.securityId}">C</td>`
+       : '<td class="chain-cell-empty">—</td>';
+     html += put
+       ? `<td class="chain-cell chain-cell-put" data-symbol="${put.symbol}" data-security-id="${put.securityId}">P</td>`
+       : '<td class="chain-cell-empty">—</td>';
+   }
+   html += '</tr>';
+  }
+  html += '</tbody></table>';
+  return html;
+}
+
+function handleChainCellClick(e) {
+  const cell = e.target.closest(".chain-cell");
+  if (!cell) return;
+  const symbol = cell.dataset.symbol;
+  const securityId = cell.dataset.securityId;
+  if (symbol && chainPickerOnSelect) {
+   chainPickerOnSelect(symbol, securityId);
+   closeChainPicker();
+  }
+}
+
 export function bindUi() {
   // Order ticket: enable/disable price field + show/hide stop-price +
   // good-till-date inputs based on type / TIF (Q1.4 #256).
@@ -1257,6 +1331,50 @@ export function bindUi() {
       }
     });
   }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // FE-OPT-2 (#498). Option chain picker modal wiring
+  // ═══════════════════════════════════════════════════════════════════
+  const chainModal = $("chain-picker-modal");
+  const chainGrid = $("chain-picker-grid");
+  const chainUnderlyingInput = $("chain-underlying");
+  const chainLoadBtn = $("chain-load-btn");
+  const openChainBtn = $("open-chain-picker");
+  
+  if (chainModal) {
+    // Close on backdrop click (click on the dialog but not its content)
+    chainModal.addEventListener("click", (e) => {
+      if (e.target === chainModal) closeChainPicker();
+    });
+    // Close on X button (class or data attr varies, common patterns)
+    chainModal.querySelector(".modal-close")?.addEventListener("click", closeChainPicker);
+    chainModal.querySelector("[data-dismiss='modal']")?.addEventListener("click", closeChainPicker);
+    // Cell clicks inside the grid
+    if (chainGrid) {
+      chainGrid.addEventListener("click", handleChainCellClick);
+    }
+  }
+  
+  if (openChainBtn) {
+    openChainBtn.addEventListener("click", () => {
+      openChainPicker((symbol, securityId) => {
+        // Populate ticket with selected option
+        const symInput = $("ticket-symbol");
+        if (symInput) {
+          symInput.value = symbol;
+          symInput.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      });
+    });
+  }
+
+  // Ctrl+O opens chain picker (Mac: Cmd+O)
+  document.addEventListener("keydown", (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "o") {
+      e.preventDefault();
+      openChainBtn?.click();
+    }
+  });
 
   subscribe(renderForSlice);
   renderAll();
@@ -3032,4 +3150,4 @@ function refreshTicketValidation() {
   }
   return result;
 }
-export { refreshTicketValidation };
+export { refreshTicketValidation, openChainPicker, closeChainPicker, buildChainGrid, handleChainCellClick };


### PR DESCRIPTION
## FE-OPT-2 (#498)

Option chain picker UI for selecting options from a grid.

### Wave 1 (API)
- `GET /instruments?underlying=PETR4` endpoint
- `SecurityDefinitionRegistry.Enumerate()` method
- `getInstruments()` client function in protocol.js

### Wave 2 (Frontend)
- Chain picker modal with underlying input + load button
- Grid: rows = strikes, columns = expiries (Call/Put sub-columns)
- Click cell → populate ticket with option symbol
- Keyboard: `Ctrl+O` opens picker
- Mobile: full-screen modal on small screens
- Colors: green (#16a34a) for calls, red (#dc2626) for puts

### Files Changed
- `InstrumentsEndpoints.cs` — new endpoint
- `SecurityDefinitionRegistry.cs` — `Enumerate()` method
- `TradingEndpointsExtensions.cs` — route registration
- `protocol.js` — `getInstruments()` client
- `ui.js` — chain picker functions
- `app.js` — load handler wiring
- `index.html` — modal + trigger button
- `styles.css` — chain picker styles

Closes #498