### PR TITLE
chore(deps): bump B3.EntryPoint SDK to 0.15.2

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.0" />
-    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.0" />
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.2" />
+    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.2" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.6.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
chore(deps): bump B3.EntryPoint SDK to 0.15.2

0.15.2 carries two downstream-facing fixes validated end-to-end against
the real-mode docker stack:

- TCP disconnect detection (pedrosakuma/B3EntryPointClient#187/#188): the
  FIXP session now transitions out of Established when the peer closes the
  connection, so /health stops reporting a stale `established` while order
  operations fail with gateway_unavailable.
- Outbound sendingTime population (pedrosakuma/B3EntryPointClient#183):
  OrderEntryEncoder previously left InboundBusinessHeader.sendingTime at 0,
  which matching gateways with clock-skew validation reject with
  BusinessMessageReject so orders never enter the book. It is now stamped
  with the current UTC nanosecond timestamp.

Closes #507

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

