### PR TITLE
fix(docker): bump matching image so working orders survive restart

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     # matching-image-bump workflow for the bump cadence.
     # Devs can still override (e.g. MATCHING_IMAGE=ghcr.io/pedrosakuma/b3-matching:latest)
     # to test the bleeding edge locally.
-    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching@sha256:0a5f6e77ec5895b0fd88ae49f7b3e051613ab77e20dc28c8f1f20e027bbbfda1}
+    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching@sha256:49fea67b24f7250589eded89d4607f8e2927c8ea097eb7d5375b2aa3b5e8103f}
     container_name: b3-matching-platform
     restart: unless-stopped
     networks:


### PR DESCRIPTION
fix(docker): bump matching image so working orders survive restart

The pinned matching-platform image (rev 2ebf1e7, 2026-05-19) keyed order
ownership by the ephemeral FIXP connection id ("conn-<id>"), so on a
matching restart every working order was dropped as an orphan
(orphansDropped=N) even though the book/WAL was intact. Restarting
matching invalidated live orders — modify/cancel then failed with
"unknown orderId / OrigClOrdID".

Upstream B3MatchingPlatform #485/#486 (commit 888566f, 2026-05-27) keys
ownership by the stable FIXP SessionId instead, so orders survive
reconnect/restart. Bump the pinned digest to rev 382cdb9f (post-#486):

  sha256:0a5f6e77... -> sha256:49fea67b...

This image also enforces tcp.sendingTimeSkewToleranceMs (default 5s) on
inbound business headers; it is satisfied by the B3.EntryPoint.Client
0.15.2 sendingTime fix that lands in #508, on which this PR is stacked.

Validated end-to-end in the real-mode stack (SDK 0.15.2, skew check at its
default): submit PETR4 order -> Working, restart matching -> order restored
(orphansDropped=0, owners=1), modify 32.50->33.00 succeeds (clOrdId 1
Replaced, clOrdId 2 Working).

Refs #507

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
