### PR TITLE
chore(deps): bump B3.EntryPoint.Client/Sbe to 0.15.3 (CancelOnDisconnect opt-in default)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.2" />
-    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.2" />
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.3" />
+    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.3" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.6.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
## What

Bumps `B3.EntryPoint.Client` and `B3.EntryPoint.Sbe` from **0.15.2 → 0.15.3**.

## Why

While manually testing restart resilience (the #507 saga), stopping the trading-host caused the matching engine to **immediately cancel all working orders** for every firm session. Root cause was a Cancel-On-Disconnect (CoD) misconfiguration originating in the SDK:

- `EntryPointClientOptions.CancelOnDisconnect` was **field-initialized to `CancelOnDisconnectOrTerminate` (3)** in the 0.15.2 options ctor, with `CodTimeoutWindowMs = 0`.
- Our wiring never sets this property, so every FIXP `Establish` went out with `cancelOnDisconnectType=3`, window `0` → any TCP drop of the host (routine restart) pulled the entire book at the venue.
- The aggressive default was invisible in decompiled C# (auto-property initializer hidden); only the raw IL and a wire capture revealed it.

Filed upstream as **pedrosakuma/B3EntryPointClient#189**, fixed in **0.15.3** (B3EntryPointClient#190 "default CancelOnDisconnect to opt-in").

## Verification

- IL of `EntryPointClientOptions..ctor` in 0.15.3: the `ldc.i4.3 → <CancelOnDisconnect>k__BackingField` store is **gone** → default is now the zero value `DoNotCancelOnDisconnectOrTerminate (0)`. CoD is strictly opt-in.
- `dotnet build B3TradingPlatform.slnx -c Release` → succeeds, 0 warnings / 0 errors.

## Notes

- Inbound traceability was already correct: a delivered cancel maps `OrderCancelled → ExecKind.Canceled` carrying `RestatementReason` (`B3EntryPointClientGateway.cs:757-766`, applied in `ExecutionReportProcessor`), so any legitimate venue cancel is still recorded with a reason.
- Follow-up to consider (separate PR): expose CoD as an explicit, configurable per-firm knob (defense-in-depth, opt-in venue enforcement per AGENTS.md) rather than relying solely on the SDK default.

Refs pedrosakuma/B3EntryPointClient#189
