### PR TITLE
fix(docker): bump matching image for Establish-path session takeover (#496)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     # matching-image-bump workflow for the bump cadence.
     # Devs can still override (e.g. MATCHING_IMAGE=ghcr.io/pedrosakuma/b3-matching:latest)
     # to test the bleeding edge locally.
-    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching@sha256:49fea67b24f7250589eded89d4607f8e2927c8ea097eb7d5375b2aa3b5e8103f}
+    image: ${MATCHING_IMAGE:-ghcr.io/pedrosakuma/b3-matching@sha256:18a934325e4259159be31e47f571bdff4e98158578c8805088999b74e7b4ac6a}
     container_name: b3-matching-platform
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## What

Bump the pinned `b3-matching` image digest to consume upstream **B3MatchingPlatform #496** (Establish-path session takeover):

```
sha256:49fea67b… (rev 382cdb9, post-#486)  ->  sha256:18a9343… (rev 1ff9b15, #497)
```

## Why

After an OMS (trading-host) restart while the matcher stays up, a cold-resume reconnect is an `Establish` with the **same** `SessionId` + `SessionVerId` (Binary EntryPoint spec §5.3). The previous image only re-attached when the prior `FixpSession` had already reached `FixpState.Suspended`. If the old TCP died without a prompt FIN (hard termination / partition) before the idle-timeout watchdog fired, the stale session was still `Established`, so the resuming `Establish` fell through to a fresh `Idle` session and was rejected **`UNNEGOTIATED`**. The client then fell back to `Negotiate`, which **bumps the `SessionVerID` and orphans the firm's resting orders** (subsequent modify/cancel rejected) — even though the orders were never lost. This made restart-resume **non-deterministic**.

`#496` mirrors the `#488` Negotiate-path takeover onto the Establish path: an `Establish` whose `SessionId` is held by a still-`Established` session with matching `SessionId` + `SessionVerId` force-suspends the stale session (preserving order ownership + persistence, skipping Cancel-on-Disconnect) and re-attaches the new transport deterministically.

## Validation (real stack)

With `idleTimeoutMs` at 30 s (so the watchdog cannot mask the test) and the prior session left `Established` via a network partition (no FIN):

- Matcher: `establish-takeover: force-suspending still-Established session … sessionVerId=105` → `re-attached transport … establish-accept` for all three firms.
- Client: cold-resume **reattach (reuse)**, same `SessionVerID` (105 / 7 / 7), **no bump**.
- A subsequent order **modify is acked by the venue** (HTTP 202; order → `Replaced`, replacement `Working`) — proving the resting order was not orphaned.
- Core invariant holds throughout: **working orders are never lost.**

## Scope

One-line digest bump only. Lineage: follows #510 (which bumped to the #486 image so orders survive a *matcher* restart); this bump covers the symmetric *OMS-restart* reconnect path.

Refs B3MatchingPlatform#496 / #497.
