### PR TITLE
feat(#512): cold-start session resume on trading-host restart

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="B3.EntryPoint.Client" Version="0.15.2" />
-    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.15.2" />
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.16.0" />
+    <PackageVersion Include="B3.EntryPoint.Sbe" Version="0.16.0" />
     <PackageVersion Include="B3.MarketData.WebSocketClient" Version="0.6.0" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/backend/src/B3.Trading.Application/ConnectSessionRollReactor.cs
+++ b/backend/src/B3.Trading.Application/ConnectSessionRollReactor.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using B3.Trading.Application.Observability;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Trading.Application;
+
+/// <summary>
+/// Shared session-roll reconciliation policy (#380 / #504). When a firm's
+/// venue session version advances past the baseline we last reconciled
+/// against, un-acked <see cref="OrderStatus.PendingNew"/> orders are the
+/// one class that cannot survive: the venue never acknowledged them, so a
+/// session roll guarantees they do not exist under any session version.
+/// Working / PartiallyFilled orders are deliberately KEPT — FIXP
+/// retransmission resynchronises them during recovery, and a terminal ER
+/// (Cancel/Fill) arrives if the venue dropped them.
+///
+/// <para>
+/// This is the single source of truth for that policy. Both the boot-time
+/// snapshot-baseline reconcile (<c>SnapshotService.ReconcileFirmSessionVerIds</c>,
+/// runs single-threaded before app start) and the runtime post-connect
+/// reactor (<see cref="PendingNewReapingConnectRollReactor"/>, runs under the
+/// dispatcher lock) call it so their behaviour can never drift apart.
+/// </para>
+/// </summary>
+public static class FirmSessionRollReconciliation
+{
+    /// <summary>
+    /// Cancels every <see cref="OrderStatus.PendingNew"/> order attached to
+    /// <paramref name="firmId"/> and returns the number actually transitioned
+    /// to <see cref="OrderStatus.Cancelled"/>. The caller owns serialisation:
+    /// boot reconcile runs before any event loop starts; the runtime reactor
+    /// runs under the <see cref="EventDispatcher"/> lock. Emits the same log
+    /// + metrics regardless of caller so dashboards/alerts are uniform.
+    /// </summary>
+    public static int CancelPendingNewForRolledFirm(
+        WorkingOrderBook orders,
+        string firmId,
+        uint fromVerId,
+        uint toVerId,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(orders);
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var cancelled = 0;
+        foreach (var order in orders.EnumerateForFirm(firmId, includeTerminal: false))
+        {
+            if (order.Status == OrderStatus.PendingNew)
+            {
+                order.MarkCancelled();
+                if (order.Status == OrderStatus.Cancelled)
+                {
+                    cancelled++;
+                }
+            }
+        }
+
+        if (cancelled > 0)
+        {
+            logger.LogWarning(
+                "event=recovery.session-rolled firm={Firm} from={From} to={To} pendingNewCancelled={Cancelled}",
+                firmId, fromVerId, toVerId, cancelled);
+        }
+        else
+        {
+            logger.LogInformation(
+                "event=recovery.session-rolled firm={Firm} from={From} to={To} (FIXP recovery handles sync)",
+                firmId, fromVerId, toVerId);
+        }
+
+        MetricsRegistry.RecoverySessionRolledFirms.Add(1,
+            new KeyValuePair<string, object?>("firm", firmId));
+        MetricsRegistry.RecoverySessionRolledOrdersDropped.Add(cancelled,
+            new KeyValuePair<string, object?>("firm", firmId));
+        return cancelled;
+    }
+}
+
+/// <summary>
+/// #512 seam. Called by the FIXP gateway immediately after the initial
+/// <c>ConnectAsync</c> when the SDK fell back from Establish-reuse to a
+/// freshly negotiated session with a BUMPED SessionVerId (a recoverable
+/// reuse reject — the venue genuinely lost the session). The boot-time
+/// #380/#504 reconcile already ran against the OLD verId before app start,
+/// so it cannot observe this deferred bump; without this seam the un-acked
+/// PendingNew "ghosts" would linger for the whole process lifetime.
+///
+/// <para>
+/// Mirrors the <see cref="IVenueDisconnectReactor"/> shape: the gateway
+/// (Infrastructure) hands the signal to an Application-side implementation
+/// without taking a direct reference to <see cref="WorkingOrderBook"/> /
+/// <see cref="EventDispatcher"/>.
+/// </para>
+/// </summary>
+public interface IConnectSessionRollReactor
+{
+    /// <summary>
+    /// Reconcile order state for <paramref name="firmId"/> after its venue
+    /// session rolled from <paramref name="fromVerId"/> to
+    /// <paramref name="toVerId"/> during the initial connect. MUST run before
+    /// the firm's event loop and the first snapshot.
+    /// </summary>
+    void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId);
+}
+
+/// <summary>
+/// Default <see cref="IConnectSessionRollReactor"/>: reaps un-acked
+/// PendingNew orders for the rolled firm under the <see cref="EventDispatcher"/>
+/// lock so the mutation is serialised against concurrently-connecting firms'
+/// event loops and the snapshot service. Durability follows the #504 model:
+/// the cancellation is captured by the next snapshot (taken under the same
+/// lock); a crash before that snapshot is backstopped by the boot-time
+/// baseline reconcile on the next restart, which re-detects the advance
+/// (the snapshot baseline still records the pre-bump verId) and re-reaps.
+/// </summary>
+public sealed class PendingNewReapingConnectRollReactor : IConnectSessionRollReactor
+{
+    private readonly WorkingOrderBook _orders;
+    private readonly EventDispatcher _dispatcher;
+    private readonly ILogger<PendingNewReapingConnectRollReactor> _logger;
+
+    public PendingNewReapingConnectRollReactor(
+        WorkingOrderBook orders,
+        EventDispatcher dispatcher,
+        ILogger<PendingNewReapingConnectRollReactor> logger)
+    {
+        _orders = orders ?? throw new ArgumentNullException(nameof(orders));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+        _dispatcher.RunExclusive(() =>
+            FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
+                _orders, firmId, fromVerId, toVerId, _logger));
+    }
+}

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -137,6 +137,7 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var venueAccountResolver = sp.GetService<IVenueAccountResolver>();
                     var investorIdResolver = sp.GetService<IInvestorIdResolver>();
                     var routingInstructionResolver = sp.GetService<IRoutingInstructionResolver>();
+                    var connectRollReactor = sp.GetService<IConnectSessionRollReactor>();
                     return new B3EntryPointClientGateway(upstream, firm.FirmId, resumeVerId, gwLogger,
                         venueDisconnectReactor: reactor,
                         riskOptions: riskOpts,
@@ -144,7 +145,12 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                         venueAccountResolver: venueAccountResolver,
                         investorIdResolver: investorIdResolver,
                         routingInstructionResolver: routingInstructionResolver,
-                        terminateOnShutdown: false);
+                        terminateOnShutdown: false,
+                        // #512. Read the SDK's effective verId off the SAME
+                        // options instance the client mutates on a cold-resume
+                        // fallback bump, and reap PendingNew if it advanced.
+                        effectiveSessionVerIdProvider: () => clientOpts.SessionVerId,
+                        connectSessionRollReactor: connectRollReactor);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingExchangeGatewayServiceCollectionExtensions.cs
@@ -98,7 +98,13 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                         lf.CreateLogger("FirmGatewayConnector").LogWarning(ex,
                             "Failed to load persisted SessionStateStore for firm {Firm}; starting from configured SessionVerId.", firm.FirmId);
                     }
-                    var resolvedVerId = SessionVerIdResolver.Resolve(firm.SessionVerId, persistedVerId);
+                    // #512 cold-start resume: do NOT pre-bump the SessionVerId on
+                    // every restart. Resume the persisted verId as-is so the venue
+                    // reattaches the SAME session (Establish-reuse) and keeps our
+                    // resting orders. The bump is now a FALLBACK only — applied by
+                    // the SDK via NextSessionVerIdSelector when the venue rejects
+                    // the reuse with a recoverable reject.
+                    var resumeVerId = persistedVerId ?? firm.SessionVerId;
 
                     // #126. Materialise the access key via the central
                     // resolver so file-mounted secrets + the legacy flat
@@ -111,7 +117,10 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     {
                         Endpoint = ep,
                         SessionId = firm.SessionId,
-                        SessionVerId = resolvedVerId,
+                        SessionVerId = resumeVerId,
+                        ConnectMode = B3.EntryPoint.Client.ConnectMode.EstablishReuseThenNegotiate,
+                        TerminateOnDispose = false,
+                        NextSessionVerIdSelector = prev => SessionVerIdResolver.Resolve(firm.SessionVerId, prev),
                         EnteringFirm = firm.EnteringFirm,
                         Credentials = B3.EntryPoint.Client.EntryPointClientOptions.AccessKey(accessKey),
                         KeepAliveIntervalMs = firm.KeepAliveIntervalMs,
@@ -128,13 +137,14 @@ public static class TradingExchangeGatewayServiceCollectionExtensions
                     var venueAccountResolver = sp.GetService<IVenueAccountResolver>();
                     var investorIdResolver = sp.GetService<IInvestorIdResolver>();
                     var routingInstructionResolver = sp.GetService<IRoutingInstructionResolver>();
-                    return new B3EntryPointClientGateway(upstream, firm.FirmId, resolvedVerId, gwLogger,
+                    return new B3EntryPointClientGateway(upstream, firm.FirmId, resumeVerId, gwLogger,
                         venueDisconnectReactor: reactor,
                         riskOptions: riskOpts,
                         subAccountWireIdMapper: subAccountMapper,
                         venueAccountResolver: venueAccountResolver,
                         investorIdResolver: investorIdResolver,
-                        routingInstructionResolver: routingInstructionResolver);
+                        routingInstructionResolver: routingInstructionResolver,
+                        terminateOnShutdown: false);
                 });
                 return new FirmGatewayRegistry(gateways);
             });

--- a/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
@@ -67,6 +67,16 @@ public static class TradingPersistenceServiceCollectionExtensions
             sp.GetRequiredService<IEventStore>(),
             sp.GetServices<IExecutionFanOutSink>()));
 
+        // #512. Runtime post-connect session-roll reactor. Reaps un-acked
+        // PendingNew under the dispatcher lock when the gateway detects a
+        // cold-resume fallback verId bump. Always available (EventDispatcher
+        // is registered unconditionally — NullEventStore when persistence is
+        // off), so the gateway's reap path degrades gracefully.
+        services.AddSingleton<IConnectSessionRollReactor>(sp => new PendingNewReapingConnectRollReactor(
+            sp.GetRequiredService<WorkingOrderBook>(),
+            sp.GetRequiredService<EventDispatcher>(),
+            sp.GetRequiredService<ILogger<PendingNewReapingConnectRollReactor>>()));
+
         return services;
     }
 }

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -104,6 +104,19 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     // resolvers MUST be deterministic per-Order so the two
     // resolutions agree (see IRoutingInstructionResolver doc).
     private readonly IRoutingInstructionResolver? _routingInstructionResolver;
+    // #512. Reads the SDK's EFFECTIVE SessionVerId after ConnectAsync
+    // returns. The SDK may have fallen back from Establish-reuse to a
+    // freshly negotiated session with a bumped verId (recoverable reuse
+    // reject); that mutation lands on the EntryPointClientOptions instance
+    // the composition root passed to the client, so the provider closes
+    // over the same instance. Null → no post-connect roll detection
+    // (legacy behaviour, matches direct-construction tests).
+    private readonly Func<uint>? _effectiveSessionVerIdProvider;
+    // #512. Hands a detected connect-time session roll to the Application
+    // layer to reap un-acked PendingNew BEFORE the event loop / first
+    // snapshot. Null → detection still syncs CurrentSessionVerId but
+    // performs no reap.
+    private readonly IConnectSessionRollReactor? _connectSessionRollReactor;
 
     public B3EntryPointClientGateway(
         Up.EntryPointClient client,
@@ -121,7 +134,9 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         IVenueAccountResolver? venueAccountResolver = null,
         IInvestorIdResolver? investorIdResolver = null,
         IRoutingInstructionResolver? routingInstructionResolver = null,
-        bool terminateOnShutdown = true)
+        bool terminateOnShutdown = true,
+        Func<uint>? effectiveSessionVerIdProvider = null,
+        IConnectSessionRollReactor? connectSessionRollReactor = null)
     {
         _terminateOnShutdown = terminateOnShutdown;
         _client = client ?? throw new ArgumentNullException(nameof(client));
@@ -139,6 +154,8 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         _venueAccountResolver = venueAccountResolver;
         _investorIdResolver = investorIdResolver;
         _routingInstructionResolver = routingInstructionResolver;
+        _effectiveSessionVerIdProvider = effectiveSessionVerIdProvider;
+        _connectSessionRollReactor = connectSessionRollReactor;
         _client.Terminated += OnTerminated;
         _client.InboundGapAtReconnect += OnInboundGapAtReconnect;
         MetricsRegistry.RecordSessionVerId(_firmId, _currentSessionVerId);
@@ -193,7 +210,78 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
         await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
+        ReconcileConnectSessionRoll();
         OnConnected();
+    }
+
+    /// <summary>
+    /// #512. Detect a deferred connect-time session-version bump and
+    /// reconcile it BEFORE the event loop / first snapshot starts.
+    ///
+    /// <para>
+    /// The #512 happy path resumes the persisted session via Establish-reuse
+    /// (verId unchanged) — this is a no-op. But when the venue rejects the
+    /// reuse with a recoverable reject, the SDK falls back to Negotiate with
+    /// a bumped verId inside the same <c>ConnectAsync</c>. The boot-time
+    /// #380/#504 baseline reconcile already ran against the OLD verId before
+    /// app start, so it never sees this bump. We read the SDK's effective
+    /// verId, sync <see cref="CurrentSessionVerId"/> (so the next snapshot
+    /// records the new baseline), and hand the roll to the Application reactor
+    /// to reap un-acked PendingNew. Mirrors the reconnect path which already
+    /// syncs the verId from the reconnect outcome.
+    /// </para>
+    /// </summary>
+    internal void ReconcileConnectSessionRoll()
+    {
+        if (_effectiveSessionVerIdProvider is null) return;
+
+        var prior = Volatile.Read(ref _currentSessionVerId);
+        uint effective;
+        try
+        {
+            effective = _effectiveSessionVerIdProvider();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to read effective SessionVerId after connect for firm {Firm}; skipping session-roll reconcile.",
+                _firmId);
+            return;
+        }
+
+        if (effective <= prior) return;
+
+        // Order matters for the cross-restart backstop. The boot reconcile
+        // re-detects a roll only while the snapshot baseline still records
+        // the OLD verId. So we must REAP first and publish the bumped verId
+        // only after the reap succeeds: a snapshot interleaving between the
+        // reap (orders already cancelled under the dispatcher lock) and the
+        // verId publish records old-baseline + cancelled-orders — safe. If
+        // we published the verId first, a snapshot could seal
+        // baseline=bumped with the ghosts still present, and a crash before
+        // the next snapshot would make next-restart boot reconcile miss the
+        // roll (storedVerId == currentVerId) — the ghosts would survive
+        // permanently. Same reasoning is why a reactor failure must NOT
+        // publish the bumped verId: leaving the baseline old keeps the
+        // backstop armed.
+        try
+        {
+            _connectSessionRollReactor?.OnSessionRolledAtConnect(_firmId, prior, effective);
+        }
+        catch (Exception ex)
+        {
+            // A reactor failure must never abort the connect — the session
+            // is established. Leave _currentSessionVerId at the old baseline
+            // so the next-restart boot reconcile still re-detects the roll
+            // and reaps the ghosts.
+            _logger.LogError(ex,
+                "Connect session-roll reactor failed for firm {Firm} (from={From} to={To}); leaving SessionVerId baseline at {Prior} to keep the restart backstop armed.",
+                _firmId, prior, effective, prior);
+            return;
+        }
+
+        Volatile.Write(ref _currentSessionVerId, effective);
+        MetricsRegistry.RecordSessionVerId(_firmId, effective);
     }
 
     private void OnConnected()

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -40,6 +40,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
     private readonly TimeSpan _initialReconnectDelay;
     private readonly TimeSpan _maxReconnectDelay;
     private readonly TimeSpan _gracefulTerminateTimeout;
+    private readonly bool _terminateOnShutdown;
     private readonly TimeProvider _clock;
     private readonly OrderEntryLatencyProbe _latencyProbe;
     private Task? _eventLoop;
@@ -119,8 +120,10 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         ISubAccountWireIdMapper? subAccountWireIdMapper = null,
         IVenueAccountResolver? venueAccountResolver = null,
         IInvestorIdResolver? investorIdResolver = null,
-        IRoutingInstructionResolver? routingInstructionResolver = null)
+        IRoutingInstructionResolver? routingInstructionResolver = null,
+        bool terminateOnShutdown = true)
     {
+        _terminateOnShutdown = terminateOnShutdown;
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _firmId = firmId ?? throw new ArgumentNullException(nameof(firmId));
         _logger = logger;
@@ -1003,7 +1006,15 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         // raises Terminated(InitiatedByClient=true) from inside TerminateAsync,
         // and we want the existing handler to record the metric / log line
         // (the _disposed guard on line 527 ensures it skips the reconnect loop).
-        if (Volatile.Read(ref _connectedState) == 1)
+        // #512 cold-start resume: when the gateway is configured to SUSPEND on
+        // shutdown (terminateOnShutdown=false), we deliberately send NO
+        // Terminate(Finished). A Terminate(Finished) tells the venue the
+        // session is permanently finished and evicts session-scoped working
+        // order ownership — exactly the bug behind #507/#512. Suspending (clean
+        // TCP close, no Terminate) lets the next boot reattach via Establish-
+        // reuse and keep its resting orders. The SDK's own DisposeAsync Terminate
+        // is independently gated by EntryPointClientOptions.TerminateOnDispose.
+        if (_terminateOnShutdown && Volatile.Read(ref _connectedState) == 1)
         {
             try
             {

--- a/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
+++ b/backend/src/B3.Trading.Infrastructure/Persistence/SnapshotService.cs
@@ -227,36 +227,13 @@ public sealed class PersistenceRecovery
             //
             // PendingNew is the one exception: the venue never acked
             // those, so a session roll guarantees they cannot exist
-            // under any session version. Fall back to MarkCancelled for
-            // those — same behaviour as PR #415.
-            var cancelled = 0;
-            foreach (var order in _orders!.EnumerateForFirm(status.FirmId, includeTerminal: false))
-            {
-                if (order.Status == B3.Trading.Domain.OrderStatus.PendingNew)
-                {
-                    order.MarkCancelled();
-                    if (order.Status == B3.Trading.Domain.OrderStatus.Cancelled)
-                    {
-                        cancelled++;
-                    }
-                }
-            }
-            if (cancelled > 0)
-            {
-                _logger.LogWarning(
-                    "event=recovery.session-rolled firm={Firm} from={From} to={To} pendingNewCancelled={Cancelled}",
-                    status.FirmId, storedVerId, status.SessionVerId, cancelled);
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "event=recovery.session-rolled firm={Firm} from={From} to={To} (FIXP recovery handles sync)",
-                    status.FirmId, storedVerId, status.SessionVerId);
-            }
-            MetricsRegistry.RecoverySessionRolledFirms.Add(1,
-                new KeyValuePair<string, object?>("firm", status.FirmId));
-            MetricsRegistry.RecoverySessionRolledOrdersDropped.Add(cancelled,
-                new KeyValuePair<string, object?>("firm", status.FirmId));
+            // under any session version. The reap policy + log + metrics
+            // live in the shared helper so this boot-time reconcile and
+            // the runtime post-connect reactor (#512) never drift apart.
+            // Boot reconcile runs single-threaded before app start, so no
+            // dispatcher lock is needed here.
+            B3.Trading.Application.FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
+                _orders!, status.FirmId, storedVerId, status.SessionVerId, _logger);
         }
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/ConnectSessionRollReactorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ConnectSessionRollReactorTests.cs
@@ -1,0 +1,106 @@
+using B3.Trading.Application;
+using B3.Trading.Application.Persistence;
+using B3.Trading.Domain;
+using B3.Trading.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #512. The runtime post-connect session-roll reactor reaps un-acked
+/// PendingNew for a firm whose venue session rolled (cold-resume fallback
+/// bump), while leaving Working orders and other firms untouched. Mirrors
+/// the boot-time #380/#504 baseline reconcile via the shared
+/// <see cref="FirmSessionRollReconciliation"/> helper.
+/// </summary>
+public class ConnectSessionRollReactorTests
+{
+    private static Order MakeOrder(ulong clOrdId, string firmId, string owner = "alice") =>
+        new(clOrdId, new EndClientId(owner), "PETR4", 4321UL, OrderSide.Buy, OrderType.Limit, 10, 1m, firmId);
+
+    private static EventDispatcher Dispatcher() => new(new NullEventStore());
+
+    [Fact]
+    public void OnSessionRolledAtConnect_CancelsPendingNew_ForFirm_KeepsWorking()
+    {
+        var book = new WorkingOrderBook();
+
+        var pendingA1 = MakeOrder(1UL, "FIRM_A");
+        var pendingA2 = MakeOrder(2UL, "FIRM_A");
+        var workingA = MakeOrder(3UL, "FIRM_A");
+        workingA.MarkWorking();
+        book.TryAdd(pendingA1);
+        book.TryAdd(pendingA2);
+        book.TryAdd(workingA);
+
+        var reactor = new PendingNewReapingConnectRollReactor(
+            book, Dispatcher(), NullLogger<PendingNewReapingConnectRollReactor>.Instance);
+
+        reactor.OnSessionRolledAtConnect("FIRM_A", fromVerId: 7, toVerId: 8);
+
+        Assert.Equal(OrderStatus.Cancelled, pendingA1.Status);
+        Assert.Equal(OrderStatus.Cancelled, pendingA2.Status);
+        Assert.Equal(OrderStatus.Working, workingA.Status);
+    }
+
+    [Fact]
+    public void OnSessionRolledAtConnect_DoesNotTouchOtherFirms()
+    {
+        var book = new WorkingOrderBook();
+        var pendingA = MakeOrder(1UL, "FIRM_A");
+        var pendingB = MakeOrder(2UL, "FIRM_B");
+        book.TryAdd(pendingA);
+        book.TryAdd(pendingB);
+
+        var reactor = new PendingNewReapingConnectRollReactor(
+            book, Dispatcher(), NullLogger<PendingNewReapingConnectRollReactor>.Instance);
+
+        reactor.OnSessionRolledAtConnect("FIRM_A", 5, 6);
+
+        Assert.Equal(OrderStatus.Cancelled, pendingA.Status);
+        Assert.Equal(OrderStatus.PendingNew, pendingB.Status);
+    }
+
+    [Fact]
+    public void Helper_ReturnsCancelledCount()
+    {
+        var book = new WorkingOrderBook();
+        book.TryAdd(MakeOrder(1UL, "FIRM_A"));
+        book.TryAdd(MakeOrder(2UL, "FIRM_A"));
+        var working = MakeOrder(3UL, "FIRM_A");
+        working.MarkWorking();
+        book.TryAdd(working);
+
+        var count = FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
+            book, "FIRM_A", 1, 2, NullLogger.Instance);
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void Helper_NoPendingNew_ReturnsZero_AndKeepsWorking()
+    {
+        var book = new WorkingOrderBook();
+        var working = MakeOrder(1UL, "FIRM_A");
+        working.MarkWorking();
+        book.TryAdd(working);
+
+        var count = FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
+            book, "FIRM_A", 1, 2, NullLogger.Instance);
+
+        Assert.Equal(0, count);
+        Assert.Equal(OrderStatus.Working, working.Status);
+    }
+
+    [Fact]
+    public void Helper_UnknownFirm_ReturnsZero()
+    {
+        var book = new WorkingOrderBook();
+        book.TryAdd(MakeOrder(1UL, "FIRM_A"));
+
+        var count = FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
+            book, "FIRM_X", 1, 2, NullLogger.Instance);
+
+        Assert.Equal(0, count);
+    }
+}

--- a/backend/tests/B3.Trading.Application.Tests/GatewayConnectSessionRollTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/GatewayConnectSessionRollTests.cs
@@ -1,0 +1,113 @@
+using B3.Trading.Application;
+using B3.Trading.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Trading.Application.Tests;
+
+/// <summary>
+/// #512. Gateway-side detection seam: after the initial ConnectAsync the
+/// gateway reads the SDK's EFFECTIVE SessionVerId; if it advanced past the
+/// resumed verId (cold-resume fallback bump), the gateway syncs
+/// CurrentSessionVerId and hands the roll to the Application reactor BEFORE
+/// the event loop / first snapshot. Exercises the internal
+/// <c>ReconcileConnectSessionRoll</c> directly so no live FIXP peer is
+/// needed.
+/// </summary>
+public class GatewayConnectSessionRollTests
+{
+    private sealed class SpyReactor : IConnectSessionRollReactor
+    {
+        public readonly List<(string Firm, uint From, uint To)> Calls = new();
+        public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+            => Calls.Add((firmId, fromVerId, toVerId));
+    }
+
+    private static B3EntryPointClientGateway BuildGateway(
+        uint initialVerId,
+        Func<uint>? provider,
+        IConnectSessionRollReactor? reactor)
+    {
+        var opts = new B3.EntryPoint.Client.EntryPointClientOptions
+        {
+            Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 65000),
+            SessionId = 1u,
+            SessionVerId = initialVerId,
+            EnteringFirm = 1u,
+            Credentials = B3.EntryPoint.Client.EntryPointClientOptions.AccessKey("0123456789ABCDEF0123456789ABCDEF"),
+        };
+        var client = new B3.EntryPoint.Client.EntryPointClient(opts);
+        return new B3EntryPointClientGateway(
+            client, "FIRM_A", initialVerId, NullLogger<B3EntryPointClientGateway>.Instance,
+            effectiveSessionVerIdProvider: provider,
+            connectSessionRollReactor: reactor);
+    }
+
+    [Fact]
+    public void ReconcileConnectSessionRoll_VerIdAdvanced_SyncsAndInvokesReactor()
+    {
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: () => 9u, reactor: reactor);
+
+        gw.ReconcileConnectSessionRoll();
+
+        Assert.Equal(9u, gw.CurrentSessionVerId);
+        var call = Assert.Single(reactor.Calls);
+        Assert.Equal(("FIRM_A", 8u, 9u), call);
+    }
+
+    [Fact]
+    public void ReconcileConnectSessionRoll_NoAdvance_IsNoOp()
+    {
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: () => 8u, reactor: reactor);
+
+        gw.ReconcileConnectSessionRoll();
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
+        Assert.Empty(reactor.Calls);
+    }
+
+    [Fact]
+    public void ReconcileConnectSessionRoll_NullProvider_IsNoOp()
+    {
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: null, reactor: reactor);
+
+        gw.ReconcileConnectSessionRoll();
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
+        Assert.Empty(reactor.Calls);
+    }
+
+    [Fact]
+    public void ReconcileConnectSessionRoll_AdvanceWithNullReactor_StillSyncsVerId()
+    {
+        var gw = BuildGateway(initialVerId: 8, provider: () => 12u, reactor: null);
+
+        gw.ReconcileConnectSessionRoll();
+
+        Assert.Equal(12u, gw.CurrentSessionVerId);
+    }
+
+    [Fact]
+    public void ReconcileConnectSessionRoll_ReactorThrows_LeavesVerIdAtOldBaseline()
+    {
+        // #512 backstop: if the reap fails, the gateway must NOT publish the
+        // bumped verId — leaving the snapshot baseline at the old value keeps
+        // the next-restart boot reconcile able to re-detect the roll.
+        var gw = BuildGateway(
+            initialVerId: 8,
+            provider: () => 9u,
+            reactor: new ThrowingReactor());
+
+        gw.ReconcileConnectSessionRoll(); // must not throw
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
+    }
+
+    private sealed class ThrowingReactor : IConnectSessionRollReactor
+    {
+        public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+            => throw new InvalidOperationException("boom");
+    }
+}


### PR DESCRIPTION
## What

Make a **trading-host process restart RESUME** the venue FIXP/Binary-EntryPoint
session (Establish-reuse, same `SessionVerId`) instead of rolling it, so working
orders resting in the venue book stay owned and modifiable across an OMS restart.

Closes #512. Refs #507.

Depends on **#513** (matching-image bump consuming the upstream
B3MatchingPlatform Establish-path takeover fix) for the venue side.

## Why

Previously every restart pre-bumped `SessionVerId` and renegotiated, which
made the venue drop the prior session's order ownership. We already added
durability on both sides via WAL/snapshot; the session itself must be resumed,
not rolled, for that durability to mean anything. This consumes SDK
**0.16.0** (`B3.EntryPoint.Client` #192): `ConnectMode.EstablishReuseThenNegotiate`,
`TerminateOnDispose`, and `NextSessionVerIdSelector`.

## Changes

**Resume happy path (commit 1):**
- `B3.EntryPoint.Client` / `B3.EntryPoint.Sbe` 0.15.2 → **0.16.0**.
- Composition: stop pre-bumping; `resumeVerId = persistedVerId ?? firm.SessionVerId`;
  set `ConnectMode = EstablishReuseThenNegotiate`, `TerminateOnDispose = false`,
  `NextSessionVerIdSelector = prev => SessionVerIdResolver.Resolve(firm.SessionVerId, prev)`.
- Gateway no longer sends `Terminate(Finished)` on a restart-class shutdown
  (`terminateOnShutdown: false`) so the venue Suspends the session (resumable).

**Post-connect fallback reconciliation (commit 2):**
- When the venue rejects the reuse with a *recoverable* reject, the SDK falls
  back to Negotiate with a **bumped** `SessionVerId` inside the initial
  `ConnectAsync`. The boot-time #380/#504 baseline reconcile runs *before*
  connect, so it can't see this deferred bump — the un-acked `PendingNew`
  ghosts would linger for the process lifetime.
- New Application seam `IConnectSessionRollReactor` +
  `PendingNewReapingConnectRollReactor`: reaps `PendingNew` for the firm under
  the `EventDispatcher` lock, before the firm's event loop / first snapshot.
- Shared `FirmSessionRollReconciliation` helper so the boot reconcile and the
  runtime reactor apply one policy (cancel only `PendingNew`; keep
  `Working`/`PartiallyFilled` — FIXP retransmission resyncs them).
- Gateway reads the SDK's effective verId off the same options instance it
  mutates; on advance it **reaps first, then publishes** the bumped baseline.
  A reap failure leaves the baseline old so the next-restart boot reconcile
  re-detects the roll (cross-restart backstop). Durability follows the #504
  model (cancellation captured by the next snapshot under the same lock).

## Behavioural notes

- `resumeVerId = persisted ?? configured`: an operator raising the configured
  `SessionVerId` no longer force-rolls when persisted state exists — configured
  is now only a fallback floor (resume always wins). Intended.
- `TerminateOnDispose=false` + `terminateOnShutdown=false` means real-mode
  gateways no longer `Terminate(Finished)` on process shutdown; operator
  end-of-day / force-finish needs a separate explicit path (out of scope here).

## Validation

- Build + `dotnet format --verify-no-changes` clean.
- Application.Tests **1310/1310**, Api.Tests **500/500**.
- New tests: reactor/helper reap behaviour, gateway detect/sync/invoke seam,
  reactor-failure backstop.
- Mandatory code-review (gpt-5.5): one High finding (verId published before
  reap → snapshot could seal bumped baseline with ghosts) — fixed by
  reordering (reap-then-publish) + covered by a regression test.
