### PR TITLE
feat(#380): stale surviving Working orders on a confirmed venue session roll

### DIFF
--- a/backend/src/B3.Trading.Application/ConnectSessionRollReactor.cs
+++ b/backend/src/B3.Trading.Application/ConnectSessionRollReactor.cs
@@ -77,16 +77,38 @@ public static class FirmSessionRollReconciliation
             new KeyValuePair<string, object?>("firm", firmId));
         return cancelled;
     }
+
+    /// <summary>
+    /// Canonical stale-reason string for a confirmed session roll, so the
+    /// runtime reactor (connect / reconnect) and any future caller emit an
+    /// identical, operator-greppable reason. Format mirrors the sibling
+    /// <c>inbound_gap:{from}-{to}</c> / <c>peer_terminated:{code}</c> reasons
+    /// produced by <see cref="OrderStaleningVenueReactor"/>.
+    /// </summary>
+    public static string SessionRolledStaleReason(uint fromVerId, uint toVerId)
+        => $"session_rolled:{fromVerId}-{toVerId}";
 }
 
 /// <summary>
-/// #512 seam. Called by the FIXP gateway immediately after the initial
-/// <c>ConnectAsync</c> when the SDK fell back from Establish-reuse to a
-/// freshly negotiated session with a BUMPED SessionVerId (a recoverable
-/// reuse reject — the venue genuinely lost the session). The boot-time
-/// #380/#504 reconcile already ran against the OLD verId before app start,
-/// so it cannot observe this deferred bump; without this seam the un-acked
-/// PendingNew "ghosts" would linger for the whole process lifetime.
+/// #512 / #380 seam. Called by the FIXP gateway after a CONFIRMED venue
+/// session roll — i.e. an Establish-reuse was REJECTED and the SDK
+/// renegotiated a fresh session with a BUMPED SessionVerId, so the venue
+/// genuinely discarded its per-session state (our working set is gone).
+/// Two callers, both high-confidence (reuse-rejected, not a benign blip):
+///
+/// <list type="number">
+///   <item>the initial <c>ConnectAsync</c> cold-resume fallback
+///         (<c>B3EntryPointClientGateway.ReconcileConnectSessionRoll</c>);</item>
+///   <item>the live reconnect loop on a <c>Renegotiated</c> outcome
+///         (<c>B3EntryPointClientGateway.ReconcileReconnectSessionRoll</c>).</item>
+/// </list>
+///
+/// The boot-time #380/#504 reconcile only sees raw verId numbers (it cannot
+/// distinguish a reuse-reject from a benign advance), so it stays
+/// conservative (reap PendingNew only). This seam carries the richer
+/// reuse-rejected signal, so it ALSO flags surviving Working / PartiallyFilled
+/// orders stale — they cannot exist under the new session and FIXP
+/// retransmission cannot recreate them.
 ///
 /// <para>
 /// Mirrors the <see cref="IVenueDisconnectReactor"/> shape: the gateway
@@ -100,43 +122,127 @@ public interface IConnectSessionRollReactor
     /// <summary>
     /// Reconcile order state for <paramref name="firmId"/> after its venue
     /// session rolled from <paramref name="fromVerId"/> to
-    /// <paramref name="toVerId"/> during the initial connect. MUST run before
+    /// <paramref name="toVerId"/> on a confirmed reuse-reject. MUST run before
     /// the firm's event loop and the first snapshot.
     /// </summary>
-    void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId);
+    void OnSessionRolled(string firmId, uint fromVerId, uint toVerId);
 }
 
 /// <summary>
-/// Default <see cref="IConnectSessionRollReactor"/>: reaps un-acked
-/// PendingNew orders for the rolled firm under the <see cref="EventDispatcher"/>
-/// lock so the mutation is serialised against concurrently-connecting firms'
-/// event loops and the snapshot service. Durability follows the #504 model:
-/// the cancellation is captured by the next snapshot (taken under the same
-/// lock); a crash before that snapshot is backstopped by the boot-time
-/// baseline reconcile on the next restart, which re-detects the advance
-/// (the snapshot baseline still records the pre-bump verId) and re-reaps.
+/// Default <see cref="IConnectSessionRollReactor"/>. On a confirmed session
+/// roll it does two things, in order:
+///
+/// <list type="number">
+///   <item>reaps un-acked <see cref="OrderStatus.PendingNew"/> orders for the
+///         rolled firm under the <see cref="EventDispatcher"/> lock (in-memory
+///         <c>MarkCancelled</c>, durable via the next snapshot — the #504
+///         model);</item>
+///   <item>flags surviving <see cref="OrderStatus.Working"/> /
+///         <see cref="OrderStatus.PartiallyFilled"/> orders STALE via
+///         <see cref="OrderStalenessService.MarkAllWorkingByFirm"/>. Unlike the
+///         boot reconcile (which cannot tell a reuse-reject from a benign verId
+///         advance and therefore keeps Working orders), this seam only fires on
+///         a reuse-reject, so the venue truly lost the order and FIXP
+///         retransmission cannot resurrect it. Staling is non-destructive
+///         (operator-clearable; auto-clears on a terminal ER) and WAL-durable
+///         per order (<c>OrderStaledEvent</c> via <c>Dispatch</c>). Recovery is
+///         ASYMMETRIC with Phase 1: PendingNew reaping is re-runnable from the
+///         restart boot reconcile, but the boot reconcile is conservative (#504,
+///         PendingNew only) and will NOT re-stale Working/PartiallyFilled. So if
+///         this phase fails mid-bulk (e.g. a WAL append error) the un-marked
+///         tail is stranded; the reactor emits
+///         <see cref="MetricsRegistry.SessionRollStaleReconcileFailed"/> +
+///         a critical log and rethrows so an operator reconciles the survivors
+///         via the admin mark-stale endpoint.</item>
+/// </list>
+///
+/// <para>
+/// The two phases are deliberately NOT nested: <see cref="OrderStalenessService.MarkAllWorkingByFirm"/>
+/// takes the dispatcher lock per order, so running it inside the PendingNew
+/// reap's <see cref="EventDispatcher.RunExclusive"/> would hold the lock across
+/// every order's payload serialisation + WAL append. PendingNew (now Cancelled)
+/// and Working/PartiallyFilled are disjoint sets, so no atomicity is needed
+/// between them.
+/// </para>
 /// </summary>
 public sealed class PendingNewReapingConnectRollReactor : IConnectSessionRollReactor
 {
     private readonly WorkingOrderBook _orders;
     private readonly EventDispatcher _dispatcher;
+    private readonly OrderStalenessService? _staleness;
+    private readonly TimeProvider _clock;
     private readonly ILogger<PendingNewReapingConnectRollReactor> _logger;
 
     public PendingNewReapingConnectRollReactor(
         WorkingOrderBook orders,
         EventDispatcher dispatcher,
-        ILogger<PendingNewReapingConnectRollReactor> logger)
+        ILogger<PendingNewReapingConnectRollReactor> logger,
+        OrderStalenessService? staleness = null,
+        TimeProvider? clock = null)
     {
         _orders = orders ?? throw new ArgumentNullException(nameof(orders));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _staleness = staleness;
+        _clock = clock ?? TimeProvider.System;
     }
 
-    public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+    public void OnSessionRolled(string firmId, uint fromVerId, uint toVerId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(firmId);
+
+        // Phase 1: reap un-acked PendingNew under the dispatcher lock.
         _dispatcher.RunExclusive(() =>
             FirmSessionRollReconciliation.CancelPendingNewForRolledFirm(
                 _orders, firmId, fromVerId, toVerId, _logger));
+
+        // Phase 2: flag surviving Working / PartiallyFilled stale. NOT nested
+        // inside RunExclusive (see class remarks).
+        if (_staleness is null)
+        {
+            // Real trading mode always wires the staleness service; a null
+            // here means a reduced composition (tests / mock exchange). Warn
+            // so a misconfigured production deployment that silently drops
+            // back to "keep Working ghosts" (#380) is visible in logs.
+            _logger.LogWarning(
+                "event=recovery.session-rolled firm={Firm} from={From} to={To} stale=skipped reason=no_staleness_service",
+                firmId, fromVerId, toVerId);
+            return;
+        }
+
+        var reason = FirmSessionRollReconciliation.SessionRolledStaleReason(fromVerId, toVerId);
+        int marked;
+        try
+        {
+            marked = _staleness.MarkAllWorkingByFirm(firmId, reason, _clock.GetUtcNow(), actorUserId: null);
+        }
+        catch (Exception ex)
+        {
+            // The staling phase is recovered ONLY by its own per-order WAL
+            // durability (OrderStaledEvent re-applied on replay): the restart
+            // boot reconcile is deliberately conservative (#504, PendingNew
+            // only) and will NOT re-stale surviving Working/PartiallyFilled
+            // orders. So a failure here (e.g. a WAL append error mid-bulk) can
+            // strand the un-marked tail. Emit a CRITICAL, operator-actionable
+            // signal — survivors for this firm must be reconciled by hand via
+            // the admin mark-stale endpoint — then rethrow so the gateway keeps
+            // SessionVerId at the old baseline (preserving the PendingNew boot
+            // backstop) and logs the reconcile failure.
+            MetricsRegistry.SessionRollStaleReconcileFailed.Add(1,
+                new KeyValuePair<string, object?>("firm", firmId));
+            _logger.LogCritical(ex,
+                "event=recovery.session-rolled.stale-failed firm={Firm} from={From} to={To} action=operator_must_mark_stale "
+                + "(confirmed session roll: surviving Working/PartiallyFilled orders may be venue ghosts that were NOT flagged stale; "
+                + "the boot reconcile will not re-stale them — reconcile via the admin mark-stale endpoint).",
+                firmId, fromVerId, toVerId);
+            throw;
+        }
+
+        if (marked > 0)
+        {
+            MetricsRegistry.OrdersAutoStaledByVenueDesync.Add(marked,
+                new KeyValuePair<string, object?>("firm", firmId),
+                new KeyValuePair<string, object?>("reason", "session_rolled"));
+        }
     }
 }

--- a/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
+++ b/backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs
@@ -573,6 +573,19 @@ public static class MetricsRegistry
         Meter.CreateCounter<long>("trading.entrypoint.orders_auto_staled");
 
     /// <summary>
+    /// #380 / #503. Counts CONFIRMED session-roll reconciliations whose
+    /// Working/PartiallyFilled staling phase FAILED (e.g. a WAL append error
+    /// mid-bulk). PendingNew reaping is recovered by the restart boot reconcile,
+    /// but the boot path is conservative (PendingNew only), so a staling failure
+    /// can leave surviving Working/PartiallyFilled orders un-flagged. This is a
+    /// critical operator signal: surviving orders for the tagged <c>{firm}</c>
+    /// must be reconciled by hand via the admin <c>mark-stale</c> endpoint.
+    /// Tagged <c>{firm}</c>; one Add per failed reconciliation.
+    /// </summary>
+    public static readonly Counter<long> SessionRollStaleReconcileFailed =
+        Meter.CreateCounter<long>("trading.entrypoint.session_roll_stale_reconcile_failed");
+
+    /// <summary>
     /// #153. Counts cash-margin reservation Restore calls (admin
     /// clear-stale path) that pushed the per-owner reserved figure
     /// above the resolved base capacity. Restore intentionally never

--- a/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
+++ b/backend/src/B3.Trading.Host/Composition/TradingPersistenceServiceCollectionExtensions.cs
@@ -67,15 +67,22 @@ public static class TradingPersistenceServiceCollectionExtensions
             sp.GetRequiredService<IEventStore>(),
             sp.GetServices<IExecutionFanOutSink>()));
 
-        // #512. Runtime post-connect session-roll reactor. Reaps un-acked
-        // PendingNew under the dispatcher lock when the gateway detects a
-        // cold-resume fallback verId bump. Always available (EventDispatcher
-        // is registered unconditionally — NullEventStore when persistence is
-        // off), so the gateway's reap path degrades gracefully.
+        // #512 / #380. Runtime session-roll reactor. On a CONFIRMED roll
+        // (Establish-reuse rejected → renegotiate, detected at connect or on a
+        // live Renegotiated reconnect) it reaps un-acked PendingNew under the
+        // dispatcher lock AND flags surviving Working/PartiallyFilled stale via
+        // OrderStalenessService (operator-clearable; WAL-durable). The boot
+        // reconcile stays conservative (PendingNew only) because it cannot tell
+        // a reuse-reject from a benign verId advance. EventDispatcher is always
+        // registered (NullEventStore when persistence is off); OrderStalenessService
+        // is optional so reduced/mock compositions degrade to reap-only (the
+        // reactor logs a warning).
         services.AddSingleton<IConnectSessionRollReactor>(sp => new PendingNewReapingConnectRollReactor(
             sp.GetRequiredService<WorkingOrderBook>(),
             sp.GetRequiredService<EventDispatcher>(),
-            sp.GetRequiredService<ILogger<PendingNewReapingConnectRollReactor>>()));
+            sp.GetRequiredService<ILogger<PendingNewReapingConnectRollReactor>>(),
+            sp.GetService<OrderStalenessService>(),
+            sp.GetService<TimeProvider>()));
 
         return services;
     }

--- a/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
+++ b/backend/src/B3.Trading.Infrastructure/B3EntryPointClientGateway.cs
@@ -266,7 +266,7 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
         // backstop armed.
         try
         {
-            _connectSessionRollReactor?.OnSessionRolledAtConnect(_firmId, prior, effective);
+            _connectSessionRollReactor?.OnSessionRolled(_firmId, prior, effective);
         }
         catch (Exception ex)
         {
@@ -282,6 +282,64 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
 
         Volatile.Write(ref _currentSessionVerId, effective);
         MetricsRegistry.RecordSessionVerId(_firmId, effective);
+    }
+
+    /// <summary>
+    /// #380 / #503. Reconcile a live-reconnect session-version transition.
+    /// Called by <see cref="ReconnectLoopAsync"/> after a successful reconnect,
+    /// before <see cref="OnConnected"/>.
+    ///
+    /// <para>
+    /// On a <see cref="Up.ReconnectKind.Renegotiated"/> outcome the SDK fell
+    /// back from Establish-reuse to a fresh Negotiate because the venue
+    /// REJECTED the reuse — a confirmed session roll: the venue discarded our
+    /// working set, so un-acked PendingNew cannot exist and surviving
+    /// Working / PartiallyFilled orders are ghosts that FIXP retransmission
+    /// cannot resurrect. We hand the roll to the Application reactor (reap
+    /// PendingNew + flag Working/PartiallyFilled stale) and publish the bumped
+    /// verId only AFTER the reactor succeeds. A reactor failure leaves
+    /// <see cref="CurrentSessionVerId"/> at the old baseline so the next
+    /// restart's boot reconcile re-detects the roll — identical backstop
+    /// reasoning to <see cref="ReconcileConnectSessionRoll"/>.
+    /// </para>
+    ///
+    /// <para>
+    /// On a <see cref="Up.ReconnectKind.Reattached"/> outcome the venue kept
+    /// our working set (verId preserved); we simply mirror the SDK's verId and
+    /// do no reconciliation. The conditional inbound-gap / peer-terminate
+    /// staleness for that case is handled separately by
+    /// <see cref="NotifyVenueDisconnectReactor"/>.
+    /// </para>
+    /// </summary>
+    internal void ReconcileReconnectSessionRoll(Up.ReconnectKind kind, uint priorVerId, uint effectiveVerId)
+    {
+        var confirmedRoll = kind == Up.ReconnectKind.Renegotiated && effectiveVerId > priorVerId;
+        if (!confirmedRoll)
+        {
+            // Reattach (or a defensive no-advance Renegotiate): mirror the
+            // SDK's verId. No ghosts — venue kept our set.
+            Volatile.Write(ref _currentSessionVerId, effectiveVerId);
+            MetricsRegistry.RecordSessionVerId(_firmId, effectiveVerId);
+            return;
+        }
+
+        try
+        {
+            _connectSessionRollReactor?.OnSessionRolled(_firmId, priorVerId, effectiveVerId);
+        }
+        catch (Exception ex)
+        {
+            // A reactor failure must never abort the reconnect — the session
+            // is established. Leave _currentSessionVerId at the old baseline
+            // so the next-restart boot reconcile still re-detects the roll.
+            _logger.LogError(ex,
+                "Reconnect session-roll reactor failed for firm {Firm} (from={From} to={To}); leaving SessionVerId baseline at {Prior} to keep the restart backstop armed.",
+                _firmId, priorVerId, effectiveVerId, priorVerId);
+            return;
+        }
+
+        Volatile.Write(ref _currentSessionVerId, effectiveVerId);
+        MetricsRegistry.RecordSessionVerId(_firmId, effectiveVerId);
     }
 
     private void OnConnected()
@@ -957,13 +1015,19 @@ public sealed class B3EntryPointClientGateway : IExchangeGateway, IEntryPointCli
                         Up.ReconnectMode.EstablishReuseThenNegotiate,
                         BumpSessionVerIdSelector,
                         ct).ConfigureAwait(false);
-                    _currentSessionVerId = outcome.SessionVerId;
                     MetricsRegistry.EntryPointReconnectSucceeded.Add(1,
                         new KeyValuePair<string, object?>("firm", _firmId),
                         new KeyValuePair<string, object?>("kind", ReconnectKindTag(outcome.Kind)));
                     _logger.LogInformation(
                         "EntryPoint reconnect ok for firm {Firm} on attempt {N} (kind={Kind} sessionVerId={Ver} priorVerId={Prior} retransmitWindowReady={RetransmitReady}).",
                         _firmId, attempt, outcome.Kind, outcome.SessionVerId, priorVerId, outcome.RetransmitWindowReady);
+                    // Reconcile the session-version transition BEFORE restarting
+                    // the event loop (so the reap/stale lands ahead of ER replay)
+                    // and, on a confirmed roll, BEFORE publishing the bumped
+                    // verId (so a snapshot can't seal the new baseline with
+                    // ghosts still present — same backstop reasoning as the
+                    // connect path).
+                    ReconcileReconnectSessionRoll(outcome.Kind, priorVerId, outcome.SessionVerId);
                     OnConnected();
                     NotifyVenueDisconnectReactor();
                     return;

--- a/backend/tests/B3.Trading.Application.Tests/ConnectSessionRollReactorTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/ConnectSessionRollReactorTests.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using B3.Trading.Application;
 using B3.Trading.Application.Persistence;
 using B3.Trading.Domain;
@@ -21,7 +25,99 @@ public class ConnectSessionRollReactorTests
     private static EventDispatcher Dispatcher() => new(new NullEventStore());
 
     [Fact]
-    public void OnSessionRolledAtConnect_CancelsPendingNew_ForFirm_KeepsWorking()
+    public void OnSessionRolled_WithStaleness_ReapsPendingNew_AndStalesWorkingAndPartiallyFilled()
+    {
+        var book = new WorkingOrderBook();
+        var pending = MakeOrder(1UL, "FIRM_A");
+        var working = MakeOrder(2UL, "FIRM_A");
+        working.MarkWorking();
+        var partial = MakeOrder(3UL, "FIRM_A");
+        partial.MarkWorking();
+        partial.ApplyCumulativeFill(5); // 5 of 10 → PartiallyFilled
+        var otherFirm = MakeOrder(4UL, "FIRM_B");
+        otherFirm.MarkWorking();
+        book.TryAdd(pending);
+        book.TryAdd(working);
+        book.TryAdd(partial);
+        book.TryAdd(otherFirm);
+
+        var dispatcher = Dispatcher();
+        var staleness = new OrderStalenessService(dispatcher, book);
+        var reactor = new PendingNewReapingConnectRollReactor(
+            book, dispatcher, NullLogger<PendingNewReapingConnectRollReactor>.Instance, staleness);
+
+        reactor.OnSessionRolled("FIRM_A", fromVerId: 7, toVerId: 8);
+
+        // PendingNew reaped.
+        Assert.Equal(OrderStatus.Cancelled, pending.Status);
+        Assert.False(pending.IsStale);
+        // Working + PartiallyFilled flagged stale (non-destructive — status kept).
+        Assert.Equal(OrderStatus.Working, working.Status);
+        Assert.True(working.IsStale);
+        Assert.Equal("session_rolled:7-8", working.StaleReason);
+        Assert.Equal(OrderStatus.PartiallyFilled, partial.Status);
+        Assert.True(partial.IsStale);
+        Assert.Equal("session_rolled:7-8", partial.StaleReason);
+        // Other firm untouched.
+        Assert.False(otherFirm.IsStale);
+        Assert.Equal(OrderStatus.Working, otherFirm.Status);
+    }
+
+    [Fact]
+    public void OnSessionRolled_NoStalenessService_StillReapsPendingNew_KeepsWorking()
+    {
+        var book = new WorkingOrderBook();
+        var pending = MakeOrder(1UL, "FIRM_A");
+        var working = MakeOrder(2UL, "FIRM_A");
+        working.MarkWorking();
+        book.TryAdd(pending);
+        book.TryAdd(working);
+
+        var reactor = new PendingNewReapingConnectRollReactor(
+            book, Dispatcher(), NullLogger<PendingNewReapingConnectRollReactor>.Instance, staleness: null);
+
+        reactor.OnSessionRolled("FIRM_A", 7, 8);
+
+        Assert.Equal(OrderStatus.Cancelled, pending.Status);
+        Assert.Equal(OrderStatus.Working, working.Status);
+        Assert.False(working.IsStale);
+    }
+
+    [Fact]
+    public void OnSessionRolled_StalingPhaseThrows_RethrowsAfterReapingPendingNew()
+    {
+        var book = new WorkingOrderBook();
+        var pending = MakeOrder(1UL, "FIRM_A");
+        var working = MakeOrder(2UL, "FIRM_A");
+        working.MarkWorking();
+        book.TryAdd(pending);
+        book.TryAdd(working);
+
+        // Shared dispatcher whose WAL append throws — Phase 1 reap (in-memory,
+        // under RunExclusive, no append) still completes; Phase 2 staling
+        // (per-order Dispatch → Append) fails.
+        var dispatcher = new EventDispatcher(new ThrowingEventStore());
+        var staleness = new OrderStalenessService(dispatcher, book);
+        var reactor = new PendingNewReapingConnectRollReactor(
+            book, dispatcher, NullLogger<PendingNewReapingConnectRollReactor>.Instance, staleness);
+
+        Assert.ThrowsAny<Exception>(() => reactor.OnSessionRolled("FIRM_A", 7, 8));
+
+        // Phase 1 completed (reap is durable via snapshot, not WAL); the
+        // rethrow lets the gateway keep SessionVerId at the old baseline so the
+        // PendingNew boot backstop stays armed.
+        Assert.Equal(OrderStatus.Cancelled, pending.Status);
+    }
+
+    [Fact]
+    public void Helper_SessionRolledStaleReason_FormatsFromTo()
+    {
+        Assert.Equal("session_rolled:7-8",
+            FirmSessionRollReconciliation.SessionRolledStaleReason(7, 8));
+    }
+
+    [Fact]
+    public void OnSessionRolled_CancelsPendingNew_ForFirm_KeepsWorking()
     {
         var book = new WorkingOrderBook();
 
@@ -36,7 +132,7 @@ public class ConnectSessionRollReactorTests
         var reactor = new PendingNewReapingConnectRollReactor(
             book, Dispatcher(), NullLogger<PendingNewReapingConnectRollReactor>.Instance);
 
-        reactor.OnSessionRolledAtConnect("FIRM_A", fromVerId: 7, toVerId: 8);
+        reactor.OnSessionRolled("FIRM_A", fromVerId: 7, toVerId: 8);
 
         Assert.Equal(OrderStatus.Cancelled, pendingA1.Status);
         Assert.Equal(OrderStatus.Cancelled, pendingA2.Status);
@@ -44,7 +140,7 @@ public class ConnectSessionRollReactorTests
     }
 
     [Fact]
-    public void OnSessionRolledAtConnect_DoesNotTouchOtherFirms()
+    public void OnSessionRolled_DoesNotTouchOtherFirms()
     {
         var book = new WorkingOrderBook();
         var pendingA = MakeOrder(1UL, "FIRM_A");
@@ -55,7 +151,7 @@ public class ConnectSessionRollReactorTests
         var reactor = new PendingNewReapingConnectRollReactor(
             book, Dispatcher(), NullLogger<PendingNewReapingConnectRollReactor>.Instance);
 
-        reactor.OnSessionRolledAtConnect("FIRM_A", 5, 6);
+        reactor.OnSessionRolled("FIRM_A", 5, 6);
 
         Assert.Equal(OrderStatus.Cancelled, pendingA.Status);
         Assert.Equal(OrderStatus.PendingNew, pendingB.Status);
@@ -102,5 +198,22 @@ public class ConnectSessionRollReactorTests
             book, "FIRM_X", 1, 2, NullLogger.Instance);
 
         Assert.Equal(0, count);
+    }
+
+    private sealed class ThrowingEventStore : IEventStore
+    {
+        public long CurrentSeq => 0;
+        public long Append(WalEvent evt) => throw new IOException("wal down");
+        public long Append(WalEvent evt, ReadOnlyMemory<byte> preSerialisedPayload)
+            => throw new IOException("wal down");
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public async IAsyncEnumerable<(long Seq, WalEvent Event)> ReadFromAsync(
+            long sinceSeqExclusive,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/backend/tests/B3.Trading.Application.Tests/GatewayConnectSessionRollTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/GatewayConnectSessionRollTests.cs
@@ -18,7 +18,7 @@ public class GatewayConnectSessionRollTests
     private sealed class SpyReactor : IConnectSessionRollReactor
     {
         public readonly List<(string Firm, uint From, uint To)> Calls = new();
-        public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+        public void OnSessionRolled(string firmId, uint fromVerId, uint toVerId)
             => Calls.Add((firmId, fromVerId, toVerId));
     }
 
@@ -107,7 +107,62 @@ public class GatewayConnectSessionRollTests
 
     private sealed class ThrowingReactor : IConnectSessionRollReactor
     {
-        public void OnSessionRolledAtConnect(string firmId, uint fromVerId, uint toVerId)
+        public void OnSessionRolled(string firmId, uint fromVerId, uint toVerId)
             => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    public void ReconcileReconnectSessionRoll_Renegotiated_Advanced_InvokesReactor_AndPublishesVerId()
+    {
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: null, reactor: reactor);
+
+        gw.ReconcileReconnectSessionRoll(
+            B3.EntryPoint.Client.ReconnectKind.Renegotiated, priorVerId: 8, effectiveVerId: 9);
+
+        Assert.Equal(9u, gw.CurrentSessionVerId);
+        var call = Assert.Single(reactor.Calls);
+        Assert.Equal(("FIRM_A", 8u, 9u), call);
+    }
+
+    [Fact]
+    public void ReconcileReconnectSessionRoll_Reattached_NoReactor_MirrorsVerId()
+    {
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: null, reactor: reactor);
+
+        // Reattach preserves the verId (effective == prior); no ghosts.
+        gw.ReconcileReconnectSessionRoll(
+            B3.EntryPoint.Client.ReconnectKind.Reattached, priorVerId: 8, effectiveVerId: 8);
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
+        Assert.Empty(reactor.Calls);
+    }
+
+    [Fact]
+    public void ReconcileReconnectSessionRoll_Renegotiated_NoAdvance_IsNoReactorCall()
+    {
+        // Defensive: Renegotiated but verId did not advance — treat as no roll.
+        var reactor = new SpyReactor();
+        var gw = BuildGateway(initialVerId: 8, provider: null, reactor: reactor);
+
+        gw.ReconcileReconnectSessionRoll(
+            B3.EntryPoint.Client.ReconnectKind.Renegotiated, priorVerId: 8, effectiveVerId: 8);
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
+        Assert.Empty(reactor.Calls);
+    }
+
+    [Fact]
+    public void ReconcileReconnectSessionRoll_ReactorThrows_LeavesVerIdAtOldBaseline()
+    {
+        // Backstop: a reactor failure must NOT publish the bumped verId, so the
+        // next-restart boot reconcile can re-detect the roll.
+        var gw = BuildGateway(initialVerId: 8, provider: null, reactor: new ThrowingReactor());
+
+        gw.ReconcileReconnectSessionRoll(
+            B3.EntryPoint.Client.ReconnectKind.Renegotiated, priorVerId: 8, effectiveVerId: 9); // must not throw
+
+        Assert.Equal(8u, gw.CurrentSessionVerId);
     }
 }


### PR DESCRIPTION
## What & why

On a **confirmed** venue session roll — the venue **rejects** our Establish-reuse and the SDK renegotiates a fresh session with a **bumped `SessionVerId`** — the venue has discarded its per-session order state. Until now we only reaped un-acked `PendingNew`; surviving `Working`/`PartiallyFilled` orders were left as ghosts that no FIXP retransmission can resurrect.

Refs #380, #503.

## Change

Three reconcile paths, by design:

1. **Boot** (`SnapshotService.ReconcileFirmSessionVerIds`) — **UNCHANGED**. It only sees raw verId numbers and cannot distinguish a reuse-reject from a benign advance, so it stays conservative (PendingNew-only, #504). `RolledForward_ConfirmedOrders_NotStaled_FixpHandlesSync` stays green.
2. **Connect** cold-resume fallback (`ReconcileConnectSessionRoll`) — high-confidence reuse-reject → reap PendingNew **+ stale Working/PartiallyFilled**.
3. **Reconnect** (`ReconcileReconnectSessionRoll`, **new**) — gates on `ReconnectKind.Renegotiated && effective > prior`; `Reattached` just mirrors the verId.

Reactor (`PendingNewReapingConnectRollReactor`):
- **Phase 1** reaps `PendingNew` under the dispatcher lock (in-memory, durable via next snapshot — #504 model).
- **Phase 2** flags surviving `Working`/`PartiallyFilled` stale via `OrderStalenessService.MarkAllWorkingByFirm` — **non-destructive** (a flag; auto-clears on a terminal ER; operator-clearable via the admin `mark-stale` endpoint), **WAL-durable per order**.

On a `Renegotiated` reconnect the reactor runs **before** publishing the bumped verId; a reactor failure keeps verId at the **old baseline** so the restart boot reconcile re-detects the roll (PendingNew backstop).

### Recovery-asymmetry mitigation

PendingNew reaping is recoverable by the (conservative) boot reconcile, but staling is **not** — so a Phase 2 WAL failure mid-bulk can strand the un-marked tail. The reactor emits a distinct critical `SessionRollStaleReconcileFailed` metric + log directing the operator to reconcile survivors via the admin `mark-stale` endpoint. (Chosen over a durable roll-marker: under a hard WAL-down condition no durable mechanism can record anything anyway.)

## Tests

- Reactor: reaps PendingNew + stales Working/PartiallyFilled (`session_rolled:{from}-{to}`); null-staleness still reaps + warns; Phase-2-throws rethrows after Phase-1 reap.
- Gateway `ReconcileReconnectSessionRoll`: Renegotiated+advance → reactor called once + verId published; Reattached / no-advance → verId mirrored, no reactor; throwing reactor → verId kept at old baseline.
- Full `B3.Trading.Application.Tests` green (1319), `dotnet format` clean.

## Out of scope / follow-ups

- **#380(A) durable MassStatusRequest reconciliation** is **upstream-blocked**: SDK 0.16.0 exposes no order-status/mass-status query API. Will open a `B3EntryPointClient` issue.
- Cancel-reject ER WS surfacing (#380 item 3) — separate investigation.
