### PR TITLE
fix(#518): round algo child slices to instrument lot size

### DIFF
--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -91,6 +91,9 @@ public static class AlgoEndpoints
             // off-lot child — which the venue rejects, terminally suspending
             // the parent. Validating the total (and, below, slice-derived
             // quantities) up front keeps every algo child a whole lot.
+            // TWAP is excluded here: its §4.8 branch performs the same
+            // off-lot-total check but returns the richer rejection body
+            // (impliedSliceQuantity / totalQuantity / sliceCount echo).
             long lotSize = 1;
             if (symbols.TryGetSpec(req.Symbol, out var instrumentSpec)
                 && instrumentSpec.LotSize is { } configuredLot
@@ -98,7 +101,7 @@ public static class AlgoEndpoints
             {
                 lotSize = configuredLot;
             }
-            if (lotSize > 1 && req.TotalQuantity % lotSize != 0)
+            if (lotSize > 1 && type != AlgoType.Twap && req.TotalQuantity % lotSize != 0)
                 return Results.BadRequest(new
                 {
                     error = $"totalQuantity {req.TotalQuantity} is not a multiple of lot size {lotSize} for {req.Symbol}",
@@ -148,18 +151,23 @@ public static class AlgoEndpoints
                     if (childType == OrderType.Limit && req.Twap.ChildPrice is null)
                         return Results.BadRequest(new { error = "twap.childPrice is required when twap.childOrderType is Limit" });
                     // RFC §4.8 / #518: reject when the implied per-slice
-                    // quantity rounds to zero — computed in lot units when a
-                    // lot is configured so sliceCount cannot exceed the
-                    // available whole lots. Echo the floor in the error body
-                    // so the caller can lower sliceCount or raise
-                    // totalQuantity without guessing.
+                    // quantity rounds to zero — or, on a round-lot
+                    // instrument, when the total itself is not a whole
+                    // number of lots (an off-lot total would otherwise
+                    // strand an off-lot remainder on the last slice). Both
+                    // are computed in lot units when a lot is configured.
+                    // Echo the floor / total / sliceCount in the error body
+                    // so the caller can fix either input without guessing.
                     var floorQty = TwapPlan.FloorSliceQty(req.TotalQuantity, req.Twap.SliceCount, lotSize);
-                    if (floorQty <= 0)
+                    var offLotTotal = lotSize > 1 && req.TotalQuantity % lotSize != 0;
+                    if (floorQty <= 0 || offLotTotal)
                         return Results.BadRequest(new
                         {
-                            error = lotSize > 1
-                                ? $"twap.sliceCount produces a per-slice quantity below one lot ({lotSize}) for {req.Symbol}"
-                                : "twap.sliceCount produces a per-slice quantity of zero",
+                            error = offLotTotal
+                                ? $"totalQuantity {req.TotalQuantity} is not a multiple of lot size {lotSize} for {req.Symbol}"
+                                : lotSize > 1
+                                    ? $"twap.sliceCount produces a per-slice quantity below one lot ({lotSize}) for {req.Symbol}"
+                                    : "twap.sliceCount produces a per-slice quantity of zero",
                             impliedSliceQuantity = floorQty,
                             totalQuantity = req.TotalQuantity,
                             sliceCount = req.Twap.SliceCount,

--- a/backend/src/B3.Trading.Api/AlgoEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AlgoEndpoints.cs
@@ -85,6 +85,26 @@ public static class AlgoEndpoints
             if (securityId == 0)
                 return Results.BadRequest(new { error = "securityId is required" });
 
+            // #518. Lot-size gate mirroring the per-order MinLotSizeCheck.
+            // The algo parent never hits the risk pipeline, so without this
+            // an off-lot total would only surface when the engine submits an
+            // off-lot child — which the venue rejects, terminally suspending
+            // the parent. Validating the total (and, below, slice-derived
+            // quantities) up front keeps every algo child a whole lot.
+            long lotSize = 1;
+            if (symbols.TryGetSpec(req.Symbol, out var instrumentSpec)
+                && instrumentSpec.LotSize is { } configuredLot
+                && configuredLot > 1)
+            {
+                lotSize = configuredLot;
+            }
+            if (lotSize > 1 && req.TotalQuantity % lotSize != 0)
+                return Results.BadRequest(new
+                {
+                    error = $"totalQuantity {req.TotalQuantity} is not a multiple of lot size {lotSize} for {req.Symbol}",
+                    code = "min_lot_size",
+                });
+
             // Type-specific parameter validation. v0 keeps the rules
             // explicit + duplicated rather than hiding them behind a
             // visitor — the surface is small and the failure messages
@@ -99,6 +119,15 @@ public static class AlgoEndpoints
                         return Results.BadRequest(new { error = "iceberg.displayQuantity must be positive" });
                     if (req.Iceberg.DisplayQuantity > req.TotalQuantity)
                         return Results.BadRequest(new { error = "iceberg.displayQuantity must be <= totalQuantity" });
+                    // #518. The display quantity is the child order size, so
+                    // it must itself be a whole lot or every iceberg child is
+                    // risk-rejected.
+                    if (lotSize > 1 && req.Iceberg.DisplayQuantity % lotSize != 0)
+                        return Results.BadRequest(new
+                        {
+                            error = $"iceberg.displayQuantity {req.Iceberg.DisplayQuantity} is not a multiple of lot size {lotSize} for {req.Symbol}",
+                            code = "min_lot_size",
+                        });
                     parameters = new IcebergParameters(req.Iceberg.DisplayQuantity, req.Iceberg.LimitPrice);
                     break;
 
@@ -118,15 +147,19 @@ public static class AlgoEndpoints
                     // unpriced child orders that contradict the user's chosen type.
                     if (childType == OrderType.Limit && req.Twap.ChildPrice is null)
                         return Results.BadRequest(new { error = "twap.childPrice is required when twap.childOrderType is Limit" });
-                    // RFC §4.8: reject when the implied per-slice quantity
-                    // rounds to zero. Echo the floor in the error body so
-                    // the caller can lower sliceCount or raise totalQuantity
-                    // without guessing.
-                    var floorQty = TwapPlan.FloorSliceQty(req.TotalQuantity, req.Twap.SliceCount);
+                    // RFC §4.8 / #518: reject when the implied per-slice
+                    // quantity rounds to zero — computed in lot units when a
+                    // lot is configured so sliceCount cannot exceed the
+                    // available whole lots. Echo the floor in the error body
+                    // so the caller can lower sliceCount or raise
+                    // totalQuantity without guessing.
+                    var floorQty = TwapPlan.FloorSliceQty(req.TotalQuantity, req.Twap.SliceCount, lotSize);
                     if (floorQty <= 0)
                         return Results.BadRequest(new
                         {
-                            error = "twap.sliceCount produces a per-slice quantity of zero",
+                            error = lotSize > 1
+                                ? $"twap.sliceCount produces a per-slice quantity below one lot ({lotSize}) for {req.Symbol}"
+                                : "twap.sliceCount produces a per-slice quantity of zero",
                             impliedSliceQuantity = floorQty,
                             totalQuantity = req.TotalQuantity,
                             sliceCount = req.Twap.SliceCount,

--- a/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
+++ b/backend/src/B3.Trading.Application/Algo/AlgoEngine.cs
@@ -158,7 +158,8 @@ public sealed class AlgoEngine : BackgroundService
         PeggedRepegBook? peggedRepeg = null,
         PendingReplacementRegistry? replacements = null,
         RiskPipeline? risk = null,
-        IReplaceMarginCoordinator? replaceMargin = null)
+        IReplaceMarginCoordinator? replaceMargin = null,
+        SymbolDirectory? symbols = null)
     {
         _queue = queue;
         _algos = algos;
@@ -180,6 +181,49 @@ public sealed class AlgoEngine : BackgroundService
         _replacements = replacements;
         _risk = risk;
         _replaceMargin = replaceMargin;
+        _symbols = symbols;
+    }
+
+    /// <summary>
+    /// #518. Instrument lot-size table (optional, null-tolerant for test
+    /// compositions). Used by <see cref="ResolveLotSize"/> /
+    /// <see cref="RoundDownToLot"/> so every algo child slice is a whole
+    /// multiple of the instrument lot — otherwise the pre-trade
+    /// <c>MinLotSizeCheck</c> rejects the child and terminally suspends the
+    /// parent on round-lot venues (every B3 equity has lot 100).
+    /// </summary>
+    private readonly SymbolDirectory? _symbols;
+
+    /// <summary>
+    /// #518. Resolves the instrument lot size for <paramref name="symbol"/>,
+    /// or 1 when unknown / unconstrained (fail-open, mirroring
+    /// <c>MinLotSizeCheck</c>'s posture for unconfigured symbols).
+    /// </summary>
+    private long ResolveLotSize(string symbol)
+    {
+        if (_symbols is not null
+            && _symbols.TryGetSpec(symbol, out var spec)
+            && spec.LotSize is { } lot
+            && lot > 1)
+        {
+            return lot;
+        }
+        return 1;
+    }
+
+    /// <summary>
+    /// #518. Rounds <paramref name="qty"/> down to the largest whole
+    /// multiple of the instrument lot size. A no-op when the lot is 1 /
+    /// unknown or <paramref name="qty"/> is already aligned. A positive
+    /// sub-lot quantity floors to zero, which the slice dispatcher treats
+    /// as "defer this tick" rather than submitting an odd lot the venue
+    /// would reject.
+    /// </summary>
+    private long RoundDownToLot(string symbol, long qty)
+    {
+        if (qty <= 0) return qty;
+        var lot = ResolveLotSize(symbol);
+        return lot > 1 ? qty - (qty % lot) : qty;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -660,7 +704,7 @@ public sealed class AlgoEngine : BackgroundService
                     return;
                 }
                 var (qty, _, _, _) = ComputeVwapSlice(algo, vp, dueAt);
-                if (qty > 0) break;
+                if (RoundDownToLot(algo.Symbol, qty) > 0) break;
                 rt.NextSliceSeq++;
             }
         }
@@ -682,7 +726,7 @@ public sealed class AlgoEngine : BackgroundService
                 if (now < dueAt) return;
                 if (dueAt >= pp.EndUtc) return;
                 var (qty, _, _) = ComputePovSlice(algo, pp, rt, dueAt);
-                if (qty > 0) break;
+                if (RoundDownToLot(algo.Symbol, qty) > 0) break;
                 rt.NextSliceSeq++;
             }
         }
@@ -1551,9 +1595,30 @@ public sealed class AlgoEngine : BackgroundService
 
     private async Task SubmitNextSliceAsync(Algo algo, AlgoParentRuntime rt, CancellationToken ct)
     {
-        var (sliceQty, slicePrice) = ComputeNextSlice(algo);
+        var (rawQty, slicePrice) = ComputeNextSlice(algo);
+        // #518. Final lot-size invariant: no algo child leaves the engine
+        // with an odd lot the venue's MinLotSizeCheck would reject (which
+        // would terminally suspend the parent). VWAP/POV gaps and any
+        // partial-fill residue are floored to a whole lot here; TWAP
+        // (lot-unit plan), Iceberg/Pegged (lot-valid total/residue) are
+        // already aligned so this is a no-op for them on the happy path.
+        var sliceQty = RoundDownToLot(algo.Symbol, rawQty);
         if (sliceQty <= 0)
         {
+            // A positive quantity that floored to zero is a sub-lot residue
+            // (or sub-lot curve gap). It is NOT "nothing owed": submitting
+            // it would be risk-rejected and completing would strand the
+            // residue. Defer — a later tick (curve growth / fills) presents
+            // a full lot, or the window-expiry path retires the parent.
+            if (rawQty > 0)
+            {
+                if (algo.Type == AlgoType.Vwap || algo.Type == AlgoType.Pov)
+                    rt.NextSliceSeq++;
+                _logger.LogDebug(
+                    "Algo {AlgoId}/{Firm} ({Type}) owed sub-lot residue {Residue} (lot {Lot}); deferring slice.",
+                    algo.AlgoId, algo.FirmId, algo.Type, rawQty, ResolveLotSize(algo.Symbol));
+                return;
+            }
             if (algo.Type == AlgoType.Vwap || algo.Type == AlgoType.Pov)
             {
                 // VWAP/POV: empty slot — the parent is ahead of the
@@ -1571,8 +1636,24 @@ public sealed class AlgoEngine : BackgroundService
                 // next tick; we just no-op until the cache warms.
                 return;
             }
-            // Should be unreachable (RemainingQuantity == 0 is checked by
-            // callers) — defensive log + complete.
+            if (algo.RemainingQuantity > 0)
+            {
+                // #518. rawQty == 0 but the parent still owes quantity. This
+                // is reachable for TWAP when the lot table becomes
+                // authoritative AFTER admission (SDK SecurityDefinition
+                // overlay): an interior slice floors to zero in lot units
+                // while the remainder-bearing last slice still carries the
+                // outstanding quantity. Advancing the slot index lets that
+                // final slice (or, failing that, window expiry) work the
+                // residue. Completing here would silently strand it.
+                if (algo.Type == AlgoType.Twap)
+                    rt.NextSliceSeq++;
+                _logger.LogDebug(
+                    "Algo {AlgoId}/{Firm} ({Type}) produced an empty slice with {Remaining} remaining (lot {Lot}); deferring.",
+                    algo.AlgoId, algo.FirmId, algo.Type, algo.RemainingQuantity, ResolveLotSize(algo.Symbol));
+                return;
+            }
+            // Genuinely nothing owed (RemainingQuantity == 0) — terminalize.
             await RecordTerminalAsync(algo, rt, AlgoStatus.Completed, AlgoTerminalReason.None).ConfigureAwait(false);
             return;
         }
@@ -1864,7 +1945,8 @@ public sealed class AlgoEngine : BackgroundService
                     // alone — no separate persisted plan.
                     var rt = _runtime[(algo.FirmId, algo.AlgoId)];
                     var seq = rt.NextSliceSeq;
-                    var planned = TwapPlan.SliceQty(algo.TotalQuantity, tp.SliceCount, seq);
+                    var lot = ResolveLotSize(algo.Symbol);
+                    var planned = TwapPlan.SliceQty(algo.TotalQuantity, tp.SliceCount, seq, lot);
                     // Cap at remaining: fills from earlier slices may
                     // partially-cancel a slice and shift residue forward,
                     // so the planned quantity can exceed what's actually

--- a/backend/src/B3.Trading.Application/Algo/TwapPlan.cs
+++ b/backend/src/B3.Trading.Application/Algo/TwapPlan.cs
@@ -21,11 +21,15 @@ namespace B3.Trading.Application;
 /// </para>
 ///
 /// <para>
-/// <b>Quantity rounding.</b> Slices 0..n-2 each carry <c>floor(total/n)</c>
-/// and slice n-1 carries the remainder, so the parent total matches
-/// exactly. Lot-size rounding (RFC §4.8) is deferred until the lot-size
-/// table lands; v0 treats the floor as both the rounded and the unrounded
-/// value.
+/// <b>Quantity rounding.</b> Slices 0..n-2 each carry
+/// <c>floor(total/n)</c> and slice n-1 carries the remainder, so the
+/// parent total matches exactly. When a <c>lotSize &gt; 1</c> is supplied
+/// (issue #518) the distribution is computed in <b>lot units</b> instead:
+/// slices 0..n-2 carry <c>floor(totalLots/n) * lot</c> and the last slice
+/// carries the remainder, so every slice is a whole multiple of the
+/// instrument lot and <c>MinLotSizeCheck</c> never rejects an algo child.
+/// The caller (<c>POST /algo</c>) guarantees <c>total % lot == 0</c> and
+/// <c>total / lot &gt;= sliceCount</c>, so no slice rounds to zero.
 /// </para>
 /// </summary>
 public static class TwapPlan
@@ -57,8 +61,18 @@ public static class TwapPlan
     /// Quantity for slice <paramref name="sliceSeq"/>. All but the last
     /// slice get <c>floor(total/sliceCount)</c>; the last slice carries
     /// the remainder so the parent total reconciles exactly.
+    ///
+    /// <para>
+    /// When <paramref name="lotSize"/> is greater than 1 (issue #518) the
+    /// distribution is computed in lot units so every slice is a whole
+    /// multiple of the instrument lot: slices 0..n-2 carry
+    /// <c>floor(totalLots / sliceCount) * lotSize</c> and the last slice
+    /// carries the lot-valid remainder. The caller validates
+    /// <c>total % lot == 0</c> and <c>total / lot &gt;= sliceCount</c> at
+    /// submit time, so the floor never collapses an interior slice to zero.
+    /// </para>
     /// </summary>
-    public static long SliceQty(long totalQuantity, int sliceCount, int sliceSeq)
+    public static long SliceQty(long totalQuantity, int sliceCount, int sliceSeq, long lotSize = 1)
     {
         if (totalQuantity <= 0)
             throw new ArgumentOutOfRangeException(nameof(totalQuantity), "totalQuantity must be positive.");
@@ -67,8 +81,14 @@ public static class TwapPlan
         if (sliceSeq < 0 || sliceSeq >= sliceCount)
             throw new ArgumentOutOfRangeException(nameof(sliceSeq),
                 $"sliceSeq must be in [0,{sliceCount}).");
+        if (lotSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(lotSize), "lotSize must be positive.");
 
-        var floorQty = totalQuantity / sliceCount;
+        // Lot-unit distribution (#518): floor in whole lots so no interior
+        // slice is an odd lot the venue's MinLotSizeCheck would reject.
+        // lotSize == 1 degenerates to the original share-level floor.
+        var totalLots = totalQuantity / lotSize;
+        var floorQty = (totalLots / sliceCount) * lotSize;
         if (sliceSeq < sliceCount - 1)
             return floorQty;
 
@@ -82,7 +102,18 @@ public static class TwapPlan
     /// Per-slice floor quantity (RFC §4.8); echoed in the
     /// <c>POST /algo</c> error body when validation rejects the
     /// parameters because the implied per-slice quantity is zero.
+    ///
+    /// <para>
+    /// When <paramref name="lotSize"/> is greater than 1 the floor is
+    /// computed in lot units (<c>floor(total/lot/sliceCount) * lot</c>),
+    /// matching <see cref="SliceQty"/> so the endpoint's zero-check sees
+    /// the same lot-aligned interior slice the engine will emit.
+    /// </para>
     /// </summary>
-    public static long FloorSliceQty(long totalQuantity, int sliceCount) =>
-        sliceCount <= 0 ? 0 : totalQuantity / sliceCount;
+    public static long FloorSliceQty(long totalQuantity, int sliceCount, long lotSize = 1)
+    {
+        if (sliceCount <= 0 || lotSize < 1) return 0;
+        var totalLots = totalQuantity / lotSize;
+        return (totalLots / sliceCount) * lotSize;
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoEndpointsTests.cs
@@ -279,4 +279,81 @@ public class AlgoEndpointsTests
         Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
         Assert.Contains(second.StatusCode, new[] { HttpStatusCode.Accepted, HttpStatusCode.Conflict });
     }
+
+    // ──────────────────── #518 TWAP lot-size validation ────────────────────
+
+    private static TestAppFactory NewLotFactory() =>
+        TestAppFactory.WithOverrides(new Dictionary<string, string?>
+        {
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+            ["Trading:SymbolDirectory:Specs:PETR4:LotSize"] = "100",
+        });
+
+    private static object LotTwapBody(long total, int sliceCount) => new
+    {
+        Symbol = "PETR4",
+        Side = "Buy",
+        Type = "Twap",
+        TotalQuantity = total,
+        Twap = new
+        {
+            StartUtc = DateTimeOffset.UtcNow,
+            EndUtc = DateTimeOffset.UtcNow.AddMinutes(1),
+            SliceCount = sliceCount,
+            ChildOrderType = "Limit",
+            ChildPrice = 30m,
+        },
+    };
+
+    [Fact]
+    public async Task PostAlgo_Twap_ImpliedSliceBelowLot_Returns400WithEcho()
+    {
+        // #518. On a round-lot instrument (lot 100) a total that is below
+        // one lot floors to a zero per-slice quantity. The §4.8 contract
+        // requires the rejection body to echo impliedSliceQuantity /
+        // totalQuantity / sliceCount even when the lot table (not the raw
+        // share floor) is what collapses the slice. Mirrors the real-stack
+        // conformance test PostAlgoTwap_ImpliedSliceZero_Returns400WithEcho.
+        using var factory = NewLotFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", LotTwapBody(total: 2, sliceCount: 5));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(0, body.GetProperty("impliedSliceQuantity").GetInt64());
+        Assert.Equal(2, body.GetProperty("totalQuantity").GetInt64());
+        Assert.Equal(5, body.GetProperty("sliceCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_OffLotTotal_Returns400WithEcho()
+    {
+        // #518. A total that is a positive number of whole lots per slice
+        // but not itself a whole number of lots (250 with lot 100, 2 slices
+        // ⇒ slices 100/150) would strand an off-lot remainder on the last
+        // slice. The TWAP branch rejects it up front, still echoing the
+        // §4.8 fields so the rejection body shape is consistent.
+        using var factory = NewLotFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", LotTwapBody(total: 250, sliceCount: 2));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(250, body.GetProperty("totalQuantity").GetInt64());
+        Assert.Equal(2, body.GetProperty("sliceCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task PostAlgo_Twap_WholeLotTotal_Accepted()
+    {
+        // Sanity: a lot-aligned total that divides into whole lots per
+        // slice (400 with lot 100, 4 slices ⇒ 100 each) is admitted.
+        using var factory = NewLotFactory();
+        using var client = await factory.CreateAuthedClientAsync();
+
+        var resp = await client.PostAsJsonAsync("/algo/", LotTwapBody(total: 400, sliceCount: 4));
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
 }

--- a/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/VwapAlgoEndpointTests.cs
@@ -25,6 +25,18 @@ public class VwapAlgoEndpointTests
             ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
         };
 
+    // #518. Same simulator but with a round-lot instrument (lot 100, every
+    // B3 equity) so the MinLotSizeCheck is active and the algo slicing must
+    // emit whole-lot children.
+    private static IDictionary<string, string?> SimulatorWithLot() =>
+        new Dictionary<string, string?>
+        {
+            ["Trading:Exchange:Mode"] = "Mock",
+            ["Trading:Exchange:AllowErInjection"] = "true",
+            ["Trading:SymbolDirectory:SecurityIds:PETR4"] = "4321",
+            ["Trading:SymbolDirectory:Specs:PETR4:LotSize"] = "100",
+        };
+
     private static object VwapBody(long total, DateTimeOffset start, DateTimeOffset end,
         double tickSeconds = 0.2, string childType = "Limit", decimal? childPrice = 30m,
         decimal? sliceMaxPct = null, decimal? participationCap = null, decimal? priceLimit = null) => new
@@ -119,6 +131,80 @@ public class VwapAlgoEndpointTests
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var resp = await http.SendAsync(req);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAlgo_VwapOffLotTotal_Returns400_MinLotSize()
+    {
+        // #518. On a round-lot instrument (lot 100), a total that is not a
+        // whole number of lots is rejected up-front so the parent can never
+        // be admitted only to terminally suspend on the first off-lot slice.
+        using var f = TestAppFactory.WithOverrides(SimulatorWithLot());
+        using var http = f.CreateClient();
+        var token = await f.LoginAsync(http);
+
+        var now = DateTimeOffset.UtcNow;
+        var req = new HttpRequestMessage(HttpMethod.Post, "/algo/")
+        {
+            Content = JsonContent.Create(
+                VwapBody(150, now.AddSeconds(-1), now.AddSeconds(60))),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("min_lot_size", body.GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public async Task Vwap_LotConfigured_AllChildSlicesAreWholeLots()
+    {
+        // #518 regression. With a round-lot instrument (lot 100) the curve
+        // can target an off-lot gap (e.g. cdf≈0.5 of 300 ⇒ 150). Before the
+        // fix the engine submitted the raw 150, which the MinLotSizeCheck
+        // rejected, terminally suspending the parent. After the fix every
+        // child slice is floored to a whole lot, so the parent works the
+        // order down lot-by-lot and never suspends.
+        using var f = TestAppFactory.WithOverrides(SimulatorWithLot());
+        using var http = f.CreateClient();
+        var userToken = await f.LoginAsync(http);
+        var adminToken = await f.LoginAsync(http, "admin");
+
+        var now = DateTimeOffset.UtcNow;
+        var algoId = await PostAlgo(http, userToken,
+            VwapBody(total: 300, start: now.AddSeconds(-1), end: now.AddSeconds(2),
+                tickSeconds: 0.2));
+
+        var book = f.Services.GetRequiredService<WorkingOrderBook>();
+        var seenSeqs = new HashSet<int>();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            var snap = await GetAlgo(http, userToken, algoId);
+            var status = snap.GetProperty("status").GetString();
+            // The bug terminalized the parent as Suspended/RiskRejected;
+            // assert we never get there.
+            Assert.NotEqual("Suspended", status);
+            if (status == "Completed" || status == "Expired") break;
+
+            var next = book.EnumerateChildrenOf("default", ulong.Parse(algoId))
+                .FirstOrDefault(c => c.AlgoSliceSeq is { } s && seenSeqs.Add(s));
+            if (next is null) { await Task.Delay(20); continue; }
+
+            // Every child the engine submits must be a whole lot.
+            Assert.True(next.Quantity % 100 == 0,
+                $"child seq {next.AlgoSliceSeq} qty {next.Quantity} is not a whole lot");
+            await InjectEr(http, adminToken, next.ClOrdId, "Fill", lastQty: next.Quantity);
+        }
+
+        await WaitForAlgoStatus(http, userToken, algoId, "Completed", "Expired");
+        var algo = await GetAlgo(http, userToken, algoId);
+        Assert.NotEqual("Suspended", algo.GetProperty("status").GetString());
+        // Whatever was filled is itself lot-aligned (sum of whole lots).
+        var filledQty = algo.GetProperty("filledQuantity").GetInt64();
+        Assert.True(filledQty % 100 == 0, $"filled {filledQty} not lot-aligned");
     }
 
     // ───────────────────────── Happy-path slice firing ─────────────────────────

--- a/backend/tests/B3.Trading.Application.Tests/Algo/TwapPlanTests.cs
+++ b/backend/tests/B3.Trading.Application.Tests/Algo/TwapPlanTests.cs
@@ -143,4 +143,94 @@ public class TwapPlanTests
         Assert.Equal(0, TwapPlan.FloorSliceQty(3, 4));
         Assert.Equal(0, TwapPlan.FloorSliceQty(100, 0));
     }
+
+    // ──────────────────── #518 lot-aware slicing ────────────────────
+
+    [Fact]
+    public void SliceQty_WithLot_DistributesInWholeLots()
+    {
+        // total 600, lot 100, 4 slices: 6 lots / 4 = floor 1 lot = 100 on
+        // slices 0..2, remainder 300 on the last → every slice a whole lot.
+        Assert.Equal(100, TwapPlan.SliceQty(600, 4, 0, lotSize: 100));
+        Assert.Equal(100, TwapPlan.SliceQty(600, 4, 1, lotSize: 100));
+        Assert.Equal(100, TwapPlan.SliceQty(600, 4, 2, lotSize: 100));
+        Assert.Equal(300, TwapPlan.SliceQty(600, 4, 3, lotSize: 100));
+    }
+
+    [Fact]
+    public void SliceQty_WithLot_NoInteriorSliceIsAnOddLot()
+    {
+        // The unrounded floor(300/4)=75 is an odd lot that MinLotSizeCheck
+        // would reject (issue #518). In lot units every emitted slice is a
+        // multiple of 100 and the sum still reconciles to the total.
+        long sum = 0;
+        for (var seq = 0; seq < 4; seq++)
+        {
+            var qty = TwapPlan.SliceQty(300, 4, seq, lotSize: 100);
+            Assert.Equal(0, qty % 100);
+            sum += qty;
+        }
+        Assert.Equal(300, sum);
+    }
+
+    [Fact]
+    public void SliceQty_LotOne_MatchesShareLevelFloor()
+    {
+        // lotSize == 1 must be byte-identical to the original share-level
+        // distribution so existing TWAPs are unaffected.
+        for (var seq = 0; seq < 3; seq++)
+            Assert.Equal(
+                TwapPlan.SliceQty(1003, 3, seq),
+                TwapPlan.SliceQty(1003, 3, seq, lotSize: 1));
+    }
+
+    [Fact]
+    public void SliceQty_WithLot_SumReconcilesAcrossCombinations()
+    {
+        const long lot = 100;
+        var totalLots = new long[] { 1, 3, 4, 7, 10, 123 };
+        var sliceCounts = new[] { 1, 2, 3, 4 };
+        foreach (var lots in totalLots)
+        {
+            var total = lots * lot;
+            foreach (var count in sliceCounts)
+            {
+                if (count > lots) continue; // endpoint rejects this up front
+                long sum = 0;
+                for (var seq = 0; seq < count; seq++)
+                {
+                    var qty = TwapPlan.SliceQty(total, count, seq, lot);
+                    Assert.Equal(0, qty % lot);
+                    sum += qty;
+                }
+                Assert.Equal(total, sum);
+            }
+        }
+    }
+
+    [Fact]
+    public void FloorSliceQty_WithLot_IsLotAligned()
+    {
+        // 300/4 in lot units → 0 (3 whole lots can't be split into 4),
+        // so the endpoint rejects sliceCount > available lots.
+        Assert.Equal(0, TwapPlan.FloorSliceQty(300, 4, lotSize: 100));
+        // 600/4 → 1 whole lot = 100.
+        Assert.Equal(100, TwapPlan.FloorSliceQty(600, 4, lotSize: 100));
+    }
+
+    [Fact]
+    public void SliceQty_WithLot_MoreSlicesThanLots_LastSliceCarriesRemainder()
+    {
+        // #518 defense-in-depth. The endpoint rejects sliceCount > lots at
+        // admission, but the lot table can become authoritative AFTER a TWAP
+        // was admitted (SDK SecurityDefinition overlay). When that happens
+        // the interior slices floor to zero in lot units and the last slice
+        // carries the whole residue — every slice stays lot-aligned and the
+        // sum still reconciles, so the engine works the order down (via the
+        // remainder-bearing last slice) instead of stranding it.
+        Assert.Equal(0, TwapPlan.SliceQty(300, 4, 0, lotSize: 100));
+        Assert.Equal(0, TwapPlan.SliceQty(300, 4, 1, lotSize: 100));
+        Assert.Equal(0, TwapPlan.SliceQty(300, 4, 2, lotSize: 100));
+        Assert.Equal(300, TwapPlan.SliceQty(300, 4, 3, lotSize: 100));
+    }
 }


### PR DESCRIPTION
## Problem

`VWAP`/`POV`/`TWAP` child slices were never rounded to the instrument lot size. Slice quantities come from the volume curve (`round(total * cdf)`) or a share-level floor (`floor(total / sliceCount)`), so on a round-lot venue — every B3 equity has lot 100 — a slice such as **150** (curve `cdf ≈ 0.5` of 300) is not a lot multiple.

The pre-trade `MinLotSizeCheck` then rejects the child (`code = "min_lot_size"`), which the engine treats as `RiskRejected` and **terminally suspends the parent**, leaving the order unworked. `Suspended` is terminal, so cancel returns `409`.

Reproduced live on the real stack: `VWAP Sell 300 PETR4`, 90s window → first slice fired `qty=150` → rejected → parent `Suspended`, 300 unworked. Manual probe confirmed: `Sell 150 PETR4` → `{"code":"min_lot_size","reason":"quantity 150 is not a multiple of lot size 100 for PETR4"}`.

## Fix (two layers)

**Endpoint (`AlgoEndpoints.cs`)** — the algo parent never traverses the risk pipeline, so add an up-front gate. Resolve the lot via `SymbolDirectory.TryGetSpec` and reject:
- an off-lot `totalQuantity`,
- an off-lot iceberg `displayQuantity`,
- a TWAP `sliceCount` that floors a per-slice quantity below one lot.

**Engine (`AlgoEngine.cs`)** — defence in depth so a child can never leave the engine off-lot:
- inject `SymbolDirectory` (optional trailing ctor param, DI-resolved) + `ResolveLotSize` / `RoundDownToLot` helpers;
- floor every VWAP/POV gap and the TWAP slice to a whole lot at the decision points and again as a final invariant in `SubmitNextSliceAsync`;
- a positive quantity that floors to zero is **deferred** (worked by a later tick / the remainder-bearing last slice / window expiry), **never completed-with-residue** — this also holds when the SDK lot table becomes authoritative *after* the algo was admitted.

**`TwapPlan.cs`** — `SliceQty` / `FloorSliceQty` gained an optional `long lotSize = 1`; when `lot > 1` the total is distributed in whole lot units with the remainder on the last slice. `lotSize == 1` is byte-identical to the prior share-level behaviour, so recovery determinism (TWAP plan recomputed from parameters) is preserved.

## Tests
- `TwapPlanTests`: lot-unit distribution, no odd interior lot, `lot==1` parity, sum reconciliation, and the `sliceCount > lots` remainder-on-last-slice case.
- `VwapAlgoEndpointTests`: off-lot total → `400 min_lot_size`; with lot 100 configured every VWAP child is a whole lot and the parent never suspends.

Targeted suites green (`B3.Trading.Application.Tests` 120, `B3.Trading.Api.Tests` algo 103); `dotnet format --verify-no-changes` clean.

## Review
Self-reviewed with the `code-review` agent (gpt-5.5): it flagged that the TWAP zero-slice fallback could mark the parent `Completed` with remaining quantity if the lot table became authoritative post-admission. Fixed by deferring (advancing the slot index so the remainder-bearing last slice works the residue) instead of completing, and added a `TwapPlan` test locking the remainder-on-last-slice invariant.

Closes #518
