### PR TITLE
docs(#369): document the remaining emitted trading metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -46,7 +46,7 @@ One `AddMeter(MetricsRegistry.Meter.Name)` call wires the lot.
 | `trading.orders.gateway_failed` | Counter | (none) |
 | `trading.orders.cancel_requested` | Counter | (none) |
 | `trading.er.received` | Counter | `type` (Fill, Canceled, Rejected, ...) |
-| `trading.kill_switch.toggled` | Counter | `state` (on/off) |
+| `trading.kill_switch.toggled` | Counter | `scope`, `killed` |
 | `trading.wal.appended` | Counter | (none) |
 | `trading.wal.backpressure` | Counter | `call_site` |
 | `trading.wal.segments_rotated` | Counter | (none) |
@@ -94,6 +94,132 @@ v0 algo pipeline is documented in
 C1, `parentAlgoId` is intentionally **not** a metric tag (cardinality
 would explode); per-algo drill-down lives in structured logs and
 traces.
+
+## Extended application instruments (#369)
+
+The table above is the curated "dashboard-first" subset. The host emits
+many more named instruments on the same `B3.Trading` meter; the tables
+below document the remainder, grouped by area. Source of truth for every
+row is the declaration (and surrounding `.Add(...)` call sites) in
+[`MetricsRegistry.cs`](../backend/src/B3.Trading.Application/Observability/MetricsRegistry.cs).
+"Type" is the `System.Diagnostics.Metrics` instrument; "(none)" means the
+instrument is intentionally label-less to keep cardinality bounded.
+
+### Order flow
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.orders.routing_instruction_stamped` | Counter | `value`, `firmId` | Approved routing-instruction stamps on an outbound NewOrder/Replace (#473); the `BrokerOnly` slice is conflict-of-interest sensitive and alertable per firm. |
+| `trading.orders.gtd_expired` | Counter | `cancel_result` | GTD expiries the scheduler dispatched; tag is the `OrderCancelResultKind` (Accepted/NotFound/Stale/WalBackpressure/GatewayFailed). A climb on a non-Accepted bucket flags scheduler-vs-pipeline drift (#255). |
+| `trading.orders.modify_requested` | Counter | `symbol`, `side`, `firmId` | Cancel-replace (modify) requests accepted into the order pipeline. |
+| `trading.orders.ioc_no_response` | Counter | `firmId`, `symbol`, `tif` | IOC/FOK watchdog synthesised a terminal Cancel because the gateway returned no ER within the timeout (#351). A non-zero rate is a matching-image regression detector. |
+| `trading.orders.duplicate_clordid` | Counter | `op` (submit/modify), `scope` (book/pending) | Pre-flight ClOrdID collision rejections. MUST be flat at zero; non-zero means a counter-watermark regression (#108). |
+| `trading.orders.clordid_registry_corruption` | Counter | `end_client`, `reason` (invalid_observed_clordid/prefix_mismatch) | WAL-replay ClOrdID corruption / per-end-client prefix-mismatch detector. MUST be flat at zero (#157). |
+
+### Execution reports
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.er.replay_dedup` | Counter | `kind` | Idempotent ER drop (cum/terminal already known). Expected after FIXP retransmit on reconnect; a sustained spike is operator-visible. |
+| `trading.er.fill_delta_mismatch` | Counter | `kind` | Fill ER advanced cumulative-quantity by an amount ≠ its own LastQuantity — a lost or out-of-order intermediate fill. |
+| `trading.er.late_fill_after_terminal` | Counter | `kind` | Fill ER arrived for an order already terminal (Cancelled/Rejected); position is still booked, order keeps its terminal status. |
+| `trading.execution_reports.dropped_known_owner_missing_order` | Counter | `kind` | ER resolved to a known owner but the order is absent from the working book — a silent fill loss with position/cash divergence; alertable (#241). |
+| `trading.er.firm_mismatch_total` | Counter | `exec_type` | Live-wire ER carried a FirmId that does not match the resolved order's FirmId; rejected without mutating state (#317). |
+
+### Margin / risk
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.margin.commit_replace_dropped` | Counter | (none) | CommitReplace landed with neither original nor transient reservation present — reserved figure leaks until restart; alertable (#247). |
+| `trading.risk.margin_overcommit_on_restore` | Counter | `owner` | Reservation Restore (admin clear-stale) pushed the per-owner reserved figure above base capacity — safety valve; reconcile by cancelling stale orders (#153). |
+| `trading.risk.margin_stale_transition_failed` | Counter | `kind` | Suspended/Restored could not be applied to the in-process reservation ledger; recoverable on restart, but a non-zero rate signals a bug (#153). |
+| `trading.risk.margin_reservations` | ObservableGauge | `state` (active/suspended) | Live size of the cash-margin reservation ledger; a sustained climb on `suspended` is a dictionary leak until restart (#153). |
+| `trading.risk.stop_check_skipped_no_ref` | Counter | `symbol` | Stop* order approved purely because no reference price was available (the Buy≥ref / Sell≤ref relation was skipped) (#254). |
+| `trading.ratelimit.rejected_total` | Counter | `path`, `principal_kind` (user/ip/anonymous) | Requests rejected by the per-user × endpoint token-bucket limiter (#304). |
+| `trading.er_injection.enabled` | UpDownCounter | (none) | 1 when the host booted with `Trading:Exchange:AllowErInjection=true` (the synthetic-ER admin endpoint is mapped). |
+
+### Audit / compliance / session
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.audit.events_total` | Counter | `event_type`, `outcome` (success/failure/denied) | Audit envelopes emitted via `IAuditLogger`. Deliberately no per-user/firm/IP tag (#305). |
+| `trading.reports.cvm.generated_total` | Counter | `type` (35/505), `firm_id` | Successful CVM 35/505 transaction reports generated by the on-demand export pipeline (#308). |
+| `trading.reports.cvm.generation_seconds` | Histogram (s) | `type` | CVM 35/505 generation latency — full WAL scan + XML stream-write (#308). |
+| `trading.symbol_halt.toggled` | Counter | `halted`, `origin` | Per-symbol halt/resume toggles. |
+| `trading.session_phase.changed` | Counter | `scope` (default/symbol), `phase` | Session-phase changes (auction transitions, `cleared` on override removal); correlate with reject spikes (#108). |
+
+### WAL / persistence
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.wal.unknown_kind_skipped` | Counter | `kind` | WAL record whose discriminator is not in the reader's set — expected during rolling deploys, alert otherwise (#296). |
+| `trading.wal.missing_kind_corruption` | Counter | (none) | WAL record whose discriminator is missing/unextractable — torn write or corruption; replay halts on the first such record (#296). |
+| `trading.persistence.group_commit_max_records` | ObservableGauge (records) | (none) | Configured `Trading:Persistence:GroupCommitMaxRecords` — build-info gauge, reflects config reloads (#234). |
+| `trading.dispatcher.ws_fanout_dropped` | Counter | (none) | WS hub per-sink channel `DropOldest` eviction; subscribers should observe a gap and reconnect-and-replay. |
+
+### Recovery
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.recovery.session_rolled_firms` | Counter | `firm` | Firm whose gateway SessionVerId advanced past the snapshot verId — the venue rolled the session while the process was down (#380). |
+| `trading.recovery.session_rolled_orders_dropped` | Counter | `firm` | PendingNew working-book entries eagerly retired (MarkCancelled) by the session-version guard (only PendingNew, per #504). |
+
+### P&L / statement
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.fees.replay_synth` | Counter | `reconciled` | Fee-keeper deterministic replay synth over the ER→FeeAccruedEvent crash window; `reconciled=false` is the real crash case — alert above baseline (#270). |
+| `trading.pnl.realized_appended` | Counter | `firmId` | RealizedPnlEvent appended on the live dispatcher path (not replay) (#271). |
+| `trading.pnl.replay_synth` | Counter | `reconciled` | P&L replay synth mirroring the fee synth; `reconciled=false` is the ER-then-crash window (#271). |
+| `trading.pnl.endpoint_requests` | Counter | (none) | `/pnl/today` hits. |
+| `trading.statement.endpoint_requests` | Counter | `format` (json/csv) | Daily-statement endpoint hits, split by output format (#272). |
+| `trading.statement.day_trade_detected` | Counter | (none) | Statement requests that returned ≥1 IR day-trade row (informational; no tax collected) (#272). |
+| `trading.statement.master_avg_basis_degraded_total` | Counter | (none) | Master-bucket rows rendered with absent/disagreeing avg-cost basis → `AvgPrice=0` fail-closed (#316). |
+| `trading.subaccount.master_basis_unrecoverable_total` | Counter | (none) | Legacy snapshot missing `SubAccountPnlBasis` while sub-account positions exist — master basis left unseeded (#316). |
+| `trading.pnl.legacy_snapshot_basis_seeded` | Counter | (none) | Avg-cost basis reconstructed from a legacy (pre-#271) snapshot's position rows on restore (#278). |
+| `trading.pnl.legacy_snapshot_basis_skipped_zero` | Counter | (none) | Legacy position row skipped because its AverageEntryPrice was zero (would realise phantom P&L) (#278). |
+| `trading.pnl.snapshot_basis_inconsistent` | Counter | (none) | Same key present in both PnlAvgCost and PnlUnknownBasis on restore; "prefer unknown" policy applied (#278). |
+| `trading.pnl.refprice_publishes` | Counter | (none) | Coalesced refprice fan-out `pnl.me` delta publishes under the per-symbol throttle (#278). |
+| `trading.pnl.refprice_throttled` | Counter | (none) | Refprice publishes suppressed by the per-symbol throttle (#278). |
+
+### Algo engine (extended)
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.algo.vwap.slices_emitted` | Counter | (none) | Child orders the VWAP scheduler actually placed (zero-qty slots skipped) (#281). |
+| `trading.algo.vwap.target_vs_actual_diff` | Histogram (shares) | (none) | `targetCumQty − executedCum` at VWAP slice evaluation (positive = behind) (#281). |
+| `trading.algo.vwap.cancelled` | Counter | (none) | VWAP parents reaching the Cancelled terminal state (#281). |
+| `trading.algo.pov.slices_emitted` | Counter | (none) | Child orders the POV scheduler actually placed (#282). |
+| `trading.algo.pov.actual_participation_rate` | Histogram (ratio) | (none) | `cumExecuted / cumMarketVolume` sampled at each POV slice evaluation (#282). |
+| `trading.algo.pov.cancelled` | Counter | (none) | POV parents reaching the Cancelled terminal state (#282). |
+| `trading.algo.pegged.repegs_total` | Counter | (none) | Pegged repeg (cancel + place at new target) cycles; no-op evaluations excluded (#283). |
+| `trading.algo.pegged.repeg_failed` | Counter | (none) | Repeg attempts that aborted on the cancel leg; retried next tick (#283). |
+| `trading.algo.pegged.cancelled` | Counter | (none) | Pegged parents reaching the Cancelled terminal state (#283). |
+| `trading.algo.pegged.repeg_dedup_ring_evicted_total` | Counter | (none) | FIFO evictions in PeggedRepegBook's per-parent cancelled-child dedup ring; sustained increments mean the cap is too tight for venue tail-fill latency (#296). |
+| `trading.algo.child_modifies_total` | Counter | `algoType`, `reason` | Algo child cancel-replace (modify) cycles dispatched to the gateway (#285). |
+| `trading.algo.modify_rejected_total` | Counter | `algoType`, `reason` | Algo modify requests rejected before the gateway (terminal algo/child, invalid qty) (#285). |
+| `trading.algo.modify_send_ambiguous_total` | Counter | `algoType` | Algo modify dispatch threw post-WAL but may have been venue-accepted; intent preserved for a late Replaced ER (#299). |
+| `trading.algo.modify_retired_child_evicted_total` | Counter | `algoType` | Retired-child FIFO entries evicted from the per-parent `ChildBookedCum` bookkeeping cap (#299). |
+| `trading.algo.modify_ambiguous_intent_expired_total` | Counter | `algoType` | Ambiguous-send replace intents expired by the scheduler TTL sweep; held margin reservation released (#299). |
+| `trading.algos.algoid_registry_corruption` | Counter | `firm`, `reason` | AlgoId watermark-advance refusals during WAL replay. MUST be flat at zero (#160). |
+
+### EntryPoint (extended)
+
+| OTel name | Type | Tags | Notes |
+|---|---|---|---|
+| `trading.entrypoint.reconnect_succeeded` | Counter | `firm`, `kind` | Successful gateway reconnects (reattach vs renegotiate). |
+| `trading.entrypoint.reconnect_failed` | Counter | `firm`, `reason` | Failed gateway reconnect attempts. |
+| `trading.entrypoint.reconnecting` | ObservableGauge | `firm` | 1 while the gateway is actively inside its reconnect loop (distinguishes "trying" from "gave up"). |
+| `trading.entrypoint.session_state` | ObservableGauge | `firm`, `state` | One-hot FIXP wire-protocol state per firm (exactly one row = 1), pulled live from the SDK on each scrape. |
+| `trading.entrypoint.session_ver_id` | ObservableGauge | `firm` | Last SessionVerId successfully Established per firm; a frozen gauge while attempts climb flags a stuck reconnect. |
+| `trading.entrypoint.gap_detected` | Counter | `firm` | Inbound seqnum gap flagged by the defensive check on top of SDK retransmit. |
+| `trading.entrypoint.duplicate_inbound` | Counter | `firm` | Duplicate/out-of-order inbound replay dropped (or idempotently deduped downstream). |
+| `trading.entrypoint.order_entry_call_ms` | Histogram (ms) | `firm`, `op` (submit/cancel/replace) | Local SDK await duration (network write + serialization) for successful order-entry calls. |
+| `trading.entrypoint.order_entry_to_ack_ms` | Histogram (ms) | `firm`, `op` | Submit-to-first-ER round trip. |
+| `trading.entrypoint.orders_auto_staled` | Counter | `firm`, `reason` | Orders auto-marked stale by the venue reactor after a desync signal (gap-at-reconnect / peer-terminate) (#132). |
+| `trading.entrypoint.session_roll_stale_reconcile_failed` | Counter | `firm` | Confirmed session-roll reconciliation whose Working/PartiallyFilled staling phase failed — surviving orders need a manual admin `mark-stale` (#380/#503). |
+| `trading.entrypoint_listener.outbound_drain_shutdown_timeout` | ObservableGauge (s) | (none) | Configured `EntryPointListener:Buffers:OutboundDrainShutdownTimeout` — build-info gauge, reflects reloads (#234). |
+| `trading.fixp.outbound.drain.shutdown.abandoned` | Counter | (none) | Per-connection outbound drain loop abandoned >250 ms past the shutdown timeout; sibling of the structured warn log (#233). |
 
 ## Option-specific surveillance (OPT-F / #488)
 


### PR DESCRIPTION
## What

`docs/METRICS.md` documented only the curated 35-metric dashboard subset, while the trading-host `MetricsRegistry` emits 100+ named instruments (the #369 audit flagged ~65 undocumented; it has since grown). Ops couldn't write SLIs without grepping source.

This PR documents **every remaining emitted `trading.*` instrument** in a new **Extended application instruments** section, grouped by area:

- Order flow, Execution reports, Margin/risk, Audit/compliance/session, WAL/persistence, Recovery, P&L/statement, Algo engine (extended), EntryPoint (extended).

Each row carries: OTel name, instrument **type** (Counter/Histogram/UpDownCounter/ObservableGauge), **unit** for histograms/gauges, the **real tag set** (read from the actual `.Add(...)` / `.Record(...)` call sites, not guessed), and a one-line note tying it to the emitting path / issue.

## Verification

- Diffed every `"trading.*"` string declared in `MetricsRegistry.cs` against the doc → **0 registry metrics undocumented**.
- Tag sets sourced from call sites across `Application`/`Api`/`Host`/`Infrastructure` (union of keys).

## Also

Fixed a stale tag set on the already-documented `trading.kill_switch.toggled` (real tags are `scope`/`killed`, doc said `state (on/off)` — verified at `AdminEndpoints.cs:570`).

Docs-only; no code or test changes.

Closes #369

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
