### PR TITLE
test(#345,#347): de-flake pegged/modify algo tests (drop RetryFact, poll instead of sleep)

### DIFF
--- a/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/AlgoModifyEndpointTests.cs
@@ -404,9 +404,10 @@ public class AlgoModifyEndpointTests
         Assert.Equal(replace.NewClOrdId, newChild.ClOrdId);
     }
 
-    // #347. Known timing-flake under CI parallelism; retry up to 3x
-    // (a real regression still fails after 3 attempts).
-    [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 250)]
+    // #347. Root cause was a fixed Task.Delay racing the async ER
+    // pipeline; fixed by polling the projected filledQuantity (see
+    // WaitForAlgoLong) instead of sleeping, so no retry is needed.
+    [Fact]
     public async Task Modify_ReplacedErWithStaleZeroCum_ClampsBaselineToOriginal()
     {
         // Pass-2 review (#299) P1. Translators in
@@ -439,8 +440,7 @@ public class AlgoModifyEndpointTests
         // Partial fill of 30 on the OLD child BEFORE the modify dispatch.
         await InjectEr(http, adminToken, oldChild.ClOrdId, "PartialFill",
             lastQty: 30, lastPx: 30.0m);
-        await Task.Delay(150);
-        var algoBefore = await GetAlgo(http, token, algoId);
+        var algoBefore = await WaitForAlgoLong(http, token, algoId, "filledQuantity", 30L);
         Assert.Equal(30L, algoBefore.GetProperty("filledQuantity").GetInt64());
 
         // Operator modify: keep quantity unchanged (100) but bump price.
@@ -480,9 +480,8 @@ public class AlgoModifyEndpointTests
         // Drive a Fill ER for the NEW child taking total cum to 50.
         await InjectEr(http, adminToken, newChild.ClOrdId, "PartialFill",
             lastQty: 20, lastPx: 30.5m);
-        await Task.Delay(150);
 
-        var algoAfter = await GetAlgo(http, token, algoId);
+        var algoAfter = await WaitForAlgoLong(http, token, algoId, "filledQuantity", 50L);
         Assert.Equal(50L, algoAfter.GetProperty("filledQuantity").GetInt64());
         Assert.Equal(50L, algoAfter.GetProperty("remainingQuantity").GetInt64());
     }
@@ -1044,5 +1043,31 @@ public class AlgoModifyEndpointTests
             await Task.Delay(20);
         }
         throw new TimeoutException($"Algo {algoId} did not reach any of [{string.Join(",", anyOf)}] within 5s; last={last}");
+    }
+
+    // Polls GET /algo/{id} until the given long-valued property equals
+    // the expected value, then returns the latest snapshot. Replaces
+    // fixed Task.Delay sleeps that race the async ER pipeline under load
+    // (#347): the ExecutionReportProcessor → AlgoEngine → projection hop
+    // is asynchronous, so a fixed sleep can read stale state on a
+    // contended runner.
+    private static async Task<JsonElement> WaitForAlgoLong(
+        HttpClient http, string token, string algoId, string property, long expected,
+        TimeSpan? timeout = null)
+    {
+        var deadline = timeout ?? TimeSpan.FromSeconds(5);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        long last = long.MinValue;
+        JsonElement algo = default;
+        while (sw.Elapsed < deadline)
+        {
+            algo = await GetAlgo(http, token, algoId);
+            last = algo.GetProperty(property).GetInt64();
+            if (last == expected) return algo;
+            await Task.Delay(20);
+        }
+        throw new TimeoutException(
+            $"Algo {algoId} property '{property}' did not reach {expected} within " +
+            $"{deadline.TotalSeconds}s; last={last}");
     }
 }

--- a/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/PeggedAlgoEndpointTests.cs
@@ -8,7 +8,6 @@ using B3.Trading.Domain;
 using B3.Trading.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using xRetry;
 
 namespace B3.Trading.Api.Tests;
 
@@ -955,8 +954,11 @@ public class PeggedAlgoEndpointTests
 
     // ──────────────── Pass-4 review (#296) regression tests ────────────────
 
-    // #345. ~50% failure rate in CI under load; retry 3x.
-    [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 250)]
+    // #345. The orphan-child / stale-cum root cause was the
+    // AlgoEngine.OnChildErAsync adoption-before-bookkeeping race fixed
+    // in #469 (LiveChildClOrdId reorder + lock fence). The test is fully
+    // poll-based (WaitForAlgoStatus / WaitFor), so no retry is needed.
+    [Fact]
     public async Task Pegged_FillRacesRepegReplace_DelayInjectedFill_NoOrphanReplacementChildAndIntentReleased()
     {
         // #300 retrofit. Window-3 race for the cancel-replace path:


### PR DESCRIPTION
## What

Two algo tests carried a `RetryFact(3x)` band-aid for flakes #347 and #345:

- `AlgoModifyEndpointTests.Modify_ReplacedErWithStaleZeroCum_ClampsBaselineToOriginal` (#347)
- `PeggedAlgoEndpointTests.Pegged_FillRacesRepegReplace_DelayInjectedFill_NoOrphanReplacementChildAndIntentReleased` (#345)

The shared **root cause** — `AlgoEngine.OnChildErAsync` publishing `LiveChildClOrdId` *before* the adoption bookkeeping (`RetireChildSlot` / `ChildBookedCum` seed / pegged-repeg resolve) committed — was fixed three weeks ago in **#469** (engine reorder + per-runtime lock fence). #469 explicitly noted #347/#345 "should drop off the flake list — closing them after a few days of CI quiet." This PR does that closeout.

## Changes

- **Both tests**: remove `RetryFact` → plain `[Fact]` (root cause gone); remove the now-unused `using xRetry;` in `PeggedAlgoEndpointTests`.
- **#347 hardening**: the test also used a fixed `await Task.Delay(150)` before reading the projected `filledQuantity` — a *second* timing window that races the async ER → AlgoEngine → projection hop under CI contention (the documented `expected 50, actual 30` signature). Replaced both sleeps with a new `WaitForAlgoLong(http, token, algoId, property, expected)` poll helper (same pattern as the existing `WaitForAlgoStatus` / `WaitFor`, mirroring the #339 bounded-poll precedent). The assertion now waits for the value deterministically; a real regression (e.g. double-booking to 80) still fails fast via timeout with a clear message.
- **#345**: already fully poll-based (`WaitForAlgoStatus` / `WaitFor`), so only the retry wrapper is removed.

## Verification

- Both tests **20× green locally** (40 executions, 0 failures).
- Full `PeggedAlgoEndpointTests` + `AlgoModifyEndpointTests`: **38/38 green**.
- `dotnet format --verify-no-changes` clean on both files.

Note: the flake is CI-contention-specific and not reproducible on this fast devbox even with `Task.Delay(0)` and no retry; the fix removes the timing assumption rather than relying on a faster machine.

Closes #347
Closes #345

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
