### PR TITLE
feat(#370): complete Stage A admin surface for venue halts

### DIFF
--- a/backend/src/B3.Trading.Api/AdminEndpoints.cs
+++ b/backend/src/B3.Trading.Api/AdminEndpoints.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace B3.Trading.Api;
@@ -46,13 +47,23 @@ public static class AdminEndpoints
         // restart — losing a halt on crash would be the worst
         // possible default for a safety control.
         group.MapGet("/halts", (SymbolHaltService svc) =>
-            Results.Ok(new { Symbols = svc.ListHalted() }));
+            Results.Ok(new
+            {
+                // Back-compat: the flat symbol list pre-#370 callers
+                // (and existing tests) deserialise.
+                Symbols = svc.ListHalted(),
+                // #370 Stage A: additive per-symbol origin so the
+                // operator UI can label a halt "operator" vs "venue"
+                // vs both, and reason about who must clear it.
+                Halts = svc.ListHaltedWithOrigin()
+                    .Select(e => new { e.Symbol, Origin = HaltOriginLabel(e.Flags) }),
+            }));
 
-        group.MapPost("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
-            ToggleHalt(dispatcher, audit, symbol, halted: true, ctx, () => svc.Halt(symbol)));
+        group.MapPost("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit, ILoggerFactory loggerFactory) =>
+            ToggleHalt(dispatcher, audit, svc, loggerFactory, symbol, halted: true, ctx));
 
-        group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit) =>
-            ToggleHalt(dispatcher, audit, symbol, halted: false, ctx, () => svc.Resume(symbol)));
+        group.MapDelete("/halts/{symbol}", (string symbol, HttpContext ctx, SymbolHaltService svc, EventDispatcher dispatcher, IAuditLogger audit, ILoggerFactory loggerFactory) =>
+            ToggleHalt(dispatcher, audit, svc, loggerFactory, symbol, halted: false, ctx));
 
         // ── Session phase (#108) ──────────────────────────────────
         // Per-symbol override + global default trading phase. Drives
@@ -585,10 +596,11 @@ public static class AdminEndpoints
     private static IResult ToggleHalt(
         EventDispatcher dispatcher,
         IAuditLogger audit,
+        SymbolHaltService svc,
+        ILoggerFactory loggerFactory,
         string symbol,
         bool halted,
-        HttpContext ctx,
-        Action mutate)
+        HttpContext ctx)
     {
         var actor = ctx.User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
         try
@@ -606,12 +618,39 @@ public static class AdminEndpoints
                     Symbol = symbol,
                     Halted = halted,
                     ActorUserId = actor,
-                    Origin = B3.Trading.Application.MarketData.HaltOrigin.Operator,
+                    Origin = HaltOrigin.Operator,
                 },
-                mutate);
+                // The operator surface only ever touches the operator
+                // origin flag; a venue halt observed via market data is
+                // independent (see SymbolHaltService / HaltOrigin).
+                () =>
+                {
+                    if (halted) svc.Halt(symbol, HaltOrigin.Operator);
+                    else svc.Resume(symbol, HaltOrigin.Operator);
+                });
             MetricsRegistry.SymbolHaltToggled.Add(1,
                 new KeyValuePair<string, object?>("halted", halted),
                 new KeyValuePair<string, object?>("origin", "operator"));
+
+            // #370 Stage A exit criterion: an operator resume clears
+            // only the operator flag. If the venue still has the symbol
+            // halted, the symbol stays halted — warn loudly and tell the
+            // caller so nobody assumes the ticket is tradeable again.
+            if (!halted && svc.IsHaltedBy(symbol, HaltOrigin.Venue))
+            {
+                loggerFactory
+                    .CreateLogger("B3.Trading.Api.AdminEndpoints.Halts")
+                    .LogWarning(
+                        "Operator resume for {Symbol} cleared the operator halt, but the venue still has it halted; the symbol remains halted until the venue resumes.",
+                        symbol);
+                return Results.Ok(new
+                {
+                    symbol,
+                    resumed = false,
+                    stillHaltedBy = "venue",
+                    detail = "Operator halt cleared, but the venue still has this symbol halted. It remains halted until the venue resumes.",
+                });
+            }
             return Results.NoContent();
         }
         catch (WalBackpressureException ex)
@@ -622,6 +661,24 @@ public static class AdminEndpoints
                 new { error = "system busy (WAL backpressure)", detail = ex.Message },
                 statusCode: StatusCodes.Status503ServiceUnavailable);
         }
+    }
+
+    /// <summary>
+    /// Maps the <see cref="SymbolHaltEntry.Flags"/> bitmask
+    /// (Operator=1, Venue=2) to a stable label for the admin halt
+    /// listing. "operator+venue" means both origins hold the halt and
+    /// it stays halted until both clear.
+    /// </summary>
+    private static string HaltOriginLabel(byte flags)
+    {
+        var hasOperator = (flags & (1 << (int)HaltOrigin.Operator)) != 0;
+        var hasVenue = (flags & (1 << (int)HaltOrigin.Venue)) != 0;
+        return (hasOperator, hasVenue) switch
+        {
+            (true, true) => "operator+venue",
+            (false, true) => "venue",
+            _ => "operator",
+        };
     }
     private static IResult ChangeSessionPhase(
         EventDispatcher dispatcher,

--- a/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
+++ b/backend/tests/B3.Trading.Api.Tests/RiskAndAdminEndpointsTests.cs
@@ -5,6 +5,9 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using B3.Trading.Api.WebSockets;
+using B3.Trading.Application.MarketData;
+using B3.Trading.Application.Risk;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace B3.Trading.Api.Tests;
 
@@ -63,6 +66,72 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
         var state = await admin.GetFromJsonAsync<HaltStateDto>("/admin/halts");
         Assert.Contains("ABEV3", state!.Symbols);
         await admin.DeleteAsync("/admin/halts/ABEV3");
+    }
+
+    [Fact]
+    public async Task AdminGetHalts_ExposesOriginPerSymbol()
+    {
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var halts = _factory.Services.GetRequiredService<SymbolHaltService>();
+        // Distinct symbol to avoid contaminating the shared factory.
+        halts.Resume("CSNA3", HaltOrigin.Venue);
+        await admin.DeleteAsync("/admin/halts/CSNA3");
+
+        // A venue halt observed via market data plus an operator halt.
+        halts.Halt("CSNA3", HaltOrigin.Venue);
+        await admin.PostAsync("/admin/halts/CSNA3", content: null);
+        try
+        {
+            var state = await admin.GetFromJsonAsync<HaltStateDto>("/admin/halts");
+            var entry = Assert.Single(state!.Halts, h => h.Symbol == "CSNA3");
+            Assert.Equal("operator+venue", entry.Origin);
+        }
+        finally
+        {
+            await admin.DeleteAsync("/admin/halts/CSNA3");
+            halts.Resume("CSNA3", HaltOrigin.Venue);
+        }
+    }
+
+    [Fact]
+    public async Task OperatorResume_WhileVenueStillHalted_StaysHaltedAndReportsResidualVenueHalt()
+    {
+        using var http = _factory.CreateClient();
+        var token = await _factory.LoginAsync(http, "bob");
+        using var admin = await _factory.CreateAuthedClientAsync("admin");
+        var halts = _factory.Services.GetRequiredService<SymbolHaltService>();
+        halts.Resume("USIM5", HaltOrigin.Venue);
+        await admin.DeleteAsync("/admin/halts/USIM5");
+
+        // Venue halts the symbol (observed via market data), operator
+        // also halts it manually.
+        halts.Halt("USIM5", HaltOrigin.Venue);
+        await admin.PostAsync("/admin/halts/USIM5", content: null);
+        try
+        {
+            // Operator clears their own halt — but the venue still
+            // holds it, so the endpoint must report the residual venue
+            // halt instead of a bare 204.
+            var resume = await admin.DeleteAsync("/admin/halts/USIM5");
+            Assert.Equal(HttpStatusCode.OK, resume.StatusCode);
+            var body = await resume.Content.ReadFromJsonAsync<ResumeResidualDto>();
+            Assert.False(body!.Resumed);
+            Assert.Equal("venue", body.StillHaltedBy);
+
+            // And the symbol genuinely stays halted on the order path.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var ws = await OpenSubscribedAsync(token, Channels.ExecutionsMe);
+            var blocked = await PostAsync(http, token, "/orders",
+                new { Symbol = "USIM5", SecurityId = 7777UL, Side = "Buy", Type = "Limit", Quantity = 1, Price = 10m });
+            Assert.Equal(HttpStatusCode.Accepted, blocked.StatusCode);
+            var delta = await ReadJsonAsync(ws, cts.Token);
+            Assert.Equal("Rejected", delta.GetProperty("data").GetProperty("kind").GetString());
+            Assert.Contains("halted", delta.GetProperty("data").GetProperty("rejectReason").GetString());
+        }
+        finally
+        {
+            halts.Resume("USIM5", HaltOrigin.Venue);
+        }
     }
 
     [Fact]
@@ -247,6 +316,8 @@ public class RiskAndAdminEndpointsTests : IClassFixture<TestAppFactory>
     }
 
     private sealed record KillStateDto(string[] EndClients, string[] Firms);
-    private sealed record HaltStateDto(string[] Symbols);
+    private sealed record HaltStateDto(string[] Symbols, HaltOriginDto[] Halts);
+    private sealed record HaltOriginDto(string Symbol, string Origin);
+    private sealed record ResumeResidualDto(string Symbol, bool Resumed, string StillHaltedBy, string Detail);
     private sealed record SessionPhaseStateDto(string Default, Dictionary<string, string> Overrides);
 }


### PR DESCRIPTION
## What

Completes the **#370 Stage A** REST admin surface. The Stage-A backend
(origin flags on `SymbolHaltService`, venue `TradingStatus` delta-detection,
WAL `Origin`, snapshot/recovery) already shipped in #371; this fills two
remaining ends in `AdminEndpoints.cs`:

1. **`GET /admin/halts`** now also returns a `Halts` array with each
   symbol's origin (`operator` | `venue` | `operator+venue`). The legacy
   `Symbols` field is retained for back-compat.
2. **`DELETE /admin/halts/{symbol}`** (operator resume) previously
   discarded the `Resume()` result and always returned `204`. When the
   **venue** still holds the symbol halted, it now logs a `WARNING` and
   returns `200 { resumed=false, stillHaltedBy="venue", detail=... }`.
   The normal resume still returns `204`.

## Why

Closes the last unmet **exit criterion** in #370:
> Operator resume após venue halt: registra warn no log, permanece halted até venue resumir.

Previously an operator `DELETE` while the venue still halted the symbol
silently looked like a full resume (bare 204), even though the symbol
stayed halted on the order path — a misleading and potentially unsafe UX.

## Invariants preserved

Operator and venue halt origins are **independent flags**; neither clears
the other (`SymbolHaltService` / `HaltOrigin`). This PR only reads/reports
state — the mutation semantics are unchanged.

## Tests

- `AdminGetHalts_ExposesOriginPerSymbol` — operator+venue halt → origin label.
- `OperatorResume_WhileVenueStillHalted_StaysHaltedAndReportsResidualVenueHalt`
  — operator clears their flag, endpoint reports residual venue halt, and
  the symbol still rejects orders on the wire.

All Api + Application halt tests green; `dotnet format` clean; code-review
(`gpt-5.5`) clean.

Refs #370 (Stage B — typed SDK `InstrumentStatus` event — remains blocked
on upstream `B3.MarketData.WebSocketClient`; current 0.6.0 still exposes
only the `InfoSnapshot.TradingStatus` field Stage A consumes).
